### PR TITLE
fix(ci): align cache-deps env vars with pr workflow

### DIFF
--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings -D unused_extern_crates"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
 


### PR DESCRIPTION
## Summary

`Swatinem/rust-cache` hashes all `CARGO_*` and `RUST*` env vars into the cache key. `cache-deps.yaml` was missing `CARGO_TERM_COLOR` and `RUST_BACKTRACE` that `pr.yaml` sets, producing different env hashes (`20c1516b` vs `e5e5ea6f`). This prevented PR runs from restoring the cache warmed on main, forcing full recompilation on every PR push.

Adds the two missing env vars to `cache-deps.yaml` so both workflows produce the same cache key.