### PR TITLE
Observer tests and config.

### DIFF
--- a/bin/telcoin-network/src/genesis/mod.rs
+++ b/bin/telcoin-network/src/genesis/mod.rs
@@ -110,7 +110,7 @@ impl Initialize {
 /// Take a string and return the deterministic account derived from it.  This is be used
 /// with similiar functionality in the test client to allow easy testing using simple strings
 /// for accounts.
-fn account_from_word(key_word: &str) -> Address {
+pub(crate) fn account_from_word(key_word: &str) -> Address {
     if key_word.starts_with("0x") {
         key_word.parse().expect("not a valid account!")
     } else {

--- a/bin/telcoin-network/src/keytool/generate.rs
+++ b/bin/telcoin-network/src/keytool/generate.rs
@@ -1,11 +1,14 @@
 //! Generate subcommand
 
-use crate::args::{clap_address_parser, clap_genesis_parser};
+use crate::{
+    args::{clap_address_parser, clap_genesis_parser},
+    genesis::account_from_word,
+};
 use clap::{value_parser, Args, Subcommand};
 use std::sync::Arc;
 use tn_config::{Config, KeyConfig, TelcoinDirs};
 use tn_reth::{dirs::DataDirPath, MaybePlatformPath, RethChainSpec};
-use tn_types::Address;
+use tn_types::{Address, GenesisAccount, U256};
 use tracing::info;
 
 /// Generate keypairs and save them to a file.
@@ -30,6 +33,9 @@ pub enum NodeType {
     /// Generate all validator keys and write them to file.
     #[command(name = "validator", alias = "all")]
     ValidatorKeys(ValidatorArgs),
+    /// Generate all observer (non-validator) keys and write them to file.
+    #[command(name = "observer")]
+    ObserverKeys(ObserverArgs),
     // primary keys
     // worker key
     // execution key
@@ -109,6 +115,76 @@ impl ValidatorArgs {
 
         // add execution address
         config.update_execution_address(self.address)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ObserverArgs {
+    /// The chain this node is running.
+    ///
+    /// The value parser matches either a known chain, the path
+    /// to a json file, or a json formatted string in-memory. The json can be either
+    /// a serialized [ChainSpec] or Genesis struct.
+    #[arg(
+        long,
+        value_name = "CHAIN_OR_PATH",
+        verbatim_doc_comment,
+        default_value = "adiri",
+        value_parser = clap_genesis_parser,
+        global = true,
+    )]
+    pub chain: Arc<RethChainSpec>,
+
+    /// Overwrite existing keys, if present.
+    ///
+    /// Warning: Existing keys will be lost.
+    #[arg(
+        long = "force",
+        alias = "overwrite",
+        help_heading = "Overwrite existing keys. Warning: existing keys will be lost.",
+        verbatim_doc_comment
+    )]
+    pub force: bool,
+
+    /// Used to add a funded account (by simple text string).  Use this on a dev cluster
+    /// (must provide on all validator genesis inits) to have an account with a deterministically
+    /// derived key. This is ONLY for dev testing, never use this for other chains.
+    #[arg(long)]
+    pub dev_funded_account: Option<String>,
+}
+
+impl ObserverArgs {
+    /// Create all necessary information needed for validator and save to file.
+    pub fn execute<TND: TelcoinDirs>(
+        &self,
+        config: &mut Config,
+        tn_datadir: &TND,
+        passphrase: Option<String>,
+    ) -> eyre::Result<()> {
+        info!(target: "tn::generate_keys", "generating keys for full validator node");
+
+        let key_config = KeyConfig::generate_and_save(tn_datadir, passphrase)?;
+        let proof = key_config.generate_proof_of_possession_bls(&self.chain)?;
+        config.update_protocol_key(key_config.primary_public_key())?;
+        config.update_proof_of_possession(proof)?;
+
+        // network keypair for authority
+        let network_publickey = key_config.primary_network_public_key();
+        config.update_primary_network_key(network_publickey)?;
+
+        // network keypair for workers
+        let network_publickey = key_config.worker_network_public_key();
+        config.update_worker_network_key(network_publickey)?;
+
+        if let Some(acct_str) = &self.dev_funded_account {
+            let addr = account_from_word(acct_str);
+            config.genesis.alloc.insert(
+                addr,
+                GenesisAccount::default().with_balance(U256::from(10).pow(U256::from(27))), // One Billion TEL
+            );
+        }
 
         Ok(())
     }

--- a/bin/telcoin-network/src/keytool/mod.rs
+++ b/bin/telcoin-network/src/keytool/mod.rs
@@ -110,6 +110,16 @@ impl KeyArgs {
                         debug!("{config:?}");
                         Config::store_path(self.config_path(), config, ConfigFmt::YAML)?;
                     }
+                    NodeType::ObserverKeys(args) => {
+                        let authority_key_path = datadir.validator_keys_path();
+                        // initialize path and warn users if overwriting keys
+                        self.init_path(&authority_key_path, args.force)?;
+                        // execute and store keypath
+                        args.execute(&mut config, &datadir, passphrase)?;
+
+                        debug!("{config:?}");
+                        Config::store_path(self.config_path(), config, ConfigFmt::YAML)?;
+                    }
                 }
             }
 

--- a/bin/telcoin-network/tests/it/restarts.rs
+++ b/bin/telcoin-network/tests/it/restarts.rs
@@ -292,7 +292,7 @@ fn do_restarts(delay: u64) -> eyre::Result<()> {
         send_term(child);
     }
 
-    // kill children before returnin final_result
+    // kill children before returning final_result
     for child in children.iter_mut() {
         let child = child.as_mut().expect("missing a child");
         kill_child(child);
@@ -306,6 +306,84 @@ fn do_restarts(delay: u64) -> eyre::Result<()> {
 #[ignore = "should not run with a default cargo test, run restart tests as seperate step"]
 fn test_restartstt() -> eyre::Result<()> {
     do_restarts(2)
+}
+
+/// Run some test to make sure an observer is participating in the network.
+fn run_observer_tests(client_urls: &[String; 4], obs_url: &str) -> eyre::Result<()> {
+    network_advancing(client_urls)?;
+    std::thread::sleep(Duration::from_secs(2)); // Advancing, so pause so that upcoming checks will fail if a node is lagging.
+
+    let key = get_key("test-source");
+    let to_account = address_from_word("testing");
+
+    test_blocks_same(client_urls)?;
+    // Send to observer, validator confirms.
+    send_and_confirm(&obs_url, &client_urls[2], &key, to_account, 0)?;
+    // Send to observer, validator confirms- second time.
+    send_and_confirm(&obs_url, &client_urls[3], &key, to_account, 1)?;
+
+    // Send to a validator, observer sees transfer.
+    send_and_confirm(&client_urls[0], &obs_url, &key, to_account, 2)?;
+
+    test_blocks_same(client_urls)?;
+    Ok(())
+}
+
+/// Test an observer node can submit txns.
+#[test]
+#[ignore = "should not run with a default cargo test, run restart tests as seperate step"]
+fn test_restarts_observer() -> eyre::Result<()> {
+    let _guard = IT_TEST_MUTEX.lock();
+    init_test_tracing();
+    info!(target: "restart-test", "do_restarts_observer");
+    // the tmp dir should be removed once tmp_quard is dropped
+    let tmp_guard = tempfile::TempDir::new().expect("tempdir is okay");
+    // create temp path for test
+    let temp_path = tmp_guard.path().to_path_buf();
+    {
+        let rt = Runtime::new()?;
+        rt.block_on(config_local_testnet(temp_path.clone(), Some("restart_test".to_string())))
+            .expect("failed to config");
+    }
+    let mut exe_path =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Missing CARGO_MANIFEST_DIR!"));
+    exe_path.push("../../target/debug/telcoin-network");
+    let mut children: [Option<Child>; 4] = [None, None, None, None];
+    let mut client_urls = [
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+    ];
+    let mut rpc_ports: [u16; 4] = [0, 0, 0, 0];
+    for (i, child) in children.iter_mut().enumerate() {
+        let rpc_port = get_available_tcp_port("127.0.0.1")
+            .expect("Failed to get an ephemeral rpc port for child!");
+        rpc_ports[i] = rpc_port;
+        client_urls[i].push_str(&format!(":{rpc_port}"));
+        *child = Some(start_validator(i, &exe_path, &temp_path, rpc_port));
+    }
+    let obs_rpc_port = get_available_tcp_port("127.0.0.1")
+        .expect("Failed to get an ephemeral rpc port for child!");
+    let obs_url = format!("http://127.0.0.1:{obs_rpc_port}");
+    let mut obs_child = start_observer(4, &exe_path, &temp_path, obs_rpc_port);
+    let res = run_observer_tests(&client_urls, &obs_url);
+
+    // SIGTERM children so they can shutdown in parrellel.
+    for child in children.iter_mut() {
+        let child = child.as_mut().expect("missing a child");
+        send_term(child);
+    }
+    send_term(&mut obs_child);
+
+    // kill children before returning final_result
+    for child in children.iter_mut() {
+        let child = child.as_mut().expect("missing a child");
+        kill_child(child);
+        info!(target: "restart-test", "kill and wait on child complete for final result");
+    }
+    kill_child(&mut obs_child);
+    res
 }
 
 /// Test a restart case with a long delay, the stopped node should not rejoin consensus but follow
@@ -341,6 +419,29 @@ fn start_validator(instance: usize, exe_path: &Path, base_dir: &Path, mut rpc_po
         .arg("--public-key") // If the binary is built with the faucet need this to start...
         .arg("0223382261d641424b8d8b63497a811c56f85ee89574f9853474c3e9ab0d690d99");
 
+    command.spawn().expect("failed to execute")
+}
+
+/// Start a process running an observer node.
+fn start_observer(instance: usize, exe_path: &Path, base_dir: &Path, mut rpc_port: u16) -> Child {
+    let data_dir = base_dir.join("observer".to_string());
+    // The instance option will still change a set port so account for that.
+    rpc_port += instance as u16;
+    let mut command = Command::new(exe_path);
+    command
+        .env("TN_BLS_PASSPHRASE", "restart_test")
+        .arg("node")
+        .arg("--observer")
+        .arg("--datadir")
+        .arg(&*data_dir.to_string_lossy())
+        .arg("--chain")
+        .arg("adiri")
+        .arg("--disable-discovery")
+        .arg("--instance")
+        .arg(format!("{}", instance + 1))
+        .arg("--http")
+        .arg("--http.port")
+        .arg(format!("{rpc_port}"));
     command.spawn().expect("failed to execute")
 }
 

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -670,10 +670,7 @@ where
         // update the authorized publishers for gossip every epoch
         network_handle
             .inner_handle()
-            .subscribe_with_publishers(
-                consensus_config.network_config().libp2p_config().worker_txn_topic(),
-                consensus_config.worker_cache().all_workers().keys().copied().collect(),
-            )
+            .subscribe(consensus_config.network_config().libp2p_config().worker_txn_topic())
             .await?;
 
         // spawn worker network

--- a/etc/local-testnet.sh
+++ b/etc/local-testnet.sh
@@ -122,7 +122,15 @@ else
         cp "${GENESIS_JSON_PATH}" "${DATADIR}/genesis"
     done
 
-    target/${RELEASE}/telcoin-network genesis init --datadir "${ROOTDIR}"
+    echo "creating datadir for observer"
+    DATADIR="${ROOTDIR}/observer"
+    mkdir -p "${DATADIR}/genesis"
+    target/${RELEASE}/telcoin-network keytool generate observer \
+        --datadir "${DATADIR}" \
+        --dev-funded-account $DEV_FUNDS
+    cp "${COMMITTEE_PATH}" "${DATADIR}/genesis"
+    cp "${WORKER_CACHE_PATH}" "${DATADIR}/genesis"
+    cp "${GENESIS_JSON_PATH}" "${DATADIR}/genesis"
 fi
 
 if [ "$START" = true ]; then
@@ -146,8 +154,23 @@ if [ "$START" = true ]; then
            --log.stdout.format log-fmt \
            -vvv \
            --http > "${ROOTDIR}/${VALIDATOR}.log" &
-
     done
+
+    DATADIR="${ROOTDIR}/observer"
+    METRICS="127.0.0.1:9094"
+    CONSENSUS_METRICS="127.0.0.1:9104"
+    echo "Starting Observer in background, rpc endpoint http://localhost:8541"
+    target/${RELEASE}/telcoin-network node --datadir "${DATADIR}" \
+       --genesis "${DATADIR}/genesis/genesis.json" \
+       --observer \
+       --disable-discovery \
+       --instance 5 \
+       --metrics "${METRICS}" \
+       --consensus-metrics "${CONSENSUS_METRICS}" \
+       --log.stdout.format log-fmt \
+       -vvv \
+       --http > "${ROOTDIR}/observer.log" &
+
     echo "$LENGTH validators started in background, \
     use 'killall telcoin-network' to bring the test network down"
 fi


### PR DESCRIPTION
Makes configuring an observer more straightforward.  Adds a restart test to make sure an observer is participating in a network and adds an observer to the local testate script.

Also updated tn-contracts, I needed to pull master for something and this happened...