### PR TITLE
Remove the fast crypto crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "base64 0.21.7",
  "bitflags 1.3.2",
  "bytes",
@@ -1367,7 +1367,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1387,6 +1387,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1425,25 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -2155,7 +2200,7 @@ name = "consensus-metrics"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "eyre",
  "futures",
  "once_cell",
@@ -4009,6 +4054,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.5.2",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5349,6 +5407,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -6699,7 +6763,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror 1.0.69",
 ]
 
@@ -6833,11 +6896,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "bytes",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11158,7 +11233,7 @@ dependencies = [
  "tn-test-utils",
  "tn-types",
  "tokio",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
  "vergen",
 ]
@@ -11499,7 +11574,7 @@ dependencies = [
  "tn-test-utils",
  "tn-types",
  "tokio",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
 ]
 
@@ -11540,7 +11615,7 @@ dependencies = [
  "tn-worker",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
 ]
 
@@ -11583,7 +11658,7 @@ dependencies = [
  "serde",
  "snap",
  "tn-types",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
 ]
 
@@ -11822,7 +11897,7 @@ dependencies = [
  "tn-types",
  "tn-worker",
  "tokio",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -11915,7 +11990,7 @@ dependencies = [
  "tn-test-utils",
  "tn-types",
  "tokio",
- "tonic 0.10.2",
+ "tonic 0.13.0",
  "tracing",
 ]
 
@@ -12090,50 +12165,20 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
- "percent-encoding",
- "pin-project 1.1.8",
- "prost 0.12.6",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project 1.1.8",
  "prost 0.12.6",
@@ -12147,6 +12192,35 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots 0.26.7",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+dependencies = [
+ "async-trait",
+ "axum 0.8.1",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.8",
+ "prost 0.13.4",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -12178,11 +12252,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.7.1",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more",
  "k256",
  "rand",
  "serde",
@@ -230,7 +230,7 @@ dependencies = [
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more",
  "itoa",
  "serde",
  "serde_json",
@@ -274,7 +274,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "k256",
  "rand",
  "serde",
@@ -294,7 +294,7 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "once_cell",
@@ -391,7 +391,7 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "foldhash",
  "getrandom",
  "hashbrown 0.15.2",
@@ -406,7 +406,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.0",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -602,7 +602,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonrpsee-types",
@@ -872,7 +872,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "nybbles",
  "proptest",
  "proptest-derive",
@@ -991,23 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,30 +1074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-secp256r1"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,21 +1089,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1398,12 +1345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,21 +1557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,25 +1595,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array",
 ]
 
@@ -1699,12 +1611,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "block-padding"
@@ -1899,12 +1805,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
@@ -1921,26 +1821,6 @@ dependencies = [
  "memchr",
  "regex-automata 0.4.9",
  "serde",
-]
-
-[[package]]
-name = "bulletproofs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e698f1df446cc6246afd823afbe2d121134d089c9102c1dd26d1264991ba32"
-dependencies = [
- "byteorder",
- "clear_on_drop",
- "curve25519-dalek-ng",
- "digest 0.9.0",
- "merlin",
- "rand",
- "rand_core",
- "serde",
- "serde_derive",
- "sha3 0.9.1",
- "subtle-ng",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2067,15 +1947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -2220,15 +2091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,18 +2206,6 @@ name = "const-str"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -2603,20 +2453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core",
- "serde",
- "subtle-ng",
- "zeroize",
-]
-
-[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,23 +2594,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2857,19 +2682,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -2883,7 +2695,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -3045,13 +2857,13 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.9",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "serdect",
  "signature",
- "spki 0.7.3",
+ "spki",
 ]
 
 [[package]]
@@ -3060,23 +2872,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature",
-]
-
-[[package]]
-name = "ed25519-consensus"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
-dependencies = [
- "curve25519-dalek-ng",
- "hex",
- "rand_core",
- "serde",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "zeroize",
 ]
 
 [[package]]
@@ -3112,8 +2909,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "serdect",
@@ -3158,7 +2955,7 @@ dependencies = [
  "rand",
  "secp256k1 0.29.1",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "zeroize",
 ]
 
@@ -3293,92 +3090,6 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
-name = "fastcrypto"
-version = "0.1.7"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=802c1ac98061687d6ce024849c747a250dbeea52#802c1ac98061687d6ce024849c747a250dbeea52"
-dependencies = [
- "aes",
- "aes-gcm",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-secp256r1",
- "ark-serialize 0.4.2",
- "auto_ops",
- "base64ct",
- "bincode",
- "blake2",
- "blake3",
- "blst",
- "bs58 0.4.0",
- "bulletproofs",
- "cbc",
- "ctr",
- "curve25519-dalek-ng",
- "derive_more 0.99.18",
- "digest 0.10.7",
- "ecdsa",
- "ed25519-consensus",
- "elliptic-curve",
- "eyre",
- "fastcrypto-derive",
- "generic-array",
- "hex",
- "hkdf",
- "lazy_static",
- "merlin",
- "once_cell",
- "p256",
- "rand",
- "readonly",
- "rfc6979",
- "rsa",
- "schemars",
- "secp256k1 0.27.0",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_with 2.3.3",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "signature",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=802c1ac98061687d6ce024849c747a250dbeea52#802c1ac98061687d6ce024849c747a250dbeea52"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fastcrypto-tbls"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=802c1ac98061687d6ce024849c747a250dbeea52#802c1ac98061687d6ce024849c747a250dbeea52"
-dependencies = [
- "bcs",
- "bincode",
- "digest 0.10.7",
- "fastcrypto",
- "fastcrypto-derive",
- "hex",
- "itertools 0.10.5",
- "rand",
- "serde",
- "sha3 0.10.8",
- "typenum",
- "zeroize",
-]
 
 [[package]]
 name = "fastrand"
@@ -4664,7 +4375,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "block-padding 0.3.3",
+ "block-padding",
  "generic-array",
 ]
 
@@ -5114,12 +4825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
 name = "libp2p"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,7 +4956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
  "asn1_der",
- "bs58 0.5.1",
+ "bs58",
  "ed25519-dalek",
  "hkdf",
  "libsecp256k1",
@@ -5667,18 +5372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core",
- "zeroize",
 ]
 
 [[package]]
@@ -6238,23 +5931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6307,7 +5983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -6410,7 +6085,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "serde",
  "serde_with 3.12.0",
  "thiserror 2.0.11",
@@ -6429,7 +6104,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -6531,18 +6206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6623,15 +6286,6 @@ checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -6765,35 +6419,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
-dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.9",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6931,15 +6563,6 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -7476,17 +7099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "readonly"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7877,7 +7489,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "derive_more 1.0.0",
+ "derive_more",
  "metrics 0.24.1",
  "parking_lot",
  "pin-project 1.1.8",
@@ -7908,7 +7520,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more",
  "once_cell",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -8044,7 +7656,7 @@ name = "reth-codecs-derive"
 version = "1.1.5"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb207661361ac9fe1d7de4b5b8e"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -8073,7 +7685,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more",
  "reth-primitives",
  "reth-primitives-traits",
 ]
@@ -8124,7 +7736,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
  "metrics 0.24.1",
  "page_size",
@@ -8159,7 +7771,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "metrics 0.24.1",
  "modular-bitfield",
  "parity-scale-codec",
@@ -8255,7 +7867,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
+ "derive_more",
  "discv5",
  "enr",
  "futures",
@@ -8335,7 +7947,7 @@ dependencies = [
  "aes",
  "alloy-primitives",
  "alloy-rlp",
- "block-padding 0.3.3",
+ "block-padding",
  "byteorder",
  "cipher",
  "concat-kdf",
@@ -8349,7 +7961,7 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.29.1",
  "sha2 0.10.8",
- "sha3 0.10.8",
+ "sha3",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
@@ -8444,7 +8056,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "metrics 0.24.1",
  "rayon",
@@ -8532,7 +8144,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "pin-project 1.1.8",
  "reth-codecs",
@@ -8562,7 +8174,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-forks",
@@ -8869,7 +8481,7 @@ dependencies = [
  "bitflags 2.8.0",
  "byteorder",
  "dashmap 6.1.0",
- "derive_more 1.0.0",
+ "derive_more",
  "indexmap 2.7.1",
  "parking_lot",
  "reth-mdbx-sys",
@@ -8932,7 +8544,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more",
  "discv5",
  "enr",
  "futures",
@@ -8983,7 +8595,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more",
  "enr",
  "futures",
  "reth-eth-wire-types",
@@ -9007,7 +8619,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "parking_lot",
  "reth-consensus",
@@ -9057,7 +8669,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "anyhow",
  "bincode",
- "derive_more 1.0.0",
+ "derive_more",
  "lz4_flex",
  "memmap2",
  "reth-fs-util",
@@ -9163,7 +8775,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
- "derive_more 1.0.0",
+ "derive_more",
  "dirs-next",
  "eyre",
  "futures",
@@ -9239,7 +8851,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "humantime",
  "pin-project 1.1.8",
@@ -9300,7 +8912,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "once_cell",
  "op-alloy-consensus",
  "rand",
@@ -9403,7 +9015,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more",
  "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
@@ -9436,7 +9048,7 @@ dependencies = [
  "auto_impl",
  "byteorder",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "k256",
  "modular-bitfield",
  "op-alloy-consensus",
@@ -9533,7 +9145,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more",
  "modular-bitfield",
  "reth-codecs",
  "serde",
@@ -9582,7 +9194,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -9773,7 +9385,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
- "derive_more 1.0.0",
+ "derive_more",
  "futures",
  "itertools 0.13.0",
  "jsonrpsee-core",
@@ -9958,7 +9570,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "alloy-primitives",
  "clap",
- "derive_more 1.0.0",
+ "derive_more",
  "serde",
  "strum",
 ]
@@ -9996,7 +9608,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
+ "derive_more",
  "reth-fs-util",
  "reth-primitives-traits",
  "reth-static-file-types",
@@ -10125,7 +9737,7 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "hash-db",
  "itertools 0.13.0",
  "nybbles",
@@ -10143,7 +9755,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
+ "derive_more",
  "metrics 0.24.1",
  "reth-db",
  "reth-db-api",
@@ -10164,7 +9776,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.1.5#3212af2d85a54eb2076
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
+ "derive_more",
  "itertools 0.13.0",
  "metrics 0.24.1",
  "rayon",
@@ -10400,27 +10012,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rsa"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
-dependencies = [
- "byteorder",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1",
- "pkcs8 0.9.0",
- "rand_core",
- "sha2 0.10.8",
- "signature",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "rtnetlink"
@@ -10727,30 +10318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "schnellru"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10790,9 +10357,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.9",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "serdect",
  "subtle",
  "zeroize",
@@ -10804,8 +10371,6 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
- "rand",
  "secp256k1-sys 0.8.1",
 ]
 
@@ -10935,30 +10500,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11133,18 +10678,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -11350,22 +10883,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.9",
+ "der",
 ]
 
 [[package]]
@@ -11455,12 +10978,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -11600,7 +11117,6 @@ dependencies = [
  "const-str",
  "ethereum-tx-sign",
  "eyre",
- "fastcrypto",
  "fdlimit",
  "futures",
  "gcloud-sdk",
@@ -11849,7 +11365,6 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "eyre",
- "fastcrypto",
  "futures-util",
  "metrics 0.23.0",
  "prometheus",
@@ -11914,9 +11429,8 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "blake2",
- "bs58 0.5.1",
+ "bs58",
  "eyre",
- "fastcrypto",
  "humantime-serde",
  "libp2p",
  "parking_lot",
@@ -11939,7 +11453,6 @@ name = "tn-engine"
 version = "0.1.0"
 dependencies = [
  "eyre",
- "fastcrypto",
  "futures",
  "futures-util",
  "reth-blockchain-tree",
@@ -11968,7 +11481,6 @@ dependencies = [
  "bytes",
  "consensus-metrics",
  "eyre",
- "fastcrypto",
  "futures",
  "indexmap 2.7.1",
  "mockall",
@@ -12001,7 +11513,6 @@ dependencies = [
  "consensus-metrics",
  "ecdsa",
  "eyre",
- "fastcrypto",
  "futures",
  "gcloud-sdk",
  "humantime",
@@ -12087,7 +11598,6 @@ dependencies = [
  "dirs-next",
  "enr",
  "eyre",
- "fastcrypto",
  "fdlimit",
  "futures",
  "jsonrpsee",
@@ -12180,8 +11690,6 @@ dependencies = [
  "consensus-metrics",
  "criterion",
  "eyre",
- "fastcrypto",
- "fastcrypto-tbls",
  "futures",
  "governor",
  "indexmap 2.7.1",
@@ -12246,7 +11754,6 @@ version = "0.1.0"
 dependencies = [
  "dashmap 6.1.0",
  "eyre",
- "fastcrypto",
  "fdlimit",
  "futures",
  "ouroboros",
@@ -12276,7 +11783,6 @@ dependencies = [
  "consensus-metrics",
  "criterion",
  "eyre",
- "fastcrypto",
  "fdlimit",
  "futures",
  "indexmap 2.7.1",
@@ -12332,11 +11838,9 @@ dependencies = [
  "bincode",
  "blake2",
  "blst",
- "bs58 0.5.1",
+ "bs58",
  "derive_builder",
  "eyre",
- "fastcrypto",
- "fastcrypto-tbls",
  "futures",
  "hex",
  "indexmap 2.7.1",
@@ -12391,7 +11895,6 @@ dependencies = [
  "bytes",
  "consensus-metrics",
  "eyre",
- "fastcrypto",
  "futures",
  "governor",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,12 +1717,13 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
+ "serde",
  "threadpool",
  "zeroize",
 ]
@@ -12330,12 +12331,14 @@ dependencies = [
  "bcs",
  "bincode",
  "blake2",
+ "blst",
  "bs58 0.5.1",
  "derive_builder",
  "eyre",
  "fastcrypto",
  "fastcrypto-tbls",
  "futures",
+ "hex",
  "indexmap 2.7.1",
  "libp2p",
  "match_opt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,8 +236,6 @@ tn-primary-metrics = { path = "./crates/consensus/primary-metrics" }
 tn-utils = { path = "./crates/tn-utils" }
 
 # misc
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "802c1ac98061687d6ce024849c747a250dbeea52" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "802c1ac98061687d6ce024849c747a250dbeea52" }
 match_opt = "0.1.2"
 serde = { version = "^1.0", features = ["derive", "rc"] }
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,8 +251,8 @@ serde-reflection = "0.3.6"
 indexmap = { version = "2.5.0", features = ["serde"] }
 itertools = "0.10.5"
 once_cell = "1.18.0"
-prometheus = "0.13.3"
-tonic = { version = "0.10", features = ["transport", "tls"] }
+prometheus = { version = "0.13.4", default-features = false }
+tonic = { version = "0.13" }
 async-trait = "0.1.61"
 dashmap = "6.0.1"
 parking_lot = "0.12.3"
@@ -282,7 +282,7 @@ tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 serde_yaml = "0.8.26"
 byteorder = "1.4.3"
 rustversion = "1.0.9"
-protobuf = { version = "2.28", features = ["with-bytes"] }
+protobuf = { version = "3.7.2", features = ["with-bytes"] }
 bytes = "1.4.0"
 anyhow = "1.0.71"
 multiaddr = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,6 +289,8 @@ bytes = "1.4.0"
 anyhow = "1.0.71"
 multiaddr = "0.18"
 humantime = "2.1.0"
+blst = "0.3.14"
+hex = "0.4.3"
 
 criterion = { version = "0.5.0", features = [
     "async",

--- a/bin/telcoin-network/Cargo.toml
+++ b/bin/telcoin-network/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 pin-project = { workspace = true }
 metrics = { workspace = true }
-fastcrypto = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 prometheus = { workspace = true }

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -2,7 +2,6 @@
 mod tests {
     use crate::util::spawn_local_testnet;
     use alloy::{network::EthereumWallet, primitives::Uint, providers::ProviderBuilder};
-    use fastcrypto::traits::{KeyPair, ToFromBytes};
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
     use rand::{rngs::StdRng, SeedableRng};
     use reth_chainspec::ChainSpec;
@@ -113,7 +112,7 @@ mod tests {
                 // generate random bls, ed25519, and ecdsa keys for each validator
                 let mut rng = StdRng::from_entropy();
                 let bls_keypair = BlsKeypair::generate(&mut rng);
-                let bls_pubkey = bls_keypair.public().as_bytes().to_vec();
+                let bls_pubkey = bls_keypair.public().to_bytes().to_vec();
                 let ed_25519_keypair = NetworkKeypair::generate_ed25519();
                 let ecdsa_pubkey = Address::random();
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,7 +15,6 @@ authors = [
 [dependencies]
 thiserror = { workspace = true }
 tracing = { workspace = true }
-fastcrypto = { workspace = true }
 tn-network-types = { workspace = true }
 tn-storage = { workspace = true }
 tn-types = { workspace = true }

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -2,7 +2,6 @@
 use crate::{
     Config, ConfigFmt, ConfigTrait as _, KeyConfig, NetworkConfig, Parameters, TelcoinDirs,
 };
-use fastcrypto::hash::Hash as _;
 use libp2p::PeerId;
 use std::{
     collections::{HashMap, HashSet},
@@ -11,7 +10,7 @@ use std::{
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
     network_public_key_to_libp2p, Authority, AuthorityIdentifier, Certificate, CertificateDigest,
-    Committee, Database, Multiaddr, Notifier, WorkerCache, WorkerId,
+    Committee, Database, Hash as _, Multiaddr, Notifier, WorkerCache, WorkerId,
 };
 
 #[derive(Debug)]

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 
 [dependencies]
 async-trait.workspace = true
-fastcrypto.workspace = true
 futures.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -2,7 +2,6 @@
 
 use crate::{errors::SubscriberResult, SubscriberError};
 use consensus_metrics::monitored_future;
-use fastcrypto::hash::Hash;
 use futures::{stream::FuturesOrdered, StreamExt};
 use state_sync::{
     get_missing_consensus, last_executed_consensus_block, save_consensus, spawn_state_sync,
@@ -21,8 +20,8 @@ use tn_primary::{
 use tn_storage::CertificateStore;
 use tn_types::{
     AuthorityIdentifier, Batch, BlockHash, CommittedSubDag, Committee, ConsensusHeader,
-    ConsensusOutput, Database, Noticer, TaskManager, TaskManagerClone, Timestamp, TnReceiver,
-    TnSender, B256,
+    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskManagerClone, Timestamp,
+    TnReceiver, TnSender, B256,
 };
 use tracing::{debug, error, info};
 
@@ -503,8 +502,7 @@ mod tests {
             .round(round)
             .epoch(0)
             .parents(parents)
-            .build()
-            .expect("valid header built for test certificate");
+            .build();
 
         let cert = committee.certificate(&header);
         (cert.digest(), cert, batches)

--- a/crates/consensus/executor/tests/consensus_integration_tests.rs
+++ b/crates/consensus/executor/tests/consensus_integration_tests.rs
@@ -1,6 +1,5 @@
 //! IT tests
 
-use fastcrypto::hash::Hash;
 use std::{collections::BTreeSet, sync::Arc};
 use tn_executor::get_restored_consensus_output;
 use tn_primary::{
@@ -10,7 +9,7 @@ use tn_primary::{
 use tn_storage::{mem_db::MemDatabase, CertificateStore, ConsensusStore};
 use tn_test_utils::CommitteeFixture;
 use tn_types::{
-    Certificate, ExecHeader, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
+    Certificate, ExecHeader, Hash as _, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 

--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -34,8 +34,6 @@ tower = { workspace = true }
 tracing = { workspace = true }
 tap = { workspace = true }
 
-fastcrypto = { workspace = true }
-fastcrypto-tbls = { workspace = true }
 blake2 = { workspace = true }
 tn-network-types = { workspace = true }
 tn-types = { workspace = true }

--- a/crates/consensus/primary/src/aggregators/votes.rs
+++ b/crates/consensus/primary/src/aggregators/votes.rs
@@ -48,7 +48,7 @@ impl VotesAggregator {
         ensure!(self.authorities_seen.insert(author), DagError::AuthorityReuse(author.to_string()));
 
         // accumulate vote and voting power
-        self.votes.push((author, vote.signature().clone()));
+        self.votes.push((author, *vote.signature()));
         self.weight += committee.stake_by_id(author);
 
         // update metrics
@@ -64,21 +64,19 @@ impl VotesAggregator {
                 Digest::from(cert.digest());
 
             // check aggregate signature verification
-            if let Err(e) = BlsAggregateSignature::try_from(
-                cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
+            if !BlsAggregateSignature::from_signature(
+                &cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
             )
-            .map_err(|_| DagError::InvalidSignature)?
             .verify_secure(&to_intent_message(certificate_digest), &pks[..])
             {
                 warn!(
                     target: "primary::votes_aggregator",
-                    ?e,
                     ?certificate_digest,
                     "Failed to verify aggregated sig on certificate",
                 );
                 self.votes.retain(|(id, sig)| {
                     let pk = committee.authority_safe(id).protocol_key();
-                    if sig.verify_secure(&to_intent_message(certificate_digest), pk).is_err() {
+                    if !sig.verify_secure(&to_intent_message(certificate_digest), pk) {
                         warn!(target: "primary::votes_aggregator", "Invalid signature on header from authority: {}", id);
                         self.weight -= committee.stake(pk);
                         false
@@ -93,7 +91,7 @@ impl VotesAggregator {
                 // cert signature verified
                 cert.set_signature_verification_state(
                     SignatureVerificationState::VerifiedDirectly(
-                        cert.aggregated_signature().ok_or(DagError::InvalidSignature)?.clone(),
+                        cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
                     ),
                 );
 

--- a/crates/consensus/primary/src/aggregators/votes.rs
+++ b/crates/consensus/primary/src/aggregators/votes.rs
@@ -1,13 +1,12 @@
 //! Aggregate votes after proposing a header.
 
-use fastcrypto::hash::{Digest, Hash};
 use std::{collections::HashSet, sync::Arc};
 use tn_primary_metrics::PrimaryMetrics;
 use tn_types::{
     ensure,
     error::{DagError, DagResult},
     to_intent_message, AuthorityIdentifier, BlsAggregateSignature, BlsSignature, Certificate,
-    Committee, Header, ProtocolSignature, SignatureVerificationState, Stake,
+    Committee, Digest, Hash as _, Header, ProtocolSignature, SignatureVerificationState, Stake,
     ValidatorAggregateSignature, Vote,
 };
 use tracing::{trace, warn};

--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -4,10 +4,11 @@ use crate::consensus::{
     utils, ConsensusError, ConsensusMetrics, ConsensusState, Dag, LeaderSchedule, LeaderSwapTable,
     Outcome,
 };
-use fastcrypto::hash::Hash;
 use std::{collections::VecDeque, sync::Arc};
 use tn_storage::ConsensusStore;
-use tn_types::{Certificate, CommittedSubDag, Committee, ReputationScores, Round, Stake};
+use tn_types::{
+    Certificate, CommittedSubDag, Committee, Hash as _, ReputationScores, Round, Stake,
+};
 use tokio::time::Instant;
 use tracing::{debug, error_span};
 

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -5,7 +5,6 @@ use crate::{
     ConsensusBus, NodeMode,
 };
 use consensus_metrics::monitored_future;
-use fastcrypto::hash::Hash;
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -16,7 +15,7 @@ use tn_config::ConsensusConfig;
 use tn_storage::{CertificateStore, ConsensusStore};
 use tn_types::{
     AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Committee, Database,
-    Noticer, Round, TaskManager, Timestamp, TnReceiver, TnSender,
+    Hash as _, Noticer, Round, TaskManager, Timestamp, TnReceiver, TnSender,
 };
 use tracing::{debug, info, instrument};
 

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -4,13 +4,12 @@ use crate::{
     consensus::{Bullshark, Consensus, ConsensusMetrics, LeaderSchedule, LeaderSwapTable},
     ConsensusBus,
 };
-use fastcrypto::hash::Hash;
 use std::{collections::BTreeSet, sync::Arc};
 use tn_storage::{mem_db::MemDatabase, CertificateStore, ConsensusStore};
 use tn_test_utils::CommitteeFixture;
 use tn_types::{
-    Certificate, ExecHeader, ReputationScores, SealedHeader, TaskManager, TnReceiver, TnSender,
-    B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    Certificate, ExecHeader, Hash as _, ReputationScores, SealedHeader, TaskManager, TnReceiver,
+    TnSender, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 
 /// This test is trying to compare the output of the Consensus algorithm when:

--- a/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
@@ -4,7 +4,6 @@ use crate::consensus::{
     Bullshark, ConsensusMetrics, ConsensusState, LeaderSchedule, LeaderSwapTable,
 };
 use blake2::Digest as _;
-use fastcrypto::hash::Hash;
 use futures::{stream::FuturesUnordered, StreamExt};
 use rand::{
     distributions::{Bernoulli, Distribution},
@@ -21,7 +20,8 @@ use std::{
 use tn_storage::{mem_db::MemDatabase, open_db, ConsensusStore};
 use tn_test_utils::{mock_certificate_with_rand, CommitteeFixture};
 use tn_types::{
-    Authority, AuthorityIdentifier, Certificate, CertificateDigest, Committee, Round, Stake,
+    Authority, AuthorityIdentifier, Certificate, CertificateDigest, Committee, Hash as _, Round,
+    Stake,
 };
 use tokio::sync::mpsc::channel;
 

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -7,7 +7,6 @@ use crate::{
     state_sync::{CertificateCollector, StateSynchronizer},
     ConsensusBus,
 };
-use fastcrypto::hash::Hash;
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -24,7 +23,7 @@ use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
     now, try_decode, AuthorityIdentifier, BlockHash, Certificate, CertificateDigest,
-    ConsensusHeader, Database, Header, Round, SignatureVerificationState, Vote,
+    ConsensusHeader, Database, Hash as _, Header, Round, SignatureVerificationState, Vote,
 };
 use tracing::{debug, error, warn};
 

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -165,10 +165,8 @@ where
             let verified = parents
                 .into_iter()
                 .map(|mut cert| {
-                    let sig = cert
-                        .aggregated_signature()
-                        .cloned()
-                        .ok_or(HeaderError::ParentMissingSignature)?;
+                    let sig =
+                        cert.aggregated_signature().ok_or(HeaderError::ParentMissingSignature)?;
                     cert.set_signature_verification_state(SignatureVerificationState::Unverified(
                         sig,
                     ));

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -345,8 +345,8 @@ where
                 //     if let Err(e) =
                 //         network_handle.handle.set_application_score(peer_id, -100.0).await
                 //     {
-                //         error!(target: "primary::network", ?e, "failed to penalize malicious peer")
-                //     }
+                //         error!(target: "primary::network", ?e, "failed to penalize malicious
+                // peer")     }
                 // }
 
                 // match on error to lower peer score

--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use std::sync::Arc;
 use tn_config::ConsensusConfig;
-use tn_types::{network_public_key_to_libp2p, traits::EncodeDecodeBase64, Database, TaskManager};
+use tn_types::{network_public_key_to_libp2p, Database, TaskManager};
 use tracing::info;
 
 #[cfg(test)]
@@ -41,7 +41,7 @@ impl<DB: Database> Primary<DB> {
         info!(
             "Boot primary node with peer id {} and public key {}",
             own_peer_id,
-            config.authority().protocol_key().encode_base64(),
+            config.authority().protocol_key().encode_base58(),
         );
 
         let worker_receiver_handler =

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -11,7 +11,6 @@ use crate::{
     ConsensusBus,
 };
 use consensus_metrics::monitored_scope;
-use fastcrypto::hash::Hash as _;
 use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
@@ -20,7 +19,7 @@ use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
     error::{CertificateError, HeaderError},
-    Certificate, CertificateDigest, Database, TnReceiver as _, TnSender as _,
+    Certificate, CertificateDigest, Database, Hash as _, TnReceiver as _, TnSender as _,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, error};

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -8,12 +8,11 @@ use crate::{
     ConsensusBus,
 };
 use consensus_metrics::monitored_scope;
-use fastcrypto::hash::Hash as _;
 use std::{collections::HashSet, sync::Arc, time::Instant};
 use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
-    error::CertificateError, Certificate, CertificateDigest, Database, Round,
+    error::CertificateError, Certificate, CertificateDigest, Database, Hash as _, Round,
     SignatureVerificationState, TnSender as _,
 };
 use tokio::sync::oneshot;

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -364,8 +364,7 @@ where
     fn mark_verified_indirectly(&self, cert: &mut Certificate) -> CertManagerResult<()> {
         cert.set_signature_verification_state(SignatureVerificationState::VerifiedIndirectly(
             cert.aggregated_signature()
-                .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?
-                .clone(),
+                .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?,
         ));
 
         Ok(())

--- a/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
@@ -7,10 +7,9 @@ use crate::{
     error::{CertManagerError, CertManagerResult},
     ConsensusBus,
 };
-use fastcrypto::hash::Hash as _;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use tn_config::ConsensusConfig;
-use tn_types::{Certificate, CertificateDigest, Database, Round};
+use tn_types::{Certificate, CertificateDigest, Database, Hash as _, Round};
 use tracing::debug;
 
 /// A certificate that is missing parents and pending approval.

--- a/crates/consensus/primary/src/tests/cert_collector_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_collector_tests.rs
@@ -1,11 +1,10 @@
 //! State sync tests for primaries.
 
 use crate::{network::MissingCertificatesRequest, state_sync::CertificateCollector};
-use fastcrypto::hash::Hash;
 use std::{collections::BTreeSet, num::NonZeroUsize};
 use tn_storage::{mem_db::MemDatabase, CertificateStore};
 use tn_test_utils::CommitteeFixture;
-use tn_types::{AuthorityIdentifier, Certificate, SignatureVerificationState};
+use tn_types::{AuthorityIdentifier, Certificate, Hash as _, SignatureVerificationState};
 
 #[test]
 fn test_certificate_iterator() {

--- a/crates/consensus/primary/src/tests/cert_manager_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_manager_tests.rs
@@ -3,7 +3,7 @@
 use super::CertificateManager;
 use crate::{error::CertManagerError, state_sync::AtomicRound, ConsensusBus};
 use assert_matches::assert_matches;
-use fastcrypto::{hash::Hash as _, traits::KeyPair};
+use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::{make_optimal_signed_certificates, CommitteeFixture};

--- a/crates/consensus/primary/src/tests/cert_manager_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_manager_tests.rs
@@ -3,11 +3,10 @@
 use super::CertificateManager;
 use crate::{error::CertManagerError, state_sync::AtomicRound, ConsensusBus};
 use assert_matches::assert_matches;
-use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::{make_optimal_signed_certificates, CommitteeFixture};
-use tn_types::{Certificate, SignatureVerificationState};
+use tn_types::{Certificate, Hash as _, SignatureVerificationState};
 
 struct TestTypes<DB = MemDatabase> {
     /// The CertificateManager

--- a/crates/consensus/primary/src/tests/cert_validator_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_validator_tests.rs
@@ -5,12 +5,12 @@ use crate::{
     state_sync::{AtomicRound, CertificateManagerCommand},
     ConsensusBus,
 };
-use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::{make_optimal_signed_certificates, CommitteeFixture};
 use tn_types::{
-    BlsSignature, Certificate, Round, SignatureVerificationState, TnReceiver as _, TnSender,
+    BlsSignature, Certificate, Hash as _, Round, SignatureVerificationState, TnReceiver as _,
+    TnSender,
 };
 
 struct TestTypes<DB = MemDatabase> {

--- a/crates/consensus/primary/src/tests/cert_validator_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_validator_tests.rs
@@ -5,13 +5,12 @@ use crate::{
     state_sync::{AtomicRound, CertificateManagerCommand},
     ConsensusBus,
 };
-use fastcrypto::{hash::Hash as _, traits::KeyPair};
+use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::{make_optimal_signed_certificates, CommitteeFixture};
 use tn_types::{
-    BlsAggregateSignatureBytes, Certificate, Round, SignatureVerificationState, TnReceiver as _,
-    TnSender,
+    BlsSignature, Certificate, Round, SignatureVerificationState, TnReceiver as _, TnSender,
 };
 
 struct TestTypes<DB = MemDatabase> {
@@ -158,7 +157,7 @@ async fn test_process_fetched_certificates_in_parallel() -> eyre::Result<()> {
         let mut cert = cert.clone();
         if cert.round() != LEAF_ROUND {
             cert.set_signature_verification_state(SignatureVerificationState::Unverified(
-                BlsAggregateSignatureBytes::default(),
+                BlsSignature::default(),
             ));
         }
         certs.push(cert);
@@ -175,7 +174,7 @@ async fn test_process_fetched_certificates_in_parallel() -> eyre::Result<()> {
         let mut cert = cert.clone();
         if round == VERIFICATION_ROUND || round == LEAF_ROUND {
             cert.set_signature_verification_state(SignatureVerificationState::Unverified(
-                BlsAggregateSignatureBytes::default(),
+                BlsSignature::default(),
             ));
         }
         certs.push(cert);
@@ -192,7 +191,7 @@ async fn test_process_fetched_certificates_in_parallel() -> eyre::Result<()> {
         let mut cert = cert.clone();
         if r != VERIFICATION_ROUND && r != LEAF_ROUND {
             cert.set_signature_verification_state(SignatureVerificationState::Unverified(
-                BlsAggregateSignatureBytes::default(),
+                BlsSignature::default(),
             ));
         }
         certs.push(cert);

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -8,13 +8,14 @@ use crate::{
     ConsensusBus,
 };
 use assert_matches::assert_matches;
-use fastcrypto::hash::Hash;
 use itertools::Itertools;
 use std::{collections::BTreeSet, time::Duration};
 use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};
 use tn_storage::{mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils::CommitteeFixture;
-use tn_types::{BlsSignature, Certificate, Header, SignatureVerificationState, TaskManager};
+use tn_types::{
+    BlsSignature, Certificate, Hash as _, Header, SignatureVerificationState, TaskManager,
+};
 use tokio::{
     sync::mpsc::{self, error::TryRecvError},
     time::sleep,

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -14,9 +14,7 @@ use std::{collections::BTreeSet, time::Duration};
 use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};
 use tn_storage::{mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils::CommitteeFixture;
-use tn_types::{
-    BlsAggregateSignatureBytes, Certificate, Header, SignatureVerificationState, TaskManager,
-};
+use tn_types::{BlsSignature, Certificate, Header, SignatureVerificationState, TaskManager};
 use tokio::{
     sync::mpsc::{self, error::TryRecvError},
     time::sleep,
@@ -344,9 +342,7 @@ async fn fetch_certificates_basic() {
                     for cert in certificates.iter().skip(num_written).take(204) {
                         let mut cert = cert.clone();
                         cert.set_signature_verification_state(
-                            SignatureVerificationState::Unverified(
-                                BlsAggregateSignatureBytes::default(),
-                            ),
+                            SignatureVerificationState::Unverified(BlsSignature::default()),
                         );
                         certs.push(cert);
                     }

--- a/crates/consensus/primary/src/tests/certificate_processing_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_processing_tests.rs
@@ -11,15 +11,14 @@ use crate::{
     ConsensusBus,
 };
 use assert_matches::assert_matches;
-use fastcrypto::hash::Hash as _;
 use std::{collections::BTreeSet, time::Duration};
 use tn_storage::{mem_db::MemDatabase, CertificateStore};
 use tn_test_utils::{
     make_optimal_signed_certificates, signed_cert_for_test, AuthorityFixture, CommitteeFixture,
 };
 use tn_types::{
-    error::CertificateError, Certificate, CertificateDigest, Database, Round, TaskManager,
-    TnReceiver as _, TnSender,
+    error::CertificateError, Certificate, CertificateDigest, Database, Hash as _, Round,
+    TaskManager, TnReceiver as _, TnSender,
 };
 use tokio::time::timeout;
 

--- a/crates/consensus/primary/src/tests/certificate_processing_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_processing_tests.rs
@@ -11,7 +11,7 @@ use crate::{
     ConsensusBus,
 };
 use assert_matches::assert_matches;
-use fastcrypto::{hash::Hash as _, traits::KeyPair};
+use fastcrypto::hash::Hash as _;
 use std::{collections::BTreeSet, time::Duration};
 use tn_storage::{mem_db::MemDatabase, CertificateStore};
 use tn_test_utils::{

--- a/crates/consensus/primary/src/tests/certificate_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_tests.rs
@@ -1,6 +1,5 @@
 //! Certificate tests
 
-use fastcrypto::traits::KeyPair as _;
 use rand::{
     rngs::{OsRng, StdRng},
     SeedableRng,

--- a/crates/consensus/primary/src/tests/certifier_tests.rs
+++ b/crates/consensus/primary/src/tests/certifier_tests.rs
@@ -5,7 +5,6 @@ use crate::{
     network::{PrimaryRequest, PrimaryResponse},
     ConsensusBus,
 };
-use fastcrypto::traits::KeyPair;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashMap, num::NonZeroUsize};
 use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};

--- a/crates/consensus/primary/src/tests/header_validator_tests.rs
+++ b/crates/consensus/primary/src/tests/header_validator_tests.rs
@@ -4,10 +4,9 @@ use std::collections::HashMap;
 
 use crate::{consensus::ConsensusRound, state_sync::HeaderValidator, ConsensusBus};
 use assert_matches::assert_matches;
-use fastcrypto::hash::Hash as _;
 use tn_storage::{mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils::{fixture_batch_with_transactions, CommitteeFixture};
-use tn_types::error::HeaderError;
+use tn_types::{error::HeaderError, Hash as _};
 
 #[tokio::test]
 async fn test_sync_batches_drops_old_rounds() -> eyre::Result<()> {
@@ -28,8 +27,7 @@ async fn test_sync_batches_drops_old_rounds() -> eyre::Result<()> {
             let header = a
                 .header_builder(&committee)
                 .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-                .build()
-                .expect("header for authority");
+                .build();
             let cert = fixture.certificate(&header);
             let digest = cert.digest();
             certificate_store.write(cert.clone()).expect("write cert to storage");
@@ -46,8 +44,7 @@ async fn test_sync_batches_drops_old_rounds() -> eyre::Result<()> {
         .round(2)
         .parents(certs.keys().cloned().collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .expect("test header build");
+        .build();
 
     // update round
     let committed_round = 30;

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -7,14 +7,13 @@ use crate::{
     ConsensusBus, RecentBlocks,
 };
 use assert_matches::assert_matches;
-use fastcrypto::hash::Hash as _;
 use std::collections::{BTreeMap, BTreeSet};
 use tn_network_libp2p::PeerId;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
 use tn_types::{
     error::HeaderError, network_public_key_to_libp2p, now, AuthorityIdentifier, BlockHash,
-    BlockHeader, BlockNumHash, Certificate, CertificateDigest, ExecHeader, SealedHeader,
+    BlockHeader, BlockNumHash, Certificate, CertificateDigest, ExecHeader, Hash as _, SealedHeader,
     TaskManager,
 };
 use tracing::debug;
@@ -96,7 +95,7 @@ async fn test_vote_succeeds() -> eyre::Result<()> {
         .header_builder_last_authority()
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, parents).await;
@@ -123,7 +122,7 @@ async fn test_vote_fails_too_many_parents() -> eyre::Result<()> {
         .header_builder_last_authority()
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, too_many_parents).await;
@@ -138,15 +137,14 @@ async fn test_vote_fails_wrong_authority_network_key() -> eyre::Result<()> {
     let TestTypes { committee, handler, parent, .. } = create_test_types();
 
     let parents = Vec::with_capacity(0);
-    // workaround until anemo/fastcrypto replaced
-    let random_peer_id = PeerId::random(); //network_public_key_to_libp2p(&default);
+    let random_peer_id = PeerId::random();
 
     // create valid header proposed by last peer in the committee for round 1
     let header = committee
         .header_builder_last_authority()
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(random_peer_id, header, parents).await;
@@ -177,7 +175,7 @@ async fn test_vote_fails_invalid_genesis_parent() -> eyre::Result<()> {
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
         .parents(wrong_genesis)
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, parents).await;
@@ -239,7 +237,7 @@ async fn test_vote_fails_invalid_timestamp() -> eyre::Result<()> {
         .header_builder_last_authority()
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(wrong_time)
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, parents).await;
@@ -264,7 +262,7 @@ async fn test_vote_fails_wrong_epoch() -> eyre::Result<()> {
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
         .epoch(wrong_epoch)
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, parents).await;
@@ -289,7 +287,7 @@ async fn test_vote_fails_unknown_authority() -> eyre::Result<()> {
         .author(wrong_authority)
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
-        .build()?;
+        .build();
 
     // process vote
     let res = handler.vote(peer_id, header, parents).await;

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -8,7 +8,6 @@ use crate::{
     state_sync::StateSynchronizer,
     ConsensusBus,
 };
-use fastcrypto::hash::Hash;
 use itertools::Itertools;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -25,7 +24,7 @@ use tn_test_utils::{
 };
 use tn_types::{
     now, AuthorityIdentifier, BlockNumHash, Certificate, Committee, Database, ExecHeader,
-    SealedHeader, SignatureVerificationState, TaskManager,
+    Hash as _, SealedHeader, SignatureVerificationState, TaskManager,
 };
 use tokio::{sync::mpsc, time::timeout};
 
@@ -96,8 +95,7 @@ async fn test_request_vote_has_missing_execution_block() {
         .latest_execution_block(BlockNumHash::default()) // dummy_hash would be correct here but this is the test...
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
     // headers with some parents but not all available. Round 1 certificates should be written
@@ -166,8 +164,7 @@ async fn test_request_vote_older_execution_block() {
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
     // headers with some parents but not all available. Round 1 certificates should be written
@@ -231,8 +228,7 @@ async fn test_request_vote_has_missing_parents() {
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
     // headers with some parents but not all available. Round 1 certificates should be written
@@ -320,8 +316,7 @@ async fn test_request_vote_accept_missing_parents() {
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     // Populate all round 1 certificates and some round 2 certificates into the storage.
     // The new header will have some round 2 certificates missing as parents, but these parents
@@ -396,8 +391,7 @@ async fn test_request_vote_missing_batches() {
         let header = primary
             .header_builder(&fixture.committee())
             .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-            .build()
-            .unwrap();
+            .build();
 
         let certificate = fixture.certificate(&header);
         let digest = certificate.clone().digest();
@@ -414,8 +408,7 @@ async fn test_request_vote_missing_batches() {
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(certificates.keys().cloned().collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     // Set up mock worker.
     let worker = primary.worker();
@@ -465,8 +458,7 @@ async fn test_request_vote_already_voted() {
         let header = primary
             .header_builder(&fixture.committee())
             .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-            .build()
-            .unwrap();
+            .build();
 
         let certificate = fixture.certificate(&header);
         let digest = certificate.clone().digest();
@@ -492,8 +484,7 @@ async fn test_request_vote_already_voted() {
         .parents(certificates.keys().cloned().collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     let vote = if let PrimaryResponse::Vote(vote) = tokio::time::timeout(
         Duration::from_secs(10),
@@ -525,8 +516,7 @@ async fn test_request_vote_already_voted() {
         .parents(certificates.keys().cloned().collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-        .build()
-        .unwrap();
+        .build();
 
     let response = handler.vote(peer, test_header, Vec::new()).await;
     assert!(response.is_err());
@@ -671,8 +661,7 @@ async fn test_request_vote_created_at_in_future() {
         let header = primary
             .header_builder(&fixture.committee())
             .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
-            .build()
-            .unwrap();
+            .build();
 
         let certificate = fixture.certificate(&header);
         let digest = certificate.clone().digest();
@@ -703,8 +692,7 @@ async fn test_request_vote_created_at_in_future() {
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
         .created_at(created_at)
-        .build()
-        .unwrap();
+        .build();
 
     // For such a future header we get back an error
     assert!(handler.vote(peer, test_header, Vec::new()).await.is_err());
@@ -721,8 +709,7 @@ async fn test_request_vote_created_at_in_future() {
         .parents(certificates.keys().cloned().collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
         .created_at(created_at)
-        .build()
-        .unwrap();
+        .build();
 
     let _vote = if let PrimaryResponse::Vote(vote) =
         handler.vote(peer, test_header, Vec::new()).await.unwrap()

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -8,7 +8,7 @@ use crate::{
     state_sync::StateSynchronizer,
     ConsensusBus,
 };
-use fastcrypto::{hash::Hash, traits::KeyPair as _};
+use fastcrypto::hash::Hash;
 use itertools::Itertools;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},

--- a/crates/consensus/primary/src/tests/synchronizer_tests.rs
+++ b/crates/consensus/primary/src/tests/synchronizer_tests.rs
@@ -6,7 +6,6 @@ use crate::{
     synchronizer::Synchronizer,
     ConsensusBus,
 };
-use fastcrypto::{hash::Hash, traits::KeyPair};
 use itertools::Itertools;
 use std::{
     collections::{BTreeSet, HashMap},
@@ -21,8 +20,8 @@ use tn_test_utils::{
 };
 use tn_types::{
     error::{CertificateError, HeaderError},
-    BlsAggregateSignatureBytes, Certificate, Committee, Round, SignatureVerificationState,
-    TaskManager, TnReceiver, TnSender,
+    BlsAggregateSignatureBytes, Certificate, Committee, Hash as _, Round,
+    SignatureVerificationState, TaskManager, TnReceiver, TnSender,
 };
 
 /// Try to accept certificate. Sleep if error.

--- a/crates/consensus/primary/tests/certificate_order_test.rs
+++ b/crates/consensus/primary/tests/certificate_order_test.rs
@@ -33,7 +33,6 @@ async fn test_certificate_signers_are_ordered() {
         1,
         1,
         IndexMap::new(),
-        Vec::new(),
         BTreeSet::new(),
         BlockNumHash::default(),
     );

--- a/crates/consensus/worker/Cargo.toml
+++ b/crates/consensus/worker/Cargo.toml
@@ -25,7 +25,6 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 
 tn-storage = { workspace = true }
-fastcrypto = { workspace = true, features = ["copy_key"] }
 tn-network-types = { workspace = true }
 tn-types = { workspace = true }
 tn-config = { workspace = true }

--- a/crates/consensus/worker/src/tests/worker_tests.rs
+++ b/crates/consensus/worker/src/tests/worker_tests.rs
@@ -7,7 +7,6 @@
 
 use super::*;
 use async_trait::async_trait;
-use fastcrypto::encoding::{Encoding, Hex};
 use prometheus::Registry;
 use std::time::Duration;
 use tempfile::TempDir;

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 
 [dependencies]
-fastcrypto = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -313,7 +313,6 @@ impl<BT, CE> std::fmt::Debug for ExecutorEngine<BT, CE> {
 #[cfg(test)]
 mod tests {
     use crate::ExecutorEngine;
-    use fastcrypto::hash::Hash as _;
     use reth_blockchain_tree::BlockchainTreeViewer;
     use reth_chainspec::ChainSpec;
     use reth_provider::{BlockIdReader, BlockNumReader, BlockReader, TransactionVariant};
@@ -324,8 +323,8 @@ mod tests {
     use tn_types::{
         adiri_chain_spec_arc, adiri_genesis, max_batch_gas, now, Address, BlockHash,
         BlockHashOrNumber, Bloom, Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput,
-        Notifier, ReputationScores, TaskManager, B256, EMPTY_OMMER_ROOT_HASH, EMPTY_WITHDRAWALS,
-        MIN_PROTOCOL_BASE_FEE, U256,
+        Hash as _, Notifier, ReputationScores, TaskManager, B256, EMPTY_OMMER_ROOT_HASH,
+        EMPTY_WITHDRAWALS, MIN_PROTOCOL_BASE_FEE, U256,
     };
     use tokio::{sync::oneshot, time::timeout};
     use tokio_stream::wrappers::BroadcastStream;

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -3,7 +3,6 @@
 //! This approach heavily inspired by reth's `default_ethereum_payload_builder`.
 
 use crate::error::{EngineResult, TnEngineError};
-use fastcrypto::hash::Hash as _;
 use reth_blockchain_tree::{BlockValidationKind, BlockchainTreeEngine};
 use reth_chainspec::ChainSpec;
 use reth_evm::ConfigureEvm;
@@ -21,9 +20,9 @@ use std::sync::Arc;
 use tn_node_traits::{BuildArguments, TNPayload, TNPayloadAttributes};
 use tn_types::{
     calculate_transaction_root, max_batch_gas, Batch, Block, BlockBody, BlockExt as _,
-    ConsensusOutput, ExecHeader, Receipt, SealedBlockWithSenders, SealedHeader, TransactionSigned,
-    Withdrawals, B256, EMPTY_OMMER_ROOT_HASH, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS,
-    EMPTY_WITHDRAWALS, U256,
+    ConsensusOutput, ExecHeader, Hash as _, Receipt, SealedBlockWithSenders, SealedHeader,
+    TransactionSigned, Withdrawals, B256, EMPTY_OMMER_ROOT_HASH, EMPTY_RECEIPTS,
+    EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, U256,
 };
 use tracing::{debug, error, info, warn};
 

--- a/crates/execution/batch-builder/Cargo.toml
+++ b/crates/execution/batch-builder/Cargo.toml
@@ -41,7 +41,6 @@ tn-test-utils = { workspace = true }
 assert_matches = { workspace = true }
 reth-blockchain-tree = { workspace = true }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
-fastcrypto = { workspace = true }
 tempfile = { workspace = true }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-consensus = { workspace = true }

--- a/crates/execution/faucet/Cargo.toml
+++ b/crates/execution/faucet/Cargo.toml
@@ -48,7 +48,6 @@ tn-types = { workspace = true }
 
 [dev-dependencies]
 prometheus = { workspace = true }
-fastcrypto = { workspace = true }
 consensus-metrics = { workspace = true }
 tn-test-utils = { workspace = true }
 tn-network-types = { workspace = true }

--- a/crates/network-libp2p/src/error.rs
+++ b/crates/network-libp2p/src/error.rs
@@ -2,7 +2,6 @@
 
 use libp2p::{
     gossipsub::{ConfigBuilderError, PublishError, SubscriptionError},
-    identity::DecodingError,
     request_response::OutboundFailure,
     swarm::DialError,
     TransportError,
@@ -65,9 +64,6 @@ pub enum NetworkError {
     /// Failed to build swarm with behavior.
     #[error("SwarmBuilder::with_behaviour failed somehow.")]
     BuildSwarm,
-    /// Temporary error - used when converting fastcrypto -> libp2p key
-    #[error(transparent)]
-    Ed25519Decode(#[from] DecodingError),
     /// Request/response RPC Error
     #[error("{0}")]
     RPCError(String),

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -26,7 +26,6 @@ enr = { workspace = true, default-features = false, features = [
     "rust-secp256k1",
 ] }
 
-fastcrypto = { workspace = true }
 tn-executor = { workspace = true }
 tn-node-traits = { workspace = true }
 tn-primary = { workspace = true }

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -1,5 +1,4 @@
 //! Hierarchical type to hold tasks spawned for a worker in the network.
-use fastcrypto::traits::VerifyingKey;
 use std::sync::Arc;
 use tn_config::ConsensusConfig;
 use tn_executor::{Executor, SubscriberResult};
@@ -9,9 +8,7 @@ use tn_primary::{
     ConsensusBus, Primary, StateSynchronizer,
 };
 use tn_primary_metrics::Metrics;
-use tn_types::{
-    BlsPublicKey, Database as ConsensusDatabase, TaskManager, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
-};
+use tn_types::{Database as ConsensusDatabase, TaskManager, DEFAULT_BAD_NODES_STAKE_THRESHOLD};
 use tokio::sync::RwLock;
 use tracing::instrument;
 
@@ -62,10 +59,7 @@ impl<CDB: ConsensusDatabase> PrimaryNodeInner<CDB> {
         &self,
         consensus_bus: &ConsensusBus,
         task_manager: &TaskManager,
-    ) -> SubscriberResult<LeaderSchedule>
-    where
-        BlsPublicKey: VerifyingKey,
-    {
+    ) -> SubscriberResult<LeaderSchedule> {
         let leader_schedule = LeaderSchedule::from_store(
             self.consensus_config.committee().clone(),
             self.consensus_config.node_storage().clone(),

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,7 +11,6 @@ authors = [
 publish = false
 
 [dependencies]
-fastcrypto.workspace = true
 tn-utils.workspace = true
 tracing.workspace = true
 tn-types = { workspace = true }

--- a/crates/storage/src/stores/certificate_store.rs
+++ b/crates/storage/src/stores/certificate_store.rs
@@ -1,6 +1,5 @@
 //! NOTE: tests for this module are in test-utils storage_tests.rs to avoid circular dependancies.
 
-use fastcrypto::hash::Hash;
 use std::{
     cmp::{max, Ordering},
     collections::BTreeMap,
@@ -14,7 +13,7 @@ use crate::{
     StoreResult, ROUNDS_TO_KEEP,
 };
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, Database, DbTx, DbTxMut, Round,
+    AuthorityIdentifier, Certificate, CertificateDigest, Database, DbTx, DbTxMut, Hash, Round,
 };
 use tn_utils::sync::notify_read::NotifyRead;
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -22,7 +22,6 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 once_cell = { workspace = true }
 
-fastcrypto = { workspace = true }
 tn-network-libp2p = { workspace = true }
 tn-network-types = { workspace = true }
 tn-node = { workspace = true }

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -1,7 +1,7 @@
 //! Authority fixture for the cluster
 
 use crate::WorkerFixture;
-use fastcrypto::{hash::Hash, traits::KeyPair as _};
+use fastcrypto::hash::Hash;
 use std::num::NonZeroUsize;
 use tn_config::{Config, ConsensusConfig, KeyConfig};
 use tn_types::{

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -1,13 +1,12 @@
 //! Authority fixture for the cluster
 
 use crate::WorkerFixture;
-use fastcrypto::hash::Hash;
 use std::num::NonZeroUsize;
 use tn_config::{Config, ConsensusConfig, KeyConfig};
 use tn_types::{
     Address, Authority, AuthorityIdentifier, BlsKeypair, BlsPublicKey, Certificate, Committee,
-    Database, Header, HeaderBuilder, Multiaddr, NetworkKeypair, NetworkPublicKey, Round, Vote,
-    WorkerCache,
+    Database, Hash as _, Header, HeaderBuilder, Multiaddr, NetworkKeypair, NetworkPublicKey, Round,
+    Vote, WorkerCache,
 };
 
 /// Fixture representing an validator node within the network.
@@ -73,12 +72,12 @@ impl<DB: Database> AuthorityFixture<DB> {
 
     /// Create a [Header] with a default payload based on the [Committee] argument.
     pub fn header(&self, committee: &Committee) -> Header {
-        self.header_builder(committee).build().unwrap()
+        self.header_builder(committee).build()
     }
 
     /// Create a [Header] with a default payload based on the [Committee] and [Round] arguments.
     pub fn header_with_round(&self, committee: &Committee, round: Round) -> Header {
-        self.header_builder(committee).payload(Default::default()).round(round).build().unwrap()
+        self.header_builder(committee).payload(Default::default()).round(round).build()
     }
 
     /// Return a [HeaderV1Builder] for round 1. The builder is constructed

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -15,8 +15,8 @@ use std::{
 };
 use tn_config::KeyConfig;
 use tn_types::{
-    get_available_udp_port, traits::KeyPair, Address, Authority, BlsKeypair, Committee, Database,
-    Epoch, Multiaddr, Stake, WorkerCache, WorkerIndex, DEFAULT_PRIMARY_PORT, DEFAULT_WORKER_PORT,
+    get_available_udp_port, Address, Authority, BlsKeypair, Committee, Database, Epoch, Multiaddr,
+    Stake, WorkerCache, WorkerIndex, DEFAULT_PRIMARY_PORT, DEFAULT_WORKER_PORT,
 };
 
 pub struct Builder<DB, F, R = OsRng> {
@@ -126,7 +126,7 @@ where
                 format!("authority{i}"),
             );
             authorities.insert(
-                authority.protocol_key().clone(),
+                *authority.protocol_key(),
                 (primary_keypair, key_config, authority.clone()),
             );
         }
@@ -162,7 +162,7 @@ where
                     .map(|(primary_keypair, _key_config, _authority, worker)| {
                         let mut worker_index = BTreeMap::new();
                         worker_index.insert(0, worker.info().clone());
-                        (primary_keypair.public().clone(), WorkerIndex(worker_index.clone()))
+                        (*primary_keypair.public(), WorkerIndex(worker_index.clone()))
                     })
                     .collect(),
             ),

--- a/crates/test-utils/src/committee.rs
+++ b/crates/test-utils/src/committee.rs
@@ -159,7 +159,7 @@ impl<DB: Database> CommitteeFixture<DB> {
     pub fn certificate(&self, header: &Header) -> Certificate {
         let committee = self.committee();
         let votes: Vec<_> =
-            self.votes(header).into_iter().map(|x| (x.author(), x.signature().clone())).collect();
+            self.votes(header).into_iter().map(|x| (x.author(), *x.signature())).collect();
         Certificate::new_unverified(&committee, header.clone(), votes).unwrap()
     }
 

--- a/crates/test-utils/src/committee.rs
+++ b/crates/test-utils/src/committee.rs
@@ -2,11 +2,10 @@
 
 use super::{AuthorityFixture, Builder};
 use crate::fixture_batch_with_transactions;
-use fastcrypto::hash::Hash as _;
 use std::collections::BTreeSet;
 use tn_types::{
-    Certificate, CertificateDigest, Committee, Database, Header, HeaderBuilder, Round, Vote,
-    WorkerCache,
+    Certificate, CertificateDigest, Committee, Database, Hash as _, Header, HeaderBuilder, Round,
+    Vote, WorkerCache,
 };
 
 /// Fixture representing a committee to reach consensus.
@@ -129,7 +128,6 @@ impl<DB: Database> CommitteeFixture<DB> {
                     .parents(parents.clone())
                     .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
                     .build()
-                    .unwrap()
             })
             .collect();
 

--- a/crates/test-utils/src/helpers.rs
+++ b/crates/test-utils/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Helper methods for creating useful structs during tests.
 
 use crate::execution::TransactionFactory;
-use fastcrypto::{hash::Hash, traits::KeyPair as _};
+use fastcrypto::hash::Hash;
 use indexmap::IndexMap;
 use rand::{
     distributions::Bernoulli, prelude::Distribution, rngs::StdRng, thread_rng, Rng, RngCore,

--- a/crates/test-utils/src/helpers.rs
+++ b/crates/test-utils/src/helpers.rs
@@ -1,7 +1,6 @@
 //! Helper methods for creating useful structs during tests.
 
 use crate::execution::TransactionFactory;
-use fastcrypto::hash::Hash;
 use indexmap::IndexMap;
 use rand::{
     distributions::Bernoulli, prelude::Distribution, rngs::StdRng, thread_rng, Rng, RngCore,
@@ -14,7 +13,7 @@ use std::{
 use tn_types::{
     adiri_chain_spec_arc, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash,
     BlsKeypair, BlsSignature, Bytes, Certificate, CertificateDigest, Committee, Epoch, ExecHeader,
-    HeaderBuilder, ProtocolSignature, Round, Stake, TimestampSec, WorkerId, U256,
+    Hash as _, HeaderBuilder, ProtocolSignature, Round, Stake, TimestampSec, WorkerId, U256,
 };
 
 pub fn temp_dir() -> std::path::PathBuf {
@@ -513,8 +512,7 @@ pub fn mock_certificate_with_rand<R: RngCore + ?Sized>(
         .epoch(0)
         .parents(parents)
         .payload(fixture_payload_with_rand(1, rand))
-        .build()
-        .unwrap();
+        .build();
     let certificate = Certificate::new_unsigned(committee, header, Vec::new()).unwrap();
     (certificate.digest(), certificate)
 }
@@ -546,8 +544,7 @@ pub fn mock_certificate_with_epoch(
         .epoch(epoch)
         .parents(parents)
         .payload(fixture_payload(1))
-        .build()
-        .unwrap();
+        .build();
     let certificate = Certificate::new_unsigned(committee, header, Vec::new()).unwrap();
     (certificate.digest(), certificate)
 }
@@ -566,8 +563,7 @@ pub fn signed_cert_for_test(
         .round(round)
         .epoch(0)
         .parents(parents)
-        .build()
-        .expect("valid header built for test certificate");
+        .build();
 
     let cert = Certificate::new_unsigned(committee, header.clone(), Vec::new())
         .expect("new unsigned cert for tests");

--- a/crates/test-utils/src/tests/output_tests.rs
+++ b/crates/test-utils/src/tests/output_tests.rs
@@ -20,8 +20,7 @@ fn test_zero_timestamp_in_sub_dag() {
         .created_at(50)
         .payload(IndexMap::new())
         .parents(BTreeSet::new())
-        .build()
-        .unwrap();
+        .build();
 
     let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
 
@@ -55,8 +54,7 @@ fn test_monotonically_incremented_commit_timestamps() {
         .created_at(newer_timestamp)
         .payload(IndexMap::new())
         .parents(BTreeSet::new())
-        .build()
-        .unwrap();
+        .build();
 
     let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
 
@@ -81,8 +79,7 @@ fn test_monotonically_incremented_commit_timestamps() {
         .created_at(older_timestamp)
         .payload(IndexMap::new())
         .parents(BTreeSet::new())
-        .build()
-        .unwrap();
+        .build();
 
     let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
 

--- a/crates/test-utils/src/tests/storage_tests.rs
+++ b/crates/test-utils/src/tests/storage_tests.rs
@@ -7,13 +7,12 @@ use std::{
 };
 
 use crate::{fixture_batch_with_transactions, temp_dir, CommitteeFixture};
-use fastcrypto::hash::Hash;
 use futures::future::join_all;
 use tempfile::TempDir;
 use tn_storage::{mem_db::MemDatabase, open_db, CertificateStore, ConsensusStore, ProposerStore};
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Header, HeaderBuilder,
-    ReputationScores, Round,
+    AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Hash as _, Header,
+    HeaderBuilder, ReputationScores, Round,
 };
 
 pub fn create_header_for_round(round: Round) -> Header {
@@ -28,7 +27,6 @@ pub fn create_header_for_round(round: Round) -> Header {
         .parents([CertificateDigest::default()].iter().cloned().collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0, 0)
         .build()
-        .unwrap()
 }
 
 // helper method that creates certificates for the provided

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -37,8 +37,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt", "macros", "signal"] }
 tracing = { workspace = true }
 eyre = { workspace = true }
-fastcrypto = { workspace = true, features = ["copy_key"] }
-fastcrypto-tbls = { workspace = true }
 once_cell = { workspace = true }
 match_opt = { workspace = true }
 multiaddr = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -50,7 +50,9 @@ secp256k1 = { workspace = true }
 libp2p = { workspace = true }
 bs58 = { workspace = true }
 blake2 = { workspace = true }
+blst = { workspace = true, features = ["serde"] }
 alloy = { workspace = true, features = ["genesis"] }
+hex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -5,7 +5,6 @@ use crate::{
     error::{CommitteeUpdateError, ConfigError},
     Address, Multiaddr,
 };
-use fastcrypto::serde_helpers::ToFromByteArray;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -305,26 +304,6 @@ impl Committee {
     /// Returns the keys in the committee
     pub fn keys(&self) -> Vec<BlsPublicKey> {
         self.authorities.keys().cloned().collect::<Vec<BlsPublicKey>>()
-    }
-
-    /// Returns info from the committee needed for randomness DKG.
-    pub fn randomness_dkg_info(
-        &self,
-    ) -> Vec<(
-        AuthorityIdentifier,
-        fastcrypto_tbls::ecies::PublicKey<fastcrypto::groups::bls12381::G2Element>,
-        Stake,
-    )> {
-        self.authorities_by_id
-            .iter()
-            .map(|(id, authority)| {
-                let pk = fastcrypto::groups::bls12381::G2Element::from_byte_array(
-                    authority.protocol_key().as_ref().try_into().expect("key length should match"),
-                )
-                .expect("should work to convert BLS key to G2Element");
-                (*id, fastcrypto_tbls::ecies::PublicKey::from(pk), authority.stake())
-            })
-            .collect()
     }
 
     pub fn authorities(&self) -> impl Iterator<Item = &Authority> {

--- a/crates/types/src/crypto/bls_keypair.rs
+++ b/crates/types/src/crypto/bls_keypair.rs
@@ -20,7 +20,6 @@ impl BlsKeypair {
     pub fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
         let mut ikm = [0u8; 32];
         rng.fill_bytes(&mut ikm);
-        // TODO: Consider moving to key gen version 5.
         let private = BlsPrivateKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
         let pubkey = private.sk_to_pk();
         let mut bytes = [0_u8; 96];

--- a/crates/types/src/crypto/bls_keypair.rs
+++ b/crates/types/src/crypto/bls_keypair.rs
@@ -1,0 +1,57 @@
+use rand::{CryptoRng, RngCore};
+
+use super::{BlsPublicKey, BlsSignature, Signer};
+use blst::min_sig::SecretKey as BlsPrivateKey;
+
+/// Validator's main protocol keypair.
+#[derive(Debug)]
+pub struct BlsKeypair {
+    public: BlsPublicKey,
+    private: BlsPrivateKey,
+}
+
+pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_"; // min sig
+const _DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_"; // min pk
+impl BlsKeypair {
+    pub fn public(&self) -> &BlsPublicKey {
+        &self.public
+    }
+
+    pub fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+        let mut ikm = [0u8; 32];
+        rng.fill_bytes(&mut ikm);
+        // TODO: Consider moving to key gen version 5.
+        let private = BlsPrivateKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
+        let pubkey = private.sk_to_pk();
+        let mut bytes = [0_u8; 96];
+        bytes.copy_from_slice(&pubkey.to_bytes());
+        Self { public: pubkey.into(), private }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.private.to_bytes()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> eyre::Result<Self> {
+        let private = BlsPrivateKey::from_bytes(bytes)
+            .map_err(|_| eyre::eyre!("invalid bls private key bytes!"))?;
+        let pubkey = private.sk_to_pk();
+        Ok(Self { public: pubkey.into(), private })
+    }
+
+    pub fn copy(&self) -> Self {
+        Self { public: self.public, private: self.private.clone() }
+    }
+}
+
+impl Signer for BlsKeypair {
+    fn sign(&self, msg: &[u8]) -> BlsSignature {
+        self.private.sign(msg, DST_G1, &[]).into()
+    }
+}
+
+impl Signer for BlsPrivateKey {
+    fn sign(&self, msg: &[u8]) -> BlsSignature {
+        self.sign(msg, DST_G1, &[]).into()
+    }
+}

--- a/crates/types/src/crypto/bls_public_key.rs
+++ b/crates/types/src/crypto/bls_public_key.rs
@@ -1,0 +1,252 @@
+//! Implement thin wrappers around BLST crates public keys.
+
+use core::fmt;
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+
+use blst::min_sig::PublicKey as CorePublicKey;
+
+/// Byte representation of validator's main protocol public key.
+/// This should ONLY be created from a valid key and comtain valid bytes.
+/// Not enforcing this may cause the From trait to panic.
+#[derive(Copy, Clone)]
+pub struct BlsPublicKeyBytes([u8; 96]);
+
+impl std::hash::Hash for BlsPublicKeyBytes {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialEq for BlsPublicKeyBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for BlsPublicKeyBytes {}
+
+impl PartialOrd for BlsPublicKeyBytes {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BlsPublicKeyBytes {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl std::fmt::Debug for BlsPublicKeyBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(self.0).into_string())
+    }
+}
+
+impl std::fmt::Display for BlsPublicKeyBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(self.0).into_string())
+    }
+}
+
+// Validator's main protocol public key.
+#[derive(Copy, Clone)]
+pub struct BlsPublicKey {
+    pubkey: CorePublicKey,
+    bytes: BlsPublicKeyBytes,
+}
+
+impl Default for BlsPublicKey {
+    fn default() -> Self {
+        let pubkey = CorePublicKey::default();
+        let mut bytes = [0_u8; 96];
+        bytes.copy_from_slice(&pubkey.to_bytes());
+        Self { pubkey, bytes: BlsPublicKeyBytes(bytes) }
+    }
+}
+
+impl From<CorePublicKey> for BlsPublicKey {
+    fn from(pubkey: CorePublicKey) -> Self {
+        let mut bytes = [0_u8; 96];
+        bytes.copy_from_slice(&pubkey.to_bytes());
+        Self { pubkey, bytes: BlsPublicKeyBytes(bytes) }
+    }
+}
+
+impl BlsPublicKey {
+    pub fn encode_base58(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl std::hash::Hash for BlsPublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl PartialEq for BlsPublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.pubkey == other.pubkey
+    }
+}
+
+impl Eq for BlsPublicKey {}
+
+impl PartialOrd for BlsPublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BlsPublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl std::fmt::Debug for BlsPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let bytes: BlsPublicKeyBytes = self.into();
+        write!(f, "{}", bytes)
+    }
+}
+
+impl std::fmt::Display for BlsPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let bytes: BlsPublicKeyBytes = self.into();
+        write!(f, "{}", bytes)
+    }
+}
+
+impl AsRef<[u8]> for BlsPublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes.0
+    }
+}
+
+impl Deref for BlsPublicKey {
+    type Target = blst::min_sig::PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pubkey
+    }
+}
+
+impl From<BlsPublicKey> for BlsPublicKeyBytes {
+    fn from(value: BlsPublicKey) -> Self {
+        let mut bytes = [0_u8; 96];
+        bytes.copy_from_slice(&value.to_bytes());
+        Self(bytes)
+    }
+}
+
+impl From<&BlsPublicKey> for BlsPublicKeyBytes {
+    fn from(value: &BlsPublicKey) -> Self {
+        let mut bytes = [0_u8; 96];
+        bytes.copy_from_slice(&value.to_bytes());
+        Self(bytes)
+    }
+}
+
+impl From<BlsPublicKeyBytes> for BlsPublicKey {
+    fn from(bytes: BlsPublicKeyBytes) -> Self {
+        Self {
+            pubkey: blst::min_sig::PublicKey::from_bytes(&bytes.0)
+                .expect("valid BLS public key bytes"),
+            bytes,
+        }
+    }
+}
+
+impl From<&BlsPublicKeyBytes> for BlsPublicKey {
+    fn from(bytes: &BlsPublicKeyBytes) -> Self {
+        Self {
+            pubkey: blst::min_sig::PublicKey::from_bytes(&bytes.0)
+                .expect("valid BLS public key bytes"),
+            bytes: *bytes,
+        }
+    }
+}
+
+// ----- Serde implementations -----
+
+impl Serialize for BlsPublicKeyBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            serializer.serialize_bytes(&self.0)
+        }
+    }
+}
+
+impl Serialize for BlsPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let bytes: BlsPublicKeyBytes = self.into();
+        bytes.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BlsPublicKeyBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::*;
+
+        struct BlsPublicKeyBytesVisitor;
+
+        impl Visitor<'_> for BlsPublicKeyBytesVisitor {
+            type Value = BlsPublicKeyBytes;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "valid bls public key bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                // Deserialize into an actual BLS publix key so we are sure to have valid bytes.
+                let pubkey: CorePublicKey = blst::min_sig::PublicKey::deserialize(v)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(v), &self))?;
+                let pubkey: BlsPublicKey = pubkey.into();
+                Ok(pubkey.into())
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes = bs58::decode(v)
+                    .into_vec()
+                    .map_err(|_| Error::invalid_value(Unexpected::Str(v), &self))?;
+                self.visit_bytes(&bytes)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(BlsPublicKeyBytesVisitor)
+        } else {
+            deserializer.deserialize_bytes(BlsPublicKeyBytesVisitor)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BlsPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(BlsPublicKeyBytes::deserialize(deserializer)?.into())
+    }
+}

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -1,0 +1,297 @@
+use std::{fmt, ops::Deref};
+
+use blst::min_sig::{
+    AggregateSignature as CoreBlsAggregateSignature, Signature as CoreBlsSignature,
+};
+use reth_chainspec::ChainSpec;
+use serde::{Deserialize, Serialize};
+
+use crate::encode;
+
+use super::{BlsKeypair, BlsPublicKey, Intent, IntentMessage, IntentScope, Signer, DST_G1};
+
+/// Validator's main protocol key signature.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BlsSignature(CoreBlsSignature);
+
+/// Validator's main protocol key aggrigate signature.
+/// Collection of validator main protocol key signatures.
+#[derive(Clone, Copy)]
+pub struct BlsAggregateSignature(CoreBlsAggregateSignature);
+
+impl BlsSignature {
+    pub fn from_bytes(bytes: &[u8]) -> eyre::Result<Self> {
+        let sig = CoreBlsSignature::from_bytes(bytes)
+            .map_err(|_| eyre::eyre!("Invalid signature bytes!"))?;
+        Ok(Self(sig))
+    }
+}
+
+impl Deref for BlsSignature {
+    type Target = CoreBlsSignature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<CoreBlsSignature> for BlsSignature {
+    fn from(value: CoreBlsSignature) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&CoreBlsSignature> for BlsSignature {
+    fn from(value: &CoreBlsSignature) -> Self {
+        Self(*value)
+    }
+}
+
+impl From<BlsSignature> for CoreBlsSignature {
+    fn from(value: BlsSignature) -> Self {
+        value.0
+    }
+}
+
+impl From<&BlsSignature> for CoreBlsSignature {
+    fn from(value: &BlsSignature) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Debug for BlsSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(&self.0.to_bytes()).into_string())
+    }
+}
+
+impl std::fmt::Display for BlsSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(&self.0.to_bytes()).into_string())
+    }
+}
+
+impl Default for BlsSignature {
+    /// Create a default [BlsSignature] using the infinity point.
+    /// See more: https://github.com/supranational/blst#serialization-format
+    fn default() -> Self {
+        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
+        // the second bit represents its infinity point.
+        let mut infinity = [0_u8; 48];
+        infinity[0] = 0xc0;
+
+        BlsSignature::from_bytes(&infinity).expect("decode infinity signature")
+    }
+}
+
+impl BlsAggregateSignature {
+    // Aggregate
+    pub fn aggregate(sigs: &[&BlsSignature], sigs_groupcheck: bool) -> eyre::Result<Self> {
+        let t_sigs: Vec<CoreBlsSignature> = sigs.iter().map(|s| s.0).collect();
+        let sigs: Vec<&CoreBlsSignature> = t_sigs.iter().collect();
+        let sig = CoreBlsAggregateSignature::aggregate(&sigs, sigs_groupcheck)
+            .map_err(|_| eyre::eyre!("Failed to aggregate signatures!"))?;
+        Ok(Self(sig))
+    }
+
+    pub fn to_signature(&self) -> BlsSignature {
+        BlsSignature(CoreBlsAggregateSignature::to_signature(self))
+    }
+
+    pub fn from_signature(signature: &BlsSignature) -> BlsAggregateSignature {
+        BlsAggregateSignature(CoreBlsAggregateSignature::from_signature(&signature.0))
+    }
+}
+impl Deref for BlsAggregateSignature {
+    type Target = CoreBlsAggregateSignature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<CoreBlsAggregateSignature> for BlsAggregateSignature {
+    fn from(value: CoreBlsAggregateSignature) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&CoreBlsAggregateSignature> for BlsAggregateSignature {
+    fn from(value: &CoreBlsAggregateSignature) -> Self {
+        Self(*value)
+    }
+}
+
+impl std::fmt::Debug for BlsAggregateSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(&self.0.to_signature().to_bytes()).into_string())
+    }
+}
+
+impl std::fmt::Display for BlsAggregateSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", bs58::encode(&self.0.to_signature().to_bytes()).into_string())
+    }
+}
+
+/// Creates a proof of that the authority account address is owned by the
+/// holder of authority protocol key, and also ensures that the authority
+/// protocol public key exists.
+///
+/// The proof of possession is a [BlsSignature] committed over the intent message
+/// `intent || message` (See more at [IntentMessage] and [Intent]).
+/// The message is constructed as: [BlsPublicKey] || [Genesis].
+pub fn generate_proof_of_possession_bls(
+    keypair: &BlsKeypair,
+    chain_spec: &ChainSpec,
+) -> eyre::Result<BlsSignature> {
+    let mut msg = keypair.public().to_bytes().to_vec();
+    let genesis_bytes = encode(&chain_spec.genesis);
+    msg.extend_from_slice(genesis_bytes.as_slice());
+    let sig = BlsSignature::new_secure(
+        &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
+        keypair,
+    );
+    Ok(sig)
+}
+
+/// Verify proof of possession against the expected intent message,
+///
+/// The intent message is expected to contain the validator's public key
+/// and the [Genesis] for the network.
+pub fn verify_proof_of_possession_bls(
+    proof: &BlsSignature,
+    public_key: &BlsPublicKey,
+    chain_spec: &ChainSpec,
+) -> eyre::Result<()> {
+    public_key.validate().map_err(|_| eyre::eyre!("Bls Publkic Key not valid!"))?;
+    let mut msg = public_key.to_bytes().to_vec();
+    let genesis_bytes = encode(&chain_spec.genesis);
+    msg.extend_from_slice(genesis_bytes.as_slice());
+    if proof.verify_secure(
+        &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
+        public_key,
+    ) {
+        Ok(())
+    } else {
+        Err(eyre::eyre!("Failed to verify proof of possession!"))
+    }
+}
+
+/// A trait for sign and verify over an intent message, instead of the message itself. See more at
+/// [struct IntentMessage].
+pub trait ProtocolSignature {
+    /// Create a new signature over an intent message.
+    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer) -> Self
+    where
+        T: Serialize;
+
+    /// Verify the signature over an intent message against a public key.
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, public_key: &BlsPublicKey) -> bool
+    where
+        T: Serialize;
+}
+
+impl ProtocolSignature for BlsSignature {
+    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer) -> Self
+    where
+        T: Serialize,
+    {
+        let message = encode(&value);
+        secret.sign(&message)
+    }
+
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, public_key: &BlsPublicKey) -> bool
+    where
+        T: Serialize,
+    {
+        let message = encode(&value);
+        self.verify(true, &message, DST_G1, &[], public_key, true) == blst::BLST_ERROR::BLST_SUCCESS
+    }
+}
+
+pub trait ValidatorAggregateSignature {
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, pks: &[BlsPublicKey]) -> bool
+    where
+        T: Serialize;
+}
+
+impl ValidatorAggregateSignature for BlsAggregateSignature {
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, pks: &[BlsPublicKey]) -> bool
+    where
+        T: Serialize,
+    {
+        if pks.is_empty() {
+            return true;
+        }
+        let message = encode(&value);
+        let mut pk_s: Vec<&blst::min_sig::PublicKey> = Vec::with_capacity(pks.len());
+        let mut messages = Vec::with_capacity(pks.len());
+        for pk in pks {
+            pk_s.push(pk.deref());
+            messages.push(&message[..]);
+        }
+        self.to_signature().aggregate_verify(true, &messages, DST_G1, &pk_s, true)
+            == blst::BLST_ERROR::BLST_SUCCESS
+    }
+}
+
+// ----- Serde implementations -----
+
+impl Serialize for BlsSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            serializer.serialize_bytes(&self.0.to_bytes())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BlsSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::*;
+
+        struct BlsSignatureVisitor;
+
+        impl Visitor<'_> for BlsSignatureVisitor {
+            type Value = BlsSignature;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "valid bls public key bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                // Deserialize into an actual BLS publix key so we are sure to have valid bytes.
+                let sig = CoreBlsSignature::from_bytes(v)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(v), &self))?;
+                Ok(sig.into())
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes = bs58::decode(v)
+                    .into_vec()
+                    .map_err(|_| Error::invalid_value(Unexpected::Str(v), &self))?;
+                self.visit_bytes(&bytes)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(BlsSignatureVisitor)
+        } else {
+            deserializer.deserialize_bytes(BlsSignatureVisitor)
+        }
+    }
+}

--- a/crates/types/src/crypto/intent.rs
+++ b/crates/types/src/crypto/intent.rs
@@ -2,7 +2,6 @@
 
 use crate::try_decode;
 use eyre::eyre;
-use fastcrypto::encoding::decode_bytes_hex;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::str::FromStr;
@@ -96,7 +95,8 @@ pub struct Intent {
 impl FromStr for Intent {
     type Err = eyre::Report;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s: Vec<u8> = decode_bytes_hex(s).map_err(|_| eyre!("Invalid Intent"))?;
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let s = hex::decode(s)?;
         if s.len() != 3 {
             return Err(eyre!("Invalid Intent"));
         }

--- a/crates/types/src/crypto/mod.rs
+++ b/crates/types/src/crypto/mod.rs
@@ -7,42 +7,28 @@
 //! - use generic schemes (avoid using the algo's `Struct`` impl functions)
 //! - change type aliases to update codebase with new crypto
 
-use blake2::digest::consts::U32;
-use eyre::Context;
-use fastcrypto::{
-    bls12381,
-    error::FastCryptoError,
-    traits::{AggregateAuthenticator, KeyPair, Signer, ToFromBytes, VerifyingKey},
-};
-use libp2p::PeerId;
 use std::future::Future;
+
+use blake2::digest::consts::U32;
+use libp2p::PeerId;
 // This re-export allows using the trait-defined APIs
-pub use fastcrypto::traits;
-use reth_chainspec::ChainSpec;
-use serde::Serialize;
+mod bls_keypair;
+mod bls_public_key;
+mod bls_signature;
 mod intent;
 mod network;
-use crate::encode;
+
+pub use bls_keypair::*;
+pub use bls_public_key::*;
+pub use bls_signature::*;
 pub use intent::*;
 pub use network::*;
 
-//
-// CONSENSUS
-//
-/// Validator's main protocol public key.
-pub type BlsPublicKey = bls12381::min_sig::BLS12381PublicKey;
-/// Byte representation of validator's main protocol public key.
-pub type BlsPublicKeyBytes = bls12381::min_sig::BLS12381PublicKeyAsBytes;
-/// Validator's main protocol key signature.
-pub type BlsSignature = bls12381::min_sig::BLS12381Signature;
-/// Collection of validator main protocol key signatures.
-pub type BlsAggregateSignature = bls12381::min_sig::BLS12381AggregateSignature;
-/// Byte representation of the collection of validator main protocol key signatures.
-pub type BlsAggregateSignatureBytes = bls12381::min_sig::BLS12381AggregateSignatureAsBytes;
-/// Validator's main protocol private key.
-pub type BlsPrivateKey = bls12381::min_sig::BLS12381PrivateKey;
-/// Validator's main protocol keypair.
-pub type BlsKeypair = bls12381::min_sig::BLS12381KeyPair;
+/// Trait impl'd by a key/keypair that can create signatures.
+pub trait Signer {
+    /// Create a new signature over a message.
+    fn sign(&self, msg: &[u8]) -> BlsSignature;
+}
 
 //
 // EXECUTION
@@ -73,117 +59,6 @@ pub trait BlsSigner: Clone + Send + Sync + Unpin + 'static {
     }
 }
 
-/// Creates a proof of that the authority account address is owned by the
-/// holder of authority protocol key, and also ensures that the authority
-/// protocol public key exists.
-///
-/// The proof of possession is a [BlsSignature] committed over the intent message
-/// `intent || message` (See more at [IntentMessage] and [Intent]).
-/// The message is constructed as: [BlsPublicKey] || [Genesis].
-pub fn generate_proof_of_possession_bls(
-    keypair: &BlsKeypair,
-    chain_spec: &ChainSpec,
-) -> eyre::Result<BlsSignature> {
-    let mut msg = keypair.public().as_bytes().to_vec();
-    let genesis_bytes = encode(&chain_spec.genesis);
-    msg.extend_from_slice(genesis_bytes.as_slice());
-    let sig = BlsSignature::new_secure(
-        &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
-        keypair,
-    );
-    Ok(sig)
-}
-
-/// Verify proof of possession against the expected intent message,
-///
-/// The intent message is expected to contain the validator's public key
-/// and the [Genesis] for the network.
-pub fn verify_proof_of_possession_bls(
-    proof: &BlsSignature,
-    public_key: &BlsPublicKey,
-    chain_spec: &ChainSpec,
-) -> eyre::Result<()> {
-    public_key.validate().with_context(|| "Provided public key invalid")?;
-    let mut msg = public_key.as_bytes().to_vec();
-    let genesis_bytes = encode(&chain_spec.genesis);
-    msg.extend_from_slice(genesis_bytes.as_slice());
-    let result = proof.verify_secure(
-        &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),
-        public_key,
-    );
-
-    Ok(result?)
-}
-
-/// A trait for sign and verify over an intent message, instead of the message itself. See more at
-/// [struct IntentMessage].
-pub trait ProtocolSignature {
-    /// The type used to verify the signature.
-    type Pubkey: VerifyingKey;
-
-    /// Create a new signature over an intent message.
-    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Self>) -> Self
-    where
-        T: Serialize;
-
-    /// Verify the signature over an intent message against a public key.
-    fn verify_secure<T>(
-        &self,
-        value: &IntentMessage<T>,
-        public_key: &Self::Pubkey,
-    ) -> Result<(), FastCryptoError>
-    where
-        T: Serialize;
-}
-
-impl ProtocolSignature for BlsSignature {
-    type Pubkey = BlsPublicKey;
-
-    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn Signer<Self>) -> Self
-    where
-        T: Serialize,
-    {
-        let message = encode(&value);
-        secret.sign(&message)
-    }
-
-    fn verify_secure<T>(
-        &self,
-        value: &IntentMessage<T>,
-        public_key: &BlsPublicKey,
-    ) -> Result<(), FastCryptoError>
-    where
-        T: Serialize,
-    {
-        let message = encode(&value);
-        public_key.verify(&message, self)
-    }
-}
-
-pub trait ValidatorAggregateSignature {
-    fn verify_secure<T>(
-        &self,
-        value: &IntentMessage<T>,
-        pks: &[BlsPublicKey],
-    ) -> Result<(), FastCryptoError>
-    where
-        T: Serialize;
-}
-
-impl ValidatorAggregateSignature for BlsAggregateSignature {
-    fn verify_secure<T>(
-        &self,
-        value: &IntentMessage<T>,
-        pks: &[BlsPublicKey],
-    ) -> Result<(), FastCryptoError>
-    where
-        T: Serialize,
-    {
-        let message = encode(&value);
-        self.verify(pks, &message)
-    }
-}
-
 /// Wrap a message in an intent message. Currently in Consensus, the scope is always
 /// IntentScope::ConsensusDigest and the app id is AppId::Consensus.
 pub fn to_intent_message<T>(value: T) -> IntentMessage<T> {
@@ -199,7 +74,6 @@ pub fn network_public_key_to_libp2p(public_key: &NetworkPublicKey) -> PeerId {
 mod tests {
     use super::{generate_proof_of_possession_bls, verify_proof_of_possession_bls};
     use crate::{adiri_chain_spec_arc, adiri_genesis, BlsKeypair};
-    use fastcrypto::traits::KeyPair;
     use rand::{
         rngs::{OsRng, StdRng},
         SeedableRng,

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -4,7 +4,7 @@ use crate::{
     crypto, BlockNumHash, CertificateDigest, Epoch, HeaderDigest, Round, SendError, TimestampSec,
     VoteDigest, WorkerId,
 };
-use fastcrypto::{error::FastCryptoError, hash::Digest};
+use fastcrypto::hash::Digest;
 use libp2p::PeerId;
 use std::sync::Arc;
 use thiserror::Error;
@@ -299,7 +299,7 @@ pub enum CertificateError {
     Inquorate { stake: u64, threshold: u64 },
     /// The BLS aggregate signature is invalid
     #[error("Invalid aggregate signature")]
-    InvalidSignature(#[from] FastCryptoError),
+    InvalidSignature,
     /// The certificates's round is too far behind.
     #[error("Certificate {0} for round {1} is too old for GC round {2}")]
     TooOld(CertificateDigest, Round, Round),

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -1,10 +1,9 @@
 //! Error types whenn validating types during consensus.
 
 use crate::{
-    crypto, BlockNumHash, CertificateDigest, Epoch, HeaderDigest, Round, SendError, TimestampSec,
-    VoteDigest, WorkerId,
+    crypto, BlockNumHash, CertificateDigest, Digest, Epoch, HeaderDigest, Round, SendError,
+    TimestampSec, VoteDigest, WorkerId,
 };
-use fastcrypto::hash::Digest;
 use libp2p::PeerId;
 use std::sync::Arc;
 use thiserror::Error;

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -7,9 +7,8 @@
 //! if not directly participating in consesus.
 
 use super::{CommittedSubDag, ConsensusOutput};
-use crate::{crypto, error::CertificateResult, BlockHash, Certificate, Committee, B256};
+use crate::{crypto, error::CertificateResult, BlockHash, Certificate, Committee, Hash, B256};
 use blake2::Digest as _;
-use fastcrypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -12,11 +12,10 @@ use crate::{
     error::{CertificateError, CertificateResult, DagError, DagResult, HeaderError},
     now,
     serde::CertificateSignatures,
-    AuthorityIdentifier, BlockHash, Committee, Epoch, Header, Round, Stake, TimestampSec,
-    WorkerCache,
+    AuthorityIdentifier, BlockHash, Committee, Digest, Epoch, Hash, Header, Round, Stake,
+    TimestampSec, WorkerCache,
 };
 use base64::{engine::general_purpose, Engine};
-use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{collections::VecDeque, fmt};
@@ -453,7 +452,9 @@ pub fn validate_received_certificate(
 }
 
 /// Certificate digest.
-#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord,
+)]
 pub struct CertificateDigest([u8; crypto::DIGEST_LENGTH]);
 
 impl CertificateDigest {

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -410,23 +410,23 @@ impl From<&Certificate> for Vec<u8> {
 ///    - `VerifiedDirectly` status with different signature bytes than what was actually verified
 ///    - an unsigned state containing signature bytes
 ///    - a verified state with missing/corrupted signature bytes
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
 pub enum SignatureVerificationState {
-    // This state occurs when the certificate has not yet received a quorum of
-    // signatures.
+    /// This state occurs when the certificate has not yet received a quorum of
+    /// signatures.
     Unsigned(BlsSignature),
-    // This state occurs when a certificate has just been received from the network
-    // and has not been verified yet.
+    /// This state occurs when a certificate has just been received from the network
+    /// and has not been verified yet.
     Unverified(BlsSignature),
-    // This state occurs when a certificate was either created locally, received
-    // via brodacast, or fetched but was not the parent of another certificate.
-    // Therefore this certificate had to be verified directly.
+    /// This state occurs when a certificate was either created locally, received
+    /// via brodacast, or fetched but was not the parent of another certificate.
+    /// Therefore this certificate had to be verified directly.
     VerifiedDirectly(BlsSignature),
-    // This state occurs when the cert was a parent of another fetched certificate
-    // that was verified directly, then this certificate is verified indirectly.
+    /// This state occurs when the cert was a parent of another fetched certificate
+    /// that was verified directly, then this certificate is verified indirectly.
     VerifiedIndirectly(BlsSignature),
-    // This state occurs only for genesis certificates which always has valid
-    // signatures bytes but the bytes are garbage so we don't mark them as verified.
+    /// This state occurs only for genesis certificates which always has valid
+    /// signatures bytes but the bytes are garbage so we don't mark them as verified.
     Genesis,
 }
 

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     crypto::{
-        self, to_intent_message, BlsAggregateSignature, BlsAggregateSignatureBytes, BlsPublicKey,
-        BlsSignature, ValidatorAggregateSignature,
+        self, to_intent_message, BlsAggregateSignature, BlsPublicKey, BlsSignature,
+        ValidatorAggregateSignature,
     },
     ensure,
     error::{CertificateError, CertificateResult, DagError, DagResult, HeaderError},
@@ -16,10 +16,7 @@ use crate::{
     WorkerCache,
 };
 use base64::{engine::general_purpose, Engine};
-use fastcrypto::{
-    hash::{Digest, Hash},
-    traits::AggregateAuthenticator,
-};
+use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{collections::VecDeque, fmt};
@@ -27,7 +24,7 @@ use std::{collections::VecDeque, fmt};
 /// Certificates are the output of consensus.
 /// The certificate issued after a successful round of consensus.
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Certificate {
     /// Certificate's header.
     pub header: Header,
@@ -125,21 +122,20 @@ impl Certificate {
             DagError::CertificateRequiresQuorum
         );
 
-        let aggregated_signature = if sigs.is_empty() {
-            BlsAggregateSignature::default()
+        let sigs: Vec<&BlsSignature> = sigs.iter().map(|(_, sig)| sig).collect();
+        let bls_signature = if sigs.is_empty() {
+            BlsSignature::default()
         } else {
-            BlsAggregateSignature::aggregate::<BlsSignature, Vec<&BlsSignature>>(
-                sigs.iter().map(|(_, sig)| sig).collect(),
-            )
-            .map_err(|_| DagError::InvalidSignature)?
+            let aggregated_signature = BlsAggregateSignature::aggregate(&sigs[..], true)
+                .map_err(|_| DagError::InvalidSignature)?;
+
+            aggregated_signature.to_signature()
         };
 
-        let aggregate_signature_bytes = BlsAggregateSignatureBytes::from(&aggregated_signature);
-
         let signature_verification_state = if !check_stake {
-            SignatureVerificationState::Unsigned(aggregate_signature_bytes)
+            SignatureVerificationState::Unsigned(bls_signature)
         } else {
-            SignatureVerificationState::Unverified(aggregate_signature_bytes)
+            SignatureVerificationState::Unverified(bls_signature)
         };
 
         Ok(Certificate {
@@ -178,7 +174,7 @@ impl Certificate {
                 }
                 _ => false,
             })
-            .map(|(_, authority)| authority.protocol_key().clone())
+            .map(|(_, authority)| *authority.protocol_key())
             .collect();
         (weight, pks)
     }
@@ -256,11 +252,11 @@ impl Certificate {
     /// Check the verification state and try to verify directly.
     fn verify_signature(mut self, pks: Vec<BlsPublicKey>) -> CertificateResult<Certificate> {
         // get signature from verification state
-        let aggregrate_signature_bytes = match self.signature_verification_state {
+        let signature = match self.signature_verification_state {
             SignatureVerificationState::VerifiedIndirectly(_)
             | SignatureVerificationState::VerifiedDirectly(_)
             | SignatureVerificationState::Genesis => return Ok(self),
-            SignatureVerificationState::Unverified(ref bytes) => bytes,
+            SignatureVerificationState::Unverified(ref sig) => sig,
             SignatureVerificationState::Unsigned(_) => {
                 return Err(CertificateError::Unsigned);
             }
@@ -268,11 +264,13 @@ impl Certificate {
 
         // Verify the signatures
         let certificate_digest = self.digest();
-        BlsAggregateSignature::try_from(aggregrate_signature_bytes)?
-            .verify_secure(&to_intent_message(certificate_digest), &pks[..])?;
+        let aggregate_signature = BlsAggregateSignature::from_signature(signature);
+        if !aggregate_signature.verify_secure(&to_intent_message(certificate_digest), &pks[..]) {
+            return Err(CertificateError::InvalidSignature);
+        }
 
         self.signature_verification_state =
-            SignatureVerificationState::VerifiedDirectly(aggregrate_signature_bytes.clone());
+            SignatureVerificationState::VerifiedDirectly(*signature);
 
         Ok(self)
     }
@@ -281,8 +279,7 @@ impl Certificate {
     pub fn validate_received(mut self) -> CertificateResult<Self> {
         self.set_signature_verification_state(SignatureVerificationState::Unverified(
             self.aggregated_signature()
-                .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?
-                .clone(),
+                .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?,
         ));
         Ok(self)
     }
@@ -313,12 +310,12 @@ impl Certificate {
     }
 
     /// The aggregate signature for the certriciate.
-    pub fn aggregated_signature(&self) -> Option<&BlsAggregateSignatureBytes> {
+    pub fn aggregated_signature(&self) -> Option<BlsSignature> {
         match &self.signature_verification_state {
-            SignatureVerificationState::VerifiedDirectly(bytes)
-            | SignatureVerificationState::Unverified(bytes)
-            | SignatureVerificationState::VerifiedIndirectly(bytes)
-            | SignatureVerificationState::Unsigned(bytes) => Some(bytes),
+            SignatureVerificationState::VerifiedDirectly(sig)
+            | SignatureVerificationState::Unverified(sig)
+            | SignatureVerificationState::VerifiedIndirectly(sig)
+            | SignatureVerificationState::Unsigned(sig) => Some(*sig),
             SignatureVerificationState::Genesis => None,
         }
     }
@@ -418,17 +415,17 @@ impl From<&Certificate> for Vec<u8> {
 pub enum SignatureVerificationState {
     // This state occurs when the certificate has not yet received a quorum of
     // signatures.
-    Unsigned(BlsAggregateSignatureBytes),
+    Unsigned(BlsSignature),
     // This state occurs when a certificate has just been received from the network
     // and has not been verified yet.
-    Unverified(BlsAggregateSignatureBytes),
+    Unverified(BlsSignature),
     // This state occurs when a certificate was either created locally, received
     // via brodacast, or fetched but was not the parent of another certificate.
     // Therefore this certificate had to be verified directly.
-    VerifiedDirectly(BlsAggregateSignatureBytes),
+    VerifiedDirectly(BlsSignature),
     // This state occurs when the cert was a parent of another fetched certificate
     // that was verified directly, then this certificate is verified indirectly.
-    VerifiedIndirectly(BlsAggregateSignatureBytes),
+    VerifiedIndirectly(BlsSignature),
     // This state occurs only for genesis certificates which always has valid
     // signatures bytes but the bytes are garbage so we don't mark them as verified.
     Genesis,
@@ -436,7 +433,7 @@ pub enum SignatureVerificationState {
 
 impl Default for SignatureVerificationState {
     fn default() -> Self {
-        SignatureVerificationState::Unsigned(BlsAggregateSignatureBytes::default())
+        SignatureVerificationState::Unsigned(BlsSignature::default())
     }
 }
 
@@ -450,8 +447,7 @@ pub fn validate_received_certificate(
     certificate.set_signature_verification_state(SignatureVerificationState::Unverified(
         certificate
             .aggregated_signature()
-            .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?
-            .clone(),
+            .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?,
     ));
     Ok(certificate)
 }

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -225,8 +225,7 @@ impl CommittedSubDag {
                 cert.set_signature_verification_state(
                     SignatureVerificationState::VerifiedIndirectly(
                         cert.aggregated_signature()
-                            .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?
-                            .clone(),
+                            .ok_or(CertificateError::RecoverBlsAggregateSignatureBytes)?,
                     ),
                 );
                 new_certs.push(cert);

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -5,11 +5,10 @@ use super::{CertificateDigest, ConsensusHeader, SignatureVerificationState};
 use crate::{
     crypto, encode,
     error::{CertificateError, CertificateResult},
-    Address, Batch, BlockHash, Certificate, Committee, Epoch, ReputationScores, Round,
-    TimestampSec, B256,
+    Address, Batch, BlockHash, Certificate, Committee, Digest, Epoch, Hash, ReputationScores,
+    Round, TimestampSec, B256,
 };
 use blake2::Digest as _;
-use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashSet, VecDeque},
@@ -268,7 +267,7 @@ impl From<ConsensusDigest> for B256 {
 pub type ShutdownToken = mpsc::Sender<()>;
 
 // Digest of ConsususOutput and CommittedSubDag
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord)]
 pub struct ConsensusDigest([u8; crypto::DIGEST_LENGTH]);
 
 impl AsRef<[u8]> for ConsensusDigest {

--- a/crates/types/src/primary/vote.rs
+++ b/crates/types/src/primary/vote.rs
@@ -1,16 +1,11 @@
 //! Vote implementation for consensus
 
 use crate::{
-    crypto::{
-        self, to_intent_message, BlsPublicKey, BlsSignature, IntentMessage, ProtocolSignature,
-    },
-    encode, AuthorityIdentifier, BlsSigner, Epoch, Header, HeaderDigest, Round,
+    crypto::{self, to_intent_message, BlsSignature, IntentMessage, ProtocolSignature},
+    encode, AuthorityIdentifier, BlsSigner, Epoch, Header, HeaderDigest, Round, Signer,
 };
 use base64::{engine::general_purpose, Engine};
-use fastcrypto::{
-    hash::{Digest, Hash},
-    traits::{Signer, VerifyingKey},
-};
+use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -29,7 +24,7 @@ pub struct Vote {
     /// Author of this vote.
     pub author: AuthorityIdentifier,
     /// Signature of the HeaderDigest.
-    pub signature: <BlsPublicKey as VerifyingKey>::Sig,
+    pub signature: BlsSignature,
 }
 
 impl Vote {
@@ -40,18 +35,7 @@ impl Vote {
         author: &AuthorityIdentifier,
         signature_service: &BLS,
     ) -> Self {
-        let vote = Self {
-            header_digest: header.digest(),
-            round: header.round(),
-            epoch: header.epoch(),
-            origin: header.author(),
-            author: *author,
-            signature: BlsSignature::default(),
-        };
-        let vote_digest: Digest<{ crypto::DIGEST_LENGTH }> = vote.digest().into();
-        let signature =
-            signature_service.request_signature(encode(&to_intent_message(vote_digest))).await;
-        Self { signature, ..vote }
+        Self::new_sync(header, author, signature_service)
     }
 
     /// Create a new instance of [Vote], sync version.
@@ -60,39 +44,37 @@ impl Vote {
         author: &AuthorityIdentifier,
         signature_service: &BLS,
     ) -> Self {
-        let vote = Self {
-            header_digest: header.digest(),
+        let header_digest = header.digest();
+        let vote_digest: Digest<{ crypto::DIGEST_LENGTH }> = header_digest.into();
+        let signature =
+            signature_service.request_signature_direct(&encode(&to_intent_message(vote_digest)));
+        Self {
+            header_digest,
             round: header.round(),
             epoch: header.epoch(),
             origin: header.author(),
             author: *author,
-            signature: BlsSignature::default(),
-        };
-        let vote_digest: Digest<{ crypto::DIGEST_LENGTH }> = vote.digest().into();
-        let signature =
-            signature_service.request_signature_direct(&encode(&to_intent_message(vote_digest)));
-        Self { signature, ..vote }
+            signature,
+        }
     }
 
     /// Create a vote directly with a suplied signer (private key).
     /// Used for testing, other wise use one BlsSigner versions.
     pub fn new_with_signer<S>(header: &Header, author: &AuthorityIdentifier, signer: &S) -> Self
     where
-        S: Signer<BlsSignature>,
+        S: Signer,
     {
-        let vote = Self {
-            header_digest: header.digest(),
+        let header_digest = header.digest();
+        let vote_digest: Digest<{ crypto::DIGEST_LENGTH }> = header_digest.into();
+        let signature = BlsSignature::new_secure(&to_intent_message(vote_digest), signer);
+        Self {
+            header_digest,
             round: header.round(),
             epoch: header.epoch(),
             origin: header.author(),
             author: *author,
-            signature: BlsSignature::default(),
-        };
-
-        let vote_digest: Digest<{ crypto::DIGEST_LENGTH }> = vote.digest().into();
-        let signature = BlsSignature::new_secure(&to_intent_message(vote_digest), signer);
-
-        Self { signature, ..vote }
+            signature,
+        }
     }
 
     pub fn header_digest(&self) -> HeaderDigest {
@@ -110,7 +92,7 @@ impl Vote {
     pub fn author(&self) -> AuthorityIdentifier {
         self.author
     }
-    pub fn signature(&self) -> &<BlsPublicKey as VerifyingKey>::Sig {
+    pub fn signature(&self) -> &BlsSignature {
         &self.signature
     }
 }

--- a/crates/types/src/primary/vote.rs
+++ b/crates/types/src/primary/vote.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     crypto::{self, to_intent_message, BlsSignature, IntentMessage, ProtocolSignature},
-    encode, AuthorityIdentifier, BlsSigner, Epoch, Header, HeaderDigest, Round, Signer,
+    encode, AuthorityIdentifier, BlsSigner, Digest, Epoch, Hash, Header, HeaderDigest, Round,
+    Signer,
 };
 use base64::{engine::general_purpose, Engine};
-use fastcrypto::hash::{Digest, Hash};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -122,7 +122,6 @@ impl From<VoteDigest> for HeaderDigest {
 
 impl From<VoteDigest> for Digest<{ crypto::INTENT_MESSAGE_LENGTH }> {
     fn from(digest: VoteDigest) -> Self {
-        // let intent_message = to_intent_message(HeaderDigest(digest.0));
         let intent_message: IntentMessage<HeaderDigest> = to_intent_message(digest.into());
         Digest {
             digest: encode(&intent_message).try_into().expect("INTENT_MESSAGE_LENGTH is correct"),


### PR DESCRIPTION
- Replace the fast crypto BLS key support with the underlying BLST crate support.
- Bring in the Hash trait and Digest structure since these were core for us and small.
- Tweak a few package versions to clear dependabot alerts.
- Remove "systemMessages'- they were never used and they were heavily invested in fast crypto.