### PR TITLE
Allow the base fee address to be set at genesis.

### DIFF
--- a/bin/telcoin-network/src/genesis/mod.rs
+++ b/bin/telcoin-network/src/genesis/mod.rs
@@ -46,6 +46,20 @@ pub struct GenesisArgs {
     )]
     pub consensus_registry_owner: Address,
 
+    /// The address recieves all transaction base fees.
+    ///
+    /// This should probably be a conbtract address that will distrubute/manage basefees.
+    ///
+    /// Address doesn't have to start with "0x", but the CLI supports the "0x" format too.
+    #[arg(
+        long = "basefee-address",
+        alias = "basefee_address",
+        help_heading = "The recipient of base fees",
+        value_parser = clap_address_parser,
+        verbatim_doc_comment
+    )]
+    pub basefee_address: Option<Address>,
+
     /// The initial stake credited to each validator in genesis.
     #[arg(
         long = "initial-stake-per-validator",
@@ -90,8 +104,8 @@ pub struct GenesisArgs {
     pub epoch_duration: u32,
 
     /// Used to add a funded account (by simple text string).  Use this on a dev cluster
-    /// (must provide on all validator genesis inits) to have an account with a deterministically
-    /// derived key. This is ONLY for dev testing, never use this for other chains.
+    /// to have an account with a deterministically derived key. This is ONLY for dev
+    /// testing, never use this for other chains.
     #[arg(long)]
     pub dev_funded_account: Option<String>,
     /// Max delay for a node to produce a new header.
@@ -241,6 +255,7 @@ impl GenesisArgs {
         if let Some(min_header_delay_ms) = self.min_header_delay_ms {
             parameters.min_header_delay = Duration::from_millis(min_header_delay_ms);
         }
+        parameters.basefee_address = self.basefee_address;
 
         // write genesis and config to file
         Config::write_to_path(

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -204,6 +204,8 @@ pub struct Parameters {
     /// Worker timeout when request vote from peers.
     #[serde(default = "Parameters::default_batch_vote_timeout")]
     pub batch_vote_timeout: Duration,
+    /// If set the Address that will recieve basefees.
+    pub basefee_address: Option<Address>,
 }
 
 impl Parameters {
@@ -305,6 +307,7 @@ impl Default for Parameters {
             max_batch_delay: Parameters::default_max_batch_delay(),
             max_concurrent_requests: Parameters::default_max_concurrent_requests(),
             batch_vote_timeout: Parameters::default_batch_vote_timeout(),
+            basefee_address: None,
         }
     }
 }

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -512,7 +512,9 @@ where
         reth_db: RethDb,
     ) -> eyre::Result<ExecutionNode> {
         // create execution components (ie - reth env)
-        let reth_env = RethEnv::new(&self.builder.node_config, engine_task_manager, reth_db)?;
+        let basefee_address = self.builder.tn_config.parameters.basefee_address;
+        let reth_env =
+            RethEnv::new(&self.builder.node_config, engine_task_manager, reth_db, basefee_address)?;
         let engine = ExecutionNode::new(&self.builder, reth_env)?;
 
         Ok(engine)

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -131,7 +131,7 @@ pub fn faucet_test_execution_node(
     let reth_db = RethEnv::new_database(&node_config, tmp_dir.join("db"))?;
     let engine = ExecutionNode::new(
         &builder,
-        RethEnv::new(&node_config, &TaskManager::default(), reth_db)?,
+        RethEnv::new(&node_config, &TaskManager::default(), reth_db, None)?,
     )?;
 
     Ok(engine)

--- a/crates/tn-reth/src/evm/handler.rs
+++ b/crates/tn-reth/src/evm/handler.rs
@@ -16,7 +16,7 @@ use reth_revm::{
 };
 use tn_types::Address;
 
-use crate::GOVERNANCE_ADDRESS;
+use crate::basefee_address;
 
 /// The handler that executes TN evm types.
 ///
@@ -35,7 +35,7 @@ impl<EVM> TNEvmHandler<EVM> {
 
 impl<EVM> Default for TNEvmHandler<EVM> {
     fn default() -> Self {
-        TNEvmHandler::new(Some(GOVERNANCE_ADDRESS))
+        TNEvmHandler::new(basefee_address())
     }
 }
 

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -511,6 +511,7 @@ impl RethEnv {
         reth_config: &RethConfig,
         task_manager: &TaskManager,
         database: RethDb,
+        basefee_address: Option<Address>,
     ) -> eyre::Result<Self> {
         let node_config = reth_config.0.clone();
         let evm_config = TnEvmConfig::new(reth_config.0.chain.clone());
@@ -926,7 +927,7 @@ impl RethEnv {
         };
         let reth_config = RethConfig(node_config);
         let database = Self::new_database(&reth_config, db_path)?;
-        Self::new(&reth_config, task_manager, database)
+        Self::new(&reth_config, task_manager, database, None)
     }
 
     /// Convenience method for compiling storage and bytecode to include genesis.

--- a/etc/local-testnet.sh
+++ b/etc/local-testnet.sh
@@ -10,6 +10,8 @@ START=false
 # must be prefixed with 0x and be a valid account.
 DEV_FUNDS=""
 
+BASEFEE_ADDRESS=""
+
 export TN_BLS_PASSPHRASE="local"
 
 while [ "$1" != "" ]; do
@@ -20,6 +22,10 @@ while [ "$1" != "" ]; do
         --dev-funds )
                 shift
                 DEV_FUNDS=$1
+                ;;
+        --basefee-address )
+                shift
+                BASEFEE_ADDRESS=$1
                 ;;
         * )     echo "Invalid option: $1"
                 exit 1
@@ -92,13 +98,24 @@ else
 
     # Use the validator infos to Create genesis, committee and worker cache yamls.
     # Speed up blocks for testing, use a bogus chain id
-    target/${RELEASE}/telcoin-network genesis \
-        --datadir "${ROOTDIR}" \
-        --chain-id 0x1e7 \
-        --dev-funded-account $DEV_FUNDS \
-        --max-header-delay-ms 1000 \
-        --min-header-delay-ms 1000 \
-        --consensus-registry-owner $DEV_FUNDS
+    if [ "$BASEFEE_ADDRESS" = "" ]; then
+        target/${RELEASE}/telcoin-network genesis \
+            --datadir "${ROOTDIR}" \
+            --chain-id 0x1e7 \
+            --dev-funded-account $DEV_FUNDS \
+            --max-header-delay-ms 1000 \
+            --min-header-delay-ms 1000 \
+            --consensus-registry-owner $DEV_FUNDS
+    else
+        target/${RELEASE}/telcoin-network genesis \
+            --datadir "${ROOTDIR}" \
+            --chain-id 0x1e7 \
+            --dev-funded-account $DEV_FUNDS \
+            --basefee-address $BASEFEE_ADDRESS \
+            --max-header-delay-ms 1000 \
+            --min-header-delay-ms 1000 \
+            --consensus-registry-owner $DEV_FUNDS
+    fi
 
     # Copy the generated genesis, committee, worker_cache and parameters to each validator.
     for ((i=0; i<$LENGTH; i++)); do


### PR DESCRIPTION
This uses a global (OnceLock) to work around getting the base fee to where it needs to be.