### PR TITLE
Fix a race that effected nodes catching up.

### DIFF
--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -19,6 +19,7 @@ pub fn execute_consensus_output(
 ) -> EngineResult<SealedHeader> {
     // rename canonical header for clarity
     let BuildArguments { reth_env, mut output, parent_header: mut canonical_header } = args;
+    gas_accumulator.rewards_counter().inc_leader_count(output.leader().origin());
     let epoch = output.leader().epoch();
     // output digest returns the `ConsensusHeader` digest
     let output_digest: B256 = output.digest().into();

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -535,13 +535,8 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     let all_batch_digests: Vec<BlockHash> = batch_digests_1.into();
 
     //=== Execution
-    // setup rewards for first two rounds of consensus
     let rewards_counter = gas_accumulator.rewards_counter();
     rewards_counter.set_committee(committee.clone());
-
-    // inc leader counter - normally performed by `EpochManager`
-    rewards_counter.inc_leader_count(consensus_output_1.leader().origin());
-    rewards_counter.inc_leader_count(consensus_output_2.leader().origin());
 
     // retrieve rewards info for current epoch
     let EpochState { epoch_info, .. } = execution_node.epoch_state_from_canonical_tip().await?;
@@ -1051,13 +1046,8 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     let all_batch_digests: Vec<BlockHash> = batch_digests_1.into();
 
     //=== Execution
-    // setup rewards for first two rounds of consensus
     let rewards_counter = gas_accumulator.rewards_counter();
     rewards_counter.set_committee(committee.clone());
-
-    // inc leader counter - normally performed by `EpochManager`
-    rewards_counter.inc_leader_count(consensus_output_1.leader().origin());
-    rewards_counter.inc_leader_count(consensus_output_2.leader().origin());
 
     // retrieve rewards info for current epoch
     let EpochState { epoch_info, .. } = execution_node.epoch_state_from_canonical_tip().await?;
@@ -1076,7 +1066,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
         parent,
         shutdown.subscribe(),
         task_manager.get_spawner(),
-        GasAccumulator::default(),
+        gas_accumulator.clone(),
     );
 
     // queue the first output - simulate already received from channel
@@ -1633,12 +1623,8 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
     let consensus_output_hash = consensus_output.consensus_header_hash();
 
     //=== Execution
-    // setup rewards for first two rounds of consensus
     let rewards_counter = gas_accumulator.rewards_counter();
     rewards_counter.set_committee(committee.clone());
-
-    // inc leader counter - normally performed by `EpochManager`
-    rewards_counter.inc_leader_count(consensus_output.leader().origin());
 
     // create engine
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -121,7 +121,6 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
             Some(output) = consensus_output.recv() => {
                 debug!(target: "gas-test", output=?output.leader(), round=output.leader().round(), "received output");
                 let leader = output.leader().origin().clone();
-                gas_accumulator.rewards_counter().inc_leader_count(&leader);
                 // manually track values as well
                 rewards.entry(leader).and_modify(|count| *count += 1).or_insert(1);
                 to_engine.send(output).await?;

--- a/crates/types/src/primary/info.rs
+++ b/crates/types/src/primary/info.rs
@@ -26,7 +26,7 @@ impl Default for NodeP2pInfo {
         // They need to work for tests though so localhost and a random port are good.
         let host = "127.0.0.1".to_string();
         let primary_udp_port = get_available_udp_port(&host).unwrap_or(49584);
-        let worker_udp_port = get_available_udp_port(&host).unwrap_or(49584);
+        let worker_udp_port = get_available_udp_port(&host).unwrap_or(49594);
 
         Self {
             primary: P2pNode {


### PR DESCRIPTION
Move the incrementing the leader into the payload builder.  It was not being incremented in one place and this makes sure it always incremented right before execution no matter how we get here.