### PR TITLE
refactor(consensus): replace watch send() with send_replace() and remove stored receivers

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -124,7 +124,7 @@ where
             // We seem to be too far behind to be an active CVV, try to go
             // inactive to catch up.
             warn!(target: "primary", "we are behind, go to catchup mode!, epoch: {epoch}, exec_epoch: {exec_epoch}, number: {number:?}, exec_number: {exec_number}");
-            let _ = self.consensus_bus.node_mode().send(NodeMode::CvvInactive);
+            self.consensus_bus.node_mode().send_replace(NodeMode::CvvInactive);
             self.consensus_config.shutdown().notify();
             true
         } else {
@@ -232,10 +232,9 @@ where
                             // sure it is valid. Receivers will count on
                             // this being verified.
                             info!(target: "primary", "got new consensus {number}/{hash}");
-                            let _ = self
-                                .consensus_bus
+                            self.consensus_bus
                                 .last_published_consensus_num_hash()
-                                .send((number, hash));
+                                .send_replace((number, hash));
                             self.consensus_certs.lock().clear();
                         } else {
                             self.consensus_certs.lock().insert(consensus_result_hash, sigs + 1);
@@ -249,7 +248,7 @@ where
                         // Not sure we can sanity check this epoch.  However if it is bogus the code
                         // to handle it should be fine and will reset requested_missing_epoch to
                         // sanity.
-                        let _ = self.consensus_bus.requested_missing_epoch().send(epoch);
+                        self.consensus_bus.requested_missing_epoch().send_replace(epoch);
                     }
                 }
             }

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -408,7 +408,7 @@ impl<DB: Database> Proposer<DB> {
                 // late (or just joined the network).
                 self.round = round;
                 // broadcast new round
-                let _ = self.consensus_bus.primary_round_updates().send(self.round);
+                self.consensus_bus.primary_round_updates().send_replace(self.round);
                 self.last_parents = parents;
                 // Reset advance flag.
                 self.advance_round = false;
@@ -555,7 +555,7 @@ impl<DB: Database> Proposer<DB> {
         if updated_round > self.round {
             self.round = updated_round;
         }
-        let _ = self.consensus_bus.primary_round_updates().send(self.round);
+        self.consensus_bus.primary_round_updates().send_replace(self.round);
 
         debug!(target: "primary::proposer", authority=?self.authority_id, round=self.round, "advanced round - proposing next block...");
 

--- a/crates/consensus/primary/src/tests/consensus_bus_tests.rs
+++ b/crates/consensus/primary/src/tests/consensus_bus_tests.rs
@@ -9,10 +9,10 @@ async fn test_is_cvv() {
     // Default is CvvActive, which is a CVV
     assert!(bus.is_cvv());
 
-    bus.node_mode().send(NodeMode::CvvInactive).unwrap();
+    bus.node_mode().send_replace(NodeMode::CvvInactive);
     assert!(bus.is_cvv());
 
-    bus.node_mode().send(NodeMode::Observer).unwrap();
+    bus.node_mode().send_replace(NodeMode::Observer);
     assert!(!bus.is_cvv());
 }
 
@@ -26,13 +26,13 @@ async fn test_is_active_cvv_default() {
 #[tokio::test]
 async fn test_is_active_cvv_after_change() {
     let bus = ConsensusBus::new();
-    bus.node_mode().send(NodeMode::Observer).unwrap();
+    bus.node_mode().send_replace(NodeMode::Observer);
     assert!(!bus.is_active_cvv());
 
-    bus.node_mode().send(NodeMode::CvvInactive).unwrap();
+    bus.node_mode().send_replace(NodeMode::CvvInactive);
     assert!(!bus.is_active_cvv());
 
-    bus.node_mode().send(NodeMode::CvvActive).unwrap();
+    bus.node_mode().send_replace(NodeMode::CvvActive);
     assert!(bus.is_active_cvv());
 }
 
@@ -42,13 +42,13 @@ async fn test_is_cvv_inactive() {
     // Default is CvvActive, not inactive
     assert!(!bus.is_cvv_inactive());
 
-    bus.node_mode().send(NodeMode::CvvInactive).unwrap();
+    bus.node_mode().send_replace(NodeMode::CvvInactive);
     assert!(bus.is_cvv_inactive());
 
-    bus.node_mode().send(NodeMode::CvvActive).unwrap();
+    bus.node_mode().send_replace(NodeMode::CvvActive);
     assert!(!bus.is_cvv_inactive());
 
-    bus.node_mode().send(NodeMode::Observer).unwrap();
+    bus.node_mode().send_replace(NodeMode::Observer);
     assert!(!bus.is_cvv_inactive());
 }
 
@@ -61,7 +61,7 @@ async fn test_committed_round_default() {
 #[tokio::test]
 async fn test_committed_round_after_update() {
     let bus = ConsensusBus::new();
-    bus.committed_round_updates().send(42).unwrap();
+    bus.committed_round_updates().send_replace(42);
     assert_eq!(bus.committed_round(), 42);
 }
 
@@ -82,7 +82,7 @@ async fn test_primary_round_default() {
 #[tokio::test]
 async fn test_primary_round_after_update() {
     let bus = ConsensusBus::new();
-    bus.primary_round_updates().send(100).unwrap();
+    bus.primary_round_updates().send_replace(100);
     assert_eq!(bus.primary_round(), 100);
 }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -82,9 +82,7 @@ fn create_test_types() -> TestTypes {
     // set the latest execution result to genesis - test headers are proposed for round 1
     let mut recent = RecentBlocks::new(1);
     recent.push_latest(parent.clone());
-    cb.recent_blocks()
-        .send(recent)
-        .expect("watch channel updates for default parent in primary handler tests");
+    cb.recent_blocks().send_replace(recent);
 
     let handler = RequestHandler::new(config.clone(), cb.clone(), synchronizer);
     TestTypes { committee, handler, parent, task_manager, consensus_bus: cb }

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -201,7 +201,7 @@ async fn test_request_vote_older_execution_block() {
         certificate_store.write(cert.clone()).unwrap();
     }
 
-    let _ = cb.committed_round_updates().send(2);
+    cb.committed_round_updates().send_replace(2);
     // Trying to build on off of a missing execution block, will be an error.
     let result =
         timeout(Duration::from_secs(5), handler.vote(author_peer, test_header, Vec::new())).await;
@@ -267,7 +267,7 @@ async fn test_request_vote_has_missing_parents() {
         certificate_store.write(cert.clone()).unwrap();
     }
 
-    let _ = cb.committed_round_updates().send(1);
+    cb.committed_round_updates().send_replace(1);
     // TEST PHASE 1: Handler should report missing parent certificates to caller.
     let missing = if let PrimaryResponse::MissingParents(missing) =
         handler.vote(author_peer, test_header.clone(), Vec::new()).await.unwrap()
@@ -296,7 +296,7 @@ async fn test_request_vote_has_missing_parents() {
 
     // TEST PHASE 3: Handler should return error if header is too old.
     // Increase round threshold.
-    let _ = cb.primary_round_updates().send(100);
+    cb.primary_round_updates().send_replace(100);
     // Because round 1 certificates are not in store, the missing parents will not be accepted yet.
     let result =
         timeout(Duration::from_secs(5), handler.vote(author_peer, test_header, Vec::new()))
@@ -375,7 +375,7 @@ async fn test_request_vote_accept_missing_parents() {
         payload_store.write_payload(digest, worker_id).unwrap();
     }
 
-    let _ = cb.committed_round_updates().send(2);
+    cb.committed_round_updates().send_replace(2);
     // TEST PHASE 1: Handler should report missing parent certificates to caller.
     let missing = if let PrimaryResponse::MissingParents(missing) =
         handler.vote(author_peer, test_header.clone(), Vec::new()).await.unwrap()
@@ -453,7 +453,7 @@ async fn test_request_vote_missing_batches() {
 
     client.set_primary_to_worker_local_handler(Arc::new(mock_server));
 
-    let _ = cb.committed_round_updates().send(1);
+    cb.committed_round_updates().send_replace(1);
     // Verify Handler synchronizes missing batches and generates a Vote.
     let _vote = timeout(Duration::from_secs(5), handler.vote(author_peer, test_header, Vec::new()))
         .await
@@ -519,7 +519,7 @@ async fn test_request_vote_already_voted() {
         .with_payload_batch(fixture_batch_with_transactions(10), 0)
         .build();
 
-    let _ = cb.committed_round_updates().send(1);
+    cb.committed_round_updates().send_replace(1);
     let vote = if let PrimaryResponse::Vote(vote) = tokio::time::timeout(
         Duration::from_secs(10),
         handler.vote(author_peer, test_header.clone(), Vec::new()),
@@ -786,7 +786,7 @@ async fn test_request_vote_created_at_in_future() {
         .created_at(created_at)
         .build();
 
-    let _ = cb.committed_round_updates().send(1);
+    cb.committed_round_updates().send_replace(1);
     let _vote = if let PrimaryResponse::Vote(vote) =
         handler.vote(author_peer, test_header, Vec::new()).await.unwrap()
     {

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -224,7 +224,7 @@ where
         let consensus_bus = ConsensusBus::new_with_args(builder.tn_config.parameters.gc_depth);
         if builder.tn_config.observer {
             // Don't risk keeping the default CVV active mode...
-            let _ = consensus_bus.node_mode().send(NodeMode::Observer);
+            consensus_bus.node_mode().send_replace(NodeMode::Observer);
         }
         let worker_event_stream = QueChannel::new();
 

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -66,7 +66,7 @@ async fn get_consensus_header<DB: TNDatabase>(
                 .unwrap_or_default();
             if header.number > last_seen_header_number {
                 // Update our last seen valid consensus header if it is newer.
-                let _ = consensus_bus.last_consensus_header().send(Some(header));
+                consensus_bus.last_consensus_header().send_replace(Some(header));
             }
             Some((epoch, parent_number, parent))
         }

--- a/crates/state-sync/src/epoch.rs
+++ b/crates/state-sync/src/epoch.rs
@@ -130,7 +130,7 @@ where
                 if last_epoch < requested_epoch {
                     // Small sanity check in case someone sends a malicious large epoch restore to
                     // sanity.
-                    let _ = consensus_bus.requested_missing_epoch().send(last_epoch);
+                    consensus_bus.requested_missing_epoch().send_replace(last_epoch);
                 }
             }
             // Wait until the watch is updated to indicate we have more work to do.


### PR DESCRIPTION
## Summary

- Replace all `watch::Sender::send()` calls with `send_replace()` across the consensus layer, making channel updates infallible
- Remove 7 stored `watch::Receiver` fields from `ConsensusBusAppInner` that were only kept to prevent `send()` from failing
- Clean up now-unnecessary error handling paths (e.g. `SubscriberError::ClosedChannel` for watch channels)

Closes #529