### PR TITLE
Update CI GitAttestationRegistry contract address

### DIFF
--- a/.github/scripts/verify_commit_hash.sh
+++ b/.github/scripts/verify_commit_hash.sh
@@ -8,7 +8,7 @@ set -e  # Exit immediately if a command exits with a non-zero status
 # adiri contract details
 #
 # NOTE: this contract must match local test-and-attest.sh
-CONTRACT_ADDRESS="0x1f2f25561a11762bdffd91014c6d0e49af334447"
+CONTRACT_ADDRESS="0xba26a2c8e1c54d5bbb96e891fd4a9d853f438eb9"
 RPC_ENDPOINT="https://rpc.adiri.tel"
 
 # Function call

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -21,7 +21,7 @@ if [ -z "$GITHUB_ATTESTATION_PRIVATE_KEY" ]; then
 fi
 
 # NOTE: this contract must match CI
-CONTRACT_ADDRESS="0x1f2f25561a11762bdffd91014c6d0e49af334447"
+CONTRACT_ADDRESS="0xba26a2c8e1c54d5bbb96e891fd4a9d853f438eb9"
 RPC_ENDPOINT="https://rpc.adiri.tel"
 ATTEST_CALL="attestGitCommitHash(bytes20,bool)"
 VERIFY_CALL="gitCommitHashAttested(bytes20)"


### PR DESCRIPTION
For some reason the create2 deployment for the GitAttestationRegistry contract (that the git CI uses) is producing a different address and I seem to have lost the broadcast log for its deployment script. 

Since the network has been restarted I'm not able to inspect the contract creation's transaction details and resolve it (probably some constructor arg or variable name diff), but changing the config only requires two small adjustments so we can just update to a new contract address.

I have saved the create2 broadcast logs to a remote repo so it will be constant across network restarts from now on