### PR TITLE
PATCH: refactor tests after sporadic failure

### DIFF
--- a/crates/network-libp2p/src/peers/cache.rs
+++ b/crates/network-libp2p/src/peers/cache.rs
@@ -84,8 +84,8 @@ where
             return Vec::new();
         }
 
-        let mut removed_elements = Vec::new();
         let now = Instant::now();
+        let mut removed_elements = Vec::new();
         // remove any expired results
         while let Some(element) = self.list.pop_front() {
             if element.inserted + self.duration > now {

--- a/crates/network-libp2p/src/tests/cache_peers.rs
+++ b/crates/network-libp2p/src/tests/cache_peers.rs
@@ -144,21 +144,18 @@ fn test_remove_expired_ordering() {
 
     // assert peer1 expired
     let expired = cache.heartbeat();
-    println!("expired: {expired:?}");
     assert_eq!(expired.len(), 1, "Only Peer1 should be expired");
     assert_eq!(expired[0], peer1, "Peer1 should be expired");
 
     // wait for peer2 to expire
     std::thread::sleep(Duration::from_millis(20));
     let expired = cache.heartbeat();
-    println!("expired: {expired:?}");
     assert_eq!(expired.len(), 1, "Only peer2 should be expired");
     assert_eq!(expired[0], peer2, "Peer2 should be expired");
 
     // wait for peer3 and peer4 to expire
     std::thread::sleep(Duration::from_millis(41));
     let expired = cache.heartbeat();
-    println!("expired: {expired:?}");
     assert_eq!(expired.len(), 2, "Peer3 and Peer4 should be expired");
     assert_eq!(expired[0], peer3, "The first expired element should be peer3");
     assert_eq!(expired[1], peer4, "The second expired element should be peer4");

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -429,7 +429,6 @@ async fn test_temporarily_banned_peer() {
 
     // Verify there's an unbanned event
     let unbanned_events = extract_events(&events, |e| matches!(e, PeerEvent::Unbanned(_)));
-    println!("events: {unbanned_events:?}");
     assert!(
         matches!(
             unbanned_events.first().unwrap(), PeerEvent::Unbanned(id) if *id == peer_id

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::common::{create_multiaddr, ensure_score_config, random_ip_addr};
-use libp2p::{multiaddr::Protocol, PeerId};
+use libp2p::PeerId;
 use std::{
     net::IpAddr,
     time::{Duration, Instant},
@@ -265,12 +265,8 @@ fn test_is_validator() {
 fn test_ip_and_peer_banned() {
     let mut all_peers = create_all_peers(None);
     let peer_id = PeerId::random();
-    let addr = create_multiaddr(None);
-
-    let expected_ip = match addr.iter().next() {
-        Some(Protocol::Ip4(ip)) => IpAddr::V4(ip),
-        _ => panic!("only ip4 created for multiaddr"),
-    };
+    let ip = IpAddr::V4("52.3.3.3".parse().unwrap());
+    let addr = create_multiaddr(Some(ip));
 
     // Add a peer and ban it
     all_peers.update_connection_status(
@@ -288,7 +284,7 @@ fn test_ip_and_peer_banned() {
     assert!(!banned);
 
     // check if IP is banned
-    assert!(!all_peers.ip_banned(&expected_ip));
+    assert!(!all_peers.ip_banned(&ip));
     assert!(!all_peers.ip_banned(&random_ip_addr()));
 
     // new peer connects from same IP


### PR DESCRIPTION
- fix unit tests that would generate a ipv4 addr ~80% of the time
- take time sooner for cache tests to limit sporadic failures when timestamp accuracy > 20ms