### PR TITLE
Remove ommers and worker block provides a Header not SealedHeader.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,4 +126,4 @@ init-submodules:
 
 # update tn-contracts submodule
 update-tn-contracts:
-	cd tn-contracts && git pull && forge build && cd ..
+	git submodule update foreach get

--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -90,15 +90,13 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
     let faucet_impl_address = Address::random();
     let stablecoin_impl_address = Address::random();
     // fetch bytecode attributes from compiled jsons in tn-contracts repo
-    let faucet_standard_json = fetch_file_content(
-        "../../tn-contracts/out/StablecoinManager.sol/StablecoinManager.json".into(),
-    );
+    let faucet_standard_json =
+        fetch_file_content("../../tn-contracts/artifacts/StablecoinManager.json".into());
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_standard_json).expect("json parsing failure");
     let faucet_bytecode =
         hex::decode(faucet_contract.deployed_bytecode.object).expect("invalid bytecode hexstring");
-    let stablecoin_json =
-        fetch_file_content("../../tn-contracts/out/Stablecoin.sol/Stablecoin.json".into());
+    let stablecoin_json = fetch_file_content("../../tn-contracts/artifacts/Stablecoin.json".into());
     let stablecoin_contract: ContractStandardJson =
         serde_json::from_str(&stablecoin_json).expect("json parsing failure");
     let stablecoin_impl_bytecode = hex::decode(stablecoin_contract.deployed_bytecode.object)
@@ -157,8 +155,7 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json =
-        fetch_file_content("../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+    let proxy_json = fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -30,9 +30,8 @@ mod tests {
         let tmp_chain: Arc<ChainSpec> = Arc::new(network_genesis.into());
 
         // fetch registry impl bytecode from compiled output in tn-contracts
-        let registry_standard_json = fetch_file_content(
-            "../../tn-contracts/out/ConsensusRegistry.sol/ConsensusRegistry.json".into(),
-        );
+        let registry_standard_json =
+            fetch_file_content("../../tn-contracts/artifacts/ConsensusRegistry.json".into());
         let registry_contract: ContractStandardJson =
             serde_json::from_str(&registry_standard_json).expect("json parsing failure");
         let registry_impl_bytecode = hex::decode(registry_contract.deployed_bytecode.object)
@@ -65,7 +64,7 @@ mod tests {
 
         // fetch and construct registry proxy deployment transaction
         let registry_proxy_json =
-            fetch_file_content("../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
         let registry_proxy_contract: ContractStandardJson =
             serde_json::from_str(&registry_proxy_json).expect("json parsing failure");
         let registry_proxy_initcode = hex::decode(registry_proxy_contract.bytecode.object)
@@ -185,7 +184,7 @@ mod tests {
             .expect("registry address missing from bundle state")
             .storage;
         let proxy_json =
-            fetch_file_content("../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
         let proxy_contract: ContractStandardJson =
             serde_json::from_str(&proxy_json).expect("json parsing failure");
         let proxy_bytecode = hex::decode(proxy_contract.deployed_bytecode.object)

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -119,9 +119,8 @@ async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
 
     // extend genesis accounts to fund factory_address and etch impl bytecode on faucet_impl
     let faucet_impl_address = Address::random();
-    let faucet_json = fetch_file_content(
-        "../../../tn-contracts/out/StablecoinManager.sol/StablecoinManager.json".into(),
-    );
+    let faucet_json =
+        fetch_file_content("../../../tn-contracts/artifacts/StablecoinManager.json".into());
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_json).expect("json parsing failure");
     let faucet_bytecode =
@@ -172,8 +171,7 @@ async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json =
-        fetch_file_content("../../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+    let proxy_json = fetch_file_content("../../../tn-contracts/artifacts/ERC1967Proxy.json".into());
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =
@@ -406,15 +404,14 @@ async fn test_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> 
     let faucet_impl_address = Address::random();
     let stablecoin_address = Address::random();
     // fetch bytecode attributes from compiled jsons in tn-contracts repo
-    let faucet_json = fetch_file_content(
-        "../../../tn-contracts/out/StablecoinManager.sol/StablecoinManager.json".into(),
-    );
+    let faucet_json =
+        fetch_file_content("../../../tn-contracts/artifacts/StablecoinManager.json".into());
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_json).expect("json parsing failure");
     let faucet_bytecode =
         hex::decode(faucet_contract.deployed_bytecode.object).expect("invalid bytecode hexstring");
     let stablecoin_json =
-        fetch_file_content("../../../tn-contracts/out/Stablecoin.sol/Stablecoin.json".into());
+        fetch_file_content("../../../tn-contracts/artifacts/Stablecoin.json".into());
     let stablecoin_contract: ContractStandardJson =
         serde_json::from_str(&stablecoin_json).expect("json parsing failure");
     let stablecoin_bytecode = hex::decode(stablecoin_contract.deployed_bytecode.object)
@@ -472,8 +469,7 @@ async fn test_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> 
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json =
-        fetch_file_content("../../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+    let proxy_json = fetch_file_content("../../../tn-contracts/artifacts/ERC1967Proxy.json".into());
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =

--- a/crates/tn-types/src/genesis.rs
+++ b/crates/tn-types/src/genesis.rs
@@ -212,9 +212,8 @@ impl NetworkGenesis {
         }
 
         let registry_impl = Address::random();
-        let registry_standard_json = fetch_file_content(
-            "../../tn-contracts/out/ConsensusRegistry.sol/ConsensusRegistry.json".into(),
-        );
+        let registry_standard_json =
+            fetch_file_content("../../tn-contracts/artifacts/ConsensusRegistry.json".into());
         let registry_contract: ContractStandardJson =
             serde_json::from_str(&registry_standard_json).expect("json parsing failure");
         let registry_bytecode = hex::decode(registry_contract.deployed_bytecode.object)
@@ -222,7 +221,7 @@ impl NetworkGenesis {
         let registry_proxy = Address::from_hex("0x07e17e17e17e17e17e17e17e17e17e17e17e17e1")
             .expect("invalid hex address");
         let proxy_standard_json =
-            fetch_file_content("../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
         let proxy_contract: ContractStandardJson =
             serde_json::from_str(&proxy_standard_json).expect("json parsing failure");
         let proxy_bytecode = hex::decode(proxy_contract.deployed_bytecode.object)
@@ -709,7 +708,7 @@ mod tests {
             Address::from_hex("0x07e17e17e17e17e17e17e17e17e17e17e17e17e1")
                 .expect("failed to parse address");
         let proxy_standard_json =
-            fetch_file_content("../../tn-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json".into());
+            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
         let proxy_contract: ContractStandardJson =
             serde_json::from_str(&proxy_standard_json).expect("failed to parse json");
         let proxy_bytecode = hex::decode(proxy_contract.deployed_bytecode.object)


### PR DESCRIPTION
Per scrum discussion this removes ommers. I also replaced the sealed_header() function on WorkerBlock with header() (not sealed).  The one place in real code that uses it only needs a header and it only needs it to implement a trait from Reth so no way around it.  We are not actually using it in our implementation but still probably better to be closer to something real in case that changes.  But no need to seal, the tests that want that can seal it themselves, this will avoid unnecessary seals in prod code.