### PR TITLE
Dont allow a bogus vote to derail the certifier.

### DIFF
--- a/crates/consensus/primary/src/aggregators/votes.rs
+++ b/crates/consensus/primary/src/aggregators/votes.rs
@@ -5,11 +5,10 @@ use tn_primary_metrics::PrimaryMetrics;
 use tn_types::{
     ensure,
     error::{DagError, DagResult},
-    to_intent_message, AuthorityIdentifier, BlsAggregateSignature, BlsSignature, Certificate,
-    Committee, Digest, Hash as _, Header, ProtocolSignature, SignatureVerificationState,
-    ValidatorAggregateSignature, Vote, VotingPower,
+    to_intent_message, AuthorityIdentifier, BlsSignature, Certificate, Committee, Header,
+    ProtocolSignature, SignatureVerificationState, Vote, VotingPower,
 };
-use tracing::{trace, warn};
+use tracing::trace;
 
 /// Aggregates votes for a particular header to form a certificate
 pub(crate) struct VotesAggregator {
@@ -48,8 +47,21 @@ impl VotesAggregator {
             self.authorities_seen.insert(author.clone()),
             DagError::AuthorityReuse(author.to_string())
         );
+        // ensure digest matches the header
+        ensure!(vote.header_digest == header.digest(), DagError::InvalidHeaderDigest);
+        // ensure this came from a committee member and that the signature is valid
+        if let Some(auth) = committee.authority(author) {
+            ensure!(
+                vote.signature()
+                    .verify_secure(&to_intent_message(vote.header_digest), auth.protocol_key()),
+                DagError::InvalidSignature
+            );
+        } else {
+            return Err(DagError::UnknownAuthority(author.to_string()));
+        }
 
         // accumulate vote and voting power
+        // note that we have verified the vote already so are good to save and count it
         self.votes.push((author.clone(), *vote.signature()));
         self.weight += committee.voting_power_by_id(author);
 
@@ -60,49 +72,14 @@ impl VotesAggregator {
         if self.weight >= committee.quorum_threshold() {
             let mut cert =
                 Certificate::new_unverified(committee, header.clone(), self.votes.clone())?;
-            let (_, pks) = cert.signed_by(committee);
 
-            let certificate_digest: Digest<{ tn_types::DIGEST_LENGTH }> =
-                Digest::from(cert.digest());
+            trace!(target: "primary::votes_aggregator", ?cert, "certificate verified");
+            // cert signature verified
+            cert.set_signature_verification_state(SignatureVerificationState::VerifiedDirectly(
+                cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
+            ));
 
-            // check aggregate signature verification
-            if !BlsAggregateSignature::from_signature(
-                &cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
-            )
-            .verify_secure(&to_intent_message(certificate_digest), &pks[..])
-            {
-                warn!(
-                    target: "primary::votes_aggregator",
-                    ?certificate_digest,
-                    "Failed to verify aggregated sig on certificate",
-                );
-                self.votes.retain(|(id, sig)| {
-                    if let Some(auth) = committee.authority(id) {
-                        let pk = auth.protocol_key();
-                        if !sig.verify_secure(&to_intent_message(certificate_digest), pk) {
-                            warn!(target: "primary::votes_aggregator", "Invalid signature on header from authority: {}", id);
-                            self.weight -= committee.voting_power(pk);
-                            false
-                        } else {
-                            true
-                        }
-                    } else {
-                        false
-                    }
-                });
-
-                return Ok(None);
-            } else {
-                trace!(target: "primary::votes_aggregator", ?cert, "certificate verified");
-                // cert signature verified
-                cert.set_signature_verification_state(
-                    SignatureVerificationState::VerifiedDirectly(
-                        cert.aggregated_signature().ok_or(DagError::InvalidSignature)?,
-                    ),
-                );
-
-                return Ok(Some(cert));
-            }
+            return Ok(Some(cert));
         }
         Ok(None)
     }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -403,8 +403,7 @@ where
                     &header,
                     self.consensus_config.authority_id().expect("only validators can vote"),
                     self.consensus_config.key_config(),
-                )
-                .await;
+                );
                 if vote.digest() != vote_info.vote_digest() {
                     warn!(
                         "Authority {} submitted different header {:?} for voting",
@@ -432,8 +431,7 @@ where
             &header,
             self.consensus_config.authority_id().expect("only validators can vote"),
             self.consensus_config.key_config(),
-        )
-        .await;
+        );
 
         debug!(target: "primary", "Created vote {vote:?} for {} at round {}", header, header.round());
 

--- a/crates/consensus/primary/tests/it/certificate_order_test.rs
+++ b/crates/consensus/primary/tests/it/certificate_order_test.rs
@@ -46,8 +46,7 @@ async fn test_certificate_signers_are_ordered() {
         sorted_signers.push(authority.primary_public_key());
 
         let vote =
-            Vote::new(&header.clone(), authority.id(), authority.consensus_config().key_config())
-                .await;
+            Vote::new(&header.clone(), authority.id(), authority.consensus_config().key_config());
         votes.push((vote.author().clone(), *vote.signature()));
     }
 

--- a/crates/test-utils-committee/src/authority.rs
+++ b/crates/test-utils-committee/src/authority.rs
@@ -87,7 +87,7 @@ impl<DB: Database> AuthorityFixture<DB> {
 
     /// Sign a [Header] and return a [Vote] with no additional validation.
     pub fn vote(&self, header: &Header) -> Vote {
-        Vote::new_sync(header, self.id(), self.consensus_config.key_config())
+        Vote::new(header, self.id(), self.consensus_config.key_config())
     }
 
     /// Return the consensus config.

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -2,10 +2,7 @@
 
 #![warn(unused_crate_dependencies)]
 
-pub use tn_test_utils_committee::AuthorityFixture;
-pub use tn_test_utils_committee::Builder;
-pub use tn_test_utils_committee::CommitteeFixture;
-pub use tn_test_utils_committee::WorkerFixture;
+pub use tn_test_utils_committee::{AuthorityFixture, Builder, CommitteeFixture, WorkerFixture};
 mod consensus;
 pub use consensus::*;
 mod execution;

--- a/crates/types/src/primary/vote.rs
+++ b/crates/types/src/primary/vote.rs
@@ -28,16 +28,7 @@ pub struct Vote {
 
 impl Vote {
     /// Create a new instance of [Vote]
-    pub async fn new<BLS: BlsSigner>(
-        header: &Header,
-        author: AuthorityIdentifier,
-        signature_service: &BLS,
-    ) -> Self {
-        Self::new_sync(header, author, signature_service)
-    }
-
-    /// Create a new instance of [Vote], sync version.
-    pub fn new_sync<BLS: BlsSigner>(
+    pub fn new<BLS: BlsSigner>(
         header: &Header,
         author: AuthorityIdentifier,
         signature_service: &BLS,


### PR DESCRIPTION
Note, the error called out in the issue https://github.com/Telcoin-Association/telcoin-network/issues/413 was not quite correct.  Returning None when it did was Ok but the function has been cleaned up to be more obvious.  Also there was the same issue with a properly bad vote, the certifier could be derailed and consensus broken for the node.