### PR TITLE
patch: Measure Peer's Valid Header Threshold from MS to Sec

### DIFF
--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -625,7 +625,6 @@ impl PrimaryReceiverHandler {
         } else {
             let mut validated_received_parents = vec![];
             for parent in parents {
-                println!("validating received parents...");
                 validated_received_parents.push(
                     validate_received_certificate_version(parent).map_err(|err| {
                         error!("request vote parents processing error: {err}");

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -528,9 +528,7 @@ async fn test_request_vote_accept_missing_parents() {
     let result = handler.request_vote(request).await;
 
     let expected_missing: HashSet<_> = round_2_missing.iter().map(|c| c.digest()).collect();
-    println!("expected missing:\n {:?}", expected_missing);
     let received_missing: HashSet<_> = result.unwrap().into_body().missing.into_iter().collect();
-    println!("\nreceived missing:\n {:?}", received_missing);
     assert_eq!(expected_missing, received_missing);
 
     // TEST PHASE 2: Handler should process missing parent certificates and succeed.


### PR DESCRIPTION
- Header threshold originally used ms, but seconds used for EVM compatibility
- Update unit test for missing parents
    - test_request_vote_accept_missing_parents
    - test_fetch_certificates_v2_handler renamed to test_fetch_certificates_handler + updates
- May consider going back to MS for consensus and converting to seconds for execution