### PR TITLE
Epoch Transition

### DIFF
--- a/bin/telcoin-network/src/genesis/add_validator.rs
+++ b/bin/telcoin-network/src/genesis/add_validator.rs
@@ -30,17 +30,6 @@ pub struct AddValidator {
     #[arg(long, value_name = "CONFIG_FILE", verbatim_doc_comment)]
     pub config: Option<PathBuf>,
 
-    /// The path to the genesis directory.
-    ///
-    /// The GENESIS_DIRECTORY contains more directories:
-    /// - committee
-    /// - todo
-    ///
-    /// Validators add their information to the directory using VCS like
-    /// github. Using individual files prevents merge conflicts.
-    #[arg(long, value_name = "GENESIS_DIRECTORY", verbatim_doc_comment)]
-    pub genesis: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -63,7 +52,6 @@ impl AddValidator {
     ///
     /// Process:
     /// - load [NetworkGenesis] from genesis dir
-    /// - TODO: load validator information keys (assume safe for now)
     /// - add validator to network genesis
     /// - save NetworkGenesis as files in genesis dir again
     pub fn execute(&self) -> eyre::Result<()> {
@@ -73,44 +61,15 @@ impl AddValidator {
         let data_dir: DataDirChainPath =
             self.datadir.unwrap_or_chain_default(self.chain.chain, default_datadir_args()).into();
         let config_path = self.config.clone().unwrap_or(data_dir.node_config_path());
-
         let config = self.load_config(config_path.clone())?;
 
         info!(target: "genesis::ceremony", path = ?config_path, "Configuration loaded");
 
-        // load config file
-        // load committee file
-        // errors here?
-        //
-        // call function to "get_validator_key()"
-        //  - provides flexibility down the road how we want to do this
-        //  - ENV VAR at first, then EIP-2335
-        //  - note: ssh-keygen / ssh-agent already do this for ed25519 keys!
-        //
-        // adding validator needs EL public key
-        //
-        // steps:
-        // read validator info from config / source of info
-        //
-        // ensure:
-        // - worker index is length 1
-        // - no defaults are used
-        //
-        // load network_genesis from genesis dir
-        //
-        // add validator info to network genesis
-        //
-        // write network genesis to file
-
         let genesis_path = data_dir.genesis_path();
-
-        // TODO: is this the right approach?
         let validator_info = config.validator_info.clone();
-
         let mut network_genesis = NetworkGenesis::load_from_path(&data_dir)?;
 
         network_genesis.add_validator(validator_info);
-
         network_genesis.write_to_path(genesis_path)
     }
 
@@ -119,32 +78,4 @@ impl AddValidator {
         Config::load_from_path::<Config>(config_path.clone(), ConfigFmt::YAML)
             .wrap_err_with(|| format!("Could not load config file {config_path:?}"))
     }
-
-    // /// Get bls key for validator
-    // ///
-    // /// TODO: this is not secure and only meant as a placeholder until a more secure
-    // /// approach to key management is implemented. EIP-2335 & ssh-agent
-    // fn get_bls_key(&self, path: &PathBuf) -> eyre::Result<BlsKeypair> {
-    //     self.read_authority_keypair_from_file::<BlsKeypair, _>(path)
-    // }
-
-    // /// Get network keys for validator:
-    // /// - 1 primary
-    // /// - 1 worker
-    // ///
-    // /// TODO: this is not secure and only meant as a placeholder until a more secure
-    // /// approach to key management is implemented. EIP-2335 & ssh-agent
-    // fn get_network_key(&self, path: &PathBuf) -> eyre::Result<NetworkKeypair> {
-    //     self.read_authority_keypair_from_file::<NetworkKeypair, _>(path)
-    // }
-
-    // /// Read from file as Base64 encoded `privkey` and return a KeyPair.
-    // pub fn read_authority_keypair_from_file<KP, P>(&self, path: P) -> eyre::Result<KP>
-    // where
-    //     KP: KeyPairTrait,
-    //     P: AsRef<Path>,
-    // {
-    //     let contents = std::fs::read_to_string(path)?;
-    //     KP::decode_base64(contents.as_str().trim()).map_err(|e| eyre::eyre!(e))
-    // }
 }

--- a/bin/telcoin-network/src/genesis/validate.rs
+++ b/bin/telcoin-network/src/genesis/validate.rs
@@ -27,17 +27,6 @@ pub struct ValidateArgs {
     #[arg(long, value_name = "CONFIG_FILE", verbatim_doc_comment)]
     pub config: Option<PathBuf>,
 
-    /// The path to the genesis directory.
-    ///
-    /// The GENESIS_DIRECTORY contains more directories:
-    /// - committee
-    /// - todo
-    ///
-    /// Validators add their information to the directory using VCS like
-    /// github. Using individual files prevents merge conflicts.
-    #[arg(long, value_name = "GENESIS_DIRECTORY", verbatim_doc_comment)]
-    pub genesis: Option<PathBuf>,
-
     /// The chain this node is running.
     ///
     /// Possible values are either a built-in chain or the path to a chain specification file.
@@ -61,8 +50,6 @@ impl ValidateArgs {
     /// Process:
     /// - loop through validators within the genesis directory
     /// - ensure valid state for validators
-    ///
-    /// TODO: `validate` only verifies proof of possession for now
     pub fn execute(&self) -> eyre::Result<()> {
         info!(target: "genesis::validate", "validating validators nominated for committee");
 

--- a/bin/telcoin-network/src/keytool/generate.rs
+++ b/bin/telcoin-network/src/keytool/generate.rs
@@ -36,9 +36,6 @@ pub enum NodeType {
     /// Generate all observer (non-validator) keys and write them to file.
     #[command(name = "observer")]
     ObserverKeys(ObserverArgs),
-    // primary keys
-    // worker key
-    // execution key
 }
 
 #[derive(Debug, Clone, Args)]
@@ -83,7 +80,7 @@ pub struct ValidatorArgs {
         long = "address",
         alias = "execution-address",
         help_heading = "The address that should receive block rewards. Pass `0` to use the zero address.",
-        env = "EXECUTION_ADDRESS", // TODO: this doesn't work like it should
+        env = "EXECUTION_ADDRESS",
         value_parser = clap_address_parser,
         verbatim_doc_comment
     )]
@@ -97,7 +94,7 @@ fn update_keys<TND: TelcoinDirs>(
     passphrase: Option<String>,
 ) -> eyre::Result<()> {
     let key_config = KeyConfig::generate_and_save(tn_datadir, passphrase)?;
-    let proof = key_config.generate_proof_of_possession_bls(chain)?;
+    let proof = key_config.generate_proof_of_possession_bls(chain.genesis())?;
     config.update_protocol_key(key_config.primary_public_key())?;
     config.update_proof_of_possession(proof)?;
 

--- a/bin/telcoin-network/src/keytool/mod.rs
+++ b/bin/telcoin-network/src/keytool/mod.rs
@@ -4,7 +4,7 @@ mod generate;
 use self::generate::NodeType;
 use crate::args::clap_genesis_parser;
 use clap::{value_parser, Args, Subcommand};
-use eyre::Context;
+use eyre::{eyre, Context};
 
 use generate::GenerateKeys;
 use std::{
@@ -108,7 +108,7 @@ impl KeyArgs {
                         args.execute(&mut config, &datadir, passphrase)?;
 
                         debug!("{config:?}");
-                        Config::store_path(self.config_path(), config, ConfigFmt::YAML)?;
+                        Config::write_to_path(self.config_path(), config, ConfigFmt::YAML)?;
                     }
                     NodeType::ObserverKeys(args) => {
                         let authority_key_path = datadir.validator_keys_path();
@@ -118,7 +118,7 @@ impl KeyArgs {
                         args.execute(&mut config, &datadir, passphrase)?;
 
                         debug!("{config:?}");
-                        Config::store_path(self.config_path(), config, ConfigFmt::YAML)?;
+                        Config::write_to_path(self.config_path(), config, ConfigFmt::YAML)?;
                     }
                 }
             }
@@ -141,28 +141,8 @@ impl KeyArgs {
                 format!("Could not create authority key directory {}", rpath.display())
             })?;
         } else if !force {
-            warn!("overwriting keys for validator")
-            // TODO: this causes an infinite recursion of the question
-            // when run from the adiri genesis makefile
-
-            // // ask user if they want to continue generating new keys
-            // let answer =
-            //     Question::new("Keys might already exist. Do you want to generate new keys?
-            // (y/n)")         .confirm();
-
-            // if answer != Answer::YES {
-            //     // TODO: something better than panic here
-            //     panic!("Abandoning new key generation.")
-            // }
-
-            // // double-check
-            // let answer = Question::new("Warning: this action is irreversable. Are you sure you
-            // want to overwrite authority keys? (y/n)")     .confirm();
-
-            // if answer != Answer::YES {
-            //     // TODO: something better than panic here
-            //     panic!("Abandoning new key generation.")
-            // }
+            warn!("pass `force` to overwrite keys for validator");
+            return Err(eyre!("cannot overwrite validator keys without passing --force"));
         }
 
         Ok(())

--- a/bin/telcoin-network/tests/it/faucet.rs
+++ b/bin/telcoin-network/tests/it/faucet.rs
@@ -315,7 +315,8 @@ async fn test_faucet_transfers_tel_and_xyz_with_google_kms_e2e() -> eyre::Result
 
     // start canonical adiri chain with fetched storage
     let real_genesis = adiri_genesis();
-    let genesis = real_genesis.extend_accounts(genesis_accounts.into_iter());
+    let genesis =
+        real_genesis.extend_accounts(genesis_accounts.into_iter()).with_timestamp(tn_types::now());
     let chain: Arc<RethChainSpec> = Arc::new(genesis.clone().into());
 
     // create and launch validator nodes on local network,

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -35,8 +35,8 @@ use tracing::debug;
 
 #[tokio::test]
 async fn test_genesis_with_its() -> eyre::Result<()> {
-    // create genesis with a proxy
-    let genesis = adiri_genesis();
+    // create genesis with current timestamp to prevent immediate epoch boundary
+    let genesis = adiri_genesis().with_timestamp(tn_types::now());
 
     // spawn testnet for RPC calls
     spawn_local_testnet(

--- a/crates/config/src/keys.rs
+++ b/crates/config/src/keys.rs
@@ -8,12 +8,12 @@ use aes_gcm_siv::{aead::Aead as _, Aes256GcmSiv, Key, KeyInit, Nonce};
 use pbkdf2::pbkdf2_hmac;
 use rand::{rngs::StdRng, Rng as _, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use reth_chainspec::ChainSpec;
 use sha2::Sha256;
 use std::sync::Arc;
 use tn_types::{
-    encode, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner, DefaultHashFunction, Intent,
-    IntentMessage, IntentScope, NetworkKeypair, NetworkPublicKey, ProtocolSignature as _, Signer,
+    encode, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner, DefaultHashFunction, Genesis,
+    Intent, IntentMessage, IntentScope, NetworkKeypair, NetworkPublicKey, ProtocolSignature as _,
+    Signer,
 };
 
 #[derive(Debug)]
@@ -211,10 +211,10 @@ impl KeyConfig {
     /// The message is constructed as: [BlsPublicKey] || [Genesis].
     pub fn generate_proof_of_possession_bls(
         &self,
-        chain_spec: &ChainSpec,
+        genesis: &Genesis,
     ) -> eyre::Result<BlsSignature> {
         let mut msg = self.primary_public_key().as_ref().to_vec();
-        let genesis_bytes = encode(&chain_spec.genesis);
+        let genesis_bytes = encode(&genesis);
         msg.extend_from_slice(genesis_bytes.as_slice());
         let sig = BlsSignature::new_secure(
             &IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg),

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -65,7 +65,7 @@ impl NetworkConfig {
     /// Write the current network config to file.
     pub fn write_config<TND: TelcoinDirs>(&self, tn_datadir: &TND) -> eyre::Result<()> {
         let path = tn_datadir.network_config_path();
-        Self::store_path(path, self, ConfigFmt::YAML)
+        Self::write_to_path(path, self, ConfigFmt::YAML)
     }
 }
 

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -89,6 +89,12 @@ impl Config {
         Ok(())
     }
 
+    /// Update genesis.
+    pub fn with_genesis(mut self, genesis: Genesis) -> Self {
+        self.genesis = genesis;
+        self
+    }
+
     /// Return a reference to the
     pub fn genesis(&self) -> &Genesis {
         &self.genesis

--- a/crates/config/src/traits.rs
+++ b/crates/config/src/traits.rs
@@ -56,7 +56,7 @@ pub trait ConfigTrait {
                     fs::create_dir_all(parent).with_context(|| "Directory creation failed")?;
                 }
                 let cfg = T::default();
-                Self::store_path(path, &cfg, fmt)?;
+                Self::write_to_path(path, &cfg, fmt)?;
                 Ok(cfg)
             }
             Err(e) => eyre::bail!("Failed to open file: {e}"),
@@ -70,7 +70,7 @@ pub trait ConfigTrait {
     /// and behavior, see [`store`]'s documentation.
     ///
     /// [`store`]: fn.store.html
-    fn store_path<T: Serialize>(
+    fn write_to_path<T: Serialize>(
         path: impl AsRef<Path>,
         cfg: T,
         fmt: ConfigFmt,

--- a/crates/consensus/executor/src/lib.rs
+++ b/crates/consensus/executor/src/lib.rs
@@ -15,7 +15,7 @@ use crate::subscriber::spawn_subscriber;
 pub use errors::{SubscriberError, SubscriberResult};
 use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBus};
-use tn_types::{Database, Noticer, TaskManager, TimestampSec};
+use tn_types::{Database, Noticer, TaskManager};
 use tracing::info;
 
 /// A client subscribing to the consensus output and executing every transaction.
@@ -29,10 +29,9 @@ impl Executor {
         consensus_bus: ConsensusBus,
         task_manager: &TaskManager,
         network: PrimaryNetworkHandle,
-        epoch_boundary: TimestampSec,
     ) {
         // Spawn the subscriber.
-        spawn_subscriber(config, rx_shutdown, consensus_bus, task_manager, network, epoch_boundary);
+        spawn_subscriber(config, rx_shutdown, consensus_bus, task_manager, network);
 
         // Return the handle.
         info!("Consensus subscriber successfully started");

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -15,7 +15,7 @@ use std::{
 use tn_config::ConsensusConfig;
 use tn_network_types::{local::LocalNetwork, PrimaryToWorkerClient};
 use tn_primary::{
-    consensus::ConsensusRound, network::PrimaryNetworkHandle, ConsensusBus, NodeMode,
+    consensus::ConsensusRound, network::PrimaryNetworkHandle, ConsensusBus, NodeMode, RestartReason,
 };
 use tn_storage::CertificateStore;
 use tn_types::{
@@ -190,7 +190,10 @@ impl<DB: Database> Subscriber<DB> {
                 // We are caught up enough so try to jump back into consensus
                 info!(target: "subscriber", "attempting to rejoin consensus, consensus block height {consensus_header_number}");
                 // Set restart flag and trigger shutdown by returning.
-                self.consensus_bus.set_restart();
+                if let Err(e) = self.consensus_bus.restart_reason().send(RestartReason::Sync) {
+                    error!(target: "subscriber", ?e, "failed to send restart reason on consensus bus.");
+                    return Err(SubscriberError::ClosedChannel("restart-reason-sync".to_string()));
+                };
                 let _ = self.consensus_bus.node_mode().send(NodeMode::CvvActive);
                 return Ok(());
             }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -20,8 +20,8 @@ use tn_primary::{
 use tn_storage::CertificateStore;
 use tn_types::{
     AuthorityIdentifier, Batch, BlockHash, CommittedSubDag, Committee, ConsensusHeader,
-    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp,
-    TimestampSec, TnReceiver, TnSender, B256,
+    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp, TnReceiver,
+    TnSender, B256,
 };
 use tracing::{debug, error, info};
 
@@ -52,12 +52,6 @@ struct Inner {
     committee: Committee,
     /// The client to request worker batches and build consensus output.
     client: LocalNetwork,
-    /// The timestamp for when this epoch closes.
-    ///
-    /// The subscriber monitors leader timestamps for the epoch boundary.
-    /// If the timestamp of the leader is >= the epoch_boundary then the
-    /// subscriber indicates that the epoch should close.
-    epoch_boundary: TimestampSec,
 }
 
 /// Spawn the subscriber in the correct mode based on the validator status for the current epoch.
@@ -67,7 +61,6 @@ pub fn spawn_subscriber<DB: Database>(
     consensus_bus: ConsensusBus,
     task_manager: &TaskManager,
     network_handle: PrimaryNetworkHandle,
-    epoch_boundary: TimestampSec,
 ) {
     let authority_id = config.authority_id();
     let committee = config.committee().clone();
@@ -78,7 +71,7 @@ pub fn spawn_subscriber<DB: Database>(
         consensus_bus,
         config,
         network_handle,
-        inner: Arc::new(Inner { authority_id, committee, client, epoch_boundary }),
+        inner: Arc::new(Inner { authority_id, committee, client }),
     };
     match mode {
         // If we are active then partcipate in consensus.
@@ -340,9 +333,6 @@ impl<DB: Database> Subscriber<DB> {
             false
         };
 
-        // logic to indicate engine should conclude epoch
-        let close_epoch = deliver.commit_timestamp() >= self.inner.epoch_boundary;
-
         if num_blocks == 0 {
             debug!(target: "subscriber", "No blocks to fetch, payload is empty");
             return Ok(ConsensusOutput {
@@ -354,8 +344,7 @@ impl<DB: Database> Subscriber<DB> {
                 number,
                 extra: B256::default(),
                 early_finalize,
-                // always false for now
-                close_epoch,
+                close_epoch: false, // epoch manager will update
             });
         }
 
@@ -369,7 +358,7 @@ impl<DB: Database> Subscriber<DB> {
             number,
             extra: B256::default(),
             early_finalize,
-            close_epoch,
+            close_epoch: false, // epoch manager will update
         };
 
         let mut batch_set: HashSet<BlockHash> = HashSet::new();
@@ -485,7 +474,7 @@ impl<DB: Database> Subscriber<DB> {
 mod tests {
     use super::*;
     use indexmap::IndexMap;
-    use std::{collections::BTreeSet, ops::RangeInclusive, time::Duration};
+    use std::{collections::BTreeSet, ops::RangeInclusive};
     use tn_network_libp2p::types::{MessageId, NetworkCommand};
     use tn_network_types::MockPrimaryToWorkerClient;
     use tn_primary::consensus::{Bullshark, Consensus, LeaderSchedule};
@@ -495,7 +484,7 @@ mod tests {
         now, Certificate, CertificateDigest, ExecHeader, HeaderBuilder, Round, SealedHeader,
         TimestampSec, WorkerId, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     };
-    use tokio::{sync::mpsc, time::timeout};
+    use tokio::sync::mpsc;
 
     fn random_batches(
         number_of_batches: usize,
@@ -594,8 +583,6 @@ mod tests {
             }
         });
         let network = PrimaryNetworkHandle::new_for_test(tx);
-        // ensure epoch boundary is not reached
-        let epoch_boundary = u64::MAX;
 
         // spawn the executor
         spawn_subscriber(
@@ -604,7 +591,6 @@ mod tests {
             consensus_bus.clone(),
             &task_manager,
             network,
-            epoch_boundary,
         );
 
         // yield for subscriber to spawn
@@ -670,99 +656,6 @@ mod tests {
             last_header.digest(),
             consensus_headers_seen.last().expect("last consensus header").digest()
         );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_epoch_boundary() -> eyre::Result<()> {
-        let num_sub_dags_per_schedule = 3;
-
-        // create committee with epoch boundary `now`
-        let epoch_boundary = now();
-        // note: setting epoch boundary here doesn't actually affect the test
-        let fixture =
-            CommitteeFixture::builder(MemDatabase::default).with_epoch_boundary(now()).build();
-        let committee = fixture.committee();
-        let primary = fixture.authorities().next().unwrap();
-        let config = primary.consensus_config().clone();
-        let consensus_store = config.node_storage().clone();
-        let task_manager = TaskManager::new("subscriber tests");
-        let rx_shutdown = config.shutdown().subscribe();
-        let consensus_bus = ConsensusBus::new();
-
-        // subscribe to channels early
-        let rx_consensus_headers = consensus_bus.last_consensus_header().subscribe();
-        let mut consensus_output = consensus_bus.consensus_output().subscribe();
-
-        let (tx, mut rx) = mpsc::channel(5);
-        tokio::spawn(async move {
-            while let Some(com) = rx.recv().await {
-                if let NetworkCommand::Publish { topic: _, msg: _, reply } = com {
-                    reply.send(Ok(MessageId::new(&[0]))).unwrap();
-                }
-            }
-        });
-        let network = PrimaryNetworkHandle::new_for_test(tx);
-
-        // spawn the executor
-        spawn_subscriber(
-            config.clone(),
-            rx_shutdown,
-            consensus_bus.clone(),
-            &task_manager,
-            network,
-            epoch_boundary,
-        );
-
-        // yield for subscriber to spawn
-        tokio::task::yield_now().await;
-
-        // make certificates for rounds 1 to 3 (inclusive)
-        let (certificates, _next_parents, batches) = create_test_data(1..=3, &fixture);
-
-        // Set up mock worker.
-        let worker = primary.worker();
-        let _worker_address = &worker.info().worker_address;
-        let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
-        config.local_network().set_primary_to_worker_local_handler(mock_client);
-
-        let leader_schedule = LeaderSchedule::from_store(
-            committee.clone(),
-            consensus_store.clone(),
-            DEFAULT_BAD_NODES_STAKE_THRESHOLD,
-        );
-        let bullshark = Bullshark::new(
-            committee.clone(),
-            consensus_store.clone(),
-            Arc::new(Default::default()),
-            num_sub_dags_per_schedule,
-            leader_schedule.clone(),
-            DEFAULT_BAD_NODES_STAKE_THRESHOLD,
-        );
-
-        let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
-        consensus_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
-        let task_manager = TaskManager::default();
-        Consensus::spawn(config.clone(), &consensus_bus, bullshark, &task_manager);
-
-        // forward certificates to trigger subdag commit
-        for certificate in certificates.iter() {
-            consensus_bus.new_certificates().send(certificate.clone()).await.unwrap();
-        }
-
-        let output = timeout(Duration::from_secs(5), consensus_output.recv())
-            .await
-            .expect("dag commits")
-            .expect("recv consensus output");
-        let last_header = rx_consensus_headers.borrow().clone();
-
-        // NOTE: output.consensus_header() creates the consensus header and should be the same
-        // result
-        assert_eq!(last_header.digest(), output.consensus_header().digest());
-
-        // assert epoch boundary reached
-        assert!(output.close_epoch);
 
         Ok(())
     }

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -7,10 +7,7 @@ use crate::{
     proposer::OurDigestMessage, state_sync::CertificateManagerCommand, RecentBlocks,
 };
 use consensus_metrics::metered_channel::{self, channel_with_total_sender, MeteredMpscChannel};
-use std::{
-    error::Error,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{error::Error, fmt, sync::Arc};
 use tn_config::Parameters;
 use tn_primary_metrics::{ChannelMetrics, ConsensusMetrics, ExecutorMetrics, Metrics};
 use tn_types::{
@@ -54,6 +51,33 @@ impl NodeMode {
     /// True if this node is only an obsever and will never participate in an committee.
     pub fn is_observer(&self) -> bool {
         matches!(self, NodeMode::Observer)
+    }
+}
+
+/// The type to indicate node progress during an epoch.
+///
+/// The node's consensus occasionally returns when:
+/// - epoch boundary reached
+/// - syncing progress to rejoin consensus
+/// - errors
+///
+/// This value is read from the consensus bus when the task manager resolves all futures
+/// and is used by the epoch manager to decide the next action to take.
+#[derive(Clone, Default, Debug)]
+pub enum RestartReason {
+    /// The default status. If consensus exits and this is the status, it indicates an
+    /// unexpected event caused consensus to shutdown. (error)
+    #[default]
+    Unknown,
+    /// The status indicates the node was syncing and is ready to rejoin consensus.
+    Sync,
+    /// The status to indicate the epoch boundary was reached.
+    Epoch,
+}
+
+impl fmt::Display for RestartReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 
@@ -138,7 +162,9 @@ struct ConsensusBusInner {
     executor_metrics: Arc<ExecutorMetrics>,
 
     /// Flag to indicate a node should restart after a shutdown.
-    restart: AtomicBool,
+    ///
+    /// Nodes restart at epoch boundaries and when syncing.
+    tx_restart_reason: watch::Sender<RestartReason>,
 }
 
 /// The type that holds the collection of send/sync channels for
@@ -245,6 +271,8 @@ impl ConsensusBus {
 
         let (consensus_header, _rx_consensus_header) = broadcast::channel(CHANNEL_CAPACITY);
 
+        let (tx_restart_reason, _rx_restart_reason) = watch::channel(RestartReason::default());
+
         Self {
             inner: Arc::new(ConsensusBusInner {
                 new_certificates,
@@ -277,7 +305,7 @@ impl ConsensusBus {
                 primary_metrics,
                 channel_metrics,
                 executor_metrics,
-                restart: AtomicBool::new(false),
+                tx_restart_reason,
             }),
         }
     }
@@ -426,19 +454,9 @@ impl ConsensusBus {
         &self.inner.executor_metrics
     }
 
-    /// Set the restart flag to indicate node restart after shutdown.
-    pub fn set_restart(&self) {
-        self.inner.restart.store(true, std::sync::atomic::Ordering::SeqCst);
-    }
-
-    /// Clear the restart flag to indicate node NOT restart after shutdown.
-    pub fn clear_restart(&self) {
-        self.inner.restart.store(false, std::sync::atomic::Ordering::SeqCst);
-    }
-
-    /// True if the node should restart after shutdown.
-    pub fn restart(&self) -> bool {
-        self.inner.restart.load(std::sync::atomic::Ordering::SeqCst)
+    /// Set the restart reason to indicate node restart after shutdown.
+    pub fn restart_reason(&self) -> &watch::Sender<RestartReason> {
+        &self.inner.tx_restart_reason
     }
 
     /// Update consensus round watch channels.

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -77,7 +77,12 @@ pub enum RestartReason {
 
 impl fmt::Display for RestartReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        let s = match self {
+            Self::Unknown => "unknown",
+            Self::Sync => "sync",
+            Self::Epoch => "epoch",
+        };
+        write!(f, "{s}")
     }
 }
 

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -71,6 +71,7 @@ async fn test_empty_output_executes_early_finalize() -> eyre::Result<()> {
         from_consensus,
         genesis_header.clone(),
         shutdown.subscribe(),
+        task_manager.get_spawner(),
     );
 
     // send output
@@ -228,6 +229,7 @@ async fn test_empty_output_executes_late_finalize() -> eyre::Result<()> {
         from_consensus,
         genesis_header.clone(),
         shutdown.subscribe(),
+        task_manager.get_spawner(),
     );
 
     // send output
@@ -423,6 +425,7 @@ async fn test_queued_output_executes_after_sending_channel_closed() -> eyre::Res
         from_consensus,
         parent,
         shutdown.subscribe(),
+        task_manager.get_spawner(),
     );
 
     // assert beneficiary account balances 0
@@ -749,6 +752,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
         from_consensus,
         parent,
         shutdown.subscribe(),
+        task_manager.get_spawner(),
     );
 
     // queue the first output - simulate already received from channel
@@ -1046,6 +1050,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
         from_consensus,
         parent,
         shutdown.subscribe(),
+        task_manager.get_spawner(),
     );
 
     // queue both output - simulate already received from channel

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -62,6 +62,7 @@ impl ExecutionNodeInner {
             rx_output,
             parent_header,
             rx_shutdown,
+            self.reth_env.get_task_spawner().clone(),
         );
 
         // spawn tn engine

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -21,8 +21,7 @@ use tn_types::{
     Address, BatchSender, BatchValidation, ConsensusOutput, ExecHeader, Noticer, SealedHeader,
     TaskSpawner, WorkerId, B256, MIN_PROTOCOL_BASE_FEE,
 };
-use tokio::sync::broadcast;
-use tokio_stream::wrappers::BroadcastStream;
+use tokio::sync::mpsc;
 use tracing::{error, info};
 
 /// Inner type for holding execution layer types.
@@ -50,7 +49,7 @@ impl ExecutionNodeInner {
     /// All tasks are spawned with the [ExecutionNodeInner]'s [TaskManager].
     pub(super) async fn start_engine(
         &self,
-        from_consensus: broadcast::Receiver<ConsensusOutput>,
+        rx_output: mpsc::Receiver<ConsensusOutput>,
         rx_shutdown: Noticer,
     ) -> eyre::Result<()> {
         let parent_header = self.reth_env.lookup_head()?;
@@ -59,7 +58,7 @@ impl ExecutionNodeInner {
         let tn_engine = ExecutorEngine::new(
             self.reth_env.clone(),
             self.reth_env.get_debug_max_round(),
-            BroadcastStream::new(from_consensus),
+            rx_output,
             parent_header,
             rx_shutdown,
         );

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -15,10 +15,12 @@ use builder::ExecutionNodeBuilder;
 use std::{net::SocketAddr, sync::Arc};
 use tn_config::Config;
 use tn_faucet::FaucetArgs;
-use tn_reth::{system_calls::EpochState, RethConfig, RethEnv, WorkerTxPool};
+use tn_reth::{
+    system_calls::EpochState, CanonStateNotificationStream, RethConfig, RethEnv, WorkerTxPool,
+};
 use tn_types::{
-    BatchSender, BatchValidation, ConsensusOutput, ExecHeader, Noticer, SealedBlock, SealedHeader,
-    TaskSpawner, WorkerId, B256,
+    BatchSender, BatchValidation, ConsensusOutput, ExecHeader, Noticer, SealedHeader, TaskSpawner,
+    WorkerId, B256,
 };
 use tokio::sync::{mpsc, RwLock};
 mod builder;
@@ -117,7 +119,7 @@ impl ExecutionNode {
     }
 
     /// Return a receiver for canonical blocks.
-    pub async fn canonical_block_stream(&self) -> mpsc::Receiver<SealedBlock> {
+    pub async fn canonical_block_stream(&self) -> CanonStateNotificationStream {
         let guard = self.internal.read().await;
         let reth_env = guard.get_reth_env();
         reth_env.canonical_block_stream()

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -26,17 +26,17 @@ use tn_network_libp2p::{
 };
 use tn_primary::{
     network::{PrimaryNetwork, PrimaryNetworkHandle},
-    ConsensusBus, NodeMode, RestartReason, StateSynchronizer,
+    ConsensusBus, NodeMode, StateSynchronizer,
 };
 use tn_reth::{
     system_calls::{ConsensusRegistry, EpochState},
-    RethDb, RethEnv,
+    CanonStateNotificationStream, RethDb, RethEnv,
 };
 use tn_storage::{open_db, open_network_db, tables::ConsensusBlocks, DatabaseType};
 use tn_types::{
     BatchValidation, BlsPublicKey, Committee, CommitteeBuilder, ConsensusHeader, ConsensusOutput,
-    Database as TNDatabase, Epoch, Multiaddr, Noticer, Notifier, SealedBlock, TaskManager,
-    TaskSpawner, TimestampSec, WorkerCache, WorkerIndex, WorkerInfo,
+    Database as TNDatabase, Epoch, Multiaddr, Noticer, Notifier, TaskManager, TaskSpawner,
+    TimestampSec, WorkerCache, WorkerIndex, WorkerInfo,
 };
 use tn_worker::{WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::{
@@ -44,7 +44,7 @@ use tokio::sync::{
     mpsc::{self},
 };
 use tokio_stream::StreamExt;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// The long-running task manager name.
 const NODE_TASK_MANAGER: &str = "Node Task Manager";
@@ -80,6 +80,12 @@ pub struct EpochManager<P> {
     ///
     /// This should only be accessed elsewhere through the epoch's [ConsensusBus].
     consensus_output: broadcast::Sender<ConsensusOutput>,
+    /// The timestamp to close the current epoch.
+    ///
+    /// The manager monitors leader timestamps for the epoch boundary.
+    /// If the timestamp of the leader is >= the epoch_boundary then the
+    /// manager closes the epoch after the engine executes all data.
+    epoch_boundary: TimestampSec,
 }
 
 impl<P> EpochManager<P>
@@ -117,6 +123,7 @@ where
             key_config,
             node_shutdown,
             consensus_output,
+            epoch_boundary: Default::default(),
         })
     }
 
@@ -179,7 +186,8 @@ where
         }
     }
 
-    /// Create the epoch directory for consensus data if it doesn't exist and open the consensus database connection.
+    /// Create the epoch directory for consensus data if it doesn't exist and open the consensus
+    /// database connection.
     async fn open_consensus_db(&self, epoch: Epoch) -> eyre::Result<DatabaseType> {
         //
         // TODO: read from execution state here??
@@ -299,46 +307,39 @@ where
         network_config: NetworkConfig,
         to_engine: mpsc::Sender<ConsensusOutput>,
     ) -> eyre::Result<()> {
-        // The task manager that resets every epoch.
-        // Short-running tasks for the lifetime of the epoch.
+        // The task manager that resets every epoch and manages
+        // short-running tasks for the lifetime of the epoch.
         let mut epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
-        let mut running = true;
 
-        // initialize long-running components for the first epoch
+        // initialize long-running components for node startup
         let mut initial_epoch = true;
 
-        // start the epoch
-        while running {
-            running = {
-                let epoch_result = self
-                    .run_epoch(
-                        engine,
-                        consensus_db.clone(),
-                        &mut epoch_task_manager,
-                        &network_config,
-                        &to_engine,
-                        &mut initial_epoch,
-                    )
-                    .await;
+        // loop through epochs
+        loop {
+            let epoch_result = self
+                .run_epoch(
+                    engine,
+                    consensus_db.clone(),
+                    &mut epoch_task_manager,
+                    &network_config,
+                    &to_engine,
+                    &mut initial_epoch,
+                )
+                .await;
 
-                info!(target: "epoch-manager", ?epoch_result, "aborting epoch tasks for next epoch");
+            // abort all epoch-related tasks
+            epoch_task_manager.abort_all_tasks();
 
-                // abort all epoch-related tasks
-                epoch_task_manager.abort_all_tasks();
+            // create new manager for next epoch
+            epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
 
-                // create new manager for next epoch
-                epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
+            // ensure no errors
+            epoch_result.inspect_err(|e| {
+                error!(target: "epoch-manager", ?e, "epoch returned error");
+            })?;
 
-                // return result after aborting all tasks
-                match epoch_result? {
-                    RestartReason::Sync => true,     // loop again,
-                    RestartReason::Epoch => true,    // start new epoch,
-                    RestartReason::Unknown => false, // break and shutdown,
-                }
-            }
+            info!(target: "epoch-manager", "looping next epoch");
         }
-
-        Ok(())
     }
 
     /// Run a single epoch.
@@ -353,7 +354,7 @@ where
         network_config: &NetworkConfig,
         to_engine: &mpsc::Sender<ConsensusOutput>,
         initial_epoch: &mut bool,
-    ) -> eyre::Result<RestartReason> {
+    ) -> eyre::Result<()> {
         info!(target: "epoch-manager", "Starting epoch");
 
         // start consensus metrics for the epoch
@@ -366,6 +367,9 @@ where
             );
         }
 
+        // subscribe to output early to prevent missed messages
+        let consensus_output = self.consensus_output.subscribe();
+
         // create primary and worker nodes
         let (primary, worker_node) = self
             .create_consensus(
@@ -376,9 +380,6 @@ where
                 initial_epoch,
             )
             .await?;
-
-        // create receiving channel before spawning primary to ensure messages are not lost
-        let consensus_bus = primary.consensus_bus().await;
 
         // start primary
         let mut primary_task_manager = primary.start().await?;
@@ -404,56 +405,80 @@ where
 
         info!(target: "epoch-manager", tasks=?epoch_task_manager, "EPOCH TASKS\n");
 
+        // await the epoch boundary or the epoch task manager exiting
+        // this can also happen due to committee nodes re-syncing and errors
         tokio::select! {
-            _ = self.wait_for_epoch_boundary(to_engine, &engine) => (),
+            // wait for epoch boundary to transition
+            res = self.wait_for_epoch_boundary(to_engine, engine, consensus_output, consensus_shutdown.clone()) => {
+                res.inspect_err(|e| {
+                    error!(target: "epoch-manager", ?e, "failed to reach epoch boundary");
+                })?;
 
-            // Errors should have been logged already.
-            _ = epoch_task_manager.join_until_exit(consensus_shutdown) => (),
+                info!(target: "epoch-manager", "epoch boundary reached");
+            },
+
+            // return any errors
+            res = epoch_task_manager.join_until_exit(consensus_shutdown) => {
+                res.inspect_err(|e| {
+                    error!(target: "epoch-manager", ?e, "failed to reach epoch boundary");
+                })?;
+                info!(target: "epoch-manager", "epoch task manager exited - likely syncing with committee");
+            },
         }
 
-        // epoch complete
-        let restart_reason = consensus_bus.restart_reason().borrow().clone();
-
-        // shutdown consensus metrics
+        // shutdown metrics
         metrics_shutdown.notify();
 
-        info!(target: "epoch-manager", "TASKS complete, restart: {restart_reason}");
-
-        Ok(restart_reason)
+        Ok(())
     }
 
+    /// Monitor consensus output for the last block of the epoch.
+    ///
+    /// This method forwards all consensus output to the engine for execution.
+    /// Once the epoch boundary is reached, the manager initiates the epoch transitions.
     async fn wait_for_epoch_boundary(
         &self,
         to_engine: &mpsc::Sender<ConsensusOutput>,
         engine: &ExecutionNode,
+        mut consensus_output: broadcast::Receiver<ConsensusOutput>,
+        shutdown_consensus: Notifier,
     ) -> eyre::Result<()> {
-        let mut consensus_output = self.consensus_output.subscribe();
-
         // receive output from consensus and forward to engine
-        while let Ok(output) = consensus_output.recv().await {
-            //
-            // TODO: epoch manager should close epoch, not subscriber
-            //
-            if output.close_epoch {
+        'epoch: while let Ok(mut output) = consensus_output.recv().await {
+            // observe epoch boundary to initiate epoch transition
+            if output.committed_at() >= self.epoch_boundary {
+                // subscribe to engine blocks to confirm epoch closed on-chain
+                let mut executed_output = engine.canonical_block_stream().await;
+
+                // update output so engine closes epoch
+                output.close_epoch = true;
+
+                // obtain hash to monitor execution progress
                 let target_hash = output.consensus_header_hash();
+
                 // forward the output to the engine
                 to_engine.send(output).await?;
 
-                // TODO: don't wait for execution complete - shutdown consensus
+                // begin consensus shutdown while engine executes
+                shutdown_consensus.notify();
 
                 // wait for execution result before proceeding
-                let mut executed_output = engine.canonical_block_stream().await;
-                while let Some(output) = executed_output.recv().await {
-                    // wait for execution result
-                    if output.parent_beacon_block_root == Some(target_hash) {
-                        // wait for the execution to complete
-                        // so canonical tip is updated
+                while let Some(output) = executed_output.next().await {
+                    // ensure canonical tip is updated with closing epoch info
+                    if output.tip().block.parent_beacon_block_root == Some(target_hash) {
+                        // return
+                        break 'epoch;
                     }
                 }
+
+                // `None` indicates all senders have dropped
+                error!(
+                    target: "epoch-manager",
+                    "canon state notifications dropped while awaiting engine execution for closing epoch",
+                );
+                return Err(eyre!("engine failed to report output for closing epoch"));
             }
         }
-
-        // Err means all senders have dropped
 
         Ok(())
     }
@@ -534,7 +559,7 @@ where
     /// This method reads the canonical tip to read the epoch information needed
     /// to create the current committee and the consensus config.
     async fn configure_consensus(
-        &self,
+        &mut self,
         engine: &ExecutionNode,
         network_config: &NetworkConfig,
         consensus_db: &DatabaseType,
@@ -551,11 +576,11 @@ where
             .collect::<Result<HashMap<_, _>, _>>()
             .map_err(|err| eyre!("failed to create bls key from on-chain bytes: {err:?}"))?;
 
-        let epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
+        self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
 
         // send these to the swarm for validator discovery
         let keys_for_worker_cache = validators.keys().cloned().collect();
-        let committee = self.create_committee_from_state(epoch, epoch_boundary, validators).await?;
+        let committee = self.create_committee_from_state(epoch, validators).await?;
         let worker_cache =
             self.create_worker_cache_from_state(epoch, keys_for_worker_cache).await?;
 
@@ -578,7 +603,6 @@ where
     async fn create_committee_from_state(
         &self,
         epoch: Epoch,
-        epoch_boundary: TimestampSec,
         validators: HashMap<BlsPublicKey, &ConsensusRegistry::ValidatorInfo>,
     ) -> eyre::Result<Committee> {
         info!(target: "epoch-manager", "creating committee from state");
@@ -600,7 +624,7 @@ where
                 .await?;
 
             // build the committee using kad network
-            let mut committee_builder = CommitteeBuilder::new(epoch, epoch_boundary);
+            let mut committee_builder = CommitteeBuilder::new(epoch, self.epoch_boundary);
 
             // loop through the primary info returned from network query
             while let Some(info) = primary_network_infos.next().await {
@@ -998,7 +1022,7 @@ where
         &self,
         shutdown: Noticer,
         consensus_bus: ConsensusBus,
-        mut engine_state: mpsc::Receiver<SealedBlock>,
+        mut engine_state: CanonStateNotificationStream,
         epoch_task_manager: &TaskManager,
     ) {
         // spawn epoch-specific task to forward blocks from the engine to consensus
@@ -1009,9 +1033,9 @@ where
                         info!(target: "engine", "received shutdown from consensus to stop updating consensus bus recent blocks");
                         break;
                     }
-                    latest = engine_state.recv() => {
+                    latest = engine_state.next() => {
                         if let Some(latest) = latest {
-                            consensus_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(latest.header));
+                            consensus_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(latest.tip().block.header.clone()));
                         } else {
                             break;
                         }

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -94,7 +94,6 @@ impl<CDB: ConsensusDatabase> PrimaryNodeInner<CDB> {
             consensus_bus.clone(),
             task_manager,
             self.primary.network_handle().clone(),
-            self.consensus_config.committee().epoch_boundary(),
         );
 
         Ok(leader_schedule)

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -61,11 +61,8 @@ alloy = { workspace = true, features = ["genesis"] }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 alloy-consensus = { workspace = true }
-
+tokio = { workspace = true, features = ["macros", "time"] }
 secp256k1 = { workspace = true, optional = true }
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["macros"] }
 
 [features]
 default = []

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -53,7 +53,6 @@ rand_chacha = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt", "macros", "signal"] }
 tracing = { workspace = true }
 eyre = { workspace = true }
 alloy = { workspace = true, features = ["genesis"] }
@@ -62,6 +61,9 @@ serde_json = { workspace = true }
 alloy-consensus = { workspace = true }
 
 secp256k1 = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }
 
 [features]
 default = []

--- a/crates/tn-reth/src/evm_config.rs
+++ b/crates/tn-reth/src/evm_config.rs
@@ -66,6 +66,7 @@ impl TnEvmConfig {
                 basefee_account.data.info.balance =
                     basefee_account.data.info.balance.saturating_add(basefee * gas_used);
             }
+
             Ok(())
         });
     }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1,4 +1,3 @@
-//! This crate is designed to encaptulate Reth functionality and abstract it away.
 //! This should allow for easier upgrades.
 //! It still re-exports some stuff and a few places use Reth directly but eventually
 //! it all should go through this crate.
@@ -30,7 +29,6 @@ use enr::secp256k1::rand::Rng as _;
 use error::{TnRethError, TnRethResult};
 use evm_config::TnEvmConfig;
 use eyre::OptionExt;
-use futures::StreamExt as _;
 use jsonrpsee::Methods;
 use rand_chacha::rand_core::SeedableRng as _;
 use reth::{
@@ -98,7 +96,6 @@ use tn_types::{
     SealedHeader, TaskManager, TaskSpawner, TransactionSigned, TxKind, B256, EMPTY_OMMER_ROOT_HASH,
     EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, U256,
 };
-use tokio::sync::mpsc::{self};
 use tracing::{debug, error, info, warn};
 use traits::{TNPayload, TelcoinNode, TelcoinNodeTypes as _};
 
@@ -112,7 +109,7 @@ pub use reth_cli_util::{parse_duration_from_secs, parse_socket_address};
 pub use reth_errors::{CanonicalError, ProviderError, RethError};
 pub use reth_node_core::args::LogArgs;
 pub use reth_primitives_traits::crypto::secp256k1::sign_message;
-pub use reth_provider::ExecutionOutcome;
+pub use reth_provider::{CanonStateNotificationStream, ExecutionOutcome};
 pub use reth_rpc_eth_types::EthApiError;
 pub use reth_tracing::FileWorkerGuard;
 pub use reth_transaction_pool::{
@@ -464,20 +461,8 @@ impl RethEnv {
     }
 
     /// Return a channel reciever that will return each canonical block in turn.
-    pub fn canonical_block_stream(&self) -> mpsc::Receiver<SealedBlock> {
-        let mut stream = self.blockchain_provider.canonical_state_stream();
-        let (tx, rx) = mpsc::channel(100);
-
-        // non-critical: batch builder uses this task for each epoch
-        self.task_spawner.spawn_task("canonical-block-stream", async move {
-            while let Some(latest) = stream.next().await {
-                let block = latest.tip().block.clone();
-                if let Err(_e) = tx.send(block).await {
-                    break;
-                }
-            }
-        });
-        rx
+    pub fn canonical_block_stream(&self) -> CanonStateNotificationStream {
+        self.blockchain_provider.canonical_state_stream()
     }
 
     /// Return a reference to the [TaskSpawner] for spawning tasks.

--- a/crates/types/src/crypto/mod.rs
+++ b/crates/types/src/crypto/mod.rs
@@ -7,9 +7,8 @@
 //! - use generic schemes (avoid using the algo's `Struct`` impl functions)
 //! - change type aliases to update codebase with new crypto
 
-use std::{fmt, future::Future};
-
 use libp2p::PeerId;
+use std::{fmt, future::Future};
 // This re-export allows using the trait-defined APIs
 mod bls_keypair;
 mod bls_public_key;
@@ -163,7 +162,7 @@ pub fn network_public_key_to_libp2p(public_key: &NetworkPublicKey) -> PeerId {
 #[cfg(test)]
 mod tests {
     use super::{generate_proof_of_possession_bls, verify_proof_of_possession_bls};
-    use crate::{adiri_chain_spec_arc, adiri_genesis, BlsKeypair};
+    use crate::{adiri_genesis, BlsKeypair};
     use rand::{
         rngs::{OsRng, StdRng},
         SeedableRng,
@@ -172,36 +171,36 @@ mod tests {
     #[test]
     fn test_proof_of_possession_success() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
-        let chain_spec = adiri_chain_spec_arc();
-        let proof = generate_proof_of_possession_bls(&keypair, &chain_spec).unwrap();
-        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &chain_spec).is_ok())
+        let genesis = adiri_genesis();
+        let proof = generate_proof_of_possession_bls(&keypair, &genesis).unwrap();
+        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &genesis).is_ok())
     }
 
     #[test]
     fn test_proof_of_possession_fails_wrong_signature() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
         let malicious_key = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
-        let chain_spec = adiri_chain_spec_arc();
-        let proof = generate_proof_of_possession_bls(&malicious_key, &chain_spec).unwrap();
-        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &chain_spec).is_err())
+        let genesis = adiri_genesis();
+        let proof = generate_proof_of_possession_bls(&malicious_key, &genesis).unwrap();
+        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &genesis).is_err())
     }
 
     #[test]
     fn test_proof_of_possession_fails_wrong_public_key() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
         let malicious_key = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
-        let chain_spec = adiri_chain_spec_arc();
-        let proof = generate_proof_of_possession_bls(&keypair, &chain_spec).unwrap();
-        assert!(verify_proof_of_possession_bls(&proof, malicious_key.public(), &chain_spec).is_err())
+        let genesis = adiri_genesis();
+        let proof = generate_proof_of_possession_bls(&keypair, &genesis).unwrap();
+        assert!(verify_proof_of_possession_bls(&proof, malicious_key.public(), &genesis).is_err())
     }
 
     #[test]
     fn test_proof_of_possession_fails_wrong_message() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_rng(OsRng).unwrap());
-        let chain_spec = adiri_chain_spec_arc();
+        let genesis = adiri_genesis();
         let mut wrong = adiri_genesis();
         wrong.timestamp = 0;
-        let proof = generate_proof_of_possession_bls(&keypair, &wrong.into()).unwrap();
-        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &chain_spec).is_err())
+        let proof = generate_proof_of_possession_bls(&keypair, &wrong).unwrap();
+        assert!(verify_proof_of_possession_bls(&proof, keypair.public(), &genesis).is_err())
     }
 }


### PR DESCRIPTION
- update epoch manager to fully close epoch at boundary
- move logic to close epoch from subscriber to epoch manager
- use mpsc instead of broadcast for consensus output
- export canonical state stream directly
- follow up PR to address test failures and cleanup