### PR TITLE
Misc refactors and moved network keys to new native libp2p.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,17 +3626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
-
-[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,31 +4013,6 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand",
- "socket2",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
 version = "0.25.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d063c0692ee669aa6d261988aa19ca5510f1cc40e4f211024f50c888499a35d7"
@@ -4054,32 +4030,12 @@ dependencies = [
  "once_cell",
  "rand",
  "serde",
+ "socket2",
  "thiserror 2.0.11",
  "tinyvec",
  "tokio",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.24.2",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4090,7 +4046,7 @@ checksum = "42bc352e4412fb657e795f79b4efcf2bd60b59ee5ca0187f3554194cd1107a27"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.0-alpha.4",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
@@ -4588,16 +4544,18 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "log",
  "rand",
  "tokio",
@@ -5063,7 +5021,7 @@ dependencies = [
  "base64 0.21.7",
  "js-sys",
  "pem",
- "ring 0.17.8",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -5129,7 +5087,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -5162,9 +5120,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
 dependencies = [
  "bytes",
  "either",
@@ -5187,38 +5145,36 @@ dependencies = [
  "multiaddr",
  "pin-project 1.1.8",
  "rw-stream-sink",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+checksum = "193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef"
 dependencies = [
  "either",
  "fnv",
@@ -5234,23 +5190,21 @@ dependencies = [
  "quick-protobuf",
  "rand",
  "rw-stream-sink",
- "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tracing",
  "unsigned-varint 0.8.0",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver 0.24.2",
+ "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
@@ -5260,10 +5214,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
 dependencies = [
+ "async-channel",
  "asynchronous-codec",
  "base64 0.22.1",
  "byteorder",
@@ -5271,8 +5226,9 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-ticker",
+ "futures-timer",
  "getrandom",
+ "hashlink",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
@@ -5283,9 +5239,7 @@ dependencies = [
  "rand",
  "regex",
  "sha2 0.10.8",
- "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
@@ -5311,13 +5265,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
 dependencies = [
- "data-encoding",
  "futures",
- "hickory-proto 0.24.2",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -5327,14 +5280,13 @@ dependencies = [
  "socket2",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5348,53 +5300,48 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
 dependencies = [
- "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot",
  "quinn",
  "rand",
- "ring 0.17.8",
+ "ring",
  "rustls 0.23.21",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
 dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "rand",
  "smallvec",
  "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
 dependencies = [
  "either",
  "fnv",
@@ -5410,7 +5357,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
- "void",
  "web-time",
 ]
 
@@ -5428,16 +5374,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "libp2p-identity",
  "socket2",
  "tokio",
  "tracing",
@@ -5445,28 +5390,28 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
- "ring 0.17.8",
+ "ring",
  "rustls 0.23.21",
  "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "x509-parser",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5475,7 +5420,6 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
@@ -5640,15 +5584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -7368,7 +7303,7 @@ dependencies = [
  "bytes",
  "getrandom",
  "rand",
- "ring 0.17.8",
+ "ring",
  "rustc-hash 2.1.0",
  "rustls 0.23.21",
  "rustls-pki-types",
@@ -7528,12 +7463,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -8343,7 +8279,7 @@ dependencies = [
  "alloy-primitives",
  "data-encoding",
  "enr",
- "hickory-resolver 0.25.0-alpha.4",
+ "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
  "reth-ethereum-forks",
@@ -10361,31 +10297,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -10624,7 +10544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -10636,7 +10556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -10651,7 +10571,7 @@ checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -10731,8 +10651,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -10741,9 +10661,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -10858,8 +10778,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -11411,12 +11331,6 @@ dependencies = [
  "rand",
  "sha1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -11998,12 +11912,14 @@ name = "tn-config"
 version = "0.1.0"
 dependencies = [
  "backoff",
+ "blake2",
  "eyre",
  "fastcrypto",
  "humantime-serde",
  "libp2p",
  "parking_lot",
  "rand",
+ "rand_chacha",
  "reth-chainspec",
  "serde",
  "serde_json",
@@ -12256,6 +12172,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backoff",
+ "blake2",
  "bytes",
  "cfg-if",
  "consensus-metrics",
@@ -12411,6 +12328,8 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "bincode",
+ "blake2",
+ "bs58 0.5.1",
  "derive_builder",
  "eyre",
  "fastcrypto",
@@ -13102,12 +13021,6 @@ checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -13200,12 +13113,6 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11913,6 +11913,7 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "blake2",
+ "bs58 0.5.1",
  "eyre",
  "fastcrypto",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,9 @@ backoff = { version = "0.4.0", features = [
     "tokio_1",
 ] }
 
-libp2p = { version = "0.54", features = [] }
+libp2p = { version = "0.55", features = [] }
+bs58 = { version = "0.5.1" }
+blake2 = { version = "0.10.6" }
 
 # [patch.crates-io]
 # alloy-sol-type-parser = { git = "https://github.com/alloy-rs/core", commit = "6bd4aeddc899c7649c2ce9be383fd5a3d4c0b691" }

--- a/bin/telcoin-network/src/keytool/mod.rs
+++ b/bin/telcoin-network/src/keytool/mod.rs
@@ -104,8 +104,7 @@ impl KeyArgs {
                         // initialize path and warn users if overwriting keys
                         self.init_path(&authority_key_path, args.force)?;
                         // execute and store keypath
-                        args.execute(&authority_key_path, &mut config)?;
-                        config.keypath = authority_key_path;
+                        args.execute(&mut config, &datadir)?;
 
                         debug!("{config:?}");
                         Config::store_path(self.config_path(), config, ConfigFmt::YAML)?;

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -1,11 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::util::spawn_local_testnet;
-    use alloy::{
-        network::EthereumWallet,
-        primitives::{FixedBytes, Uint},
-        providers::ProviderBuilder,
-    };
+    use alloy::{network::EthereumWallet, primitives::Uint, providers::ProviderBuilder};
     use fastcrypto::traits::{KeyPair, ToFromBytes};
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
     use rand::{rngs::StdRng, SeedableRng};
@@ -118,14 +114,17 @@ mod tests {
                 let mut rng = StdRng::from_entropy();
                 let bls_keypair = BlsKeypair::generate(&mut rng);
                 let bls_pubkey = bls_keypair.public().as_bytes().to_vec();
-                let ed_25519_keypair = NetworkKeypair::generate(&mut rng);
+                let ed_25519_keypair = NetworkKeypair::generate_ed25519();
                 let ecdsa_pubkey = Address::random();
 
                 ConsensusRegistry::ValidatorInfo {
                     blsPubkey: bls_pubkey.clone().into(),
-                    ed25519Pubkey: FixedBytes::<32>::from_slice(
-                        ed_25519_keypair.public().as_bytes(),
-                    ),
+                    ed25519Pubkey: ed_25519_keypair
+                        .public()
+                        .try_into_ed25519()
+                        .expect("is an ed_25519")
+                        .to_bytes()
+                        .into(),
                     ecdsaPubkey: ecdsa_pubkey,
                     activationEpoch: activation_epoch,
                     exitEpoch: exit_epoch,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -31,6 +31,7 @@ humantime-serde = { workspace = true }
 libp2p = { workspace = true }
 backoff = { workspace = true }
 blake2 = { workspace = true }
+bs58 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,6 +21,7 @@ tn-storage = { workspace = true }
 tn-types = { workspace = true }
 eyre = { workspace = true }
 rand = { workspace = true }
+rand_chacha = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
@@ -29,6 +30,7 @@ reth-chainspec = { workspace = true }
 humantime-serde = { workspace = true }
 libp2p = { workspace = true }
 backoff = { workspace = true }
+blake2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -85,7 +85,7 @@ where
         worker_cache: WorkerCache,
     ) -> eyre::Result<Self> {
         let local_network =
-            LocalNetwork::new_from_public_key(config.validator_info.primary_network_key());
+            LocalNetwork::new_from_public_key(&key_config.primary_network_public_key());
 
         let primary_public_key = key_config.primary_public_key();
         let authority = committee

--- a/crates/config/src/keys.rs
+++ b/crates/config/src/keys.rs
@@ -1,13 +1,16 @@
 //! Cryptographic keys used by the node.
 
-use crate::{
-    read_validator_keypair_from_file, TelcoinDirs, BLS_KEYFILE, PRIMARY_NETWORK_KEYFILE,
-    WORKER_NETWORK_KEYFILE,
-};
+use crate::{TelcoinDirs, BLS_KEYFILE};
+use blake2::Digest;
+use rand::{rngs::StdRng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use reth_chainspec::ChainSpec;
 use std::sync::Arc;
 use tn_types::{
-    traits::{AllowedRng, KeyPair, Signer},
-    BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner, NetworkKeypair, NetworkPublicKey,
+    encode,
+    traits::{AllowedRng, EncodeDecodeBase64 as _, KeyPair, Signer, ToFromBytes},
+    BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner, DefaultHashFunction, Intent, IntentMessage,
+    IntentScope, NetworkKeypair, NetworkPublicKey, ProtocolSignature as _,
 };
 
 #[derive(Debug)]
@@ -15,7 +18,9 @@ struct KeyConfigInner {
     // DO NOT expose the private key to other code.  Tests that need this will provide a primary
     // key. Use the BlsSigner trait for signing for the primary.
     primary_keypair: BlsKeypair,
+    // Derived from the primary_keypair.
     primary_network_keypair: NetworkKeypair,
+    // Derived from the primary_keypair.
     worker_network_keypair: NetworkKeypair,
 }
 
@@ -26,22 +31,45 @@ pub struct KeyConfig {
 }
 
 impl KeyConfig {
-    pub fn new<TND: TelcoinDirs>(tn_datadir: &TND) -> eyre::Result<Self> {
+    pub fn read_config<TND: TelcoinDirs>(tn_datadir: &TND) -> eyre::Result<Self> {
         // TODO: find a better way to manage keys
         //
         // load keys to start the primary
         let validator_keypath = tn_datadir.validator_keys_path();
         tracing::info!(target: "telcoin::consensus_config", "loading validator keys at {:?}", validator_keypath);
+        let contents = std::fs::read_to_string(tn_datadir.validator_keys_path().join(BLS_KEYFILE))?;
         let primary_keypair =
-            read_validator_keypair_from_file(validator_keypath.join(BLS_KEYFILE))?;
-        let network_keypair =
-            read_validator_keypair_from_file(validator_keypath.join(PRIMARY_NETWORK_KEYFILE))?;
+            BlsKeypair::decode_base64(contents.as_str().trim()).map_err(|e| eyre::eyre!(e))?;
+        let primary_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "primary network keypair");
         let worker_network_keypair =
-            read_validator_keypair_from_file(validator_keypath.join(WORKER_NETWORK_KEYFILE))?;
+            Self::generate_network_keypair(&primary_keypair, "worker network keypair");
         Ok(Self {
             inner: Arc::new(KeyConfigInner {
                 primary_keypair,
-                primary_network_keypair: network_keypair,
+                primary_network_keypair,
+                worker_network_keypair,
+            }),
+        })
+    }
+
+    /// Generate a new random primary BLS key and save to the config file.
+    /// Note, this is not very secure in that it is writing the private key to a file...
+    pub fn generate_and_save<TND: TelcoinDirs>(tn_datadir: &TND) -> eyre::Result<Self> {
+        // TODO: discuss with @Utku
+        let rng = ChaCha20Rng::from_entropy();
+        // note: StdRng uses ChaCha12
+        let primary_keypair = BlsKeypair::generate(&mut StdRng::from_rng(rng)?);
+        let primary_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "primary network keypair");
+        let worker_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "worker network keypair");
+        let contents = primary_keypair.encode_base64();
+        std::fs::write(tn_datadir.validator_keys_path().join(BLS_KEYFILE), contents)?;
+        Ok(Self {
+            inner: Arc::new(KeyConfigInner {
+                primary_keypair,
+                primary_network_keypair,
                 worker_network_keypair,
             }),
         })
@@ -52,30 +80,29 @@ impl KeyConfig {
     /// Useful for testing.
     pub fn with_random<R: AllowedRng>(rng: &mut R) -> Self {
         let primary_keypair = BlsKeypair::generate(rng);
-        let network_keypair = NetworkKeypair::generate(rng);
-        let worker_network_keypair = NetworkKeypair::generate(rng);
+        let primary_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "primary network keypair");
+        let worker_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "worker network keypair");
         Self {
             inner: Arc::new(KeyConfigInner {
                 primary_keypair,
-                primary_network_keypair: network_keypair,
+                primary_network_keypair,
                 worker_network_keypair,
             }),
         }
     }
 
-    /// Generate a config with a provided primary and random network keys with provided RNG.
-    ///
-    /// Useful for testing ONLY.
-    pub fn with_primary_random_networks<R: AllowedRng>(
-        primary_keypair: BlsKeypair,
-        rng: &mut R,
-    ) -> Self {
-        let network_keypair = NetworkKeypair::generate(rng);
-        let worker_network_keypair = NetworkKeypair::generate(rng);
+    /// Create a config with a provided key- this is ONLY for testing.
+    pub fn new_with_testing_key(primary_keypair: BlsKeypair) -> Self {
+        let primary_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "primary network keypair");
+        let worker_network_keypair =
+            Self::generate_network_keypair(&primary_keypair, "worker network keypair");
         Self {
             inner: Arc::new(KeyConfigInner {
                 primary_keypair,
-                primary_network_keypair: network_keypair,
+                primary_network_keypair,
                 worker_network_keypair,
             }),
         }
@@ -87,25 +114,53 @@ impl KeyConfig {
     }
 
     /// Provide the keypair (with private key) for the network.
-    /// Allows building the anemo network.
+    /// Allows building the libp2p network.
     pub fn primary_network_keypair(&self) -> &NetworkKeypair {
         &self.inner.primary_network_keypair
     }
 
     /// The [NetworkPublicKey] for the primary network.
     pub fn primary_network_public_key(&self) -> NetworkPublicKey {
-        self.inner.primary_network_keypair.public().clone()
+        self.primary_network_keypair().public().clone().into()
     }
 
     /// Provide the keypair (with private key) for the worker network.
-    /// Allows building the anemo worker network.
+    /// Allows building the libp2p worker network.
     pub fn worker_network_keypair(&self) -> &NetworkKeypair {
         &self.inner.worker_network_keypair
     }
 
     /// The [NetworkPublicKey] for the worker network.
     pub fn worker_network_public_key(&self) -> NetworkPublicKey {
-        self.inner.worker_network_keypair.public().clone()
+        self.worker_network_keypair().public().clone().into()
+    }
+
+    /// Creates a proof of that the authority account address is owned by the
+    /// holder of authority protocol key, and also ensures that the authority
+    /// protocol public key exists.
+    ///
+    /// The proof of possession is a [BlsSignature] committed over the intent message
+    /// `intent || message` (See more at [IntentMessage] and [Intent]).
+    /// The message is constructed as: [BlsPublicKey] || [Genesis].
+    pub fn generate_proof_of_possession_bls(
+        &self,
+        chain_spec: &ChainSpec,
+    ) -> eyre::Result<BlsSignature> {
+        let mut msg = self.primary_public_key().as_bytes().to_vec();
+        let genesis_bytes = encode(&chain_spec.genesis);
+        msg.extend_from_slice(genesis_bytes.as_slice());
+        let sig = BlsSignature::new_secure(
+            &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
+            &self.inner.primary_keypair,
+        );
+        Ok(sig)
+    }
+
+    fn generate_network_keypair(primary_keypair: &BlsKeypair, seed_str: &str) -> NetworkKeypair {
+        let mut hasher = DefaultHashFunction::new();
+        hasher.update(primary_keypair.sign(seed_str.as_bytes()).as_bytes());
+        let hash = hasher.finalize();
+        NetworkKeypair::ed25519_from_bytes(hash[0..32].to_vec()).expect("invalid network key bytes")
     }
 }
 

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -12,6 +12,10 @@ use tracing::info;
 
 /// The filename to use when reading/writing the validator's BlsKey.
 pub const BLS_KEYFILE: &str = "bls.key";
+/// The filename to use when reading/writing the primary's network keys seed.
+pub const PRIMARY_NETWORK_SEED_FILE: &str = "primary.seed";
+/// The filename to use when reading/writing the network key seed used by all workers.
+pub const WORKER_NETWORK_SEED_FILE: &str = "worker.seed";
 
 /// Configuration for the Telcoin Network node.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -1,13 +1,9 @@
 //! Configurations for the Telcoin Network.
 
 use crate::{ConfigTrait, ValidatorInfo};
-use fastcrypto::traits::KeyPair as KeyPairTrait;
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize};
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::time::Duration;
 use tn_types::{
     adiri_genesis, get_available_tcp_port, get_available_udp_port, Address, BlsPublicKey,
     BlsSignature, Genesis, Multiaddr, NetworkPublicKey, WorkerIndex,
@@ -16,19 +12,10 @@ use tracing::info;
 
 /// The filename to use when reading/writing the validator's BlsKey.
 pub const BLS_KEYFILE: &str = "bls.key";
-/// The filename to use when reading/writing the primary's network key.
-pub const PRIMARY_NETWORK_KEYFILE: &str = "primary.key";
-/// The filename to use when reading/writing the network key used by all workers.
-pub const WORKER_NETWORK_KEYFILE: &str = "worker.key";
 
 /// Configuration for the Telcoin Network node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// The path where keys are stored, if successfully generated.
-    ///
-    /// Note: `PathBuf` default is "".
-    pub keypath: PathBuf,
-
     /// [ValidatorInfo] for the node
     pub validator_info: ValidatorInfo,
 
@@ -37,17 +24,20 @@ pub struct Config {
 
     /// The [Genesis] for the node.
     pub genesis: Genesis,
+
+    /// Is this an observer node?
+    pub observer: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             // defaults
-            keypath: Default::default(),
             validator_info: Default::default(),
             parameters: Default::default(),
             // specify adiri chain spec
             genesis: adiri_genesis(),
+            observer: false,
         }
     }
 }
@@ -106,11 +96,6 @@ impl Config {
     /// Return a reference to the primary's public BLS key.
     pub fn primary_bls_key(&self) -> &BlsPublicKey {
         self.validator_info.public_key()
-    }
-
-    /// Return a reference to the primary's public network key.
-    pub fn primary_network_key(&self) -> &NetworkPublicKey {
-        self.validator_info.primary_network_key()
     }
 
     /// Return a reference to the primary's [WorkerIndex].
@@ -307,16 +292,4 @@ impl Parameters {
         info!("Max concurrent requests set to {}", self.max_concurrent_requests);
         info!("Prometheus metrics server will run on {}", self.prometheus_metrics.socket_addr);
     }
-}
-
-/// Read from file as Base64 encoded `privkey` and return a KeyPair.
-///
-/// TODO: where should this function go?
-pub fn read_validator_keypair_from_file<KP, P>(path: P) -> eyre::Result<KP>
-where
-    KP: KeyPairTrait,
-    P: AsRef<Path>,
-{
-    let contents = std::fs::read_to_string(path)?;
-    KP::decode_base64(contents.as_str().trim()).map_err(|e| eyre::eyre!(e))
 }

--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -36,6 +36,7 @@ tap = { workspace = true }
 
 fastcrypto = { workspace = true }
 fastcrypto-tbls = { workspace = true }
+blake2 = { workspace = true }
 tn-network-types = { workspace = true }
 tn-types = { workspace = true }
 tn-config = { workspace = true }

--- a/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
@@ -3,7 +3,8 @@
 use crate::consensus::{
     Bullshark, ConsensusMetrics, ConsensusState, LeaderSchedule, LeaderSwapTable,
 };
-use fastcrypto::hash::{Hash, HashFunction};
+use blake2::Digest as _;
+use fastcrypto::hash::Hash;
 use futures::{stream::FuturesUnordered, StreamExt};
 use rand::{
     distributions::{Bernoulli, Distribution},

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -24,7 +24,7 @@ use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
     now, try_decode, AuthorityIdentifier, BlockHash, Certificate, CertificateDigest,
-    ConsensusHeader, Database, Header, Round, SignatureVerificationState, TnSender as _, Vote,
+    ConsensusHeader, Database, Header, Round, SignatureVerificationState, Vote,
 };
 use tracing::{debug, error, warn};
 
@@ -65,7 +65,6 @@ where
     /// the certificate can be retrieved and timesout after some time. It's important to give up
     /// after enough time to limit the DoS attack surface. Peers who timeout must lose reputation.
     pub(super) async fn process_gossip(&self, msg: &GossipMessage) -> PrimaryNetworkResult<()> {
-        let msg_clone = msg.clone();
         // deconstruct message
         let GossipMessage { data, .. } = msg;
 
@@ -83,9 +82,6 @@ where
                 let _ = self.consensus_bus.last_published_consensus_num_hash().send((number, hash));
             }
         }
-        // Send the raw gossip out to whoever else might need it.
-        // This should probably be multiple more focussed channels but sorting this out now.
-        let _ = self.consensus_bus.consensus_network_gossip().try_send(msg_clone);
 
         Ok(())
     }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -9,12 +9,13 @@ use crate::{
 use assert_matches::assert_matches;
 use fastcrypto::hash::Hash as _;
 use std::collections::{BTreeMap, BTreeSet};
+use tn_network_libp2p::PeerId;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
 use tn_types::{
-    error::HeaderError, network_public_key_to_libp2p, now, traits::InsecureDefault,
-    AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash, Certificate, CertificateDigest,
-    ExecHeader, SealedHeader, TaskManager,
+    error::HeaderError, network_public_key_to_libp2p, now, AuthorityIdentifier, BlockHash,
+    BlockHeader, BlockNumHash, Certificate, CertificateDigest, ExecHeader, SealedHeader,
+    TaskManager,
 };
 use tracing::debug;
 
@@ -138,8 +139,7 @@ async fn test_vote_fails_wrong_authority_network_key() -> eyre::Result<()> {
 
     let parents = Vec::with_capacity(0);
     // workaround until anemo/fastcrypto replaced
-    let default = fastcrypto::ed25519::Ed25519PublicKey::insecure_default();
-    let random_peer_id = network_public_key_to_libp2p(&default);
+    let random_peer_id = PeerId::random(); //network_public_key_to_libp2p(&default);
 
     // create valid header proposed by last peer in the committee for round 1
     let header = committee

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -165,9 +165,8 @@ mod tests {
     use crate::{WorkerRequest, WorkerResponse};
 
     use super::*;
-    use fastcrypto::traits::KeyPair;
     use itertools::Itertools as _;
-    use rand::rngs::StdRng;
+    use rand::{rngs::StdRng, RngCore};
     use tempfile::TempDir;
     use tn_network_libp2p::{
         types::{NetworkCommand, NetworkHandle},
@@ -175,7 +174,7 @@ mod tests {
     };
     use tn_storage::open_db;
     use tn_test_utils::transaction;
-    use tn_types::{network_public_key_to_libp2p, NetworkKeypair};
+    use tn_types::NetworkKeypair;
     use tokio::sync::{mpsc, Mutex};
 
     #[tokio::test]
@@ -460,6 +459,11 @@ mod tests {
     fn test_pk(i: u8) -> PeerId {
         use rand::SeedableRng;
         let mut rng = StdRng::from_seed([i; 32]);
-        network_public_key_to_libp2p(NetworkKeypair::generate(&mut rng).public())
+        let mut bytes = [0_u8; 32];
+        rng.fill_bytes(&mut bytes);
+        NetworkKeypair::ed25519_from_bytes(bytes)
+            .expect("invalid network key bytes")
+            .public()
+            .to_peer_id()
     }
 }

--- a/crates/execution/tn-rpc/src/handshake.rs
+++ b/crates/execution/tn-rpc/src/handshake.rs
@@ -2,8 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 use tn_types::{
-    generate_proof_of_possession_network, traits::KeyPair, verify_proof_of_possession_network,
-    Genesis, Multiaddr, NetworkKeypair, NetworkPublicKey, NetworkSignature,
+    generate_proof_of_possession_network, verify_proof_of_possession_network, Genesis, Multiaddr,
+    NetworkKeypair, NetworkPublicKey, NetworkSignature,
 };
 
 /// The struct containing the necessary information for peer handshake.
@@ -63,14 +63,13 @@ impl HandshakeBuilder {
         // generate proof of possession using network keys
         let proof = generate_proof_of_possession_network(&network_keypair, &genesis);
 
-        Handshake { network_key: network_keypair.public().clone(), proof, address }
+        Handshake { network_key: network_keypair.public().clone().into(), proof, address }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{rngs::StdRng, SeedableRng as _};
     use std::str::FromStr as _;
     use tn_types::adiri_genesis;
 
@@ -78,7 +77,7 @@ mod tests {
     fn test_handshake_proof() {
         let multiaddr: Multiaddr =
             Multiaddr::from_str("/ip4/10.10.10.33/udp/49590").expect("valid multiaddr");
-        let network_keypair = NetworkKeypair::generate(&mut StdRng::from_seed([0; 32]));
+        let network_keypair = NetworkKeypair::generate_ed25519();
         let genesis = adiri_genesis();
 
         let mut handshake =
@@ -86,7 +85,7 @@ mod tests {
         assert!(handshake.verify_proof(&genesis));
 
         // use wrong key
-        let malicious_key = NetworkKeypair::generate(&mut StdRng::from_seed([3; 32]));
+        let malicious_key = NetworkKeypair::generate_ed25519();
         let malicious_sig = generate_proof_of_possession_network(&malicious_key, &genesis);
         handshake.proof = malicious_sig;
 

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -26,7 +26,7 @@ use std::{
     time::Duration,
 };
 use tn_config::{ConsensusConfig, LibP2pConfig};
-use tn_types::network_public_key_to_libp2p;
+use tn_types::NetworkKeypair;
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     oneshot,
@@ -125,7 +125,7 @@ where
         DB: tn_types::database_traits::Database,
     {
         let topics = vec![IdentTopic::new("tn-primary")];
-        let network_key = config.key_config().primary_network_keypair().as_ref().to_vec();
+        let network_key = config.key_config().primary_network_keypair().clone();
         let authorized_publishers = config.committee_peer_ids();
         Self::new(config, event_stream, topics, network_key, authorized_publishers)
     }
@@ -139,13 +139,9 @@ where
         DB: tn_types::database_traits::Database,
     {
         let topics = vec![IdentTopic::new("tn-worker")];
-        let network_key = config.key_config().worker_network_keypair().as_ref().to_vec();
-        let authorized_publishers = config
-            .worker_cache()
-            .all_workers()
-            .iter()
-            .map(|(id, _)| network_public_key_to_libp2p(id))
-            .collect();
+        let network_key = config.key_config().worker_network_keypair().clone();
+        let authorized_publishers =
+            config.worker_cache().all_workers().iter().map(|(id, _)| *id).collect();
         Self::new(config, event_stream, topics, network_key, authorized_publishers)
     }
 
@@ -154,16 +150,12 @@ where
         consensus_config: &ConsensusConfig<DB>,
         event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
         topics: Vec<IdentTopic>,
-        mut ed25519_private_key_bytes: Vec<u8>,
+        keypair: NetworkKeypair,
         authorized_publishers: HashSet<PeerId>,
     ) -> NetworkResult<Self>
     where
         DB: tn_types::database_traits::Database,
     {
-        // create libp2p keypair from ed25519 secret bytes
-        let keypair =
-            libp2p::identity::Keypair::ed25519_from_bytes(&mut ed25519_private_key_bytes)?;
-
         let gossipsub_config = gossipsub::ConfigBuilder::default()
             // explicitly set default
             .heartbeat_interval(Duration::from_secs(1))
@@ -512,14 +504,12 @@ where
                 trace!(target: "network", ?msg_acceptance, "gossip message verification status");
 
                 // report message validation results
-                if let Err(e) =
-                    self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
-                        &message_id,
-                        &propagation_source,
-                        msg_acceptance.into(),
-                    )
-                {
-                    error!(target: "network", topics=?self.topics, ?propagation_source, ?message_id, ?e, "error reporting message validation result");
+                if !self.swarm.behaviour_mut().gossipsub.report_message_validation_result(
+                    &message_id,
+                    &propagation_source,
+                    msg_acceptance.into(),
+                ) {
+                    error!(target: "network", topics=?self.topics, ?propagation_source, ?message_id, "error reporting message validation result");
                 }
             }
             GossipEvent::Subscribed { peer_id, topic } => {
@@ -532,6 +522,9 @@ where
                 // TODO: remove peer at self point?
                 trace!(target: "network", topics=?self.topics, ?peer_id, "gossipsub event - not supported")
             }
+            GossipEvent::SlowPeer { peer_id, failed_messages } => {
+                trace!(target: "network", topics=?self.topics, ?peer_id, ?failed_messages, "gossipsub event - not supported")
+            }
         }
 
         Ok(())
@@ -540,7 +533,7 @@ where
     /// Process req/res events.
     fn process_reqres_event(&mut self, event: ReqResEvent<Req, Res>) -> NetworkResult<()> {
         match event {
-            ReqResEvent::Message { peer, message } => {
+            ReqResEvent::Message { peer, message, connection_id: _ } => {
                 match message {
                     request_response::Message::Request { request_id, request, channel } => {
                         let (notify, cancel) = oneshot::channel();
@@ -568,7 +561,7 @@ where
                     }
                 }
             }
-            ReqResEvent::OutboundFailure { peer, request_id, error } => {
+            ReqResEvent::OutboundFailure { peer, request_id, error, connection_id: _ } => {
                 error!(target: "network", ?peer, ?error, "outbound failure");
                 // try to forward error to original caller
                 let _ = self
@@ -577,7 +570,7 @@ where
                     .ok_or(NetworkError::PendingRequestChannelLost)?
                     .send(Err(error.into()));
             }
-            ReqResEvent::InboundFailure { peer, request_id, error } => {
+            ReqResEvent::InboundFailure { peer, request_id, error, connection_id: _ } => {
                 match error {
                     ReqResInboundFailure::Io(e) => {
                         // TODO: update peer score - could be malicious

--- a/crates/network-types/src/local.rs
+++ b/crates/network-types/src/local.rs
@@ -6,11 +6,7 @@ use crate::{
 use libp2p::PeerId;
 use parking_lot::RwLock;
 use std::{collections::HashSet, sync::Arc};
-use tn_types::{
-    network_public_key_to_libp2p,
-    traits::{InsecureDefault, KeyPair},
-    BlockHash, NetworkKeypair, NetworkPublicKey,
-};
+use tn_types::{network_public_key_to_libp2p, BlockHash, NetworkKeypair, NetworkPublicKey};
 
 // // //
 //
@@ -62,7 +58,7 @@ impl LocalNetwork {
     }
 
     pub fn new_from_keypair(primary_network_keypair: &NetworkKeypair) -> Self {
-        Self::new(network_public_key_to_libp2p(primary_network_keypair.public()))
+        Self::new(primary_network_keypair.public().to_peer_id())
     }
 
     /// Create a new [LocalNetwork] from the primary's network key.
@@ -71,7 +67,7 @@ impl LocalNetwork {
     }
 
     pub fn new_with_empty_id() -> Self {
-        Self::new(network_public_key_to_libp2p(&NetworkPublicKey::insecure_default()))
+        Self::new(network_public_key_to_libp2p(&NetworkKeypair::generate_ed25519().public().into()))
     }
 
     pub fn set_worker_to_primary_local_handler(&self, handler: Arc<dyn WorkerToPrimaryClient>) {

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -42,8 +42,8 @@ impl<DB: Database> AuthorityFixture<DB> {
     }
 
     /// The authority's ed25519 [NetworkKeypair] used to sign messages on the network.
-    pub fn primary_network_keypair(&self) -> NetworkKeypair {
-        self.consensus_config.key_config().primary_network_keypair().copy()
+    pub fn primary_network_keypair(&self) -> &NetworkKeypair {
+        self.consensus_config.key_config().primary_network_keypair()
     }
 
     /// The authority's [Address] for execution layer.

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -107,8 +107,7 @@ where
         // Pass 1 to make the authorities so we can make the committee struct we need later.
         for i in 0..committee_size {
             let primary_keypair = BlsKeypair::generate(&mut rng);
-            let key_config =
-                KeyConfig::with_primary_random_networks(primary_keypair.copy(), &mut rng);
+            let key_config = KeyConfig::new_with_testing_key(primary_keypair.copy());
             let host = "127.0.0.1";
             let port = if self.randomize_ports {
                 get_available_udp_port(host).unwrap_or(DEFAULT_WORKER_PORT)

--- a/crates/test-utils/src/worker.rs
+++ b/crates/test-utils/src/worker.rs
@@ -1,6 +1,5 @@
 //! Worker fixture for the cluster
 
-use fastcrypto::traits::KeyPair as _;
 use tn_config::KeyConfig;
 use tn_types::{NetworkKeypair, WorkerId, WorkerInfo};
 
@@ -15,8 +14,8 @@ pub struct WorkerFixture {
 }
 
 impl WorkerFixture {
-    pub fn keypair(&self) -> NetworkKeypair {
-        self.key_config.worker_network_keypair().copy()
+    pub fn keypair(&self) -> &NetworkKeypair {
+        self.key_config.worker_network_keypair()
     }
 
     pub fn info(&self) -> &WorkerInfo {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -48,6 +48,8 @@ parking_lot = { workspace = true }
 serde_yaml = { workspace = true }
 secp256k1 = { workspace = true }
 libp2p = { workspace = true }
+bs58 = { workspace = true }
+blake2 = { workspace = true }
 alloy = { workspace = true, features = ["genesis"] }
 
 [dev-dependencies]

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -627,7 +627,7 @@ mod tests {
         let authorities = (0..num_of_authorities)
             .map(|i| {
                 let keypair = BlsKeypair::generate(&mut rng);
-                let network_keypair = NetworkKeypair::generate(&mut rng);
+                let network_keypair = NetworkKeypair::generate_ed25519();
                 let execution_address = Address::random();
 
                 let a = Authority::new(
@@ -635,7 +635,7 @@ mod tests {
                     1,
                     Multiaddr::empty(),
                     execution_address,
-                    network_keypair.public().clone(),
+                    network_keypair.public().clone().into(),
                     i.to_string(),
                 );
 

--- a/crates/types/src/crypto/network.rs
+++ b/crates/types/src/crypto/network.rs
@@ -2,38 +2,8 @@
 
 use super::{
     Intent, IntentMessage, IntentScope, NetworkKeypair, NetworkPublicKey, NetworkSignature,
-    ProtocolSignature,
 };
 use crate::{encode, Genesis};
-use fastcrypto::{
-    error::FastCryptoError,
-    traits::{KeyPair as _, Signer, ToFromBytes as _, VerifyingKey as _},
-};
-use serde::Serialize;
-
-impl ProtocolSignature for NetworkSignature {
-    type Pubkey = NetworkPublicKey;
-
-    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Self>) -> Self
-    where
-        T: Serialize,
-    {
-        let message = encode(&value);
-        secret.sign(&message)
-    }
-
-    fn verify_secure<T>(
-        &self,
-        value: &IntentMessage<T>,
-        public_key: &NetworkPublicKey,
-    ) -> Result<(), FastCryptoError>
-    where
-        T: Serialize,
-    {
-        let message = encode(&value);
-        public_key.verify(&message, self)
-    }
-}
 
 /// Generate a proof for handshake.
 ///
@@ -46,13 +16,11 @@ pub fn generate_proof_of_possession_network(
     keypair: &NetworkKeypair,
     genesis: &Genesis,
 ) -> NetworkSignature {
-    let mut msg = keypair.public().as_bytes().to_vec();
+    let mut msg = keypair.public().encode_protobuf();
     let genesis_bytes = encode(&genesis);
     msg.extend_from_slice(genesis_bytes.as_slice());
-    NetworkSignature::new_secure(
-        &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
-        keypair,
-    )
+    let message = encode(&IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg));
+    keypair.sign(&message).expect("failed to sign proof of possession")
 }
 
 /// Verify proof of possession against the expected intent message.
@@ -64,13 +32,9 @@ pub fn verify_proof_of_possession_network(
     public_key: &NetworkPublicKey,
     genesis: &Genesis,
 ) -> bool {
-    let mut msg = public_key.as_bytes().to_vec();
+    let mut msg = public_key.encode_protobuf();
     let genesis_bytes = encode(genesis);
     msg.extend_from_slice(genesis_bytes.as_slice());
-    proof
-        .verify_secure(
-            &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
-            public_key,
-        )
-        .is_ok()
+    let message = encode(&IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg));
+    public_key.verify(&message, proof)
 }

--- a/crates/types/src/crypto/network.rs
+++ b/crates/types/src/crypto/network.rs
@@ -1,9 +1,99 @@
 //! Crypto functions to help with new node handshake using network keys.
 
-use super::{
-    Intent, IntentMessage, IntentScope, NetworkKeypair, NetworkPublicKey, NetworkSignature,
-};
+use std::{fmt, ops::Deref};
+
+use serde::{Deserialize, Serialize};
+
+use super::{Intent, IntentMessage, IntentScope};
 use crate::{encode, Genesis};
+
+/// Public key used to sign network messages between peers during consensus.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NetworkPublicKey(libp2p::identity::PublicKey);
+/// Keypair used to sign network messages between peers during consensus.
+pub type NetworkKeypair = libp2p::identity::Keypair;
+/// Signature using network key.
+pub type NetworkSignature = Vec<u8>;
+
+impl NetworkPublicKey {}
+
+impl From<libp2p::identity::PublicKey> for NetworkPublicKey {
+    fn from(value: libp2p::identity::PublicKey) -> Self {
+        Self(value)
+    }
+}
+
+impl From<NetworkPublicKey> for libp2p::identity::PublicKey {
+    fn from(value: NetworkPublicKey) -> Self {
+        value.0
+    }
+}
+
+impl Deref for NetworkPublicKey {
+    type Target = libp2p::identity::PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for NetworkPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&bs58::encode(self.encode_protobuf()).into_string())
+        } else {
+            serializer.serialize_bytes(&self.encode_protobuf()[..])
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NetworkPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::*;
+
+        struct NetworkPublicKeyVisitor;
+
+        impl Visitor<'_> for NetworkPublicKeyVisitor {
+            type Value = NetworkPublicKey;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "valid network public key")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(NetworkPublicKey(
+                    libp2p::identity::PublicKey::try_decode_protobuf(v)
+                        .map_err(|_| Error::invalid_value(Unexpected::Bytes(v), &self))?,
+                ))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes = bs58::decode(v)
+                    .into_vec()
+                    .map_err(|_| Error::invalid_value(Unexpected::Str(v), &self))?;
+                self.visit_bytes(&bytes)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(NetworkPublicKeyVisitor)
+        } else {
+            deserializer.deserialize_bytes(NetworkPublicKeyVisitor)
+        }
+    }
+}
 
 /// Generate a proof for handshake.
 ///

--- a/crates/types/src/database_traits.rs
+++ b/crates/types/src/database_traits.rs
@@ -28,7 +28,7 @@ pub trait DbTx {
 }
 
 /// Interface to a DB write transaction.
-pub trait DbTxMut {
+pub trait DbTxMut: DbTx {
     /// Returns the value for the given key from the map, if it exists.
     fn insert<T: Table>(&mut self, key: &T::Key, value: &T::Value) -> eyre::Result<()>;
 

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -8,7 +8,8 @@
 
 use super::{CommittedSubDag, ConsensusOutput};
 use crate::{crypto, error::CertificateResult, BlockHash, Certificate, Committee, B256};
-use fastcrypto::hash::{Hash, HashFunction};
+use blake2::Digest as _;
+use fastcrypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -50,7 +51,7 @@ impl ConsensusHeader {
         hasher.update(parent_hash);
         hasher.update(sub_dag.digest());
         hasher.update(number.to_le_bytes());
-        BlockHash::from_slice(&hasher.finalize().digest)
+        BlockHash::from_slice(&hasher.finalize()[..])
     }
 
     /// Verify that all of the contained certificates are valid and signed by a quorum of committee.

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -5,8 +5,9 @@ use crate::{
     Round, TimestampSec, VoteDigest, WorkerCache, WorkerId,
 };
 use base64::{engine::general_purpose, Engine};
+use blake2::Digest as _;
 use derive_builder::Builder;
-use fastcrypto::hash::{Digest, Hash, HashFunction};
+use fastcrypto::hash::{Digest, Hash};
 use fastcrypto_tbls::{tbls::ThresholdBls, types::ThresholdBls12381MinSig};
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;

--- a/crates/types/src/primary/info.rs
+++ b/crates/types/src/primary/info.rs
@@ -1,6 +1,5 @@
 //! Primary information for peers.
-use crate::{crypto::NetworkPublicKey, get_available_udp_port, Multiaddr, WorkerIndex};
-use fastcrypto::traits::InsecureDefault;
+use crate::{get_available_udp_port, Multiaddr, NetworkKeypair, NetworkPublicKey, WorkerIndex};
 use serde::{Deserialize, Serialize};
 
 /// Information for the Primary.
@@ -46,11 +45,11 @@ impl Default for PrimaryInfo {
         let primary_udp_port = get_available_udp_port(&host).unwrap_or(49590).to_string();
 
         Self {
-            network_key: NetworkPublicKey::insecure_default(),
+            network_key: NetworkKeypair::generate_ed25519().public().into(),
             network_address: format!("/ip4/{}/udp/{}/quic-v1", &host, primary_udp_port)
                 .parse()
                 .expect("multiaddr parsed for primary"),
-            worker_network_key: NetworkPublicKey::insecure_default(),
+            worker_network_key: NetworkKeypair::generate_ed25519().public().into(),
             worker_index: Default::default(),
         }
     }

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -8,7 +8,8 @@ use crate::{
     Address, Batch, BlockHash, Certificate, Committee, Epoch, ReputationScores, Round,
     TimestampSec, B256,
 };
-use fastcrypto::hash::{Digest, Hash, HashFunction};
+use blake2::Digest as _;
+use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashSet, VecDeque},

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -7,7 +7,7 @@ use crate::{
     adiri_chain_spec, crypto, encode, now, Address, BlockHash, ExecHeader, TimestampSec,
     MIN_PROTOCOL_BASE_FEE,
 };
-use fastcrypto::hash::HashFunction;
+use blake2::Digest as _;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
@@ -113,7 +113,7 @@ impl Batch {
         let mut hasher = crypto::DefaultHashFunction::new();
         hasher.update(encode(self));
         // finalize
-        BlockHash::from_slice(&hasher.finalize().digest)
+        BlockHash::from_slice(&hasher.finalize()[..])
     }
 
     /// Timestamp of this batch header.


### PR DESCRIPTION
- Add a -observer command line arg (not fully functional yet).
- Minor version bump of libp2p and a couple fixes for that.
- Move Network Keys to native libp2p format and away from fast crypto.
- Derive network keys from a nodes BLS primary key now, no need to save them on disk and should be helpful when we properly protect the BLS key.
- Refactors around KeyConfig so it generates and saves the keys now itself (as well as loads them).  Get this functionality in one place.