### PR TITLE
Re-propose headers when no progress is being made.

### DIFF
--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -315,7 +315,7 @@ impl<DB: Database> Certifier<DB> {
                 },
                 _ = rx_headers.recv() => {
                     warn!(target: "primary::certifier", ?authority_id, "canceling Header proposal {header} for round {}", header.round());
-                    // This allows us to inturupt the propose_header future- just put it back on the headers channel to get picked up in outer select.
+                    // This allows us to interupt the propose_header future- just put it back on the headers channel to get picked up in outer select.
                     let _ = self.consensus_bus.headers().send(header).await;
                     return Err(DagError::Canceled)
                 },

--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -92,6 +92,7 @@ impl<DB: Database> Primary<DB> {
                 config.authority_id().expect("CVV has an auth id"),
                 consensus_bus.clone(),
                 leader_schedule,
+                task_manager.get_spawner(),
             );
 
             proposer.spawn(task_manager);

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -14,14 +14,15 @@ async fn test_empty_proposal() {
 
     let cb = ConsensusBus::new();
     let mut rx_headers = cb.headers().subscribe();
+    let task_manager = TaskManager::default();
     let proposer = Proposer::new(
         primary.consensus_config(),
         primary.consensus_config().authority_id().expect("authority"),
         cb.clone(),
         LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
     );
 
-    let task_manager = TaskManager::default();
     proposer.spawn(&task_manager);
 
     // Ensure the proposer makes a correct empty header.
@@ -48,14 +49,15 @@ async fn test_equivocation_protection_after_restart() {
     // Spawn the proposer.
     let cb = ConsensusBus::new();
     let mut rx_headers = cb.headers().subscribe();
+    let mut task_manager = TaskManager::default();
     let proposer = Proposer::new(
         primary.consensus_config(),
         primary.consensus_config().authority_id().expect("authority"),
         cb.clone(),
         LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
     );
 
-    let mut task_manager = TaskManager::default();
     proposer.spawn(&task_manager);
 
     // Send enough digests for the header payload.
@@ -95,14 +97,15 @@ async fn test_equivocation_protection_after_restart() {
 
     let cb = ConsensusBus::new();
     let mut rx_headers = cb.headers().subscribe();
+    let task_manager = TaskManager::default();
     let proposer = Proposer::new(
         primary.consensus_config(),
         primary.consensus_config().authority_id().expect("authority"),
         cb.clone(),
         LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
     );
 
-    let task_manager = TaskManager::default();
     proposer.spawn(&task_manager);
 
     // Send enough digests for the header payload.


### PR DESCRIPTION
Attempt to break a potential race when restarting the entire network (after initial startup).