### PR TITLE
Use a saturating sub call for a gas calc.

### DIFF
--- a/bin/telcoin-network/tests/it/epochs.rs
+++ b/bin/telcoin-network/tests/it/epochs.rs
@@ -67,7 +67,6 @@ async fn test_epoch_boundary_inner(
     })
     .await?;
 
-    //tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     // submit txs to: issue NFT, stake, and activate new validator
     for tx in txs {
         let mut pending = provider.send_raw_transaction(&tx).await?;

--- a/crates/types/src/primary/epoch.rs
+++ b/crates/types/src/primary/epoch.rs
@@ -230,5 +230,3 @@ mod test {
         }
     }
 }
-
-// If we have the record but not the cert then wait a beat for it to show up.


### PR DESCRIPTION
It should not really be possible to have more gas refunded than spent (?) but use a saturating sub (via a gas method) just in case.  Note no added test, we would just be testing saturating_sub which it should be safe to assume works.

https://github.com/Telcoin-Association/telcoin-network/issues/411