### PR TITLE
Initial addition of kademlia to network for peer discovery.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-gossipsub",
  "libp2p-identity",
+ "libp2p-kad",
  "libp2p-swarm",
  "pin-project 1.1.8",
  "prometheus-client",

--- a/crates/network-libp2p/Cargo.toml
+++ b/crates/network-libp2p/Cargo.toml
@@ -15,6 +15,7 @@ libp2p = { workspace = true, features = [
     "tokio",
     "quic",
     "macros",
+    "kad",
 ] }
 tokio = { workspace = true, features = ["rt", "net", "sync", "macros", "time"] }
 tn-types = { workspace = true }

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -16,19 +16,23 @@ use libp2p::{
         self, Event as GossipEvent, IdentTopic, Message as GossipMessage, MessageAcceptance, Topic,
         TopicHash,
     },
+    kad::{self, store::MemoryStore, Mode},
     request_response::{
         self, Codec, Event as ReqResEvent, InboundFailure as ReqResInboundFailure,
         InboundRequestId, OutboundRequestId,
     },
     swarm::{NetworkBehaviour, SwarmEvent},
-    PeerId, Swarm, SwarmBuilder,
+    Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tn_config::{ConsensusConfig, LibP2pConfig};
-use tn_types::{Database, NetworkKeypair};
+use tn_config::{ConsensusConfig, KeyConfig, LibP2pConfig};
+use tn_types::{
+    encode, try_decode, BlsPublicKey, BlsSignature, BlsSigner, Database, NetworkKeypair,
+};
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     oneshot,
@@ -53,6 +57,8 @@ where
     pub(crate) req_res: request_response::Behaviour<C>,
     /// The peer manager.
     pub(crate) peer_manager: peers::PeerManager,
+    /// Used for peer discovery.
+    pub(crate) kademlia: kad::Behaviour<MemoryStore>,
 }
 
 impl<C> TNBehavior<C>
@@ -64,9 +70,10 @@ where
         gossipsub: gossipsub::Behaviour,
         req_res: request_response::Behaviour<C>,
         consensus_config: &ConsensusConfig<DB>,
+        kademlia: kad::Behaviour<MemoryStore>,
     ) -> Self {
         let peer_manager = PeerManager::new(consensus_config);
-        Self { gossipsub, req_res, peer_manager }
+        Self { gossipsub, req_res, peer_manager, kademlia }
     }
 }
 
@@ -122,6 +129,16 @@ where
     /// This explicitly tracked and is a VecDeque so we can use to round robin requests without an
     /// explicit peer.
     connected_peers: VecDeque<PeerId>,
+    /// Key manager, provide the BLS public key and sign peer records published to kademlia.
+    key_config: KeyConfig,
+    /// If true then add peers to kademlia- useful for testing to set false.
+    kad_add_peers: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct AddrList {
+    signature: BlsSignature,
+    value: Vec<Multiaddr>,
 }
 
 impl<Req, Res> ConsensusNetwork<Req, Res>
@@ -185,9 +202,11 @@ where
             consensus_config.network_config().libp2p_config().supported_req_res_protocols.clone(),
             request_response::Config::default(),
         );
+        let peer_id: PeerId = keypair.public().into();
+        let kademlia = kad::Behaviour::new(peer_id, MemoryStore::new(peer_id));
 
         // create custom behavior
-        let behavior = TNBehavior::new(gossipsub, req_res, consensus_config);
+        let behavior = TNBehavior::new(gossipsub, req_res, consensus_config, kademlia);
 
         // create swarm
         let swarm = SwarmBuilder::with_existing_identity(keypair)
@@ -231,7 +250,14 @@ where
             config,
             connected_peers: VecDeque::new(),
             pending_px_disconnects,
+            key_config: consensus_config.key_config().clone(),
+            kad_add_peers: true,
         })
+    }
+
+    /// After this call peers will not be added to kademlia, for testing.
+    pub fn no_kad_peers_for_test(&mut self) {
+        self.kad_add_peers = false;
     }
 
     /// Return a [NetworkHandle] to send commands to this network.
@@ -239,8 +265,58 @@ where
         NetworkHandle::new(self.handle.clone())
     }
 
+    /// Return a kademlia record keyed on our BlsPublicKey with our peer_id and network addresses.
+    fn get_peer_record(&self) -> kad::Record {
+        let key = kad::RecordKey::new(&encode(&self.key_config.primary_public_key()));
+        let value: Vec<Multiaddr> = self.swarm.external_addresses().cloned().collect();
+        let peer_id = *self.swarm.local_peer_id();
+        let expires = Instant::now().checked_add(Duration::from_secs(60 * 60 * 24)); // one day
+        let signature = self.key_config.request_signature_direct(&encode(&value));
+        let addr_list = AddrList { signature, value };
+        kad::Record {
+            key: key.clone(),
+            value: encode(&addr_list),
+            publisher: Some(peer_id),
+            expires,
+        }
+    }
+
+    /// Verify the addres list in Record was signed by the key.
+    fn peer_record_valid(&self, record: &kad::Record) -> Option<(BlsPublicKey, AddrList)> {
+        let key = try_decode::<BlsPublicKey>(record.key.as_ref()).ok()?;
+        let addr_list = try_decode::<AddrList>(record.value.as_ref()).ok()?;
+        if addr_list.signature.verify_raw(&encode(&addr_list.value), &key) {
+            Some((key, addr_list))
+        } else {
+            None
+        }
+    }
+
+    /// Publish and provide our network addresses and peer id under our BLS public key for
+    /// discovery.
+    fn provide_our_data(&mut self) {
+        let record = self.get_peer_record();
+        let key = record.key.clone();
+        if let Err(err) = self.swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One) {
+            error!(target: "network-kad", "Failed to store record locally: {err}");
+        }
+        if let Err(err) = self.swarm.behaviour_mut().kademlia.start_providing(key) {
+            error!(target: "network-kad", "Failed to start providing key: {err}");
+        }
+    }
+
+    /// Publish our network addresses and peer id under our BLS public key for discovery.
+    fn publish_our_data(&mut self) {
+        let record = self.get_peer_record();
+        if let Err(err) = self.swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One) {
+            error!(target: "network-kad", "Failed to publish record: {err}");
+        }
+    }
+
     /// Run the network loop to process incoming gossip.
     pub async fn run(mut self) -> NetworkResult<()> {
+        self.swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
+        self.provide_our_data();
         loop {
             tokio::select! {
                 event = self.swarm.select_next_some() => self.process_event(event).await?,
@@ -266,6 +342,7 @@ where
                 TNBehaviorEvent::Gossipsub(event) => self.process_gossip_event(event)?,
                 TNBehaviorEvent::ReqRes(event) => self.process_reqres_event(event)?,
                 TNBehaviorEvent::PeerManager(event) => self.process_peer_manager_event(event)?,
+                TNBehaviorEvent::Kademlia(event) => self.process_kad_event(event)?,
             },
             SwarmEvent::ExpiredListenAddr { address, .. } => {
                 debug!(
@@ -694,7 +771,11 @@ where
             PeerEvent::PeerConnected(peer_id, addr) => {
                 // register peer for request-response behaviour
                 // NOTE: gossipsub handles `FromSwarm::ConnectionEstablished`
-                self.swarm.add_peer_address(peer_id, addr);
+                self.swarm.add_peer_address(peer_id, addr.clone());
+                if self.kad_add_peers {
+                    self.swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
+                    self.publish_our_data();
+                }
 
                 // manage connected peers for
                 self.connected_peers.push_back(peer_id);
@@ -716,6 +797,94 @@ where
             }
         }
 
+        Ok(())
+    }
+
+    fn process_kad_event(&mut self, event: kad::Event) -> NetworkResult<()> {
+        match event {
+            kad::Event::InboundRequest { request } => {
+                info!(target: "network-kad", "inbound {request:?}")
+            }
+            kad::Event::OutboundQueryProgressed { id: _, result, stats: _, step: _ } => {
+                match result {
+                    kad::QueryResult::GetProviders(Ok(kad::GetProvidersOk::FoundProviders {
+                        key,
+                        providers,
+                        ..
+                    })) => match try_decode::<BlsPublicKey>(key.as_ref()) {
+                        Ok(key) => {
+                            for peer in providers {
+                                info!(target: "network-kad",
+                                    "Peer {peer:?} provides key {:?}",
+                                    key,
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            error!(target: "network-kad", "Failed to decode a kad Key: {err}")
+                        }
+                    },
+                    kad::QueryResult::GetProviders(Err(err)) => {
+                        error!(target: "network-kad", "Failed to get providers: {err:?}");
+                    }
+                    kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(
+                        kad::PeerRecord { record, .. },
+                    ))) => {
+                        if let Some((key, value)) = self.peer_record_valid(&record) {
+                            info!(target: "network-kad", "Got record {key} {value:?}");
+                        } else {
+                            error!(target: "network-kad", "Recieved invalid peer record!");
+                        }
+                    }
+                    kad::QueryResult::GetRecord(Ok(_)) => {}
+                    kad::QueryResult::GetRecord(Err(err)) => {
+                        error!(target: "network-kad", "Failed to get record: {err:?}");
+                    }
+                    kad::QueryResult::PutRecord(Ok(kad::PutRecordOk { key })) => {
+                        match try_decode::<BlsPublicKey>(key.as_ref()) {
+                            Ok(key) => {
+                                info!(target: "network-kad", "Successfully put record {key}")
+                            }
+                            Err(err) => {
+                                error!(target: "network-kad", "Failed to decode a kad Key: {err}")
+                            }
+                        }
+                    }
+                    kad::QueryResult::PutRecord(Err(err)) => {
+                        error!(target: "network-kad", "Failed to put record: {err:?}");
+                    }
+                    kad::QueryResult::StartProviding(Ok(kad::AddProviderOk { key })) => {
+                        match try_decode::<BlsPublicKey>(key.as_ref()) {
+                            Ok(key) => {
+                                info!(target: "network-kad", "Successfully put provider record {:?}", key)
+                            }
+                            Err(err) => {
+                                error!(target: "network-kad", "Failed to decode a kad Key: {err}")
+                            }
+                        }
+                    }
+                    kad::QueryResult::StartProviding(Err(err)) => {
+                        error!(target: "network-kad", "Failed to put provider record: {err:?}");
+                    }
+                    _ => {}
+                }
+            }
+            kad::Event::RoutingUpdated { peer, is_new_peer, addresses, bucket_range, old_peer } => {
+                info!(target: "network-kad", "routing updated peer {peer:?} new {is_new_peer} addrs {addresses:?} bucketr {bucket_range:?} old {old_peer:?}")
+            }
+            kad::Event::UnroutablePeer { peer } => {
+                info!(target: "network-kad", "unroutable peer {peer:?}")
+            }
+            kad::Event::RoutablePeer { peer, address } => {
+                info!(target: "network-kad", "routable peer {peer:?}/{address:?}")
+            }
+            kad::Event::PendingRoutablePeer { peer, address } => {
+                info!(target: "network-kad", "pending routable peer {peer:?}/{address:?}")
+            }
+            kad::Event::ModeChanged { new_mode } => {
+                info!(target: "network-kad", "mode changed {new_mode:?}")
+            }
+        }
         Ok(())
     }
 }

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -274,7 +274,7 @@ impl PeerManager {
     ///
     /// This is called before accepting new connections. Also checks that the peer
     /// wasn't temporarily banned due to excess peers connections.
-    pub(super) fn peer_banned(&self, peer_id: &PeerId) -> bool {
+    pub(crate) fn peer_banned(&self, peer_id: &PeerId) -> bool {
         self.temporarily_banned.contains(peer_id) || self.peers.peer_banned(peer_id)
     }
 

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -10,7 +10,9 @@ use libp2p::{
     request_response::ResponseChannel,
     Multiaddr, PeerId, TransportError,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use tn_types::BlsSignature;
 use tokio::sync::{mpsc, oneshot};
 
 /// The result for network operations.
@@ -467,6 +469,20 @@ where
         self.sender.send(NetworkCommand::NewEpoch { committee }).await?;
         Ok(())
     }
+}
+
+/// List of addresses for a node, signature will be the nodes BLS signature
+/// over the addresses to verify they are from the node in question.
+/// Used to publish this to kademlia.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct AddrList {
+    /// Signature of the value field with the nodes BLS key.
+    /// This is part of a kademlia record keyed on a BLS public key
+    /// that can be used for verifiction.  Intended to stop malicious
+    /// nodes from poisoning the routing table.
+    pub signature: BlsSignature,
+    /// Vector of libp2p network addresses for node.
+    pub value: Vec<Multiaddr>,
 }
 
 /// Helper macro for sending oneshot replies and logging errors.

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -25,6 +25,11 @@ impl BlsSignature {
             .map_err(|_| eyre::eyre!("Invalid signature bytes!"))?;
         Ok(Self(sig))
     }
+
+    /// Verify a signature over a message (raw bytes) with public key.
+    pub fn verify_raw(&self, message: &[u8], public_key: &BlsPublicKey) -> bool {
+        self.verify(true, message, DST_G1, &[], public_key, true) == blst::BLST_ERROR::BLST_SUCCESS
+    }
 }
 
 impl Deref for BlsSignature {


### PR DESCRIPTION
This adds kademlia to the network stack for peer discovery.  It seems to work but better hooks and tests will be incoming.  It also publishes a signed record keyed on a nodes BLS key.  Not used yet but this will allow nodes to change network setting/keys and still be located by their BLS key.