### PR TITLE
Cantina-30: sanitize missing certificates requests

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -3,7 +3,7 @@
 use super::{message::MissingCertificatesRequest, PrimaryResponse};
 use crate::{
     error::{CertManagerError, PrimaryNetworkError, PrimaryNetworkResult},
-    network::message::PrimaryGossip,
+    network::{message::PrimaryGossip, MAX_CERTIFICATES_PER_REQUEST},
     state_sync::{CertificateCollector, StateSynchronizer},
     ConsensusBus,
 };
@@ -429,8 +429,17 @@ where
         &self,
         request: MissingCertificatesRequest,
     ) -> PrimaryNetworkResult<PrimaryResponse> {
+        // ensure max items within bounds
+        let requested_max = request.max_items;
+        if requested_max > MAX_CERTIFICATES_PER_REQUEST {
+            return Err(PrimaryNetworkError::InvalidRequest(format!(
+                "requested too many items: {}. max allowed: {}",
+                requested_max, MAX_CERTIFICATES_PER_REQUEST
+            )));
+        }
+
         // Create a time-bounded iter for collecting certificates
-        let mut missing = Vec::with_capacity(request.max_items);
+        let mut missing = Vec::with_capacity(requested_max);
 
         // validates request is within limits
         let mut collector = CertificateCollector::new(request, self.consensus_config.clone())?;

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -30,6 +30,8 @@ mod message;
 #[path = "../tests/network_tests.rs"]
 mod network_tests;
 
+// Maximum number of certificates for one request.
+pub(crate) const MAX_CERTIFICATES_PER_REQUEST: usize = 2_000;
 /// Convenience type for Primary network.
 pub(crate) type Req = PrimaryRequest;
 /// Convenience type for Primary network.

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -1,7 +1,10 @@
 //! Primary tests
 
 use crate::{
-    network::{handler::RequestHandler, MissingCertificatesRequest, PrimaryResponse},
+    network::{
+        handler::RequestHandler, MissingCertificatesRequest, PrimaryResponse,
+        MAX_CERTIFICATES_PER_REQUEST,
+    },
     state_sync::StateSynchronizer,
     ConsensusBus,
 };
@@ -571,8 +574,33 @@ async fn test_fetch_certificates_handler() {
         // Check that round 2 and 4 are fetched for the last authority, skipping round 3.
         (1, vec![vec![], vec![], vec![3], vec![3]], 5, vec![2, 2, 2, 4]),
     ];
-    for (lower_bound_round, skip_rounds_vec, max_items, expected_rounds) in test_cases {
+    for (lower_bound_round, skip_rounds_vec, max_items, expected_rounds) in &test_cases {
         let missing_req = MissingCertificatesRequest::default()
+            .set_bounds(
+                *lower_bound_round,
+                authorities
+                    .clone()
+                    .into_iter()
+                    .zip(
+                        skip_rounds_vec
+                            .into_iter()
+                            .map(|rounds| rounds.iter().map(|r| *r).collect()),
+                    )
+                    .collect(),
+            )
+            .expect("boundary set")
+            .set_max_items(*max_items);
+        let resp = handler.retrieve_missing_certs(missing_req).await.unwrap();
+        if let PrimaryResponse::RequestedCertificates(certs) = resp {
+            assert_eq!(certs.iter().map(|cert| cert.round()).collect::<Vec<_>>(), *expected_rounds);
+        } else {
+            panic!("did not get certs response!");
+        }
+    }
+
+    // assert error for valid requests that exceeds max items
+    for (lower_bound_round, skip_rounds_vec, _max_items, _expected_rounds) in test_cases {
+        let too_big = MissingCertificatesRequest::default()
             .set_bounds(
                 lower_bound_round,
                 authorities
@@ -582,13 +610,9 @@ async fn test_fetch_certificates_handler() {
                     .collect(),
             )
             .expect("boundary set")
-            .set_max_items(max_items);
-        let resp = handler.retrieve_missing_certs(missing_req).await.unwrap();
-        if let PrimaryResponse::RequestedCertificates(certs) = resp {
-            assert_eq!(certs.iter().map(|cert| cert.round()).collect::<Vec<_>>(), expected_rounds);
-        } else {
-            panic!("did not get certs response!");
-        }
+            .set_max_items(MAX_CERTIFICATES_PER_REQUEST + 1);
+        let resp = handler.retrieve_missing_certs(too_big).await;
+        assert!(resp.is_err());
     }
 }
 


### PR DESCRIPTION
- sanitize requested max items before allocating memory for vec
- use same limit for all requested certs from peers