### PR TITLE
Embedd genesis contract files so the binary can start.

### DIFF
--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -27,7 +27,7 @@ use reth_primitives::{public_key_to_address, Address, GenesisAccount, B256, U256
 use reth_tracing::init_test_tracing;
 use secp256k1::PublicKey;
 use std::{str::FromStr, sync::Arc, time::Duration};
-use tn_config::{fetch_file_content, ContractStandardJson};
+use tn_config::{test_fetch_file_content_relative_to_manifest, ContractStandardJson};
 use tn_test_utils::TransactionFactory;
 use tn_types::adiri_genesis;
 use tokio::{runtime::Handle, task::JoinHandle, time::timeout};
@@ -91,13 +91,16 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
     let faucet_impl_address = Address::random();
     let stablecoin_impl_address = Address::random();
     // fetch bytecode attributes from compiled jsons in tn-contracts repo
-    let faucet_standard_json =
-        fetch_file_content("../../tn-contracts/artifacts/StablecoinManager.json".into());
+    let faucet_standard_json = test_fetch_file_content_relative_to_manifest(
+        "../../tn-contracts/artifacts/StablecoinManager.json".into(),
+    );
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_standard_json).expect("json parsing failure");
     let faucet_bytecode =
         hex::decode(faucet_contract.deployed_bytecode.object).expect("invalid bytecode hexstring");
-    let stablecoin_json = fetch_file_content("../../tn-contracts/artifacts/Stablecoin.json".into());
+    let stablecoin_json = test_fetch_file_content_relative_to_manifest(
+        "../../tn-contracts/artifacts/Stablecoin.json".into(),
+    );
     let stablecoin_contract: ContractStandardJson =
         serde_json::from_str(&stablecoin_json).expect("json parsing failure");
     let stablecoin_impl_bytecode = hex::decode(stablecoin_contract.deployed_bytecode.object)
@@ -156,7 +159,9 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json = fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
+    let proxy_json = test_fetch_file_content_relative_to_manifest(
+        "../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
+    );
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -18,7 +18,7 @@ mod tests {
     };
     use reth_chainspec::ChainSpec;
     use std::{sync::Arc, time::Duration};
-    use tn_config::{fetch_file_content, ContractStandardJson};
+    use tn_config::{test_fetch_file_content_relative_to_manifest, ContractStandardJson};
     use tn_test_utils::TransactionFactory;
     use tn_types::{adiri_genesis, BlsKeypair, NetworkKeypair};
     use tokio::runtime::Handle;
@@ -29,8 +29,9 @@ mod tests {
         let tmp_chain: Arc<ChainSpec> = Arc::new(network_genesis.into());
 
         // fetch registry impl bytecode from compiled output in tn-contracts
-        let registry_standard_json =
-            fetch_file_content("../../tn-contracts/artifacts/ConsensusRegistry.json".into());
+        let registry_standard_json = test_fetch_file_content_relative_to_manifest(
+            "../../tn-contracts/artifacts/ConsensusRegistry.json".into(),
+        );
         let registry_contract: ContractStandardJson =
             serde_json::from_str(&registry_standard_json).expect("json parsing failure");
         let registry_impl_bytecode = hex::decode(registry_contract.deployed_bytecode.object)
@@ -62,8 +63,9 @@ mod tests {
         );
 
         // fetch and construct registry proxy deployment transaction
-        let registry_proxy_json =
-            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
+        let registry_proxy_json = test_fetch_file_content_relative_to_manifest(
+            "../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
+        );
         let registry_proxy_contract: ContractStandardJson =
             serde_json::from_str(&registry_proxy_json).expect("json parsing failure");
         let registry_proxy_initcode = hex::decode(registry_proxy_contract.bytecode.object)
@@ -182,8 +184,9 @@ mod tests {
             .get(&registry_proxy_address)
             .expect("registry address missing from bundle state")
             .storage;
-        let proxy_json =
-            fetch_file_content("../../tn-contracts/artifacts/ERC1967Proxy.json".into());
+        let proxy_json = test_fetch_file_content_relative_to_manifest(
+            "../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
+        );
         let proxy_contract: ContractStandardJson =
             serde_json::from_str(&proxy_json).expect("json parsing failure");
         let proxy_bytecode = hex::decode(proxy_contract.deployed_bytecode.object)

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -30,7 +30,7 @@ use reth_transaction_pool::TransactionPool;
 use secp256k1::PublicKey;
 use std::{str::FromStr, sync::Arc, time::Duration};
 use tempfile::TempDir;
-use tn_config::{fetch_file_content, ContractStandardJson};
+use tn_config::{test_fetch_file_content_relative_to_manifest, ContractStandardJson};
 use tn_faucet::Drip;
 use tn_network::local::LocalNetwork;
 use tn_storage::open_db;
@@ -118,8 +118,9 @@ async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
 
     // extend genesis accounts to fund factory_address and etch impl bytecode on faucet_impl
     let faucet_impl_address = Address::random();
-    let faucet_json =
-        fetch_file_content("../../../tn-contracts/artifacts/StablecoinManager.json".into());
+    let faucet_json = test_fetch_file_content_relative_to_manifest(
+        "../../../tn-contracts/artifacts/StablecoinManager.json".into(),
+    );
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_json).expect("json parsing failure");
     let faucet_bytecode =
@@ -170,7 +171,9 @@ async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json = fetch_file_content("../../../tn-contracts/artifacts/ERC1967Proxy.json".into());
+    let proxy_json = test_fetch_file_content_relative_to_manifest(
+        "../../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
+    );
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =
@@ -403,14 +406,16 @@ async fn test_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> 
     let faucet_impl_address = Address::random();
     let stablecoin_address = Address::random();
     // fetch bytecode attributes from compiled jsons in tn-contracts repo
-    let faucet_json =
-        fetch_file_content("../../../tn-contracts/artifacts/StablecoinManager.json".into());
+    let faucet_json = test_fetch_file_content_relative_to_manifest(
+        "../../../tn-contracts/artifacts/StablecoinManager.json".into(),
+    );
     let faucet_contract: ContractStandardJson =
         serde_json::from_str(&faucet_json).expect("json parsing failure");
     let faucet_bytecode =
         hex::decode(faucet_contract.deployed_bytecode.object).expect("invalid bytecode hexstring");
-    let stablecoin_json =
-        fetch_file_content("../../../tn-contracts/artifacts/Stablecoin.json".into());
+    let stablecoin_json = test_fetch_file_content_relative_to_manifest(
+        "../../../tn-contracts/artifacts/Stablecoin.json".into(),
+    );
     let stablecoin_contract: ContractStandardJson =
         serde_json::from_str(&stablecoin_json).expect("json parsing failure");
     let stablecoin_bytecode = hex::decode(stablecoin_contract.deployed_bytecode.object)
@@ -468,7 +473,9 @@ async fn test_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> 
     // construct create data for faucet proxy address
     let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
-    let proxy_json = fetch_file_content("../../../tn-contracts/artifacts/ERC1967Proxy.json".into());
+    let proxy_json = test_fetch_file_content_relative_to_manifest(
+        "../../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
+    );
     let proxy_contract: ContractStandardJson =
         serde_json::from_str(&proxy_json).expect("json parsing failure");
     let proxy_initcode =


### PR DESCRIPTION
This keeps the behavior of tests the same and still allows an external file to be provided for consensus registry storage.  Maybe we don't need to do these things?  But for now it just embeds the contract and storage files so that a binary can start on it's own.