### PR TITLE
Reworked batch fetching to work with NVV and observer nodes.

### DIFF
--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -5,63 +5,38 @@ use crate::{
     network::{message::RequestBatchesResponse, WorkerNetworkHandle},
 };
 use async_trait::async_trait;
-use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
-use itertools::Itertools;
-use prometheus::IntGauge;
-use rand::{rngs::ThreadRng, seq::SliceRandom};
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
+use thiserror::Error;
+use tn_network_libp2p::error::NetworkError;
 use tn_storage::tables::Batches;
-use tn_types::{
-    network_public_key_to_libp2p, now, Batch, BlockHash, Database, DbTxMut, NetworkPublicKey,
-};
-use tokio::{
-    select,
-    time::{sleep, sleep_until, Instant},
-};
+use tn_types::{now, Batch, BlockHash, Database, DbTxMut};
+use tokio::time::{error::Elapsed, sleep};
 use tracing::debug;
 
-const REMOTE_PARALLEL_FETCH_INTERVAL: Duration = Duration::from_secs(2);
 const WORKER_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 pub struct BatchFetcher<DB> {
-    name: NetworkPublicKey,
     network: Arc<dyn RequestBatchesNetwork>,
     batch_store: DB,
     metrics: Arc<WorkerMetrics>,
 }
 
 impl<DB: Database> BatchFetcher<DB> {
-    pub fn new(
-        name: NetworkPublicKey,
-        network: WorkerNetworkHandle,
-        batch_store: DB,
-        metrics: Arc<WorkerMetrics>,
-    ) -> Self {
-        Self { name, network: Arc::new(network), batch_store, metrics }
+    pub fn new(network: WorkerNetworkHandle, batch_store: DB, metrics: Arc<WorkerMetrics>) -> Self {
+        Self { network: Arc::new(network), batch_store, metrics }
     }
 
     /// Bulk fetches payload from local storage and remote workers.
-    /// This function performs infinite retries and batchs until all batches are available.
-    pub async fn fetch(
-        &self,
-        digests: HashSet<BlockHash>,
-        known_workers: HashSet<NetworkPublicKey>,
-    ) -> HashMap<BlockHash, Batch> {
-        debug!(
-            "Attempting to fetch {} digests from {} workers",
-            digests.len(),
-            known_workers.len()
-        );
+    /// This function performs infinite retries and until all batches are available.
+    pub async fn fetch(&self, digests: HashSet<BlockHash>) -> HashMap<BlockHash, Batch> {
+        debug!("Attempting to fetch {} digests from peers", digests.len(),);
 
         let mut remaining_digests = digests;
         let mut fetched_batches = HashMap::new();
-        // TODO: verify known_workers meets quorum threshold, or just use all other workers.
-        let known_workers =
-            known_workers.into_iter().filter(|worker| worker != &self.name).collect_vec();
 
         loop {
             if remaining_digests.is_empty() {
@@ -77,62 +52,38 @@ impl<DB: Database> BatchFetcher<DB> {
             }
             drop(_timer);
 
-            // Fetch from remote workers.
-            // TODO: Can further parallelize this by target worker_id if necessary.
+            // Fetch from peers.
             let _timer = self.metrics.worker_remote_fetch_latency.start_timer();
-            let mut known_workers: Vec<_> = known_workers.iter().collect();
-            known_workers.shuffle(&mut ThreadRng::default());
-            let mut known_workers = VecDeque::from(known_workers);
-            let mut stagger = Duration::from_secs(0);
-            let mut futures = FuturesUnordered::new();
-
-            loop {
-                assert!(!remaining_digests.is_empty());
-                if let Some(worker) = known_workers.pop_front() {
-                    let future = self.fetch_remote(worker.clone(), remaining_digests.clone());
-                    futures.push(future.boxed());
-                } else {
-                    // No more worker to fetch from. This happens after sending requests to all
-                    // workers and then another staggered interval has passed.
-                    break;
+            if let Ok(new_batches) =
+                self.safe_request_batches(&remaining_digests, Duration::from_secs(10)).await
+            {
+                // Set received_at timestamp for remote batches.
+                let mut updated_new_batches = HashMap::new();
+                let mut txn =
+                    self.batch_store.write_txn().expect("unable to create DB transaction!");
+                for (digest, batch) in
+                    new_batches.iter().filter(|(d, _)| remaining_digests.remove(*d))
+                {
+                    let mut batch = (*batch).clone();
+                    batch.set_received_at(now());
+                    updated_new_batches.insert(*digest, batch.clone());
+                    // Also persist the batches, so they are available after restarts.
+                    if let Err(e) = txn.insert::<Batches>(digest, &batch) {
+                        tracing::error!("failed to insert batch! We can not continue.. {e}");
+                        panic!("failed to insert batch! We can not continue.. {e}");
+                    }
                 }
-                stagger += REMOTE_PARALLEL_FETCH_INTERVAL;
-                let mut interval = Box::pin(sleep(stagger));
-                select! {
-                    result = futures.next() => {
-                        if let Some(remote_batches) = result {
-                            let new_batches: HashMap<_, _> = remote_batches.iter().filter(|(d, _)| remaining_digests.remove(*d)).collect();
+                if let Err(e) = txn.commit() {
+                    tracing::error!("failed to commit batch! We can not continue.. {e}");
+                    panic!("failed to commit batch! We can not continue.. {e}");
+                }
+                fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
 
-                            // Set received_at timestamp for remote batches.
-                            let mut updated_new_batches = HashMap::new();
-                            let mut txn = self.batch_store.write_txn().expect("unable to create DB transaction!");
-                            for (digest, batch) in new_batches {
-                                let mut batch = (*batch).clone();
-                                batch.set_received_at(now());
-                                updated_new_batches.insert(*digest, batch.clone());
-                                // Also persist the batches, so they are available after restarts.
-                                if let Err(e) = txn.insert::<Batches>(digest, &batch) {
-                                    tracing::error!("failed to insert batch! We can not continue.. {e}");
-                                    panic!("failed to insert batch! We can not continue.. {e}");
-                                }
-                            }
-                            if let Err(e) = txn.commit() {
-                                tracing::error!("failed to commit batch! We can not continue.. {e}");
-                                panic!("failed to commit batch! We can not continue.. {e}");
-                            }
-                            fetched_batches.extend(updated_new_batches.iter().map(|(d, b)| (*d, (*b).clone())));
-
-                            if remaining_digests.is_empty() {
-                                return fetched_batches;
-                            }
-                        }
-                    }
-                    _ = interval.as_mut() => {
-                    }
+                if remaining_digests.is_empty() {
+                    return fetched_batches;
                 }
             }
-
-            // After all known remote workers have been tried, restart the outer loop to fetch
+            // After all known connected peers have been tried, restart the outer loop to fetch
             // from local storage then remote workers again.
             sleep(WORKER_RETRY_INTERVAL).await;
         }
@@ -161,63 +112,12 @@ impl<DB: Database> BatchFetcher<DB> {
         fetched_batches
     }
 
-    /// This future performs a fetch from a given remote worker
-    /// This future performs infinite retries with exponential backoff
-    /// You can specify stagger_delay before request is issued
-    async fn fetch_remote(
-        &self,
-        worker: NetworkPublicKey,
-        digests: HashSet<BlockHash>,
-    ) -> HashMap<BlockHash, Batch> {
-        // TODO: Make these config parameters
-        let max_timeout = Duration::from_secs(60);
-        let mut timeout = Duration::from_secs(10);
-        let mut attempt = 0usize;
-        loop {
-            attempt += 1;
-            debug!("Remote attempt #{attempt} to fetch {} digests from {worker}", digests.len(),);
-            let deadline = Instant::now() + timeout;
-            let request_guard =
-                PendingGuard::make_inc(&self.metrics.pending_remote_request_batches);
-            let response =
-                self.safe_request_batches(digests.clone(), worker.clone(), timeout).await;
-            drop(request_guard);
-            match response {
-                Ok(remote_batches) => {
-                    self.metrics.batch_fetch.with_label_values(&["remote", "success"]).inc();
-                    debug!("Found {} batches remotely", remote_batches.len());
-                    return remote_batches;
-                }
-                Err(err) => {
-                    if err.to_string().contains("Timeout") {
-                        self.metrics.batch_fetch.with_label_values(&["remote", "timeout"]).inc();
-                        debug!("Timed out retrieving payloads {digests:?} from {worker} attempt {attempt}: {err}");
-                    } else if err.to_string().contains("[Protocol violation]") {
-                        self.metrics.batch_fetch.with_label_values(&["remote", "fail"]).inc();
-                        debug!("Failed retrieving payloads {digests:?} from possibly byzantine {worker} attempt {attempt}: {err}");
-                        // Do not bother retrying if the remote worker is byzantine.
-                        return HashMap::new();
-                    } else {
-                        self.metrics.batch_fetch.with_label_values(&["remote", "fail"]).inc();
-                        debug!("Error retrieving payloads {digests:?} from {worker} attempt {attempt}: {err}");
-                    }
-                }
-            }
-            timeout += timeout / 2;
-            timeout = std::cmp::min(max_timeout, timeout);
-            // Since the call might have returned before timeout, we wait until originally planned
-            // deadline
-            sleep_until(deadline).await;
-        }
-    }
-
     /// Issue request_batches RPC and verifies response integrity
     async fn safe_request_batches(
         &self,
-        digests_to_fetch: HashSet<BlockHash>,
-        worker: NetworkPublicKey,
+        digests_to_fetch: &HashSet<BlockHash>,
         timeout: Duration,
-    ) -> eyre::Result<HashMap<BlockHash, Batch>> {
+    ) -> Result<HashMap<BlockHash, Batch>, RequestBatchesNetworkError> {
         let mut fetched_batches = HashMap::new();
         if digests_to_fetch.is_empty() {
             return Ok(fetched_batches);
@@ -225,16 +125,10 @@ impl<DB: Database> BatchFetcher<DB> {
 
         let RequestBatchesResponse { batches, is_size_limit_reached: _ } = self
             .network
-            .request_batches(digests_to_fetch.clone().into_iter().collect(), &worker, timeout)
+            .request_batches_from_all(digests_to_fetch.clone().into_iter().collect(), timeout)
             .await?;
         for batch in batches {
             let batch_digest = batch.digest();
-            if !digests_to_fetch.contains(&batch_digest) {
-                eyre::bail!(
-                    "[Protocol violation] Worker {worker} returned batch with digest \
-                    {batch_digest} which is not part of the requested digests: {digests_to_fetch:?}"
-                );
-            }
             // This batch is part of a certificate, so no need to validate it.
             fetched_batches.insert(batch_digest, batch);
         }
@@ -243,77 +137,68 @@ impl<DB: Database> BatchFetcher<DB> {
     }
 }
 
-// todo - make it generic so that other can reuse
-struct PendingGuard<'a> {
-    metric: &'a IntGauge,
+/// Possible errors when requesting batches.
+#[derive(Debug, Error)]
+enum RequestBatchesNetworkError {
+    #[error(transparent)]
+    Timeout(#[from] Elapsed),
+    #[error(transparent)]
+    Network(#[from] NetworkError),
 }
 
-impl<'a> PendingGuard<'a> {
-    pub fn make_inc(metric: &'a IntGauge) -> Self {
-        metric.inc();
-        Self { metric }
-    }
-}
-
-impl Drop for PendingGuard<'_> {
-    fn drop(&mut self) {
-        self.metric.dec()
-    }
-}
-
-// Trait for unit tests
-// TODO: migrate this WorkerRpc.
+// Utility trait to add a timeout to a batch request.
 #[async_trait]
-pub trait RequestBatchesNetwork: Send + Sync {
-    async fn request_batches(
+trait RequestBatchesNetwork: Send + Sync {
+    async fn request_batches_from_all(
         &self,
         batch_digests: Vec<BlockHash>,
-        worker: &NetworkPublicKey,
         timeout: Duration,
-    ) -> eyre::Result<RequestBatchesResponse>;
+    ) -> Result<RequestBatchesResponse, RequestBatchesNetworkError>;
 }
 
 #[async_trait]
 impl RequestBatchesNetwork for WorkerNetworkHandle {
-    async fn request_batches(
+    async fn request_batches_from_all(
         &self,
         batch_digests: Vec<BlockHash>,
-        worker: &NetworkPublicKey,
         timeout: Duration,
-    ) -> eyre::Result<RequestBatchesResponse> {
-        let peer_id = network_public_key_to_libp2p(worker);
+    ) -> Result<RequestBatchesResponse, RequestBatchesNetworkError> {
         let res =
-            tokio::time::timeout(timeout, self.request_batches(peer_id, batch_digests)).await??;
+            tokio::time::timeout(timeout, self.request_batches_from_all(batch_digests)).await??;
         Ok(res)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::{WorkerRequest, WorkerResponse};
+
     use super::*;
     use fastcrypto::traits::KeyPair;
+    use itertools::Itertools as _;
     use rand::rngs::StdRng;
     use tempfile::TempDir;
+    use tn_network_libp2p::{
+        types::{NetworkCommand, NetworkHandle},
+        PeerId,
+    };
     use tn_storage::open_db;
     use tn_test_utils::transaction;
-    use tn_types::NetworkKeypair;
+    use tn_types::{network_public_key_to_libp2p, NetworkKeypair};
+    use tokio::sync::{mpsc, Mutex};
 
     #[tokio::test]
-    pub async fn test_fetcher() {
+    pub async fn test_fetchertt() {
         let mut network = TestRequestBatchesNetwork::new();
         let temp_dir = TempDir::new().unwrap();
         let batch_store = open_db(temp_dir.path());
         let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batch1.digest(), batch2.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2])),
-        );
-        network.put(&[1, 2], batch1.clone());
-        network.put(&[2, 3], batch2.clone());
+        let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest()]);
+        network.put(&[1, 2], batch1.clone()).await;
+        network.put(&[2, 3], batch2.clone()).await;
         let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
+            network: Arc::new(network.handle()),
             batch_store: batch_store.clone(),
             metrics: Arc::new(WorkerMetrics::default()),
         };
@@ -321,7 +206,7 @@ mod tests {
             (batch1.digest(), batch1.clone()),
             (batch2.digest(), batch2.clone()),
         ]);
-        let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
+        let mut fetched_batches = fetcher.fetch(digests).await;
         // Reset metadata from the fetched and expected batches
         for batch in fetched_batches.values_mut() {
             // assert received_at was set to some value before resetting.
@@ -352,19 +237,15 @@ mod tests {
         let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2, 3])),
-        );
+        let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
         for batch in &[&batch1, &batch2, &batch3] {
             batch_store.insert::<Batches>(&batch.digest(), batch).unwrap();
         }
-        network.put(&[1, 2], batch1.clone());
-        network.put(&[2, 3], batch2.clone());
-        network.put(&[3, 4], batch3.clone());
+        network.put(&[1, 2], batch1.clone()).await;
+        network.put(&[2, 3], batch2.clone()).await;
+        network.put(&[3, 4], batch3.clone()).await;
         let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
+            network: Arc::new(network.handle()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
         };
@@ -373,7 +254,7 @@ mod tests {
             (batch2.digest(), batch2.clone()),
             (batch3.digest(), batch3.clone()),
         ]);
-        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        let fetched_batches = fetcher.fetch(digests).await;
         assert_eq!(fetched_batches, expected_batches);
     }
 
@@ -387,16 +268,12 @@ mod tests {
         let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-            HashSet::from_iter(test_pks(&[2, 3, 4])),
-        );
-        network.put(&[3, 4], batch1.clone());
-        network.put(&[2, 3], batch2.clone());
-        network.put(&[2, 3, 4], batch3.clone());
+        let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
+        network.put(&[3, 4], batch1.clone()).await;
+        network.put(&[2, 3], batch2.clone()).await;
+        network.put(&[2, 3, 4], batch3.clone()).await;
         let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
+            network: Arc::new(network.handle()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
         };
@@ -405,7 +282,7 @@ mod tests {
             (batch2.digest(), batch2.clone()),
             (batch3.digest(), batch3.clone()),
         ]);
-        let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
+        let mut fetched_batches = fetcher.fetch(digests).await;
 
         // Reset metadata from the fetched and expected batches
         for batch in fetched_batches.values_mut() {
@@ -428,17 +305,13 @@ mod tests {
         let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
         let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let (digests, known_workers) = (
-            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-            HashSet::from_iter(test_pks(&[1, 2, 3, 4])),
-        );
+        let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
         batch_store.insert::<Batches>(&batch1.digest(), &batch1).unwrap();
-        network.put(&[1, 2, 3], batch1.clone());
-        network.put(&[2, 3, 4], batch2.clone());
-        network.put(&[1, 4], batch3.clone());
+        network.put(&[1, 2, 3], batch1.clone()).await;
+        network.put(&[2, 3, 4], batch2.clone()).await;
+        network.put(&[1, 4], batch3.clone()).await;
         let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
+            network: Arc::new(network.handle()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
         };
@@ -447,7 +320,7 @@ mod tests {
             (batch2.digest(), batch2.clone()),
             (batch3.digest(), batch3.clone()),
         ]);
-        let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
+        let mut fetched_batches = fetcher.fetch(digests).await;
 
         // Reset metadata from the fetched and expected remote batches
         for batch in fetched_batches.values_mut() {
@@ -479,30 +352,26 @@ mod tests {
             let batch = Batch { transactions: vec![transaction()], ..Default::default() };
             local_digests.push(batch.digest());
             batch_store.insert::<Batches>(&batch.digest(), &batch).unwrap();
-            network.put(&[1, 2, 3], batch.clone());
+            network.put(&[1, 2, 3], batch.clone()).await;
             expected_batches.push(batch);
         }
         // 6 batches available remotely with response size limit of 2
         for _i in (num_digests / 2)..num_digests {
             let batch = Batch { transactions: vec![transaction()], ..Default::default() };
-            network.put(&[1, 2, 3], batch.clone());
+            network.put(&[1, 2, 3], batch.clone()).await;
             expected_batches.push(batch);
         }
 
         let mut expected_batches = HashMap::from_iter(
             expected_batches.iter().map(|batch| (batch.digest(), batch.clone())),
         );
-        let (digests, known_workers) = (
-            HashSet::from_iter(expected_batches.clone().into_keys()),
-            HashSet::from_iter(test_pks(&[1, 2, 3])),
-        );
+        let digests = HashSet::from_iter(expected_batches.clone().into_keys());
         let fetcher = BatchFetcher {
-            name: test_pk(0),
-            network: Arc::new(network.clone()),
+            network: Arc::new(network.handle()),
             batch_store,
             metrics: Arc::new(WorkerMetrics::default()),
         };
-        let mut fetched_batches = fetcher.fetch(digests, known_workers).await;
+        let mut fetched_batches = fetcher.fetch(digests).await;
 
         // Reset metadata from the fetched and expected remote batches
         for batch in fetched_batches.values_mut() {
@@ -526,66 +395,86 @@ mod tests {
     #[derive(Clone)]
     struct TestRequestBatchesNetwork {
         // Worker name -> batch digests it has -> batches.
-        data: HashMap<NetworkPublicKey, HashMap<BlockHash, Batch>>,
+        data: Arc<Mutex<HashMap<PeerId, HashMap<BlockHash, Batch>>>>,
+        handle: WorkerNetworkHandle,
     }
 
     impl TestRequestBatchesNetwork {
         pub fn new() -> Self {
-            Self { data: HashMap::new() }
+            let data: Arc<Mutex<HashMap<PeerId, HashMap<BlockHash, Batch>>>> =
+                Arc::new(Mutex::new(HashMap::new()));
+            let data_clone = data.clone();
+            let (rx, mut tx) = mpsc::channel(100);
+            let handle = WorkerNetworkHandle::new(NetworkHandle::new(rx));
+            tokio::spawn(async move {
+                while let Some(r) = tx.recv().await {
+                    match r {
+                        NetworkCommand::ConnectedPeers { reply } => {
+                            reply.send(data_clone.lock().await.keys().copied().collect()).unwrap();
+                        }
+                        NetworkCommand::SendRequest { peer, request, reply } => match request {
+                            WorkerRequest::RequestBatches { batch_digests: digests } => {
+                                // Use this to simulate server side response size limit in
+                                // RequestBlocks
+                                const MAX_REQUEST_BATCHES_RESPONSE_SIZE: usize = 2;
+                                const MAX_READ_BLOCK_DIGESTS: usize = 5;
+
+                                let mut is_size_limit_reached = false;
+                                let mut batches = Vec::new();
+                                let mut total_size = 0;
+
+                                let digests_chunks = digests
+                                    .chunks(MAX_READ_BLOCK_DIGESTS)
+                                    .map(|chunk| chunk.to_vec())
+                                    .collect_vec();
+                                for digests_chunk in digests_chunks {
+                                    for digest in digests_chunk {
+                                        if let Some(batch) =
+                                            data_clone.lock().await.get(&peer).unwrap().get(&digest)
+                                        {
+                                            if total_size < MAX_REQUEST_BATCHES_RESPONSE_SIZE {
+                                                batches.push(batch.clone());
+                                                total_size += batch.size();
+                                            } else {
+                                                is_size_limit_reached = true;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                reply
+                                    .send(Ok(WorkerResponse::RequestBatches(
+                                        RequestBatchesResponse { batches, is_size_limit_reached },
+                                    )))
+                                    .unwrap();
+                            }
+                            _ => {}
+                        },
+                        _ => {}
+                    }
+                }
+            });
+            Self { data, handle }
         }
 
-        pub fn put(&mut self, keys: &[u8], batch: Batch) {
+        pub async fn put(&mut self, keys: &[u8], batch: Batch) {
             for key in keys {
                 let key = test_pk(*key);
-                let entry = self.data.entry(key).or_default();
+                let mut guard = self.data.lock().await;
+                let entry = guard.entry(key.into()).or_default();
                 entry.insert(batch.digest(), batch.clone());
             }
         }
-    }
 
-    #[async_trait]
-    impl RequestBatchesNetwork for TestRequestBatchesNetwork {
-        async fn request_batches(
-            &self,
-            digests: Vec<BlockHash>,
-            worker: &NetworkPublicKey,
-            _timeout: Duration,
-        ) -> eyre::Result<RequestBatchesResponse> {
-            // Use this to simulate server side response size limit in RequestBlocks
-            const MAX_REQUEST_BATCHES_RESPONSE_SIZE: usize = 2;
-            const MAX_READ_BLOCK_DIGESTS: usize = 5;
-
-            let mut is_size_limit_reached = false;
-            let mut batches = Vec::new();
-            let mut total_size = 0;
-
-            let digests_chunks =
-                digests.chunks(MAX_READ_BLOCK_DIGESTS).map(|chunk| chunk.to_vec()).collect_vec();
-            for digests_chunk in digests_chunks {
-                for digest in digests_chunk {
-                    if let Some(batch) = self.data.get(worker).unwrap().get(&digest) {
-                        if total_size < MAX_REQUEST_BATCHES_RESPONSE_SIZE {
-                            batches.push(batch.clone());
-                            total_size += batch.size();
-                        } else {
-                            is_size_limit_reached = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            Ok(RequestBatchesResponse { batches, is_size_limit_reached })
+        pub fn handle(&self) -> WorkerNetworkHandle {
+            self.handle.clone()
         }
     }
 
-    fn test_pk(i: u8) -> NetworkPublicKey {
+    fn test_pk(i: u8) -> PeerId {
         use rand::SeedableRng;
         let mut rng = StdRng::from_seed([i; 32]);
-        NetworkKeypair::generate(&mut rng).public().clone()
-    }
-
-    fn test_pks(i: &[u8]) -> Vec<NetworkPublicKey> {
-        i.iter().map(|i| test_pk(*i)).collect()
+        network_public_key_to_libp2p(NetworkKeypair::generate(&mut rng).public())
     }
 }

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -38,7 +38,6 @@ impl Worker {
         let node_metrics = metrics.worker_metrics.clone();
 
         let batch_fetcher = BatchFetcher::new(
-            worker_name,
             network_handle.clone(),
             consensus_config.node_storage().clone(),
             node_metrics.clone(),

--- a/crates/network-libp2p/src/error.rs
+++ b/crates/network-libp2p/src/error.rs
@@ -74,6 +74,9 @@ pub enum NetworkError {
     /// If a request is made to "any" peer and no peers are currently connected.
     #[error("No connected peers")]
     NoPeers,
+    /// Response violated the protocol.
+    #[error("Protocol error: {0}")]
+    ProtocolError(String),
 }
 
 impl From<oneshot::error::RecvError> for NetworkError {


### PR DESCRIPTION
This was a response to https://github.com/Telcoin-Association/telcoin-network/issues/191
It does not add errors since we need batches to progress.  It does the following:
- Asks all its connected peers for batches vs just workers.  If not a CVV then it may not even have access to a particular worker (or any) so this makes it more general to handle NVV and observer nodes as well.
- Refactors some of the error checking into lower level code.
- Changed the test harness code to test more of the fetching stack.

This PR basically sends a batch request to every connected peer.  This is similar to how it used to use workers, it this what we want to do?