### PR TITLE
fix: use sequential sub_dag_index instead of nonce for LeaderSchedule

### DIFF
--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -44,6 +44,9 @@ pub struct ConsensusState {
     pub dag: Dag,
     /// Metrics handler
     pub metrics: Arc<ConsensusMetrics>,
+    /// Next sequential sub_dag_index to assign. This counter increments by 1 for each
+    /// committed sub dag, regardless of which rounds are committed or skipped.
+    next_sub_dag_index: u64,
 }
 
 impl ConsensusState {
@@ -56,6 +59,7 @@ impl ConsensusState {
             dag: Default::default(),
             last_committed_sub_dag: None,
             metrics,
+            next_sub_dag_index: 0,
         }
     }
 
@@ -65,6 +69,7 @@ impl ConsensusState {
         gc_depth: Round,
         recovered_last_committed: HashMap<AuthorityIdentifier, Round>,
         latest_sub_dag: Option<CommittedSubDag>,
+        next_sub_dag_index: u64,
         cert_store: DB,
     ) -> Self {
         let last_round = ConsensusRound::new_with_gc_depth(last_committed_round, gc_depth);
@@ -94,6 +99,7 @@ impl ConsensusState {
             last_committed_sub_dag,
             dag,
             metrics,
+            next_sub_dag_index,
         }
     }
 
@@ -230,6 +236,14 @@ impl ConsensusState {
         }
         Ok(())
     }
+
+    /// Returns the next sequential sub_dag_index and increments the counter.
+    /// This ensures each committed sub dag gets a unique, monotonically increasing index.
+    pub fn next_sub_dag_index(&mut self) -> u64 {
+        let index = self.next_sub_dag_index;
+        self.next_sub_dag_index += 1;
+        index
+    }
 }
 
 /// Holds information about a committed round in consensus.
@@ -313,11 +327,15 @@ impl<DB: Database> Consensus<DB> {
             .map(|(_k, v)| *v)
             .unwrap_or_else(|| 0);
 
-        // ignore previous epochs
-        let latest_sub_dag = consensus_config
-            .node_storage()
-            .get_latest_sub_dag()
-            .filter(|subdag| subdag.leader_epoch() >= current_epoch);
+        // Get the global latest sub_dag_index before filtering by epoch.
+        // This ensures the sequential counter continues across epoch boundaries.
+        let global_latest_sub_dag = consensus_config.node_storage().get_latest_sub_dag();
+        let next_sub_dag_index =
+            global_latest_sub_dag.as_ref().map(|s| s.sub_dag_index() + 1).unwrap_or(0);
+
+        // ignore previous epochs for DAG reconstruction
+        let latest_sub_dag =
+            global_latest_sub_dag.filter(|subdag| subdag.leader_epoch() >= current_epoch);
 
         debug!(target: "epoch-manager", ?latest_sub_dag, "recovered latest subdag:");
         if let Some(sub_dag) = &latest_sub_dag {
@@ -337,6 +355,7 @@ impl<DB: Database> Consensus<DB> {
             consensus_config.parameters().gc_depth,
             recovered_last_committed,
             latest_sub_dag,
+            next_sub_dag_index,
             consensus_config.node_storage().clone(),
         );
 
@@ -423,7 +442,7 @@ impl<DB: Database> Consensus<DB> {
                     return Ok(());
                 }
 
-                tracing::debug!(target: "telcoin::consensus_state", "Commit in Sequence {:?}", committed_sub_dag.leader.nonce());
+                tracing::debug!(target: "telcoin::consensus_state", "Commit in Sequence {:?}", committed_sub_dag.sub_dag_index());
 
                 for certificate in &committed_sub_dag.certificates {
                     committed_certificates.push(certificate.clone());

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -252,8 +252,12 @@ async fn test_consensus_recovery_with_bullshark() {
     // AND ensure that scores are exactly the same
     assert_eq!(score_with_crash.scores_per_authority.len(), 4);
     assert_eq!(score_with_crash, score_no_crash);
+    // With sequential sub_dag_index and num_sub_dags_per_schedule = 3:
+    // - Round 2 (index 0): reset, scores = 0
+    // - Round 4 (index 1): scores = 1 (vote for round 2 leader)
+    // - Round 6 (index 2): scores = 2 (vote for round 4 leader)
     assert_eq!(
-        score_with_crash.scores_per_authority.into_iter().filter(|(_, score)| *score == 1).count(),
+        score_with_crash.scores_per_authority.into_iter().filter(|(_, score)| *score == 2).count(),
         4
     );
 }


### PR DESCRIPTION
This commit fixes issue #472 where the LeaderSchedule was using the Certificate's nonce (epoch << 32 | round) instead of a sequential subdag index for reputation score calculations.

Changes:
- Add `sub_dag_index` field to CommittedSubDag for sequential tracking
- Replace `leader.nonce()` with `state.next_sub_dag_index()` in Bullshark
- Remove the `/2` division hack that was compensating for round-based indices
- Persist sub_dag_index across epoch boundaries by recovering it from the global latest subdag before filtering by current epoch
- Add test `sub_dag_index_persists_across_epochs` to verify the fix

The sequential index ensures that:
- ReputationScores are recalculated at consistent intervals (every 60 commits)
- final_of_schedule is triggered correctly regardless of epoch changes
- LeaderSwapTable updates happen predictably