### PR TITLE
Make authority ids peer ids.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,7 @@ dependencies = [
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identity",
+ "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-quic",
@@ -5002,6 +5003,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand",
  "regex",
+ "serde",
  "sha2 0.10.8",
  "tracing",
  "web-time",
@@ -5021,10 +5023,39 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand",
+ "serde",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
+ "uint 0.10.0",
+ "web-time",
 ]
 
 [[package]]
@@ -5774,6 +5805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
+ "serde",
  "unsigned-varint 0.8.0",
 ]
 

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -9,8 +9,8 @@ use std::{
 };
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
-    network_public_key_to_libp2p, Authority, AuthorityIdentifier, Certificate, CertificateDigest,
-    Committee, Database, Hash as _, Multiaddr, Notifier, WorkerCache, WorkerId,
+    Authority, AuthorityIdentifier, Certificate, CertificateDigest, Committee, Database, Hash as _,
+    Multiaddr, Notifier, WorkerCache, WorkerId,
 };
 
 #[derive(Debug)]
@@ -22,7 +22,6 @@ struct ConsensusConfigInner<DB> {
     authority: Authority,
     local_network: LocalNetwork,
     network_config: NetworkConfig,
-    authority_map: AuthorityMapping,
     genesis: HashMap<CertificateDigest, Certificate>,
 }
 
@@ -108,7 +107,6 @@ where
 
         let shutdown = Notifier::new();
         let network_config = NetworkConfig::default();
-        let authority_map = AuthorityMapping::new(&committee);
         let genesis = Certificate::genesis(&committee)
             .into_iter()
             .map(|cert| (cert.digest(), cert))
@@ -123,7 +121,6 @@ where
                 authority,
                 local_network,
                 network_config,
-                authority_map,
                 genesis,
             }),
             worker_cache,
@@ -183,18 +180,11 @@ where
 
     /// Committee network peer ids.
     pub fn committee_peer_ids(&self) -> HashSet<PeerId> {
-        // XXXX- authority map should live on committee or better yet go away.
-        self.inner.authority_map.peer_id_to_authority.keys().copied().collect()
+        self.inner.committee.authorities().iter().map(|a| a.peer_id()).collect()
     }
 
-    /// Return the libp2p network [PeerId] for an authority.
-    pub fn peer_id_for_authority(&self, authority_id: &AuthorityIdentifier) -> Option<PeerId> {
-        self.inner.authority_map.authority_to_peer_id.get(authority_id).copied()
-    }
-
-    /// Return the [AuthorityIdentifier] for a libp2p network [PeerId].
-    pub fn authority_for_peer_id(&self, peer_id: &PeerId) -> Option<AuthorityIdentifier> {
-        self.inner.authority_map.peer_id_to_authority.get(peer_id).cloned()
+    pub fn in_committee(&self, id: &AuthorityIdentifier) -> bool {
+        self.inner.committee.is_authority(id)
     }
 
     /// Retrieve the worker's network address by id.
@@ -204,34 +194,5 @@ where
             .worker(self.authority().protocol_key(), id)
             .expect("Our public key or worker id is not in the worker cache")
             .worker_address
-    }
-}
-
-/// Authority mappings between authority id (used by consensus) and peer id (used by network).
-#[derive(Debug)]
-pub struct AuthorityMapping {
-    /// Map the [AuthorityIdentifier] to the network [PeerId].
-    authority_to_peer_id: HashMap<AuthorityIdentifier, PeerId>,
-    /// Map the [PeerId] to the network [AuthorityIdentifier].
-    peer_id_to_authority: HashMap<PeerId, AuthorityIdentifier>,
-}
-
-impl AuthorityMapping {
-    /// Create a new instance of [Self].
-    pub fn new(committee: &Committee) -> Self {
-        let authority_to_peer_id: HashMap<AuthorityIdentifier, PeerId> = committee
-            .authorities()
-            .iter()
-            .map(|a| {
-                let fc = a.network_key();
-                let peer_id = network_public_key_to_libp2p(&fc);
-                (a.id(), peer_id)
-            })
-            .collect();
-
-        let peer_id_to_authority =
-            authority_to_peer_id.iter().map(|(a, p_id)| (*p_id, a.clone())).collect();
-
-        Self { authority_to_peer_id, peer_id_to_authority }
     }
 }

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -194,7 +194,7 @@ where
 
     /// Return the [AuthorityIdentifier] for a libp2p network [PeerId].
     pub fn authority_for_peer_id(&self, peer_id: &PeerId) -> Option<AuthorityIdentifier> {
-        self.inner.authority_map.peer_id_to_authority.get(peer_id).copied()
+        self.inner.authority_map.peer_id_to_authority.get(peer_id).cloned()
     }
 
     /// Retrieve the worker's network address by id.
@@ -230,7 +230,7 @@ impl AuthorityMapping {
             .collect();
 
         let peer_id_to_authority =
-            authority_to_peer_id.iter().map(|(a, p_id)| (*p_id, *a)).collect();
+            authority_to_peer_id.iter().map(|(a, p_id)| (*p_id, a.clone())).collect();
 
         Self { authority_to_peer_id, peer_id_to_authority }
     }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -297,12 +297,12 @@ impl<DB: Database> Subscriber<DB> {
         let num_certs = deliver.len();
 
         // get the execution address of the authority or use zero address
-        let leader = self.inner.committee.authority(&deliver.leader.origin());
+        let leader = self.inner.committee.authority(deliver.leader.origin());
         let address = if let Some(authority) = leader {
             authority.execution_address()
         } else {
             error!(target: "subscriber", "Execution address missing for {}", &deliver.leader.origin());
-            return Err(SubscriberError::UnexpectedAuthority(deliver.leader.origin()));
+            return Err(SubscriberError::UnexpectedAuthority(deliver.leader.origin().clone()));
         };
 
         let early_finalize = if self.consensus_bus.node_mode().borrow().is_active_cvv() {
@@ -524,7 +524,7 @@ mod tests {
             next_parents.clear();
             for id in &ids {
                 let (digest, certificate, payload) =
-                    signed_cert(*id, round, parents.clone(), fixture);
+                    signed_cert(id.clone(), round, parents.clone(), fixture);
                 certificates.push_back(certificate);
                 next_parents.insert(digest);
                 batches.extend(payload);

--- a/crates/consensus/executor/tests/consensus_integration_tests.rs
+++ b/crates/consensus/executor/tests/consensus_integration_tests.rs
@@ -30,10 +30,15 @@ async fn test_recovery() {
         tn_test_utils::make_optimal_certificates(&committee, 1..=4, &genesis, &ids);
 
     // Make two certificate (f+1) with round 5 to trigger the commits.
-    let (_, certificate) =
-        tn_test_utils::mock_certificate(&committee, ids[0], 5, next_parents.clone());
+    let (_, certificate) = tn_test_utils::mock_certificate(
+        &committee,
+        ids.get(0).unwrap().clone(),
+        5,
+        next_parents.clone(),
+    );
     certificates.push_back(certificate);
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[1], 5, next_parents);
+    let (_, certificate) =
+        tn_test_utils::mock_certificate(&committee, ids.get(1).unwrap().clone(), 5, next_parents);
     certificates.push_back(certificate);
 
     const NUM_SUB_DAGS_PER_SCHEDULE: u32 = 100;

--- a/crates/consensus/primary/src/aggregators/certificates.rs
+++ b/crates/consensus/primary/src/aggregators/certificates.rs
@@ -77,16 +77,16 @@ impl CertificatesAggregator {
         certificate: Certificate,
         committee: &Committee,
     ) -> Option<Vec<Certificate>> {
-        let origin = certificate.origin();
+        let origin = certificate.origin().clone();
 
         // ensure authority hasn't issued certificate already
-        if !self.authorities_seen.insert(origin) {
+        if !self.authorities_seen.insert(origin.clone()) {
             return None;
         }
 
         // accumulate certificates and voting power
         self.certificates.push(certificate);
-        self.weight += committee.stake_by_id(origin);
+        self.weight += committee.stake_by_id(&origin);
 
         // check for quorum
         if self.weight >= committee.quorum_threshold() {

--- a/crates/consensus/primary/src/aggregators/sync.rs
+++ b/crates/consensus/primary/src/aggregators/sync.rs
@@ -82,16 +82,16 @@ impl CertificatesAggregator {
         certificate: Certificate,
         committee: &Committee,
     ) -> Option<Vec<Certificate>> {
-        let origin = certificate.origin();
+        let origin = certificate.origin().clone();
 
         // ensure authority hasn't issued certificate already
-        if !self.authorities_seen.insert(origin) {
+        if !self.authorities_seen.insert(origin.clone()) {
             return None;
         }
 
         // accumulate certificates and voting power
         self.certificates.push(certificate);
-        self.weight += committee.stake_by_id(origin);
+        self.weight += committee.stake_by_id(&origin);
 
         // check for quorum
         if self.weight >= committee.quorum_threshold() {

--- a/crates/consensus/primary/src/aggregators/votes.rs
+++ b/crates/consensus/primary/src/aggregators/votes.rs
@@ -44,10 +44,13 @@ impl VotesAggregator {
     ) -> DagResult<Option<Certificate>> {
         // ensure authority hasn't voted already
         let author = vote.author();
-        ensure!(self.authorities_seen.insert(author), DagError::AuthorityReuse(author.to_string()));
+        ensure!(
+            self.authorities_seen.insert(author.clone()),
+            DagError::AuthorityReuse(author.to_string())
+        );
 
         // accumulate vote and voting power
-        self.votes.push((author, *vote.signature()));
+        self.votes.push((author.clone(), *vote.signature()));
         self.weight += committee.stake_by_id(author);
 
         // update metrics

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -157,7 +157,7 @@ impl<DB: Database> CertificateFetcher<DB> {
                     // Unnecessary to validate the header and certificate further, since it has
                     // already been validated.
 
-                    if let Some(r) = self.targets.get(&header.author()) {
+                    if let Some(r) = self.targets.get(header.author()) {
                         if header.round() <= *r {
                             // Ignore fetch request when we already need to sync to a later
                             // certificate from the same authority. Although this certificate may
@@ -190,7 +190,7 @@ impl<DB: Database> CertificateFetcher<DB> {
                     };
 
                     // Update the target rounds for the authority.
-                    self.targets.insert(header.author(), header.round());
+                    self.targets.insert(header.author().clone(), header.round());
 
                     // Kick start a fetch task if there is no other task running.
                     if self.fetch_certificates_task.is_empty() {
@@ -321,7 +321,7 @@ async fn run_fetch_task<DB: Database>(
         .set_bounds(gc_round, written_rounds)
         .set_max_items(MAX_CERTIFICATES_TO_FETCH);
     let Some(response) = fetch_certificates_helper(
-        state.authority_id,
+        &state.authority_id,
         state.network.clone(),
         &committee,
         request,
@@ -346,7 +346,7 @@ async fn run_fetch_task<DB: Database>(
 /// request. Terminates after the 1st successful response is received.
 #[instrument(level = "debug", skip_all)]
 async fn fetch_certificates_helper<DB: Database>(
-    name: AuthorityIdentifier,
+    name: &AuthorityIdentifier,
     network: PrimaryNetworkHandle,
     committee: &Committee,
     request: FetchCertificatesRequest,

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -320,14 +320,9 @@ async fn run_fetch_task<DB: Database>(
     let request = FetchCertificatesRequest::default()
         .set_bounds(gc_round, written_rounds)
         .set_max_items(MAX_CERTIFICATES_TO_FETCH);
-    let Some(response) = fetch_certificates_helper(
-        &state.authority_id,
-        state.network.clone(),
-        &committee,
-        request,
-        state.config.clone(),
-    )
-    .await
+    let Some(response) =
+        fetch_certificates_helper(&state.authority_id, state.network.clone(), &committee, request)
+            .await
     else {
         error!(target: "primary::cert_fetcher", "error awaiting fetch_certificates_helper");
         return Err(CertManagerError::NoCertificateFetched);
@@ -345,12 +340,11 @@ async fn run_fetch_task<DB: Database>(
 /// Fetches certificates from other primaries concurrently, with ~5 sec interval between each
 /// request. Terminates after the 1st successful response is received.
 #[instrument(level = "debug", skip_all)]
-async fn fetch_certificates_helper<DB: Database>(
+async fn fetch_certificates_helper(
     name: &AuthorityIdentifier,
     network: PrimaryNetworkHandle,
     committee: &Committee,
     request: FetchCertificatesRequest,
-    config: ConsensusConfig<DB>,
 ) -> Option<FetchCertificatesResponse> {
     let _scope = monitored_scope("FetchingCertificatesFromPeers");
     trace!(target: "primary::cert_fetcher", "Start sending fetch certificates requests");
@@ -359,7 +353,7 @@ async fn fetch_certificates_helper<DB: Database>(
     let mut peers: Vec<PeerId> = committee
         .others_primaries_by_id(name)
         .into_iter()
-        .map(|(auth_id, _, _)| config.peer_id_for_authority(&auth_id).expect("missing peer id!"))
+        .map(|(auth_id, _, _)| auth_id.peer_id())
         .collect();
     peers.shuffle(&mut ThreadRng::default());
     let fetch_timeout = PARALLEL_FETCH_REQUEST_INTERVAL_SECS

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -141,7 +141,7 @@ impl<DB: Database> Certifier<DB> {
         header: Header,
     ) -> DagResult<Vote> {
         debug!(target: "primary::certifier", ?authority, ?header, "requesting vote for header...");
-        let peer_id = self.config.peer_id_for_authority(&authority).expect("missing peer id!");
+        let peer_id = authority.peer_id();
 
         let mut missing_parents: Vec<CertificateDigest> = Vec::new();
         let mut attempt: u32 = 0;

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -79,14 +79,14 @@ impl<DB: Database> Certifier<DB> {
         // tx_own_certificate_broadcast.send()
         let broadcast_targets: Vec<(_, _)> = config
             .committee()
-            .others_primaries_by_id(config.authority().id())
+            .others_primaries_by_id(&config.authority().id())
             .into_iter()
             .map(|(name, _addr, _network_key)| (name, tx_own_certificate_broadcast.subscribe()))
             .collect();
 
         let highest_created_certificate = config
             .node_storage()
-            .last_round(config.authority().id())
+            .last_round(&config.authority().id())
             .expect("certificate store available");
 
         // TODO- these tasks to send to each peer should be replaced with a libp2p pub/sub topic.
@@ -211,7 +211,7 @@ impl<DB: Database> Certifier<DB> {
         ensure!(
             vote.header_digest() == header.digest()
                 && vote.origin() == header.author()
-                && vote.author() == authority,
+                && vote.author() == &authority,
             DagError::UnexpectedVote(vote.header_digest())
         );
         // Possible equivocations.
@@ -245,7 +245,7 @@ impl<DB: Database> Certifier<DB> {
         header: Header,
         rx_headers: &mut RXH,
     ) -> DagResult<Certificate> {
-        let authority_id = self.authority_id;
+        let authority_id = &self.authority_id;
         debug!(target: "primary::certifier", ?authority_id, "proposing header");
         if header.epoch() != self.committee.epoch() {
             error!(
@@ -264,13 +264,13 @@ impl<DB: Database> Certifier<DB> {
 
         // Reset the votes aggregator and sign our own header.
         let mut votes_aggregator = VotesAggregator::new(self.metrics.clone());
-        let vote = Vote::new(&header, &self.authority_id, &self.signature_service).await;
+        let vote = Vote::new(&header, self.authority_id.clone(), &self.signature_service).await;
         let mut certificate = votes_aggregator.append(vote, &self.committee, &header)?;
 
         // Trigger vote requests.
         let peers = self
             .committee
-            .others_primaries_by_id(self.authority_id)
+            .others_primaries_by_id(&self.authority_id)
             .into_iter()
             .map(|(name, _, network_key)| (name, network_key));
         let mut requests: FuturesUnordered<_> = peers

--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -340,7 +340,7 @@ impl<DB: ConsensusStore> Bullshark<DB> {
 
         to_commit.iter().for_each(|certificate| {
             let authority = committee
-                .authority(&certificate.origin())
+                .authority(certificate.origin())
                 .expect("verified certificate signed by authority in committee");
 
             metrics.leader_election.with_label_values(&["committed", authority.hostname()]).inc();

--- a/crates/consensus/primary/src/consensus/leader_schedule.rs
+++ b/crates/consensus/primary/src/consensus/leader_schedule.rs
@@ -39,7 +39,7 @@ impl Debug for LeaderSwapTable {
             self.round,
             self.good_nodes.iter().map(|a| a.id()).collect::<Vec<AuthorityIdentifier>>(),
             self.good_nodes.iter().map(|a| a.stake()).sum::<VotingPower>(),
-            self.bad_nodes.iter().map(|a| *a.0).collect::<Vec<AuthorityIdentifier>>(),
+            self.bad_nodes.iter().map(|a| a.0.clone()).collect::<Vec<AuthorityIdentifier>>(),
             self.bad_nodes.iter().map(|a| a.1.stake()).sum::<VotingPower>(),
         ))
     }
@@ -157,7 +157,7 @@ impl LeaderSwapTable {
 
         let mut stake = 0;
         for (authority_id, _score) in authorities {
-            stake += committee.stake_by_id(authority_id);
+            stake += committee.stake_by_id(&authority_id);
 
             // if the total accumulated stake has surpassed the stake threshold then we omit this
             // last authority and we exit the loop.

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -156,7 +156,7 @@ impl ConsensusState {
         if let Some((_, existing_certificate)) = dag
             .entry(certificate.round())
             .or_default()
-            .insert(certificate.origin(), (certificate.digest(), certificate.clone()))
+            .insert(certificate.origin().clone(), (certificate.digest(), certificate.clone()))
         {
             // we want to error only if we try to insert a different certificate in the dag
             if existing_certificate.digest() != certificate.digest() {
@@ -168,13 +168,13 @@ impl ConsensusState {
         }
 
         Ok(certificate.round()
-            > last_committed.get(&certificate.origin()).cloned().unwrap_or_default())
+            > last_committed.get(certificate.origin()).cloned().unwrap_or_default())
     }
 
     /// Update and clean up internal state after committing a certificate.
     pub fn update(&mut self, certificate: &Certificate) {
         self.last_committed
-            .entry(certificate.origin())
+            .entry(certificate.origin().clone())
             .and_modify(|r| *r = max(*r, certificate.round()))
             .or_insert_with(|| certificate.round());
         self.last_round = self.last_round.update(certificate.round(), self.gc_depth);

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -76,11 +76,11 @@ async fn commit_one_with_leader_schedule_change() {
             description: "When schedule change is enabled, then authority 0 is bad node and swapped with authority 3".to_string(),
             rounds: 11,
             expected_leaders: VecDeque::from(vec![
-                AuthorityIdentifier(0),
-                AuthorityIdentifier(1),
-                AuthorityIdentifier(2),
-                AuthorityIdentifier(3),
-                AuthorityIdentifier(3),
+                AuthorityIdentifier::dummy_for_test(0),
+                AuthorityIdentifier::dummy_for_test(1),
+                AuthorityIdentifier::dummy_for_test(2),
+                AuthorityIdentifier::dummy_for_test(3),
+                //XXXXAuthorityIdentifier::dummy_for_test(3),
             ]),
         },
     ];
@@ -165,7 +165,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         6,
         tn_test_utils::TestLeaderConfiguration {
             round: 6,
-            authority: AuthorityIdentifier(2),
+            authority: AuthorityIdentifier::dummy_for_test(2),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::Weak),
         },
@@ -178,7 +178,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         8,
         tn_test_utils::TestLeaderConfiguration {
             round: 8,
-            authority: AuthorityIdentifier(3),
+            authority: AuthorityIdentifier::dummy_for_test(3),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::NoSupport),
         },
@@ -196,7 +196,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         10,
         tn_test_utils::TestLeaderConfiguration {
             round: 10,
-            authority: AuthorityIdentifier(0),
+            authority: AuthorityIdentifier::dummy_for_test(0),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::Weak),
         },
@@ -261,7 +261,10 @@ async fn not_enough_support_with_leader_schedule_change() {
                 // update happened the leader schedule changed and now the Authority
                 // 0 is flagged as low score and it will be swapped with Authority
                 // 3.
-                assert_eq!(committed_dag_10.leader.origin(), AuthorityIdentifier(3));
+                assert_eq!(
+                    committed_dag_10.leader.origin(),
+                    AuthorityIdentifier::dummy_for_test(3)
+                );
 
                 assert_eq!(outcome, Outcome::Commit);
             }
@@ -278,7 +281,10 @@ async fn not_enough_support_with_leader_schedule_change() {
 
                 assert_eq!(committed_dag_14.leader_round(), 14);
 
-                assert_eq!(committed_dag_14.leader.origin(), AuthorityIdentifier(2));
+                assert_eq!(
+                    committed_dag_14.leader.origin(),
+                    AuthorityIdentifier::dummy_for_test(2)
+                );
             }
         }
     }
@@ -314,7 +320,7 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
             round,
             tn_test_utils::TestLeaderConfiguration {
                 round,
-                authority: AuthorityIdentifier(authority_id),
+                authority: AuthorityIdentifier::dummy_for_test(authority_id as u8),
                 should_omit: false,
                 support: Some(tn_test_utils::TestLeaderSupport::Weak),
             },
@@ -387,7 +393,10 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
                 // update happened the leader schedule changed and now the Authority
                 // 0 is flagged as low score and it will be swapped with Authority
                 // 3.
-                assert_eq!(committed_dag_10.leader.origin(), AuthorityIdentifier(3));
+                assert_eq!(
+                    committed_dag_10.leader.origin(),
+                    AuthorityIdentifier::dummy_for_test(3)
+                );
 
                 // The leaders of round 12 & 14 shouldn't change from the "original" schedule
                 let schedule = LeaderSchedule::new(committee, LeaderSwapTable::default());

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -80,18 +80,20 @@ async fn commit_one_with_leader_schedule_change() {
                 AuthorityIdentifier::dummy_for_test(1),
                 AuthorityIdentifier::dummy_for_test(2),
                 AuthorityIdentifier::dummy_for_test(3),
-                //XXXXAuthorityIdentifier::dummy_for_test(3),
+                AuthorityIdentifier::dummy_for_test(3),
             ]),
         },
     ];
 
-    for mut test_case in test_cases {
+    for test_case in test_cases {
         tracing::debug!("Running test case \"{}\"", test_case.description);
         // GIVEN
         let fixture = CommitteeFixture::builder(MemDatabase::default).build();
         let committee = fixture.committee();
         // Make certificates for rounds 1 to 9.
         let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
+        let mut expected_leaders: VecDeque<AuthorityIdentifier> = ids.iter().cloned().collect();
+        expected_leaders.push_back(ids.last().unwrap().clone());
         let genesis =
             Certificate::genesis(&committee).iter().map(|x| x.digest()).collect::<BTreeSet<_>>();
         let (certificates, _next_parents) = tn_test_utils::make_optimal_certificates(
@@ -124,17 +126,14 @@ async fn commit_one_with_leader_schedule_change() {
 
             if outcome == Outcome::Commit {
                 for sub_dag in &committed {
-                    assert_eq!(
-                        sub_dag.leader.origin(),
-                        test_case.expected_leaders.pop_front().unwrap()
-                    )
+                    assert_eq!(sub_dag.leader.origin(), &expected_leaders.pop_front().unwrap())
                 }
             }
 
             committed_sub_dags.extend(committed);
         }
 
-        assert!(test_case.expected_leaders.is_empty());
+        assert!(expected_leaders.is_empty());
     }
 }
 
@@ -165,7 +164,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         6,
         tn_test_utils::TestLeaderConfiguration {
             round: 6,
-            authority: AuthorityIdentifier::dummy_for_test(2),
+            authority: ids.get(2).unwrap().clone(),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::Weak),
         },
@@ -178,7 +177,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         8,
         tn_test_utils::TestLeaderConfiguration {
             round: 8,
-            authority: AuthorityIdentifier::dummy_for_test(3),
+            authority: ids.get(3).unwrap().clone(),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::NoSupport),
         },
@@ -196,7 +195,7 @@ async fn not_enough_support_with_leader_schedule_change() {
         10,
         tn_test_utils::TestLeaderConfiguration {
             round: 10,
-            authority: AuthorityIdentifier::dummy_for_test(0),
+            authority: ids.get(0).unwrap().clone(),
             should_omit: false,
             support: Some(tn_test_utils::TestLeaderSupport::Weak),
         },
@@ -261,10 +260,7 @@ async fn not_enough_support_with_leader_schedule_change() {
                 // update happened the leader schedule changed and now the Authority
                 // 0 is flagged as low score and it will be swapped with Authority
                 // 3.
-                assert_eq!(
-                    committed_dag_10.leader.origin(),
-                    AuthorityIdentifier::dummy_for_test(3)
-                );
+                assert_eq!(committed_dag_10.leader.origin(), ids.get(3).unwrap());
 
                 assert_eq!(outcome, Outcome::Commit);
             }
@@ -281,10 +277,7 @@ async fn not_enough_support_with_leader_schedule_change() {
 
                 assert_eq!(committed_dag_14.leader_round(), 14);
 
-                assert_eq!(
-                    committed_dag_14.leader.origin(),
-                    AuthorityIdentifier::dummy_for_test(2)
-                );
+                assert_eq!(committed_dag_14.leader.origin(), ids.get(2).unwrap());
             }
         }
     }
@@ -320,7 +313,7 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
             round,
             tn_test_utils::TestLeaderConfiguration {
                 round,
-                authority: AuthorityIdentifier::dummy_for_test(authority_id as u8),
+                authority: ids.get(authority_id).unwrap().clone(),
                 should_omit: false,
                 support: Some(tn_test_utils::TestLeaderSupport::Weak),
             },
@@ -393,16 +386,13 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
                 // update happened the leader schedule changed and now the Authority
                 // 0 is flagged as low score and it will be swapped with Authority
                 // 3.
-                assert_eq!(
-                    committed_dag_10.leader.origin(),
-                    AuthorityIdentifier::dummy_for_test(3)
-                );
+                assert_eq!(committed_dag_10.leader.origin(), ids.get(3).unwrap());
 
                 // The leaders of round 12 & 14 shouldn't change from the "original" schedule
                 let schedule = LeaderSchedule::new(committee, LeaderSwapTable::default());
 
-                assert_eq!(committed_dag_12.leader.origin(), schedule.leader(12).id());
-                assert_eq!(committed_dag_14.leader.origin(), schedule.leader(14).id());
+                assert_eq!(committed_dag_12.leader.origin(), &schedule.leader(12).id());
+                assert_eq!(committed_dag_14.leader.origin(), &schedule.leader(14).id());
 
                 assert_eq!(outcome, Outcome::Commit);
 
@@ -429,10 +419,15 @@ async fn commit_one() {
         tn_test_utils::make_optimal_certificates(&committee, 1..=2, &genesis, &ids);
 
     // Make two certificate (f+1) with round 3 to trigger the commits.
-    let (_, certificate) =
-        tn_test_utils::mock_certificate(&committee, ids[0], 3, next_parents.clone());
+    let (_, certificate) = tn_test_utils::mock_certificate(
+        &committee,
+        ids.get(0).unwrap().clone(),
+        3,
+        next_parents.clone(),
+    );
     certificates.push_back(certificate);
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[1], 3, next_parents);
+    let (_, certificate) =
+        tn_test_utils::mock_certificate(&committee, ids.get(1).unwrap().clone(), 3, next_parents);
     certificates.push_back(certificate);
 
     let config = fixture.authorities().next().unwrap().consensus_config();
@@ -563,7 +558,7 @@ async fn dead_node() {
             // For any other commit we expect to always have a +1 score for each authority, as
             // everyone always votes for the leader
             for (key, score) in &sub_dag.reputation_score.scores_per_authority {
-                if *key == dead_node {
+                if key == &dead_node {
                     assert_eq!(*score as usize, 0);
                 } else {
                     assert_eq!(*score as usize, index);
@@ -595,8 +590,12 @@ async fn not_enough_support() {
 
     // Round 2: Fully connect graph. But remember the digest of the leader. Note that this
     // round is the only one with 4 certificates.
-    let (leader_2_digest, certificate) =
-        tn_test_utils::mock_certificate(&committee, ids[0], 2, parents.clone());
+    let (leader_2_digest, certificate) = tn_test_utils::mock_certificate(
+        &committee,
+        ids.get(0).unwrap().clone(),
+        2,
+        parents.clone(),
+    );
     certificates.push_back(certificate);
 
     let nodes: Vec<_> = ids.iter().skip(1).cloned().collect();
@@ -607,19 +606,19 @@ async fn not_enough_support() {
     // Round 3: Only node 0 links to the leader of round 2.
     let mut next_parents = BTreeSet::new();
 
-    let name = ids[1];
+    let name = ids.get(1).unwrap().clone();
     let (digest, certificate) =
         tn_test_utils::mock_certificate(&committee, name, 3, parents.clone());
     certificates.push_back(certificate);
     next_parents.insert(digest);
 
-    let name = ids[2];
+    let name = ids.get(2).unwrap().clone();
     let (digest, certificate) =
         tn_test_utils::mock_certificate(&committee, name, 3, parents.clone());
     certificates.push_back(certificate);
     next_parents.insert(digest);
 
-    let name = ids[0];
+    let name = ids.get(0).unwrap().clone();
     parents.insert(leader_2_digest);
     let (digest, certificate) =
         tn_test_utils::mock_certificate(&committee, name, 3, parents.clone());
@@ -635,9 +634,15 @@ async fn not_enough_support() {
     certificates.extend(out);
 
     // Round 5: Send f+1 certificates to trigger the commit of leader 4.
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[0], 5, parents.clone());
+    let (_, certificate) = tn_test_utils::mock_certificate(
+        &committee,
+        ids.get(0).unwrap().clone(),
+        5,
+        parents.clone(),
+    );
     certificates.push_back(certificate);
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[1], 5, parents);
+    let (_, certificate) =
+        tn_test_utils::mock_certificate(&committee, ids.get(1).unwrap().clone(), 5, parents);
     certificates.push_back(certificate);
 
     let config = fixture.authorities().next().unwrap().consensus_config();
@@ -702,7 +707,7 @@ async fn not_enough_support() {
     // with value 1, and everything else should be zero.
     assert_eq!(committed_sub_dag.reputation_score.total_authorities(), 4);
 
-    let node_0_name: AuthorityIdentifier = ids[0];
+    let node_0_name: AuthorityIdentifier = ids.get(0).unwrap().clone();
     committed_sub_dag.reputation_score.scores_per_authority.iter().for_each(|(key, score)| {
         if *key == node_0_name {
             assert_eq!(*score, 1_u64);
@@ -738,9 +743,15 @@ async fn missing_leader() {
     certificates.extend(out);
 
     // Add f+1 certificates of round 5 to commit the leader of round 4.
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[0], 5, parents.clone());
+    let (_, certificate) = tn_test_utils::mock_certificate(
+        &committee,
+        ids.get(0).unwrap().clone(),
+        5,
+        parents.clone(),
+    );
     certificates.push_back(certificate);
-    let (_, certificate) = tn_test_utils::mock_certificate(&committee, ids[1], 5, parents);
+    let (_, certificate) =
+        tn_test_utils::mock_certificate(&committee, ids.get(1).unwrap().clone(), 5, parents);
     certificates.push_back(certificate);
 
     let config = fixture.authorities().next().unwrap().consensus_config();
@@ -1093,14 +1104,19 @@ async fn restart_with_new_committee() {
         // Make two certificate (f+1) with round 3 to trigger the commits.
         let (_, certificate) = tn_test_utils::mock_certificate_with_epoch(
             &committee,
-            ids[0],
+            ids.get(0).unwrap().clone(),
             3,
             epoch,
             next_parents.clone(),
         );
         certificates.push_back(certificate);
-        let (_, certificate) =
-            tn_test_utils::mock_certificate_with_epoch(&committee, ids[1], 3, epoch, next_parents);
+        let (_, certificate) = tn_test_utils::mock_certificate_with_epoch(
+            &committee,
+            ids.get(1).unwrap().clone(),
+            3,
+            epoch,
+            next_parents,
+        );
         certificates.push_back(certificate);
 
         // Feed all certificates to the consensus. Only the last certificate should trigger
@@ -1153,10 +1169,10 @@ async fn garbage_collection_basic() {
     // not see any certificate committed for authority 4.
     let ids: Vec<AuthorityIdentifier> =
         committee.authorities().iter().map(|authority| authority.id()).collect();
-    let slow_node = ids[3];
+    let slow_node = ids.get(3).unwrap().clone();
     let genesis = Certificate::genesis(&committee);
 
-    let slow_nodes = vec![(slow_node, 0.0_f64)];
+    let slow_nodes = vec![(slow_node.clone(), 0.0_f64)];
     let (certificates, _round_5_certificates) = tn_test_utils::make_certificates_with_slow_nodes(
         &committee,
         1..=7,
@@ -1186,7 +1202,7 @@ async fn garbage_collection_basic() {
         sub_dags.iter().for_each(|sub_dag| {
             // ensure nothing has been committed for authority 4
             assert!(
-                !sub_dag.certificates.iter().any(|c| c.header().author() == slow_node),
+                !sub_dag.certificates.iter().any(|c| c.header().author() == &slow_node),
                 "Slow authority shouldn't be amongst the committed ones"
             );
 
@@ -1234,10 +1250,10 @@ async fn slow_node() {
     // not see any certificate committed for authority 4.
     let ids: Vec<AuthorityIdentifier> =
         committee.authorities().iter().map(|authority| authority.id()).collect();
-    let slow_node = ids[3];
+    let slow_node = ids.get(3).unwrap().clone();
     let genesis = Certificate::genesis(&committee);
 
-    let slow_nodes = vec![(slow_node, 0.0_f64)];
+    let slow_nodes = vec![(slow_node.clone(), 0.0_f64)];
     let (certificates, round_8_certificates) = tn_test_utils::make_certificates_with_slow_nodes(
         &committee,
         1..=8,
@@ -1251,7 +1267,7 @@ async fn slow_node() {
 
     // Now we keep only the certificates from authorities 1-3
     certificates.retain(|c| {
-        if c.origin() == slow_node {
+        if c.origin() == &slow_node {
             // if it is slow node's add it to the dedicated vec
             slow_node_certificates.push_back(c.clone());
             return false;
@@ -1329,7 +1345,7 @@ async fn slow_node() {
                 }
 
                 let slow_node_total =
-                    sub_dag.certificates.iter().filter(|c| c.origin() == slow_node).count();
+                    sub_dag.certificates.iter().filter(|c| c.origin() == &slow_node).count();
 
                 assert_eq!(slow_node_total, 4);
 
@@ -1360,7 +1376,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
 
     // take the first 3 nodes only - 4th one won't propose anything
     let keys_with_dead_node = ids[0..=2].to_vec();
-    let slow_node = ids[3];
+    let slow_node = ids.get(3).unwrap().clone();
     let slow_nodes = vec![(slow_node, 0.0_f64)];
     let genesis = Certificate::genesis(&committee);
 
@@ -1380,16 +1396,18 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
         if id == first_node {
             let parents =
                 round_2_certificates.iter().map(|cert| cert.digest()).collect::<BTreeSet<_>>();
-            let (_, certificate) = tn_test_utils::mock_certificate(&committee, *id, 3, parents);
+            let (_, certificate) =
+                tn_test_utils::mock_certificate(&committee, id.clone(), 3, parents);
             round_3_certificates.push(certificate);
         } else {
             // we filter out the round 2 leader
             let parents = round_2_certificates
                 .iter()
-                .filter(|cert| cert.origin() != *first_node)
+                .filter(|cert| cert.origin() != first_node)
                 .map(|cert| cert.digest())
                 .collect::<BTreeSet<_>>();
-            let (_, certificate) = tn_test_utils::mock_certificate(&committee, *id, 3, parents);
+            let (_, certificate) =
+                tn_test_utils::mock_certificate(&committee, id.clone(), 3, parents);
             round_3_certificates.push(certificate);
         }
     }
@@ -1400,13 +1418,13 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
     for id in ids.iter().filter(|a| *a != missing_leader) {
         let parents =
             round_3_certificates.iter().map(|cert| cert.digest()).collect::<BTreeSet<_>>();
-        let (_, certificate) = tn_test_utils::mock_certificate(&committee, *id, 4, parents);
+        let (_, certificate) = tn_test_utils::mock_certificate(&committee, id.clone(), 4, parents);
         round_4_certificates.push(certificate);
     }
 
     // now from round 5 to 7 create all certificates. Node 1 is now a slow node and won't create
     // referrencies to the certificates of that one.
-    let slow_node = ids[0];
+    let slow_node = ids.get(0).unwrap().clone();
     let slow_nodes = vec![(slow_node, 0.0_f64)];
 
     let (certificates_5_to_7, _round_7_certificates) =

--- a/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
@@ -21,7 +21,7 @@ async fn test_leader_swap_table() {
     let mut scores = ReputationScores::new(&committee);
     scores.final_of_schedule = true;
     for (score, id) in authority_ids.iter().enumerate() {
-        scores.add_score(*id, score as u64);
+        scores.add_score(id, score as u64);
     }
 
     let table = LeaderSwapTable::new(
@@ -58,7 +58,7 @@ async fn test_leader_swap_table() {
     let mut scores = ReputationScores::new(&committee);
     scores.final_of_schedule = true;
     for (score, id) in authority_ids.iter().enumerate() {
-        scores.add_score(*id, score as u64);
+        scores.add_score(id, score as u64);
     }
 
     // We expect the first 3 authorities (f) to be amongst the bad nodes
@@ -99,7 +99,7 @@ async fn test_leader_schedule() {
     let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
     // Call the leader for round 2. It should give us the validator of position 0
-    let original_leader = authority_ids[0];
+    let original_leader = authority_ids.get(0).unwrap().clone();
     let leader_2 = schedule.leader(2);
 
     assert_eq!(leader_2.id(), original_leader);
@@ -108,7 +108,7 @@ async fn test_leader_schedule() {
     let mut scores = ReputationScores::new(&committee);
     scores.final_of_schedule = true;
     for (score, id) in authority_ids.iter().enumerate() {
-        scores.add_score(*id, score as u64);
+        scores.add_score(id, score as u64);
     }
 
     // Update the schedule
@@ -169,7 +169,7 @@ async fn test_leader_schedule_from_store() {
     let mut scores = ReputationScores::new(&committee);
     scores.final_of_schedule = true;
     for (score, id) in fixture.authorities().map(|a| a.id()).enumerate() {
-        scores.add_score(id, score as u64);
+        scores.add_score(&id, score as u64);
     }
 
     let sub_dag = CommittedSubDag::new(vec![], Certificate::default(), 0, scores, None);

--- a/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
@@ -366,7 +366,7 @@ pub fn make_certificates_with_parameters(
             // We want to ensure that we always refer to "our" certificate of the previous round -
             // assuming that exist, so we can re-add it later.
             let my_parent_digest = if let Some(my_previous_round) =
-                current_parents.iter().find(|c| c.origin() == authority.id())
+                current_parents.iter().find(|c| c.origin() == &authority.id())
             {
                 parent_digests.remove(&my_previous_round.digest());
                 Some(my_previous_round.digest())

--- a/crates/consensus/primary/src/consensus/utils.rs
+++ b/crates/consensus/primary/src/consensus/utils.rs
@@ -36,7 +36,7 @@ pub fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Certificat
                     let mut skip = already_ordered.contains(&digest);
                     skip |= state
                         .last_committed
-                        .get(&certificate.origin())
+                        .get(certificate.origin())
                         .map_or_else(|| false, |r| &certificate.round() <= r);
                     if !skip {
                         buffer.push(certificate);

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -110,10 +110,11 @@ where
             .certificates_in_votes
             .inc_by(num_parents as u64);
 
-        let committee_peer = self
-            .consensus_config
-            .authority_for_peer_id(&peer)
-            .ok_or(HeaderError::UnknownNetworkKey(peer))?;
+        let committee_peer: AuthorityIdentifier = peer.into();
+        ensure!(
+            self.consensus_config.in_committee(&committee_peer),
+            HeaderError::UnknownNetworkKey(peer).into()
+        );
         ensure!(header.author() == &committee_peer, HeaderError::PeerNotAuthor.into());
 
         // TODO: ensure peer's header isn't too far in the past

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -89,7 +89,7 @@ impl MissingCertificatesRequest {
                     .into_iter()
                     .map(|r| self.exclusive_lower_bound + r as Round)
                     .collect::<BTreeSet<Round>>();
-                Ok((*k, rounds))
+                Ok((k.clone(), rounds))
             })
             .collect::<PrimaryNetworkResult<BTreeMap<_, _>>>()?;
         Ok((self.exclusive_lower_bound, skip_rounds))

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -378,7 +378,7 @@ impl<DB: Database> Proposer<DB> {
     fn update_leader(&mut self) -> bool {
         let leader = self.leader_schedule.leader(self.round);
         self.last_leader =
-            self.last_parents.iter().find(|cert| cert.origin() == leader.id()).cloned();
+            self.last_parents.iter().find(|cert| cert.origin() == &leader.id()).cloned();
 
         debug!(target: "primary::proposer", leader=?self.last_leader, round=self.round, "Last leader for round?");
 
@@ -683,7 +683,7 @@ impl<DB: Database> Proposer<DB> {
                 let num_of_digests = self.digests.len().min(self.max_header_num_of_batches);
                 let digests: VecDeque<_> = self.digests.drain(..num_of_digests).collect();
                 let parents = std::mem::take(&mut self.last_parents);
-                let authority_id = self.authority_id;
+                let authority_id = self.authority_id.clone();
                 let min_delay = self.min_header_delay; // copy
                 let leader_and_support = if current_round % 2 == 0 {
                     let authority = self.leader_schedule.leader(current_round);
@@ -694,7 +694,7 @@ impl<DB: Database> Proposer<DB> {
                     }
                 } else {
                     let authority = self.leader_schedule.leader(current_round - 1);
-                    if parents.iter().any(|c| c.origin() == authority.id()) {
+                    if parents.iter().any(|c| c.origin() == &authority.id()) {
                         "odd_round_gives_support"
                     } else {
                         "odd_round_no_support"

--- a/crates/consensus/primary/src/state_handler.rs
+++ b/crates/consensus/primary/src/state_handler.rs
@@ -45,7 +45,7 @@ impl StateHandler {
         let own_rounds_committed: Vec<_> = certificates
             .iter()
             .filter_map(|cert| {
-                if cert.header().author() == self.authority_id {
+                if cert.header().author() == &self.authority_id {
                     Some(cert.header().round())
                 } else {
                     None

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -235,7 +235,7 @@ where
             let highest_processed_round =
                 self.highest_processed_round.fetch_max(cert.round()).max(cert.round());
             let certificate_source =
-                if self.config.authority().id().eq(&cert.origin()) { "own" } else { "other" };
+                if self.config.authority().id().eq(cert.origin()) { "own" } else { "other" };
             self.consensus_bus
                 .primary_metrics()
                 .node_metrics

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -131,7 +131,7 @@ where
         debug!(target: "primary::cert_validator", round=certificate.round(), ?certificate, "processing certificate");
 
         let certificate_source =
-            if self.config.authority().id().eq(&certificate.origin()) { "own" } else { "other" };
+            if self.config.authority().id().eq(certificate.origin()) { "own" } else { "other" };
         self.forward_verified_certs(certificate_source, certificate.round(), vec![certificate])
             .await
     }

--- a/crates/consensus/primary/src/state_sync/header_validator.rs
+++ b/crates/consensus/primary/src/state_sync/header_validator.rs
@@ -73,7 +73,7 @@ where
     ) -> HeaderResult<()> {
         // skip batch sync for own workers
         let authority_id = self.config.authority().id();
-        if header.author() == authority_id {
+        if header.author() == &authority_id {
             debug!(target: "primary::header_validator", "skipping sync_batches for header - no need to sync payload from own workers");
             return Ok(());
         }
@@ -128,7 +128,7 @@ where
                 let digests = digests.clone();
                 let message = WorkerSynchronizeMessage {
                     digests: digests.clone(),
-                    target: header.author(),
+                    target: header.author().clone(),
                     is_certified,
                 };
                 let client = client.clone();

--- a/crates/consensus/primary/src/tests/cert_collector_tests.rs
+++ b/crates/consensus/primary/src/tests/cert_collector_tests.rs
@@ -49,10 +49,10 @@ fn test_certificate_iterator() {
     // already in store. But this does not matter for testing here.
     let mut authorities = Vec::<AuthorityIdentifier>::new();
     for i in 0..total_authorities {
-        authorities.push(certificates[i].header().author());
+        authorities.push(certificates[i].header().author().clone());
         for j in 0..=i {
             let mut cert = certificates[i + j * total_authorities].clone();
-            assert_eq!(&cert.header().author(), authorities.last().unwrap());
+            assert_eq!(&cert.header().author(), &authorities.last().unwrap());
             if i == 3 && j == 3 {
                 // Simulating only 1 directly verified certificate (Auth 3 Round 4) being stored.
                 cert.set_signature_verification_state(

--- a/crates/consensus/primary/src/tests/certificate_processing_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_processing_tests.rs
@@ -186,7 +186,7 @@ async fn test_accept_pending_certs() -> eyre::Result<()> {
     let wrong_round = 2000;
     let (digest, cert) = signed_cert_for_test(
         keys.as_slice(),
-        all_certificates.iter().last().cloned().unwrap().origin(),
+        all_certificates.iter().last().cloned().unwrap().origin().clone(),
         wrong_round,
         next_parents,
         &committee,

--- a/crates/consensus/primary/src/tests/certificate_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_tests.rs
@@ -38,7 +38,7 @@ fn test_valid_certificate_verification() {
     // 3 Signers satisfies the 2F + 1 signed stake requirement
     for authority in fixture.authorities().take(3) {
         let vote = authority.vote(&header);
-        signatures.push((vote.author(), vote.signature().clone()));
+        signatures.push((vote.author().clone(), vote.signature().clone()));
     }
 
     let certificate = Certificate::new_unverified(&committee, header, signatures).unwrap();
@@ -62,7 +62,7 @@ fn test_certificate_insufficient_signatures() {
     // 2 Signatures. This is less than 2F + 1 (3).
     for authority in fixture.authorities().take(2) {
         let vote = authority.vote(&header);
-        signatures.push((vote.author(), vote.signature().clone()));
+        signatures.push((vote.author().clone(), vote.signature().clone()));
     }
 
     assert!(Certificate::new_unverified(&committee, header.clone(), signatures.clone()).is_err());
@@ -85,8 +85,8 @@ fn test_certificate_validly_repeated_public_keys() {
         let vote = authority.vote(&header);
         // We double every (pk, signature) pair - these should be ignored when forming the
         // certificate.
-        signatures.push((vote.author(), vote.signature().clone()));
-        signatures.push((vote.author(), vote.signature().clone()));
+        signatures.push((vote.author().clone(), vote.signature().clone()));
+        signatures.push((vote.author().clone(), vote.signature().clone()));
     }
 
     let certificate_res = Certificate::new_unverified(&committee, header, signatures);
@@ -107,14 +107,14 @@ fn test_unknown_signature_in_certificate() {
     // 2 Signatures. This is less than 2F + 1 (3).
     for authority in fixture.authorities().take(2) {
         let vote = authority.vote(&header);
-        signatures.push((vote.author(), vote.signature().clone()));
+        signatures.push((vote.author().clone(), vote.signature().clone()));
     }
 
     let malicious_key = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
     let malicious_id: AuthorityIdentifier = AuthorityIdentifier::dummy_for_test(50u8);
 
-    let vote = Vote::new_with_signer(&header, &malicious_id, &malicious_key);
-    signatures.push((vote.author(), vote.signature().clone()));
+    let vote = Vote::new_with_signer(&header, malicious_id, &malicious_key);
+    signatures.push((vote.author().clone(), vote.signature().clone()));
 
     assert!(Certificate::new_unverified(&committee, header, signatures).is_err());
 }
@@ -136,7 +136,7 @@ proptest::proptest! {
 
         for authority in fixture.authorities().take(quorum_threshold) {
             let vote = authority.vote(&header);
-            signatures.push((vote.author(), vote.signature().clone()));
+            signatures.push((vote.author().clone(), vote.signature().clone()));
         }
 
         let certificate = Certificate::new_unverified(&committee, header, signatures).unwrap();

--- a/crates/consensus/primary/src/tests/certificate_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_tests.rs
@@ -111,7 +111,7 @@ fn test_unknown_signature_in_certificate() {
     }
 
     let malicious_key = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
-    let malicious_id: AuthorityIdentifier = AuthorityIdentifier(50u16);
+    let malicious_id: AuthorityIdentifier = AuthorityIdentifier::dummy_for_test(50u8);
 
     let vote = Vote::new_with_signer(&header, &malicious_id, &malicious_key);
     signatures.push((vote.author(), vote.signature().clone()));

--- a/crates/consensus/primary/src/tests/certifier_tests.rs
+++ b/crates/consensus/primary/src/tests/certifier_tests.rs
@@ -33,7 +33,7 @@ async fn propose_header_to_form_certificate() {
         let name = peer.id();
         let vote =
             Vote::new(&proposed_header, name.clone(), peer.consensus_config().key_config()).await;
-        let id = primary.consensus_config().peer_id_for_authority(&name).unwrap();
+        let id = name.peer_id();
         peer_votes.insert(id, vote);
     }
 
@@ -183,7 +183,7 @@ async fn run_vote_aggregator_with_param(
         } else {
             Vote::new(&proposed_header, name.clone(), peer.consensus_config().key_config()).await
         };
-        let id = primary.consensus_config().peer_id_for_authority(&name).unwrap();
+        let id = name.peer_id();
         peer_votes.insert(id, vote);
     }
 

--- a/crates/consensus/primary/src/tests/certifier_tests.rs
+++ b/crates/consensus/primary/src/tests/certifier_tests.rs
@@ -31,7 +31,8 @@ async fn propose_header_to_form_certificate() {
     let mut peer_votes = HashMap::new();
     for peer in fixture.authorities().filter(|a| a.id() != id) {
         let name = peer.id();
-        let vote = Vote::new(&proposed_header, &name, peer.consensus_config().key_config()).await;
+        let vote =
+            Vote::new(&proposed_header, name.clone(), peer.consensus_config().key_config()).await;
         let id = primary.consensus_config().peer_id_for_authority(&name).unwrap();
         peer_votes.insert(id, vote);
     }
@@ -178,9 +179,9 @@ async fn run_vote_aggregator_with_param(
         // Create bad signature for a number of byzantines.
         let vote = if i < num_byzantine {
             let bad_key = BlsKeypair::generate(&mut StdRng::from_seed([0; 32]));
-            Vote::new_with_signer(&proposed_header, &name, &bad_key)
+            Vote::new_with_signer(&proposed_header, name.clone(), &bad_key)
         } else {
-            Vote::new(&proposed_header, &name, peer.consensus_config().key_config()).await
+            Vote::new(&proposed_header, name.clone(), peer.consensus_config().key_config()).await
         };
         let id = primary.consensus_config().peer_id_for_authority(&name).unwrap();
         peer_votes.insert(id, vote);

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -284,7 +284,7 @@ async fn test_vote_fails_unknown_authority() -> eyre::Result<()> {
     let wrong_authority = AuthorityIdentifier::dummy_for_test(100);
     let header = committee
         .header_builder_last_authority()
-        .author(wrong_authority)
+        .author(wrong_authority.clone())
         .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
         .created_at(1) // parent is 0
         .build();

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -24,8 +24,8 @@ fn test_missing_certs_request() {
     let max = 10;
     let expected_gc_round = 3;
     let expected_skip_rounds: BTreeMap<_, _> = [
-        (AuthorityIdentifier(0), BTreeSet::from([4, 5, 6, 7])),
-        (AuthorityIdentifier(2), BTreeSet::from([6, 7, 8])),
+        (AuthorityIdentifier::dummy_for_test(0), BTreeSet::from([4, 5, 6, 7])),
+        (AuthorityIdentifier::dummy_for_test(2), BTreeSet::from([6, 7, 8])),
     ]
     .into_iter()
     .collect();
@@ -281,7 +281,7 @@ async fn test_vote_fails_unknown_authority() -> eyre::Result<()> {
         network_public_key_to_libp2p(&committee.last_authority().primary_network_public_key());
 
     // create valid header proposed by last peer in the committee for round 1
-    let wrong_authority = AuthorityIdentifier(100);
+    let wrong_authority = AuthorityIdentifier::dummy_for_test(100);
     let header = committee
         .header_builder_last_authority()
         .author(wrong_authority)

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -61,8 +61,7 @@ async fn test_request_vote_has_missing_execution_block() {
     let target = fixture.authorities().next().unwrap();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        target.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
 
     let certificate_store = target.consensus_config().node_storage().clone();
     let payload_store = target.consensus_config().node_storage().clone();
@@ -123,8 +122,7 @@ async fn test_request_vote_older_execution_block() {
     let target = fixture.authorities().next().unwrap();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        target.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
 
     let certificate_store = target.consensus_config().node_storage().clone();
     let payload_store = target.consensus_config().node_storage().clone();
@@ -192,8 +190,7 @@ async fn test_request_vote_has_missing_parents() {
     let target = fixture.authorities().next().unwrap();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        target.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
 
     let certificate_store = target.consensus_config().node_storage().clone();
     let payload_store = target.consensus_config().node_storage().clone();
@@ -278,8 +275,7 @@ async fn test_request_vote_accept_missing_parents() {
     let target = fixture.authorities().next().unwrap();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        target.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
 
     let certificate_store = target.consensus_config().node_storage().clone();
     let payload_store = target.consensus_config().node_storage().clone();
@@ -368,8 +364,7 @@ async fn test_request_vote_missing_batches() {
     let authority_id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        primary.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
     let client = primary.consensus_config().local_network().clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();
@@ -434,8 +429,7 @@ async fn test_request_vote_already_voted() {
     let id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        primary.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
     let client = primary.consensus_config().local_network().clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();
@@ -638,8 +632,7 @@ async fn test_request_vote_created_at_in_future() {
     let id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_id = author.id();
-    let peer =
-        primary.consensus_config().peer_id_for_authority(&author_id).expect("missing peer id!");
+    let peer = author_id.peer_id();
     let client = primary.consensus_config().local_network().clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -571,10 +571,10 @@ async fn test_fetch_certificates_handler() {
     // already in store. But this does not matter for testing here.
     let mut authorities = Vec::<AuthorityIdentifier>::new();
     for i in 0..total_authorities {
-        authorities.push(certificates[i].header().author());
+        authorities.push(certificates[i].header().author().clone());
         for j in 0..=i {
             let mut cert = certificates[i + j * total_authorities].clone();
-            assert_eq!(&cert.header().author(), authorities.last().unwrap());
+            assert_eq!(&cert.header().author(), &authorities.last().unwrap());
             if i == 3 && j == 3 {
                 // Simulating only 1 directly verified certificate (Auth 3 Round 4) being stored.
                 cert.set_signature_verification_state(

--- a/crates/consensus/primary/tests/certificate_order_test.rs
+++ b/crates/consensus/primary/tests/certificate_order_test.rs
@@ -46,9 +46,9 @@ async fn test_certificate_signers_are_ordered() {
         sorted_signers.push(authority.primary_public_key());
 
         let vote =
-            Vote::new(&header.clone(), &authority.id(), authority.consensus_config().key_config())
+            Vote::new(&header.clone(), authority.id(), authority.consensus_config().key_config())
                 .await;
-        votes.push((vote.author(), vote.signature().clone()));
+        votes.push((vote.author().clone(), vote.signature().clone()));
     }
 
     // Just shuffle to ensure that any underlying sorting will work correctly

--- a/crates/network-libp2p/src/tests/tn_codec_tests.rs
+++ b/crates/network-libp2p/src/tests/tn_codec_tests.rs
@@ -86,7 +86,7 @@ async fn test_fail_to_write_message_too_big() {
 
 #[tokio::test]
 async fn test_reject_message_prefix_too_big() {
-    let max_chunk_size = 416; // 416 bytes
+    let max_chunk_size = 344; // 344 bytes
     let mut honest_peer = TNCodec::<TestPrimaryRequest, TestPrimaryResponse>::new(max_chunk_size);
     let protocol = StreamProtocol::new("/tn-test");
     // malicious peer writes legit messages that are too big
@@ -100,7 +100,8 @@ async fn test_reject_message_prefix_too_big() {
     // sanity check
     let mut encoded = Vec::new();
 
-    // this is 416 bytes uncompressed (max chunk size)
+    //println!("size: {}", std::mem::size_of::<TestPrimaryRequest>());
+    // this is 344 bytes uncompressed (max chunk size)
     let request = TestPrimaryRequest::Vote {
         header: Header::default(),
         parents: vec![Certificate::default()],

--- a/crates/network-libp2p/src/tests/tn_codec_tests.rs
+++ b/crates/network-libp2p/src/tests/tn_codec_tests.rs
@@ -86,7 +86,7 @@ async fn test_fail_to_write_message_too_big() {
 
 #[tokio::test]
 async fn test_reject_message_prefix_too_big() {
-    let max_chunk_size = 208; // 208 bytes
+    let max_chunk_size = 416; // 416 bytes
     let mut honest_peer = TNCodec::<TestPrimaryRequest, TestPrimaryResponse>::new(max_chunk_size);
     let protocol = StreamProtocol::new("/tn-test");
     // malicious peer writes legit messages that are too big
@@ -100,7 +100,7 @@ async fn test_reject_message_prefix_too_big() {
     // sanity check
     let mut encoded = Vec::new();
 
-    // this is 208 bytes uncompressed (max chunk size)
+    // this is 416 bytes uncompressed (max chunk size)
     let request = TestPrimaryRequest::Vote {
         header: Header::default(),
         parents: vec![Certificate::default()],
@@ -149,8 +149,10 @@ async fn test_reject_message_prefix_too_big() {
 
     // now encode legit message that's too big for honest peer
     let mut encoded = Vec::new();
-    // 274 bytes uncompressed
+    // > 416 bytes uncompressed
     let big_response = TestPrimaryResponse::MissingCertificates(vec![
+        Certificate::default(),
+        Certificate::default(),
         Certificate::default(),
         Certificate::default(),
     ]);

--- a/crates/network-types/src/request.rs
+++ b/crates/network-types/src/request.rs
@@ -53,7 +53,7 @@ impl FetchCertificatesRequest {
                             .into_iter()
                             .map(|r| self.exclusive_lower_bound + r as Round)
                             .collect();
-                        Some((*k, rounds))
+                        Some((k.clone(), rounds))
                     }
                     Err(e) => {
                         warn!("Failed to deserialize RoaringBitmap {e}");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -136,7 +136,7 @@ async fn start_networks<DB: TNDatabase>(
     let peers_connected = Arc::new(AtomicU32::new(0));
     let workers_connected = Arc::new(AtomicU32::new(0));
     for (authority_id, addr, _) in
-        consensus_config.committee().others_primaries_by_id(consensus_config.authority().id())
+        consensus_config.committee().others_primaries_by_id(&consensus_config.authority().id())
     {
         let peer_id =
             consensus_config.peer_id_for_authority(&authority_id).expect("missing peer id!");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -138,8 +138,7 @@ async fn start_networks<DB: TNDatabase>(
     for (authority_id, addr, _) in
         consensus_config.committee().others_primaries_by_id(&consensus_config.authority().id())
     {
-        let peer_id =
-            consensus_config.peer_id_for_authority(&authority_id).expect("missing peer id!");
+        let peer_id = authority_id.peer_id();
         dial_primary(primary_network_handle.clone(), peer_id, addr, peers_connected.clone());
     }
     for (peer_id, addr) in consensus_config.worker_cache().all_workers() {

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -349,7 +349,7 @@ async fn max_consensus_header_from_committee<DB: Database>(
 fn get_peers<DB: Database>(config: &ConsensusConfig<DB>) -> Vec<PeerId> {
     config
         .committee()
-        .others_primaries_by_id(config.authority().id())
+        .others_primaries_by_id(&config.authority().id())
         .into_iter()
         .map(|(auth_id, _, _)| config.peer_id_for_authority(&auth_id).expect("missing peer id!"))
         .collect()

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -351,7 +351,7 @@ fn get_peers<DB: Database>(config: &ConsensusConfig<DB>) -> Vec<PeerId> {
         .committee()
         .others_primaries_by_id(&config.authority().id())
         .into_iter()
-        .map(|(auth_id, _, _)| config.peer_id_for_authority(&auth_id).expect("missing peer id!"))
+        .map(|(auth_id, _, _)| auth_id.peer_id())
         .collect()
 }
 

--- a/crates/storage/src/stores/consensus_store.rs
+++ b/crates/storage/src/stores/consensus_store.rs
@@ -68,7 +68,7 @@ impl<DB: Database> ConsensusStore for DB {
         for (id, round, certs) in
             self.reverse_iter::<ConsensusBlocks>().take(50).map(|(_, block)| {
                 (
-                    block.sub_dag.leader.origin(),
+                    block.sub_dag.leader.origin().clone(),
                     block.sub_dag.leader_round(),
                     block.sub_dag.certificates,
                 )
@@ -76,7 +76,7 @@ impl<DB: Database> ConsensusStore for DB {
         {
             res.entry(id).and_modify(|r| *r = max(*r, round)).or_insert_with(|| round);
             for c in &certs {
-                res.entry(c.origin())
+                res.entry(c.origin().clone())
                     .and_modify(|r| *r = max(*r, c.round()))
                     .or_insert_with(|| c.round());
             }

--- a/crates/storage/src/stores/vote_digest_store.rs
+++ b/crates/storage/src/stores/vote_digest_store.rs
@@ -20,7 +20,7 @@ impl<DB: Database> VoteDigestStore for DB {
     fn write_vote(&self, vote: &Vote) -> eyre::Result<()> {
         fail_point!("vote-digest-store-before-write");
 
-        let result = self.insert::<Votes>(&vote.origin(), &vote.into());
+        let result = self.insert::<Votes>(vote.origin(), &vote.into());
 
         fail_point!("vote-digest-store-after-write");
         result

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -92,7 +92,7 @@ impl<DB: Database> AuthorityFixture<DB> {
 
     /// Sign a [Header] and return a [Vote] with no additional validation.
     pub fn vote(&self, header: &Header) -> Vote {
-        Vote::new_sync(header, &self.id(), self.consensus_config.key_config())
+        Vote::new_sync(header, self.id(), self.consensus_config.key_config())
     }
 
     /// Return the consensus config.

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -15,8 +15,9 @@ use std::{
 };
 use tn_config::KeyConfig;
 use tn_types::{
-    get_available_udp_port, Address, Authority, BlsKeypair, Committee, Database, Epoch, Multiaddr,
-    VotingPower, WorkerCache, WorkerIndex, DEFAULT_PRIMARY_PORT, DEFAULT_WORKER_PORT,
+    get_available_udp_port, Address, Authority, AuthorityIdentifier, BlsKeypair, Committee,
+    Database, Epoch, Multiaddr, VotingPower, WorkerCache, WorkerIndex, DEFAULT_PRIMARY_PORT,
+    DEFAULT_WORKER_PORT,
 };
 
 pub struct Builder<DB, F, R = OsRng> {
@@ -166,26 +167,23 @@ where
             ),
         };
         // All the authorities use the same worker cache.
-        let mut authorities: Vec<AuthorityFixture<DB>> = committee_info
+        let authorities: BTreeMap<AuthorityIdentifier, AuthorityFixture<DB>> = committee_info
             .into_iter()
             .map(|(primary_keypair, key_config, authority, worker)| {
-                AuthorityFixture::generate(
-                    self.number_of_workers,
-                    authority,
-                    (primary_keypair, key_config),
-                    committee.clone(),
-                    (self.new_db)(),
-                    worker,
-                    worker_cache.clone(),
+                (
+                    authority.id(),
+                    AuthorityFixture::generate(
+                        self.number_of_workers,
+                        authority,
+                        (primary_keypair, key_config),
+                        committee.clone(),
+                        (self.new_db)(),
+                        worker,
+                        worker_cache.clone(),
+                    ),
                 )
             })
             .collect();
-
-        // now order the AuthorityFixtures by the authority BlsPublicKey so when we iterate either
-        // via the committee.authorities() or via the fixture.authorities() we'll get the
-        // same order.
-        // These are probably already sorted but this does not hurt and the comment is helpful.
-        authorities.sort_by_key(|a1| a1.primary_public_key());
 
         CommitteeFixture { authorities, committee }
     }

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -117,7 +117,6 @@ where
             let primary_network_address: Multiaddr =
                 format!("/ip4/{host}/udp/{port}/quic-v1").parse().unwrap();
             let authority = Authority::new_for_test(
-                (i as u16).into(),
                 key_config.primary_public_key(),
                 *self.stake.get(i).unwrap_or(&1),
                 primary_network_address,
@@ -133,8 +132,7 @@ where
         // Reset the authority ids so they are in sort order.  Some tests require this.
         for (i, (_, (primary_keypair, key_config, authority))) in authorities.iter_mut().enumerate()
         {
-            authority.initialise((i as u16).into());
-            let worker = WorkerFixture::generate(key_config.clone(), authority.id().0, |host| {
+            let worker = WorkerFixture::generate(key_config.clone(), i as u16, |host| {
                 if self.randomize_ports {
                     get_available_udp_port(host).unwrap_or(DEFAULT_PRIMARY_PORT)
                 } else {

--- a/crates/test-utils/src/helpers.rs
+++ b/crates/test-utils/src/helpers.rs
@@ -207,7 +207,7 @@ fn rounds_of_certificates(
         for id in ids {
             let this_cert_parents = this_cert_parents(&parents, failure_probability);
 
-            let (digest, certificate) = make_one_certificate(*id, round, this_cert_parents);
+            let (digest, certificate) = make_one_certificate(id.clone(), round, this_cert_parents);
             certificates.push_back(certificate);
             next_parents.insert(digest);
         }
@@ -268,7 +268,8 @@ pub fn make_certificates_with_slow_nodes(
                 committee,
             );
 
-            let (_, certificate) = mock_certificate(committee, *name, round, this_cert_parents);
+            let (_, certificate) =
+                mock_certificate(committee, name.clone(), round, this_cert_parents);
             certificates.push_back(certificate.clone());
             next_parents.push(certificate);
         }
@@ -342,7 +343,7 @@ pub fn make_certificates_with_leader_configuration(
                             let leader_certificate = certificates
                                 .iter()
                                 .find(|c| {
-                                    c.round() == round - 1 && c.origin() == leader_config.authority
+                                    c.round() == round - 1 && c.origin() == &leader_config.authority
                                 })
                                 .unwrap();
 
@@ -369,7 +370,7 @@ pub fn make_certificates_with_leader_configuration(
                             let c = certificates
                                 .iter()
                                 .find(|c| {
-                                    c.round() == round - 1 && c.origin() == leader_config.authority
+                                    c.round() == round - 1 && c.origin() == &leader_config.authority
                                 })
                                 .unwrap();
                             let mut p = parents.clone();
@@ -386,7 +387,7 @@ pub fn make_certificates_with_leader_configuration(
             };
 
             // Create the certificates
-            let (_, certificate) = mock_certificate(committee, *name, round, cert_parents);
+            let (_, certificate) = mock_certificate(committee, name.clone(), round, cert_parents);
             certificates.push_back(certificate.clone());
             next_parents.insert(certificate.digest());
         }
@@ -414,13 +415,12 @@ pub fn this_cert_parents_with_slow_nodes(
     let mut total_stake = 0;
 
     for parent in ancestors {
-        let authority = committee.authority(&parent.origin()).unwrap();
+        let authority = committee.authority(parent.origin()).unwrap();
 
         // Identify if the parent is within the slow nodes - and is not the same author as the
         // one we want to create the certificate for.
-        if let Some((_, inclusion_probability)) = slow_nodes
-            .iter()
-            .find(|(id, _)| *id != *authority_id && *id == parent.header().author())
+        if let Some((_, inclusion_probability)) =
+            slow_nodes.iter().find(|(id, _)| id != authority_id && id == parent.header().author())
         {
             let b = Bernoulli::new(*inclusion_probability).unwrap();
             let should_include = b.sample(rand);
@@ -442,7 +442,7 @@ pub fn this_cert_parents_with_slow_nodes(
     // ensure we'll have enough parents (2f + 1)
     while total_stake < committee.quorum_threshold() {
         let parent = not_included.pop().unwrap();
-        let authority = committee.authority(&parent.origin()).unwrap();
+        let authority = committee.authority(parent.origin()).unwrap();
 
         total_stake += authority.stake();
 
@@ -475,7 +475,7 @@ pub fn make_certificates_with_epoch(
         next_parents.clear();
         for name in keys {
             let (digest, certificate) =
-                mock_certificate_with_epoch(committee, *name, round, epoch, parents.clone());
+                mock_certificate_with_epoch(committee, name.clone(), round, epoch, parents.clone());
             certificates.push_back(certificate);
             next_parents.insert(digest);
         }
@@ -492,7 +492,7 @@ pub fn make_signed_certificates(
     keys: &[(AuthorityIdentifier, BlsKeypair)],
     failure_probability: f64,
 ) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
-    let ids = keys.iter().map(|(authority, _)| *authority).collect::<Vec<_>>();
+    let ids = keys.iter().map(|(authority, _)| authority.clone()).collect::<Vec<_>>();
     let generator = |pk, round, parents| signed_cert_for_test(keys, pk, round, parents, committee);
 
     rounds_of_certificates(range, initial_parents, &ids[..], failure_probability, generator)
@@ -571,7 +571,10 @@ pub fn signed_cert_for_test(
     let votes = signers
         .iter()
         .map(|(name, signer)| {
-            (*name, BlsSignature::new_secure(&to_intent_message(cert.header().digest()), signer))
+            (
+                name.clone(),
+                BlsSignature::new_secure(&to_intent_message(cert.header().digest()), signer),
+            )
         })
         .collect();
 

--- a/crates/test-utils/src/tests/output_tests.rs
+++ b/crates/test-utils/src/tests/output_tests.rs
@@ -106,32 +106,32 @@ fn test_authority_sorting_in_reputation_scores() {
 
     let mut scores = ReputationScores::new(&committee);
 
-    let ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
+    let mut ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
 
     // adding some scores
-    scores.add_score(ids[0], 0);
-    scores.add_score(ids[1], 10);
-    scores.add_score(ids[2], 10);
-    scores.add_score(ids[3], 10);
-    scores.add_score(ids[4], 10);
-    scores.add_score(ids[5], 20);
-    scores.add_score(ids[6], 30);
-    scores.add_score(ids[7], 30);
-    scores.add_score(ids[8], 40);
-    scores.add_score(ids[9], 40);
+    scores.add_score(ids.get(0).unwrap(), 0);
+    scores.add_score(ids.get(1).unwrap(), 10);
+    scores.add_score(ids.get(2).unwrap(), 10);
+    scores.add_score(ids.get(3).unwrap(), 10);
+    scores.add_score(ids.get(4).unwrap(), 10);
+    scores.add_score(ids.get(5).unwrap(), 20);
+    scores.add_score(ids.get(6).unwrap(), 30);
+    scores.add_score(ids.get(7).unwrap(), 30);
+    scores.add_score(ids.get(8).unwrap(), 40);
+    scores.add_score(ids.get(9).unwrap(), 40);
 
     // the expected authorities
     let expected_authorities = vec![
-        (ids[9], 40),
-        (ids[8], 40),
-        (ids[7], 30),
-        (ids[6], 30),
-        (ids[5], 20),
-        (ids[4], 10),
-        (ids[3], 10),
-        (ids[2], 10),
-        (ids[1], 10),
-        (ids[0], 0),
+        (ids.pop().unwrap(), 40),
+        (ids.pop().unwrap(), 40),
+        (ids.pop().unwrap(), 30),
+        (ids.pop().unwrap(), 30),
+        (ids.pop().unwrap(), 20),
+        (ids.pop().unwrap(), 10),
+        (ids.pop().unwrap(), 10),
+        (ids.pop().unwrap(), 10),
+        (ids.pop().unwrap(), 10),
+        (ids.pop().unwrap(), 0),
     ];
 
     // sorting the authorities

--- a/crates/test-utils/src/tests/output_tests.rs
+++ b/crates/test-utils/src/tests/output_tests.rs
@@ -14,7 +14,7 @@ fn test_zero_timestamp_in_sub_dag() {
 
     let header_builder = HeaderBuilder::default();
     let header = header_builder
-        .author(AuthorityIdentifier(1u16))
+        .author(AuthorityIdentifier::default())
         .round(2)
         .epoch(0)
         .created_at(50)
@@ -48,7 +48,7 @@ fn test_monotonically_incremented_commit_timestamps() {
 
     let header_builder = HeaderBuilder::default();
     let header = header_builder
-        .author(AuthorityIdentifier(1u16))
+        .author(AuthorityIdentifier::default())
         .round(2)
         .epoch(0)
         .created_at(newer_timestamp)
@@ -73,7 +73,7 @@ fn test_monotonically_incremented_commit_timestamps() {
     // Now create the leader of round 4 with the older timestamp
     let header_builder = HeaderBuilder::default();
     let header = header_builder
-        .author(AuthorityIdentifier(1u16))
+        .author(AuthorityIdentifier::default())
         .round(4)
         .epoch(0)
         .created_at(older_timestamp)

--- a/crates/test-utils/src/tests/storage_tests.rs
+++ b/crates/test-utils/src/tests/storage_tests.rs
@@ -240,15 +240,15 @@ async fn test_certificate_store_last_two_rounds() {
 
     // create certificates for 50 rounds
     let certs = certificates(50);
-    let origin = certs[0].origin();
+    let origin = certs[0].origin().clone();
 
     // store them in both main and secondary index
     store.write_all(certs).unwrap();
 
     // WHEN
     let result = store.last_two_rounds_certs().unwrap();
-    let last_round_cert = store.last_round(origin).unwrap().unwrap();
-    let last_round_number = store.last_round_number(origin).unwrap().unwrap();
+    let last_round_cert = store.last_round(&origin).unwrap().unwrap();
+    let last_round_number = store.last_round_number(&origin).unwrap().unwrap();
     let highest_round_number = store.highest_round_number();
 
     // THEN
@@ -271,8 +271,8 @@ async fn test_certificate_store_last_round_in_empty_store() {
 
     // WHEN
     let result = store.last_two_rounds_certs().unwrap();
-    let last_round_cert = store.last_round(AuthorityIdentifier::default()).unwrap();
-    let last_round_number = store.last_round_number(AuthorityIdentifier::default()).unwrap();
+    let last_round_cert = store.last_round(&AuthorityIdentifier::default()).unwrap();
+    let last_round_number = store.last_round_number(&AuthorityIdentifier::default()).unwrap();
     let highest_round_number = store.highest_round_number();
 
     // THEN

--- a/crates/test-utils/src/tests/storage_tests.rs
+++ b/crates/test-utils/src/tests/storage_tests.rs
@@ -249,7 +249,6 @@ async fn test_certificate_store_last_two_rounds() {
     let result = store.last_two_rounds_certs().unwrap();
     let last_round_cert = store.last_round(origin).unwrap().unwrap();
     let last_round_number = store.last_round_number(origin).unwrap().unwrap();
-    let last_round_number_not_exist = store.last_round_number(AuthorityIdentifier(10u16)).unwrap();
     let highest_round_number = store.highest_round_number();
 
     // THEN
@@ -263,7 +262,6 @@ async fn test_certificate_store_last_two_rounds() {
                 || (certificate.round() == last_round_number - 1)
         );
     }
-    assert!(last_round_number_not_exist.is_none());
 }
 
 #[tokio::test]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -45,7 +45,7 @@ alloy-rlp = { workspace = true }
 parking_lot = { workspace = true }
 serde_yaml = { workspace = true }
 secp256k1 = { workspace = true }
-libp2p = { workspace = true }
+libp2p = { workspace = true, features = ["serde"] }
 bs58 = { workspace = true }
 blake2 = { workspace = true }
 blst = { workspace = true, features = ["serde"] }

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -86,6 +86,11 @@ impl Authority {
         self.network_key.to_peer_id().into()
     }
 
+    /// Return the peer id for the primary network.
+    pub fn peer_id(&self) -> PeerId {
+        self.network_key.to_peer_id()
+    }
+
     pub fn protocol_key(&self) -> &BlsPublicKey {
         // Skip the assert here, this is called in testing before the initialise...
         &self.protocol_key
@@ -214,6 +219,10 @@ impl AuthorityIdentifier {
         .expect("valid multihash bytes")
         .into()
     }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.into()
+    }
 }
 
 impl Default for AuthorityIdentifier {
@@ -241,6 +250,12 @@ impl From<PeerId> for AuthorityIdentifier {
 
 impl From<AuthorityIdentifier> for PeerId {
     fn from(value: AuthorityIdentifier) -> Self {
+        *value.0
+    }
+}
+
+impl From<&AuthorityIdentifier> for PeerId {
+    fn from(value: &AuthorityIdentifier) -> Self {
         *value.0
     }
 }
@@ -314,6 +329,12 @@ impl Committee {
     pub fn authorities(&self) -> Vec<Authority> {
         // Return sorted by id (using the id keyed BTree) since this may be important to some code.
         self.inner.read().authorities_by_id.values().cloned().collect()
+    }
+
+    /// Return true if the authority for id is in the committee.
+    pub fn is_authority(&self, id: &AuthorityIdentifier) -> bool {
+        // Return sorted by id (using the id keyed BTree) since this may be important to some code.
+        self.inner.read().authorities_by_id.contains_key(id)
     }
 
     /// Returns the number of authorities.

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -135,10 +135,9 @@ impl CommitteeInner {
     pub fn load(&mut self) {
         self.authorities_by_id = self
             .authorities
-            .iter()
-            .map(|(_key, authority)| {
+            .values()
+            .map(|authority| {
                 let id = authority.id();
-
                 (id, authority.clone())
             })
             .collect();

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -351,7 +351,7 @@ impl Committee {
         self.inner
             .read()
             .authorities_by_id
-            .get(&id)
+            .get(id)
             .map_or_else(|| 0, |authority| authority.voting_power)
     }
 

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -84,7 +84,7 @@ impl Header {
         }
 
         // Ensure the authority has voting rights.
-        let voting_rights = committee.stake_by_id(self.author);
+        let voting_rights = committee.stake_by_id(&self.author);
         if voting_rights == 0 {
             return Err(HeaderError::UnknownAuthority(self.author.to_string()));
         }
@@ -106,8 +106,8 @@ impl Header {
     }
 
     /// The [AuthorityIdentifier] that produced the header.
-    pub fn author(&self) -> AuthorityIdentifier {
-        self.author
+    pub fn author(&self) -> &AuthorityIdentifier {
+        &self.author
     }
     /// The [Round] for the header.
     pub fn round(&self) -> Round {

--- a/crates/types/src/primary/reputation.rs
+++ b/crates/types/src/primary/reputation.rs
@@ -27,11 +27,12 @@ impl ReputationScores {
         Self { scores_per_authority, ..Default::default() }
     }
     /// Adds the provided `score` to the existing score for the provided `authority`
-    pub fn add_score(&mut self, authority: AuthorityIdentifier, score: u64) {
-        self.scores_per_authority
-            .entry(authority)
-            .and_modify(|value| *value += score)
-            .or_insert(score);
+    pub fn add_score(&mut self, authority: &AuthorityIdentifier, score: u64) {
+        if let Some(val) = self.scores_per_authority.get_mut(authority) {
+            *val += score;
+        } else {
+            self.scores_per_authority.insert(authority.clone(), score);
+        }
     }
 
     /// The total number of authorities.
@@ -49,7 +50,7 @@ impl ReputationScores {
         let mut authorities: Vec<_> = self
             .scores_per_authority
             .iter()
-            .map(|(authority, score)| (*authority, *score))
+            .map(|(authority, score)| (authority.clone(), *score))
             .collect();
 
         authorities.sort_by(|a1, a2| {

--- a/crates/types/src/primary/vote.rs
+++ b/crates/types/src/primary/vote.rs
@@ -32,7 +32,7 @@ impl Vote {
     /// Create a new instance of [Vote]
     pub async fn new<BLS: BlsSigner>(
         header: &Header,
-        author: &AuthorityIdentifier,
+        author: AuthorityIdentifier,
         signature_service: &BLS,
     ) -> Self {
         Self::new_sync(header, author, signature_service)
@@ -41,7 +41,7 @@ impl Vote {
     /// Create a new instance of [Vote], sync version.
     pub fn new_sync<BLS: BlsSigner>(
         header: &Header,
-        author: &AuthorityIdentifier,
+        author: AuthorityIdentifier,
         signature_service: &BLS,
     ) -> Self {
         let header_digest = header.digest();
@@ -52,15 +52,15 @@ impl Vote {
             header_digest,
             round: header.round(),
             epoch: header.epoch(),
-            origin: header.author(),
-            author: *author,
+            origin: header.author().clone(),
+            author,
             signature,
         }
     }
 
     /// Create a vote directly with a suplied signer (private key).
     /// Used for testing, other wise use one BlsSigner versions.
-    pub fn new_with_signer<S>(header: &Header, author: &AuthorityIdentifier, signer: &S) -> Self
+    pub fn new_with_signer<S>(header: &Header, author: AuthorityIdentifier, signer: &S) -> Self
     where
         S: Signer,
     {
@@ -71,8 +71,8 @@ impl Vote {
             header_digest,
             round: header.round(),
             epoch: header.epoch(),
-            origin: header.author(),
-            author: *author,
+            origin: header.author().clone(),
+            author,
             signature,
         }
     }
@@ -86,11 +86,11 @@ impl Vote {
     pub fn epoch(&self) -> Epoch {
         self.epoch
     }
-    pub fn origin(&self) -> AuthorityIdentifier {
-        self.origin
+    pub fn origin(&self) -> &AuthorityIdentifier {
+        &self.origin
     }
-    pub fn author(&self) -> AuthorityIdentifier {
-        self.author
+    pub fn author(&self) -> &AuthorityIdentifier {
+        &self.author
     }
     pub fn signature(&self) -> &BlsSignature {
         &self.signature


### PR DESCRIPTION
Part of committee refactor for epoch support.  Addresses https://github.com/Telcoin-Association/telcoin-network/issues/200 .

Make the AuthorityId a PeerId. 
- Wrapped the PeerId in the AuthorityIdentifier in an Arc.  This reduces the size but removes Copy from AuthorityIdentifier.
- Use BTrees to sort the authorities by their ids, some code and many tests need this.
- Removes the old mapping from peer to auth ids- they can just "into" each other now.
