### PR TITLE
fix JSON serialization for tn_latestHeader RPC (#375)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12149,6 +12149,7 @@ dependencies = [
  "roaring",
  "secp256k1 0.31.0",
  "serde",
+ "serde_json",
  "serde_repr",
  "serde_with 2.3.3",
  "serde_yaml",

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -51,7 +51,6 @@ where
     N: Send + Sync + 'static,
 {
     async fn latest_header(&self) -> TelcoinNetworkRpcResult<ConsensusHeader> {
-        // TODO fix me (JSON won't serialize)- issue 375.
         Ok(self.inner_node_network.get_latest_consensus_block())
     }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -45,6 +45,9 @@ hex = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [features]
 default = []
 test-utils = ["tracing-subscriber", "clap"]


### PR DESCRIPTION
## Summary      
  - Implement custom Serialize/Deserialize for AuthorityIdentifier using bs58 for JSON and raw bytes for bincode                                                                                                           
  - Add FromStr impl with proper error handling                                                                                                                                                                            
  - Remove the TODO comment in rpc_ext.rs                                                                                                                                                                                  
                                                                                                                                                                                                                           
  This fixes the root cause: any HashMap<AuthorityIdentifier, T> now serializes correctly to JSON automatically.                                                                                                           
                                                                                                                                                                                                                           
  Closes #375