### PR TITLE
cantina-926: remove unused `total_fees` var during batch execution

### DIFF
--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -618,8 +618,8 @@ impl RethEnv {
                 })?;
 
             // forks are impossible
-            let _gas_used = match builder.execute_transaction(recovered.clone()) {
-                Ok(gas_used) => gas_used,
+            match builder.execute_transaction(recovered.clone()) {
+                Ok(_gas_used) => (),
                 Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                     error,
                     ..
@@ -632,7 +632,7 @@ impl RethEnv {
                 }
                 // this is an error that we should treat as fatal for this attempt
                 Err(err) => return Err(err.into()),
-            };
+            }
         }
 
         let BlockBuilderOutcome { execution_result, block, hashed_state, trie_updates } =


### PR DESCRIPTION
- remove unused `gas_used` var
     - TN executes after consensus, so gas fees do not influence possible forks

closes #410 