### PR TITLE
Subcribe to Topics

### DIFF
--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -183,6 +183,17 @@ where
         self.inner.committee.authorities().iter().map(|a| a.peer_id()).collect()
     }
 
+    /// Map of primary peer ids and multiaddrs in the current committee.
+    pub fn primary_network_map(&self) -> HashMap<PeerId, Multiaddr> {
+        self.inner
+            .committee
+            .authorities()
+            .iter()
+            .map(|a| (a.peer_id(), a.primary_network_address().clone()))
+            .collect()
+    }
+
+    /// Bool indicating if an authority identifier is in the current committee.
     pub fn in_committee(&self, id: &AuthorityIdentifier) -> bool {
         self.inner.committee.is_authority(id)
     }
@@ -194,5 +205,10 @@ where
             .worker(self.authority().protocol_key(), id)
             .expect("Our public key or worker id is not in the worker cache")
             .worker_address
+    }
+
+    /// Map of worker peer ids and multiaddrs in the current committee.
+    pub fn worker_network_map(&self) -> HashMap<PeerId, Multiaddr> {
+        self.worker_cache().all_workers()
     }
 }

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -104,12 +104,12 @@ pub struct LibP2pConfig {
 
 impl LibP2pConfig {
     /// Return topics for primary.
-    pub fn primary_topics(&self) -> String {
+    pub fn primary_topic(&self) -> String {
         String::from("tn-primary")
     }
 
     /// Return topics for worker.
-    pub fn worker_topics(&self) -> String {
+    pub fn worker_topic(&self) -> String {
         String::from("tn-worker")
     }
 }

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -102,6 +102,18 @@ pub struct LibP2pConfig {
     pub px_disconnect_timeout: Duration,
 }
 
+impl LibP2pConfig {
+    /// Return topics for primary.
+    pub fn primary_topics(&self) -> String {
+        String::from("tn-primary")
+    }
+
+    /// Return topics for worker.
+    pub fn worker_topics(&self) -> String {
+        String::from("tn-worker")
+    }
+}
+
 impl Default for LibP2pConfig {
     fn default() -> Self {
         Self {

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -12,9 +12,7 @@ use message::{PrimaryGossip, PrimaryRPCError};
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{
     error::NetworkError,
-    types::{
-        IdentTopic, IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResult,
-    },
+    types::{IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResult},
     GossipMessage, Multiaddr, PeerExchangeMap, PeerId, Penalty, ResponseChannel,
 };
 use tn_network_types::{
@@ -73,7 +71,7 @@ impl PrimaryNetworkHandle {
     /// Publish a certificate to the consensus network.
     pub async fn publish_certificate(&self, certificate: Certificate) -> NetworkResult<()> {
         let data = encode(&PrimaryGossip::Certificate(Box::new(certificate)));
-        self.handle.publish(IdentTopic::new("tn-primary"), data).await?;
+        self.handle.publish("tn-primary".into(), data).await?;
         Ok(())
     }
 
@@ -84,7 +82,7 @@ impl PrimaryNetworkHandle {
         consensus_header_hash: BlockHash,
     ) -> NetworkResult<()> {
         let data = encode(&PrimaryGossip::Consenus(consensus_block_num, consensus_header_hash));
-        self.handle.publish(IdentTopic::new("tn-primary"), data).await?;
+        self.handle.publish("tn-primary".into(), data).await?;
         Ok(())
     }
 

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{
     error::NetworkError,
-    types::{IdentTopic, NetworkEvent, NetworkHandle, NetworkResult},
+    types::{NetworkEvent, NetworkHandle, NetworkResult},
     GossipMessage, Multiaddr, PeerExchangeMap, PeerId, Penalty, ResponseChannel,
 };
 use tn_network_types::{FetchBatchResponse, PrimaryToWorkerClient, WorkerSynchronizeMessage};
@@ -62,7 +62,7 @@ impl WorkerNetworkHandle {
     /// Publish a batch digest to the worker network.
     pub async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Batch(batch_digest));
-        self.handle.publish(IdentTopic::new("tn-worker"), data).await?;
+        self.handle.publish("tn-worker".into(), data).await?;
         Ok(())
     }
 

--- a/crates/network-libp2p/src/peers/banned.rs
+++ b/crates/network-libp2p/src/peers/banned.rs
@@ -2,6 +2,9 @@
 //!
 //! Peers that score poorly are eventually banned.
 
+use libp2p::PeerId;
+use tracing::warn;
+
 use super::peer::Peer;
 use std::{
     collections::{HashMap, HashSet},
@@ -52,6 +55,24 @@ impl BannedPeers {
                 }
             })
             .collect()
+    }
+
+    /// Remove IP address associated with validator.
+    ///
+    /// This method is a precaution to ensure a committee member's IP address won't become
+    /// blocked during initial connection. It's possible the IP address becomes banned again,
+    /// but the validator won't be disconnected because it is a trusted peer.
+    pub(super) fn remove_validator_ip(
+        &mut self,
+        peer_id: &PeerId,
+        ip_addresses: impl Iterator<Item = IpAddr>,
+    ) {
+        for ip in ip_addresses {
+            if let Some((_, _)) = self.banned_peers_by_ip.remove_entry(&ip) {
+                warn!(target: "peer-manager", ?peer_id, "removed banned ip address associated with validator");
+                self.total = self.total.saturating_sub(1);
+            }
+        }
     }
 
     /// Add IP addresses to the banned peers collection and update counts.

--- a/crates/network-libp2p/src/peers/behavior.rs
+++ b/crates/network-libp2p/src/peers/behavior.rs
@@ -110,7 +110,7 @@ impl NetworkBehaviour for PeerManager {
             FromSwarm::ExternalAddrConfirmed(_) => {
                 // The external address was confirmed: possible to support NAT traversal
                 //
-                // TODO: update metrics here
+                // TODO: Issue #254 update metrics here
             }
             _ => {
                 // `FromSwarm` is non-exhaustive
@@ -182,7 +182,7 @@ impl PeerManager {
             "connection established"
         );
 
-        // TODO: update metrics
+        // TODO: Issue #254 update metrics
 
         // check connection limits
         if self.peer_limit_reached(endpoint) && !self.peer_is_important(&peer_id) {
@@ -243,7 +243,7 @@ impl PeerManager {
         // when this happens, the peer manager still needs to register this peer
         self.register_disconnected(&peer_id);
 
-        // TODO: update metrics
+        // TODO: Issue #254 update metrics
     }
 
     /// Dial attempt failed.

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -12,7 +12,11 @@ use crate::{
     error::NetworkError, peers::status::ConnectionStatus, send_or_log_error, types::NetworkResult,
 };
 use libp2p::{core::ConnectedPoint, Multiaddr, PeerId};
-use std::{collections::VecDeque, net::IpAddr, task::Context};
+use std::{
+    collections::{HashMap, VecDeque},
+    net::IpAddr,
+    task::Context,
+};
 use tn_config::{ConsensusConfig, PeerConfig};
 use tn_types::Database;
 use tokio::sync::oneshot;
@@ -93,7 +97,12 @@ impl PeerManager {
         reply: oneshot::Sender<NetworkResult<()>>,
     ) {
         self.peers.add_trusted_peer(peer_id, multiaddr.clone());
-        let _ = self.temporarily_banned.remove(&peer_id);
+
+        // remove from temporary banned and warn if peer was banned
+        if self.temporarily_banned.remove(&peer_id) {
+            warn!(target: "peer-manager", ?peer_id, "removed trusted peer from temporarily banned list");
+        }
+
         self.dial_peer(peer_id, multiaddr, reply);
     }
 
@@ -198,7 +207,7 @@ impl PeerManager {
             self.apply_peer_action(peer_id, action);
         }
 
-        // TODO: update metrics
+        // TODO: Issue #254 update metrics
 
         self.prune_connected_peers();
 
@@ -247,6 +256,10 @@ impl PeerManager {
     }
 
     /// Returns a boolean if the peer is a known validator.
+    ///
+    /// `AllPeers` only tracks CVVs for now. (current voting validators)
+    ///
+    /// This method will be extended to support any staked validator.
     pub(super) fn is_validator(&self, peer_id: &PeerId) -> bool {
         self.peers.is_validator(peer_id)
     }
@@ -420,7 +433,7 @@ impl PeerManager {
         let ready_to_prune = connected_peers
             .iter()
             .filter_map(|(peer_id, peer)| {
-                if !self.peers.is_validator(peer_id) && !peer.is_trusted() {
+                if !self.is_validator(peer_id) && !peer.is_trusted() {
                     Some(**peer_id)
                 } else {
                     None
@@ -482,5 +495,23 @@ impl PeerManager {
     pub(crate) fn peer_is_important(&self, peer_id: &PeerId) -> bool {
         self.is_validator(peer_id)
             || self.peers.get_peer(peer_id).map(|p| p.is_trusted()).unwrap_or_default()
+    }
+
+    /// Update the committee for the new epoch.
+    pub(crate) fn new_epoch(&mut self, committee: HashMap<PeerId, Multiaddr>) {
+        // remove from temporary banned and warn if validator was banned
+        for peer_id in committee.keys() {
+            if self.temporarily_banned.remove(peer_id) {
+                warn!(target: "peer-manager", ?peer_id, "removed committee member from temporarily banned list");
+            }
+        }
+
+        // add trusted peer record
+        let unban_actions = self.peers.new_epoch(committee);
+
+        // apply unban for any banned validators
+        for (peer_id, action) in unban_actions {
+            self.apply_peer_action(peer_id, action);
+        }
     }
 }

--- a/crates/network-libp2p/src/tests/banned_peers.rs
+++ b/crates/network-libp2p/src/tests/banned_peers.rs
@@ -7,7 +7,7 @@ use std::net::Ipv4Addr;
 
 /// Helper function to create a peer with specific IP addresses.
 fn create_peer_with_ips(ips: Vec<IpAddr>) -> Peer {
-    ensure_score_config();
+    ensure_score_config(None);
 
     let mut peer = Peer::default();
 
@@ -89,7 +89,7 @@ fn test_add_multiple_peers_same_ip() {
 
 #[test]
 fn test_add_peer_no_ip() {
-    ensure_score_config();
+    ensure_score_config(None);
     let mut banned_peers = BannedPeers::default();
 
     // Create a peer with no IP addresses

--- a/crates/network-libp2p/src/tests/common.rs
+++ b/crates/network-libp2p/src/tests/common.rs
@@ -22,12 +22,10 @@ static INIT: Once = Once::new();
 // but it is used in `all_peers` and `banned_peers`
 /// Initialize without error for unit tests.
 #[allow(dead_code)]
-pub(crate) fn ensure_score_config() {
+pub(crate) fn ensure_score_config(config: Option<ScoreConfig>) {
     INIT.call_once(|| {
-        // use default
-        let config = ScoreConfig::default();
         // ignore result
-        let _ = GLOBAL_SCORE_CONFIG.set(Arc::new(config));
+        let _ = GLOBAL_SCORE_CONFIG.set(Arc::new(config.unwrap_or_default()));
     });
 }
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -978,16 +978,8 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
             .start_listening(peer.config.authority().primary_network_address().clone())
             .await?;
 
-        // add target peer as authorized
-        peer.network_handle
-            .update_authorized_publishers(HashMap::from([(
-                TEST_TOPIC.into(),
-                HashSet::from([target_peer_id]),
-            )]))
-            .await?;
-
-        // Subscribe to test topic
-        peer.network_handle.subscribe(TEST_TOPIC.into(), peer.config.committee_peer_ids()).await?;
+        // subscribe to test topic with target peer as authorized publisher
+        peer.network_handle.subscribe(TEST_TOPIC.into(), HashSet::from([target_peer_id])).await?;
 
         // Connect to target peer
         peer.network_handle.dial(target_peer_id, target_addr.clone()).await?;
@@ -1031,6 +1023,265 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
             peer_id
         );
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
+    // Start with two peers
+    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    let NetworkPeer { config: config_2, network_handle: peer2, network, .. } = peer2;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    // Start swarm listening
+    peer1.start_listening(config_1.authority().primary_network_address().clone()).await?;
+    peer2.start_listening(config_2.authority().primary_network_address().clone()).await?;
+
+    let peer2_id = peer2.local_peer_id().await?;
+    let peer2_addr = peer2.listeners().await?.first().expect("peer2 listen addr").clone();
+
+    // Connect peers
+    peer1.dial(peer2_id, peer2_addr.clone()).await?;
+
+    // Wait for connection to establish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify connection established
+    let connected_peers = peer1.connected_peers().await?;
+    assert!(connected_peers.contains(&peer2_id), "Peer2 should be connected initially");
+
+    // Apply fatal penalty to peer2 - should ban it
+    peer1.report_penalty(peer2_id, Penalty::Fatal).await;
+
+    // Wait for ban to take effect
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    // Verify peer2 is disconnected and banned
+    let connected_peers = peer1.connected_peers().await?;
+    assert!(!connected_peers.contains(&peer2_id), "Peer2 should be disconnected after ban");
+
+    let score = peer1.peer_score(peer2_id).await?.unwrap();
+    let min_score = config_1.network_config().peer_config().score_config.min_score;
+    assert_eq!(score, min_score, "Peer2 should have ban-level score");
+
+    // Now simulate a new epoch where peer2 is in the committee
+    let committee = HashMap::from([(peer2_id, peer2_addr.clone())]);
+
+    // Send NewEpoch command to peer1
+    let handle = peer1.clone();
+    tokio::spawn(async move {
+        handle.new_epoch(committee).await.expect("Failed to send NewEpoch command");
+    })
+    .await?;
+
+    // Wait for unban to take effect
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    // Verify peer2's score has improved and is no longer banned
+    let score_after_epoch = peer1.peer_score(peer2_id).await?.unwrap();
+    assert_eq!(
+        score_after_epoch,
+        config_1.network_config().peer_config().score_config.max_score,
+        "Peer2 should have improved score after new epoch"
+    );
+
+    // Try reconnecting peer2
+    let dial_result = peer1.dial(peer2_id, peer2_addr).await;
+    warn!(target: "network", ?dial_result, "dial result??");
+    assert!(dial_result.is_ok(), "Should be able to reconnect to peer2 after unban");
+
+    // Wait for connection to reestablish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify connection reestablished
+    let connected_peers_after = peer1.connected_peers().await?;
+    assert!(connected_peers_after.contains(&peer2_id), "Peer2 should be reconnected after unban");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
+    // Create multiple peers for this test
+    let num_peers = NonZeroUsize::new(4).unwrap();
+    let (mut target_peer, _) =
+        create_test_peers::<TestWorkerRequest, TestWorkerResponse>(num_peers, None);
+
+    // create new committee
+    let (_, mut other_peers) =
+        create_test_peers::<TestWorkerRequest, TestWorkerResponse>(num_peers, None);
+
+    // Start target peer network
+    let target_network = target_peer.network.take().expect("target network is some");
+    tokio::spawn(async move {
+        target_network.run().await.expect("network run failed!");
+    });
+
+    // Start listening
+    target_peer
+        .network_handle
+        .start_listening(target_peer.config.authority().primary_network_address().clone())
+        .await?;
+
+    // Take peer1 and peer2 from other_peers
+    let mut peer1 = other_peers.remove(0);
+    let mut peer2 = other_peers.remove(0);
+
+    // Start peer1 network
+    let peer1_network = peer1.network.take().expect("peer1 network is some");
+    let peer1_network_task = tokio::spawn(async move {
+        peer1_network.run().await.expect("network run failed!");
+    });
+
+    peer1
+        .network_handle
+        .start_listening(peer1.config.authority().primary_network_address().clone())
+        .await?;
+    let peer1_id = peer1.network_handle.local_peer_id().await?;
+    let peer1_addr =
+        peer1.network_handle.listeners().await?.first().expect("peer1 listen addr").clone();
+
+    // Start peer2 network - this will be our future committee member
+    // Use the SAME multiaddr as peer1 to simulate same IP
+    let peer2_network = peer2.network.take().expect("peer2 network is some");
+    tokio::spawn(async move {
+        peer2_network.run().await.expect("network run failed!");
+    });
+
+    // For peer2, create a multiaddr with the same IP as peer1 but different port
+    // Extract IP from peer1's multiaddr
+    let peer2_addr = peer1_addr.clone();
+    let peer2_id = peer2.network_handle.local_peer_id().await?;
+
+    // Connect target to peer1
+    target_peer.network_handle.dial(peer1_id, peer1_addr.clone()).await?;
+
+    // Wait for connection to establish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Apply fatal penalty to peer1 - should ban it and its IP
+    target_peer.network_handle.report_penalty(peer1_id, Penalty::Fatal).await;
+
+    // Wait for ban to take effect
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    // Verify peer1 is disconnected and banned
+    let connected_peers = target_peer.network_handle.connected_peers().await?;
+    assert!(!connected_peers.contains(&peer1_id), "Peer1 should be disconnected after ban");
+
+    // shutdown peer1 network
+    peer1_network_task.abort();
+
+    // allow os to make port available again
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    peer2.network_handle.start_listening(peer2_addr.clone()).await?;
+
+    // Now simulate a new epoch where peer2 is in the committee with the same IP as banned peer1
+    let committee = HashMap::from([(peer2_id, peer2_addr)]);
+    let handle = target_peer.network_handle.clone();
+    tokio::spawn(async move {
+        handle.new_epoch(committee).await.expect("Failed to send NewEpoch command");
+    })
+    .await?;
+
+    // Verify connection can be established with peer2 despite sharing IP with banned peer1
+    target_peer.network_handle.dial(peer2_id, peer1_addr.clone()).await?;
+
+    // Wait for connection to establish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify connection established with peer2
+    let connected_peers_after = target_peer.network_handle.connected_peers().await?;
+    assert!(
+        connected_peers_after.contains(&peer2_id),
+        "Peer2 should be connected despite sharing IP with banned peer1"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> {
+    // Start with two peers
+    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    let NetworkPeer { config: config_2, network_handle: peer2, network, .. } = peer2;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    // Start swarm listening
+    peer1.start_listening(config_1.authority().primary_network_address().clone()).await?;
+    peer2.start_listening(config_2.authority().primary_network_address().clone()).await?;
+
+    let peer2_id = peer2.local_peer_id().await?;
+    let peer2_addr = peer2.listeners().await?.first().expect("peer2 listen addr").clone();
+
+    // Connect peers
+    peer1.dial(peer2_id, peer2_addr.clone()).await?;
+
+    // Wait for connection to establish
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify connection established
+    let connected_peers = peer1.connected_peers().await?;
+    assert!(connected_peers.contains(&peer2_id), "Peer2 should be connected initially");
+
+    // Apply severe penalties to put peer in a disconnecting state pending ban
+    // We need to apply penalties but not enough to cause immediate ban
+    // First apply medium penalties
+    for _ in 0..3 {
+        peer1.report_penalty(peer2_id, Penalty::Medium).await;
+    }
+
+    // Then apply a severe penalty - should trigger disconnect pending ban
+    peer1.report_penalty(peer2_id, Penalty::Severe).await;
+
+    // Wait for disconnect to begin but not complete
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Now simulate a new epoch where peer2 is in the committee
+    let committee = HashMap::from([(peer2_id, peer2_addr.clone())]);
+
+    // Send NewEpoch command to peer1
+    let handle = peer1.clone();
+    tokio::spawn(async move {
+        handle.new_epoch(committee).await.expect("Failed to send NewEpoch command");
+    })
+    .await?;
+
+    // Wait for epoch processing
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    // Verify peer2's score has improved and is trusted
+    let score_after_epoch = peer1.peer_score(peer2_id).await?.unwrap();
+    assert!(score_after_epoch > 0.0, "Peer2 should have a positive score after new epoch");
+
+    // Try reconnecting peer2 if it was disconnected during the process
+    if !peer1.connected_peers().await?.contains(&peer2_id) {
+        let dial_result = peer1.dial(peer2_id, peer2_addr).await;
+        assert!(dial_result.is_ok(), "Should be able to reconnect to peer2 after new epoch");
+
+        // Wait for connection to reestablish
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Verify connection is established
+    let connected_peers_after = peer1.connected_peers().await?;
+    assert!(connected_peers_after.contains(&peer2_id), "Peer2 should be connected after new epoch");
 
     Ok(())
 }

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -522,10 +522,14 @@ async fn test_is_validator() {
     let mut authorities = all_nodes.authorities();
     let authority_1 = authorities.next().expect("first authority");
     let config = authority_1.consensus_config();
-    let peer_manager = PeerManager::new(&config);
-
+    let mut peer_manager = PeerManager::new(&config);
     let validator = authority_1.id().peer_id();
     let random_peer_id = PeerId::random();
+
+    // update epoch with random multiaddr
+    let committee =
+        config.committee_peer_ids().into_iter().map(|id| (id, create_multiaddr(None))).collect();
+    peer_manager.new_epoch(committee);
 
     // Verify validator peer is recognized
     assert!(peer_manager.is_validator(&validator));

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -7,39 +7,42 @@ use std::{
     net::IpAddr,
     time::{Duration, Instant},
 };
-use tn_config::ScoreConfig;
+use tn_config::{PeerConfig, ScoreConfig};
 
 /// Helper function to create a test AllPeers instance
-fn create_all_peers() -> AllPeers {
-    ensure_score_config();
+fn create_all_peers(peer_config: Option<PeerConfig>) -> AllPeers {
+    let config = peer_config.unwrap_or_default();
+    ensure_score_config(Some(config.score_config));
     let dial_timeout = Duration::from_secs(5);
-    let max_banned_peers = 10;
-    let max_disconnected_peers = 10;
-    AllPeers::new(dial_timeout, max_banned_peers, max_disconnected_peers)
+    AllPeers::new(dial_timeout, config.max_banned_peers, config.max_disconnected_peers)
 }
 
 #[test]
 fn test_add_trusted_peer() {
     let config = ScoreConfig::default();
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
     all_peers.add_trusted_peer(peer_id, addr.clone());
 
     assert!(all_peers.peers.contains_key(&peer_id));
-    let peer = all_peers.peers.get(&peer_id).unwrap();
+    let peer = all_peers.peers.get_mut(&peer_id).unwrap();
     assert_eq!(peer.reputation(), Reputation::Trusted);
     assert_eq!(peer.score().aggregate_score(), config.max_score);
 
-    // check that address is stored
+    // assert that peer exchange doesn't include address for disconnected
+    assert!(!peer.exchange_info().iter().any(|a| a == &addr));
+
+    // update connection and assert exchange info
+    peer.register_outgoing(addr.clone());
     assert!(peer.exchange_info().iter().any(|a| a == &addr));
 }
 
 #[test]
 fn test_process_penalty() {
     let config = ScoreConfig::default();
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // add connected peer first and set as this node dialed
@@ -78,7 +81,7 @@ fn test_process_penalty() {
 
 #[test]
 fn test_ensure_peer_exists() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // Unknown peer, valid initial state
@@ -98,7 +101,7 @@ fn test_ensure_peer_exists() {
 
 #[test]
 fn test_peer_exchange() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
 
     // Add some connected peers
     for _ in 1..4 {
@@ -125,7 +128,7 @@ fn test_peer_exchange() {
 
 #[test]
 fn test_connected_peers_by_score() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
 
     // Add some connected peers
     for _ in 1..4 {
@@ -152,7 +155,7 @@ fn test_connected_peers_by_score() {
 
 #[test]
 fn test_heartbeat_maintenance() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // Add a dialing peer
@@ -178,10 +181,12 @@ fn test_heartbeat_maintenance() {
 
 #[test]
 fn test_pruning_logic() {
-    let mut all_peers = create_all_peers();
+    let config = PeerConfig::default();
+    let mut all_peers = create_all_peers(Some(config));
 
     // Add many disconnected peers
-    for i in 1..1002_u16 {
+    let peer_num = 101;
+    for i in 1..=peer_num {
         let peer_id = PeerId::random();
 
         all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
@@ -199,20 +204,20 @@ fn test_pruning_logic() {
         }
     }
 
-    assert_eq!(all_peers.disconnected_peers, 1001);
+    assert_eq!(all_peers.disconnected_peers, peer_num);
 
     // Pruning happens in register_disconnected
     all_peers.register_disconnected(&PeerId::random());
 
     // Should be pruned to MAX_DISCONNECTED_PEERS (1000)
-    assert_eq!(all_peers.disconnected_peers, 1000);
-    assert_eq!(all_peers.peers.len(), 1000);
+    assert_eq!(all_peers.disconnected_peers, config.max_disconnected_peers);
+    assert_eq!(all_peers.peers.len(), config.max_disconnected_peers);
 
     // Now test banned peers pruning
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
 
     // Add many banned peers
-    for i in 1..1002 {
+    for i in 1..=peer_num {
         let peer_id = PeerId::random();
 
         // Need to go through disconnecting first
@@ -235,30 +240,30 @@ fn test_pruning_logic() {
         }
     }
 
-    assert_eq!(all_peers.banned_peers.total(), 1001);
+    assert_eq!(all_peers.banned_peers.total(), peer_num);
 
     // Trigger pruning
     let (_, pruned) = all_peers.register_disconnected(&PeerId::random());
 
     // Should be pruned to MAX_BANNED_PEERS (1000)
-    assert_eq!(all_peers.banned_peers.total(), 1000);
-    assert_eq!(pruned.len(), 1); // 1 peer should be pruned
+    assert_eq!(all_peers.banned_peers.total(), config.max_banned_peers);
+    let expected = peer_num - config.max_banned_peers;
+    assert_eq!(pruned.len(), expected); // 1 peer should be pruned
 }
 
 #[test]
 fn test_is_validator() {
-    ensure_score_config();
-
+    ensure_score_config(None);
     let validator_id = PeerId::random();
     let mut all_peers = AllPeers::new(Duration::from_secs(5), 10, 10);
-    all_peers.validators.insert(validator_id);
+    all_peers.current_committee.insert(validator_id);
     assert!(all_peers.is_validator(&validator_id));
     assert!(!all_peers.is_validator(&PeerId::random()));
 }
 
 #[test]
 fn test_ip_and_peer_banned() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
@@ -310,7 +315,7 @@ fn test_ip_and_peer_banned() {
 
 #[test]
 fn test_connected_peer_methods() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
 
     // Add some connected peers
     let connected_peer_id = PeerId::random();
@@ -355,7 +360,7 @@ fn test_connected_peer_methods() {
 
 #[test]
 fn test_unknown_to_connected_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
@@ -376,7 +381,7 @@ fn test_unknown_to_connected_transition() {
 
 #[test]
 fn test_connected_to_disconnecting_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
@@ -401,7 +406,7 @@ fn test_connected_to_disconnecting_transition() {
 
 #[test]
 fn test_disconnecting_to_disconnected_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
@@ -428,7 +433,7 @@ fn test_disconnecting_to_disconnected_transition() {
 
 #[test]
 fn test_disconnected_to_dialing_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // set to Disconnected
@@ -447,7 +452,7 @@ fn test_disconnected_to_dialing_transition() {
 
 #[test]
 fn test_dialing_to_connected_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 
@@ -471,7 +476,7 @@ fn test_dialing_to_connected_transition() {
 
 #[test]
 fn test_disconnected_to_banned_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // Setup: Set to Disconnected
@@ -488,7 +493,7 @@ fn test_disconnected_to_banned_transition() {
 
 #[test]
 fn test_banned_to_unbanned_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
 
     // Setup: Disconnected -> Banned
@@ -506,7 +511,7 @@ fn test_banned_to_unbanned_transition() {
 
 #[test]
 fn test_connected_to_banned_transition() {
-    let mut all_peers = create_all_peers();
+    let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
     let addr = create_multiaddr(None);
 

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -233,6 +233,11 @@ where
         /// The reply to caller.
         reply: oneshot::Sender<PeerExchangeMap>,
     },
+    /// Start a new epoch.
+    NewEpoch {
+        /// The epoch committee.
+        committee: HashMap<PeerId, Multiaddr>,
+    },
 }
 
 /// Network handle.
@@ -455,6 +460,12 @@ where
         let (reply, res) = oneshot::channel();
         self.sender.send(NetworkCommand::PeersForExchange { reply }).await?;
         res.await.map_err(Into::into)
+    }
+
+    /// Create a [PeerExchangeMap] for exchanging peers.
+    pub async fn new_epoch(&self, committee: HashMap<PeerId, Multiaddr>) -> NetworkResult<()> {
+        self.sender.send(NetworkCommand::NewEpoch { committee }).await?;
+        Ok(())
     }
 }
 

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -3,7 +3,7 @@
 use crate::{
     codec::TNMessage, error::NetworkError, peers::Penalty, GossipMessage, PeerExchangeMap,
 };
-pub use libp2p::gossipsub::{IdentTopic, MessageId};
+pub use libp2p::gossipsub::MessageId;
 use libp2p::{
     core::transport::ListenerId,
     gossipsub::{PublishError, SubscriptionError, TopicHash},
@@ -77,8 +77,8 @@ where
     /// This list is used to verify messages came from an authorized source.
     /// Only valid for Subscriber implementations.
     UpdateAuthorizedPublishers {
-        /// The unique set of authorized peers.
-        authorities: HashSet<PeerId>,
+        /// The unique set of authorized peers by topic.
+        authorities: HashMap<String, HashSet<PeerId>>,
         /// The acknowledgement that the set was updated.
         reply: oneshot::Sender<NetworkResult<()>>,
     },
@@ -157,14 +157,16 @@ where
     /// Subscribe to a topic.
     Subscribe {
         /// The topic to subscribe to.
-        topic: IdentTopic,
+        topic: String,
+        /// Authorized publishers.
+        publishers: HashSet<PeerId>,
         /// The reply to caller.
         reply: oneshot::Sender<Result<bool, SubscriptionError>>,
     },
     /// Publish a message to topic subscribers.
     Publish {
         /// The topic to publish the message on.
-        topic: IdentTopic,
+        topic: String,
         /// The encoded message to publish.
         msg: Vec<u8>,
         /// The reply to caller.
@@ -188,7 +190,7 @@ where
     /// Collection of all mesh peers by a certain topic hash.
     MeshPeers {
         /// The topic to filter peers.
-        topic: TopicHash,
+        topic: String,
         /// Reply to caller.
         reply: oneshot::Sender<Vec<PeerId>>,
     },
@@ -265,7 +267,7 @@ where
     /// Update the list of authorized publishers.
     pub async fn update_authorized_publishers(
         &self,
-        authorities: HashSet<PeerId>,
+        authorities: HashMap<String, HashSet<PeerId>>,
     ) -> NetworkResult<()> {
         let (reply, ack) = oneshot::channel();
         self.sender.send(NetworkCommand::UpdateAuthorizedPublishers { authorities, reply }).await?;
@@ -322,15 +324,19 @@ where
     /// Subscribe to a topic.
     ///
     /// Return swarm error to caller.
-    pub async fn subscribe(&self, topic: IdentTopic) -> NetworkResult<bool> {
+    pub async fn subscribe(
+        &self,
+        topic: String,
+        publishers: HashSet<PeerId>,
+    ) -> NetworkResult<bool> {
         let (reply, already_subscribed) = oneshot::channel();
-        self.sender.send(NetworkCommand::Subscribe { topic, reply }).await?;
+        self.sender.send(NetworkCommand::Subscribe { topic, publishers, reply }).await?;
         let res = already_subscribed.await?;
         res.map_err(Into::into)
     }
 
     /// Publish a message on a certain topic.
-    pub async fn publish(&self, topic: IdentTopic, msg: Vec<u8>) -> NetworkResult<MessageId> {
+    pub async fn publish(&self, topic: String, msg: Vec<u8>) -> NetworkResult<MessageId> {
         let (reply, published) = oneshot::channel();
         self.sender.send(NetworkCommand::Publish { topic, msg, reply }).await?;
         published.await?.map_err(Into::into)
@@ -358,7 +364,7 @@ where
     }
 
     /// Collection of all mesh peers by a certain topic hash.
-    pub async fn mesh_peers(&self, topic: TopicHash) -> NetworkResult<Vec<PeerId>> {
+    pub async fn mesh_peers(&self, topic: String) -> NetworkResult<Vec<PeerId>> {
         let (reply, mesh_peers) = oneshot::channel();
         self.sender.send(NetworkCommand::MeshPeers { topic, reply }).await?;
         mesh_peers.await.map_err(Into::into)

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 use tn_config::{ConsensusConfig, KeyConfig, NetworkConfig, TelcoinDirs};
-use tn_network_libp2p::{types::IdentTopic, ConsensusNetwork, PeerId};
+use tn_network_libp2p::{ConsensusNetwork, PeerId};
 use tn_node_traits::TelcoinNode;
 use tn_primary::{
     network::{PrimaryNetwork, PrimaryNetworkHandle},
@@ -119,7 +119,12 @@ async fn start_networks<DB: TNDatabase>(
     });
 
     // subscribe to epoch closing gossip messages
-    primary_network_handle.subscribe(IdentTopic::new("tn-primary")).await?;
+    primary_network_handle
+        .subscribe(
+            consensus_config.network_config().libp2p_config().primary_topics(),
+            consensus_config.committee_peer_ids(),
+        )
+        .await?;
 
     let my_authority = consensus_config.authority();
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -124,7 +124,7 @@ async fn start_networks<DB: TNDatabase>(
     // subscribe to epoch closing gossip messages
     primary_network_handle
         .subscribe(
-            consensus_config.network_config().libp2p_config().primary_topics(),
+            consensus_config.network_config().libp2p_config().primary_topic(),
             consensus_config.committee_peer_ids(),
         )
         .await?;

--- a/crates/types/src/worker/info.rs
+++ b/crates/types/src/worker/info.rs
@@ -12,7 +12,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
     str::FromStr,
     sync::Arc,
@@ -43,7 +43,6 @@ pub struct WorkerInfo {
 
 impl Default for WorkerInfo {
     fn default() -> Self {
-        // TODO: env vars should be applied at the CLI level, not here
         let host = std::env::var("NARWHAL_HOST").unwrap_or("127.0.0.1".to_string());
         let worker_udp_port = get_available_udp_port(&host).unwrap_or(49594).to_string();
 
@@ -239,7 +238,7 @@ impl WorkerCache {
     }
 
     /// Returns the addresses of all known workers.
-    pub fn all_workers(&self) -> Vec<(PeerId, Multiaddr)> {
+    pub fn all_workers(&self) -> HashMap<PeerId, Multiaddr> {
         self.workers
             .iter()
             .flat_map(|(_, w)| {


### PR DESCRIPTION
- use `String` for topics to support Eq/Ord traits
- refactor authorized publishers as a map to support different publishers per topic