### PR TITLE
Use random RPC ports, can start in faucet mode when not configured.

### DIFF
--- a/crates/execution/faucet/src/cli_ext.rs
+++ b/crates/execution/faucet/src/cli_ext.rs
@@ -150,7 +150,8 @@ impl FaucetArgs {
 
         // TODO: support local/hardcoded hot wallet signatures
         warn!(target: "faucet", "Google KMS inactive - skipping faucet extension.");
-        todo!("Only Google KMS supported right now.")
+        Err(eyre::Report::msg("Google KMS inactive - skipping faucet extension."))
+        //todo!("Only Google KMS supported right now.")
     }
 }
 


### PR DESCRIPTION
The binary being used in the test will have faucet enabled when compiled with the default --all-features so make it able to start.