### PR TITLE
Tweak epoch code to hopefully avoid some races.

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -682,8 +682,9 @@ where
                         .try_send(NetworkEvent::Gossip(message, propagation_source))
                     {
                         error!(target: "network", topics=?self.authorized_publishers.keys(), ?propagation_source, ?message_id, ?e, "failed to forward gossip!");
-                        // fatal - unable to process gossip messages
-                        return Err(e.into());
+                        // ignore failures at the epoch boundary
+                        // During epoch change the event_stream reciever can be closed.
+                        return Ok(());
                     }
                 } else {
                     let GossipMessage { source, topic, .. } = message;
@@ -735,6 +736,7 @@ where
                         }) {
                             error!(target: "network", topics=?self.authorized_publishers.keys(), ?request_id, ?e, "failed to forward request!");
                             // ignore failures at the epoch boundary
+                            // During epoch change the event_stream reciever can be closed.
                             return Ok(());
                         }
 

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -34,7 +34,7 @@ pub use tn_reth::worker::*;
 ///
 /// Used to build the node until upstream reth supports
 /// broader node customization.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TnBuilder {
     /// The node configuration.
     pub node_config: RethConfig,

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -480,7 +480,7 @@ where
         // abort all epoch-related tasks
         epoch_task_manager.abort_all_tasks();
         // Expect complaints from join so swallow those errors...
-        // If we timeout here somethign is not playing nice and shutting down so return the timeout.
+        // If we timeout here something is not playing nice and shutting down so return the timeout.
         let _ = tokio::time::timeout(
             Duration::from_secs(5),
             epoch_task_manager.join(consensus_shutdown),

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -175,12 +175,6 @@ where
     }
 
     /// Run the node, handling epoch transitions.
-    ///
-    /// This will bring up a tokio runtime and start the app within it.
-    /// It also will shutdown this runtime, potentially violently, to make
-    /// sure any lefteover tasks are ended.  This allows it to be called more
-    /// than once per program execution to support changing modes of the
-    /// running node.
     pub async fn run(&mut self) -> eyre::Result<()> {
         // create dbs to survive between sync state transitions
         let reth_db =
@@ -220,6 +214,16 @@ where
         let network_config = NetworkConfig::read_config(&self.tn_datadir)?;
         self.spawn_node_networks(node_task_spawner, &network_config).await?;
 
+        // start consensus metrics for the epoch
+        let metrics_shutdown = Notifier::new();
+        if let Some(metrics_socket) = self.builder.metrics {
+            start_prometheus_server(
+                metrics_socket,
+                &node_task_manager,
+                metrics_shutdown.subscribe(),
+            );
+        }
+
         // add engine task manager
         node_task_manager.add_task_manager(engine_task_manager);
         node_task_manager.update_tasks();
@@ -227,7 +231,7 @@ where
         info!(target: "epoch-manager", tasks=?node_task_manager, "NODE TASKS\n");
 
         // await all tasks on epoch-task-manager or node shutdown
-        tokio::select! {
+        let result = tokio::select! {
             // run long-living node tasks
             res = node_task_manager.join_until_exit(self.node_shutdown.clone()) => {
                 match res {
@@ -238,7 +242,12 @@ where
 
             // loop through short-term epochs
             epoch_result = self.run_epochs(&engine, consensus_db, network_config, to_engine, gas_accumulator) => epoch_result
-        }
+        };
+
+        // shutdown metrics
+        metrics_shutdown.notify();
+
+        result
     }
 
     /// Create the epoch directory for consensus data if it doesn't exist and open the consensus
@@ -355,10 +364,6 @@ where
         to_engine: mpsc::Sender<ConsensusOutput>,
         gas_accumulator: GasAccumulator,
     ) -> eyre::Result<()> {
-        // The task manager that resets every epoch and manages
-        // short-running tasks for the lifetime of the epoch.
-        let mut epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
-
         // initialize long-running components for node startup
         let mut initial_epoch = true;
 
@@ -368,19 +373,12 @@ where
                 .run_epoch(
                     engine,
                     consensus_db.clone(),
-                    &mut epoch_task_manager,
                     &network_config,
                     &to_engine,
                     &mut initial_epoch,
                     gas_accumulator.clone(),
                 )
                 .await;
-
-            // abort all epoch-related tasks
-            epoch_task_manager.abort_all_tasks();
-
-            // create new manager for next epoch
-            epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
 
             // ensure no errors
             epoch_result.inspect_err(|e| {
@@ -395,12 +393,10 @@ where
     ///
     /// If it returns Ok(true) this indicates a mode change occurred and a restart
     /// is required.
-    #[allow(clippy::too_many_arguments)]
     async fn run_epoch(
         &mut self,
         engine: &ExecutionNode,
         mut consensus_db: DatabaseType,
-        epoch_task_manager: &mut TaskManager,
         network_config: &NetworkConfig,
         to_engine: &mpsc::Sender<ConsensusOutput>,
         initial_epoch: &mut bool,
@@ -408,15 +404,9 @@ where
     ) -> eyre::Result<()> {
         info!(target: "epoch-manager", "Starting epoch");
 
-        // start consensus metrics for the epoch
-        let metrics_shutdown = Notifier::new();
-        if let Some(metrics_socket) = self.builder.metrics {
-            start_prometheus_server(
-                metrics_socket,
-                epoch_task_manager,
-                metrics_shutdown.subscribe(),
-            );
-        }
+        // The task manager that resets every epoch and manages
+        // short-running tasks for the lifetime of the epoch.
+        let mut epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
 
         // subscribe to output early to prevent missed messages
         let consensus_output = self.consensus_output.subscribe();
@@ -426,7 +416,7 @@ where
             .create_consensus(
                 engine,
                 consensus_db.clone(),
-                epoch_task_manager,
+                &epoch_task_manager,
                 network_config,
                 initial_epoch,
                 gas_accumulator.clone(),
@@ -465,6 +455,7 @@ where
 
         // await the epoch boundary or the epoch task manager exiting
         // this can also happen due to committee nodes re-syncing and errors
+        let consensus_shutdown_clone = consensus_shutdown.clone();
         tokio::select! {
             // wait for epoch boundary to transition
             res = self.wait_for_epoch_boundary(to_engine, engine, consensus_output, consensus_shutdown.clone(), gas_accumulator) => {
@@ -477,7 +468,7 @@ where
             },
 
             // return any errors
-            res = epoch_task_manager.join_until_exit(consensus_shutdown) => {
+            res = epoch_task_manager.join_until_exit(consensus_shutdown_clone) => {
                 res.inspect_err(|e| {
                     error!(target: "epoch-manager", ?e, "failed to reach epoch boundary");
                 })?;
@@ -485,8 +476,16 @@ where
             },
         }
 
-        // shutdown metrics
-        metrics_shutdown.notify();
+        consensus_shutdown.notify();
+        // abort all epoch-related tasks
+        epoch_task_manager.abort_all_tasks();
+        // Expect complaints from join so swallow those errors...
+        // If we timeout here somethign is not playing nice and shutting down so return the timeout.
+        let _ = tokio::time::timeout(
+            Duration::from_secs(5),
+            epoch_task_manager.join(consensus_shutdown),
+        )
+        .await?;
 
         Ok(())
     }

--- a/etc/local-testnet.sh
+++ b/etc/local-testnet.sh
@@ -102,7 +102,7 @@ else
         target/${RELEASE}/telcoin-network genesis \
             --datadir "${ROOTDIR}" \
             --chain-id 0x1e7 \
-            --epoch-duration-in-secs 60 \
+            --epoch-duration-in-secs 30 \
             --dev-funded-account $DEV_FUNDS \
             --max-header-delay-ms 1000 \
             --min-header-delay-ms 1000 \
@@ -111,7 +111,7 @@ else
         target/${RELEASE}/telcoin-network genesis \
             --datadir "${ROOTDIR}" \
             --chain-id 0x1e7 \
-            --epoch-duration-in-secs 60 \
+            --epoch-duration-in-secs 30 \
             --dev-funded-account $DEV_FUNDS \
             --basefee-address $BASEFEE_ADDRESS \
             --max-header-delay-ms 1000 \


### PR DESCRIPTION
- Move the metrics service to the node task manager.
- Attempt to wait until the epoch task manager has shutdown before restarting.  This can timeout pretty quickly.
- Fixed a race with the network event_stream during epoch rotation. 
