### PR TITLE
Conclude Epoch System Call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11667,6 +11667,7 @@ dependencies = [
  "eyre",
  "futures",
  "jsonrpsee",
+ "rand_chacha",
  "reth",
  "reth-blockchain-tree",
  "reth-chainspec",
@@ -11695,11 +11696,14 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-db",
  "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tn-config",
  "tn-types",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11703,7 +11703,6 @@ dependencies = [
  "tn-types",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -83,7 +83,7 @@ mod tests {
                 let ecdsa_pubkey = Address::random();
 
                 ConsensusRegistry::ValidatorInfo {
-                    blsPubkey: bls_pubkey.clone().into(),
+                    blsPubkey: bls_pubkey.into(),
                     ed25519Pubkey: ed_25519_keypair
                         .public()
                         .try_into_ed25519()
@@ -145,12 +145,7 @@ mod tests {
             .get(&registry_proxy_address)
             .expect("registry address missing from bundle state")
             .storage;
-        let proxy_json = test_fetch_file_content_relative_to_manifest(
-            "../../tn-contracts/artifacts/ERC1967Proxy.json".into(),
-        );
-        let proxy_contract: ContractStandardJson =
-            serde_json::from_str(&proxy_json).expect("json parsing failure");
-        let proxy_bytecode = hex::decode(proxy_contract.deployed_bytecode.object)
+        let proxy_bytecode = hex::decode(registry_proxy_contract.deployed_bytecode.object)
             .expect("invalid bytecode hexstring");
 
         // perform canonical adiri chain genesis with fetched storage

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -1,17 +1,18 @@
 #[cfg(test)]
 mod tests {
     use crate::util::spawn_local_testnet;
-    use alloy::{network::EthereumWallet, primitives::Uint, providers::ProviderBuilder};
+    use alloy::{
+        network::EthereumWallet, primitives::Uint, providers::ProviderBuilder, sol_types::SolCall,
+    };
     use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
     use rand::{rngs::StdRng, SeedableRng};
     use std::{sync::Arc, time::Duration};
     use tempfile::TempDir;
     use tn_config::{test_fetch_file_content_relative_to_manifest, ContractStandardJson};
-    use tn_reth::RethChainSpec;
+    use tn_reth::{system_calls::ConsensusRegistry, RethChainSpec};
     use tn_test_utils::{get_contract_state_for_genesis, TransactionFactory};
     use tn_types::{
-        adiri_genesis, hex, sol, Address, BlsKeypair, Bytes, GenesisAccount, NetworkKeypair,
-        SolValue, U256,
+        adiri_genesis, hex, sol, Address, BlsKeypair, Bytes, GenesisAccount, SolValue, U256,
     };
 
     #[tokio::test]
@@ -46,7 +47,6 @@ mod tests {
 
         // ERC1967Proxy interface
         sol!(
-            #[allow(clippy::too_many_arguments)]
             #[sol(rpc)]
             contract ERC1967Proxy {
                 constructor(address implementation, bytes memory _data);
@@ -65,44 +65,9 @@ mod tests {
         let registry_create_data =
             [registry_proxy_initcode.as_slice(), &constructor_params[..]].concat();
 
-        // ConsensusRegistry interface
-        sol!(
-            #[allow(clippy::too_many_arguments)]
-            #[sol(rpc)]
-            contract ConsensusRegistry {
-                enum ValidatorStatus {
-                    Undefined,
-                    PendingActivation,
-                    Active,
-                    PendingExit,
-                    Exited
-                }
-                struct ValidatorInfo {
-                    bytes blsPubkey;
-                    bytes32 ed25519Pubkey;
-                    address ecdsaPubkey;
-                    uint32 activationEpoch;
-                    uint32 exitEpoch;
-                    uint24 validatorIndex;
-                    ValidatorStatus currentStatus;
-                }
-                struct EpochInfo {
-                    address[] committee;
-                    uint64 blockHeight;
-                }
-                function initialize(
-                    address rwTEL_,
-                    uint256 stakeAmount_,
-                    uint256 minWithdrawAmount_,
-                    ValidatorInfo[] memory initialValidators_,
-                    address owner_
-                );
-                function getValidators(uint8 status) public view returns (ValidatorInfo[] memory);
-                function getEpochInfo(uint32 epoch) public view returns (EpochInfo memory epochInfo);
-            }
-        );
+        let registry_init_selector = ConsensusRegistry::initializeCall::SELECTOR;
+        // let registry_init_selector = [97, 175, 158, 105];
 
-        let registry_init_selector = [97, 175, 158, 105];
         let activation_epoch = u32::default();
         let exit_epoch = u32::default();
         let active_status = ConsensusRegistry::ValidatorStatus::Active;
@@ -114,7 +79,7 @@ mod tests {
                 let mut rng = StdRng::from_entropy();
                 let bls_keypair = BlsKeypair::generate(&mut rng);
                 let bls_pubkey = bls_keypair.public().to_bytes().to_vec();
-                let ed_25519_keypair = NetworkKeypair::generate_ed25519();
+                let ed_25519_keypair = tn_types::NetworkKeypair::generate_ed25519();
                 let ecdsa_pubkey = Address::random();
 
                 ConsensusRegistry::ValidatorInfo {

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { workspace = true }
 # Use reth directly to avoid circular deps.
 reth-chainspec = { workspace = true }
 humantime-serde = { workspace = true }
-libp2p = { workspace = true }
+libp2p = { workspace = true, features = ["request-response"] }
 backoff = { workspace = true }
 blake2 = { workspace = true }
 bs58 = { workspace = true }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -323,6 +323,8 @@ impl<DB: Database> Subscriber<DB> {
                 number,
                 extra: B256::default(),
                 early_finalize,
+                // always false for now
+                close_epoch: false,
             });
         }
 
@@ -336,6 +338,8 @@ impl<DB: Database> Subscriber<DB> {
             number,
             extra: B256::default(),
             early_finalize,
+            // always false for now
+            close_epoch: false,
         };
 
         let mut batch_set: HashSet<BlockHash> = HashSet::new();

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -310,6 +310,7 @@ mod tests {
                 previous_sub_dag,
             )
             .into(),
+            close_epoch: false,
             batches: Default::default(), // empty
             beneficiary,
             batch_digests: Default::default(), // empty
@@ -472,6 +473,7 @@ mod tests {
                 previous_sub_dag,
             )
             .into(),
+            close_epoch: false,
             batches: Default::default(), // empty
             beneficiary,
             batch_digests: Default::default(), // empty
@@ -647,6 +649,7 @@ mod tests {
             number: 0,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
 
         // create second output
@@ -677,6 +680,7 @@ mod tests {
             number: 1,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -977,6 +981,7 @@ mod tests {
             number: 0,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
 
         // create second output
@@ -1009,6 +1014,7 @@ mod tests {
             number: 1,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
         let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
 
@@ -1281,6 +1287,7 @@ mod tests {
             number: 0,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
         let consensus_output_1_hash = consensus_output_1.consensus_header_hash();
 
@@ -1312,6 +1319,7 @@ mod tests {
             number: 1,
             extra: Default::default(),
             early_finalize: true,
+            close_epoch: false,
         };
 
         //=== Execution

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -16,12 +16,14 @@ fn finalize_signed_blocks(
     canonical_header: &SealedHeader,
 ) -> EngineResult<()> {
     let mut last_executed = output.sub_dag.leader.header.latest_execution_block;
+
     // Find the latest block that was signed off by the committee.
     for cert in &output.sub_dag.certificates {
         if cert.header.latest_execution_block.number > last_executed.number {
             last_executed = cert.header.latest_execution_block;
         }
     }
+
     if last_executed.number <= canonical_header.number {
         if let Some(block) = reth_env.sealed_header_by_hash(last_executed.hash)? {
             // finalize the last block from a cert in consensus output and update chain info
@@ -94,8 +96,8 @@ pub fn execute_consensus_output(args: BuildArguments) -> EngineResult<SealedHead
 
         // add block to the tree and skip state root validation
         reth_env.insert_block(next_canonical_block).inspect_err(|e| {
-                error!(target: "engine", header=?canonical_header, ?e, "failed to insert next canonical block");
-            })?;
+            error!(target: "engine", header=?canonical_header, ?e, "failed to insert next canonical block");
+        })?;
     } else {
         // loop and construct blocks with transactions
         for (block_index, block) in batches.into_iter().enumerate() {
@@ -111,7 +113,7 @@ pub fn execute_consensus_output(args: BuildArguments) -> EngineResult<SealedHead
             let withdrawals = Withdrawals::new(vec![]);
             let payload_attributes = TNPayloadAttributes::new(
                 canonical_header,
-                block_index as u64,
+                block_index,
                 batch_digest,
                 &output,
                 output_digest,
@@ -136,8 +138,8 @@ pub fn execute_consensus_output(args: BuildArguments) -> EngineResult<SealedHead
 
             // add block to the tree and skip state root validation
             reth_env.insert_block(next_canonical_block).inspect_err(|e| {
-                    error!(target: "engine", header=?canonical_header, ?e, "failed to insert next canonical block");
-                })?;
+                error!(target: "engine", header=?canonical_header, ?e, "failed to insert next canonical block");
+            })?;
         }
     } // end block execution for round
 

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -100,20 +100,20 @@ pub fn execute_consensus_output(args: BuildArguments) -> EngineResult<SealedHead
         })?;
     } else {
         // loop and construct blocks with transactions
-        for (block_index, block) in batches.into_iter().enumerate() {
+        for (batch_index, batch) in batches.into_iter().enumerate() {
             let batch_digest =
                 output.next_batch_digest().ok_or(TnEngineError::NextBlockDigestMissing)?;
             // use batch's base fee, gas limit, and withdrawals
-            let base_fee_per_gas = block.base_fee_per_gas.unwrap_or_default();
-            let gas_limit = max_batch_gas(block.timestamp);
+            let base_fee_per_gas = batch.base_fee_per_gas.unwrap_or_default();
+            let gas_limit = max_batch_gas(batch.timestamp);
 
-            // apply XOR bitwise operator with worker's digest to ensure unique mixed hash per block
+            // apply XOR bitwise operator with worker's digest to ensure unique mixed hash per batch
             // for round
-            let mix_hash = output_digest ^ block.digest();
+            let mix_hash = output_digest ^ batch.digest();
             let withdrawals = Withdrawals::new(vec![]);
             let payload_attributes = TNPayloadAttributes::new(
                 canonical_header,
-                block_index,
+                batch_index,
                 batch_digest,
                 &output,
                 output_digest,
@@ -127,7 +127,7 @@ pub fn execute_consensus_output(args: BuildArguments) -> EngineResult<SealedHead
             // execute
             let next_canonical_block = reth_env.build_block_from_batch_payload(
                 payload,
-                block,
+                batch,
                 output.consensus_header_hash(),
             )?;
 

--- a/crates/execution/batch-builder/src/batch.rs
+++ b/crates/execution/batch-builder/src/batch.rs
@@ -9,7 +9,7 @@
 use tn_reth::TxPool;
 use tn_types::{
     max_batch_gas, max_batch_size, now, Batch, BatchBuilderArgs, Encodable2718 as _,
-    PendingBlockConfig, TransactionTrait as _, TxHash,
+    PendingBatchConfig, TransactionTrait as _, TxHash,
 };
 use tracing::{debug, warn};
 
@@ -48,7 +48,7 @@ pub fn build_batch<P: TxPool>(args: BatchBuilderArgs<P>) -> BatchBuilderOutput {
     let gas_limit = max_batch_gas(batch_config.parent_info.timestamp);
     let max_size = max_batch_size(batch_config.parent_info.timestamp);
     let base_fee_per_gas = batch_config.parent_info.base_fee_per_gas;
-    let PendingBlockConfig { beneficiary, parent_info } = batch_config;
+    let PendingBatchConfig { beneficiary, parent_info } = batch_config;
 
     // NOTE: this obtains a `read` lock on the tx pool
     // pull best transactions and rely on watch channel to ensure basefee is current

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -651,6 +651,7 @@ mod tests {
                 number: 0,
                 extra: Default::default(),
                 early_finalize: true,
+                close_epoch: false,
             };
             // execute output to trigger canonical update
             let args = BuildArguments::new(reth_env.clone(), output, parent);

--- a/crates/execution/batch-builder/src/lib.rs
+++ b/crates/execution/batch-builder/src/lib.rs
@@ -33,7 +33,7 @@ use std::{
 };
 use tn_reth::{RethEnv, TxPool as _, WorkerTxPool};
 use tn_types::{
-    error::BlockSealError, Address, BatchBuilderArgs, BatchSender, PendingBlockConfig, SealedBlock,
+    error::BlockSealError, Address, BatchBuilderArgs, BatchSender, PendingBatchConfig, SealedBlock,
     TxHash,
 };
 use tokio::{
@@ -126,8 +126,8 @@ impl BatchBuilder {
         let pool = self.pool.clone();
         let to_worker = self.to_worker.clone();
 
-        // configure params for next block to build
-        let config = PendingBlockConfig::new(self.address, self.last_canonical_update.clone());
+        // configure params for next building the next batch
+        let config = PendingBatchConfig::new(self.address, self.last_canonical_update.clone());
         let build_args = BatchBuilderArgs::new(pool.clone(), config);
         let (result, done) = oneshot::channel();
 

--- a/crates/execution/batch-builder/src/test_utils.rs
+++ b/crates/execution/batch-builder/src/test_utils.rs
@@ -10,7 +10,7 @@ use tn_reth::{
     PoolTxnId, SenderIdentifiers, TxPool,
 };
 use tn_types::{
-    Batch, BatchBuilderArgs, BlockBody, PendingBlockConfig, RecoveredTx, SealedBlock, SealedHeader,
+    Batch, BatchBuilderArgs, BlockBody, PendingBatchConfig, RecoveredTx, SealedBlock, SealedHeader,
     TransactionTrait as _, TxHash, MIN_PROTOCOL_BASE_FEE,
 };
 
@@ -22,7 +22,7 @@ pub fn execute_test_batch(test_batch: &mut Batch, parent: &SealedHeader) {
 
     let parent_info = SealedBlock::new(parent.clone(), BlockBody::default());
 
-    let batch_config = PendingBlockConfig::new(test_batch.beneficiary, parent_info);
+    let batch_config = PendingBatchConfig::new(test_batch.beneficiary, parent_info);
     let args = BatchBuilderArgs { pool, batch_config };
     let BatchBuilderOutput { batch, .. } = build_batch(args);
     test_batch.parent_hash = batch.parent_hash;

--- a/crates/execution/batch-builder/tests/it/batch_builder.rs
+++ b/crates/execution/batch-builder/tests/it/batch_builder.rs
@@ -473,6 +473,7 @@ async fn test_canonical_notification_updates_pool() {
         number: 0,
         extra: Default::default(),
         early_finalize: true,
+        close_epoch: false,
     };
 
     // execute output to trigger canonical update

--- a/crates/network-libp2p/src/tests/cache_peers.rs
+++ b/crates/network-libp2p/src/tests/cache_peers.rs
@@ -141,7 +141,7 @@ fn test_remove_expired_ordering() {
     cache.insert(peer4);
 
     // Wait with more buffer time
-    std::thread::sleep(Duration::from_millis(550)); // Wait for peer1 to expire
+    std::thread::sleep(Duration::from_millis(210)); // Wait for peer1 to expire
 
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Only Peer1 should be expired");
@@ -152,7 +152,7 @@ fn test_remove_expired_ordering() {
     assert_eq!(expired.len(), 1, "Only peer2 should be expired");
     assert_eq!(expired[0], peer2, "Peer2 should be expired");
 
-    std::thread::sleep(Duration::from_millis(150)); // Wait for peer3 and peer4 to expire
+    std::thread::sleep(Duration::from_millis(200)); // Wait for peer3 and peer4 to expire
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 2, "Peer3 and Peer4 should be expired");
     assert_eq!(expired[0], peer3, "The first expired element should be peer3");

--- a/crates/network-libp2p/src/tests/cache_peers.rs
+++ b/crates/network-libp2p/src/tests/cache_peers.rs
@@ -124,37 +124,35 @@ fn test_remove_expired_empty_cache() {
 
 #[test]
 fn test_remove_expired_ordering() {
-    let mut cache = BannedPeerCache::new(Duration::from_millis(100));
+    // Use a larger timeout to reduce flakiness
+    let mut cache = BannedPeerCache::new(Duration::from_millis(500));
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
     let peer4 = PeerId::random();
 
-    // Insert multiple elements with delays to test expiration ordering
+    // Insert with larger gaps between insertions
     cache.insert(peer1);
-    std::thread::sleep(Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(100));
     cache.insert(peer2);
-    std::thread::sleep(Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(100));
     cache.insert(peer3);
-    std::thread::sleep(Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(100));
     cache.insert(peer4);
 
-    // wait for peer1 to expire
-    std::thread::sleep(Duration::from_millis(41));
+    // Wait with more buffer time
+    std::thread::sleep(Duration::from_millis(550)); // Wait for peer1 to expire
 
-    // assert peer1 expired
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Only Peer1 should be expired");
     assert_eq!(expired[0], peer1, "Peer1 should be expired");
 
-    // wait for peer2 to expire
-    std::thread::sleep(Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(100)); // Wait for peer2 to expire
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Only peer2 should be expired");
     assert_eq!(expired[0], peer2, "Peer2 should be expired");
 
-    // wait for peer3 and peer4 to expire
-    std::thread::sleep(Duration::from_millis(41));
+    std::thread::sleep(Duration::from_millis(150)); // Wait for peer3 and peer4 to expire
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 2, "Peer3 and Peer4 should be expired");
     assert_eq!(expired[0], peer3, "The first expired element should be peer3");

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -62,4 +62,3 @@ alloy = { workspace = true, features = ["genesis"] }
 [dev-dependencies]
 tempfile = { workspace = true }
 serde_json = { workspace = true }
-tracing-subscriber = { workspace = true }

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -20,7 +20,6 @@ enr = { workspace = true, default-features = false, features = [
     "rust-secp256k1",
 ] }
 
-
 reth = { workspace = true }
 reth-db = { workspace = true }
 reth-db-common = { workspace = true }
@@ -51,7 +50,7 @@ reth-discv4 = { workspace = true }
 reth-eth-wire = { workspace = true }
 reth-tracing = { workspace = true }
 
-
+rand_chacha = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -61,3 +60,6 @@ eyre = { workspace = true }
 alloy = { workspace = true, features = ["genesis"] }
 
 [dev-dependencies]
+tempfile = { workspace = true }
+serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/tn-reth/src/error.rs
+++ b/crates/tn-reth/src/error.rs
@@ -36,6 +36,9 @@ pub enum TnRethError {
     /// An RPC failed.
     #[error("RPC failed: {0}")]
     Rpc(#[from] RpcError),
+    /// Error decoding alloy abi.
+    #[error("Error encoding/decoding abi for sol type: {0}")]
+    SolAbi(#[from] alloy::sol_types::Error),
 }
 
 impl From<TnRethError> for EthApiError {

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1270,13 +1270,11 @@ impl RethEnv {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr as _;
-
-    use crate::traits::TNPayloadAttributes;
-
     use super::*;
+    use crate::traits::TNPayloadAttributes;
     use alloy::{hex, primitives::Uint};
     use rand_chacha::ChaCha8Rng;
+    use std::str::FromStr as _;
     use tempfile::TempDir;
     use tn_config::{test_fetch_file_content_relative_to_manifest, ContractStandardJson};
     use tn_types::{
@@ -1310,9 +1308,6 @@ mod tests {
             ExecutionResult::Success { output, .. } => {
                 let data = output.into_data();
                 // use SolValue to decode the result
-                // let res = T::abi_decode(&data, true)?;
-                // Ok(res)
-                // Ok(T::abi_decode(&data, true)?)
                 let decoded = alloy::sol_types::SolValue::abi_decode(&data, true)?;
                 Ok(decoded)
             }
@@ -1320,8 +1315,7 @@ mod tests {
         }
     }
 
-    /// TODO: move this to consensus output.
-    /// !!!!!!!!!!!
+    /// Helper function for creating a consensus output for tests.
     fn consensus_output_for_tests() -> ConsensusOutput {
         let mut leader = Certificate::default();
         let sub_dag_index = 0;
@@ -1352,13 +1346,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_validator_shuffle() -> eyre::Result<()> {
-        // TODO: REMOVE - init_test_tracing
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
-            .with_writer(std::io::stdout)
-            .try_init();
-
         let task_manager = TaskManager::new("Test Task Manager");
         let tmp_dir = TempDir::new().unwrap();
 
@@ -1518,8 +1505,6 @@ mod tests {
         debug!(target: "engine", "new epoch info:{:#?}", new_epoch_info);
 
         assert_eq!(new_epoch_info, expected);
-
-        // TODO: assert event emitted
 
         // merge transitions to apply state changes
         evm.context.evm.db.merge_transitions(BundleRetention::PlainState);

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -57,6 +57,7 @@ sol!(
         }
 
         /// The epoch info stored on-chain.
+        #[derive(PartialEq, Debug)]
         struct EpochInfo {
             /// The committee of validators responsible for the epoch.
             address[] committee;
@@ -83,6 +84,8 @@ sol!(
         function getValidators(uint8 status) public view returns (ValidatorInfo[] memory);
         /// Return committee epoch info for a specific epoch.
         function getEpochInfo(uint32 epoch) public view returns (EpochInfo memory epochInfo);
+        /// Return the current epoch.
+        function getCurrentEpoch() public view returns (uint32) ;
         /// Conclude the current epoch. Caller must pass a new committee of eligible validators.
         function concludeEpoch(address[] calldata newCommittee) external;
     }

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -1,0 +1,89 @@
+//! Module for solidity interface.
+//!
+//! These compile into types for interacting with smart contracts through
+//! System Calls.
+
+use alloy::{primitives::address, sol};
+use tn_types::Address;
+
+/// The system address.
+pub(super) const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
+
+/// The address for consensus registry.
+pub(super) const CONSENSUS_REGISTRY_ADDRESS: Address =
+    address!("07E17e17E17e17E17e17E17E17E17e17e17E17e1");
+
+// ConsensusRegistry interface. See tn-contracts submodule.
+sol!(
+    #[sol(rpc)]
+    contract ConsensusRegistry {
+        /// The validator's eligibility status for being
+        /// considered in the next committee.
+        #[derive(Debug)]
+        enum ValidatorStatus {
+            /// Match any status.
+            Any,
+            /// The validator is staked but has not indicated
+            /// it is ready to participate in committee to earn
+            /// rewards.
+            PendingActivation,
+            /// The validator is actively participating in consensus.
+            Active,
+            /// The validator has indicated interest to exit the protocol.
+            PendingExit,
+            /// The validator is no longer participating in consensus.
+            Exited
+        }
+
+        /// The validator's information.
+        #[derive(Debug)]
+        struct ValidatorInfo {
+            /// The BLS12-381 public key.
+            bytes blsPubkey;
+            /// TODO: remove this - keeping for now until tn-contracts upstream pr merged
+            bytes32 ed25519Pubkey;
+            /// The ECDSA public key.
+            address ecdsaPubkey;
+            /// The epoch which the validator's status
+            /// become "Active" and eligible to participate
+            /// in a committee.
+            uint32 activationEpoch;
+            /// The epoch that the validator exited the protocol.
+            uint32 exitEpoch;
+            /// The staking index of the validator.
+            uint24 validatorIndex;
+            /// The current status of the validator.
+            ValidatorStatus currentStatus;
+        }
+
+        /// The epoch info stored on-chain.
+        struct EpochInfo {
+            /// The committee of validators responsible for the epoch.
+            address[] committee;
+            /// The block height when the epoch started and the
+            /// committee became active.
+            uint64 blockHeight;
+        }
+
+        /// Initialize the contract.
+        function initialize(
+            /// The rwTEL contract address.
+            address rwTEL_,
+            /// The stake amount required to be eligible as a validator.
+            uint256 stakeAmount_,
+            /// The min amount accumulated to withdraw.
+            uint256 minWithdrawAmount_,
+            /// The initial validators with stake.
+            ValidatorInfo[] memory initialValidators_,
+            /// The address of the owner.
+            address owner_
+        );
+
+        /// Return the validators by status. Pass `0` for status to return all validators.
+        function getValidators(uint8 status) public view returns (ValidatorInfo[] memory);
+        /// Return committee epoch info for a specific epoch.
+        function getEpochInfo(uint32 epoch) public view returns (EpochInfo memory epochInfo);
+        /// Conclude the current epoch. Caller must pass a new committee of eligible validators.
+        function concludeEpoch(address[] calldata newCommittee) external;
+    }
+);

--- a/crates/tn-reth/src/traits.rs
+++ b/crates/tn-reth/src/traits.rs
@@ -16,9 +16,6 @@ use reth_node_ethereum::{
     BasicBlockExecutorProvider, EthEngineTypes, EthExecutionStrategyFactory, EthExecutorProvider,
 };
 use reth_provider::EthStorage;
-use reth_revm::primitives::{
-    BlobExcessGasAndPrice, BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, SpecId,
-};
 use reth_trie_db::MerklePatriciaTrie;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -182,47 +179,6 @@ impl TNPayload {
         Self { attributes }
     }
 
-    // /// Create a Reth config and block environment.
-    // pub(crate) fn cfg_and_block_env(
-    //     &self,
-    //     chain_spec: &ChainSpec,
-    // ) -> (CfgEnvWithHandlerCfg, BlockEnv) {
-    //     // configure evm env based on parent block
-    //     let cfg = CfgEnv::default().with_chain_id(chain_spec.chain().id());
-
-    //     // ensure we're not missing any timestamp based hardforks
-    //     let spec_id = SpecId::SHANGHAI;
-
-    //     // use the blob excess gas and price set by the worker during batch creation
-    //     let blob_excess_gas_and_price = Some(BlobExcessGasAndPrice::new(0, false));
-
-    //     // use the basefee set by the worker during batch creation
-    //     let basefee = U256::from(self.attributes.base_fee_per_gas);
-
-    //     // ensure gas_limit enforced during block validation
-    //     let gas_limit = U256::from(self.attributes.gas_limit);
-
-    //     // create block environment to re-execute worker's block
-    //     let block_env = BlockEnv {
-    //         // the block's number should come from the canonical tip, NOT the batch's number
-    //         number: U256::from(self.attributes.parent_header.number + 1),
-    //         // special fee address
-    //         coinbase: self.suggested_fee_recipient(),
-    //         timestamp: U256::from(self.timestamp()),
-    //         // leave difficulty zero
-    //         // this value is useful for post-execution, but worker's block is created with this
-    //         // value
-    //         difficulty: U256::ZERO,
-    //         prevrandao: Some(self.prev_randao()),
-    //         gas_limit,
-    //         basefee,
-    //         // calculate excess gas based on parent block's blob gas usage
-    //         blob_excess_gas_and_price,
-    //     };
-
-    //     (CfgEnvWithHandlerCfg::new_with_spec_id(cfg, spec_id), block_env)
-    // }
-
     /// Passthrough attribute timestamp.
     pub(crate) fn timestamp(&self) -> u64 {
         self.attributes.timestamp
@@ -290,7 +246,8 @@ pub struct TNPayloadAttributes {
     ///
     /// This is currently always empty vec. This comes from the batch block's withdrawals.
     pub withdrawals: Withdrawals,
-    /// Boolean indicating if the payload should use system calls to close the epoch during execution.
+    /// Boolean indicating if the payload should use system calls to close the epoch during
+    /// execution.
     ///
     /// This is the last batch for the `ConsensusOutput` if the epoch is closing.
     pub close_epoch: Option<BlsSignature>,
@@ -337,7 +294,7 @@ impl TNPayloadAttributes {
 
     /// Method to create an instance of Self useful for tests.
     ///
-    /// WARNING: only use this for tests.
+    /// WARNING: only use this for tests. Data is invalid.
     pub fn new_for_test(parent_header: SealedHeader, output: &ConsensusOutput) -> Self {
         let batch_index = 0;
         let batch_digest = B256::random();

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -51,6 +51,10 @@ pub struct ConsensusOutput {
     /// be false unless running a node with the potential to advertise a forked block or
     /// two before quitting.
     pub early_finalize: bool,
+    /// Boolean indicating if this is the last output for the epoch.
+    ///
+    /// The engine should make a system call to consensus registry contract to close the epoch.
+    pub close_epoch: bool,
 }
 
 impl ConsensusOutput {
@@ -107,6 +111,14 @@ impl ConsensusOutput {
     /// Return the hash of the consensus header that matches this output.
     pub fn consensus_header_hash(&self) -> B256 {
         ConsensusHeader::digest_from_parts(self.parent_hash, &self.sub_dag, self.number)
+    }
+
+    /// Return the index of the last batch if the epoch should be closed.
+    ///
+    /// This is used by the engine to apply system calls at the end of the epoch.
+    pub fn epoch_closing_index(&self) -> Option<usize> {
+        // handle edge case for no transactions
+        self.close_epoch.then(|| self.batch_digests.len().saturating_sub(1))
     }
 }
 

--- a/crates/types/src/worker/pending_batch.rs
+++ b/crates/types/src/worker/pending_batch.rs
@@ -10,19 +10,19 @@ pub struct BatchBuilderArgs<Pool> {
     /// The transaction pool.
     pub pool: Pool,
     /// The attributes for the next block.
-    pub batch_config: PendingBlockConfig,
+    pub batch_config: PendingBatchConfig,
 }
 
 impl<Pool> BatchBuilderArgs<Pool> {
     /// Create a new instance of [Self].
-    pub fn new(pool: Pool, batch_config: PendingBlockConfig) -> Self {
+    pub fn new(pool: Pool, batch_config: PendingBatchConfig) -> Self {
         Self { pool, batch_config }
     }
 }
 
 /// The configuration to use for building the next batch.
 #[derive(Debug)]
-pub struct PendingBlockConfig {
+pub struct PendingBatchConfig {
     /// The worker primary's address.
     pub beneficiary: Address,
     /// The current information from canonical tip and finalized batch.
@@ -33,7 +33,7 @@ pub struct PendingBlockConfig {
     pub parent_info: SealedBlock,
 }
 
-impl PendingBlockConfig {
+impl PendingBatchConfig {
     /// Creates a new instance of [Self].
     pub fn new(beneficiary: Address, parent_info: SealedBlock) -> Self {
         Self { beneficiary, parent_info }


### PR DESCRIPTION
- add closing epoch field to consensus output
- support for calling `concludeEpoch` on consensus registry contract
- simple fischer-yates shuffle algo based on leader cert's aggregate BLS signature and chacharand8
- update genesis tests to use main sol interface
- rename `block` -> `batch` leftovers

The `close_epoch` field is always set to `false` on consensus output so the closing epoch is never called. This will be addressed in a follow-up PR.