### PR TITLE
Engine Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,11 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-# Remember to update .clippy.toml and README.md with rust-version
-rust-version = "1.82"
+# Remember to update:
+# - .clippy.toml
+# - README.md
+# - Dockerfile
+rust-version = "1.82" # see note
 license = "MIT OR Apache-2.0"
 homepage = "https://telcoin.network"
 repository = "https://github.com/telcoin/telcoin-network"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -269,9 +269,6 @@ where
                 match receiver.poll_unpin(cx) {
                     Poll::Ready(res) => {
                         let finalized_header = res.map_err(Into::into).and_then(|res| res)?;
-                        // TODO: broadcast engine event
-                        // this.pipeline_events = events;
-                        //
                         // store last executed header in memory
                         this.parent_header = finalized_header;
 
@@ -342,10 +339,6 @@ mod tests {
         // are randomly generated
         //
         // for each tx, seed address with funds in genesis
-        //
-        // TODO: this does not use a "real" `ConsensusOutput` certificate
-        //
-        // refactor with valid data once test util helpers are in place
         let mut leader = Certificate::default();
         let sub_dag_index = 0;
         leader.header.round = sub_dag_index as u32;
@@ -480,8 +473,6 @@ mod tests {
         // TODO: randomly generate contract transactions as well!!!
         assert_eq!(expected_block.logs_bloom, genesis_header.logs_bloom);
         // gas limit should come from parent for empty execution
-        //
-        // TODO: ensure batch validation prevents peer workers from changing this value
         assert_eq!(expected_block.gas_limit, genesis_header.gas_limit);
         // no gas should be used - no txs
         assert_eq!(expected_block.gas_used, 0);
@@ -491,7 +482,7 @@ mod tests {
         assert_eq!(expected_block.extra_data.as_ref(), &[0; 32]);
         // assert withdrawals are empty
         //
-        // TODO: this is currently always empty
+        // NOTE: this is currently always empty
         assert_eq!(expected_block.withdrawals_root, genesis_header.withdrawals_root);
 
         Ok(())
@@ -575,8 +566,6 @@ mod tests {
         // are randomly generated
         //
         // for each tx, seed address with funds in genesis
-        //
-        // TODO: this does not use a "real" `ConsensusOutput` certificate
         let timestamp = now();
         let mut leader_1 = Certificate::default();
         // update timestamp
@@ -768,8 +757,6 @@ mod tests {
                 // expect header number 1 for batch bc of genesis
                 assert_eq!(block.number, 1);
             } else {
-                // TODO: this is inefficient
-                //
                 // assert parents executed in order (sanity check)
                 let expected_parent = executed_blocks[idx - 1].header.hash_slow();
                 assert_eq!(block.parent_hash, expected_parent);
@@ -786,8 +773,6 @@ mod tests {
             // TODO: randomly generate contract transactions as well!!!
             assert_eq!(block.logs_bloom, Bloom::default());
             // gas limit should come from batch
-            //
-            // TODO: ensure batch validation prevents peer workers from changing this value
             assert_eq!(block.gas_limit, max_batch_gas(block.number));
             // difficulty should match the batch's index within consensus output
             assert_eq!(block.difficulty, U256::from(expected_batch_index));
@@ -795,7 +780,7 @@ mod tests {
             assert_eq!(&block.extra_data, all_batch_digests[idx].as_slice());
             // assert batch's withdrawals match
             //
-            // TODO: this is currently always empty
+            // NOTE: this is currently always empty
             assert_eq!(block.withdrawals_root, Some(EMPTY_WITHDRAWALS));
         }
 
@@ -905,8 +890,6 @@ mod tests {
         // are randomly generated
         //
         // for each tx, seed address with funds in genesis
-        //
-        // TODO: this does not use a "real" `ConsensusOutput`
         let timestamp = now();
         let mut leader_1 = Certificate::default();
         // update timestamp
@@ -1119,8 +1102,6 @@ mod tests {
                 // first block's parent is expected to be genesis
                 assert_eq!(block.parent_hash, chain.genesis_hash());
             } else {
-                // TODO: this is inefficient
-                //
                 // assert parents executed in order (sanity check)
                 let expected_parent = executed_blocks[idx - 1].header.hash_slow();
                 assert_eq!(block.parent_hash, expected_parent);
@@ -1135,8 +1116,6 @@ mod tests {
             // TODO: this doesn't actually test anything bc there are no contract txs
             assert_eq!(block.logs_bloom, Bloom::default());
             // gas limit should come from batch
-            //
-            // TODO: ensure batch validation prevents peer workers from changing this value
             assert_eq!(block.gas_limit, max_batch_gas(block.number));
             // difficulty should match the batch's index within consensus output
             assert_eq!(block.difficulty, U256::from(expected_batch_index));
@@ -1144,7 +1123,7 @@ mod tests {
             assert_eq!(&block.extra_data, all_batch_digests[idx].as_slice());
             // assert batch's withdrawals match
             //
-            // TODO: this is currently always empty
+            // NOTE: this is currently always empty
             assert_eq!(block.withdrawals_root, Some(EMPTY_WITHDRAWALS));
         }
 
@@ -1213,8 +1192,6 @@ mod tests {
         // are randomly generated
         //
         // for each tx, seed address with funds in genesis
-        //
-        // TODO: this does not use a "real" `ConsensusOutput` certificate
         let timestamp = now();
         let mut leader_1 = Certificate::default();
         // update timestamp

--- a/crates/execution/batch-validator/src/validator.rs
+++ b/crates/execution/batch-validator/src/validator.rs
@@ -78,7 +78,6 @@ where
         // validate beneficiary?
         // no - tips would go to someone else
 
-        // TODO: validate basefee doesn't actually do anything yet
         self.validate_basefee()?;
         Ok(())
     }
@@ -153,7 +152,6 @@ where
 
     /// TODO: Validate the block's basefee
     fn validate_basefee(&self) -> BlockValidationResult<()> {
-        // TODO: validate basefee by consensus round
         Ok(())
     }
 }
@@ -416,7 +414,6 @@ mod tests {
     async fn test_invalid_batch_wrong_size_in_bytes() {
         let TestTools { valid_batch, validator } = test_tools().await;
         // create enough transactions to exceed 1MB
-        // TODO: clean this up - taken from `test_types` fn
         // because validator uses provided with same genesis
         // and tx_factory needs funds
         let genesis = adiri_genesis();
@@ -500,7 +497,4 @@ mod tests {
             Err(BatchValidationError::HeaderTransactionBytesExceedsMax(wrong)) if wrong == too_big
         );
     }
-
-    // // TODO:
-    // // - basefee
 }

--- a/crates/execution/node-traits/src/engine.rs
+++ b/crates/execution/node-traits/src/engine.rs
@@ -210,9 +210,6 @@ pub struct TNPayloadAttributes {
     /// Value for the `extra_data` field in the new block.
     pub batch_digest: B256,
     /// Hash value for [ConsensusOutput]. Used as the executed block's "parent_beacon_block_root".
-    ///
-    /// TODO: ensure optimized hashing of output:
-    /// - don't rehash batches, just hash their hashes?
     pub consensus_output_digest: B256,
     /// The base fee per gas used to construct this block.
     /// The value comes from the proposed batch.

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -190,7 +190,7 @@ impl Header {
         BlockNumHash { hash: self.latest_execution_block, number: self.latest_execution_block_num }
     }
 
-    /// The nonce this header.
+    /// The nonce of this header used during execution.
     pub fn nonce(&self) -> u64 {
         ((self.epoch as u64) << 32) | self.round as u64
     }

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-slim-bookworm AS builder
+FROM rust:1.82-slim-bookworm AS builder
 
 WORKDIR /usr/src/telcoin-network
 


### PR DESCRIPTION
- rename `ConsensusOutputDigest` -> `ConsensusDigest`
- remove old todos
- build execution blocks off consensus header instead of consensus output