### PR TITLE
Last fixes to allow startup of a validator with an empty DB.

### DIFF
--- a/crates/consensus/primary/src/consensus/mod.rs
+++ b/crates/consensus/primary/src/consensus/mod.rs
@@ -16,7 +16,7 @@ pub use crate::consensus::{
 use thiserror::Error;
 pub use tn_primary_metrics::consensus::{ChannelMetrics, ConsensusMetrics};
 use tn_storage::StoreError;
-use tn_types::Certificate;
+use tn_types::{Certificate, CertificateDigest};
 
 /// The default channel size used in the consensus and subscriber logic.
 pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
@@ -34,6 +34,12 @@ pub enum ConsensusError {
 
     #[error("System shutting down")]
     ShuttingDown,
+
+    #[error("Parent digest {0:?} not found in DAG for {1:?}!")]
+    MissingParent(CertificateDigest, Certificate),
+
+    #[error("Parent round not found in DAG for {0:?}!")]
+    MissingParentRound(Certificate),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -112,7 +112,7 @@ impl ConsensusState {
 
         let mut num_certs = 0;
         for cert in &certificates {
-            if Self::try_insert_in_dag(&mut dag, last_committed, gc_round, cert)? {
+            if Self::try_insert_in_dag(&mut dag, last_committed, gc_round, cert, false)? {
                 info!("Inserted certificate: {:?}", cert);
                 num_certs += 1;
             }
@@ -129,6 +129,7 @@ impl ConsensusState {
             &self.last_committed,
             self.last_round.gc_round,
             certificate,
+            true,
         )
     }
 
@@ -138,6 +139,7 @@ impl ConsensusState {
         last_committed: &HashMap<AuthorityIdentifier, Round>,
         gc_round: Round,
         certificate: &Certificate,
+        check_parents: bool,
     ) -> Result<bool, ConsensusError> {
         if certificate.round() <= gc_round {
             debug!(target: "telcoin::consensus_state",
@@ -146,7 +148,9 @@ impl ConsensusState {
             );
             return Ok(false);
         }
-        Self::check_parents(certificate, dag, gc_round);
+        if check_parents {
+            Self::check_parents(certificate, dag, gc_round)?;
+        }
 
         // Always insert the certificate even if it is below last committed round of its origin,
         // to allow verifying parent existence.
@@ -197,25 +201,31 @@ impl ConsensusState {
         self.dag.retain(|r, _| *r > self.last_round.gc_round);
     }
 
-    // Checks that the provided certificate's parents exist and crashes if not.
-    fn check_parents(certificate: &Certificate, dag: &Dag, gc_round: Round) {
+    // Checks that the provided certificate's parents exist return an error if they do not.
+    fn check_parents(
+        certificate: &Certificate,
+        dag: &Dag,
+        gc_round: Round,
+    ) -> Result<(), ConsensusError> {
         let round = certificate.round();
         // Skip checking parents if they are GC'ed.
         // Also not checking genesis parents for simplicity.
         if round <= gc_round + 1 {
-            return;
+            return Ok(());
         }
         if let Some(round_table) = dag.get(&(round - 1)) {
             let store_parents: BTreeSet<&CertificateDigest> =
                 round_table.iter().map(|(_, (digest, _))| digest).collect();
             for parent_digest in certificate.header().parents() {
                 if !store_parents.contains(parent_digest) {
-                    panic!("Parent digest {parent_digest:?} not found in DAG for {certificate:?}!");
+                    return Err(ConsensusError::MissingParent(*parent_digest, certificate.clone()));
                 }
             }
         } else {
             tracing::error!(target: "telcoin::consensus_state", "Parent round not found in DAG for {certificate:?}!");
+            return Err(ConsensusError::MissingParentRound(certificate.clone()));
         }
+        Ok(())
     }
 }
 

--- a/etc/local-testnet.sh
+++ b/etc/local-testnet.sh
@@ -81,12 +81,14 @@ else
 
         echo "creating datadir for ${VALIDATOR}"
         target/${RELEASE}/telcoin-network genesis init --datadir "${DATADIR}" \
-            --dev-funded-account $DEV_FUNDS
-            # You can add the arguments below to the genesis init command above to build
-            # blocks much faster than default.
+            --dev-funded-account $DEV_FUNDS \
+            --max-header-delay-ms 1000 \
+            --min-header-delay-ms 1000
+			# The min|max_header_delay_ms options above cause blocks to be generated
+			# faster for testing.  Remove then to build blocks at "default" speed.
+			# With these blocks are built every couple seconds, without them every ten seconds.
+			# This is just to make local testing faster.
             # NOTE: this has to happen at genesis to have any effect.
-            #--max-header-delay-ms 1000
-            #--min-header-delay-ms 1000
 
         echo "creating validator keys"
         target/${RELEASE}/telcoin-network keytool generate validator \


### PR DESCRIPTION
https://github.com/Telcoin-Association/telcoin-network/issues/186

Closes the gap on being able to restart after deleting all data.  Note all data includes these dirs:
static_files/
db/
consensus-db/

Not removing all will lead to issues.  This should also apply later to add a new validator after he chain is started.