### PR TITLE
Initial migration to an application life timed consensus bus.

### DIFF
--- a/bin/telcoin-network/tests/it/epochs.rs
+++ b/bin/telcoin-network/tests/it/epochs.rs
@@ -33,7 +33,6 @@ const EPOCH_DURATION: u64 = 5;
 #[tokio::test]
 /// Test a new node joining the network and being shuffled into the committee.
 async fn test_epoch_boundary() -> eyre::Result<()> {
-    tn_types::test_utils::init_test_tracing();
     // create validator and governance wallets for adding new validator later
     let mut new_validator = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(6));
     let mut governance_wallet =

--- a/bin/telcoin-network/tests/it/epochs.rs
+++ b/bin/telcoin-network/tests/it/epochs.rs
@@ -33,6 +33,7 @@ const EPOCH_DURATION: u64 = 5;
 #[tokio::test]
 /// Test a new node joining the network and being shuffled into the committee.
 async fn test_epoch_boundary() -> eyre::Result<()> {
+    tn_types::test_utils::init_test_tracing();
     // create validator and governance wallets for adding new validator later
     let mut new_validator = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(6));
     let mut governance_wallet =

--- a/bin/telcoin-network/tests/it/epochs.rs
+++ b/bin/telcoin-network/tests/it/epochs.rs
@@ -111,7 +111,7 @@ async fn test_epoch_boundary() -> eyre::Result<()> {
     // n ~= 25 iterations
     for i in 0..25 {
         let new_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
-        assert!(new_epoch_info != current_epoch_info);
+        assert!(new_epoch_info != current_epoch_info, "Old and new epoch equal on iteration {i}");
         assert!(new_epoch_info.blockHeight > last_epoch_block_height);
         assert_eq!(new_epoch_info.epochDuration as u64, EPOCH_DURATION);
 
@@ -131,7 +131,7 @@ async fn test_epoch_boundary() -> eyre::Result<()> {
         current_epoch_info = new_epoch_info;
 
         // sleep for epoch duration
-        tokio::time::sleep(std::time::Duration::from_secs(EPOCH_DURATION)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(EPOCH_DURATION + 1)).await;
     }
 
     // return error if loop didn't return

--- a/bin/telcoin-network/tests/it/genesis_tests.rs
+++ b/bin/telcoin-network/tests/it/genesis_tests.rs
@@ -4,9 +4,7 @@
 //! however, the RPC calls don't work. The beginning of the test is left
 //! because the proxy version may be re-prioritized later.
 use crate::util::{spawn_local_testnet, IT_TEST_MUTEX};
-use alloy::{
-    hex, network::EthereumWallet, primitives::utils::parse_ether, providers::ProviderBuilder,
-};
+use alloy::{network::EthereumWallet, primitives::utils::parse_ether, providers::ProviderBuilder};
 use core::panic;
 use eyre::OptionExt;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -52,7 +52,7 @@ async fn test_make_batch_el_to_cl() {
         network_client,
         store.clone(),
         timeout,
-        WorkerNetworkHandle::new_for_test(),
+        WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
         &mut task_manager,
     );
 

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -446,7 +446,8 @@ async fn commit_one() {
 
     let cb = ConsensusBus::new();
     let mut rx_output = cb.sequence().subscribe();
-    Consensus::spawn(config, &cb, bullshark, &TaskManager::default());
+    let task_manager = TaskManager::default();
+    Consensus::spawn(config, &cb, bullshark, &task_manager);
     let cb_clone = cb.clone();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
@@ -512,7 +513,8 @@ async fn dead_node() {
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
     let mut rx_output = cb.sequence().subscribe();
-    Consensus::spawn(config, &cb, bullshark, &TaskManager::default());
+    let task_manager = TaskManager::default();
+    Consensus::spawn(config, &cb, bullshark, &task_manager);
     let cb_clone = cb.clone();
     tokio::spawn(async move {
         let mut rx_primary = cb_clone.committed_certificates().subscribe();
@@ -647,7 +649,8 @@ async fn not_enough_support() {
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
     let mut rx_output = cb.sequence().subscribe();
-    Consensus::spawn(config, &cb, bullshark, &TaskManager::default());
+    let task_manager = TaskManager::default();
+    Consensus::spawn(config, &cb, bullshark, &task_manager);
     let cb_clone = cb.clone();
     tokio::spawn(async move {
         let mut rx_primary = cb_clone.committed_certificates().subscribe();
@@ -748,7 +751,8 @@ async fn missing_leader() {
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
     let mut rx_output = cb.sequence().subscribe();
-    Consensus::spawn(config, &cb, bullshark, &TaskManager::default());
+    let task_manager = TaskManager::default();
+    Consensus::spawn(config, &cb, bullshark, &task_manager);
     let cb_clone = cb.clone();
     tokio::spawn(async move {
         let mut rx_primary = cb_clone.committed_certificates().subscribe();

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -126,6 +126,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     // AND shutdown consensus
     task_manager.abort();
+    drop(task_manager);
 
     certificate_store.clear().unwrap();
     consensus_store.clear_consensus_chain_for_test();
@@ -191,6 +192,7 @@ async fn test_consensus_recovery_with_bullshark() {
 
     // AND shutdown (crash) consensus
     task_manager.abort();
+    drop(task_manager);
 
     let bad_nodes_stake_threshold = 0;
     let bullshark = Bullshark::new(
@@ -206,7 +208,8 @@ async fn test_consensus_recovery_with_bullshark() {
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
     let mut rx_output = cb.sequence().subscribe();
-    Consensus::spawn(config, &cb, bullshark, &TaskManager::default());
+    let task_manager = TaskManager::default();
+    Consensus::spawn(config, &cb, bullshark, &task_manager);
 
     // WHEN send the certificates of round >= 5 to trigger a leader election for round 4
     // and start committing.

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -7,20 +7,112 @@ use crate::{
     proposer::OurDigestMessage, state_sync::CertificateManagerCommand, RecentBlocks,
 };
 use consensus_metrics::metered_channel::{self, channel_with_total_sender, MeteredMpscChannel};
-use std::{error::Error, sync::Arc};
+use std::{
+    error::Error,
+    sync::{atomic::AtomicU32, Arc},
+};
 use tn_config::Parameters;
+use tn_network_libp2p::types::NetworkEvent;
 use tn_primary_metrics::{ChannelMetrics, ConsensusMetrics, ExecutorMetrics, Metrics};
 use tn_types::{
     BlockHash, BlockNumHash, Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput,
-    Header, Round, TnSender, CHANNEL_CAPACITY,
+    Header, Round, TnReceiver, TnSender, CHANNEL_CAPACITY,
 };
 use tokio::{
     sync::{
-        broadcast,
+        broadcast, mpsc,
         watch::{self, error::RecvError},
+        Mutex,
     },
     time::error::Elapsed,
 };
+
+/// Wrapper around a receiver and a subs count to make sure only one of these exists at a time.
+/// Note this does NOT implement Clone on purpose, do not implement it else managing subscriptions
+/// will break.
+#[derive(Debug)]
+struct QueChanReceiver<T> {
+    receiver: Arc<Mutex<mpsc::Receiver<T>>>,
+    subs: Arc<AtomicU32>,
+}
+
+/// Use the Drop to decrement subs.
+impl<T> Drop for QueChanReceiver<T> {
+    fn drop(&mut self) {
+        self.subs.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Wrapper around an mpsc channel.  It allows a channel to exist for application lifetime
+/// even if used for epoch messages.  It tracks subscibers so that each epoch will be able to
+/// "subscribe" to the channel (after the last epoch has dropped it's subscription).
+#[derive(Debug)]
+pub struct QueChannel<T> {
+    channel: mpsc::Sender<T>,
+    // Putting this in a lock is unfortunate but if want an mpsc under the hood is needed.
+    receiver: Arc<Mutex<mpsc::Receiver<T>>>,
+    subs: Arc<AtomicU32>,
+}
+
+impl<T> QueChannel<T> {
+    /// Create a new QueChannel.
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let subs = Arc::new(AtomicU32::new(0));
+        let receiver = Arc::new(Mutex::new(rx));
+        Self { channel: tx, receiver, subs }
+    }
+}
+
+impl<T> Default for QueChannel<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Clone for QueChannel<T> {
+    fn clone(&self) -> Self {
+        Self {
+            channel: self.channel.clone(),
+            receiver: self.receiver.clone(),
+            subs: self.subs.clone(),
+        }
+    }
+}
+
+impl<T: Send + 'static> TnSender<T> for QueChannel<T> {
+    async fn send(&self, value: T) -> Result<(), tn_types::SendError<T>> {
+        Ok(self.channel.send(value).await?)
+    }
+
+    fn try_send(&self, value: T) -> Result<(), tn_types::TrySendError<T>> {
+        Ok(self.channel.try_send(value)?)
+    }
+
+    fn subscribe(&self) -> impl TnReceiver<T> + 'static {
+        if self.subs.load(std::sync::atomic::Ordering::Relaxed) > 0 {
+            panic!("Another subscription is already in use!")
+        }
+        self.subs.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        QueChanReceiver { receiver: self.receiver.clone(), subs: self.subs.clone() }
+    }
+}
+
+impl<T: Send + 'static> TnReceiver<T> for QueChanReceiver<T> {
+    async fn recv(&mut self) -> Option<T> {
+        self.receiver.lock().await.recv().await
+    }
+
+    fn try_recv(&mut self) -> Result<T, tn_types::TryRecvError> {
+        // Can implement if ever needed but this will be tricky with the async lock and not being
+        // async. Can use blocking_lock but would need to tink this through...
+        panic!("try_recv() not implemented for this receiver!")
+    }
+
+    fn poll_recv(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Option<T>> {
+        panic!("poll_recv() not implemented for this receiver!")
+    }
+}
 
 /// Has sync completed?
 #[derive(Copy, Clone, Debug, Default)]
@@ -59,14 +151,9 @@ impl NodeMode {
 
 /// The thread-safe inner type that holds all the channels for inner-consensus
 /// communication between different tasks.
-#[derive(Debug)]
-struct ConsensusBusInner {
-    /// New certificates from the primary. The primary should send us new certificates
-    /// only if it already sent us its whole history.
-    new_certificates: MeteredMpscChannel<Certificate>,
-    /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
-    committed_certificates: MeteredMpscChannel<(Round, Vec<Certificate>)>,
-
+/// This contains things that exist for the app lifetime.
+#[derive(Clone, Debug)]
+struct ConsensusBusAppInner {
     /// Outputs the highest committed round & corresponding gc_round in the consensus.
     tx_committed_round_updates: watch::Sender<Round>,
     /// Hold onto a receiver to keep it "open".
@@ -76,28 +163,6 @@ struct ConsensusBusInner {
     tx_gc_round_updates: watch::Sender<Round>,
     /// Hold onto a receiver to keep it "open".
     _rx_gc_round_updates: watch::Receiver<Round>,
-
-    /// Sends missing certificates to the `CertificateFetcher`.
-    /// Receives certificates with missing parents from the `Synchronizer`.
-    certificate_fetcher: MeteredMpscChannel<CertificateFetcherCommand>,
-    /// Send valid a quorum of certificates' ids to the `Proposer` (along with their round).
-    /// Receives the parents to include in the next header (along with their round number) from
-    /// `Synchronizer`.
-    parents: MeteredMpscChannel<(Vec<Certificate>, Round)>,
-    /// Receives the batches' digests from our workers.
-    our_digests: MeteredMpscChannel<OurDigestMessage>,
-    /// Sends newly created headers to the `Certifier`.
-    headers: MeteredMpscChannel<Header>,
-    /// Updates when headers were committed by consensus.
-    ///
-    /// NOTE: this does not mean the header was executed yet.
-    committed_own_headers: MeteredMpscChannel<(Round, Vec<Round>)>,
-
-    /// Outputs the sequence of ordered certificates to the application layer.
-    sequence: MeteredMpscChannel<CommittedSubDag>,
-
-    /// Messages to the Certificate Manager.
-    certificate_manager: MeteredMpscChannel<CertificateManagerCommand>,
 
     /// Signals a new round
     tx_primary_round_updates: watch::Sender<Round>,
@@ -128,6 +193,9 @@ struct ConsensusBusInner {
     /// Hold onto the recent sync_status to keep it "open"
     _rx_sync_status: watch::Receiver<NodeMode>,
 
+    /// The que channel for primary network events.
+    primary_network_events: QueChannel<NetworkEvent<crate::network::Req, crate::network::Res>>,
+
     /// Hold onto the consensus_metrics (mostly for testing)
     consensus_metrics: Arc<ConsensusMetrics>,
     /// Hold onto the primary metrics (allow early creation)
@@ -138,12 +206,177 @@ struct ConsensusBusInner {
     executor_metrics: Arc<ExecutorMetrics>,
 }
 
+impl ConsensusBusAppInner {
+    fn new(recent_blocks: u32) -> Self {
+        let consensus_metrics = Arc::new(ConsensusMetrics::default());
+        let primary_metrics = Arc::new(Metrics::default()); // Initialize the metrics
+        let channel_metrics = Arc::new(ChannelMetrics::default());
+        let executor_metrics = Arc::new(ExecutorMetrics::default());
+        let (tx_committed_round_updates, _rx_committed_round_updates) =
+            watch::channel(Round::default());
+
+        let (tx_gc_round_updates, _rx_gc_round_updates) = watch::channel(Round::default());
+
+        let (tx_primary_round_updates, _rx_primary_round_updates) = watch::channel(0u32);
+        let (tx_last_consensus_header, _rx_last_consensus_header) =
+            watch::channel(ConsensusHeader::default());
+        let (tx_last_published_consensus_num_hash, _rx_last_published_consensus_num_hash) =
+            watch::channel((0, BlockHash::default()));
+
+        let (tx_recent_blocks, _rx_recent_blocks) =
+            watch::channel(RecentBlocks::new(recent_blocks as usize));
+        let (tx_sync_status, _rx_sync_status) = watch::channel(NodeMode::default());
+
+        let (consensus_header, _rx_consensus_header) = broadcast::channel(CHANNEL_CAPACITY);
+        let (consensus_output, _rx_consensus_output) = broadcast::channel(100);
+
+        Self {
+            tx_committed_round_updates,
+            _rx_committed_round_updates,
+            tx_gc_round_updates,
+            _rx_gc_round_updates,
+
+            tx_primary_round_updates,
+            _rx_primary_round_updates,
+            tx_recent_blocks,
+            _rx_recent_blocks,
+            tx_last_consensus_header,
+            _rx_last_consensus_header,
+            tx_last_published_consensus_num_hash,
+            _rx_last_published_consensus_num_hash,
+            consensus_output,
+            consensus_header,
+            tx_sync_status,
+            _rx_sync_status,
+            primary_network_events: QueChannel::new(),
+            consensus_metrics,
+            primary_metrics,
+            channel_metrics,
+            executor_metrics,
+        }
+    }
+
+    /// Reset for a new epoch.
+    /// This is primarily so we can resubscribe to "one-time" subscription channels.
+    pub fn reset_for_epoch(&self) {
+        let _ = self.tx_committed_round_updates.send(Round::default());
+        let _ = self.tx_gc_round_updates.send(Round::default());
+        let _ = self.tx_primary_round_updates.send(0u32);
+        let _ = self.tx_last_consensus_header.send(ConsensusHeader::default());
+        let _ = self.tx_last_published_consensus_num_hash.send((0, BlockHash::default()));
+        let recent_blocks = self.tx_recent_blocks.borrow().block_capacity();
+        let _ = self.tx_recent_blocks.send(RecentBlocks::new(recent_blocks as usize));
+        let _ = self.tx_sync_status.send(NodeMode::default());
+    }
+}
+
+/// The thread-safe inner type that holds all the channels for inner-consensus
+/// communication between different tasks.
+/// These are things that are refreshed each Epoch.
+#[derive(Clone, Debug)]
+struct ConsensusBusEpochInner {
+    /// New certificates from the primary. The primary should send us new certificates
+    /// only if it already sent us its whole history.
+    new_certificates: MeteredMpscChannel<Certificate>,
+    /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
+    committed_certificates: MeteredMpscChannel<(Round, Vec<Certificate>)>,
+
+    /// Sends missing certificates to the `CertificateFetcher`.
+    /// Receives certificates with missing parents from the `Synchronizer`.
+    certificate_fetcher: MeteredMpscChannel<CertificateFetcherCommand>,
+    /// Send valid a quorum of certificates' ids to the `Proposer` (along with their round).
+    /// Receives the parents to include in the next header (along with their round number) from
+    /// `Synchronizer`.
+    parents: MeteredMpscChannel<(Vec<Certificate>, Round)>,
+    /// Receives the batches' digests from our workers.
+    our_digests: MeteredMpscChannel<OurDigestMessage>,
+    /// Sends newly created headers to the `Certifier`.
+    headers: MeteredMpscChannel<Header>,
+    /// Updates when headers were committed by consensus.
+    ///
+    /// NOTE: this does not mean the header was executed yet.
+    committed_own_headers: MeteredMpscChannel<(Round, Vec<Round>)>,
+
+    /// Outputs the sequence of ordered certificates to the application layer.
+    sequence: MeteredMpscChannel<CommittedSubDag>,
+
+    /// Messages to the Certificate Manager.
+    certificate_manager: MeteredMpscChannel<CertificateManagerCommand>,
+}
+
+impl ConsensusBusEpochInner {
+    fn new(app_inner: &ConsensusBusAppInner) -> Self {
+        let new_certificates = metered_channel::channel_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_new_certificates,
+        );
+
+        let committed_certificates = metered_channel::channel_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_committed_certificates,
+        );
+
+        let our_digests = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_our_digests,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_our_digests_total,
+        );
+        let parents = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_parents,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_parents_total,
+        );
+        let headers = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_headers,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_headers_total,
+        );
+        let certificate_fetcher = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_certificate_fetcher,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_certificate_fetcher_total,
+        );
+        let committed_own_headers = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_committed_own_headers,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_committed_own_headers_total,
+        );
+
+        let certificate_manager = channel_with_total_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_certificate_acceptor,
+            &app_inner.primary_metrics.primary_channel_metrics.tx_certificate_acceptor_total,
+        );
+
+        let sequence = metered_channel::channel_sender(
+            CHANNEL_CAPACITY,
+            &app_inner.channel_metrics.tx_sequence,
+        );
+
+        Self {
+            new_certificates,
+            committed_certificates,
+            certificate_fetcher,
+            parents,
+            our_digests,
+            headers,
+            committed_own_headers,
+            sequence,
+            certificate_manager,
+        }
+    }
+}
+
 /// The type that holds the collection of send/sync channels for
 /// inter-task communication during consensus.
 #[derive(Clone, Debug)]
 pub struct ConsensusBus {
     /// The inner type to make this thread-safe and cheap to own.
-    inner: Arc<ConsensusBusInner>,
+    /// This is for stuff that lasts the app lifetime.
+    inner_app: Arc<ConsensusBusAppInner>,
+    /// The inner type to make this thread-safe and cheap to own.
+    /// This is for stuff that lasts an epoch lifetime.
+    inner_epoch: Arc<ConsensusBusEpochInner>,
 }
 
 impl Default for ConsensusBus {
@@ -165,117 +398,23 @@ impl ConsensusBus {
         // (some testing liked this).  Using the default to not overly complicate
         // creation of the bus.
         // This is basically for testing.
-        let (consensus_output, _rx_consensus_output) = broadcast::channel(CHANNEL_CAPACITY);
-
-        Self::new_with_args(Parameters::default_gc_depth(), consensus_output)
+        Self::new_with_args(Parameters::default_gc_depth())
     }
 
     /// Create a new consensus bus.
     /// Store recent_blocks number of the last generated execution blocks.
-    pub fn new_with_args(
-        recent_blocks: u32,
-        consensus_output: broadcast::Sender<ConsensusOutput>,
-    ) -> Self {
-        let consensus_metrics = Arc::new(ConsensusMetrics::default());
-        let primary_metrics = Arc::new(Metrics::default()); // Initialize the metrics
-        let channel_metrics = Arc::new(ChannelMetrics::default());
-        let executor_metrics = Arc::new(ExecutorMetrics::default());
-        let new_certificates = metered_channel::channel_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_new_certificates,
-        );
+    pub fn new_with_args(recent_blocks: u32) -> Self {
+        let inner_app = Arc::new(ConsensusBusAppInner::new(recent_blocks));
+        let inner_epoch = Arc::new(ConsensusBusEpochInner::new(&inner_app));
+        Self { inner_app, inner_epoch }
+    }
 
-        let committed_certificates = metered_channel::channel_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_committed_certificates,
-        );
-
-        let (tx_committed_round_updates, _rx_committed_round_updates) =
-            watch::channel(Round::default());
-
-        let (tx_gc_round_updates, _rx_gc_round_updates) = watch::channel(Round::default());
-
-        let our_digests = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_our_digests,
-            &primary_metrics.primary_channel_metrics.tx_our_digests_total,
-        );
-        let parents = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_parents,
-            &primary_metrics.primary_channel_metrics.tx_parents_total,
-        );
-        let headers = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_headers,
-            &primary_metrics.primary_channel_metrics.tx_headers_total,
-        );
-        let certificate_fetcher = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_certificate_fetcher,
-            &primary_metrics.primary_channel_metrics.tx_certificate_fetcher_total,
-        );
-        let committed_own_headers = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_committed_own_headers,
-            &primary_metrics.primary_channel_metrics.tx_committed_own_headers_total,
-        );
-
-        let certificate_manager = channel_with_total_sender(
-            CHANNEL_CAPACITY,
-            &primary_metrics.primary_channel_metrics.tx_certificate_acceptor,
-            &primary_metrics.primary_channel_metrics.tx_certificate_acceptor_total,
-        );
-
-        let (tx_primary_round_updates, _rx_primary_round_updates) = watch::channel(0u32);
-        let (tx_last_consensus_header, _rx_last_consensus_header) =
-            watch::channel(ConsensusHeader::default());
-        let (tx_last_published_consensus_num_hash, _rx_last_published_consensus_num_hash) =
-            watch::channel((0, BlockHash::default()));
-
-        let (tx_recent_blocks, _rx_recent_blocks) =
-            watch::channel(RecentBlocks::new(recent_blocks as usize));
-        let (tx_sync_status, _rx_sync_status) = watch::channel(NodeMode::default());
-
-        let sequence =
-            metered_channel::channel_sender(CHANNEL_CAPACITY, &channel_metrics.tx_sequence);
-
-        let (consensus_header, _rx_consensus_header) = broadcast::channel(CHANNEL_CAPACITY);
-
-        Self {
-            inner: Arc::new(ConsensusBusInner {
-                new_certificates,
-                committed_certificates,
-                tx_committed_round_updates,
-                _rx_committed_round_updates,
-                tx_gc_round_updates,
-                _rx_gc_round_updates,
-                certificate_fetcher,
-                parents,
-                our_digests,
-                headers,
-                committed_own_headers,
-                sequence,
-                certificate_manager,
-
-                tx_primary_round_updates,
-                _rx_primary_round_updates,
-                tx_recent_blocks,
-                _rx_recent_blocks,
-                tx_last_consensus_header,
-                _rx_last_consensus_header,
-                tx_last_published_consensus_num_hash,
-                _rx_last_published_consensus_num_hash,
-                consensus_output,
-                consensus_header,
-                tx_sync_status,
-                _rx_sync_status,
-                consensus_metrics,
-                primary_metrics,
-                channel_metrics,
-                executor_metrics,
-            }),
-        }
+    /// Reset for a new epoch.
+    /// This is primarily so we can resubscribe to "one-time" subscription channels.
+    pub fn reset_for_epoch(&mut self) {
+        self.inner_app.reset_for_epoch();
+        let inner_epoch = Arc::new(ConsensusBusEpochInner::new(&self.inner_app));
+        self.inner_epoch = inner_epoch;
     }
 
     /// New certificates.
@@ -284,13 +423,13 @@ impl ConsensusBus {
     /// only if it already sent us its whole history.
     /// Can only be subscribed to once.
     pub fn new_certificates(&self) -> &impl TnSender<Certificate> {
-        &self.inner.new_certificates
+        &self.inner_epoch.new_certificates
     }
 
     /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
     /// Can only be subscribed to once.
     pub fn committed_certificates(&self) -> &impl TnSender<(Round, Vec<Certificate>)> {
-        &self.inner.committed_certificates
+        &self.inner_epoch.committed_certificates
     }
 
     /// Missing certificates.
@@ -299,7 +438,7 @@ impl ConsensusBus {
     /// Receives certificates with missing parents from the `Synchronizer`.
     /// Can only be subscribed to once.
     pub fn certificate_fetcher(&self) -> &impl TnSender<CertificateFetcherCommand> {
-        &self.inner.certificate_fetcher
+        &self.inner_epoch.certificate_fetcher
     }
 
     /// Valid quorum of certificates' ids.
@@ -309,34 +448,34 @@ impl ConsensusBus {
     /// `Synchronizer`.
     /// Can only be subscribed to once.
     pub fn parents(&self) -> &impl TnSender<(Vec<Certificate>, Round)> {
-        &self.inner.parents
+        &self.inner_epoch.parents
     }
 
     /// Contains the highest committed round & corresponding gc_round for consensus.
     pub fn committed_round_updates(&self) -> &watch::Sender<Round> {
-        &self.inner.tx_committed_round_updates
+        &self.inner_app.tx_committed_round_updates
     }
 
     /// Contains the highest gc_round for consensus.
     pub fn gc_round_updates(&self) -> &watch::Sender<Round> {
-        &self.inner.tx_gc_round_updates
+        &self.inner_app.tx_gc_round_updates
     }
 
     /// Signals a new round
     pub fn primary_round_updates(&self) -> &watch::Sender<Round> {
-        &self.inner.tx_primary_round_updates
+        &self.inner_app.tx_primary_round_updates
     }
 
     /// Batches' digests from our workers.
     /// Can only be subscribed to once.
     pub fn our_digests(&self) -> &impl TnSender<OurDigestMessage> {
-        &self.inner.our_digests
+        &self.inner_epoch.our_digests
     }
 
     /// Sends newly created headers to the `Certifier`.
     /// Can only be subscribed to once.
     pub fn headers(&self) -> &impl TnSender<Header> {
-        &self.inner.headers
+        &self.inner_epoch.headers
     }
 
     /// Updates when headers are committed by consensus.
@@ -344,13 +483,13 @@ impl ConsensusBus {
     /// NOTE: this does not mean the header was executed yet.
     /// Can only be subscribed to once.
     pub fn committed_own_headers(&self) -> &impl TnSender<(Round, Vec<Round>)> {
-        &self.inner.committed_own_headers
+        &self.inner_epoch.committed_own_headers
     }
 
     /// Outputs the sequence of ordered certificates from consensus.
     /// Can only be subscribed to once.
     pub fn sequence(&self) -> &impl TnSender<CommittedSubDag> {
-        &self.inner.sequence
+        &self.inner_epoch.sequence
     }
 
     /// Channel for forwarding newly received certificates for verification.
@@ -358,68 +497,82 @@ impl ConsensusBus {
     /// These channels are used to communicate with the long-running CertificateManager task.
     /// Can only be subscribed to once.
     pub(crate) fn certificate_manager(&self) -> &impl TnSender<CertificateManagerCommand> {
-        &self.inner.certificate_manager
+        &self.inner_epoch.certificate_manager
     }
 
     /// Track recent blocks.
     pub fn recent_blocks(&self) -> &watch::Sender<RecentBlocks> {
-        &self.inner.tx_recent_blocks
+        &self.inner_app.tx_recent_blocks
     }
 
     /// Track the latest consensus header.
     pub fn last_consensus_header(&self) -> &watch::Sender<ConsensusHeader> {
-        &self.inner.tx_last_consensus_header
+        &self.inner_app.tx_last_consensus_header
     }
 
     /// Track the latest published consensus header block number and hash seen on the gossip
     /// network. This is straight from the pub/sub network and should be verified before taking
     /// action with it.
     pub fn last_published_consensus_num_hash(&self) -> &watch::Sender<(u64, BlockHash)> {
-        &self.inner.tx_last_published_consensus_num_hash
+        &self.inner_app.tx_last_published_consensus_num_hash
     }
 
     /// Broadcast channel with consensus output (includes the consensus chain block).
     /// This also provides the ConsesusHeader, use this for block execution.
     pub fn consensus_output(&self) -> &impl TnSender<ConsensusOutput> {
-        &self.inner.consensus_output
+        &self.inner_app.consensus_output
     }
 
     /// Broadcast subscriber with consensus output.
     /// This breaks the trait pattern in order to return a concrete receiver to pass to the
     /// execution module.
     pub fn subscribe_consensus_output(&self) -> broadcast::Receiver<ConsensusOutput> {
-        self.inner.consensus_output.subscribe()
+        self.inner_app.consensus_output.subscribe()
     }
 
     /// Broadcast channel with consensus header.
     /// This is useful pre-consensus output when not participating in consensus.
     pub fn consensus_header(&self) -> &impl TnSender<ConsensusHeader> {
-        &self.inner.consensus_header
+        &self.inner_app.consensus_header
     }
 
     /// Status of initial sync operation.
     pub fn node_mode(&self) -> &watch::Sender<NodeMode> {
-        &self.inner.tx_sync_status
+        &self.inner_app.tx_sync_status
+    }
+
+    /// Return the channel for primary network events.
+    pub fn primary_network_events(
+        &self,
+    ) -> &impl TnSender<NetworkEvent<crate::network::Req, crate::network::Res>> {
+        &self.inner_app.primary_network_events
+    }
+
+    /// Return the channel for primary network events.  Returns a concrete clone.
+    pub fn primary_network_events_actual(
+        &self,
+    ) -> QueChannel<NetworkEvent<crate::network::Req, crate::network::Res>> {
+        self.inner_app.primary_network_events.clone()
     }
 
     /// Hold onto the consensus_metrics (mostly for testing)
     pub fn consensus_metrics(&self) -> Arc<ConsensusMetrics> {
-        self.inner.consensus_metrics.clone()
+        self.inner_app.consensus_metrics.clone()
     }
 
     /// Hold onto the primary metrics (allow early creation)
     pub fn primary_metrics(&self) -> Arc<Metrics> {
-        self.inner.primary_metrics.clone()
+        self.inner_app.primary_metrics.clone()
     }
 
     /// Hold onto the channel metrics (metrics for the sequence channel).
     pub fn channel_metrics(&self) -> Arc<ChannelMetrics> {
-        self.inner.channel_metrics.clone()
+        self.inner_app.channel_metrics.clone()
     }
 
     /// Hold onto the executor metrics
     pub fn executor_metrics(&self) -> &ExecutorMetrics {
-        &self.inner.executor_metrics
+        &self.inner_app.executor_metrics
     }
 
     /// Update consensus round watch channels.

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -538,7 +538,7 @@ impl ConsensusBus {
     }
 
     /// Return the channel for primary network events.  Returns a concrete clone.
-    pub fn primary_network_events_actual(
+    pub fn primary_network_events_cloned(
         &self,
     ) -> QueChannel<NetworkEvent<crate::network::Req, crate::network::Res>> {
         self.inner_app.primary_network_events.clone()

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -50,6 +50,9 @@ struct TestTypes<DB = MemDatabase> {
     /// num: 0
     /// hash: 0x78dec18c6d7da925bbe773c315653cdc70f6444ed6c1de9ac30bdb36cff74c3b
     parent: SealedHeader,
+    /// Task manager the synchronizer (in RequestHandler) is spawned on.
+    /// Save it so that task is not dropped early if needed.
+    task_manager: TaskManager,
 }
 
 /// Helper function to create an instance of [RequestHandler] for the first authority in the
@@ -76,13 +79,14 @@ fn create_test_types() -> TestTypes {
         .expect("watch channel updates for default parent in primary handler tests");
 
     let handler = RequestHandler::new(config.clone(), cb.clone(), synchronizer);
-    TestTypes { committee, handler, parent }
+    TestTypes { committee, handler, parent, task_manager }
 }
 
 #[tokio::test]
 async fn test_vote_succeeds() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     let parents = Vec::new();
 
@@ -104,7 +108,8 @@ async fn test_vote_succeeds() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_too_many_parents() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     // last authority produced 2 certs for round 1
     let mut too_many_parents: Vec<_> = Certificate::genesis(&committee.committee());
@@ -129,7 +134,8 @@ async fn test_vote_fails_too_many_parents() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_wrong_authority_network_key() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
     let parents = Vec::new();
 
     // create valid header proposed by last peer in the committee for round 1
@@ -150,7 +156,8 @@ async fn test_vote_fails_wrong_authority_network_key() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_invalid_genesis_parent() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     let parents = Vec::new();
 
@@ -180,7 +187,7 @@ async fn test_vote_fails_invalid_genesis_parent() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_unknown_execution_result() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, .. } = create_test_types();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } = create_test_types();
 
     // create header proposed by last peer in the committee for round 1
     let header = committee.header_from_last_authority();
@@ -197,7 +204,7 @@ async fn test_vote_fails_unknown_execution_result() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_invalid_header_digest() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, .. } = create_test_types();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } = create_test_types();
 
     let parents = Vec::new();
 
@@ -216,7 +223,8 @@ async fn test_vote_fails_invalid_header_digest() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_invalid_timestamp() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     let parents = Vec::new();
 
@@ -239,7 +247,8 @@ async fn test_vote_fails_invalid_timestamp() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_wrong_epoch() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     let parents = Vec::new();
 
@@ -263,7 +272,8 @@ async fn test_vote_fails_wrong_epoch() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_vote_fails_unknown_authority() -> eyre::Result<()> {
     // common types
-    let TestTypes { committee, handler, parent, .. } = create_test_types();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types();
 
     let parents = Vec::new();
 

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -21,7 +21,8 @@ async fn test_empty_proposal() {
         LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
-    proposer.spawn(&TaskManager::default());
+    let task_manager = TaskManager::default();
+    proposer.spawn(&task_manager);
 
     // Ensure the proposer makes a correct empty header.
     let header = rx_headers.recv().await.unwrap();

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -17,7 +17,7 @@ use tn_network_types::{FetchBatchResponse, PrimaryToWorkerClient, WorkerSynchron
 use tn_storage::tables::Batches;
 use tn_types::{
     encode, now, Batch, BatchValidation, BlockHash, BlsPublicKey, Database, DbTxMut, SealedBatch,
-    TaskManager, TaskSpawner, TnReceiver, WorkerId,
+    TaskSpawner, TnReceiver, WorkerId,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, trace, warn};
@@ -53,10 +53,9 @@ impl WorkerNetworkHandle {
 
     //// Convenience method for creating a new Self for tests- sends events no-where and does
     //// nothing.
-    pub fn new_for_test() -> Self {
+    pub fn new_for_test(task_spawner: TaskSpawner) -> Self {
         let (tx, _rx) = mpsc::channel(5);
-        let tm = TaskManager::default();
-        Self { handle: NetworkHandle::new(tx), task_spawner: tm.get_spawner() }
+        Self { handle: NetworkHandle::new(tx), task_spawner }
     }
 
     /// Return a reference to the inner handle.

--- a/crates/consensus/worker/src/tests/batch_provider_tests.rs
+++ b/crates/consensus/worker/src/tests/batch_provider_tests.rs
@@ -30,7 +30,7 @@ async fn make_batch() {
         client,
         store.clone(),
         timeout,
-        WorkerNetworkHandle::new_for_test(),
+        WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
         &mut task_manager,
     );
 

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -144,10 +144,10 @@ async fn test_empty_output_executes_early_finalize() -> eyre::Result<()> {
     assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
 
     // spawn engine task
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("Test task eng", async move {
         let res = engine.await;
         let _ = tx.send(res);
-    }));
+    });
 
     let engine_task = timeout(Duration::from_secs(10), rx).await?;
     assert!(engine_task.is_ok());
@@ -307,10 +307,10 @@ async fn test_empty_output_executes_late_finalize() -> eyre::Result<()> {
     let (tx, rx) = oneshot::channel();
 
     // spawn engine task
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("test task eng", async move {
         let res = engine.await;
         let _ = tx.send(res);
-    }));
+    });
 
     let engine_task = timeout(Duration::from_secs(10), rx).await?;
     assert!(engine_task.is_ok());
@@ -514,10 +514,10 @@ async fn test_queued_output_executes_after_sending_channel_closed() -> eyre::Res
     // spawn engine task
     //
     // one output already queued up, one output waiting in broadcast stream
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("test task eng", async move {
         let res = engine.await;
         let _ = tx.send(res);
-    }));
+    });
 
     let engine_task = timeout(Duration::from_secs(10), rx).await?;
     assert!(engine_task.is_ok());
@@ -849,10 +849,10 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     // spawn engine task
     //
     // one output already queued up, one output waiting in broadcast stream
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("test task eng", async move {
         let res = engine.await;
         let _ = tx.send(res);
-    }));
+    });
 
     let engine_task = timeout(Duration::from_secs(10), rx).await?;
     assert!(engine_task.is_ok());
@@ -1147,10 +1147,10 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     // spawn engine task
     //
     // one output already queued up, one output waiting in broadcast stream
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("test task eng", async move {
         let res = engine.await;
         let _ = tx.send(res);
-    }));
+    });
 
     let engine_task = timeout(Duration::from_secs(10), rx).await?;
     assert!(engine_task.is_ok());

--- a/crates/execution/faucet/tests/it/faucet.rs
+++ b/crates/execution/faucet/tests/it/faucet.rs
@@ -295,7 +295,7 @@ async fn test_with_creds_faucet_transfers_tel_with_google_kms() -> eyre::Result<
     let node_metrics = WorkerMetrics::default();
     let timeout = Duration::from_secs(5);
     let mut task_manager = TaskManager::default();
-    let worker_network = WorkerNetworkHandle::new_for_test();
+    let worker_network = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
     let batch_provider = Worker::new(
         0,
         Some(qw.clone()),
@@ -649,7 +649,7 @@ async fn test_with_creds_faucet_transfers_stablecoin_with_google_kms() -> eyre::
     execution_node
         .initialize_worker_components(
             worker_id,
-            WorkerNetworkHandle::new_for_test(),
+            WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
             EmptyEngToPrimary(),
         )
         .await?;

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -38,10 +38,10 @@ use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
 use tn_storage::tables::KadRecords;
 use tn_types::{
     decode, encode, try_decode, BlsPublicKey, BlsSigner, Database, NetworkKeypair,
-    NetworkPublicKey, TaskSpawner,
+    NetworkPublicKey, TaskSpawner, TnSender,
 };
 use tokio::sync::{
-    mpsc::{self, Receiver, Sender},
+    mpsc::{Receiver, Sender},
     oneshot,
 };
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -97,16 +97,17 @@ where
 /// - prevent a surge in one network message type from overwhelming all network traffic
 /// - provide more granular control over resource allocation
 /// - allow specific network configurations based on worker/primary needs
-pub struct ConsensusNetwork<Req, Res, DB>
+pub struct ConsensusNetwork<Req, Res, DB, Events>
 where
     Req: TNMessage,
     Res: TNMessage,
     DB: Database,
+    Events: TnSender<NetworkEvent<Req, Res>>,
 {
     /// The gossip network for flood publishing sealed batches.
     swarm: Swarm<TNBehavior<TNCodec<Req, Res>, DB>>,
     /// The stream for forwarding network events.
-    event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
+    event_stream: Events,
     /// The sender for network handles.
     handle: Sender<NetworkCommand<Req, Res>>,
     /// The receiver for processing network handle requests.
@@ -159,16 +160,17 @@ where
     task_spawner: TaskSpawner,
 }
 
-impl<Req, Res, DB> ConsensusNetwork<Req, Res, DB>
+impl<Req, Res, DB, Events> ConsensusNetwork<Req, Res, DB, Events>
 where
     Req: TNMessage,
     Res: TNMessage,
     DB: Database,
+    Events: TnSender<NetworkEvent<Req, Res>> + Send + 'static,
 {
     /// Convenience method for spawning a primary network instance.
     pub fn new_for_primary(
         network_config: &NetworkConfig,
-        event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
+        event_stream: Events,
         key_config: KeyConfig,
         db: DB,
         task_manager: TaskSpawner,
@@ -180,7 +182,7 @@ where
     /// Convenience method for spawning a worker network instance.
     pub fn new_for_worker(
         network_config: &NetworkConfig,
-        event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
+        event_stream: Events,
         key_config: KeyConfig,
         db: DB,
         task_manager: TaskSpawner,
@@ -192,7 +194,7 @@ where
     /// Create a new instance of Self.
     pub fn new(
         network_config: &NetworkConfig,
-        event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
+        event_stream: Events,
         key_config: KeyConfig,
         keypair: NetworkKeypair,
         db: DB,
@@ -664,7 +666,7 @@ where
                 let peers = self.swarm.behaviour_mut().peer_manager.peers_for_exchange();
                 send_or_log_error!(reply, peers, "PeersForExchange");
             }
-            NetworkCommand::NewEpoch { committee, new_event_stream } => {
+            NetworkCommand::NewEpoch { committee } => {
                 // at the start of a new epoch, each node needs to know:
                 // - the current committee
                 // - all staked nodes who will vote at the end of the epoch
@@ -679,9 +681,6 @@ where
                 info!(target: "network", this_node=?self.swarm.local_peer_id(), "network update for next committee - ensuring no committee members are banned");
                 // ensure that the next committee isn't banned
                 self.swarm.behaviour_mut().peer_manager.new_epoch(committee);
-
-                // update the stream to forward events
-                self.event_stream = new_event_stream;
             }
             NetworkCommand::FindAuthorities { requests } => {
                 // this will trigger a PeerEvent to fetch records through kad if not in the peer map
@@ -1285,11 +1284,12 @@ impl From<GossipAcceptance> for MessageAcceptance {
     }
 }
 
-impl<Req, Res, DB> std::fmt::Debug for ConsensusNetwork<Req, Res, DB>
+impl<Req, Res, DB, Events> std::fmt::Debug for ConsensusNetwork<Req, Res, DB, Events>
 where
     Req: TNMessage,
     Res: TNMessage,
     DB: Database,
+    Events: TnSender<NetworkEvent<Req, Res>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConsensusNetwork")

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -287,8 +287,6 @@ where
     NewEpoch {
         /// The epoch committee.
         committee: HashSet<BlsPublicKey>,
-        /// The new sender for events.
-        new_event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
     },
     /// Find authorities for a future committee by bls key and return to sender.
     FindAuthorities {
@@ -532,12 +530,8 @@ where
     }
 
     /// Create a [PeerExchangeMap] for exchanging peers.
-    pub async fn new_epoch(
-        &self,
-        committee: HashSet<BlsPublicKey>,
-        new_event_stream: mpsc::Sender<NetworkEvent<Req, Res>>,
-    ) -> NetworkResult<()> {
-        self.sender.send(NetworkCommand::NewEpoch { committee, new_event_stream }).await?;
+    pub async fn new_epoch(&self, committee: HashSet<BlsPublicKey>) -> NetworkResult<()> {
+        self.sender.send(NetworkCommand::NewEpoch { committee }).await?;
         Ok(())
     }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -42,12 +42,11 @@ where
         .build()?;
 
     // create the epoch manager
-    let mut epoch_manager = EpochManager::new(builder, tn_datadir, passphrase)?;
     // run the node
-    let res = runtime.block_on(async move { epoch_manager.run().await });
-
-    // shutdown background tasks
-    runtime.shutdown_background();
+    let res = runtime.block_on(async move {
+        let mut epoch_manager = EpochManager::new(builder, tn_datadir, passphrase)?;
+        epoch_manager.run().await
+    });
 
     // return result after shutdown
     res

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -19,10 +19,14 @@ use std::{
 use tn_config::{
     Config, ConfigFmt, ConfigTrait as _, ConsensusConfig, KeyConfig, NetworkConfig, TelcoinDirs,
 };
-use tn_network_libp2p::{error::NetworkError, types::NetworkHandle, ConsensusNetwork, TNMessage};
+use tn_network_libp2p::{
+    error::NetworkError,
+    types::{NetworkEvent, NetworkHandle},
+    ConsensusNetwork, TNMessage,
+};
 use tn_primary::{
     network::{PrimaryNetwork, PrimaryNetworkHandle},
-    ConsensusBus, NodeMode, StateSynchronizer,
+    ConsensusBus, NodeMode, QueChannel, StateSynchronizer,
 };
 use tn_reth::{
     system_calls::{ConsensusRegistry, EpochState},
@@ -39,13 +43,10 @@ use tn_storage::{
 use tn_types::{
     gas_accumulator::GasAccumulator, BatchValidation, BlsPublicKey, Committee, CommitteeBuilder,
     ConsensusHeader, ConsensusOutput, Database as TNDatabase, Epoch, Noticer, Notifier,
-    TaskManager, TaskSpawner, TimestampSec, MIN_PROTOCOL_BASE_FEE,
+    TaskManager, TaskSpawner, TimestampSec, TnReceiver, TnSender, MIN_PROTOCOL_BASE_FEE,
 };
-use tn_worker::{WorkerNetwork, WorkerNetworkHandle};
-use tokio::sync::{
-    broadcast,
-    mpsc::{self},
-};
+use tn_worker::{WorkerNetwork, WorkerNetworkHandle, WorkerRequest, WorkerResponse};
+use tokio::sync::mpsc::{self};
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 
@@ -79,16 +80,16 @@ pub struct EpochManager<P> {
     key_config: KeyConfig,
     /// The epoch manager's [Notifier] to shutdown all node processes.
     node_shutdown: Notifier,
-    /// Output channel for consensus blocks to be executed.
-    ///
-    /// This should only be accessed elsewhere through the epoch's [ConsensusBus].
-    consensus_output: broadcast::Sender<ConsensusOutput>,
     /// The timestamp to close the current epoch.
     ///
     /// The manager monitors leader timestamps for the epoch boundary.
     /// If the timestamp of the leader is >= the epoch_boundary then the
     /// manager closes the epoch after the engine executes all data.
     epoch_boundary: TimestampSec,
+    /// ConsensusBus for the application life.
+    consensus_bus: ConsensusBus,
+    /// Persistent event stream for woker network events.
+    worker_event_stream: QueChannel<NetworkEvent<WorkerRequest, WorkerResponse>>,
 }
 
 /// When rejoining a network mid epoch this will accumulate any gas state for previous epoch blocks.
@@ -182,7 +183,9 @@ where
 
         // shutdown long-running node components
         let node_shutdown = Notifier::new();
-        let (consensus_output, _rx_consensus_output) = broadcast::channel(100);
+
+        let consensus_bus = ConsensusBus::new_with_args(builder.tn_config.parameters.gc_depth);
+        let worker_event_stream = QueChannel::new();
 
         Ok(Self {
             builder,
@@ -191,8 +194,10 @@ where
             worker_network_handle: None,
             key_config,
             node_shutdown,
-            consensus_output,
+            //consensus_output,
             epoch_boundary: Default::default(),
+            consensus_bus,
+            worker_event_stream,
         })
     }
 
@@ -296,8 +301,6 @@ where
         //
         //=== PRIMARY
         //
-        // this is a temporary event stream - replaced at the start of every epoch
-        let (tmp_event_stream, _temp_rx) = mpsc::channel(1000);
 
         // create network db
         let primary_network_db = self.tn_datadir.network_db_path().join("primary");
@@ -308,7 +311,7 @@ where
         // create long-running network task for primary
         let primary_network = ConsensusNetwork::new_for_primary(
             network_config,
-            tmp_event_stream,
+            self.consensus_bus.primary_network_events_actual(),
             self.key_config.clone(),
             primary_network_db,
             node_task_spawner.clone(),
@@ -336,7 +339,7 @@ where
         //=== WORKER
         //
         // this is a temporary event stream - replaced at the start of every epoch
-        let (tmp_event_stream, _temp_rx) = mpsc::channel(1000);
+        //let (tmp_event_stream, _temp_rx) = mpsc::channel(1000);
 
         // create network db
         let worker_network_db = self.tn_datadir.network_db_path().join("worker");
@@ -347,7 +350,7 @@ where
         // create long-running network task for worker
         let worker_network = ConsensusNetwork::new_for_worker(
             network_config,
-            tmp_event_stream,
+            self.worker_event_stream.clone(),
             self.key_config.clone(),
             worker_network_db,
             node_task_spawner.clone(),
@@ -406,6 +409,7 @@ where
             })?;
 
             info!(target: "epoch-manager", "looping run epoch");
+            self.consensus_bus.reset_for_epoch();
         }
     }
 
@@ -429,7 +433,7 @@ where
         let mut epoch_task_manager = TaskManager::new(EPOCH_TASK_MANAGER);
 
         // subscribe to output early to prevent missed messages
-        let consensus_output = self.consensus_output.subscribe();
+        let consensus_output = self.consensus_bus.consensus_output().subscribe();
 
         // create primary and worker nodes
         let (primary, worker_node) = self
@@ -483,7 +487,7 @@ where
 
         tokio::select! {
             // wait for epoch boundary to transition
-            res = self.wait_for_epoch_boundary(to_engine, engine, consensus_output, consensus_shutdown.clone(), gas_accumulator) => {
+            res = self.wait_for_epoch_boundary(to_engine, engine, consensus_shutdown.clone(), gas_accumulator, consensus_output) => {
                 res.inspect_err(|e| {
                     error!(target: "epoch-manager", ?e, "failed to reach epoch boundary");
                 })?;
@@ -530,12 +534,12 @@ where
         &self,
         to_engine: &mpsc::Sender<ConsensusOutput>,
         engine: &ExecutionNode,
-        mut consensus_output: broadcast::Receiver<ConsensusOutput>,
         shutdown_consensus: Notifier,
         gas_accumulator: GasAccumulator,
+        mut consensus_output: impl TnReceiver<ConsensusOutput>,
     ) -> eyre::Result<()> {
         // receive output from consensus and forward to engine
-        'epoch: while let Ok(mut output) = consensus_output.recv().await {
+        'epoch: while let Some(mut output) = consensus_output.recv().await {
             // observe epoch boundary to initiate epoch transition
             if output.committed_at() >= self.epoch_boundary {
                 info!(
@@ -657,20 +661,16 @@ where
         *initial_epoch = false;
 
         // set execution state for consensus
-        let consensus_bus = primary.consensus_bus().await;
-        self.try_restore_state(&consensus_bus, &consensus_db, engine).await?;
+        self.try_restore_state(&consensus_db, engine).await?;
 
         let primary_network_handle = primary.network_handle().await;
-        let _mode = self
-            .identify_node_mode(&consensus_bus, &consensus_config, &primary_network_handle)
-            .await?;
+        let _mode = self.identify_node_mode(&consensus_config, &primary_network_handle).await?;
 
         // spawn task to update the latest execution results for consensus
         //
         // NOTE: this should live and die with epochs because it updates the consensus bus
         self.spawn_engine_update_task(
             consensus_config.shutdown().subscribe(),
-            consensus_bus.clone(),
             engine.canonical_block_stream().await,
             epoch_task_manager,
         );
@@ -786,11 +786,8 @@ where
         epoch_task_spawner: TaskSpawner,
         initial_epoch: &bool,
     ) -> eyre::Result<PrimaryNode<DB>> {
-        let consensus_bus = ConsensusBus::new_with_args(
-            consensus_config.config().parameters.gc_depth,
-            self.consensus_output.clone(),
-        );
-        let state_sync = StateSynchronizer::new(consensus_config.clone(), consensus_bus.clone());
+        let state_sync =
+            StateSynchronizer::new(consensus_config.clone(), self.consensus_bus.clone());
         let network_handle = self
             .primary_network_handle
             .as_ref()
@@ -800,7 +797,6 @@ where
         // create the epoch-specific `PrimaryNetwork`
         self.spawn_primary_network_for_epoch(
             consensus_config,
-            &consensus_bus,
             state_sync.clone(),
             epoch_task_spawner.clone(),
             &network_handle,
@@ -809,8 +805,12 @@ where
         .await?;
 
         // spawn primary - create node and spawn network
-        let primary =
-            PrimaryNode::new(consensus_config.clone(), consensus_bus, network_handle, state_sync);
+        let primary = PrimaryNode::new(
+            consensus_config.clone(),
+            self.consensus_bus.clone(),
+            network_handle,
+            state_sync,
+        );
 
         Ok(primary)
     }
@@ -883,14 +883,14 @@ where
     async fn spawn_primary_network_for_epoch<DB: TNDatabase>(
         &mut self,
         consensus_config: &ConsensusConfig<DB>,
-        consensus_bus: &ConsensusBus,
         state_sync: StateSynchronizer<DB>,
         epoch_task_spawner: TaskSpawner,
         network_handle: &PrimaryNetworkHandle,
         initial_epoch: &bool,
     ) -> eyre::Result<()> {
-        // create event streams for the primary network handler
-        let (event_stream, rx_event_stream) = mpsc::channel(1000);
+        // get event streams for the primary network handler
+        let event_stream = self.consensus_bus.primary_network_events().clone();
+        let rx_event_stream = event_stream.subscribe();
 
         // set committee for network to prevent banning
         debug!(target: "epoch-manager", auth=?consensus_config.authority_id(), "spawning primary network for epoch");
@@ -916,7 +916,7 @@ where
                 .await?;
         }
 
-        network_handle.inner_handle().new_epoch(committee_keys.clone(), event_stream).await?;
+        network_handle.inner_handle().new_epoch(committee_keys.clone()).await?;
         debug!(target: "epoch-manager", auth=?consensus_config.authority_id(), "event stream updated!");
 
         // start listening if the network needs to be initialized
@@ -960,7 +960,7 @@ where
             rx_event_stream,
             network_handle.clone(),
             consensus_config.clone(),
-            consensus_bus.clone(),
+            self.consensus_bus.clone(),
             state_sync,
             epoch_task_spawner.clone(), // tasks should abort with epoch
         )
@@ -1009,8 +1009,8 @@ where
         network_handle: &WorkerNetworkHandle,
         initial_epoch: &bool,
     ) -> eyre::Result<()> {
-        // create event streams for the worker network handler
-        let (event_stream, rx_event_stream) = mpsc::channel(1000);
+        // get event streams for the worker network handler
+        let rx_event_stream = self.worker_event_stream.subscribe();
         debug!(target: "epoch-manager", "spawning worker network for epoch");
 
         let committe_keys: HashSet<BlsPublicKey> = consensus_config
@@ -1019,7 +1019,7 @@ where
             .into_iter()
             .map(|a| *a.protocol_key())
             .collect();
-        network_handle.inner_handle().new_epoch(committe_keys, event_stream).await?;
+        network_handle.inner_handle().new_epoch(committe_keys).await?;
 
         // start listening if the network needs to be initialized
         if *initial_epoch {
@@ -1078,15 +1078,16 @@ where
     /// Helper method to restore execution state for the consensus components.
     async fn try_restore_state(
         &self,
-        consensus_bus: &ConsensusBus,
         db: &DatabaseType,
         engine: &ExecutionNode,
     ) -> eyre::Result<()> {
         // prime the recent_blocks watch with latest executed blocks
-        let block_capacity = consensus_bus.recent_blocks().borrow().block_capacity();
+        let block_capacity = self.consensus_bus.recent_blocks().borrow().block_capacity();
 
         for recent_block in engine.last_executed_output_blocks(block_capacity).await? {
-            consensus_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(recent_block));
+            self.consensus_bus
+                .recent_blocks()
+                .send_modify(|blocks| blocks.push_latest(recent_block));
         }
 
         // prime the last consensus header from the DB
@@ -1095,7 +1096,7 @@ where
 
         // prime the watch channel with data from the db this will be updated by state-sync if this
         // node can_cvv
-        consensus_bus.last_consensus_header().send(last_db_block)?;
+        self.consensus_bus.last_consensus_header().send(last_db_block)?;
 
         Ok(())
     }
@@ -1108,7 +1109,6 @@ where
     /// This method also updates the `ConsensusBus::node_mode()`.
     async fn identify_node_mode<DB: TNDatabase>(
         &self,
-        consensus_bus: &ConsensusBus,
         consensus_config: &ConsensusConfig<DB>,
         primary_network_handle: &PrimaryNetworkHandle,
     ) -> eyre::Result<NodeMode> {
@@ -1119,7 +1119,8 @@ where
             .unwrap_or(false);
         let mode = if !in_committee || self.builder.tn_config.observer {
             NodeMode::Observer
-        } else if state_sync::can_cvv(consensus_bus, consensus_config, primary_network_handle).await
+        } else if state_sync::can_cvv(&self.consensus_bus, consensus_config, primary_network_handle)
+            .await
         {
             NodeMode::CvvActive
         } else {
@@ -1128,7 +1129,7 @@ where
 
         debug!(target: "epoch-manager", ?mode, "node mode identified");
         // update consensus bus
-        consensus_bus.node_mode().send_modify(|v| *v = mode);
+        self.consensus_bus.node_mode().send_modify(|v| *v = mode);
 
         Ok(mode)
     }
@@ -1138,11 +1139,11 @@ where
     fn spawn_engine_update_task(
         &self,
         shutdown: Noticer,
-        consensus_bus: ConsensusBus,
         mut engine_state: CanonStateNotificationStream,
         epoch_task_manager: &TaskManager,
     ) {
         // spawn epoch-specific task to forward blocks from the engine to consensus
+        let consensus_bus = self.consensus_bus.clone();
         epoch_task_manager.spawn_critical_task("latest execution block", async move {
             loop {
                 tokio::select!(

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -194,7 +194,6 @@ where
             worker_network_handle: None,
             key_config,
             node_shutdown,
-            //consensus_output,
             epoch_boundary: Default::default(),
             consensus_bus,
             worker_event_stream,
@@ -311,7 +310,7 @@ where
         // create long-running network task for primary
         let primary_network = ConsensusNetwork::new_for_primary(
             network_config,
-            self.consensus_bus.primary_network_events_actual(),
+            self.consensus_bus.primary_network_events_cloned(),
             self.key_config.clone(),
             primary_network_db,
             node_task_spawner.clone(),
@@ -334,12 +333,6 @@ where
 
         // primary network handle
         self.primary_network_handle = Some(PrimaryNetworkHandle::new(primary_network_handle));
-
-        //
-        //=== WORKER
-        //
-        // this is a temporary event stream - replaced at the start of every epoch
-        //let (tmp_event_stream, _temp_rx) = mpsc::channel(1000);
 
         // create network db
         let worker_network_db = self.tn_datadir.network_db_path().join("worker");

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -96,7 +96,14 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
     let mut consensus_output = consensus_bus.consensus_output().subscribe();
 
     // spawn consensus to send output to engine for full execution
-    spawn_consensus(&fixture, &consensus_bus, batches, config, consensus_store.clone());
+    spawn_consensus(
+        &fixture,
+        &consensus_bus,
+        batches,
+        config,
+        consensus_store.clone(),
+        &task_manager,
+    );
 
     // send certificates to trigger subdag commit
     for certificate in certificates.iter() {
@@ -164,10 +171,10 @@ fn spawn_consensus(
     batches: HashMap<B256, Batch>,
     config: ConsensusConfig<MemDatabase>,
     consensus_store: MemDatabase,
+    task_manager: &TaskManager,
 ) {
     // components for tasks
     let committee = fixture.committee();
-    let task_manager = TaskManager::new("subscriber tests");
     let rx_shutdown = config.shutdown().subscribe();
 
     let (tx, mut rx) = mpsc::channel(10);
@@ -181,7 +188,7 @@ fn spawn_consensus(
     let network = PrimaryNetworkHandle::new_for_test(tx);
 
     // spawn the executor
-    spawn_subscriber(config.clone(), rx_shutdown, consensus_bus.clone(), &task_manager, network);
+    spawn_subscriber(config.clone(), rx_shutdown, consensus_bus.clone(), task_manager, network);
 
     // Set up mock worker.
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
@@ -204,5 +211,5 @@ fn spawn_consensus(
     // spawn consensus to await certificates
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.recent_blocks().send_modify(|blocks| blocks.push_latest(dummy_parent));
-    Consensus::spawn(config, consensus_bus, bullshark, &task_manager);
+    Consensus::spawn(config, consensus_bus, bullshark, task_manager);
 }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -86,11 +86,11 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
         gas_accumulator.clone(),
     );
     let (tx, mut rx) = oneshot::channel();
-    task_manager.spawn_blocking(Box::pin(async move {
+    task_manager.spawn_task("test task eng", async move {
         let res = engine.await;
         debug!(target: "gas-test", ?res, "res:");
         let _ = tx.send(res);
-    }));
+    });
 
     // subscribe to output early
     let mut consensus_output = consensus_bus.consensus_output().subscribe();

--- a/crates/types/src/task_manager.rs
+++ b/crates/types/src/task_manager.rs
@@ -441,6 +441,12 @@ impl TaskManager {
                             info.name,
                         )
                     }
+                    Err((info, err)) if err.is_cancelled() => tracing::info!(
+                        target: "tn::tasks",
+                        "{}: {} was cancelled",
+                        self.name,
+                        info.name,
+                    ),
                     Err((info, err)) => tracing::error!(
                         target: "tn::tasks",
                         "{}: {} shutdown with error {err}",

--- a/crates/types/src/task_manager.rs
+++ b/crates/types/src/task_manager.rs
@@ -1,6 +1,6 @@
 //! Task manager interface to spawn tasks to the tokio runtime.
 
-use crate::Notifier;
+use crate::{Noticer, Notifier};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use std::{
     collections::HashMap,
@@ -71,6 +71,15 @@ pub struct TaskManager {
     name: String,
     new_task_rx: mpsc::Receiver<TaskHandle>,
     new_task_tx: mpsc::Sender<TaskHandle>,
+    /// Thgis is used to noitify any spawned tasks to exit when task manager id dropped.
+    /// Otherwise we will end up with orphaned tasks when epochs change.
+    local_shutdown: Notifier,
+}
+
+impl Drop for TaskManager {
+    fn drop(&mut self) {
+        self.local_shutdown.notify();
+    }
 }
 
 /// The type that can spawn tasks for a parent `TaskManager`.
@@ -81,6 +90,7 @@ pub struct TaskManager {
 pub struct TaskSpawner {
     /// The channel to forward task handles to the parent [TaskManager].
     new_task_tx: mpsc::Sender<TaskHandle>,
+    rx_shutdown: Noticer,
 }
 
 impl TaskSpawner {
@@ -114,8 +124,12 @@ impl TaskSpawner {
         F::Output: Send + 'static,
     {
         let name = name.to_string();
+        let rx_shutdown = self.rx_shutdown.clone();
         let handle = tokio::spawn(async move {
-            future.await;
+            tokio::select! {
+                _ = rx_shutdown => {}
+                _ = future => {}
+            }
         });
         if let Err(err) = self.new_task_tx.try_send(TaskHandle::new(name.clone(), handle, critical))
         {
@@ -149,12 +163,21 @@ impl TaskSpawner {
         let (tx, mut rx) = tokio::sync::broadcast::channel(1);
         // Need two join handles so do this channel dance to get them.
         // Required because the task manager needs one and this foreign Reth interface return one.
+        let rx_shutdown = self.rx_shutdown.clone();
         let f = async move {
-            let value = fut.await;
-            let _ = tx.send(value);
+            tokio::select! {
+                _ = rx_shutdown => {}
+                value = fut => {
+                    let _ = tx.send(value);
+                }
+            }
         };
+        let rx_shutdown = self.rx_shutdown.clone();
         let join = tokio::spawn(async move {
-            let _ = rx.recv().await;
+            tokio::select! {
+                _ = rx_shutdown => {}
+                _ = rx.recv() => {}
+            }
         });
 
         match (critical, blocking) {
@@ -209,6 +232,7 @@ impl TaskManager {
             name: name.to_string(),
             new_task_rx,
             new_task_tx,
+            local_shutdown: Notifier::default(),
         }
     }
 
@@ -242,15 +266,22 @@ impl TaskManager {
         F::Output: Send + 'static,
     {
         let name = name.to_string();
+        let rx_shutdown = self.local_shutdown.subscribe();
         let handle = tokio::spawn(async move {
-            future.await;
+            tokio::select! {
+                _ = rx_shutdown => {}
+                _ = future => {}
+            }
         });
         self.tasks.push(TaskHandle::new(name, handle, critical));
     }
 
     /// Return a clonable spawner (also implements Reth's TaskSpawner trait).
     pub fn get_spawner(&self) -> TaskSpawner {
-        TaskSpawner { new_task_tx: self.new_task_tx.clone() }
+        TaskSpawner {
+            new_task_tx: self.new_task_tx.clone(),
+            rx_shutdown: self.local_shutdown.subscribe(),
+        }
     }
 
     /// Return a mutable reference to a submanager.
@@ -366,9 +397,9 @@ impl TaskManager {
                             if !info.critical {
                                 continue;
                             }
-                            tracing::error!(target: "tn::tasks", "{}: {} returned error {join_err}, node exiting", self.name, info.name);
                             // Ok exit is fine if we are shutting down.
                             if !rx_shutdown.noticed() {
+                                tracing::error!(target: "tn::tasks", "{}: {} returned error {join_err}, node exiting", self.name, info.name);
                                 result = Err(TaskJoinError::CriticalExitError(info.name, join_err));
                             }
                         }
@@ -376,7 +407,9 @@ impl TaskManager {
                     break;
                 }
                 Some((res, name)) = future_managers.next() => {
-                    tracing::error!(target: "tn::tasks", "{}: Sub-Task Manager {name} returned exited, node exiting", self.name);
+                    if !rx_shutdown.noticed() {
+                        tracing::error!(target: "tn::tasks", "{}: Sub-Task Manager {name} returned exited, node exiting", self.name);
+                    }
                     result = res;
                     break;
                 }


### PR DESCRIPTION
This is intended as a precursor PR to cantina 1045 (and maybe others).  It attempts to close race conditions at the epoch boundaries.
In addition to the consensus_bus lifetime change this PR also fixes the task manager to drop any async tasks it spawned when a TaskManger is dropped.