### PR TITLE
Spawn all tasks through `TaskManager`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11457,6 +11457,7 @@ dependencies = [
  "tn-storage",
  "tn-test-utils",
  "tn-types",
+ "tn-worker",
  "tokio",
  "tracing",
 ]

--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -32,7 +32,6 @@ use tracing::{debug, info};
 #[tokio::test]
 async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result<()> {
     let _guard = IT_TEST_MUTEX.lock();
-    tn_types::test_utils::init_test_tracing();
 
     // create google env and temp chain spec for state initialization
     let (tmp_chain, kms_address) = prepare_google_kms_env().await?;

--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -32,6 +32,7 @@ use tracing::{debug, info};
 #[tokio::test]
 async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result<()> {
     let _guard = IT_TEST_MUTEX.lock();
+    tn_types::test_utils::init_test_tracing();
 
     // create google env and temp chain spec for state initialization
     let (tmp_chain, kms_address) = prepare_google_kms_env().await?;

--- a/bin/telcoin-network/tests/it/restarts.rs
+++ b/bin/telcoin-network/tests/it/restarts.rs
@@ -187,9 +187,9 @@ fn network_advancing(client_urls: &[String; 4]) -> eyre::Result<()> {
         std::thread::sleep(Duration::from_secs(1));
         next_num = get_block_number(&client_urls[0])?;
         i += 1;
-        if i > 30 {
+        if i > 45 {
             return Err(eyre::eyre!(
-                "Network not advancing past {next_num} within 30 seconds after restart!"
+                "Network not advancing past {next_num} within 45 seconds after restart!"
             ));
         }
     }

--- a/bin/telcoin-network/tests/it/restarts.rs
+++ b/bin/telcoin-network/tests/it/restarts.rs
@@ -522,12 +522,12 @@ fn get_positive_balance_with_retry(node: &str, address: &str) -> eyre::Result<u1
 fn get_balance_above_with_retry(node: &str, address: &str, above: u128) -> eyre::Result<u128> {
     let mut bal = get_balance(node, address, 5)?;
     let mut i = 0;
-    while i < 30 && bal <= above {
+    while i < 45 && bal <= above {
         std::thread::sleep(Duration::from_millis(1200));
         i += 1;
         bal = get_balance(node, address, 5)?;
     }
-    if i == 30 && bal <= above {
+    if i == 45 && bal <= above {
         error!(target:"restart-test", "get_balance_above_with_retry i == 30 - returning error!!");
         Err(Report::msg(format!("Failed to get a balance {bal} for {address} above {above}")))
     } else {

--- a/crates/consensus/worker/Cargo.toml
+++ b/crates/consensus/worker/Cargo.toml
@@ -35,6 +35,7 @@ rand = { workspace = true }
 tempfile = { workspace = true }
 tn-reth = { workspace = true, features = ["test-utils"] }
 tn-test-utils = { workspace = true }
+tn-worker = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = []

--- a/crates/consensus/worker/src/lib.rs
+++ b/crates/consensus/worker/src/lib.rs
@@ -15,3 +15,6 @@ pub use crate::worker::{new_worker, Worker, CHANNEL_CAPACITY};
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
 pub const NUM_SHUTDOWN_RECEIVERS: u64 = 26;
+
+#[cfg(feature = "test-utils")]
+pub mod test_utils;

--- a/crates/consensus/worker/src/test_utils.rs
+++ b/crates/consensus/worker/src/test_utils.rs
@@ -1,0 +1,34 @@
+//! Test utilities.
+
+use crate::quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tn_types::{SealedBatch, TaskSpawner};
+use tokio::sync::oneshot;
+
+#[derive(Clone, Debug)]
+pub struct TestMakeBlockQuorumWaiter(pub Arc<Mutex<Option<SealedBatch>>>);
+impl TestMakeBlockQuorumWaiter {
+    pub fn new_test() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+}
+impl QuorumWaiterTrait for TestMakeBlockQuorumWaiter {
+    fn verify_batch(
+        &self,
+        batch: SealedBatch,
+        _timeout: Duration,
+        task_spawner: &TaskSpawner,
+    ) -> oneshot::Receiver<Result<(), QuorumWaiterError>> {
+        let data = self.0.clone();
+        let (tx, rx) = oneshot::channel();
+        let task_name = format!("qw-test-{}", batch.digest());
+        task_spawner.spawn_task(task_name, async move {
+            *data.lock().unwrap() = Some(batch);
+            tx.send(Ok(()))
+        });
+        rx
+    }
+}

--- a/crates/consensus/worker/src/tests/batch_provider_tests.rs
+++ b/crates/consensus/worker/src/tests/batch_provider_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the worker's batch provider.
 use super::*;
-use crate::{quorum_waiter::QuorumWaiterError, test_utils::TestMakeBlockQuorumWaiter};
+use crate::test_utils::TestMakeBlockQuorumWaiter;
 use tempfile::TempDir;
 use tn_network_types::MockWorkerToPrimary;
 use tn_reth::test_utils::transaction;

--- a/crates/consensus/worker/src/tests/batch_provider_tests.rs
+++ b/crates/consensus/worker/src/tests/batch_provider_tests.rs
@@ -1,33 +1,11 @@
 //! Unit tests for the worker's batch provider.
 use super::*;
-use crate::quorum_waiter::QuorumWaiterError;
-use std::sync::Mutex;
+use crate::{quorum_waiter::QuorumWaiterError, test_utils::TestMakeBlockQuorumWaiter};
 use tempfile::TempDir;
 use tn_network_types::MockWorkerToPrimary;
 use tn_reth::test_utils::transaction;
 use tn_storage::open_db;
 use tn_types::Batch;
-
-#[derive(Clone, Debug)]
-struct TestMakeBlockQuorumWaiter(Arc<Mutex<Option<SealedBatch>>>);
-impl TestMakeBlockQuorumWaiter {
-    fn new_test() -> Self {
-        Self(Arc::new(Mutex::new(None)))
-    }
-}
-impl QuorumWaiterTrait for TestMakeBlockQuorumWaiter {
-    fn verify_batch(
-        &self,
-        batch: SealedBatch,
-        _timeout: Duration,
-    ) -> tokio::task::JoinHandle<Result<(), QuorumWaiterError>> {
-        let data = self.0.clone();
-        tokio::spawn(async move {
-            *data.lock().unwrap() = Some(batch);
-            Ok(())
-        })
-    }
-}
 
 #[tokio::test]
 async fn make_batch() {

--- a/crates/consensus/worker/src/tests/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/src/tests/quorum_waiter_tests.rs
@@ -35,7 +35,11 @@ async fn wait_for_quorum() {
     let sealed_batch = batch().seal_slow();
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
-    let attest_handle = quorum_waiter.verify_batch(sealed_batch.clone(), Duration::from_secs(10));
+    let attest_handle = quorum_waiter.verify_batch(
+        sealed_batch.clone(),
+        Duration::from_secs(10),
+        &task_manager.get_spawner(),
+    );
 
     for _i in 0..3 {
         match network_rx.recv().await {
@@ -58,7 +62,11 @@ async fn wait_for_quorum() {
     let sealed_batch2 = batch().seal_slow();
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
-    let attest2_handle = quorum_waiter.verify_batch(sealed_batch2.clone(), Duration::from_secs(10));
+    let attest2_handle = quorum_waiter.verify_batch(
+        sealed_batch2.clone(),
+        Duration::from_secs(10),
+        &task_manager.get_spawner(),
+    );
 
     // Ensure the other listeners correctly received the batches.
     for _i in 0..3 {

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -222,7 +222,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         let batch_attest_handle = quorum_waiter.verify_batch(
             sealed_batch.clone(),
             self.timeout,
-            &self.network_handle.get_task_spawner(),
+            self.network_handle.get_task_spawner(),
         );
 
         // Wait for our batch to reach quorum or fail to do so.

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -219,7 +219,11 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             .with_label_values(&["latest batch size"])
             .observe(size as f64);
 
-        let batch_attest_handle = quorum_waiter.verify_batch(sealed_batch.clone(), self.timeout);
+        let batch_attest_handle = quorum_waiter.verify_batch(
+            sealed_batch.clone(),
+            self.timeout,
+            &self.network_handle.get_task_spawner(),
+        );
 
         // Wait for our batch to reach quorum or fail to do so.
         match batch_attest_handle.await {

--- a/crates/execution/batch-builder/Cargo.toml
+++ b/crates/execution/batch-builder/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = { workspace = true }
 tn-reth = { workspace = true, features = ["test-utils"] }
 
 # integration tests
-tn-worker = { workspace = true }
+tn-worker = { workspace = true, features = ["test-utils"] }
 tn-network-types = { workspace = true }
 tn-storage = { workspace = true }
 tn-batch-validator = { workspace = true }

--- a/crates/execution/batch-builder/tests/it/build_batches.rs
+++ b/crates/execution/batch-builder/tests/it/build_batches.rs
@@ -20,15 +20,12 @@ use tn_storage::{open_db, tables::Batches};
 use tn_types::{
     Address, Batch, BatchValidation, Bytes, Certificate, CommittedSubDag, ConsensusHeader,
     ConsensusOutput, Database, Encodable2718 as _, ReputationScores, SealedBatch, TaskManager,
-    TaskSpawner, U160, U256,
+    U160, U256,
 };
 use tn_worker::{
-    metrics::WorkerMetrics,
-    quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait},
-    test_utils::TestMakeBlockQuorumWaiter,
-    Worker, WorkerNetworkHandle,
+    metrics::WorkerMetrics, test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle,
 };
-use tokio::{sync::oneshot, time::timeout};
+use tokio::time::timeout;
 use tracing::debug;
 
 #[tokio::test]

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -30,8 +30,8 @@ use tn_test_utils::faucet_test_execution_node;
 
 use tn_types::{
     adiri_genesis, error::BlockSealError, hex, public_key_to_address, sol, Address, GenesisAccount,
-    SealedBatch, SolType, SolValue, TaskManager, TransactionSigned, TransactionTrait as _, B256,
-    U160, U256,
+    SealedBatch, SolType, SolValue, TaskManager, TaskSpawner, TransactionSigned,
+    TransactionTrait as _, B256, U160, U256,
 };
 use tn_worker::{
     metrics::WorkerMetrics,
@@ -51,12 +51,17 @@ impl QuorumWaiterTrait for TestChanQuorumWaiter {
         &self,
         batch: SealedBatch,
         _timeout: Duration,
-    ) -> tokio::task::JoinHandle<Result<(), QuorumWaiterError>> {
+        task_spawner: &TaskSpawner,
+    ) -> oneshot::Receiver<Result<(), QuorumWaiterError>> {
         let chan = self.0.clone();
+        let (tx, rx) = oneshot::channel();
+        let task_name = format!("verify-batch-{}", batch.digest());
+        // task_spawner.spawn_task(task_name, async move {
         tokio::spawn(async move {
             chan.send(batch).await.unwrap();
-            Ok(())
-        })
+            tx.send(Ok(()))
+        });
+        rx
     }
 }
 
@@ -284,7 +289,8 @@ async fn test_with_creds_faucet_transfers_tel_with_google_kms() -> eyre::Result<
 
     // start batch maker
     execution_node.initialize_worker_components(worker_id).await?;
-    execution_node.start_batch_builder(worker_id, batch_provider.batches_tx()).await?;
+    let spawner = task_manager.get_spawner();
+    execution_node.start_batch_builder(worker_id, batch_provider.batches_tx(), &spawner).await?;
 
     // create client
     let client = execution_node.worker_http_client(&worker_id).await?.expect("worker rpc client");
@@ -607,8 +613,9 @@ async fn test_with_creds_faucet_transfers_stablecoin_with_google_kms() -> eyre::
     // start batch maker
     let worker_id = 0;
     let (to_worker, mut next_batch) = tokio::sync::mpsc::channel(2);
+    let spawner = task_manager.get_spawner();
     execution_node.initialize_worker_components(worker_id).await?;
-    execution_node.start_batch_builder(worker_id, to_worker).await?;
+    execution_node.start_batch_builder(worker_id, to_worker, &spawner).await?;
 
     let user_address = Address::random();
     let client = execution_node.worker_http_client(&worker_id).await?.expect("worker rpc client");

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -56,8 +56,7 @@ impl QuorumWaiterTrait for TestChanQuorumWaiter {
         let chan = self.0.clone();
         let (tx, rx) = oneshot::channel();
         let task_name = format!("verify-batch-{}", batch.digest());
-        // task_spawner.spawn_task(task_name, async move {
-        tokio::spawn(async move {
+        task_spawner.spawn_task(task_name, async move {
             chan.send(batch).await.unwrap();
             tx.send(Ok(()))
         });

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -12,7 +12,7 @@ use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::{Certificate, Header};
+use tn_types::{Certificate, Header, TaskManager};
 use tokio::{sync::mpsc, time::timeout};
 
 /// Test topic for gossip.
@@ -22,7 +22,7 @@ const TEST_TOPIC: &str = "test-topic";
 fn create_test_peers<Req: TNMessage, Res: TNMessage>(
     num_peers: NonZeroUsize,
     network_config: Option<NetworkConfig>,
-) -> (TestPeer<Req, Res>, Vec<TestPeer<Req, Res>>) {
+) -> (TestPeer<Req, Res>, Vec<TestPeer<Req, Res>>, TaskManager) {
     let network_config = network_config.unwrap_or_default();
 
     let all_nodes = CommitteeFixture::builder(MemDatabase::default)
@@ -30,6 +30,7 @@ fn create_test_peers<Req: TNMessage, Res: TNMessage>(
         .with_network_config(network_config)
         .build();
     let authorities = all_nodes.authorities();
+    let task_manager = TaskManager::default();
     let mut peers: Vec<_> = authorities
         .map(|a| {
             let config = a.consensus_config();
@@ -40,6 +41,7 @@ fn create_test_peers<Req: TNMessage, Res: TNMessage>(
                 tx,
                 config.key_config().clone(),
                 network_key,
+                task_manager.get_spawner(),
             )
             .expect("peer1 network created");
 
@@ -55,7 +57,8 @@ fn create_test_peers<Req: TNMessage, Res: TNMessage>(
 
     let target = peers.remove(0);
 
-    (target, peers)
+    // return task manager to prevent drop
+    (target, peers, task_manager)
 }
 
 /// A peer on TN
@@ -99,6 +102,8 @@ where
     peer1: NetworkPeer<Req, Res, DB>,
     /// The second authority in the committee.
     peer2: NetworkPeer<Req, Res, DB>,
+    /// The owned task manager to prevent dropping.
+    _task_manager: TaskManager,
 }
 
 /// Helper function to create an instance of [RequestHandler] for the first authority in the
@@ -121,6 +126,7 @@ where
     let config_2 = authority_2.consensus_config();
     let (tx1, network_events_1) = mpsc::channel(10);
     let (tx2, network_events_2) = mpsc::channel(10);
+    let task_manager = TaskManager::default();
 
     // peer1
     let network_key_1 = config_1.key_config().primary_network_keypair().clone();
@@ -129,6 +135,7 @@ where
         tx1,
         config_1.key_config().clone(),
         network_key_1,
+        task_manager.get_spawner(),
     )
     .expect("peer1 network created");
     let network_handle_1 = peer1_network.network_handle();
@@ -146,6 +153,7 @@ where
         tx2,
         config_2.key_config().clone(),
         network_key_2,
+        task_manager.get_spawner(),
     )
     .expect("peer2 network created");
     let network_handle_2 = peer2_network.network_handle();
@@ -156,13 +164,14 @@ where
         network: peer2_network,
     };
 
-    TestTypes { peer1, peer2 }
+    TestTypes { peer1, peer2, _task_manager: task_manager }
 }
 
 #[tokio::test]
 async fn test_valid_req_res() -> eyre::Result<()> {
     // start honest peer1 network
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -227,7 +236,8 @@ async fn test_valid_req_res() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_valid_req_res_connection_closed_cleanup() -> eyre::Result<()> {
     // start honest peer1 network
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -296,7 +306,8 @@ async fn test_valid_req_res_connection_closed_cleanup() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_valid_req_res_inbound_failure() -> eyre::Result<()> {
     // start honest peer1 network
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
     let peer1_network_task = tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -522,7 +533,8 @@ async fn test_outbound_failure_malicious_response() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_publish_to_one_peer() -> eyre::Result<()> {
     // start honest cvv network
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: cvv, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -587,7 +599,8 @@ async fn test_publish_to_one_peer() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<()> {
     // start honest cvv network
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: cvv, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -671,7 +684,7 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
     network_config.peer_config_mut().excess_peers_reconnection_timeout = Duration::from_secs(10);
 
     // Set up multiple peers with the custom config
-    let (mut target_peer, mut other_peers) =
+    let (mut target_peer, mut other_peers, _) =
         create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
             NonZeroUsize::new(5).unwrap(),
             Some(network_config.clone()),
@@ -849,7 +862,7 @@ async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
     let default_score = network_config.peer_config_mut().score_config.default_score;
 
     // Set up multiple peers with the custom config
-    let (peer1, mut other_peers) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
+    let (peer1, mut other_peers, _) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
         NonZeroUsize::new(4).unwrap(),
         Some(network_config.clone()),
     );
@@ -915,7 +928,8 @@ async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_banned_peer_reconnection_attempt() -> eyre::Result<()> {
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
 
     let NetworkPeer { config: config_1, network_handle: honest_peer, network, .. } = peer1;
     tokio::spawn(async move {
@@ -1004,7 +1018,7 @@ async fn test_dial_timeout_behavior() -> eyre::Result<()> {
     let mut network_config = NetworkConfig::default();
     network_config.peer_config_mut().dial_timeout = Duration::from_millis(100);
 
-    let (mut peer1, _others) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
+    let (mut peer1, _others, _) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
         NonZeroUsize::new(4).unwrap(),
         None,
     );
@@ -1057,12 +1071,12 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
     network_config.peer_config_mut().heartbeat_interval = TEST_HEARTBEAT_INTERVAL;
 
     // committee network
-    let (mut target_peer, _committee) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
+    let (mut target_peer, _committee, _) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
         num_peers,
         Some(network_config.clone()),
     );
     // create other nvvs
-    let (_, mut other_peers) =
+    let (_, mut other_peers, _) =
         create_test_peers::<TestWorkerRequest, TestWorkerResponse>(num_peers, Some(network_config));
 
     // Start target peer
@@ -1174,7 +1188,8 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
     // Start with two peers
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -1268,11 +1283,11 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
 async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
     // Create multiple peers for this test
     let num_peers = NonZeroUsize::new(4).unwrap();
-    let (mut target_peer, _) =
+    let (mut target_peer, _, _) =
         create_test_peers::<TestWorkerRequest, TestWorkerResponse>(num_peers, None);
 
     // create new committee
-    let (_, mut other_peers) =
+    let (_, mut other_peers, _) =
         create_test_peers::<TestWorkerRequest, TestWorkerResponse>(num_peers, None);
 
     // Start target peer network
@@ -1382,7 +1397,8 @@ async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> {
     // Start with two peers
-    let TestTypes { peer1, peer2 } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
     let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
     tokio::spawn(async move {
         network.run().await.expect("network run failed!");
@@ -1475,10 +1491,11 @@ async fn test_get_kad_records() -> eyre::Result<()> {
     let num_network_peers = 5;
 
     // Set up multiple peers with the custom config
-    let (mut target_peer, mut committee) = create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
-        NonZeroUsize::new(num_network_peers).unwrap(),
-        None,
-    );
+    let (mut target_peer, mut committee, _) =
+        create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
+            NonZeroUsize::new(num_network_peers).unwrap(),
+            None,
+        );
 
     // spawn target network
     let target_network = target_peer.network.take().expect("target network is some");

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -18,7 +18,7 @@ use tn_faucet::FaucetArgs;
 use tn_reth::{system_calls::EpochState, RethConfig, RethEnv, WorkerTxPool};
 use tn_types::{
     BatchSender, BatchValidation, ConsensusOutput, ExecHeader, Noticer, SealedBlock, SealedHeader,
-    WorkerId, B256,
+    TaskSpawner, WorkerId, B256,
 };
 use tokio::sync::{broadcast, mpsc, RwLock};
 mod builder;
@@ -81,9 +81,10 @@ impl ExecutionNode {
         &self,
         worker_id: WorkerId,
         block_provider_sender: BatchSender,
+        task_spawner: &TaskSpawner,
     ) -> eyre::Result<()> {
         let mut guard = self.internal.write().await;
-        guard.start_batch_builder(worker_id, block_provider_sender).await
+        guard.start_batch_builder(worker_id, block_provider_sender, task_spawner).await
     }
 
     /// Batch validator

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -223,6 +223,7 @@ where
             network_config,
             tmp_event_stream,
             self.key_config.clone(),
+            node_task_spawner.clone(),
         )?;
         let primary_network_handle = primary_network.network_handle();
         let node_shutdown = self.node_shutdown.subscribe();
@@ -254,6 +255,7 @@ where
             network_config,
             tmp_event_stream,
             self.key_config.clone(),
+            node_task_spawner.clone(),
         )?;
         let worker_network_handle = worker_network.network_handle();
         let node_shutdown = self.node_shutdown.subscribe();

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -370,7 +370,10 @@ where
         // consensus config for shutdown subscribers
         let consensus_shutdown = primary.shutdown_signal().await;
 
-        engine.start_batch_builder(worker.id(), worker.batches_tx()).await?;
+        let batch_builder_task_spawner = epoch_task_manager.get_spawner();
+        engine
+            .start_batch_builder(worker.id(), worker.batches_tx(), &batch_builder_task_spawner)
+            .await?;
 
         // update tasks
         primary_task_manager.update_tasks();


### PR DESCRIPTION
- replace `tokio::spawn` with dedicated task spawners owned by task managers