### PR TITLE
cantina-846: read next committee size from `ConsensusRegistry`

### DIFF
--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -177,6 +177,9 @@ sol!(
         function beginExit() external override whenNotPaused;
         /// Retrieve the claimable rewards accrued for a given validator address.
         function getRewards(address validatorAddress) public view virtual returns (uint256);
+        /// Returns the next committee size
+        function getNextCommitteeSize() external view returns (uint16);
+
     }
 );
 


### PR DESCRIPTION
- read next committee size at epoch boundary from on-chain state
- see precursor [tn-contracts #60](https://github.com/Telcoin-Association/tn-contracts/pull/60)

closes #438 