### PR TITLE
Add compaction to the DB trait and use in the layered DB background thread (for redb).

### DIFF
--- a/crates/consensus/typed-store/src/redb/database.rs
+++ b/crates/consensus/typed-store/src/redb/database.rs
@@ -328,6 +328,11 @@ impl Database for ReDB {
         let read_table = self.db.read().begin_read().ok()?.open_table(td).ok()?;
         read_table.last().ok().flatten().map(|(k, v)| (k.value().clone(), v.value().clone()))
     }
+
+    fn compact(&self) -> eyre::Result<()> {
+        self.db.write().compact()?;
+        Ok(())
+    }
 }
 
 #[self_referencing(pub_extras)]

--- a/crates/consensus/typed-store/src/traits.rs
+++ b/crates/consensus/typed-store/src/traits.rs
@@ -112,4 +112,10 @@ pub trait Database: Send + Sync + Clone + 'static {
         let tx = self.read_txn()?;
         keys.into_iter().map(|key| tx.get::<T>(key.borrow())).collect()
     }
+
+    /// If the underlying DB needs to be manually compacted (looking at redb here) then this can be
+    /// overwritten to allow this.  No-op for most backends.
+    fn compact(&self) -> eyre::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
https://github.com/Telcoin-Association/telcoin-network/issues/66
 
Looks like only redb needs explicit compaction but this adds it.