### PR TITLE
`TaskManagerClone` -> `TaskSpawner`

### DIFF
--- a/crates/consensus/consensus-metrics/src/lib.rs
+++ b/crates/consensus/consensus-metrics/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
     task::{Context, Poll},
     time::Instant,
 };
+use tn_types::TaskManager;
 
 use once_cell::sync::OnceCell;
 use prometheus::{
@@ -240,7 +241,7 @@ pub const METRICS_ROUTE: &str = "/metrics";
 // Creates a new http server that has as a sole purpose to expose
 // and endpoint that prometheus agent can use to poll for the metrics.
 // A RegistryService is returned that can be used to get access in prometheus Registries.
-pub fn start_prometheus_server(addr: SocketAddr) {
+pub fn start_prometheus_server(addr: SocketAddr, task_manager: &TaskManager) {
     init_metrics();
     if cfg!(msim) {
         // prometheus uses difficult-to-support features such as TcpSocket::from_raw_fd(), so we
@@ -251,7 +252,7 @@ pub fn start_prometheus_server(addr: SocketAddr) {
 
     let app = Router::new().route(METRICS_ROUTE, get(metrics));
 
-    tokio::spawn(async move {
+    task_manager.spawn_task("ConsensusMetrics", async move {
         if let Err(e) = axum::Server::bind(&addr).serve(app.into_make_service()).await {
             tracing::error!(target: "prometheus", ?e, "server returned error");
         }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -20,7 +20,7 @@ use tn_primary::{
 use tn_storage::CertificateStore;
 use tn_types::{
     AuthorityIdentifier, Batch, BlockHash, CommittedSubDag, Committee, ConsensusHeader,
-    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskManagerClone, Timestamp,
+    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp,
     TimestampSec, TnReceiver, TnSender, B256,
 };
 use tracing::{debug, error, info};
@@ -172,7 +172,7 @@ impl<DB: Database> Subscriber<DB> {
     }
 
     /// Catch up to current consensus and then try to rejoin as an active CVV.
-    async fn catch_up_rejoin_consensus(&self, tasks: TaskManagerClone) -> SubscriberResult<()> {
+    async fn catch_up_rejoin_consensus(&self, tasks: TaskSpawner) -> SubscriberResult<()> {
         // Get a receiver than stream any missing headers so we don't miss them.
         let mut rx_consensus_headers = self.consensus_bus.consensus_header().subscribe();
         stream_missing_consensus(&self.config, &self.consensus_bus).await?;
@@ -199,7 +199,7 @@ impl<DB: Database> Subscriber<DB> {
     }
 
     /// Follow along with consensus output but do not try to join consensus.
-    async fn follow_consensus(&self, tasks: TaskManagerClone) -> SubscriberResult<()> {
+    async fn follow_consensus(&self, tasks: TaskSpawner) -> SubscriberResult<()> {
         // Get a receiver then stream any missing headers so we don't miss them.
         let mut rx_consensus_headers = self.consensus_bus.consensus_header().subscribe();
         stream_missing_consensus(&self.config, &self.consensus_bus).await?;

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -77,7 +77,9 @@ fn create_test_types() -> TestTypes {
         .send(recent)
         .expect("watch channel updates for default parent in primary handler tests");
 
-    let handler = RequestHandler::new(config.clone(), cb.clone(), synchronizer);
+    let task_manager = TaskManager::default();
+    let handler =
+        RequestHandler::new(config.clone(), cb.clone(), synchronizer, task_manager.get_spawner());
     TestTypes { committee, handler, parent }
 }
 

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -44,6 +44,7 @@ fn get_bus_and_primary<DB: Database>(
         config.clone(),
         consensus_bus.clone(),
         state_sync.clone(),
+        task_manager,
     );
     primary_network.spawn(task_manager);
 
@@ -73,7 +74,12 @@ async fn test_request_vote_has_missing_execution_block() {
     let synchronizer = StateSynchronizer::new(target.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(target.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        target.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let committee: Committee = fixture.committee();
@@ -141,7 +147,12 @@ async fn test_request_vote_older_execution_block() {
     let synchronizer = StateSynchronizer::new(target.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(target.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        target.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let committee: Committee = fixture.committee();
@@ -203,7 +214,12 @@ async fn test_request_vote_has_missing_parents() {
     let synchronizer = StateSynchronizer::new(target.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(target.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        target.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let committee: Committee = fixture.committee();
@@ -288,7 +304,12 @@ async fn test_request_vote_accept_missing_parents() {
     let synchronizer = StateSynchronizer::new(target.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(target.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        target.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let committee: Committee = fixture.committee();
@@ -378,7 +399,12 @@ async fn test_request_vote_missing_batches() {
     let synchronizer = StateSynchronizer::new(primary.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(primary.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        primary.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let mut certificates = HashMap::new();
@@ -444,7 +470,12 @@ async fn test_request_vote_already_voted() {
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
 
-    let handler = RequestHandler::new(primary.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        primary.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let mut certificates = HashMap::new();
@@ -531,7 +562,12 @@ async fn test_fetch_certificates_handler() {
     let synchronizer = StateSynchronizer::new(primary.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(primary.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        primary.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     let mut current_round: Vec<_> = Certificate::genesis(&fixture.committee())
         .into_iter()
@@ -646,7 +682,12 @@ async fn test_request_vote_created_at_in_future() {
     let synchronizer = StateSynchronizer::new(primary.consensus_config(), cb.clone());
     let task_manager = TaskManager::default();
     synchronizer.spawn(&task_manager);
-    let handler = RequestHandler::new(primary.consensus_config(), cb.clone(), synchronizer.clone());
+    let handler = RequestHandler::new(
+        primary.consensus_config(),
+        cb.clone(),
+        synchronizer.clone(),
+        task_manager.get_spawner(),
+    );
 
     // Make some mock certificates that are parents of our new header.
     let mut certificates = HashMap::new();

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -150,7 +150,7 @@ where
 
         // start consensus metrics for the epoch
         if let Some(metrics_socket) = self.builder.consensus_metrics {
-            start_prometheus_server(metrics_socket);
+            start_prometheus_server(metrics_socket, &self.epoch_task_manager);
         }
 
         // create submanager for engine tasks
@@ -396,6 +396,7 @@ where
             consensus_config.clone(),
             consensus_bus.clone(),
             state_sync,
+            &self.epoch_task_manager, // tasks should abort with epoch
         )
         .spawn(&self.node_task_manager);
 

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -12,7 +12,7 @@ use tn_primary::{
     consensus::ConsensusRound, network::PrimaryNetworkHandle, ConsensusBus, NodeMode,
 };
 use tn_storage::tables::{Batches, ConsensusBlockNumbersByDigest, ConsensusBlocks};
-use tn_types::{ConsensusHeader, ConsensusOutput, Database, DbTxMut, TaskManagerClone, TnSender};
+use tn_types::{ConsensusHeader, ConsensusOutput, Database, DbTxMut, TaskSpawner, TnSender};
 use tracing::{error, info};
 
 /// Return true if this node should be able to participate as a CVV, false otherwise.
@@ -67,7 +67,7 @@ pub fn spawn_state_sync<DB: Database>(
     config: ConsensusConfig<DB>,
     consensus_bus: ConsensusBus,
     network: PrimaryNetworkHandle,
-    task_manager: TaskManagerClone,
+    task_manager: TaskSpawner,
 ) {
     let mode = *consensus_bus.node_mode().borrow();
     match mode {


### PR DESCRIPTION
- rename the cloneable task manager type to spawn tasks