### PR TITLE
Run some tests that require credentials during attestation.

### DIFF
--- a/crates/execution/faucet/src/lib.rs
+++ b/crates/execution/faucet/src/lib.rs
@@ -256,7 +256,7 @@ mod tests {
     /// ```
     #[test]
     #[ignore = "should not run with a default cargo test"]
-    fn test_google_kms_signature() {
+    fn test_with_creds_google_kms_signature() {
         // validator 1 kms
         // asymmetric_sign for SHA256 digest (keccak)
         let response = vec![
@@ -381,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "should not run with a default cargo test"]
-    async fn test_gcloud_sdk() {
+    async fn test_with_creds_gcloud_sdk() {
         // Debug logging
 
         std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", "./gcloud-credentials.json");

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -69,7 +69,7 @@ impl QuorumWaiterTrait for TestChanQuorumWaiter {
 
 #[tokio::test]
 #[ignore = "should not run with a default cargo test"]
-async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
+async fn test_with_creds_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
     // set application credentials for accessing Google KMS API
     std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", "./gcloud-credentials.json");
     // set Project ID for google_sdk
@@ -331,7 +331,7 @@ async fn test_faucet_transfers_tel_with_google_kms() -> eyre::Result<()> {
 
 #[tokio::test]
 #[ignore = "should not run with a default cargo test"]
-async fn test_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> {
+async fn test_with_creds_faucet_transfers_stablecoin_with_google_kms() -> eyre::Result<()> {
     // set application credentials for accessing Google KMS API
     std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", "./gcloud-credentials.json");
     // set Project ID for google_sdk

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -86,6 +86,8 @@ echo "clippy for workspace: default and all features passed"
 #
 # default features
 cargo test --workspace --no-fail-fast -- --show-output
+# Run tests that require credentials.
+cargo test test_with_creds -- --ignored
 # faucet it test
 cargo test -p telcoin-network --test it --features faucet --no-fail-fast -- faucet --show-output
 


### PR DESCRIPTION
This moves some of the test ignored because they needed some credentials, etc to make cargo test work out of box for contributors to make attest.  These can only be run by a core dev with credentials anyway so make sure they get run at some point.

Closes issue 178 https://github.com/Telcoin-Association/telcoin-network/issues/178