### PR TITLE
Fix a regression in test speed, don't call test_genesis() in loops.

### DIFF
--- a/crates/consensus/primary/src/test_utils/helpers.rs
+++ b/crates/consensus/primary/src/test_utils/helpers.rs
@@ -9,13 +9,18 @@ use rand::{
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     ops::RangeInclusive,
+    sync::Arc,
 };
 use tempfile::TempDir;
-use tn_reth::test_utils::{batch, TransactionFactory};
+use tn_reth::{
+    test_utils::{batch, TransactionFactory},
+    RethChainSpec,
+};
 use tn_types::{
-    test_chain_spec_arc, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash,
-    BlsKeypair, BlsSignature, Bytes, Certificate, CertificateDigest, Committee, Epoch, ExecHeader,
-    Hash as _, HeaderBuilder, ProtocolSignature, Round, TimestampSec, VotingPower, WorkerId, U256,
+    test_chain_spec_arc, test_genesis, to_intent_message, Address, AuthorityIdentifier, Batch,
+    BlockHash, BlsKeypair, BlsSignature, Bytes, Certificate, CertificateDigest, Committee, Epoch,
+    ExecHeader, Hash as _, HeaderBuilder, ProtocolSignature, Round, TimestampSec, VotingPower,
+    WorkerId, U256,
 };
 
 pub fn temp_dir() -> TempDir {
@@ -36,8 +41,9 @@ pub fn random_key() -> BlsKeypair {
 pub fn fixture_payload(number_of_batches: u8) -> IndexMap<BlockHash, (WorkerId, TimestampSec)> {
     let mut payload: IndexMap<BlockHash, (WorkerId, TimestampSec)> = IndexMap::new();
 
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
     for _ in 0..number_of_batches {
-        let batch_digest = batch().digest();
+        let batch_digest = batch(chain.clone()).digest();
 
         payload.insert(batch_digest, (0, 0));
     }

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -169,7 +169,7 @@ mod tests {
     use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};
     use tn_reth::test_utils::transaction;
     use tn_storage::open_db;
-    use tn_types::{BlsKeypair, BlsPublicKey, TaskManager};
+    use tn_types::{test_chain_spec_arc, BlsKeypair, BlsPublicKey, TaskManager};
     use tokio::sync::{mpsc, Mutex};
 
     #[tokio::test]
@@ -177,8 +177,9 @@ mod tests {
         let mut network = TestRequestBatchesNetwork::new();
         let temp_dir = TempDir::new().unwrap();
         let batch_store = open_db(temp_dir.path());
-        let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
+        let chain = test_chain_spec_arc();
+        let batch1 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch2 = Batch { transactions: vec![transaction(chain)], ..Default::default() };
         let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest()]);
         network.put(&[1, 2], batch1.clone()).await;
         network.put(&[2, 3], batch2.clone()).await;
@@ -219,9 +220,10 @@ mod tests {
         let mut network = TestRequestBatchesNetwork::new();
         let temp_dir = TempDir::new().unwrap();
         let batch_store = open_db(temp_dir.path());
-        let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
+        let chain = test_chain_spec_arc();
+        let batch1 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch2 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch3 = Batch { transactions: vec![transaction(chain)], ..Default::default() };
         let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
         for batch in &[&batch1, &batch2, &batch3] {
             batch_store.insert::<Batches>(&batch.digest(), batch).unwrap();
@@ -250,9 +252,10 @@ mod tests {
         let mut network = TestRequestBatchesNetwork::new();
         let temp_dir = TempDir::new().unwrap();
         let batch_store = open_db(temp_dir.path());
-        let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
+        let chain = test_chain_spec_arc();
+        let batch1 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch2 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch3 = Batch { transactions: vec![transaction(chain)], ..Default::default() };
         let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
         network.put(&[3, 4], batch1.clone()).await;
         network.put(&[2, 3], batch2.clone()).await;
@@ -287,9 +290,10 @@ mod tests {
         let mut network = TestRequestBatchesNetwork::new();
         let temp_dir = TempDir::new().unwrap();
         let batch_store = open_db(temp_dir.path());
-        let batch1 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch2 = Batch { transactions: vec![transaction()], ..Default::default() };
-        let batch3 = Batch { transactions: vec![transaction()], ..Default::default() };
+        let chain = test_chain_spec_arc();
+        let batch1 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch2 = Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
+        let batch3 = Batch { transactions: vec![transaction(chain)], ..Default::default() };
         let digests = HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]);
         batch_store.insert::<Batches>(&batch1.digest(), &batch1).unwrap();
         network.put(&[1, 2, 3], batch1.clone()).await;
@@ -333,8 +337,10 @@ mod tests {
         let mut expected_batches = Vec::new();
         let mut local_digests = Vec::new();
         // 6 batches available locally with response size limit of 2
+        let chain = test_chain_spec_arc();
         for _i in 0..num_digests / 2 {
-            let batch = Batch { transactions: vec![transaction()], ..Default::default() };
+            let batch =
+                Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
             local_digests.push(batch.digest());
             batch_store.insert::<Batches>(&batch.digest(), &batch).unwrap();
             network.put(&[1, 2, 3], batch.clone()).await;
@@ -342,7 +348,8 @@ mod tests {
         }
         // 6 batches available remotely with response size limit of 2
         for _i in (num_digests / 2)..num_digests {
-            let batch = Batch { transactions: vec![transaction()], ..Default::default() };
+            let batch =
+                Batch { transactions: vec![transaction(chain.clone())], ..Default::default() };
             network.put(&[1, 2, 3], batch.clone()).await;
             expected_batches.push(batch);
         }

--- a/crates/consensus/worker/src/tests/batch_provider_tests.rs
+++ b/crates/consensus/worker/src/tests/batch_provider_tests.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 use tn_network_types::MockWorkerToPrimary;
 use tn_reth::test_utils::transaction;
 use tn_storage::open_db;
-use tn_types::Batch;
+use tn_types::{test_chain_spec_arc, Batch};
 
 #[tokio::test]
 async fn make_batch() {
@@ -35,7 +35,8 @@ async fn make_batch() {
     );
 
     // Send enough transactions to seal a batch.
-    let tx = transaction();
+    let chain = test_chain_spec_arc();
+    let tx = transaction(chain);
     let new_batch = Batch { transactions: vec![tx.clone(), tx.clone()], ..Default::default() };
 
     batch_provider.seal(new_batch.clone().seal_slow()).await.unwrap();

--- a/crates/consensus/worker/src/tests/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/src/tests/quorum_waiter_tests.rs
@@ -6,7 +6,7 @@ use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};
 use tn_reth::test_utils::batch;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::TaskManager;
+use tn_types::{test_chain_spec_arc, TaskManager};
 use tokio::sync::mpsc;
 
 #[tokio::test]
@@ -31,7 +31,8 @@ async fn wait_for_quorum() {
         QuorumWaiter::new(my_primary.authority().clone(), committee.clone(), network, node_metrics);
 
     // Make a batch.
-    let sealed_batch = batch().seal_slow();
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain.clone()).seal_slow();
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
     let attest_handle = quorum_waiter.verify_batch(
@@ -58,7 +59,7 @@ async fn wait_for_quorum() {
     assert!(attest_handle.await.unwrap().is_ok());
 
     // Send a second batch.
-    let sealed_batch2 = batch().seal_slow();
+    let sealed_batch2 = batch(chain).seal_slow();
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
     let attest2_handle = quorum_waiter.verify_batch(

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -386,8 +386,9 @@ async fn test_empty_output_executes_late_finalize() -> eyre::Result<()> {
 async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().expect("temp dir");
     // create batches for consensus output
-    let mut batches_1 = tn_reth::test_utils::batches(4); // create 4 batches
-    let mut batches_2 = tn_reth::test_utils::batches(4); // create 4 batches
+    let chain = test_chain_spec_arc();
+    let mut batches_1 = tn_reth::test_utils::batches(chain.clone(), 4); // create 4 batches
+    let mut batches_2 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
 
     // add eip1559 transactions to set max priority fee per gas so batch producer earns fees
     let genesis = test_genesis();
@@ -834,8 +835,9 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
 async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().unwrap();
     // create batches for consensus output
-    let mut batches_1 = tn_reth::test_utils::batches(4); // create 4 batches
-    let mut batches_2 = tn_reth::test_utils::batches(4); // create 4 batches
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+    let mut batches_1 = tn_reth::test_utils::batches(chain.clone(), 4); // create 4 batches
+    let mut batches_2 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
 
     // add eip1559 transactions to set max priority fee per gas so batch producer earns fees
     let genesis = test_genesis();
@@ -1337,8 +1339,9 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
 async fn test_max_round_terminates_early() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().unwrap();
     // create batches for consensus output
-    let mut batches_1 = tn_reth::test_utils::batches(4); // create 4 batches
-    let mut batches_2 = tn_reth::test_utils::batches(4); // create 4 batches
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+    let mut batches_1 = tn_reth::test_utils::batches(chain.clone(), 4); // create 4 batches
+    let mut batches_2 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
 
     // okay to clone these because they are only used to seed genesis, decode transactions, and
     // recover signers

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -104,6 +104,7 @@ impl<DB: Database> AuthorityFixture<DB> {
         db: DB,
         worker: WorkerFixture,
         network_config: NetworkConfig,
+        mut config: Config,
     ) -> Self {
         let (primary_keypair, key_config) = keys;
         // Make sure our keys are correct.
@@ -112,7 +113,6 @@ impl<DB: Database> AuthorityFixture<DB> {
         // Currently only support one worker per node.
         // If/when this is relaxed then the key_config below will need to change.
         assert_eq!(number_of_workers.get(), 1);
-        let mut config = Config::default_for_test();
         // These key updates don't return errors...
         let _ = config.update_protocol_key(key_config.primary_public_key());
         let _ = config.update_primary_network_key(key_config.primary_network_public_key());

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -9,7 +9,7 @@ use std::{
     marker::PhantomData,
     num::NonZeroUsize,
 };
-use tn_config::{KeyConfig, NetworkConfig};
+use tn_config::{Config, KeyConfig, NetworkConfig};
 use tn_types::{
     get_available_udp_port, Address, Authority, AuthorityIdentifier, BlsKeypair, BootstrapServer,
     Committee, Database, Epoch, Multiaddr, TimestampSec, VotingPower, DEFAULT_WORKER_PORT,
@@ -174,6 +174,7 @@ where
             0,
             bootstrap_servers,
         );
+        let config = Config::default_for_test();
         // All the authorities use the same worker cache.
         let authorities: BTreeMap<AuthorityIdentifier, AuthorityFixture<DB>> = committee_info
             .into_iter()
@@ -188,6 +189,7 @@ where
                         (self.new_db)(),
                         worker,
                         network_config,
+                        config.clone(),
                     ),
                 )
             })

--- a/crates/test-utils/src/consensus.rs
+++ b/crates/test-utils/src/consensus.rs
@@ -7,8 +7,8 @@ use std::{
     ops::RangeInclusive,
 };
 use tn_types::{
-    now, AuthorityIdentifier, Batch, BlockHash, Certificate, CertificateDigest, Database,
-    Hash as _, HeaderBuilder, Round, TimestampSec, WorkerId,
+    now, test_chain_spec_arc, AuthorityIdentifier, Batch, BlockHash, Certificate,
+    CertificateDigest, Database, Hash as _, HeaderBuilder, Round, TimestampSec, WorkerId,
 };
 
 /// Create a random number of batches with signed transactions.
@@ -20,8 +20,9 @@ fn random_batches(
         IndexMap::with_capacity(number_of_batches);
     let mut batches = HashMap::with_capacity(number_of_batches);
 
+    let chain = test_chain_spec_arc();
     for _ in 0..number_of_batches {
-        let batch = tn_reth::test_utils::batch();
+        let batch = tn_reth::test_utils::batch(chain.clone());
         let batch_digest = batch.digest();
 
         payload.insert(batch_digest, (0, 0));


### PR DESCRIPTION
test_genesis() is more complete now and should not be called in loops in tests.  This will slow them down a lot.