### PR TITLE
add extra 32-byte field to consensus header/output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12047,6 +12047,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "consensus-metrics",
+ "eyre",
  "fastcrypto",
  "futures",
  "indexmap 2.7.1",

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -36,7 +36,9 @@ tn-primary-metrics = { workspace = true }
 [dev-dependencies]
 indexmap.workspace = true
 tempfile.workspace = true
+eyre = { workspace = true }
 tn-primary = { workspace = true }
 tn-node = { workspace = true }
 tn-test-utils = { workspace = true }
 bytes = { workspace = true }
+tn-network = { workspace = true }

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -41,4 +41,3 @@ tn-primary = { workspace = true }
 tn-node = { workspace = true }
 tn-test-utils = { workspace = true }
 bytes = { workspace = true }
-tn-network = { workspace = true }

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -92,7 +92,6 @@ async fn test_consensus_recovery_with_bullshark() {
     let mut score_no_crash: ReputationScores = ReputationScores::default();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
-        println!("\n\n{sub_dag:?}\n\n");
         score_no_crash = sub_dag.reputation_score.clone();
         assert_eq!(sub_dag.leader.round(), consensus_index_counter);
         consensus_store.write_subdag_for_test(consensus_index_counter as u64, sub_dag.clone());

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -92,6 +92,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let mut score_no_crash: ReputationScores = ReputationScores::default();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
+        println!("\n\n{sub_dag:?}\n\n");
         score_no_crash = sub_dag.reputation_score.clone();
         assert_eq!(sub_dag.leader.round(), consensus_index_counter);
         consensus_store.write_subdag_for_test(consensus_index_counter as u64, sub_dag.clone());

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -8,6 +8,7 @@ use handler::RequestHandler;
 pub use message::{MissingCertificatesRequest, PrimaryRequest, PrimaryResponse};
 use message::{PrimaryGossip, PrimaryRPCError};
 use tn_config::ConsensusConfig;
+use tn_network_libp2p::types::NetworkCommand;
 use tn_network_libp2p::{
     error::NetworkError,
     types::{IdentTopic, IntoResponse as _, NetworkEvent, NetworkHandle, NetworkResult},
@@ -49,8 +50,14 @@ impl From<NetworkHandle<Req, Res>> for PrimaryNetworkHandle {
 }
 
 impl PrimaryNetworkHandle {
+    /// Create a new instance of Self.
     pub fn new(handle: NetworkHandle<Req, Res>) -> Self {
         Self { handle }
+    }
+
+    //// Convenience method for creating a new Self for tests.
+    pub fn new_for_test(sender: mpsc::Sender<NetworkCommand<Req, Res>>) -> Self {
+        Self { handle: NetworkHandle::new(sender) }
     }
 
     /// Dial a peer.

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -8,10 +8,11 @@ use handler::RequestHandler;
 pub use message::{MissingCertificatesRequest, PrimaryRequest, PrimaryResponse};
 use message::{PrimaryGossip, PrimaryRPCError};
 use tn_config::ConsensusConfig;
-use tn_network_libp2p::types::NetworkCommand;
 use tn_network_libp2p::{
     error::NetworkError,
-    types::{IdentTopic, IntoResponse as _, NetworkEvent, NetworkHandle, NetworkResult},
+    types::{
+        IdentTopic, IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResult,
+    },
     GossipMessage, Multiaddr, PeerId, ResponseChannel,
 };
 use tn_network_types::{

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -360,6 +360,7 @@ mod tests {
             batch_digests: Default::default(), // empty
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
+            _extra: Default::default(),
         };
         let consensus_output_hash = consensus_output.consensus_header_hash();
 
@@ -592,6 +593,7 @@ mod tests {
             batch_digests: batch_digests_1.clone(),
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
+            _extra: Default::default(),
         };
 
         // create second output
@@ -620,6 +622,7 @@ mod tests {
             batch_digests: batch_digests_2.clone(),
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
+            _extra: Default::default(),
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -918,6 +921,7 @@ mod tests {
             batch_digests: batch_digests_1.clone(),
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
+            _extra: Default::default(),
         };
 
         // create second output
@@ -948,6 +952,7 @@ mod tests {
             batch_digests: batch_digests_2.clone(),
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
+            _extra: Default::default(),
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -1217,6 +1222,7 @@ mod tests {
             batch_digests: batch_digests_1,
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
+            _extra: Default::default(),
         };
         let consensus_output_1_hash = consensus_output_1.consensus_header_hash();
 
@@ -1246,6 +1252,7 @@ mod tests {
             batch_digests: batch_digests_2,
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
+            _extra: Default::default(),
         };
 
         //=== Execution

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -360,7 +360,7 @@ mod tests {
             batch_digests: Default::default(), // empty
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
         let consensus_output_hash = consensus_output.consensus_header_hash();
 
@@ -593,7 +593,7 @@ mod tests {
             batch_digests: batch_digests_1.clone(),
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
 
         // create second output
@@ -622,7 +622,7 @@ mod tests {
             batch_digests: batch_digests_2.clone(),
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -921,7 +921,7 @@ mod tests {
             batch_digests: batch_digests_1.clone(),
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
 
         // create second output
@@ -952,7 +952,7 @@ mod tests {
             batch_digests: batch_digests_2.clone(),
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -1222,7 +1222,7 @@ mod tests {
             batch_digests: batch_digests_1,
             parent_hash: ConsensusHeader::default().digest(),
             number: 0,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
         let consensus_output_1_hash = consensus_output_1.consensus_header_hash();
 
@@ -1252,7 +1252,7 @@ mod tests {
             batch_digests: batch_digests_2,
             parent_hash: consensus_output_1.consensus_header_hash(),
             number: 1,
-            _extra: Default::default(),
+            extra: Default::default(),
         };
 
         //=== Execution

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -848,7 +848,7 @@ mod tests {
                 batch_digests: Default::default(),
                 parent_hash: ConsensusHeader::default().digest(),
                 number: 0,
-                _extra: Default::default(),
+                extra: Default::default(),
             };
             // execute output to trigger canonical update
             let args = BuildArguments::new(blockchain_db.clone(), output, parent);

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -848,6 +848,7 @@ mod tests {
                 batch_digests: Default::default(),
                 parent_hash: ConsensusHeader::default().digest(),
                 number: 0,
+                _extra: Default::default(),
             };
             // execute output to trigger canonical update
             let args = BuildArguments::new(blockchain_db.clone(), output, parent);

--- a/crates/execution/batch-builder/tests/it/batch_builder.rs
+++ b/crates/execution/batch-builder/tests/it/batch_builder.rs
@@ -612,7 +612,7 @@ async fn test_canonical_notification_updates_pool() {
         batch_digests,
         parent_hash: ConsensusHeader::default().digest(),
         number: 0,
-        _extra: Default::default(),
+        extra: Default::default(),
     };
 
     // execute output to trigger canonical update

--- a/crates/execution/batch-builder/tests/it/batch_builder.rs
+++ b/crates/execution/batch-builder/tests/it/batch_builder.rs
@@ -612,6 +612,7 @@ async fn test_canonical_notification_updates_pool() {
         batch_digests,
         parent_hash: ConsensusHeader::default().digest(),
         number: 0,
+        _extra: Default::default(),
     };
 
     // execute output to trigger canonical update

--- a/crates/network-types/src/lib.rs
+++ b/crates/network-types/src/lib.rs
@@ -52,14 +52,14 @@ impl WorkerToPrimaryClient for MockWorkerToPrimaryHang {
 pub trait PrimaryToWorkerClient: Send + Sync + 'static {
     async fn synchronize(
         &self,
-        _worker_name: NetworkPublicKey,
-        _message: WorkerSynchronizeMessage,
+        worker_name: NetworkPublicKey,
+        message: WorkerSynchronizeMessage,
     ) -> eyre::Result<()>;
 
     async fn fetch_batches(
         &self,
-        _worker_name: NetworkPublicKey,
-        _request: FetchBatchesRequest,
+        worker_name: NetworkPublicKey,
+        request: FetchBatchesRequest,
     ) -> eyre::Result<FetchBatchResponse>;
 }
 

--- a/crates/network-types/src/lib.rs
+++ b/crates/network-types/src/lib.rs
@@ -5,11 +5,10 @@ pub mod local;
 mod notify;
 mod request;
 mod response;
-use std::collections::HashMap;
-
 pub use notify::*;
 pub use request::*;
 pub use response::*;
+use std::collections::HashMap;
 use tn_types::{Batch, BlockHash, NetworkPublicKey};
 
 // async_trait for object safety, get rid of when possible.

--- a/crates/test-utils/src/committee.rs
+++ b/crates/test-utils/src/committee.rs
@@ -2,6 +2,7 @@
 
 use super::{AuthorityFixture, Builder};
 use crate::fixture_batch_with_transactions;
+use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_types::{
     Certificate, CertificateDigest, Committee, Database, Header, HeaderBuilder, Round, Vote,
@@ -178,5 +179,10 @@ impl<DB: Database> CommitteeFixture<DB> {
         for a in &self.authorities {
             a.consensus_config().shutdown().notify();
         }
+    }
+
+    /// Create the genesis certificates for the committe.
+    pub fn genesis(&self) -> impl Iterator<Item = CertificateDigest> {
+        Certificate::genesis(&self.committee()).into_iter().map(|x| x.digest())
     }
 }

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -30,7 +30,7 @@ pub struct ConsensusHeader {
 
     /// Temp extra data field - currently unused.
     /// This is included for now for testnet purposes only.
-    pub _extra: B256,
+    pub extra: B256,
 }
 
 impl ConsensusHeader {
@@ -63,7 +63,7 @@ impl Default for ConsensusHeader {
             crate::ReputationScores::default(),
             None,
         );
-        Self { parent_hash: B256::default(), sub_dag, number: 0, _extra: B256::default() }
+        Self { parent_hash: B256::default(), sub_dag, number: 0, extra: B256::default() }
     }
 }
 
@@ -73,7 +73,7 @@ impl From<ConsensusOutput> for ConsensusHeader {
             parent_hash: value.parent_hash,
             sub_dag: Arc::unwrap_or_clone(value.sub_dag),
             number: value.number,
-            _extra: value._extra,
+            extra: value.extra,
         }
     }
 }

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -27,6 +27,10 @@ pub struct ConsensusHeader {
     /// A scalar value equal to the number of ancestor blocks. The genesis block has a number of
     /// zero.
     pub number: u64,
+
+    /// Temp extra data field - currently unused.
+    /// This is included for now for testnet purposes only.
+    pub _extra: B256,
 }
 
 impl ConsensusHeader {
@@ -59,7 +63,7 @@ impl Default for ConsensusHeader {
             crate::ReputationScores::default(),
             None,
         );
-        Self { parent_hash: B256::default(), sub_dag, number: 0 }
+        Self { parent_hash: B256::default(), sub_dag, number: 0, _extra: B256::default() }
     }
 }
 
@@ -69,6 +73,7 @@ impl From<ConsensusOutput> for ConsensusHeader {
             parent_hash: value.parent_hash,
             sub_dag: Arc::unwrap_or_clone(value.sub_dag),
             number: value.number,
+            _extra: value._extra,
         }
     }
 }

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -43,7 +43,7 @@ pub struct ConsensusOutput {
     pub number: u64,
     /// Temporary extra data field - currently unused.
     /// This is included for now for testnet purposes only.
-    pub _extra: B256,
+    pub extra: B256,
 }
 
 impl ConsensusOutput {
@@ -93,7 +93,7 @@ impl ConsensusOutput {
             parent_hash: self.parent_hash,
             sub_dag: (*self.sub_dag).clone(),
             number: self.number,
-            _extra: self._extra,
+            extra: self.extra,
         }
     }
 

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -41,6 +41,9 @@ pub struct ConsensusOutput {
     /// A scalar value equal to the number of ancestor blocks. The genesis block has a number of
     /// zero.
     pub number: u64,
+    /// Temporary extra data field - currently unused.
+    /// This is included for now for testnet purposes only.
+    pub _extra: B256,
 }
 
 impl ConsensusOutput {
@@ -90,6 +93,7 @@ impl ConsensusOutput {
             parent_hash: self.parent_hash,
             sub_dag: (*self.sub_dag).clone(),
             number: self.number,
+            _extra: self._extra,
         }
     }
 


### PR DESCRIPTION
- add an extra 32-byte field to ConsensusHeader for experimenting on testnet (may be removed or repurposed later)
- subscriber unit test
- test utils