### PR TITLE
Retry test fixes.

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -182,6 +182,11 @@ impl PrimaryNetworkHandle {
     ) {
         let _ = self.handle.process_peer_exchange(peers, channel).await;
     }
+
+    /// Retrieve a collection of connected peers.
+    pub async fn connected_peers(&self) -> NetworkResult<Vec<PeerId>> {
+        self.handle.connected_peers().await
+    }
 }
 
 /// Handle inter-node communication between primaries.

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -223,6 +223,11 @@ impl WorkerNetworkHandle {
     ) {
         let _ = self.handle.process_peer_exchange(peers, channel).await;
     }
+
+    /// Retrieve a collection of connected peers.
+    pub async fn connected_peers(&self) -> NetworkResult<Vec<PeerId>> {
+        self.handle.connected_peers().await
+    }
 }
 
 /// Handle inter-node communication between primaries.

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -4,21 +4,14 @@
 use crate::{primary::PrimaryNode, worker::WorkerNode};
 use consensus_metrics::start_prometheus_server;
 use engine::{ExecutionNode, TnBuilder};
-use std::{
-    str::FromStr as _,
-    sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{str::FromStr as _, sync::Arc, time::Duration};
 use tn_config::{ConsensusConfig, KeyConfig, NetworkConfig, TelcoinDirs};
 use tn_network_libp2p::{ConsensusNetwork, PeerId};
 use tn_primary::{
     network::{PrimaryNetwork, PrimaryNetworkHandle},
     ConsensusBus, NodeMode, StateSynchronizer,
 };
-use tn_reth::RethEnv;
+use tn_reth::{RethDb, RethEnv};
 use tn_storage::{open_db, tables::ConsensusBlocks, DatabaseType};
 use tn_types::{BatchValidation, ConsensusHeader, Database as TNDatabase, Multiaddr, TaskManager};
 use tn_worker::{WorkerNetwork, WorkerNetworkHandle};
@@ -35,7 +28,6 @@ fn dial_primary(
     handle: PrimaryNetworkHandle,
     peer_id: PeerId,
     peer_addr: tn_network_libp2p::Multiaddr,
-    connected_count: Arc<AtomicU32>,
 ) {
     tokio::spawn(async move {
         let mut backoff = 1;
@@ -45,8 +37,12 @@ fn dial_primary(
             if backoff < 120 {
                 backoff += backoff;
             }
+            if let Ok(peers) = handle.connected_peers().await {
+                if peers.contains(&peer_id) {
+                    return;
+                };
+            }
         }
-        connected_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     });
 }
 
@@ -55,7 +51,6 @@ fn dial_worker(
     handle: WorkerNetworkHandle,
     peer_id: PeerId,
     peer_addr: tn_network_libp2p::Multiaddr,
-    connected_count: Arc<AtomicU32>,
 ) {
     tokio::spawn(async move {
         let mut backoff = 1;
@@ -65,8 +60,12 @@ fn dial_worker(
             if backoff < 120 {
                 backoff += backoff;
             }
+            if let Ok(peers) = handle.connected_peers().await {
+                if peers.contains(&peer_id) {
+                    return;
+                };
+            }
         }
-        connected_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     });
 }
 
@@ -135,26 +134,25 @@ async fn start_networks<DB: TNDatabase>(
     // create specific handles for primary/worker
     let primary_network_handle = PrimaryNetworkHandle::new(primary_network_handle);
     let worker_network_handle = WorkerNetworkHandle::new(worker_network_handle);
-    let peers_connected = Arc::new(AtomicU32::new(0));
-    let workers_connected = Arc::new(AtomicU32::new(0));
     for (authority_id, addr, _) in consensus_config
         .committee()
         .others_primaries_by_id(consensus_config.authority_id().as_ref())
     {
         let peer_id = authority_id.peer_id();
-        dial_primary(primary_network_handle.clone(), peer_id, addr, peers_connected.clone());
+        dial_primary(primary_network_handle.clone(), peer_id, addr);
     }
     for (peer_id, addr) in consensus_config.worker_cache().all_workers() {
         if addr != worker_address {
-            dial_worker(worker_network_handle.clone(), peer_id, addr, workers_connected.clone());
+            dial_worker(worker_network_handle.clone(), peer_id, addr);
         }
     }
-    let quorum = consensus_config.committee().quorum_threshold() as u32;
-    // Wait until we are connected to a quorum of peers (note this assumes we are a validator...).
-    while peers_connected.load(Ordering::Relaxed) < quorum
-        || workers_connected.load(Ordering::Relaxed) < quorum
-    {
+    // Wait until we have a peer, once we have that lets move on- should be able to work now (?).
+    let mut primary_peers =
+        primary_network_handle.connected_peers().await.map(|p| p.len()).unwrap_or(0);
+    while primary_peers == 0 {
         tokio::time::sleep(Duration::from_millis(500)).await;
+        primary_peers =
+            primary_network_handle.connected_peers().await.map(|p| p.len()).unwrap_or(0);
     }
     let primary_network = PrimaryNetwork::new(
         rx_event_stream,
@@ -191,6 +189,7 @@ pub fn launch_node_inner<P>(
     builder: &TnBuilder,
     tn_datadir: &P,
     db: DatabaseType,
+    reth_db: RethDb,
 ) -> eyre::Result<bool>
 where
     P: TelcoinDirs + 'static,
@@ -213,7 +212,7 @@ where
         // config for validator keys
         let config = builder.tn_config.clone();
         let mut task_manager = TaskManager::new("Task Manager");
-        let reth_env = RethEnv::new(&builder.node_config, tn_datadir.reth_db_path(), &task_manager)?;
+        let reth_env = RethEnv::new(&builder.node_config, &task_manager, reth_db)?;
         let mut engine_task_manager = TaskManager::new("Engine Task Manager");
         let engine = ExecutionNode::new(builder, reth_env)?;
         let validator = engine.new_batch_validator().await;
@@ -356,11 +355,14 @@ where
     // open storage for consensus
     // In case the DB dir does not yet exist.
     let _ = std::fs::create_dir_all(&consensus_db_path);
+    // Create both of the MDBX DBs and hold onto them.
+    // MDBX seems to have issues occasionally if recreated on a relaunch...
     let db = open_db(&consensus_db_path);
+    let reth_db = RethEnv::new_database(&builder.node_config, tn_datadir.reth_db_path())?;
 
     let mut running = true;
     while running {
-        running = launch_node_inner(&builder, &tn_datadir, db.clone())?;
+        running = launch_node_inner(&builder, &tn_datadir, db.clone(), reth_db.clone())?;
     }
     Ok(())
 }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -32,7 +32,6 @@ pub async fn can_cvv<DB: Database>(
         last_executed_consensus_block(&consensus_bus, &config).unwrap_or_default();
 
     // Set some of the round watches to the current default.
-    // TODO- replace 0 with the epoch once we have them..
     let last_consensus_epoch = last_executed_block.sub_dag.leader.epoch();
     let last_consensus_round = last_executed_block.sub_dag.leader_round();
     let _ = consensus_bus.update_consensus_rounds(ConsensusRound::new_with_gc_depth(

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -152,9 +152,10 @@ pub fn faucet_test_execution_node(
     };
 
     // create engine node
+    let reth_db = RethEnv::new_database(&node_config, tmp_dir.join("db"))?;
     let engine = ExecutionNode::new(
         &builder,
-        RethEnv::new(&node_config, tmp_dir.join("db"), &TaskManager::default())?,
+        RethEnv::new(&node_config, &TaskManager::default(), reth_db)?,
     )?;
 
     Ok(engine)

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -307,16 +307,20 @@ impl ChainSpec {
     }
 }
 
+/// Type wrapper for a Reth DB.
+/// Used primary as a opaque type to allow
+/// the node launcher to create the DB upfront and reuse.
+pub type RethDb = Arc<DatabaseEnv>;
+
 impl RethEnv {
-    /// Produce a new wrapped Reth environment from a config, DB path and task manager.
-    pub fn new<P: AsRef<Path>>(
+    /// Create a new Reth DB.
+    /// Break this out so this can be created upfront and used even on a
+    /// restart (when catching up for instance).
+    pub fn new_database<P: AsRef<Path>>(
         reth_config: &RethConfig,
         db_path: P,
-        task_manager: &TaskManager,
-    ) -> eyre::Result<Self> {
+    ) -> eyre::Result<RethDb> {
         let db_path = db_path.as_ref();
-        // create node builders for Primary and Worker
-        //
         // Register the prometheus recorder before creating the database,
         // then start metrics
         //
@@ -329,7 +333,15 @@ impl RethEnv {
         let _ = install_prometheus_recorder();
 
         info!(target: "tn::reth", path = ?db_path, "opening database");
-        let database = Arc::new(init_db(db_path, reth_config.0.db.database_args())?.with_metrics());
+        Ok(Arc::new(init_db(db_path, reth_config.0.db.database_args())?.with_metrics()))
+    }
+
+    /// Produce a new wrapped Reth environment from a config, DB path and task manager.
+    pub fn new(
+        reth_config: &RethConfig,
+        task_manager: &TaskManager,
+        database: RethDb,
+    ) -> eyre::Result<Self> {
         let node_config = reth_config.0.clone();
         let (evm_executor, evm_config) = Self::init_evm_components(&node_config);
         let provider_factory = Self::init_provider_factory(&node_config, database)?;
@@ -356,7 +368,8 @@ impl RethEnv {
             ..NodeConfig::default()
         };
         let reth_config = RethConfig(node_config);
-        Self::new(&reth_config, db_path, task_manager)
+        let database = Self::new_database(&reth_config, db_path)?;
+        Self::new(&reth_config, task_manager, database)
     }
 
     /// Create a new RethEnv for testing only.


### PR DESCRIPTION
This is primarily to improve the restart tests.  Includes two other "fixes" that seemed to improve the test reliability.
- When starting the node will progress once it can connect with one primary peer.  This is a lot looser then than the old code that expected a node to be in the committee and was also buggy which I believe occasionally derailed restart tests.
- The Reth DB (not used except to pass to Reth) is created early and not recreated on a node "restart" (currently used when a validator has caught up to rejoin consensus).  MDBX was occasionally freaking out when the DB was dropped and quickly recreated.  The consensus DB is also managed this way, always has been.  Forget specific reasons but probably similar.  There may be MDBX issues in general, have been seeing testnet issues now and then as well.  Nothing can be done about this at the moment and this seems to make it happier...

This won't fix all the issues, for instance I have recently seen port conflict issues and once had the nodes on restart advance one block and then stop.  Will get these in issues as data can be collected, it seems to be a lot more reliable now though.