### PR TITLE
certificates aggregator to reduce synchronizer logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,7 +2404,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "dashmap 6.1.0",
  "eyre",
  "futures",
  "once_cell",
@@ -12497,7 +12496,6 @@ dependencies = [
  "cfg-if",
  "consensus-metrics",
  "criterion",
- "dashmap 6.1.0",
  "eyre",
  "fastcrypto",
  "fastcrypto-tbls",

--- a/crates/consensus/consensus-metrics/Cargo.toml
+++ b/crates/consensus/consensus-metrics/Cargo.toml
@@ -19,7 +19,6 @@ prometheus = { workspace = true }
 once_cell = { workspace = true }
 tap = { workspace = true }
 tokio = { workspace = true }
-dashmap = { workspace = true }
 uuid = { workspace = true }
 parking_lot = { workspace = true }
 futures = { workspace = true }

--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -53,7 +53,6 @@ roaring = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-dashmap = { workspace = true }
 async-trait = { workspace = true }
 criterion = { workspace = true }
 futures = { workspace = true }

--- a/crates/consensus/primary/src/aggregators/certificates.rs
+++ b/crates/consensus/primary/src/aggregators/certificates.rs
@@ -1,11 +1,64 @@
 //! Aggregate certificates for the round.
 
-use std::collections::HashSet;
-use tn_types::{AuthorityIdentifier, Certificate, Committee, Stake};
+use crate::ConsensusBus;
+use parking_lot::Mutex;
+use std::collections::{BTreeMap, HashSet};
+use tn_types::{
+    error::{CertificateError, CertificateResult},
+    AuthorityIdentifier, Certificate, Committee, Round, Stake, TnSender as _,
+};
 use tracing::trace;
 
+/// Manage certificates as they aggregate through rounds.
+pub(crate) struct CertificatesAggregatorManager {
+    /// Collection of [CertificatesAggregator]s.
+    aggregators: Mutex<BTreeMap<Round, Box<CertificatesAggregator>>>,
+    /// Consensus bus to forward parents for a round to the proposer.
+    consensus_bus: ConsensusBus,
+}
+
+impl CertificatesAggregatorManager {
+    /// Create a new instance of self with allocation for the max gc-depth.
+    pub(crate) fn new(consensus_bus: ConsensusBus) -> Self {
+        Self { aggregators: Mutex::new(BTreeMap::new()), consensus_bus }
+    }
+
+    /// Append a certificate by round and alert proposer if quorum is reached (2f+1).
+    pub(crate) async fn append_certificate(
+        &self,
+        certificate: Certificate,
+        committee: &Committee,
+    ) -> CertificateResult<()> {
+        let round = certificate.round();
+
+        // append certificate
+        let quorum = self
+            .aggregators
+            .lock()
+            .entry(round)
+            .or_insert_with(|| Box::new(CertificatesAggregator::new()))
+            .append(certificate, committee);
+
+        // forward to proposer if enough parents to advance the round (2f+1)
+        if let Some(parents) = quorum {
+            self.consensus_bus
+                .parents()
+                .send((parents, round))
+                .await
+                .map_err(|_| CertificateError::TNSend)?;
+        }
+
+        Ok(())
+    }
+
+    /// Process the next gc round and remove old parents that can never be accepted in the DAG.
+    pub(crate) fn garbage_collect(&self, gc_round: &Round) {
+        self.aggregators.lock().retain(|k, _| k > gc_round);
+    }
+}
+
 /// Aggregate certificates until quorum is reached
-pub struct CertificatesAggregator {
+struct CertificatesAggregator {
     /// The accumulated amount of voting power in favor of a proposed header.
     ///
     /// This amount is used to verify enough voting power to reach quorum within the committee.
@@ -18,7 +71,7 @@ pub struct CertificatesAggregator {
 
 impl CertificatesAggregator {
     /// Create a new instance of `Self`.
-    pub(crate) fn new() -> Self {
+    fn new() -> Self {
         Self { weight: 0, certificates: Vec::new(), authorities_seen: HashSet::new() }
     }
 
@@ -26,7 +79,7 @@ impl CertificatesAggregator {
     ///
     /// This method protects against equivocation by keeping track of peers that have already issued
     /// certificates.
-    pub(crate) fn append(
+    fn append(
         &mut self,
         certificate: Certificate,
         committee: &Committee,

--- a/crates/consensus/primary/src/aggregators/mod.rs
+++ b/crates/consensus/primary/src/aggregators/mod.rs
@@ -2,5 +2,5 @@
 
 mod certificates;
 mod votes;
-pub(crate) use certificates::CertificatesAggregator;
+pub(crate) use certificates::CertificatesAggregatorManager;
 pub(crate) use votes::VotesAggregator;

--- a/crates/consensus/primary/src/synchronizer.rs
+++ b/crates/consensus/primary/src/synchronizer.rs
@@ -1,7 +1,7 @@
 //! Synchronize data between peers and workers
 
 use crate::{
-    aggregators::CertificatesAggregator, certificate_fetcher::CertificateFetcherCommand,
+    aggregators::CertificatesAggregatorManager, certificate_fetcher::CertificateFetcherCommand,
     ConsensusBus,
 };
 use consensus_metrics::{
@@ -11,7 +11,6 @@ use consensus_metrics::{
 use fastcrypto::hash::Hash as _;
 use futures::{stream::FuturesOrdered, StreamExt};
 use itertools::Itertools;
-use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::{
@@ -72,7 +71,7 @@ struct Inner<DB> {
     /// age is sent over.
     tx_batch_tasks: MeteredMpscChannel<(Header, Round)>,
     /// Aggregates certificates to use as parents for new headers.
-    certificates_aggregators: Mutex<BTreeMap<Round, Box<CertificatesAggregator>>>,
+    certificates_aggregators: CertificatesAggregatorManager,
     /// State for tracking suspended certificates and when they can be accepted.
     state: tokio::sync::Mutex<State>,
 }
@@ -88,25 +87,6 @@ impl<DB: Database> Inner<DB> {
         );
         // Verify the certificate (and the embedded header).
         certificate.verify(self.consensus_config.committee(), self.consensus_config.worker_cache())
-    }
-
-    async fn append_certificate_in_aggregator(&self, certificate: Certificate) -> DagResult<()> {
-        // Check if we have enough certificates to enter a new dag round and propose a header.
-        let Some(parents) = self
-            .certificates_aggregators
-            .lock()
-            .entry(certificate.round())
-            .or_insert_with(|| Box::new(CertificatesAggregator::new()))
-            .append(certificate.clone(), self.consensus_config.committee())
-        else {
-            return Ok(());
-        };
-        // Send it to the `Proposer`.
-        self.consensus_bus
-            .parents()
-            .send((parents, certificate.round()))
-            .await
-            .map_err(|_| DagError::ShuttingDown)
     }
 
     async fn accept_suspended_certificate(
@@ -199,7 +179,11 @@ impl<DB: Database> Inner<DB> {
 
         // Append the certificate to the aggregator of the
         // corresponding round.
-        if let Err(e) = self.append_certificate_in_aggregator(certificate.clone()).await {
+        if let Err(e) = self
+            .certificates_aggregators
+            .append_certificate(certificate.clone(), self.consensus_config.committee())
+            .await
+        {
             warn!("Failed to aggregate certificate {} for header: {}", digest, e);
             return Err(DagError::ShuttingDown);
         }
@@ -328,7 +312,7 @@ impl<DB: Database> Inner<DB> {
             let gc_round = rx_consensus_round_updates.borrow().gc_round;
             // this is the only task updating gc_round
             self.gc_round.store(gc_round, Ordering::Release);
-            self.certificates_aggregators.lock().retain(|k, _| k > &gc_round);
+            self.certificates_aggregators.garbage_collect(&gc_round);
             // Accept certificates at and below gc round, if there is any.
             let mut state = self.state.lock().await;
             while let Some(((round, digest), suspended_cert)) = state.run_gc_once(gc_round) {
@@ -723,7 +707,7 @@ impl<DB: Database> Synchronizer<DB> {
             consensus_bus: consensus_bus.clone(),
             genesis,
             tx_batch_tasks,
-            certificates_aggregators: Mutex::new(BTreeMap::new()),
+            certificates_aggregators: CertificatesAggregatorManager::new(consensus_bus.clone()),
             state: tokio::sync::Mutex::new(State::default()),
         });
 
@@ -743,8 +727,13 @@ impl<DB: Database> Synchronizer<DB> {
                     .last_two_rounds_certs()
                     .expect("Failed recovering certificates in primary core");
                 for certificate in last_round_certificates {
-                    if let Err(e) =
-                        inner_proposer.append_certificate_in_aggregator(certificate).await
+                    if let Err(e) = inner_proposer
+                        .certificates_aggregators
+                        .append_certificate(
+                            certificate,
+                            inner_proposer.consensus_config.committee(),
+                        )
+                        .await
                     {
                         debug!(
                             target: "primary::synchronizer",

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -211,10 +211,6 @@ where
 
         // spawn block building task and forward to worker
         tokio::spawn(async move {
-            // arc dashmap/hashset rwlock for txhashes for this worker by round
-            // canon updates clear set
-            // successful proposals add mined txs to set
-
             // ack once worker reaches quorum
             let (ack, rx) = oneshot::channel();
 


### PR DESCRIPTION
- refactor certificates aggregator for synchronizer to compartmentalize logic better
- remove unused deps and cleanup comments I found while grepping `dashmap`