### PR TITLE
fix flaky 

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -275,6 +275,10 @@ impl Future for BatchBuilder {
 
                         // NOTE: empty vec returned for non-fatal error during block proposal
                         if mined_transactions.is_empty() {
+                            // reset interval to prevent immediate re-wake from stale tick
+                            this.max_delay_interval.reset();
+                            let _ = this.max_delay_interval.poll_tick(cx);
+
                             // return pending and wait for canonical update to wake up again
                             break;
                         }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                              
                                                                                                                                                                                                                          
  - Reset `max_delay_interval` after a non-fatal error in block proposal to prevent the stale tick from immediately re-waking the `BatchBuilder` future   . Test flaky is : test_all_possible_error_outcomes                                                                
   
  ## Problem                                                                                                                                                                                                              
                  
  When a non-fatal error occurs during block proposal (`mined_transactions.is_empty()`), the code breaks out of the loop to return `Poll::Pending`, expecting to be woken up by the next canonical state update. However,
  the `max_delay_interval` is not reset in this path — a previously elapsed tick can immediately re-wake the future, causing a spurious re-proposal attempt.

  This is the same pattern already used in the "no pending transactions" path (L252-255) but was missing here.

  This is a likely root cause for flaky test failures where the batch builder unexpectedly retries a proposal right after a non-fatal error.

  ## Fix

  Apply the same `reset()` + `poll_tick()` pattern to the non-fatal error branch, ensuring the interval is properly re-armed before returning `Pending`.

  ## Priority

  I'd suggest merging this before other pending PRs — the interval not being reset is a plausible cause of flaky CI failures.