### PR TITLE
update libp2p with official upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5136,7 +5136,8 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
 dependencies = [
  "bytes",
  "either",
@@ -5165,8 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.5.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5175,8 +5177,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.5.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -5186,7 +5189,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d28e2d2def7c344170f5c6450c0dbe3dfef655610dbfde2f6ac28a527abbe36"
 dependencies = [
  "either",
  "fnv",
@@ -5203,14 +5207,15 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.12",
  "tracing",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.44.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
@@ -5224,8 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f58e37d8d6848e5c4c9e3c35c6f61133235bff2960c9c00a663b0849301221"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -5254,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -5275,8 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5302,8 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.47.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -5321,7 +5329,8 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5336,8 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.12.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5357,8 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.28.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
 dependencies = [
  "async-trait",
  "futures",
@@ -5374,7 +5385,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa762e5215919a34e31c35d4b18bf2e18566ecab7f8a3d39535f4a3068f8b62"
 dependencies = [
  "either",
  "fnv",
@@ -5395,7 +5407,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -5404,8 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.43.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b4e030c52c46c8d01559b2b8ca9b7c4185f10576016853129ca1fe5cd1a644"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5420,7 +5434,8 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5437,8 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.4.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5906,7 +5922,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -5929,20 +5945,21 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
  "futures",
+ "log",
  "pin-project 1.1.10",
  "smallvec",
- "tracing",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -6997,13 +7014,14 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 2.0.12",
- "unsigned-varint",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -10518,7 +10536,8 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/Telcoin-Association/rust-libp2p?rev=7c2c28a186f6d22bcc4f21cfefc2b53122a53a47#7c2c28a186f6d22bcc4f21cfefc2b53122a53a47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
  "futures",
  "pin-project 1.1.10",
@@ -12671,6 +12690,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ backoff = { version = "0.4.0", features = [
     "tokio_1",
 ] }
 
-# patch from v0.55
-libp2p = { git = "https://github.com/Telcoin-Association/rust-libp2p", rev = "7c2c28a186f6d22bcc4f21cfefc2b53122a53a47" }
+libp2p = { version = "0.56.0" }
 bs58 = { version = "0.5.1" }
 blake3 = { version = "1.8.2" }


### PR DESCRIPTION
- Update to libp2p v0.56.0