### PR TITLE
refactor: remove monitored_future, monitored_scope, and related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,10 +2401,8 @@ version = "0.1.0"
 dependencies = [
  "axum 0.8.6",
  "futures",
- "once_cell",
  "parking_lot",
  "prometheus",
- "scopeguard",
  "tn-types",
  "tokio",
  "tracing",
@@ -11327,7 +11325,6 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state-sync"
 version = "0.1.0"
 dependencies = [
- "consensus-metrics",
  "eyre",
  "tn-config",
  "tn-primary",
@@ -11851,7 +11848,6 @@ dependencies = [
 name = "tn-executor"
 version = "0.1.0"
 dependencies = [
- "consensus-metrics",
  "eyre",
  "futures",
  "state-sync",
@@ -12173,7 +12169,6 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "consensus-metrics",
  "eyre",
  "futures",
  "prometheus",

--- a/crates/consensus/consensus-metrics/Cargo.toml
+++ b/crates/consensus/consensus-metrics/Cargo.toml
@@ -13,9 +13,7 @@ edition = "2021"
 [dependencies]
 axum = { workspace = true, default_features = false, features = ["tokio", "http2"] }
 tracing = { workspace = true }
-scopeguard = { workspace = true }
 prometheus = { workspace = true }
-once_cell = { workspace = true }
 tokio = { workspace = true }
 parking_lot = { workspace = true }
 futures = { workspace = true }

--- a/crates/consensus/consensus-metrics/src/histogram.rs
+++ b/crates/consensus/consensus-metrics/src/histogram.rs
@@ -1,6 +1,5 @@
 //! Histogram
 
-use crate::monitored_scope;
 use futures::FutureExt;
 use parking_lot::Mutex;
 use prometheus::{
@@ -253,7 +252,6 @@ impl HistogramCollector {
 
 impl HistogramReporter {
     fn report(&mut self, labeled_data: HashMap<HistogramLabels, Vec<Point>>) {
-        let _scope = monitored_scope("HistogramReporter::report");
         let mut reset_labels = self.known_labels.clone();
         for (label, mut data) in labeled_data {
             self.known_labels.insert(label.clone());

--- a/crates/consensus/consensus-metrics/src/lib.rs
+++ b/crates/consensus/consensus-metrics/src/lib.rs
@@ -4,21 +4,11 @@
 #![allow(missing_docs)]
 
 use axum::{http::StatusCode, routing::get, Router};
-use once_cell::sync::OnceCell;
-use prometheus::{
-    default_registry, register_int_gauge_vec_with_registry, IntGaugeVec, Registry, TextEncoder,
-};
-pub use scopeguard;
-use std::{
-    future::Future,
-    net::SocketAddr,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Instant,
-};
+use prometheus::{default_registry, TextEncoder};
+use std::net::SocketAddr;
 use tn_types::{Noticer, TaskManager};
 use tokio::net::TcpListener;
-use tracing::{error, warn};
+use tracing::error;
 
 mod guards;
 pub mod histogram;
@@ -28,223 +18,12 @@ pub use guards::*;
 pub const TX_TYPE_SINGLE_WRITER_TX: &str = "single_writer";
 pub const TX_TYPE_SHARED_OBJ_TX: &str = "shared_object";
 
-#[derive(Debug)]
-pub struct Metrics {
-    pub tasks: IntGaugeVec,
-    pub futures: IntGaugeVec,
-    pub channels: IntGaugeVec,
-    pub scope_iterations: IntGaugeVec,
-    pub scope_duration_ns: IntGaugeVec,
-    pub scope_entrance: IntGaugeVec,
-}
-
-impl Metrics {
-    /// Create new [Metrics] for consensus performance.
-    fn try_new(registry: &Registry) -> Result<Self, prometheus::Error> {
-        Ok(Self {
-            tasks: register_int_gauge_vec_with_registry!(
-                "monitored_tasks",
-                "Number of running tasks per callsite.",
-                &["callsite"],
-                registry,
-            )?,
-            futures: register_int_gauge_vec_with_registry!(
-                "monitored_futures",
-                "Number of pending futures per callsite.",
-                &["callsite"],
-                registry,
-            )?,
-            channels: register_int_gauge_vec_with_registry!(
-                "monitored_channels",
-                "Size of channels.",
-                &["name"],
-                registry,
-            )?,
-            scope_entrance: register_int_gauge_vec_with_registry!(
-                "monitored_scope_entrance",
-                "Number of entrance in the scope.",
-                &["name"],
-                registry,
-            )?,
-            scope_iterations: register_int_gauge_vec_with_registry!(
-                "monitored_scope_iterations",
-                "Total number of times where the monitored scope runs",
-                &["name"],
-                registry,
-            )?,
-            scope_duration_ns: register_int_gauge_vec_with_registry!(
-                "monitored_scope_duration_ns",
-                "Total duration in nanosecs where the monitored scope is running",
-                &["name"],
-                registry,
-            )?,
-        })
-    }
-}
-
-/// [OnceCell] container for consensus [Metrics].
-static METRICS: OnceCell<Metrics> = OnceCell::new();
-
-/// Set the inner [Metrics] for [OnceCell].
-fn init_metrics() {
-    if let Ok(metrics) = Metrics::try_new(default_registry()) {
-        let _ = METRICS.set(metrics).inspect_err(|_| warn!("init_metrics registry overwritten"));
-    }
-}
-
-/// Return the inner [Metrics].
-pub fn get_metrics() -> Option<&'static Metrics> {
-    METRICS.get()
-}
-
-#[macro_export]
-macro_rules! monitored_future {
-    ($fut: expr) => {{
-        monitored_future!(futures, $fut, "", INFO, false)
-    }};
-
-    ($fut: expr, $name: expr, $logging_level: ident) => {{
-        monitored_future!(futures, $fut, $name, $logging_level, false)
-    }};
-
-    ($fut: expr, $name: expr) => {{
-        monitored_future!(futures, $fut, $name, INFO, false)
-    }};
-
-    ($metric: ident, $fut: expr, $name: expr, $logging_level: ident, $logging_enabled: expr) => {{
-        let location: &str = if $name.is_empty() {
-            concat!(file!(), ':', line!())
-        } else {
-            concat!(file!(), ':', $name)
-        };
-
-        async move {
-            let metrics = consensus_metrics::get_metrics();
-
-            let _metrics_guard = if let Some(m) = metrics {
-                m.$metric.with_label_values(&[location]).inc();
-                Some(consensus_metrics::scopeguard::guard(m, |metrics| {
-                    m.$metric.with_label_values(&[location]).dec();
-                }))
-            } else {
-                None
-            };
-            let _logging_guard = if $logging_enabled {
-                Some(consensus_metrics::scopeguard::guard((), |_| {
-                    tracing::event!(
-                        tracing::Level::$logging_level,
-                        "Future {} completed",
-                        location
-                    );
-                }))
-            } else {
-                None
-            };
-
-            if $logging_enabled {
-                tracing::event!(tracing::Level::$logging_level, "Spawning future {}", location);
-            }
-
-            $fut.await
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! spawn_monitored_task {
-    ($fut: expr) => {
-        tokio::task::spawn(consensus_metrics::monitored_future!(tasks, $fut, "", INFO, false))
-    };
-}
-
-#[macro_export]
-macro_rules! spawn_logged_monitored_task {
-    ($fut: expr) => {
-        tokio::task::spawn(consensus_metrics::monitored_future!(tasks, $fut, "", INFO, true))
-    };
-
-    ($fut: expr, $name: expr) => {
-        tokio::task::spawn(consensus_metrics::monitored_future!(tasks, $fut, $name, INFO, true))
-    };
-
-    ($fut: expr, $name: expr, $logging_level: ident) => {
-        tokio::task::spawn(consensus_metrics::monitored_future!(
-            tasks,
-            $fut,
-            $name,
-            $logging_level,
-            true
-        ))
-    };
-}
-
-#[derive(Debug)]
-pub struct MonitoredScopeGuard {
-    metrics: &'static Metrics,
-    name: &'static str,
-    timer: Instant,
-}
-
-impl Drop for MonitoredScopeGuard {
-    fn drop(&mut self) {
-        self.metrics
-            .scope_duration_ns
-            .with_label_values(&[self.name])
-            .add(self.timer.elapsed().as_nanos() as i64);
-        self.metrics.scope_entrance.with_label_values(&[self.name]).dec();
-    }
-}
-
-/// This function creates a named scoped object, that keeps track of
-/// - the total iterations where the scope is called in the `monitored_scope_iterations` metric.
-/// - and the total duration of the scope in the `monitored_scope_duration_ns` metric.
-///
-/// The monitored scope should be single threaded, e.g. the scoped object encompass the lifetime of
-/// a select loop or guarded by mutex.
-/// Then the rate of `monitored_scope_duration_ns`, converted to the unit of sec / sec, would be
-/// how full the single threaded scope is running.
-pub fn monitored_scope(name: &'static str) -> Option<MonitoredScopeGuard> {
-    let metrics = get_metrics();
-    if let Some(m) = metrics {
-        m.scope_iterations.with_label_values(&[name]).inc();
-        m.scope_entrance.with_label_values(&[name]).inc();
-        Some(MonitoredScopeGuard { metrics: m, name, timer: Instant::now() })
-    } else {
-        None
-    }
-}
-
-pub trait MonitoredFutureExt: Future + Sized {
-    fn in_monitored_scope(self, name: &'static str) -> MonitoredScopeFuture<Self>;
-}
-
-impl<F: Future> MonitoredFutureExt for F {
-    fn in_monitored_scope(self, name: &'static str) -> MonitoredScopeFuture<Self> {
-        MonitoredScopeFuture { f: Box::pin(self), _scope: monitored_scope(name) }
-    }
-}
-
-#[derive(Debug)]
-pub struct MonitoredScopeFuture<F: Sized> {
-    f: Pin<Box<F>>,
-    _scope: Option<MonitoredScopeGuard>,
-}
-
-impl<F: Future> Future for MonitoredScopeFuture<F> {
-    type Output = F::Output;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.f.as_mut().poll(cx)
-    }
-}
-
 pub const METRICS_ROUTE: &str = "/metrics";
 
 /// Creates a new http server that has as a sole purpose to expose
 /// and endpoint that prometheus agent can use to poll for the metrics.
 /// A RegistryService is returned that can be used to get access in prometheus Registries.
 pub fn start_prometheus_server(addr: SocketAddr, task_manager: &TaskManager, shutdown: Noticer) {
-    init_metrics();
     let app = Router::new().route(METRICS_ROUTE, get(metrics));
 
     task_manager.spawn_critical_task("ConsensusMetrics", async move {

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -20,7 +20,6 @@ tn-network-types = { workspace = true }
 state-sync = { workspace = true }
 tn-types = { workspace = true }
 tn-config = { workspace = true }
-consensus-metrics.workspace = true
 tn-primary = { workspace = true }
 
 [dev-dependencies]

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -4,7 +4,6 @@ use crate::{
     consensus::{bullshark::Bullshark, utils::gc_round, ConsensusError, ConsensusMetrics},
     ConsensusBus, NodeMode,
 };
-use consensus_metrics::monitored_future;
 use std::{
     cmp::{max, Ordering},
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -356,10 +355,7 @@ impl<DB: Database> Consensus<DB> {
         // Only run the consensus task if we are an active CVV.
         // Active means we are participating in consensus.
         if consensus_bus.is_active_cvv() {
-            task_manager.spawn_critical_task(
-                "consensus task",
-                monitored_future!(s.run(), "Consensus", INFO),
-            );
+            task_manager.spawn_critical_task("consensus task", s.run());
         }
     }
 

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -20,7 +20,6 @@ use crate::{
     error::{ProposerError, ProposerResult},
     ConsensusBus,
 };
-use consensus_metrics::monitored_future;
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, VecDeque},
@@ -750,16 +749,10 @@ impl<DB: Database> Proposer<DB> {
 
     pub(crate) fn spawn(mut self, task_manager: &TaskManager) {
         if self.consensus_bus.is_active_cvv() {
-            task_manager.spawn_critical_task(
-                "proposer task",
-                monitored_future!(
-                    async move {
-                        info!(target: "primary::proposer", "Starting proposer");
-                        self.run().await
-                    },
-                    "ProposerTask"
-                ),
-            );
+            task_manager.spawn_critical_task("proposer task", async move {
+                info!(target: "primary::proposer", "Starting proposer");
+                self.run().await
+            });
         }
         // If not an active CVV then don't propose anything.
     }

--- a/crates/consensus/primary/src/state_handler.rs
+++ b/crates/consensus/primary/src/state_handler.rs
@@ -1,7 +1,6 @@
 //! Filter consensus results to update execution state.
 
 use crate::ConsensusBus;
-use consensus_metrics::monitored_future;
 use tn_types::{
     AuthorityIdentifier, Certificate, Noticer, Round, TaskManager, TnReceiver, TnSender,
 };
@@ -26,15 +25,9 @@ impl StateHandler {
     ) {
         let state_handler =
             Self { authority_id, consensus_bus: consensus_bus.clone(), rx_shutdown };
-        task_manager.spawn_critical_task(
-            "state handler task",
-            monitored_future!(
-                async move {
-                    state_handler.run().await;
-                },
-                "StateHandlerTask"
-            ),
-        );
+        task_manager.spawn_critical_task("state handler task", async move {
+            state_handler.run().await;
+        });
     }
 
     async fn handle_sequenced(&mut self, commit_round: Round, certificates: Vec<Certificate>) {

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -12,7 +12,6 @@ use crate::{
     state_sync::cert_validator::certificate_source,
     ConsensusBus,
 };
-use consensus_metrics::monitored_scope;
 use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
@@ -146,8 +145,6 @@ where
         &self,
         certificate: &Certificate,
     ) -> CertManagerResult<HashSet<CertificateDigest>> {
-        let _scope = monitored_scope("primary::state-sync::get_missing_parents");
-
         // handle genesis cert
         if certificate.round() == 1 {
             debug!(target: "primary::cert_manager", ?certificate, "cert round 1");
@@ -206,7 +203,6 @@ where
         &mut self,
         certificates: VecDeque<Certificate>,
     ) -> CertManagerResult<()> {
-        let _scope = monitored_scope("primary::cert_manager::accept_certificate");
         debug!(target: "primary::cert_manager", ?certificates, "accepting {:?} certificates", certificates.len());
 
         // write certificates to storage

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -8,7 +8,6 @@ use crate::{
     state_sync::CertificateManagerCommand,
     ConsensusBus,
 };
-use consensus_metrics::monitored_scope;
 use std::{collections::HashSet, sync::Arc, time::Instant};
 use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
@@ -280,7 +279,6 @@ where
         &self,
         certificates: Vec<Certificate>,
     ) -> CertManagerResult<()> {
-        let _scope = monitored_scope("primary::cert_validator");
         let certificates = self.verify_collection(certificates).await?;
 
         // update metrics

--- a/crates/consensus/primary/src/state_sync/header_validator.rs
+++ b/crates/consensus/primary/src/state_sync/header_validator.rs
@@ -2,7 +2,6 @@
 
 use super::CertificateManagerCommand;
 use crate::ConsensusBus;
-use consensus_metrics::monitored_scope;
 use futures::{stream::FuturesOrdered, StreamExt as _};
 use std::collections::HashMap;
 use tn_config::{ConsensusConfig, RetryConfig};
@@ -200,8 +199,6 @@ where
         &self,
         header: &Header,
     ) -> HeaderResult<Vec<CertificateDigest>> {
-        let _scope = monitored_scope("vote::get_unknown_parent_digests");
-
         // handle genesis
         if header.round() == 1 {
             for digest in header.parents() {

--- a/crates/consensus/worker/Cargo.toml
+++ b/crates/consensus/worker/Cargo.toml
@@ -26,7 +26,6 @@ prometheus = { workspace = true }
 eyre = { workspace = true }
 tn-network-libp2p = { workspace = true }
 serde = { workspace = true }
-consensus-metrics = { workspace = true }
 rand = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/state-sync/Cargo.toml
+++ b/crates/state-sync/Cargo.toml
@@ -17,7 +17,6 @@ tn-storage = { workspace = true }
 tn-types = { workspace = true }
 tn-config = { workspace = true }
 tn-primary = { workspace = true }
-consensus-metrics.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary                                                                
  - Remove `monitored_scope` function and `MonitoredScopeGuard`                                                                                                                                                        
  - Remove `MonitoredFutureExt` trait and `MonitoredScopeFuture`                                                                                                                                                       
  - Remove `Metrics` struct and related static initialization                                                                                                                                                            
  - Remove unused dependencies (scopeguard, once_cell) 
  
  These monitoring utilities were not being used for actual metrics collection and spawned tasks via tokio directly instead of the task manager.                                                                                                            
  Refs #508