### PR TITLE
Better batch fetching.

### DIFF
--- a/bin/telcoin-network/src/cli.rs
+++ b/bin/telcoin-network/src/cli.rs
@@ -159,7 +159,7 @@ pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
 
     /// Start the node
     #[command(name = "node")]
-    Node(node::NodeCommand<Ext>),
+    Node(Box<node::NodeCommand<Ext>>),
 }
 
 #[cfg(test)]

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -44,7 +44,7 @@ const PARALLEL_FETCH_REQUEST_ADDITIONAL_TIMEOUT: Duration = Duration::from_secs(
 #[derive(Clone, Debug)]
 pub enum CertificateFetcherCommand {
     /// Fetch the certificate and its ancestors.
-    Ancestors(Certificate),
+    Ancestors(Arc<Certificate>),
     /// Fetch once from a random primary.
     Kick,
 }

--- a/crates/consensus/primary/src/consensus/mod.rs
+++ b/crates/consensus/primary/src/consensus/mod.rs
@@ -30,16 +30,16 @@ pub enum ConsensusError {
     StoreError(#[from] StoreError),
 
     #[error("Certificate {0:?} equivocates with earlier certificate {1:?}")]
-    CertificateEquivocation(Certificate, Certificate),
+    CertificateEquivocation(Box<Certificate>, Box<Certificate>),
 
     #[error("System shutting down")]
     ShuttingDown,
 
     #[error("Parent digest {0:?} not found in DAG for {1:?}!")]
-    MissingParent(CertificateDigest, Certificate),
+    MissingParent(CertificateDigest, Box<Certificate>),
 
     #[error("Parent round not found in DAG for {0:?}!")]
-    MissingParentRound(Certificate),
+    MissingParentRound(Box<Certificate>),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -957,7 +957,7 @@ async fn submitting_equivocating_certificate_should_error() {
         let err = bullshark.process_certificate(&mut state, certificate.clone()).unwrap_err();
         match err {
             ConsensusError::CertificateEquivocation(this_cert, _) => {
-                assert_eq!(this_cert, certificate);
+                assert_eq!(*this_cert, certificate);
             }
             err => panic!("Unexpected error returned: {err}"),
         }

--- a/crates/consensus/primary/src/error/proposer.rs
+++ b/crates/consensus/primary/src/error/proposer.rs
@@ -21,8 +21,7 @@ pub(crate) enum ProposerError {
     OneshotChannelClosed,
     /// Sending error for the proposer to certifier.
     #[error("Proposer failed to send header to certifier.")]
-    //CertifierSender(#[from] mpsc::error::SendError<Header>),
-    CertifierSender(#[from] tn_types::SendError<Header>),
+    CertifierSender(#[from] Box<tn_types::SendError<Header>>),
     /// Error writing to the proposer store.
     #[error("Failed to write new header to proposer store: {0}")]
     StoreError(String),

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -477,7 +477,7 @@ where
             (None, None) => self.get_latest_output()?,
         };
 
-        Ok(PrimaryResponse::ConsensusHeader(header))
+        Ok(PrimaryResponse::ConsensusHeader(Arc::new(header)))
     }
 
     /// Retrieve the consensus header by number.

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -317,7 +317,8 @@ impl<DB: Database> Proposer<DB> {
             .map_err(|e| ProposerError::StoreError(e.to_string()))?;
 
         // Send the new header to the `Certifier` that will broadcast and certify it.
-        let result = consensus_bus.headers().send(header.clone()).await.map_err(|e| e.into());
+        let result =
+            consensus_bus.headers().send(header.clone()).await.map_err(|e| Box::new(e).into());
         let num_digests = header.payload().len();
         consensus_bus
             .primary_metrics()

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 use consensus_metrics::monitored_scope;
 use fastcrypto::hash::Hash as _;
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
 use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
@@ -203,7 +206,7 @@ where
             // start fetching parents
             self.consensus_bus
                 .certificate_fetcher()
-                .send(CertificateFetcherCommand::Ancestors(certificate.clone()))
+                .send(CertificateFetcherCommand::Ancestors(Arc::new(certificate.clone())))
                 .await?;
         }
 

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use consensus_metrics::monitored_scope;
 use fastcrypto::hash::Hash as _;
-use std::{collections::HashSet, time::Instant};
+use std::{collections::HashSet, sync::Arc, time::Instant};
 use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
@@ -242,7 +242,7 @@ where
             {
                 self.consensus_bus
                     .certificate_fetcher()
-                    .send(CertificateFetcherCommand::Ancestors(cert.clone()))
+                    .send(CertificateFetcherCommand::Ancestors(Arc::new(cert.clone())))
                     .await?;
 
                 error!(target: "primary::cert_validator", "processed certificate that is too new");

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -2,15 +2,6 @@ use serde::{Deserialize, Serialize};
 use tn_network_libp2p::TNMessage;
 use tn_types::{Batch, BlockHash, SealedBatch};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RequestBatchesResponse {
-    /// Requested batches.
-    pub batches: Vec<Batch>,
-    /// If true, the primary should request the batches from the workers again.
-    /// This may not be something that can be trusted from a remote worker.
-    pub is_size_limit_reached: bool,
-}
-
 /// Worker messages on the gossip network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WorkerGossip {
@@ -41,7 +32,7 @@ pub enum WorkerRequest {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WorkerResponse {
     ReportBatch,
-    RequestBatches(RequestBatchesResponse),
+    RequestBatches(Vec<Batch>),
     /// RPC error while handling request.
     ///
     /// This is an application-layer error response.

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use error::WorkerNetworkError;
 use futures::{stream::FuturesUnordered, StreamExt};
 use handler::RequestHandler;
-use message::{RequestBatchesResponse, WorkerGossip, WorkerRPCError};
+use message::{WorkerGossip, WorkerRPCError};
 pub use message::{WorkerRequest, WorkerResponse};
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{
@@ -14,8 +14,8 @@ use tn_network_libp2p::{
 use tn_network_types::{FetchBatchResponse, PrimaryToWorkerClient, WorkerSynchronizeMessage};
 use tn_storage::tables::Batches;
 use tn_types::{
-    encode, now, BatchValidation, BlockHash, Database, DbTxMut, Noticer, SealedBatch, TaskManager,
-    WorkerId,
+    encode, now, Batch, BatchValidation, BlockHash, Database, DbTxMut, Noticer, SealedBatch,
+    TaskManager, WorkerId,
 };
 use tokio::{
     sync::{mpsc, oneshot},
@@ -90,22 +90,21 @@ impl WorkerNetworkHandle {
     }
 
     /// Request a group of batches by hashes.
-    pub async fn request_batches(
+    async fn request_batches_from_peer(
         &self,
         peer_id: PeerId,
         batch_digests: Vec<BlockHash>,
-    ) -> NetworkResult<RequestBatchesResponse> {
+        timeout: Duration,
+    ) -> NetworkResult<Vec<Batch>> {
         let request = WorkerRequest::RequestBatches { batch_digests: batch_digests.clone() };
         let res = self.handle.send_request(request, peer_id).await?;
-        let res = res.await??;
+        let res =
+            tokio::time::timeout(timeout, res).await.map_err(|_| NetworkError::Timeout)???;
         match res {
             WorkerResponse::ReportBatch => Err(NetworkError::RPCError(
                 "Got wrong response, not a request batches is report batch!".to_string(),
             )),
-            WorkerResponse::RequestBatches(RequestBatchesResponse {
-                batches,
-                mut is_size_limit_reached,
-            }) => {
+            WorkerResponse::RequestBatches(batches) => {
                 for batch in &batches {
                     let batch_digest = batch.digest();
                     if !batch_digests.contains(&batch_digest) {
@@ -116,26 +115,7 @@ impl WorkerNetworkHandle {
                         return Err(NetworkError::ProtocolError(msg));
                     }
                 }
-                let (batch_digests_len, batches_len) = (batch_digests.len(), batches.len());
-                if batches_len < batch_digests_len {
-                    // If we did not get everything make sure to set is_size_limit_reached to true.
-                    is_size_limit_reached = true;
-                }
-                if !is_size_limit_reached && batch_digests_len != batches_len {
-                    let msg = format!(
-                        "Peer {peer_id} returned is size limit FALSE but did not include all the requested batches:
-                        requested: {batch_digests:?} recieved: {batches:?}"
-                    );
-                    return Err(NetworkError::ProtocolError(msg));
-                }
-                if is_size_limit_reached && batch_digests_len == batches_len {
-                    let msg = format!(
-                        "Peer {peer_id} returned is size limit TRUE but DID include all the requested batches:
-                        requested: {batch_digests:?}"
-                    );
-                    return Err(NetworkError::ProtocolError(msg));
-                }
-                Ok(RequestBatchesResponse { batches, is_size_limit_reached })
+                Ok(batches)
             }
             WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
         }
@@ -144,20 +124,17 @@ impl WorkerNetworkHandle {
     /// Request a group of batches by hashes.
     /// Sends request to all our connected peers at once and returns Ok when we
     /// get a valid response or Err if no one responds with the batches.
-    pub async fn request_batches_from_all(
+    pub async fn request_batches(
         &self,
-        batch_digests: Vec<BlockHash>,
-    ) -> NetworkResult<RequestBatchesResponse> {
+        requested_digests: Vec<BlockHash>,
+    ) -> NetworkResult<Vec<Batch>> {
         let mut peers = self.handle.connected_peers().await?;
-        if batch_digests.is_empty() || peers.is_empty() {
+        if requested_digests.is_empty() || peers.is_empty() {
             // Nothing to do, either no digests requested or no one to ask.
             // Return nothing.
-            return Ok(RequestBatchesResponse {
-                batches: vec![],
-                is_size_limit_reached: !batch_digests.is_empty(),
-            });
+            return Ok(vec![]);
         }
-        let mut remaining_digests = batch_digests;
+        let mut remaining_digests = requested_digests.clone();
         let num_peers = peers.len();
         let mut all_batches = Vec::new();
         // Attempt to try different batches with different peers.
@@ -178,29 +155,36 @@ impl WorkerNetworkHandle {
             let mut futures = FuturesUnordered::new();
             for (peer, batch_digests) in peers.iter().zip(batch_of_batches.into_iter()) {
                 if !batch_digests.is_empty() {
-                    futures.push(self.request_batches(*peer, batch_digests));
+                    futures.push(self.request_batches_from_peer(
+                        *peer,
+                        batch_digests,
+                        Duration::from_secs(3),
+                    ));
                 }
             }
             while let Some(res) = futures.next().await {
                 match res {
-                    Ok(RequestBatchesResponse { batches, is_size_limit_reached: _ }) => {
+                    Ok(batches) => {
                         for batch in batches {
-                            if !all_batches.contains(&batch) {
-                                let batch_digest = batch.digest();
-                                remaining_digests.retain(|d| *d != batch_digest);
-                                all_batches.push(batch);
+                            let batch_digest = batch.digest();
+                            if requested_digests.contains(&batch_digest) {
+                                // Sanity check we actually asked for this digest...
+                                if !all_batches.contains(&batch) {
+                                    remaining_digests.retain(|d| *d != batch_digest);
+                                    all_batches.push(batch);
+                                }
+                            } else {
+                                // Got a batch we did not ask for...
+                                warn!(target: "worker::network", "recieved a batch not requested {batch_digest}");
                             }
                         }
                         if remaining_digests.is_empty() {
-                            return Ok(RequestBatchesResponse {
-                                batches: all_batches,
-                                is_size_limit_reached: false,
-                            });
+                            return Ok(all_batches);
                         }
                     }
                     Err(e) => {
                         // Another worker might succeed so just log this.
-                        warn!(target: "worker::network", ?e, "error requesting batches")
+                        warn!(target: "worker::network", ?e, "error requesting batches");
                     }
                 }
             }
@@ -208,7 +192,7 @@ impl WorkerNetworkHandle {
         if all_batches.is_empty() {
             Err(NetworkError::RPCError("Unable to get batches from any peers!".to_string()))
         } else {
-            Ok(RequestBatchesResponse { batches: all_batches, is_size_limit_reached: true })
+            Ok(all_batches)
         }
     }
 }
@@ -404,12 +388,12 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
 
         let response = tokio::time::timeout(
             self.request_batches_timeout,
-            network.request_batches_from_all(missing.iter().cloned().collect()),
+            network.request_batches(missing.iter().cloned().collect()),
         )
         .await??;
 
         let sealed_batches_from_response: Vec<SealedBatch> =
-            response.batches.into_iter().map(|b| b.seal_slow()).collect();
+            response.into_iter().map(|b| b.seal_slow()).collect();
 
         for sealed_batch in sealed_batches_from_response.into_iter() {
             if !message.is_certified {

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -4,7 +4,6 @@ use reth_blockchain_tree::error::InsertBlockError;
 use reth_errors::{CanonicalError, ProviderError, RethError};
 use reth_revm::primitives::EVMError;
 use reth_rpc_eth_types::EthApiError;
-use tn_types::BatchConversionError;
 use tokio::sync::oneshot;
 
 /// Result alias for [`TNEngineError`].
@@ -25,9 +24,6 @@ pub enum TnEngineError {
     /// Error recovering transaction from bytes.
     #[error(transparent)]
     RecoverTransactionBytes(#[from] EthApiError),
-    /// Error converting block to `SealedBlockWithSenders`.
-    #[error(transparent)]
-    Block(#[from] BatchConversionError),
     /// The next block digest is missing.
     #[error("Missing next block digest for recovered sealed block with senders.")]
     NextBlockDigestMissing,

--- a/crates/execution/batch-builder/src/error.rs
+++ b/crates/execution/batch-builder/src/error.rs
@@ -2,7 +2,6 @@
 
 use reth_errors::{CanonicalError, ProviderError, RethError};
 use reth_transaction_pool::error::PoolTransactionError;
-use tn_types::BatchConversionError;
 use tokio::sync::{mpsc, oneshot};
 
 /// Result alias for [`TNEngineError`].
@@ -17,9 +16,6 @@ pub enum BatchBuilderError {
     /// Error retrieving data from Provider.
     #[error(transparent)]
     Provider(#[from] ProviderError),
-    /// Error converting batch to `SealedBlockWithSenders`.
-    #[error(transparent)]
-    Batch(#[from] BatchConversionError),
     /// The next batch digest is missing.
     #[error("Missing next batch digest for recovered sealed block with senders.")]
     NextBatchDigestMissing,

--- a/crates/network-libp2p/src/codec.rs
+++ b/crates/network-libp2p/src/codec.rs
@@ -77,10 +77,7 @@ impl<Req, Res> TNCodec<Req, Res> {
 
         // ensure message length within bounds
         if length > self.max_chunk_size {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "prefix indicates message size is too large",
-            ));
+            return Err(std::io::Error::other("prefix indicates message size is too large"));
         }
 
         // resize buffer to reported message size
@@ -101,8 +98,7 @@ impl<Req, Res> TNCodec<Req, Res> {
         snappy_decoder.read_exact(&mut self.decode_buffer)?;
 
         // decode bytes
-        bcs::from_bytes(&self.decode_buffer)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        bcs::from_bytes(&self.decode_buffer).map_err(std::io::Error::other)
     }
 
     /// Convenience method to keep WRITE logic DRY.
@@ -121,15 +117,12 @@ impl<Req, Res> TNCodec<Req, Res> {
         // encode into allocated buffer
         encode_into_buffer(&mut self.decode_buffer, &msg).map_err(|e| {
             let error = format!("encode into buffer: {}", e);
-            std::io::Error::new(std::io::ErrorKind::Other, error)
+            std::io::Error::other(error)
         })?;
 
         // ensure encoded bytes are within bounds
         if self.decode_buffer.len() > self.max_chunk_size {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "encode data > max_chunk_size",
-            ));
+            return Err(std::io::Error::other("encode data > max_chunk_size"));
         }
 
         // length prefix for uncompressed bytes

--- a/crates/network-libp2p/src/error.rs
+++ b/crates/network-libp2p/src/error.rs
@@ -77,6 +77,9 @@ pub enum NetworkError {
     /// Response violated the protocol.
     #[error("Protocol error: {0}")]
     ProtocolError(String),
+    /// A network operation timed out.
+    #[error("Timed Out")]
+    Timeout,
 }
 
 impl From<oneshot::error::RecvError> for NetworkError {

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -4,24 +4,13 @@
 //! have reached quorum.
 
 use crate::{
-    adiri_chain_spec, crypto, encode, now, Address, BlockHash, ExecHeader, SealedBlock,
-    TimestampSec, MIN_PROTOCOL_BASE_FEE,
+    adiri_chain_spec, crypto, encode, now, Address, BlockHash, ExecHeader, TimestampSec,
+    MIN_PROTOCOL_BASE_FEE,
 };
 use fastcrypto::hash::HashFunction;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
-
-/// Batch validation error types
-#[derive(Error, Debug, Clone)]
-pub enum BatchConversionError {
-    /// Errors from BlockExecution
-    #[error("Failed to recover signers for sealed batch:\n{0:?}\n")]
-    RecoverSigners(SealedBlock),
-    /// Failed to decode transaction bytes
-    #[error("RLP error decoding transaction: {0}")]
-    DecodeTransaction(#[from] alloy_rlp::Error),
-}
 
 /// The batch for workers to communicate for consensus.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Addresses comment on last PR stack.
- When requesting batches from any peer divide the list up instead of request all batches from all peers.
- Remove the batch response type, the extra field could not be trusted and was never used so just return the vector of batches we could get which may or may not be complete.  All the higher level code already assumed this.