### PR TITLE
separate watch channels for committed round updates and gc round updates

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -148,10 +148,10 @@ impl<DB: Database> Subscriber<DB> {
 
         // We aren't doing consensus now but still need to update these watches before
         // we send the consensus output.
-        let _ = self
-            .consensus_bus
-            .consensus_round_updates()
-            .send(ConsensusRound::new_with_gc_depth(last_round, self.config.parameters().gc_depth));
+        let _ = self.consensus_bus.update_consensus_rounds(ConsensusRound::new_with_gc_depth(
+            last_round,
+            self.config.parameters().gc_depth,
+        ));
         let _ = self.consensus_bus.primary_round_updates().send(last_round);
 
         if let Err(e) = self.consensus_bus.consensus_output().send(consensus_output).await {

--- a/crates/consensus/primary/src/consensus/mod.rs
+++ b/crates/consensus/primary/src/consensus/mod.rs
@@ -10,7 +10,7 @@ mod utils;
 pub use crate::consensus::{
     bullshark::Bullshark,
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
-    state::{Consensus, ConsensusRound, ConsensusState, Dag},
+    state::{AtomicRound, Consensus, ConsensusRound, ConsensusState, Dag},
     utils::gc_round,
 };
 use thiserror::Error;

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -369,8 +369,7 @@ impl<DB: Database> Consensus<DB> {
         );
 
         consensus_bus
-            .consensus_round_updates()
-            .send(state.last_round.clone())
+            .update_consensus_rounds(state.last_round.clone())
             .expect("Failed to send last_committed_round on initialization!");
 
         let s = Self {
@@ -490,8 +489,7 @@ impl<DB: Database> Consensus<DB> {
                 assert_eq!(self.state.last_round.committed_round, leader_commit_round);
 
                 self.consensus_bus
-                    .consensus_round_updates()
-                    .send(self.state.last_round.clone())
+                    .update_consensus_rounds(self.state.last_round.clone())
                     .map_err(|_| ConsensusError::ShuttingDown)?;
             }
 

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -831,7 +831,7 @@ async fn committed_round_after_restart() {
         // and the expected commit round after sending in certificates up to `input_round` would
         // be 2 * r.
 
-        let last_committed_round = cb.consensus_round_updates().borrow().committed_round as usize;
+        let last_committed_round = *cb.committed_round_updates().borrow() as usize;
         assert_eq!(last_committed_round, input_round.saturating_sub(3));
         info!("Consensus started at last_committed_round={last_committed_round}");
 
@@ -855,10 +855,7 @@ async fn committed_round_after_restart() {
 
         // After sending inputs up to round 2 * r + 1 to consensus, round 2 * r should have been
         // committed.
-        assert_eq!(
-            cb.consensus_round_updates().borrow().committed_round as usize,
-            input_round.saturating_sub(1),
-        );
+        assert_eq!(*cb.committed_round_updates().borrow() as usize, input_round.saturating_sub(1),);
         info!("Committed round adanced to {}", input_round.saturating_sub(1));
 
         // Shutdown consensus and wait for it to stop.

--- a/crates/consensus/primary/src/tests/synchronizer_tests.rs
+++ b/crates/consensus/primary/src/tests/synchronizer_tests.rs
@@ -533,7 +533,7 @@ async fn sync_batches_drops_old() {
 
     tokio::task::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let _ = cb.consensus_round_updates().send(ConsensusRound::new(30, 0));
+        let _ = cb.update_consensus_rounds(ConsensusRound::new(30, 0));
     });
     match synchronizer.sync_header_batches(&test_header, 10).await {
         Err(HeaderError::TooOld(_, _, _)) => (),
@@ -617,7 +617,7 @@ async fn gc_suspended_certificates() {
     );
 
     // At commit round 8, round 3 becomes the GC round.
-    let _ = cb.consensus_round_updates().send(ConsensusRound::new(8, gc_round(8, GC_DEPTH)));
+    let _ = cb.update_consensus_rounds(ConsensusRound::new(8, gc_round(8, GC_DEPTH)));
 
     // more than enough time
     let max_timeout = Duration::from_secs(5);

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn can_cvv<DB: Database>(
     // TODO- replace 0 with the epoch once we have them..
     let last_consensus_epoch = last_executed_block.sub_dag.leader.epoch();
     let last_consensus_round = last_executed_block.sub_dag.leader_round();
-    let _ = consensus_bus.consensus_round_updates().send(ConsensusRound::new_with_gc_depth(
+    let _ = consensus_bus.update_consensus_rounds(ConsensusRound::new_with_gc_depth(
         last_consensus_round,
         config.parameters().gc_depth,
     ));


### PR DESCRIPTION
- Separate gc and committed rounds into different watch channels
  - helper method for consensus_bus to `update_consensus_rounds` that sends on both gc/committed round watch channels
- progress towards separating synchronizer
- also supports `borrow_and_update()` now since single consumer for each watch channel
  - previously it was only safe to call `borrow` because some watchers needed the commit round while others needed the gc round. this separates the two