### PR TITLE
Allow switch back from a failed/inactive CVV to active.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,3 +336,10 @@ libp2p = { version = "0.54", features = [] }
 
 # [patch.crates-io]
 # alloy-sol-type-parser = { git = "https://github.com/alloy-rs/core", commit = "6bd4aeddc899c7649c2ce9be383fd5a3d4c0b691" }
+
+# On a panic, end entire app not just a thread.
+[profile.release]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'

--- a/bin/telcoin-network/src/cli.rs
+++ b/bin/telcoin-network/src/cli.rs
@@ -5,7 +5,6 @@ use crate::{
     version::{LONG_VERSION, SHORT_VERSION},
 };
 use clap::{value_parser, Parser, Subcommand};
-use futures::Future;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::node::NoArgs;
 use reth_db::DatabaseEnv;
@@ -119,10 +118,9 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     ///     })
     ///     .unwrap();
     /// ````
-    pub async fn run<L, Fut>(mut self, launcher: L) -> eyre::Result<()>
+    pub fn run<L>(mut self, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(TnBuilder<Arc<DatabaseEnv>>, Ext, DataDirChainPath) -> Fut,
-        Fut: Future<Output = eyre::Result<()>>,
+        L: FnOnce(TnBuilder<Arc<DatabaseEnv>>, Ext, DataDirChainPath) -> eyre::Result<()>,
     {
         // add network name to logs dir
         self.logs.log_file_directory =
@@ -131,9 +129,9 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
         let _guard = self.init_tracing()?;
 
         match self.command {
-            Commands::Genesis(command) => command.execute().await,
-            Commands::Node(command) => command.execute(true, launcher).await,
-            Commands::Keytool(command) => command.execute().await,
+            Commands::Genesis(command) => command.execute(),
+            Commands::Node(command) => command.execute(true, launcher),
+            Commands::Keytool(command) => command.execute(),
         }
     }
 
@@ -223,6 +221,6 @@ mod tests {
             "debug,net=trace",
         ])
         .unwrap();
-        assert!(tn.run(|_, _, _| async move { Ok(()) }).await.is_ok());
+        assert!(tn.run(|_, _, _| { Ok(()) }).is_ok());
     }
 }

--- a/bin/telcoin-network/src/cli.rs
+++ b/bin/telcoin-network/src/cli.rs
@@ -111,13 +111,11 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     ///     pub enable: bool,
     /// }
     ///
-    /// fn main() {
-    ///     if let Err(err) = telcoin_network::cli::Cli::<MyArgs>::parse()
-    ///         .run(|builder, _, tn_datadir| launch_node(builder, tn_datadir))
-    ///     {
-    ///         eprintln!("Error: {err:?}");
-    ///         std::process::exit(1);
-    ///     }
+    /// if let Err(err) = telcoin_network::cli::Cli::<MyArgs>::parse()
+    ///     .run(|builder, _, tn_datadir| launch_node(builder, tn_datadir))
+    /// {
+    ///     eprintln!("Error: {err:?}");
+    ///     std::process::exit(1);
     /// }
     /// ```
     pub fn run<L>(mut self, launcher: L) -> eyre::Result<()>

--- a/bin/telcoin-network/src/genesis/add_validator.rs
+++ b/bin/telcoin-network/src/genesis/add_validator.rs
@@ -65,7 +65,7 @@ impl AddValidator {
     /// - TODO: load validator information keys (assume safe for now)
     /// - add validator to network genesis
     /// - save NetworkGenesis as files in genesis dir again
-    pub async fn execute(&self) -> eyre::Result<()> {
+    pub fn execute(&self) -> eyre::Result<()> {
         info!(target: "genesis::add-validator", "Adding validator to committee");
 
         // add network name to data dir

--- a/bin/telcoin-network/src/genesis/create_committee.rs
+++ b/bin/telcoin-network/src/genesis/create_committee.rs
@@ -68,7 +68,7 @@ impl CreateCommitteeArgs {
     /// - write WorkerCache to file
     ///
     /// TODO: `validate` only verifies proof of possession for now
-    pub async fn execute(&self) -> eyre::Result<()> {
+    pub fn execute(&self) -> eyre::Result<()> {
         info!(target: "genesis::add-validator", "Adding validator to committee");
 
         // load network genesis

--- a/bin/telcoin-network/src/genesis/mod.rs
+++ b/bin/telcoin-network/src/genesis/mod.rs
@@ -127,7 +127,7 @@ fn account_from_word(key_word: &str) -> reth_primitives::alloy_primitives::Addre
 
 impl GenesisArgs {
     /// Execute command
-    pub async fn execute(&self) -> eyre::Result<()> {
+    pub fn execute(&self) -> eyre::Result<()> {
         // // create datadir
         // let datadir = self.data_dir();
         // // creates a default config if none exists
@@ -171,13 +171,13 @@ impl GenesisArgs {
             }
             // add validator to the committee file
             CeremonySubcommand::AddValidator(args) => {
-                args.execute().await?;
+                args.execute()?;
             }
             CeremonySubcommand::Validate(args) => {
-                args.execute().await?;
+                args.execute()?;
             }
             CeremonySubcommand::CreateCommittee(args) => {
-                args.execute().await?;
+                args.execute()?;
             }
         }
 

--- a/bin/telcoin-network/src/genesis/validate.rs
+++ b/bin/telcoin-network/src/genesis/validate.rs
@@ -62,7 +62,7 @@ impl ValidateArgs {
     /// - ensure valid state for validators
     ///
     /// TODO: `validate` only verifies proof of possession for now
-    pub async fn execute(&self) -> eyre::Result<()> {
+    pub fn execute(&self) -> eyre::Result<()> {
         info!(target: "genesis::validate", "validating validators nominated for committee");
 
         // load network genesis

--- a/bin/telcoin-network/src/keytool/generate.rs
+++ b/bin/telcoin-network/src/keytool/generate.rs
@@ -92,11 +92,7 @@ pub struct ValidatorArgs {
 
 impl ValidatorArgs {
     /// Create all necessary information needed for validator and save to file.
-    pub async fn execute(
-        &self,
-        authority_key_path: &Path,
-        config: &mut Config,
-    ) -> eyre::Result<()> {
+    pub fn execute(&self, authority_key_path: &Path, config: &mut Config) -> eyre::Result<()> {
         info!(target: "tn::generate_keys", "generating keys for full validator node");
 
         // bls keypair for consensus - drop after write to zeroize memory

--- a/bin/telcoin-network/src/keytool/mod.rs
+++ b/bin/telcoin-network/src/keytool/mod.rs
@@ -89,7 +89,7 @@ pub struct Read; // public keys for: bls, network, execution, address
 
 impl KeyArgs {
     /// Execute command
-    pub async fn execute(&self) -> eyre::Result<()> {
+    pub fn execute(&self) -> eyre::Result<()> {
         // create datadir
         let datadir = self.data_dir();
         // creates a default config if none exists
@@ -104,7 +104,7 @@ impl KeyArgs {
                         // initialize path and warn users if overwriting keys
                         self.init_path(&authority_key_path, args.force)?;
                         // execute and store keypath
-                        args.execute(&authority_key_path, &mut config).await?;
+                        args.execute(&authority_key_path, &mut config)?;
                         config.keypath = authority_key_path;
 
                         debug!("{config:?}");
@@ -228,7 +228,7 @@ mod tests {
         ])
         .expect("cli parsed");
 
-        tn.run(|_, _, _| async move { Ok(()) }).await.expect("generate keys command");
+        tn.run(|_, _, _| Ok(())).expect("generate keys command");
 
         Config::load_from_path::<Config>(
             tempdir.join("telcoin-network.yaml").as_path(),

--- a/bin/telcoin-network/src/main.rs
+++ b/bin/telcoin-network/src/main.rs
@@ -13,24 +13,21 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[non_exhaustive]
 pub struct NoArgs;
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() {
+fn main() {
     #[cfg(not(feature = "faucet"))]
     if let Err(err) = telcoin_network::cli::Cli::<NoArgs>::parse()
-        .run(|builder, _, tn_datadir| async move { launch_node(builder, tn_datadir).await })
-        .await
+        .run(|builder, _, tn_datadir| launch_node(builder, tn_datadir))
     {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }
 
     #[cfg(feature = "faucet")]
-    if let Err(err) = telcoin_network::cli::Cli::<FaucetArgs>::parse()
-        .run(|mut builder, faucet, tn_datadir| async move {
+    if let Err(err) =
+        telcoin_network::cli::Cli::<FaucetArgs>::parse().run(|mut builder, faucet, tn_datadir| {
             builder.opt_faucet_args = Some(faucet);
-            launch_node(builder, tn_datadir).await
+            launch_node(builder, tn_datadir)
         })
-        .await
     {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -311,7 +311,7 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
 
     // create and launch validator nodes on local network,
     // use expected faucet contract address from `TransactionFactory::default` with nonce == 0
-    spawn_local_testnet(chain.clone(), &faucet_proxy_address.to_string()).await?;
+    spawn_local_testnet(chain.clone(), &faucet_proxy_address.to_string())?;
 
     info!(target: "faucet-test", "nodes started - sleeping for 10s...");
 

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -211,7 +211,6 @@ mod tests {
         let chain: Arc<ChainSpec> = Arc::new(genesis.into());
 
         spawn_local_testnet(chain, "0x0000000000000000000000000000000000000000")
-            .await
             .expect("failed to spawn testnet");
         // allow time for nodes to start
         tokio::time::sleep(Duration::from_secs(10)).await;

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -80,29 +80,31 @@ pub fn spawn_subscriber<DB: Database>(
         execute_missing: Arc::new(Mutex::new(false)),
     };
     let sub_clone = subscriber.clone();
-    if mode.is_cvv() {
+    if mode.is_active_cvv() {
+        // If we are active then partcipate in consensus.
         task_manager.spawn_task(
             "subscriber consensus",
             monitored_future!(
                 async move {
                     info!(target: "telcoin::subscriber", "Starting subscriber");
-                    sub_clone.run().await.expect("Failed to run subscriber")
+                    sub_clone.run().await
                 },
                 "SubscriberTask"
             ),
         );
+    } else {
+        // If we are not active then just follow consensus.
+        task_manager.spawn_task(
+            "subscriber follow consensus",
+            monitored_future!(
+                async move {
+                    info!(target: "telcoin::subscriber", "Starting subscriber");
+                    subscriber.follow_consensus().await
+                },
+                "SubscriberFollowTask"
+            ),
+        );
     }
-    // Keep follow consensus warm even if a CVV, might need it.
-    task_manager.spawn_task(
-        "subscriber follow consensus",
-        monitored_future!(
-            async move {
-                info!(target: "telcoin::subscriber", "Starting subscriber");
-                subscriber.follow_consensus().await.expect("Failed to run subscriber")
-            },
-            "SubscriberFollowTask"
-        ),
-    );
 }
 
 /// Returns the max consensus chain block number, epoch and round from peers.
@@ -374,151 +376,131 @@ impl<DB: Database> Subscriber<DB> {
             self.consensus_bus.recent_blocks().borrow().latest_block_num_hash();
         // infinate loop over consensus output
         loop {
-            if self.consensus_bus.node_mode().borrow().is_active_cvv() {
-                // If we are a CVV then do actual consensus and nothing here.
-                // Sleep in case we get into a failed state and need to start working.
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
-                    _ = &self.rx_shutdown => {
-                        return Ok(())
-                    }
-                }
-            } else {
-                // Otherwise just follow along...
-                for number in last_consensus_height + 1..=max_consensus_height {
-                    tracing::debug!(target: "telcoin::subscriber", "trying to get consensus block {number}");
-                    // Check if we already have this consensus output in our local DB.
-                    // This will also allow us to pre load other consensus blocks as a future
-                    // optimization.
-                    let output = if let Ok(Some(block)) = db.get::<ConsensusBlocks>(&number) {
-                        block
-                    } else {
-                        let mut try_num = 0;
-                        loop {
-                            // stop trying at some point?
-                            // rotate through clients attempting to get the headers.
-                            let client = clients
-                                .get_mut((number as usize + try_num) % clients_len)
-                                .expect("client found by index");
-                            let req = ConsensusOutputRequest { number: Some(number), hash: None };
-                            match client.request_consensus(req).await {
-                                Ok(res) => break res.into_body().output,
-                                Err(e) => {
-                                    tracing::error!(target: "telcoin::subscriber", "error requesting peer consensus {e:?}");
-                                    try_num += 1;
-                                    continue;
-                                }
+            // Otherwise just follow along...
+            for number in last_consensus_height + 1..=max_consensus_height {
+                tracing::debug!(target: "telcoin::subscriber", "trying to get consensus block {number}");
+                // Check if we already have this consensus output in our local DB.
+                // This will also allow us to pre load other consensus blocks as a future
+                // optimization.
+                let output = if let Ok(Some(block)) = db.get::<ConsensusBlocks>(&number) {
+                    block
+                } else {
+                    let mut try_num = 0;
+                    loop {
+                        // stop trying at some point?
+                        // rotate through clients attempting to get the headers.
+                        let client = clients
+                            .get_mut((number as usize + try_num) % clients_len)
+                            .expect("client found by index");
+                        let req = ConsensusOutputRequest { number: Some(number), hash: None };
+                        match client.request_consensus(req).await {
+                            Ok(res) => break res.into_body().output,
+                            Err(e) => {
+                                tracing::error!(target: "telcoin::subscriber", "error requesting peer consensus {e:?}");
+                                try_num += 1;
+                                continue;
                             }
                         }
-                    };
-                    let parent_hash = last_parent;
-                    last_parent =
-                        ConsensusHeader::digest_from_parts(parent_hash, &output.sub_dag, number);
-                    if last_parent != output.digest() {
-                        tracing::error!(target: "telcoin::subscriber", "failed to execute consensus!");
-                        return Err(SubscriberError::UnexpectedProtocolMessage);
                     }
-                    // TODO should also verify that the block output is building on is in fact
-                    // the head of our chain.
-                    let consensus_output =
-                        self.fetch_batches(output.sub_dag, parent_hash, number).await;
-                    self.save_consensus(consensus_output.clone())?;
+                };
+                let parent_hash = last_parent;
+                last_parent =
+                    ConsensusHeader::digest_from_parts(parent_hash, &output.sub_dag, number);
+                if last_parent != output.digest() {
+                    tracing::error!(target: "telcoin::subscriber", "failed to execute consensus!");
+                    return Err(SubscriberError::UnexpectedProtocolMessage);
+                }
+                // TODO should also verify that the block output is building on is in fact
+                // the head of our chain.
+                let consensus_output =
+                    self.fetch_batches(output.sub_dag, parent_hash, number).await;
+                self.save_consensus(consensus_output.clone())?;
 
-                    // If we want to rejoin consensus eventually then save certs.
-                    let _ = self
-                        .config
-                        .node_storage()
-                        .certificate_store
-                        .write(consensus_output.sub_dag.leader.clone());
-                    let _ = self
-                        .config
-                        .node_storage()
-                        .certificate_store
-                        .write_all(consensus_output.sub_dag.certificates.clone());
+                // If we want to rejoin consensus eventually then save certs.
+                let _ = self
+                    .config
+                    .node_storage()
+                    .certificate_store
+                    .write(consensus_output.sub_dag.leader.clone());
+                let _ = self
+                    .config
+                    .node_storage()
+                    .certificate_store
+                    .write_all(consensus_output.sub_dag.certificates.clone());
 
-                    let last_round = consensus_output.leader_round();
+                let last_round = consensus_output.leader_round();
 
-                    let base_execution_block =
-                        consensus_output.sub_dag.leader.header().latest_execution_block;
-                    let base_execution_block_num =
-                        consensus_output.sub_dag.leader.header().latest_execution_block_num;
-                    // We need to make sure execution has caught up so we can verify we have not
-                    // forked. This will force the follow function to not outrun
-                    // execution...  this is probably fine. Also once we can
-                    // follow gossiped consensus output this will not really be
-                    // an issue (except during initial catch up).
-                    while base_execution_block_num > latest_exec_block_num.number {
-                        rx_recent_blocks.changed().await.map_err(|e| {
-                            SubscriberError::NodeExecutionError(format!(
-                                "recent blocks changed failed: {e}"
-                            ))
-                        })?;
-                        latest_exec_block_num =
-                            self.consensus_bus.recent_blocks().borrow().latest_block_num_hash();
-                    }
-                    if !self
-                        .consensus_bus
-                        .recent_blocks()
-                        .borrow()
-                        .contains_hash(base_execution_block)
-                    {
-                        // We seem to have forked, so die.
-                        return Err(SubscriberError::NodeExecutionError(
+                let base_execution_block =
+                    consensus_output.sub_dag.leader.header().latest_execution_block;
+                let base_execution_block_num =
+                    consensus_output.sub_dag.leader.header().latest_execution_block_num;
+                // We need to make sure execution has caught up so we can verify we have not
+                // forked. This will force the follow function to not outrun
+                // execution...  this is probably fine. Also once we can
+                // follow gossiped consensus output this will not really be
+                // an issue (except during initial catch up).
+                while base_execution_block_num > latest_exec_block_num.number {
+                    rx_recent_blocks.changed().await.map_err(|e| {
+                        SubscriberError::NodeExecutionError(format!(
+                            "recent blocks changed failed: {e}"
+                        ))
+                    })?;
+                    latest_exec_block_num =
+                        self.consensus_bus.recent_blocks().borrow().latest_block_num_hash();
+                }
+                if !self.consensus_bus.recent_blocks().borrow().contains_hash(base_execution_block)
+                {
+                    // We seem to have forked, so die.
+                    return Err(SubscriberError::NodeExecutionError(
                         format!("consensus_output has a parent not in our chain, missing {}/{} recents: {:?}!",
                             base_execution_block_num,
                             base_execution_block,
                             self.consensus_bus.recent_blocks().borrow())
                     ));
-                    }
-
-                    // We aren't doing consensus now but still need to update these watches before
-                    // we send the consensus output.
-                    let _ = self.consensus_bus.consensus_round_updates().send(
-                        ConsensusRound::new_with_gc_depth(
-                            last_round,
-                            self.config.parameters().gc_depth,
-                        ),
-                    );
-                    let _ = self.consensus_bus.primary_round_updates().send(last_round);
-
-                    if let Err(e) =
-                        self.consensus_bus.consensus_output().send(consensus_output).await
-                    {
-                        error!(target: "telcoin::subscriber", "error broadcasting consensus output for authority {}: {}", self.inner.authority_id, e);
-                        return Err(SubscriberError::ClosedChannel("consensus_output".to_string()));
-                    }
                 }
-                last_consensus_height = max_consensus_height;
-                if self.consensus_bus.node_mode().borrow().is_cvv() {
+
+                // We aren't doing consensus now but still need to update these watches before
+                // we send the consensus output.
+                let _ = self.consensus_bus.consensus_round_updates().send(
+                    ConsensusRound::new_with_gc_depth(
+                        last_round,
+                        self.config.parameters().gc_depth,
+                    ),
+                );
+                let _ = self.consensus_bus.primary_round_updates().send(last_round);
+
+                if let Err(e) = self.consensus_bus.consensus_output().send(consensus_output).await {
+                    error!(target: "telcoin::subscriber", "error broadcasting consensus output for authority {}: {}", self.inner.authority_id, e);
+                    return Err(SubscriberError::ClosedChannel("consensus_output".to_string()));
+                }
+            }
+            last_consensus_height = max_consensus_height;
+            if self.consensus_bus.node_mode().borrow().is_cvv() {
+                let (new_max_consensus_height, _, _) = max_consensus_number(&mut clients)
+                    .await
+                    .unwrap_or((last_consensus_height, max_epoch, max_round));
+                max_consensus_height = new_max_consensus_height;
+                if last_consensus_height == max_consensus_height {
+                    // We are caught up so try to jump back into consensus
+                    info!(target: "telcoin::subscriber", "attempting to rejoin consensus, consensus block height {last_consensus_height}");
+                    // Set restart flag and trigger shutdown by returning.
+                    self.consensus_bus.set_restart();
+                    let _ = self.consensus_bus.node_mode().send(NodeMode::CvvActive);
+                    return Ok(());
+                }
+            } else {
+                while last_consensus_height == max_consensus_height {
+                    // Rest for bit then try see if chain has advanced and catch up if so.
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                        _ = &self.rx_shutdown => {
+                            return Ok(())
+                        }
+                    }
                     let (new_max_consensus_height, _, _) = max_consensus_number(&mut clients)
                         .await
                         .unwrap_or((last_consensus_height, max_epoch, max_round));
                     max_consensus_height = new_max_consensus_height;
-                    if last_consensus_height == max_consensus_height {
-                        // We are caught up so try to jump back into consensus
-                        info!(target: "telcoin::subscriber", "attempting to rejoin consensus, consensus block height {last_consensus_height}");
-                        if self.consensus_bus.node_mode().send(NodeMode::CvvActive).is_err() {
-                            // Lost our watch?  We are done.
-                            return Ok(());
-                        }
-                        // Set restart flag and trigger shutdown.
-                        self.consensus_bus.set_restart();
-                        self.config.shutdown().notify();
-                    }
-                } else {
-                    while last_consensus_height == max_consensus_height {
-                        // Rest for bit then try see if chain has advanced and catch up if so.
-                        tokio::select! {
-                            _ = tokio::time::sleep(Duration::from_secs(1)) => {}
-                            _ = &self.rx_shutdown => {
-                                return Ok(())
-                            }
-                        }
-                        let (new_max_consensus_height, _, _) = max_consensus_number(&mut clients)
-                            .await
-                            .unwrap_or((last_consensus_height, max_epoch, max_round));
-                        max_consensus_height = new_max_consensus_height;
-                    }
                 }
             }
         }
@@ -550,50 +532,41 @@ impl<DB: Database> Subscriber<DB> {
         let mut rx_sequence = self.consensus_bus.sequence().subscribe();
         // Listen to sequenced consensus message and process them.
         loop {
-            if self.consensus_bus.node_mode().borrow().is_active_cvv() {
-                tokio::select! {
-                    // Receive the ordered sequence of consensus messages from a consensus node.
-                    Some(sub_dag) = rx_sequence.recv(), if waiting.len() < Self::MAX_PENDING_PAYLOADS => {
-                        // We can schedule more then MAX_PENDING_PAYLOADS payloads but
-                        // don't process more consensus messages when more
-                        // then MAX_PENDING_PAYLOADS is pending
-                        let parent_hash = last_parent;
-                        let number = last_number + 1;
-                        last_parent = ConsensusHeader::digest_from_parts(parent_hash, &sub_dag, number);
-                        last_number += 1;
-                        waiting.push_back(self.fetch_batches(sub_dag, parent_hash, number));
-                    },
+            tokio::select! {
+                // Receive the ordered sequence of consensus messages from a consensus node.
+                Some(sub_dag) = rx_sequence.recv(), if waiting.len() < Self::MAX_PENDING_PAYLOADS => {
+                    // We can schedule more then MAX_PENDING_PAYLOADS payloads but
+                    // don't process more consensus messages when more
+                    // then MAX_PENDING_PAYLOADS is pending
+                    let parent_hash = last_parent;
+                    let number = last_number + 1;
+                    last_parent = ConsensusHeader::digest_from_parts(parent_hash, &sub_dag, number);
+                    last_number += 1;
+                    waiting.push_back(self.fetch_batches(sub_dag, parent_hash, number));
+                },
 
-                    // Receive consensus messages after all transaction data is downloaded
-                    // then send to the execution layer for final block production.
-                    //
-                    // NOTE: this broadcasts to all subscribers, but lagging receivers will lose messages
-                    Some(message) = waiting.next() => {
-                        self.save_consensus(message.clone())?;
-                        if let Err(e) = self.consensus_bus.consensus_output().send(message).await {
-                            error!(target: "telcoin::subscriber", "error broadcasting consensus output for authority {}: {}", self.inner.authority_id, e);
-                            return Ok(());
-                        }
-                    },
-
-                    _ = &self.rx_shutdown => {
-                        return Ok(())
+                // Receive consensus messages after all transaction data is downloaded
+                // then send to the execution layer for final block production.
+                //
+                // NOTE: this broadcasts to all subscribers, but lagging receivers will lose messages
+                Some(message) = waiting.next() => {
+                    self.save_consensus(message.clone())?;
+                    if let Err(e) = self.consensus_bus.consensus_output().send(message).await {
+                        error!(target: "telcoin::subscriber", "error broadcasting consensus output for authority {}: {}", self.inner.authority_id, e);
+                        return Ok(());
                     }
+                },
 
+                _ = &self.rx_shutdown => {
+                    return Ok(())
                 }
 
-                self.consensus_bus
-                    .executor_metrics()
-                    .waiting_elements_subscriber
-                    .set(waiting.len() as i64);
-            } else {
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
-                    _ = &self.rx_shutdown => {
-                        return Ok(())
-                    }
-                }
             }
+
+            self.consensus_bus
+                .executor_metrics()
+                .waiting_elements_subscriber
+                .set(waiting.len() as i64);
         }
     }
 

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -120,7 +120,7 @@ impl<DB: Database> CertificateFetcher<DB> {
                         fetch_certificates_task: JoinSet::new(),
                     }
                     .run()
-                    .await;
+                    .await
                 },
                 "CertificateFetcherTask"
             ),

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -16,7 +16,7 @@ use tn_config::ConsensusConfig;
 use tn_storage::{traits::Database, CertificateStore};
 use tn_types::{
     AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Committee, Noticer,
-    Round, TaskManager, Timestamp, TnReceiver, TnSender, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    Round, TaskManager, Timestamp, TnReceiver, TnSender,
 };
 use tracing::{debug, info, instrument};
 
@@ -257,8 +257,6 @@ pub struct Consensus<DB> {
     committee: Committee,
     /// The chanell "bus" for consensus (container for consesus channel and watches).
     consensus_bus: ConsensusBus,
-    /// Consensud config.
-    consensus_config: ConsensusConfig<DB>,
 
     /// Receiver for shutdown.
     rx_shutdown: Noticer,
@@ -321,7 +319,6 @@ impl<DB: Database> Consensus<DB> {
         let s = Self {
             committee: consensus_config.committee().clone(),
             consensus_bus: consensus_bus.clone(),
-            consensus_config,
             rx_shutdown,
             protocol,
             metrics,
@@ -349,7 +346,6 @@ impl<DB: Database> Consensus<DB> {
         // Clone the bus or the borrow checker will yell at us...
         let bus_clone = self.consensus_bus.clone();
         let mut rx_new_certificates = bus_clone.new_certificates().subscribe();
-        let mut rx_node_mode = bus_clone.node_mode().subscribe();
         self.active = bus_clone.node_mode().borrow().is_active_cvv();
 
         // Listen to incoming certificates.
@@ -362,25 +358,6 @@ impl<DB: Database> Consensus<DB> {
                 Some(certificate) = rx_new_certificates.recv() => {
                     self.new_certificate(certificate).await?;
                 },
-                mode_res = rx_node_mode.changed() => {
-                    // If the watch is dropped we must be done?  This should not really happen...
-                    if mode_res.is_err() {
-                        return Ok(());
-                    }
-                    if self.consensus_bus.node_mode().borrow().is_active_cvv() {
-                        if !self.active { // Make sure this is not a phantom change, etc.
-                            // We changed are now an active CVV so lets reload the leader schedule
-                            // and try to do our job.
-                            self.protocol.leader_schedule.reload_from_store(
-                                self.consensus_config.node_storage().consensus_store.clone(),
-                                DEFAULT_BAD_NODES_STAKE_THRESHOLD,
-                            );
-                        }
-                        self.active = true;
-                    } else {
-                        self.active = false;
-                    }
-                }
             }
         }
     }

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -271,6 +271,7 @@ pub struct Consensus<DB> {
     state: ConsensusState,
 
     /// Are we an active CVV?
+    /// An active CVV is participating in consensus (not catching up or following as an NVV).
     active: bool,
 }
 
@@ -327,6 +328,7 @@ impl<DB: Database> Consensus<DB> {
         };
 
         // Only run the consensus task if we are an active CVV.
+        // Active means we are participating in consensus.
         if consensus_bus.node_mode().borrow().is_active_cvv() {
             task_manager.spawn_task("consensus", monitored_future!(s.run(), "Consensus", INFO));
         }

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -12,7 +12,7 @@ use reth_primitives::{Header, B256};
 use std::collections::{BTreeSet, HashMap};
 use tn_config::ConsensusConfig;
 use tn_storage::{mem_db::MemDatabase, open_db};
-use tn_test_utils::{CommitteeFixture, TelcoinTempDirs};
+use tn_test_utils::CommitteeFixture;
 use tn_types::{
     AuthorityIdentifier, Notifier, TaskManager, TnReceiver, TnSender,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
@@ -1053,7 +1053,6 @@ async fn restart_with_new_committee() {
         let config = fixture.authorities().next().unwrap().consensus_config();
         let config = ConsensusConfig::new_with_committee(
             config.config().clone(),
-            TelcoinTempDirs::default(),
             config.node_storage().clone(),
             config.key_config().clone(),
             committee.clone(),

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -7,7 +7,7 @@ use crate::{
     proposer::OurDigestMessage, RecentBlocks,
 };
 use consensus_metrics::metered_channel::{self, channel_with_total_sender, MeteredMpscChannel};
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use tn_config::Parameters;
 use tn_primary_metrics::{ChannelMetrics, ConsensusMetrics, ExecutorMetrics, Metrics};
 use tn_types::{
@@ -106,6 +106,9 @@ struct ConsensusBusInner {
     channel_metrics: Arc<ChannelMetrics>,
     /// Hold onto the executor metrics.
     executor_metrics: Arc<ExecutorMetrics>,
+
+    /// Flag to indicate a node restart after a shutdown.
+    restart: AtomicBool,
 }
 
 #[derive(Clone, Debug)]
@@ -217,6 +220,7 @@ impl ConsensusBus {
                 primary_metrics,
                 channel_metrics,
                 executor_metrics,
+                restart: AtomicBool::new(false),
             }),
         }
     }
@@ -332,5 +336,20 @@ impl ConsensusBus {
     /// Hold onto the executor metrics
     pub fn executor_metrics(&self) -> &ExecutorMetrics {
         &self.inner.executor_metrics
+    }
+
+    /// Set the restart flag to indicate node restart after shutdown.
+    pub fn set_restart(&self) {
+        self.inner.restart.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Clear the restart flag to indicate node NOT restart after shutdown.
+    pub fn clear_restart(&self) {
+        self.inner.restart.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// True if the node should restart after shutdown.
+    pub fn restart(&self) -> bool {
+        self.inner.restart.load(std::sync::atomic::Ordering::SeqCst)
     }
 }

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -107,7 +107,7 @@ struct ConsensusBusInner {
     /// Hold onto the executor metrics.
     executor_metrics: Arc<ExecutorMetrics>,
 
-    /// Flag to indicate a node restart after a shutdown.
+    /// Flag to indicate a node should restart after a shutdown.
     restart: AtomicBool,
 }
 

--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -122,7 +122,9 @@ impl<DB: Database> Primary<DB> {
         leader_schedule: LeaderSchedule,
         task_manager: &TaskManager,
     ) {
-        self.synchronizer.spawn(task_manager);
+        if consensus_bus.node_mode().borrow().is_active_cvv() {
+            self.synchronizer.spawn(task_manager);
+        }
         let _ = tn_network::connectivity::ConnectionMonitor::spawn(
             self.network.downgrade(),
             consensus_bus.primary_metrics().network_connection_metrics.clone(),

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -828,11 +828,6 @@ impl<DB: Database> Proposer<DB> {
                 }
                 // check for new parent certificates
                 // synchronizer sends collection of certificates when there is quorum (2f+1)
-                //
-                // TODO: synchronizer will send empty Vec<Certificate> for old round
-                // - this node round: 11
-                // - synchronizer receives certs from restarted node at round 10
-                // - this debug goes off with empty vec for round 10 (during restart it test)
                 Some((certs, round)) = rx_parents.recv() => {
                     debug!(target: "primary::proposer", authority=?self.authority_id, this_round=self.round, parent_round=round, num_parents=certs.len(), "received parents");
                     self.process_parents(certs, round)?;

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -766,16 +766,21 @@ impl<DB: Database> Proposer<DB> {
     }
 
     pub fn spawn(mut self, task_manager: &TaskManager) {
-        task_manager.spawn_task(
-            "proposer task",
-            monitored_future!(
-                async move {
-                    info!(target: "primary::proposer", "Starting proposer");
-                    self.run().await.expect("Failed to run subscriber")
-                },
-                "ProposerTask"
-            ),
-        );
+        if self.consensus_bus.node_mode().borrow().is_active_cvv() {
+            task_manager.spawn_task(
+                "proposer task",
+                monitored_future!(
+                    async move {
+                        info!(target: "primary::proposer", "Starting proposer");
+                        self.run().await
+                    },
+                    "ProposerTask"
+                ),
+            );
+        }
+        // If not an active CVV then don't propose anything.
+        // TODO- send txns to a committee member.
+        // Sleep in case we become active later.
     }
 
     /// Wrapper async function to either query the pending header or never resolve.
@@ -800,136 +805,124 @@ impl<DB: Database> Proposer<DB> {
         let mut max_delay_timed_out = false;
         let mut min_delay_timed_out = false;
         loop {
-            if !self.consensus_bus.node_mode().borrow().is_active_cvv() {
-                // If not an active CVV then don't propose anything.
-                // TODO- send txns to a committee member.
-                // Sleep in case we become active later.
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
-                    _ = &self.rx_shutdown => {
-                        return Ok(())
-                    }
+            tokio::select! {
+                _ = &self.rx_shutdown => {
+                    return Ok(())
                 }
-            } else {
-                tokio::select! {
-                    _ = &self.rx_shutdown => {
-                        return Ok(())
-                    }
-                    // check for new digests from workers and send ack back to worker
-                    //
-                    // ack to worker implies that the block is recorded on the primary
-                    // and will be tracked until the block is included
-                    // ie) primary will attempt to propose this digest until it is
-                    // committed/sequenced in the DAG or the epoch concludes
-                    //
-                    // NOTE: this will not persist primary restarts
-                    Some(msg) = rx_our_digests.recv() =>
-                    {
-                        debug!(target: "primary::proposer", authority=?self.authority_id, round=self.round, "received digest");
-
-                        // parse message into parts
-                        let (ack, digest) = msg.process();
-                        let _ = ack.send(());
-                        self.digests.push_back(digest);
-                    }
-                    // check for new parent certificates
-                    // synchronizer sends collection of certificates when there is quorum (2f+1)
-                    //
-                    // TODO: synchronizer will send empty Vec<Certificate> for old round
-                    // - this node round: 11
-                    // - synchronizer receives certs from restarted node at round 10
-                    // - this debug goes off with empty vec for round 10 (during restart it test)
-                    Some((certs, round)) = rx_parents.recv() => {
-                        debug!(target: "primary::proposer", authority=?self.authority_id, this_round=self.round, parent_round=round, num_parents=certs.len(), "received parents");
-                        self.process_parents(certs, round)?;
-                    }
-                    Some((commit_round, committed_headers)) = rx_committed_own_headers.recv() => {
-                        debug!(target: "primary::proposer", authority=?self.authority_id, round=self.round, "received committed update for own header");
-                        self.process_committed_headers(commit_round, committed_headers);
-                    }
-                    res = Self::pending_header(&mut pending_header) => {
-                        pending_header = None;
-                        debug!(target: "primary::proposer", authority=?self.authority_id, "pending header task complete!");
-                        self.handle_proposal_result(res)?;
-                    }
-                    // tick intervals to ensure they advance
-                    _ = self.max_delay_interval.tick() => {
-                        max_delay_timed_out = true;
-                    }
-                    _ = self.min_delay_interval.tick() => {
-                        min_delay_timed_out = true;
-                    }
-                }
-                if pending_header.is_some() {
-                    // continue the loop, don't try to propose a header since we are already working
-                    // on one.
-                    continue;
-                }
-
-                // proposer doesn't have a pending header
-                // Check if conditions are met for proposing a new header
+                // check for new digests from workers and send ack back to worker
                 //
-                // New headers are proposed when:
+                // ack to worker implies that the block is recorded on the primary
+                // and will be tracked until the block is included
+                // ie) primary will attempt to propose this digest until it is
+                // committed/sequenced in the DAG or the epoch concludes
                 //
-                // 1) a quorum of parents (certificates) received for the current round
-                // 2) the execution layer successfully executed the previous round (parent
-                //    `BlockNumHash`)
-                // 3) One of the following:
-                // - the interval expired:
-                //      - this primary timed out on the leader
-                //      - or quit trying to gather enough votes for the leader
-                // - the worker created enough blocks (header_num_of_batches_threshold)
-                //      - this is happy path
-                //      - vote for leader or leader already has enough votes to trigger commit
-                let enough_parents = !self.last_parents.is_empty();
-                let enough_digests = self.digests.len() >= self.header_num_of_batches_threshold;
+                // NOTE: this will not persist primary restarts
+                Some(msg) = rx_our_digests.recv() =>
+                {
+                    debug!(target: "primary::proposer", authority=?self.authority_id, round=self.round, "received digest");
 
-                // evaluate conditions for bool value
-                let should_create_header = enough_parents
-                    && (max_delay_timed_out
-                        || (self.advance_round && (enough_digests || min_delay_timed_out)));
-
-                debug!(
-                    target: "primary::proposer",
-                    authority=?self.authority_id,
-                    round=self.round,
-                    enough_parents,
-                    enough_digests,
-                    self.advance_round,
-                    min_delay_timed_out,
-                    max_delay_timed_out,
-                    should_create_header,
-                    "polled...",
-                );
-
-                // if all conditions are met, create the next header
-                if should_create_header {
-                    if max_delay_timed_out {
-                        // expect this interval to expire occassionally
-                        //
-                        // if it expires too often, it either means some validators are Byzantine or
-                        // that the network is experiencing periods of asynchrony
-                        //
-                        // periods of asynchrony possibly caused by misconfigured `max_header_delay`
-                        warn!(target: "primary::proposer", interval=?self.max_delay_interval.period(), "max delay interval expired for round {}", self.round);
-                    }
-
-                    // obtain reason for metrics
-                    let reason = if max_delay_timed_out {
-                        "max_timeout"
-                    } else if enough_digests {
-                        "threshold_size_reached"
-                    } else {
-                        "min_timeout"
-                    };
-
-                    debug!(target: "primary::proposer", authority=?self.authority_id, ?reason, "proposing next header!");
-
-                    // propose header
-                    pending_header = Some(self.propose_next_header(reason.to_string())?);
-                    max_delay_timed_out = false;
-                    min_delay_timed_out = false;
+                    // parse message into parts
+                    let (ack, digest) = msg.process();
+                    let _ = ack.send(());
+                    self.digests.push_back(digest);
                 }
+                // check for new parent certificates
+                // synchronizer sends collection of certificates when there is quorum (2f+1)
+                //
+                // TODO: synchronizer will send empty Vec<Certificate> for old round
+                // - this node round: 11
+                // - synchronizer receives certs from restarted node at round 10
+                // - this debug goes off with empty vec for round 10 (during restart it test)
+                Some((certs, round)) = rx_parents.recv() => {
+                    debug!(target: "primary::proposer", authority=?self.authority_id, this_round=self.round, parent_round=round, num_parents=certs.len(), "received parents");
+                    self.process_parents(certs, round)?;
+                }
+                Some((commit_round, committed_headers)) = rx_committed_own_headers.recv() => {
+                    debug!(target: "primary::proposer", authority=?self.authority_id, round=self.round, "received committed update for own header");
+                    self.process_committed_headers(commit_round, committed_headers);
+                }
+                res = Self::pending_header(&mut pending_header) => {
+                    pending_header = None;
+                    debug!(target: "primary::proposer", authority=?self.authority_id, "pending header task complete!");
+                    self.handle_proposal_result(res)?;
+                }
+                // tick intervals to ensure they advance
+                _ = self.max_delay_interval.tick() => {
+                    max_delay_timed_out = true;
+                }
+                _ = self.min_delay_interval.tick() => {
+                    min_delay_timed_out = true;
+                }
+            }
+            if pending_header.is_some() {
+                // continue the loop, don't try to propose a header since we are already working
+                // on one.
+                continue;
+            }
+
+            // proposer doesn't have a pending header
+            // Check if conditions are met for proposing a new header
+            //
+            // New headers are proposed when:
+            //
+            // 1) a quorum of parents (certificates) received for the current round
+            // 2) the execution layer successfully executed the previous round (parent
+            //    `BlockNumHash`)
+            // 3) One of the following:
+            // - the interval expired:
+            //      - this primary timed out on the leader
+            //      - or quit trying to gather enough votes for the leader
+            // - the worker created enough blocks (header_num_of_batches_threshold)
+            //      - this is happy path
+            //      - vote for leader or leader already has enough votes to trigger commit
+            let enough_parents = !self.last_parents.is_empty();
+            let enough_digests = self.digests.len() >= self.header_num_of_batches_threshold;
+
+            // evaluate conditions for bool value
+            let should_create_header = enough_parents
+                && (max_delay_timed_out
+                    || (self.advance_round && (enough_digests || min_delay_timed_out)));
+
+            debug!(
+                target: "primary::proposer",
+                authority=?self.authority_id,
+                round=self.round,
+                enough_parents,
+                enough_digests,
+                self.advance_round,
+                min_delay_timed_out,
+                max_delay_timed_out,
+                should_create_header,
+                "polled...",
+            );
+
+            // if all conditions are met, create the next header
+            if should_create_header {
+                if max_delay_timed_out {
+                    // expect this interval to expire occassionally
+                    //
+                    // if it expires too often, it either means some validators are Byzantine or
+                    // that the network is experiencing periods of asynchrony
+                    //
+                    // periods of asynchrony possibly caused by misconfigured `max_header_delay`
+                    warn!(target: "primary::proposer", interval=?self.max_delay_interval.period(), "max delay interval expired for round {}", self.round);
+                }
+
+                // obtain reason for metrics
+                let reason = if max_delay_timed_out {
+                    "max_timeout"
+                } else if enough_digests {
+                    "threshold_size_reached"
+                } else {
+                    "min_timeout"
+                };
+
+                debug!(target: "primary::proposer", authority=?self.authority_id, ?reason, "proposing next header!");
+
+                // propose header
+                pending_header = Some(self.propose_next_header(reason.to_string())?);
+                max_delay_timed_out = false;
+                min_delay_timed_out = false;
             }
         }
     }

--- a/crates/consensus/primary/src/state_handler.rs
+++ b/crates/consensus/primary/src/state_handler.rs
@@ -69,7 +69,7 @@ impl StateHandler {
 
     async fn run(mut self) {
         info!(target: "primary::state_handler", "StateHandler on node {} has started successfully.", self.authority_id);
-        // This clone inso a variable is D-U-M, subscribe should return an owned object but here we
+        // This clone into a variable is D-U-M, subscribe should return an owned object but here we
         // are.
         let committed_certificates = self.consensus_bus.committed_certificates().clone();
         let mut rx_committed_certificates = committed_certificates.subscribe();

--- a/crates/consensus/primary/src/synchronizer.rs
+++ b/crates/consensus/primary/src/synchronizer.rs
@@ -913,7 +913,7 @@ impl<DB: Database> Synchronizer<DB> {
         let (sender, receiver) = oneshot::channel();
         self.inner
             .tx_certificate_acceptor
-            .send((certificates, sender, false))
+            .send((certificates, sender, true))
             .await
             .expect("Synchronizer should shut down before certificate acceptor task.");
         receiver.await.expect("Synchronizer should shut down before certificate acceptor task.")?;

--- a/crates/consensus/primary/src/synchronizer.rs
+++ b/crates/consensus/primary/src/synchronizer.rs
@@ -1191,8 +1191,11 @@ impl<DB: Database> Synchronizer<DB> {
         {
             warn!(target: "primary::synchronizer", "Synchronizer should shut down before certificate acceptor task.");
         }
-        if receiver.await.is_err() {
-            warn!(target: "primary::synchronizer", "Synchronizer should shut down before certificate acceptor task.");
+        match receiver.await {
+            Ok(r) => r?,
+            Err(_) => {
+                warn!(target: "primary::synchronizer", "Synchronizer should shut down before certificate acceptor task.")
+            }
         }
         Ok(())
     }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -95,13 +95,14 @@ where
 {
     /// Create a new instance of `Self`.
     pub(super) fn new(
-        tn_builder: TnBuilder<DB>,
+        tn_builder: &TnBuilder<DB>,
         evm_executor: Evm,
         evm_config: CE,
         reth_task_executor: &TaskManager,
     ) -> eyre::Result<Self> {
         // deconstruct the builder
-        let TnBuilder { database, node_config, tn_config, opt_faucet_args } = tn_builder;
+        let TnBuilder { database, node_config, tn_config, opt_faucet_args, consensus_metrics: _ } =
+            tn_builder;
 
         // resolve the node's datadir
         let datadir = node_config.datadir();
@@ -156,13 +157,13 @@ where
 
         Ok(Self {
             address,
-            node_config,
+            node_config: node_config.clone(),
             blockchain_db,
             provider_factory,
             evm_config,
             evm_executor,
-            opt_faucet_args,
-            tn_config,
+            opt_faucet_args: opt_faucet_args.clone(),
+            tn_config: tn_config.clone(),
             workers: HashMap::default(),
         })
     }

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -46,6 +46,10 @@ pub struct TnBuilder<DB> {
     /// TODO: temporary solution until upstream reth
     /// rpc hooks are publicly available.
     pub opt_faucet_args: Option<FaucetArgs>,
+    /// Enable Prometheus consensus metrics.
+    ///
+    /// The metrics will be served at the given interface and port.
+    pub consensus_metrics: Option<SocketAddr>,
 }
 
 /// Wrapper for the inner execution node components.
@@ -62,7 +66,7 @@ where
     DB: Database + DatabaseMetadata + DatabaseMetrics + Clone + Unpin + 'static,
 {
     /// Create a new instance of `Self`.
-    pub fn new(tn_builder: TnBuilder<DB>, task_manager: &TaskManager) -> eyre::Result<Self> {
+    pub fn new(tn_builder: &TnBuilder<DB>, task_manager: &TaskManager) -> eyre::Result<Self> {
         let evm_config = EthEvmConfig::default();
         let executor =
             EthExecutorProvider::new(Arc::clone(&tn_builder.node_config.chain), evm_config);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -2,6 +2,7 @@
 //! Library for managing all components used by a full-node in a single process.
 
 use crate::{primary::PrimaryNode, worker::WorkerNode};
+use consensus_metrics::start_prometheus_server;
 use engine::{ExecutionNode, TnBuilder};
 use futures::StreamExt;
 use reth_db::{
@@ -10,10 +11,11 @@ use reth_db::{
 };
 use reth_provider::CanonStateSubscriptions;
 use tn_config::{ConsensusConfig, KeyConfig, TelcoinDirs};
-use tn_primary::NodeMode;
-use tn_storage::open_db;
+use tn_primary::{ConsensusBus, NodeMode};
 pub use tn_storage::NodeStorage;
+use tn_storage::{open_db, DatabaseType};
 use tn_types::TaskManager;
+use tokio::runtime::Builder;
 use tracing::{info, instrument};
 
 pub mod dirs;
@@ -23,84 +25,93 @@ pub mod metrics;
 pub mod primary;
 pub mod worker;
 
-/// Launch all components for the node.
-///
-/// Worker, Primary, and Execution.
-#[instrument(level = "info", skip_all)]
-pub async fn launch_node<DB, P>(mut builder: TnBuilder<DB>, tn_datadir: P) -> eyre::Result<()>
+pub fn launch_node_inner<DB, P>(
+    builder: &TnBuilder<DB>,
+    tn_datadir: &P,
+    db: DatabaseType,
+) -> eyre::Result<bool>
 where
     DB: Database + DatabaseMetadata + DatabaseMetrics + Clone + Unpin + 'static,
     P: TelcoinDirs + 'static,
 {
+    // Create a tokio runtime each time this is called.
+    // This means we should be starting with a clean slate on a
+    // relaunch (old tasks should be gone with relaunch).
+    let runtime = Builder::new_multi_thread()
+        .thread_name("telcoin-network")
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("failed to build a tokio runtime");
+
+    runtime.block_on(async move {
+        if let Some(metrics_socket) = builder.consensus_metrics {
+            start_prometheus_server(metrics_socket);
+        }
+
     // config for validator keys
     let config = builder.tn_config.clone();
-    // adjust rpc instance ports
-    builder.node_config.adjust_instance_ports();
     let mut task_manager = TaskManager::new("Task Manager");
     let mut engine_task_manager = TaskManager::new("Engine Task Manager");
     let engine = ExecutionNode::new(builder, &engine_task_manager)?;
 
     info!(target: "telcoin::node", "execution engine created");
 
-    let consensus_db_path = tn_datadir.consensus_db_path();
-
-    tracing::info!(target: "telcoin::cli", "opening node storage at {:?}", consensus_db_path);
-
-    // open storage for consensus
-    // In case the DB dir does not yet exist.
-    let _ = std::fs::create_dir_all(&consensus_db_path);
-    let db = open_db(&consensus_db_path);
     let node_storage = NodeStorage::reopen(db);
     tracing::info!(target: "telcoin::cli", "node storage open");
-    let key_config = KeyConfig::new(&tn_datadir)?;
+    let key_config = KeyConfig::new(tn_datadir)?;
     let consensus_config = ConsensusConfig::new(config, tn_datadir, node_storage, key_config)?;
 
     let (worker_id, _worker_info) = consensus_config.config().workers().first_worker()?;
     let worker = WorkerNode::new(*worker_id, consensus_config.clone());
-    let primary = PrimaryNode::new(consensus_config.clone());
+    let consensus_bus =
+        ConsensusBus::new_with_recent_blocks(consensus_config.config().parameters.gc_depth);
+    let primary = PrimaryNode::new(consensus_config.clone(), consensus_bus.clone());
 
     let mut engine_state = engine.get_provider().await.canonical_state_stream();
-    let eng_bus = primary.consensus_bus().await;
 
     // Prime the recent_blocks watch with latest executed blocks.
-    let block_capacity = eng_bus.recent_blocks().borrow().block_capacity();
+    let block_capacity = consensus_bus.recent_blocks().borrow().block_capacity();
     for recent_block in engine.last_executed_output_blocks(block_capacity).await? {
-        eng_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(recent_block.seal_slow()));
+        consensus_bus
+            .recent_blocks()
+            .send_modify(|blocks| blocks.push_latest(recent_block.seal_slow()));
     }
 
     if tn_executor::subscriber::can_cvv(
-        eng_bus.clone(),
+        consensus_bus.clone(),
         consensus_config.clone(),
         primary.network().await,
     )
     .await
     {
-        eng_bus.node_mode().send_modify(|v| *v = NodeMode::CvvActive);
+        consensus_bus.node_mode().send_modify(|v| *v = NodeMode::CvvActive);
     } else {
-        eng_bus.node_mode().send_modify(|v| *v = NodeMode::CvvInactive);
+        consensus_bus.node_mode().send_modify(|v| *v = NodeMode::CvvInactive);
     }
 
     // Spawn a task to update the consensus bus with new execution blocks as they are produced.
     let latest_block_shutdown = consensus_config.shutdown().subscribe();
+    let consensus_bus_clone = consensus_bus.clone();
     task_manager.spawn_task("latest block", async move {
         loop {
             tokio::select!(
                 _ = &latest_block_shutdown => {
                     break;
-                }
-                latest = engine_state.next() => {
-                    if let Some(latest) = latest {
-                        eng_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(latest.tip().block.header.clone()));
-                    } else {
-                        break;
                     }
-                }
+                    latest = engine_state.next() => {
+                        if let Some(latest) = latest {
+                            consensus_bus_clone.recent_blocks().send_modify(|blocks| blocks.push_latest(latest.tip().block.header.clone()));
+                        } else {
+                            break;
+                        }
+                    }
             )
         }
     });
 
     // create receiving channel before spawning primary to ensure messages are not lost
-    let consensus_output_rx = primary.consensus_bus().await.subscribe_consensus_output();
+    let consensus_output_rx = consensus_bus.subscribe_consensus_output();
 
     // start the primary
     let mut primary_task_manager = primary.start().await?;
@@ -137,5 +148,36 @@ where
     info!(target:"tn", tasks=?task_manager, "TASKS");
 
     task_manager.join_until_exit(consensus_config.shutdown().clone()).await;
+    let running = consensus_bus.restart();
+    consensus_bus.clear_restart();
+    Ok(running)
+    })
+}
+
+/// Launch all components for the node.
+///
+/// Worker, Primary, and Execution.
+#[instrument(level = "info", skip_all)]
+pub fn launch_node<DB, P>(mut builder: TnBuilder<DB>, tn_datadir: P) -> eyre::Result<()>
+where
+    DB: Database + DatabaseMetadata + DatabaseMetrics + Clone + Unpin + 'static,
+    P: TelcoinDirs + 'static,
+{
+    // adjust rpc instance ports
+    builder.node_config.adjust_instance_ports();
+
+    let consensus_db_path = tn_datadir.consensus_db_path();
+
+    tracing::info!(target: "telcoin::cli", "opening node storage at {:?}", consensus_db_path);
+
+    // open storage for consensus
+    // In case the DB dir does not yet exist.
+    let _ = std::fs::create_dir_all(&consensus_db_path);
+    let db = open_db(&consensus_db_path);
+
+    let mut running = true;
+    while running {
+        running = launch_node_inner(&builder, &tn_datadir, db.clone())?;
+    }
     Ok(())
 }

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -68,25 +68,6 @@ impl<CDB: ConsensusDatabase> PrimaryNodeInner<CDB> {
     where
         BlsPublicKey: VerifyingKey,
     {
-        // TODO: this may need to be adjusted depending on how TN executes output
-        //
-        // if executor engine executes-per-batch:
-        //  - executing consensus output per batch ~> 1 batch == 1 block
-        //  - use nonce or mixed hash or difficulty to track the output's "last committed subdag"
-        //  - how to handle restart mid-execution?
-        //      - only some of the batches completed
-        //      - so, don't use `last_executed_sub_dag_index + 1`
-        //          - use just `last_executed_sub_dag_index` and re-execute the output again
-        //          - less efficient, but ensures correctness
-        //          - maybe there's a way to optimize this like only re-execute if the
-        //            blocks/batches don't match the output batch count?
-        //              - but this is probably unlikely to happen anyway
-        //                  - ie) crashes/restarts at a clean execution boundary
-        //
-        // for now, all batches are contained within a single block, (ie 1 consensus output = 1
-        // executed block) so use block number for restored consensus output
-        // since block number == last_executed_sub_dag_index
-
         let leader_schedule = LeaderSchedule::from_store(
             self.consensus_config.committee().clone(),
             self.consensus_config.node_storage().consensus_store.clone(),

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -110,9 +110,10 @@ pub struct PrimaryNode<CDB> {
 }
 
 impl<CDB: ConsensusDatabase> PrimaryNode<CDB> {
-    pub fn new(consensus_config: ConsensusConfig<CDB>) -> PrimaryNode<CDB> {
-        let consensus_bus =
-            ConsensusBus::new_with_recent_blocks(consensus_config.config().parameters.gc_depth);
+    pub fn new(
+        consensus_config: ConsensusConfig<CDB>,
+        consensus_bus: ConsensusBus,
+    ) -> PrimaryNode<CDB> {
         let primary = Primary::new(consensus_config.clone(), &consensus_bus);
 
         let inner = PrimaryNodeInner { consensus_config, consensus_bus, primary };

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -1,8 +1,7 @@
 //! Authority fixture for the cluster
 
 use crate::{
-    primary::PrimaryNodeDetails, worker::WorkerNodeDetails, TelcoinTempDirs, TestExecutionNode,
-    WorkerFixture,
+    primary::PrimaryNodeDetails, worker::WorkerNodeDetails, TestExecutionNode, WorkerFixture,
 };
 use anemo::Network;
 use fastcrypto::{hash::Hash, traits::KeyPair as _};
@@ -353,11 +352,9 @@ impl<DB: Database> AuthorityFixture<DB> {
         config.validator_info.primary_info.network_address =
             authority.primary_network_address().clone();
 
-        let tn_datadirs = TelcoinTempDirs::default();
         let node_config = tn_node::NodeStorage::reopen(db);
         let consensus_config = ConsensusConfig::new_with_committee(
             config,
-            tn_datadirs,
             node_config,
             key_config.clone(),
             committee,

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -65,7 +65,7 @@ pub fn default_test_execution_node(
     )?;
 
     // create engine node
-    let engine = ExecutionNode::new(builder, &TaskManager::default())?;
+    let engine = ExecutionNode::new(&builder, &TaskManager::default())?;
 
     Ok(engine)
 }
@@ -145,7 +145,8 @@ pub fn execution_builder<CliExt: clap::Args + fmt::Debug>(
     // TODO: this a temporary approach until upstream reth supports public rpc hooks
     let opt_faucet_args = None;
 
-    let builder = TnBuilder { database, node_config, tn_config, opt_faucet_args };
+    let builder =
+        TnBuilder { database, node_config, tn_config, opt_faucet_args, consensus_metrics: None };
 
     Ok((builder, ext))
 }
@@ -176,10 +177,16 @@ pub fn faucet_test_execution_node(
 
     // replace default builder's faucet args
     let TnBuilder { database, node_config, tn_config, .. } = builder;
-    let builder = TnBuilder { database, node_config, tn_config, opt_faucet_args: Some(faucet) };
+    let builder = TnBuilder {
+        database,
+        node_config,
+        tn_config,
+        opt_faucet_args: Some(faucet),
+        consensus_metrics: None,
+    };
 
     // create engine node
-    let engine = ExecutionNode::new(builder, &TaskManager::default())?;
+    let engine = ExecutionNode::new(&builder, &TaskManager::default())?;
 
     Ok(engine)
 }

--- a/crates/test-utils/src/primary.rs
+++ b/crates/test-utils/src/primary.rs
@@ -4,7 +4,7 @@ use anemo::Network;
 use std::sync::Arc;
 use tn_config::ConsensusConfig;
 use tn_node::primary::PrimaryNode;
-use tn_primary::consensus::ConsensusMetrics;
+use tn_primary::{consensus::ConsensusMetrics, ConsensusBus};
 use tn_storage::traits::Database;
 use tn_types::AuthorityIdentifier;
 
@@ -21,7 +21,9 @@ impl<DB: Database> PrimaryNodeDetails<DB> {
         name: AuthorityIdentifier,
         consensus_config: ConsensusConfig<DB>,
     ) -> Self {
-        let node = PrimaryNode::new(consensus_config);
+        let consensus_bus =
+            ConsensusBus::new_with_recent_blocks(consensus_config.config().parameters.gc_depth);
+        let node = PrimaryNode::new(consensus_config, consensus_bus);
 
         Self { id, name, node }
     }

--- a/etc/local-testnet.sh
+++ b/etc/local-testnet.sh
@@ -14,7 +14,6 @@ DEV_FUNDS=""
 
 #
 while [ "$1" != "" ]; do
-echo "opt: $1"
     case $1 in
         --start )
                 START=true
@@ -22,7 +21,6 @@ echo "opt: $1"
         --dev-funds )
                 shift
                 DEV_FUNDS=$1
-                echo "df: $DEV_FUNDS"
                 ;;
         * )     echo "Invalid option: $1"
                 exit 1


### PR DESCRIPTION
Issue https://github.com/Telcoin-Association/telcoin-network/issues/151

This allows a running node to "restart" by going back to node launch and rebuilding all data/services from scratch.
This allows a node to rejoin consensus after a long shutdown not just within the GC window.
Should support changing from active to inactive at epoch boundaries.
