### PR TITLE
Fix floating point precision issues, update tn-contracts commit

### DIFF
--- a/bin/telcoin-network/src/genesis/create_committee.rs
+++ b/bin/telcoin-network/src/genesis/create_committee.rs
@@ -1,11 +1,12 @@
 //! Create a committee from the validators in genesis.
 
 use crate::args::{clap_address_parser, clap_genesis_parser};
+use alloy::primitives::utils::parse_ether;
 use clap::Args;
 use core::panic;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 use tn_config::{
-    Config, ConfigFmt, ConfigTrait, NetworkGenesis, QueryResult, TelcoinDirs as _, DEPLOYMENTS_JSON,
+    Config, ConfigFmt, ConfigTrait, NetworkGenesis, TelcoinDirs as _, DEPLOYMENTS_JSON,
 };
 use tn_reth::{
     dirs::{default_datadir_args, DataDirChainPath, DataDirPath},
@@ -78,7 +79,7 @@ pub struct CreateCommitteeArgs {
         long = "initial-stake-per-validator",
         alias = "stake",
         help_heading = "The initial stake credited to each validator in genesis. The default is 1mil TEL.",
-        default_value_t = U256::from(1_000_000e18),
+        default_value_t = U256::try_from(parse_ether("1_000_000").expect("parse_ether")).expect("initial stake"),
         verbatim_doc_comment
     )]
     pub initial_stake: U256,
@@ -88,7 +89,7 @@ pub struct CreateCommitteeArgs {
         long = "min-withdraw-amount",
         alias = "min_withdraw",
         help_heading = "The minimal amount a validator can withdraw. The default is 1_000 TEL.",
-        default_value_t = U256::from(1_000e18),
+        default_value_t = U256::try_from(parse_ether("1_000").expect("parse_ether")).expect("min withdraw"),
         verbatim_doc_comment
     )]
     pub min_withdrawal: U256,
@@ -98,7 +99,7 @@ pub struct CreateCommitteeArgs {
         long = "epoch-block-rewards",
         alias = "block_rewards_per_epoch",
         help_heading = "The amount of TEL (incl 18 decimals) for the committee starting at genesis.",
-        default_value_t = U256::from(20_000_000e18).checked_div(U256::from(28)).expect("U256 div works"),
+        default_value_t = U256::try_from(parse_ether("20_000_000").expect("parse_ether")).expect("block rewards").checked_div(U256::from(28)).expect("U256 div works"),
         verbatim_doc_comment
     )]
     pub epoch_rewards: U256,
@@ -146,11 +147,11 @@ impl CreateCommitteeArgs {
             epochDuration: self.epoch_duration,
         };
         let rwtel_address =
-            match NetworkGenesis::fetch_from_json_str(DEPLOYMENTS_JSON, Some("rwTEL")) {
-                Ok(QueryResult::Single(value)) => {
-                    Address::from_str(value.as_str().expect("RWTEL address incorrect"))
-                        .expect("RWTEK address incorrect")
-                }
+            match NetworkGenesis::fetch_from_json_str(DEPLOYMENTS_JSON, Some("its.rwTEL")) {
+                Ok(res) => match res {
+                        serde_json::Value::String(s) => Address::from_str(&s).expect("RWTEL addr incorrect"),
+                        _ => panic!("RWTEL address not a string")
+                    },
                 _ => panic!("RWTEL address not found"),
             };
 

--- a/bin/telcoin-network/src/genesis/create_committee.rs
+++ b/bin/telcoin-network/src/genesis/create_committee.rs
@@ -149,9 +149,11 @@ impl CreateCommitteeArgs {
         let rwtel_address =
             match NetworkGenesis::fetch_from_json_str(DEPLOYMENTS_JSON, Some("its.rwTEL")) {
                 Ok(res) => match res {
-                        serde_json::Value::String(s) => Address::from_str(&s).expect("RWTEL addr incorrect"),
-                        _ => panic!("RWTEL address not a string")
-                    },
+                    serde_json::Value::String(s) => {
+                        Address::from_str(&s).expect("RWTEL addr incorrect")
+                    }
+                    _ => panic!("RWTEL address not a string"),
+                },
                 _ => panic!("RWTEL address not found"),
             };
 

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -5,7 +5,10 @@
 //! because the proxy version may be re-prioritized later.
 use crate::util::spawn_local_testnet;
 use alloy::{
-    network::EthereumWallet, primitives::utils::parse_ether, providers::ProviderBuilder, sol_types::{SolCall, SolConstructor}
+    network::EthereumWallet,
+    primitives::utils::parse_ether,
+    providers::ProviderBuilder,
+    sol_types::{SolCall, SolConstructor},
 };
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use rand::SeedableRng;
@@ -13,9 +16,7 @@ use rand_chacha::ChaCha8Rng;
 use serde_json::Value;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tempfile::TempDir;
-use tn_config::{
-    fetch_file_content_relative_to_manifest, NetworkGenesis, DEPLOYMENTS_JSON,
-};
+use tn_config::{fetch_file_content_relative_to_manifest, NetworkGenesis, DEPLOYMENTS_JSON};
 use tn_reth::{
     system_calls::{
         ConsensusRegistry::{self, getCurrentEpochInfoReturn, getValidatorsReturn},
@@ -87,10 +88,17 @@ async fn test_precompile_genesis_accounts() -> eyre::Result<()> {
 
     // assert all interchain token service precompile configs are present
     let its_addresses = expected_deployments.get("its").and_then(|v| v.as_object()).unwrap();
-    let addresses_with_storage: Vec<&str> = ["rwTEL", "rwTELImpl", "AxelarAmplifierGateway", "GasService", "InterchainTokenService", "InterchainTokenFactory"]
-        .iter()
-        .filter_map(|&key| its_addresses.get(key).and_then(Value::as_str))
-        .collect();
+    let addresses_with_storage: Vec<&str> = [
+        "rwTEL",
+        "rwTELImpl",
+        "AxelarAmplifierGateway",
+        "GasService",
+        "InterchainTokenService",
+        "InterchainTokenFactory",
+    ]
+    .iter()
+    .filter_map(|&key| its_addresses.get(key).and_then(Value::as_str))
+    .collect();
     its_addresses.iter()
         .filter_map(|(key, value)| value.as_str().map(|address| (key, address)))
         .for_each(|(key, address)| {
@@ -256,7 +264,8 @@ fn genesis_with_proxy(registry_impl_deployed_bytecode: Vec<u8>) -> eyre::Result<
     let initial_stake_config = ConsensusRegistry::StakeConfig {
         stakeAmount: stake_amount,
         minWithdrawAmount: U256::try_from(parse_ether("1_000").unwrap()).unwrap(),
-        epochIssuance: U256::try_from(parse_ether("20_000_000").unwrap()).unwrap()
+        epochIssuance: U256::try_from(parse_ether("20_000_000").unwrap())
+            .unwrap()
             .checked_div(U256::from(28))
             .expect("u256 div checked"),
         epochDuration: epoch_duration,

--- a/crates/config/src/genesis.rs
+++ b/crates/config/src/genesis.rs
@@ -1,9 +1,9 @@
 //! Genesis information used when configuring a node.
 use crate::{Config, ConfigFmt, ConfigTrait, TelcoinDirs};
-use eyre::{Context, OptionExt};
+use eyre::Context;
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use std::{
     collections::BTreeMap,
     ffi::OsStr,
@@ -226,21 +226,19 @@ impl NetworkGenesis {
     /// If a key is specified, return the corresponding nested object.
     /// Otherwise return the entire JSON
     /// With a generic this could be adjused to handle YAML also
-    pub fn fetch_from_json_str(
-        json_content: &str,
-        key: Option<&str>,
-    ) -> eyre::Result<Value> {
+    pub fn fetch_from_json_str(json_content: &str, key: Option<&str>) -> eyre::Result<Value> {
         let json: Value = serde_json::from_str(json_content)?;
         let result = match key {
             Some(path) => {
                 let key: Vec<&str> = path.split('.').collect();
                 let mut current_value = &json;
                 for &k in &key {
-                    current_value = current_value.get(k).ok_or_else(|| eyre::eyre!("key '{}' not found", k))?;
+                    current_value =
+                        current_value.get(k).ok_or_else(|| eyre::eyre!("key '{}' not found", k))?;
                 }
                 current_value.clone()
             }
-            None => json
+            None => json,
         };
 
         Ok(result)

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1628,7 +1628,8 @@ mod tests {
         let initial_stake_config = ConsensusRegistry::StakeConfig {
             stakeAmount: U256::try_from(parse_ether("1_000_000").unwrap()).unwrap(),
             minWithdrawAmount: U256::try_from(parse_ether("1_000").unwrap()).unwrap(),
-            epochIssuance: U256::try_from(parse_ether("20_000_000").unwrap()).unwrap()
+            epochIssuance: U256::try_from(parse_ether("20_000_000").unwrap())
+                .unwrap()
                 .checked_div(U256::from(28))
                 .expect("u256 div checked"),
             epochDuration: epoch_duration,

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1514,6 +1514,7 @@ impl From<CreateRequest> for PregenesisRequest {
 mod tests {
     use super::*;
     use crate::traits::TNPayloadAttributes;
+    use alloy::primitives::utils::parse_ether;
     use rand_chacha::ChaCha8Rng;
     use std::str::FromStr as _;
     use tempfile::TempDir;
@@ -1625,9 +1626,9 @@ mod tests {
 
         let epoch_duration = 60 * 60 * 24; // 24hrs
         let initial_stake_config = ConsensusRegistry::StakeConfig {
-            stakeAmount: U256::from(1_000_000e18),
-            minWithdrawAmount: U256::from(1_000e18),
-            epochIssuance: U256::from(20_000_000e18)
+            stakeAmount: U256::try_from(parse_ether("1_000_000").unwrap()).unwrap(),
+            minWithdrawAmount: U256::try_from(parse_ether("1_000").unwrap()).unwrap(),
+            epochIssuance: U256::try_from(parse_ether("20_000_000").unwrap()).unwrap()
                 .checked_div(U256::from(28))
                 .expect("u256 div checked"),
             epochDuration: epoch_duration,


### PR DESCRIPTION
replace use of rust scientific notation `e18` (which uses u64 floating point arithmetic prone to precision loss) with `alloy::primitives::utils::parse_ether`

update tn-contracts commit (that PR must be merged first) with improved deployments.json structure for better upstream rust logic