### PR TITLE
Cantina-364: batch validation overflow

### DIFF
--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -44,6 +44,7 @@ impl From<WorkerNetworkError> for Option<Penalty> {
                     | BatchValidationError::InvalidBaseFee { .. }
                     | BatchValidationError::InvalidWorkerId { .. }
                     | BatchValidationError::InvalidDigest
+                    | BatchValidationError::GasOverflow
                     | BatchValidationError::TimestampIsInPast { .. }
                     | BatchValidationError::CalculateMaxPossibleGas
                     | BatchValidationError::HeaderMaxGasExceedsGasLimit { .. }

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -272,4 +272,7 @@ pub enum BatchValidationError {
     /// The batch contains blob transactions EIP-4844.
     #[error("Proposed batch contains blob transaction. Tx hash: {0}")]
     InvalidTx4844(BlockHash),
+    /// The total allowable gas in the batch exceeds `u64::MAX`.
+    #[error("Overflow calculating max possible gas.")]
+    GasOverflow,
 }


### PR DESCRIPTION
- use checked addition when validating batches to handle possible u64 gas overflow