### PR TITLE
Small tweaks to Dockerfile and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ BASE_DIR:=$(shell basename $(ROOT_DIR))
 
 .DEFAULT: help
 
+# Default tag is latest if not specified
+TAG ?= latest
+
 help:
 	@echo ;
 	@echo "make attest" ;
@@ -91,7 +94,7 @@ docker-login:
 
 # build and push latest adiri image for amd64 and arm64
 docker-adiri:
-	docker buildx build -f ./etc/Dockerfile --platform linux/amd64,linux/arm64 -t us-docker.pkg.dev/telcoin-network/tn-public/adiri . --push ;
+	docker buildx build -f ./etc/Dockerfile --platform linux/amd64,linux/arm64 -t us-docker.pkg.dev/telcoin-network/tn-public/adiri:$(TAG) . --push ;
 
 # push local adiri:latest to the gcloud artifact registry
 docker-push:

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79-slim-bookworm as builder
+FROM rust:1.79-slim-bookworm AS builder
 
 WORKDIR /usr/src/telcoin-network
 


### PR DESCRIPTION
- fix docker warning 
- add `TAG` to makefile for convenience
  - ex) `make docker-adiri TAG=v0.1.2-adiri`