### PR TITLE
test: Feature to Limit PBKDF2 Encryption for Tests

### DIFF
--- a/bin/telcoin-network/Cargo.toml
+++ b/bin/telcoin-network/Cargo.toml
@@ -46,6 +46,7 @@ rpassword = { workspace = true }
 [dev-dependencies]
 tn-types = { workspace = true, features = ["test-utils"] }
 tn-reth = { workspace = true, features = ["test-utils"] }
+tn-config = { workspace = true, features = ["test-utils"]}
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 rand_chacha = { workspace = true }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -33,5 +33,9 @@ aes-gcm-siv = "0.11.1"
 pbkdf2 = "0.12.2"
 sha2 = "0.10.8"
 
+[features]
+default = []
+test-utils = []
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/config/src/keys.rs
+++ b/crates/config/src/keys.rs
@@ -18,7 +18,11 @@ use tn_types::{
 /// The work factor for PBKDF2 is implemented through an iteration count, which is based on the
 /// internal hashing algorithm used. HMAC-SHA-256 is widely supported and is recommended by NIST.
 /// OWASP recommends 600,000 iterations for PBKDF2-HMAC-SHA256.
+#[cfg(not(feature = "test-utils"))]
 const PBKDF2_HMAC_ROUNDS: u32 = 1_000_000;
+// prevent excessive delays during testing
+#[cfg(feature = "test-utils")]
+const PBKDF2_HMAC_ROUNDS: u32 = 1;
 
 #[derive(Debug)]
 struct KeyConfigInner {


### PR DESCRIPTION
- test-utils feature for pbkdf2 encryption rounds to prevent excessive time constraints during testing
    - production value causing significant delays and restart test failures