### PR TITLE
Cantina-716(a): Calculate Batch::size

### DIFF
--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -582,7 +582,11 @@ mod tests {
 
         let invalid_txs = vec![too_big];
         block.transactions = invalid_txs;
+        // ensure size method correctly accounts for struct+txs
+        assert_eq!(block.size(), 1_000_202);
         let invalid_batch = block.seal_slow();
+        // ensure size method correct accounts for struct+txs+digest
+        assert_eq!(invalid_batch.size(), 1_000_234);
         assert_matches!(
             validator.validate_batch(invalid_batch),
             Err(BatchValidationError::HeaderTransactionBytesExceedsMax(wrong)) if wrong == expected_len

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -111,9 +111,9 @@ impl Batch {
         }
     }
 
-    /// Size of the batch.
+    /// Size of the batch in bytes (including transactions).
     pub fn size(&self) -> usize {
-        size_of::<Self>()
+        size_of::<Self>() + self.transactions.iter().map(|tx| tx.len()).sum::<usize>()
     }
 
     /// Digest for this batch (the hash of the sealed header).


### PR DESCRIPTION
- include transaction bytes in `Batch::size` method