### PR TITLE
Publish and use batch gossip.

### DIFF
--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -119,14 +119,9 @@ struct ConsensusBusInner {
 
     /// Consensus output with a consensus header.
     consensus_output: broadcast::Sender<ConsensusOutput>,
-    /// Hold onto consensus output with a consensus header to keep it open.
-    _rx_consensus_output: broadcast::Receiver<ConsensusOutput>,
     /// Consensus header.  Note this can be used to create consensus output to execute for non
     /// validators.
     consensus_header: broadcast::Sender<ConsensusHeader>,
-    /// Hold onto consensus header to keep it open.
-    _rx_consensus_header: broadcast::Receiver<ConsensusHeader>,
-
     /// Status of sync?
     tx_sync_status: watch::Sender<NodeMode>,
     /// Hold onto the recent sync_status to keep it "open"
@@ -145,8 +140,6 @@ struct ConsensusBusInner {
     restart: AtomicBool,
     /// Consensus output with a consensus header.
     consensus_network_gossip: broadcast::Sender<GossipMessage>,
-    /// Hold onto consensus output with a consensus header to keep it open.
-    _rx_consensus_network_gossip: broadcast::Receiver<GossipMessage>,
 }
 
 #[derive(Clone, Debug)]
@@ -274,9 +267,7 @@ impl ConsensusBus {
                 tx_last_published_consensus_num_hash,
                 _rx_last_published_consensus_num_hash,
                 consensus_output,
-                _rx_consensus_output,
                 consensus_header,
-                _rx_consensus_header,
                 tx_sync_status,
                 _rx_sync_status,
                 consensus_metrics,
@@ -285,7 +276,6 @@ impl ConsensusBus {
                 executor_metrics,
                 restart: AtomicBool::new(false),
                 consensus_network_gossip,
-                _rx_consensus_network_gossip,
             }),
         }
     }

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -11,6 +11,7 @@ use tn_types::{
 use super::{
     error::{WorkerNetworkError, WorkerNetworkResult},
     message::WorkerGossip,
+    WorkerNetworkHandle,
 };
 
 /// The type that handles requests from peers.
@@ -22,6 +23,8 @@ pub struct RequestHandler<DB> {
     validator: Arc<dyn BatchValidation>,
     /// Consensus config with access to database.
     consensus_config: ConsensusConfig<DB>,
+    /// Network handle- so we can respond to gossip.
+    network_handle: WorkerNetworkHandle,
 }
 
 impl<DB> RequestHandler<DB>
@@ -33,25 +36,54 @@ where
         id: WorkerId,
         validator: Arc<dyn BatchValidation>,
         consensus_config: ConsensusConfig<DB>,
+        network_handle: WorkerNetworkHandle,
     ) -> Self {
-        Self { id, validator, consensus_config }
+        Self { id, validator, consensus_config, network_handle }
     }
 
     /// Process gossip from the committee.
     ///
-    /// Peers gossip the CertificateDigest so peers can request the Certificate. This waits until
-    /// the certificate can be retrieved and timesout after some time. It's important to give up
-    /// after enough time to limit the DoS attack surface. Peers who timeout must lose reputation.
+    /// Workers gossip the Batch Digests once accepted so that non-committee peers can request the
+    /// Batch.
     pub(super) async fn process_gossip(&self, msg: &GossipMessage) -> WorkerNetworkResult<()> {
         // deconstruct message
-        let GossipMessage { data, .. } = msg;
+        let GossipMessage { data, source, sequence_number: _, topic: _ } = msg;
 
         // gossip is uncompressed
         let gossip = try_decode(data)?;
 
         match gossip {
-            WorkerGossip::Batch(_block_hash) => {
-                // Retrieve the block...
+            WorkerGossip::Batch(batch_hash) => {
+                // Only accept batch gossip from the committee
+                if let Some(source) = source {
+                    if self.consensus_config.committee_peer_ids().contains(source) {
+                        // Retrieve the block...
+                        let store = self.consensus_config.node_storage();
+                        if !matches!(store.get::<Batches>(&batch_hash), Ok(Some(_))) {
+                            // If we don't have this batch already then try to get it.
+                            // If we are CVV then we should already have it.
+                            // This allows non-CVVs to pre fetch batches they will soon need.
+                            match self.network_handle.request_batches(vec![batch_hash]).await {
+                                Ok(batches) => {
+                                    if let Some(batch) = batches.first() {
+                                        store.insert::<Batches>(&batch.digest(), batch).map_err(
+                                            |e| {
+                                                WorkerNetworkError::Internal(format!(
+                                                    "failed to write to batch store: {e}"
+                                                ))
+                                            },
+                                        )?;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::error!(target: "worker:network", "failed to get gossipped batch {batch_hash}: {e}");
+                                }
+                            }
+                        }
+                    } else {
+                        tracing::warn!(target: "worker:network", "recieved batch gossip from a non-committee member! peer: {source}");
+                    }
+                }
             }
         }
 

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -44,6 +44,13 @@ impl WorkerNetworkHandle {
         Self { handle }
     }
 
+    //// Convenience method for creating a new Self for tests- sends events no-where and does
+    //// nothing.
+    pub fn new_for_test() -> Self {
+        let (tx, _rx) = mpsc::channel(5);
+        Self { handle: NetworkHandle::new(tx) }
+    }
+
     /// Dial a peer.
     ///
     /// Return swarm error to caller.
@@ -222,7 +229,8 @@ where
         validator: Arc<dyn BatchValidation>,
     ) -> Self {
         let shutdown_rx = consensus_config.shutdown().subscribe();
-        let request_handler = RequestHandler::new(id, validator, consensus_config);
+        let request_handler =
+            RequestHandler::new(id, validator, consensus_config, network_handle.clone());
         Self { network_events, network_handle, request_handler, shutdown_rx }
     }
 

--- a/crates/consensus/worker/src/tests/batch_provider_tests.rs
+++ b/crates/consensus/worker/src/tests/batch_provider_tests.rs
@@ -44,8 +44,15 @@ async fn make_batch() {
     let id = 0;
     let qw = TestMakeBlockQuorumWaiter::new_test();
     let timeout = Duration::from_secs(5);
-    let batch_provider =
-        Worker::new(id, qw.clone(), Arc::new(node_metrics), client, store.clone(), timeout);
+    let batch_provider = Worker::new(
+        id,
+        qw.clone(),
+        Arc::new(node_metrics),
+        client,
+        store.clone(),
+        timeout,
+        WorkerNetworkHandle::new_for_test(),
+    );
 
     // Send enough transactions to seal a batch.
     let tx = transaction();

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -450,7 +450,7 @@ mod tests {
     use tn_worker::{
         metrics::WorkerMetrics,
         quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait},
-        Worker,
+        Worker, WorkerNetworkHandle,
     };
     use tokio::time::timeout;
 
@@ -524,8 +524,15 @@ mod tests {
         let qw = TestMakeBlockQuorumWaiter();
         let node_metrics = WorkerMetrics::default();
         let timeout = Duration::from_secs(5);
-        let block_provider =
-            Worker::new(0, qw, Arc::new(node_metrics), client, store.clone(), timeout);
+        let block_provider = Worker::new(
+            0,
+            qw,
+            Arc::new(node_metrics),
+            client,
+            store.clone(),
+            timeout,
+            WorkerNetworkHandle::new_for_test(),
+        );
 
         let tx_pool_latest = txpool.block_info();
         let tip = SealedBlock::new(chain.sealed_genesis_header(), BlockBody::default());

--- a/crates/execution/batch-builder/tests/it/batch_builder.rs
+++ b/crates/execution/batch-builder/tests/it/batch_builder.rs
@@ -39,7 +39,7 @@ use tn_types::{
 use tn_worker::{
     metrics::WorkerMetrics,
     quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait},
-    Worker,
+    Worker, WorkerNetworkHandle,
 };
 use tokio::time::timeout;
 use tracing::debug;
@@ -73,8 +73,15 @@ async fn test_make_batch_el_to_cl() {
 
     let qw = TestMakeBlockQuorumWaiter();
     let timeout = Duration::from_secs(5);
-    let batch_provider =
-        Worker::new(0, qw.clone(), Arc::new(node_metrics), network_client, store.clone(), timeout);
+    let batch_provider = Worker::new(
+        0,
+        qw.clone(),
+        Arc::new(node_metrics),
+        network_client,
+        store.clone(),
+        timeout,
+        WorkerNetworkHandle::new_for_test(),
+    );
 
     //
     //=== Execution Layer

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -38,7 +38,7 @@ use tn_types::{
 use tn_worker::{
     metrics::WorkerMetrics,
     quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait},
-    Worker,
+    Worker, WorkerNetworkHandle,
 };
 use tokio::{
     sync::{mpsc::Sender, oneshot},
@@ -256,8 +256,15 @@ async fn test_with_creds_faucet_transfers_tel_with_google_kms() -> eyre::Result<
     let qw = TestChanQuorumWaiter(to_worker);
     let node_metrics = WorkerMetrics::default();
     let timeout = Duration::from_secs(5);
-    let batch_provider =
-        Worker::new(0, qw.clone(), Arc::new(node_metrics), client, store.clone(), timeout);
+    let batch_provider = Worker::new(
+        0,
+        qw.clone(),
+        Arc::new(node_metrics),
+        client,
+        store.clone(),
+        timeout,
+        WorkerNetworkHandle::new_for_test(),
+    );
 
     let shutdown = Notifier::default();
     // start batch maker


### PR DESCRIPTION
This is useful for non-CVVs to preemptively get batches.

- A worker will publish a batch hash after it has been accepted by the committee.
- Other nodes will confirm the gossip originated with the committee to help avoid any spoofing.
- Snuck a tiny consensus bus refactor in, no need to hold onto broadcast channel receivers, don't worry about not having anyone to send to.

This supports https://github.com/Telcoin-Association/telcoin-network/issues/149