### PR TITLE
feat: Multi-Worker Support - PR 2: Per-Worker Network Swarms

### DIFF
--- a/MULTI_WORKER_STACK_PLAN.md
+++ b/MULTI_WORKER_STACK_PLAN.md
@@ -1,0 +1,72 @@
+# Multi-Worker Stacked Branch Plan
+
+This file tracks the branch/PR stacking strategy for the multi-worker implementation.
+
+## Objective
+
+Implement multi-worker support through stacked PRs with one branch per PR, each branch based on the previous one.
+
+## Branch Naming and Stack Order
+
+1. `stack/554-config-foundation` (base: `main`)
+2. `stack/555-per-worker-swarms` (base: `stack/554-config-foundation`)
+3. `stack/556-per-worker-local-network` (base: `stack/555-per-worker-swarms`)
+4. `stack/557-epoch-manager-multi-worker-loop` (base: `stack/556-per-worker-local-network`)
+5. `stack/558-engine-initialization-multi-worker` (base: `stack/557-epoch-manager-multi-worker-loop`)
+6. `stack/559-multi-worker-tests` (base: `stack/558-engine-initialization-multi-worker`)
+
+## PR Mapping
+
+- Branch `stack/554-config-foundation` -> Issue #554
+- Branch `stack/555-per-worker-swarms` -> Issue #555
+- Branch `stack/556-per-worker-local-network` -> Issue #556
+- Branch `stack/557-epoch-manager-multi-worker-loop` -> Issue #557
+- Branch `stack/558-engine-initialization-multi-worker` -> Issue #558
+- Branch `stack/559-multi-worker-tests` -> Issue #559
+
+## Scope Per Branch
+
+### #554 Config Foundation
+- `NodeP2pInfo` transition from single worker to `workers: Vec<_>` with compatibility for old serialized format.
+- `NodeInfo` worker accessors by `WorkerId`.
+- Add `parameters.num_workers` (default `1`) and `Config::num_workers`.
+- Per-worker topic function signatures in `LibP2pConfig`.
+- Genesis validation for consistent worker count across validators.
+- Compile-safe callsite adjustments while runtime behavior remains equivalent for worker `0`.
+
+### #555 Per-Worker Swarms
+- Spawn one worker swarm per worker id.
+- Maintain `Vec<WorkerNetworkHandle>` and per-worker event streams.
+- Use worker-specific network key/address and worker-specific gossip topics.
+
+### #556 Per-Worker LocalNetwork
+- Replace single `LocalNetwork` with `Vec<LocalNetwork>`.
+- Ensure primary registers handlers on every worker local network.
+- Route worker construction with local network indexed by worker id.
+
+### #557 EpochManager Multi-Worker Loop
+- Loop worker creation and epoch orchestration over `0..num_workers`.
+- Return `Vec<WorkerNode>` from consensus creation path.
+- Update batch builder startup/orphan handling to iterate over workers.
+- Remove hardcoded `worker_id = 0` manager flow.
+
+### #558 Engine Initialization Multi-Worker
+- Initialize worker components per worker.
+- Update worker network task respawn interfaces to take all worker handles.
+- Preserve faucet attachment to worker `0` only.
+
+### #559 Multi-Worker Tests
+- Add/expand multi-worker tests and integration scenarios.
+- Keep this branch as the main testing consolidation branch for the epic.
+
+## Quality Gates
+
+- Compile checks after each branch update.
+- Targeted tests where relevant for changed area.
+- Consolidated broad tests in #559.
+
+## Notes
+
+- Keep diffs minimal and scoped to the branch issue.
+- Preserve backward behavior when `num_workers = 1`.
+- Do not perform unrelated refactors.

--- a/chain-configs/testnet/committee.yaml
+++ b/chain-configs/testnet/committee.yaml
@@ -22,27 +22,27 @@ bootstrap_servers:
     primary:
       network_address: /ip4/34.31.250.229/udp/49590/quic-v1/p2p/12D3KooWMDHuRj3E6T1bfVnDZEWJSCsrpvKDtLAryW1G71ttseYX
       network_key: 4XTTMCXyZGsWJhp9FhAEdgGQ8aoXXJbJg1Yn6hiR29FWRqRKd
-    worker:
-      network_address: /ip4/34.31.250.229/udp/49594/quic-v1/p2p/12D3KooWBR7qgvYEKh8GMkgomwTLYgrbZNkqzEem5av87afze6b7
-      network_key: 4XTTM2joVY51Jw4FvPR9DtyMAhHWG33kJ7TFzooKt9pHXbsND
+    workers:
+      - network_address: /ip4/34.31.250.229/udp/49594/quic-v1/p2p/12D3KooWBR7qgvYEKh8GMkgomwTLYgrbZNkqzEem5av87afze6b7
+        network_key: 4XTTM2joVY51Jw4FvPR9DtyMAhHWG33kJ7TFzooKt9pHXbsND
   yutgKePqdvToJeQw3ibQ51CiUgLUTjFFvchifivBSF2dnXfSXDBgkWCVMzFVkcB7B3y3B6ACDH4PVZuHZ9PvQQsq35iUKkPFykVsxARUk1NhBBhpKdUBgEvgfk1tc7gfLFY:
     primary:
       network_address: /ip4/34.102.122.126/udp/49590/quic-v1/p2p/12D3KooWHyxGM6RRgt6LLLQw1BMAdo6dPfU62sGLYsLAHbrDv7Uz
       network_key: 4XTTM9JdvCEtWJFDzMzsM8DEznPkHsLTYA5saH5jvKqTkstG6
-    worker:
-      network_address: /ip4/34.102.122.126/udp/49594/quic-v1/p2p/12D3KooWSSxajivjxX5MmpuokZHbjd6K7hhx2fPfSgkeHsb7npMs
-      network_key: 4XTTMHmeEasPpZtD1oVNDsbBRtDjybNhQ9szuAuAQL7Cekb8y
+    workers:
+      - network_address: /ip4/34.102.122.126/udp/49594/quic-v1/p2p/12D3KooWSSxajivjxX5MmpuokZHbjd6K7hhx2fPfSgkeHsb7npMs
+        network_key: 4XTTMHmeEasPpZtD1oVNDsbBRtDjybNhQ9szuAuAQL7Cekb8y
   21oDHJc5yQk1CfPoMjaG8pwfYXxGktS7HAm3MavahgoBEzVDoHwXU5jXCh4WhHCdBTxd1dKXE4JaJwHKhDKTdyiVkTHpgsq7sBq3X1ADXZC9gdU3JTLfgy7UxnjxCZZn5JrX:
     primary:
       network_address: /ip4/35.245.21.245/udp/49590/quic-v1/p2p/12D3KooWQb59v3a4Bkk4iHa9tHxA3tymHEWRhfu2gq3E5actjVuR
       network_key: 4XTTMFukomC38o7sijx2a1KqzCVdRkuVsptWGR3Sz7pERhGgX
-    worker:
-      network_address: /ip4/35.245.21.245/udp/49594/quic-v1/p2p/12D3KooWFv6FXapx9DVNWiKHoczJ2wLjuZpFMStrVH68sMqC9Fmf
-      network_key: 4XTTM7EmuNjJ2kad2YNmhvet8BXzQPEohUfW6DVVtubSj72Ym
+    workers:
+      - network_address: /ip4/35.245.21.245/udp/49594/quic-v1/p2p/12D3KooWFv6FXapx9DVNWiKHoczJ2wLjuZpFMStrVH68sMqC9Fmf
+        network_key: 4XTTM7EmuNjJ2kad2YNmhvet8BXzQPEohUfW6DVVtubSj72Ym
   23ef485gndoTaSC5tT7d7drqpn8wvK7XT46c42Hd6F24S1kcNwWm6z9CYPVeGUgR5XUmKWuCNKp8yEQxYjrPdKASNWUrj8FVMxKSAGXipx21HTWvceQRzWf89nizMCZTqBSQ:
     primary:
       network_address: /ip4/34.162.82.82/udp/49590/quic-v1/p2p/12D3KooWD3W3yw3Z7p5WhUJVSb7h9t1WsbCuoKrua7J5myKKLdke
       network_key: 4XTTM4NBhq5WdjBDAj8kuZd1XJUfBMGCMvYU9JKhqpCvrJQXk
-    worker:
-      network_address: /ip4/34.162.82.82/udp/49594/quic-v1/p2p/12D3KooWB8YJvGGvGzxgjssZEfx3PRtxu7Y8M8nYGn8t7LhRBtLv
-      network_key: 4XTTM2TDxmQjztN6LmYKyMhqsY2YdNnXaUMPmzzYe9aJx9f82
+    workers:
+      - network_address: /ip4/34.162.82.82/udp/49594/quic-v1/p2p/12D3KooWB8YJvGGvGzxgjssZEfx3PRtxu7Y8M8nYGn8t7LhRBtLv
+        network_key: 4XTTM2TDxmQjztN6LmYKyMhqsY2YdNnXaUMPmzzYe9aJx9f82

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -9,7 +9,7 @@ use std::{
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
     Authority, AuthorityIdentifier, BlsPublicKey, Certificate, CertificateDigest, Committee,
-    Database, Epoch, Hash as _, Multiaddr, NetworkPublicKey, Notifier,
+    Database, Epoch, Hash as _, Multiaddr, NetworkPublicKey, Notifier, WorkerId,
 };
 use tracing::info;
 
@@ -234,7 +234,15 @@ where
 
     /// Retrieve the worker's network address by id.
     /// Note, will panic if id is not valid.
-    pub fn worker_address(&self) -> Multiaddr {
-        self.inner.config.node_info.p2p_info.worker.network_address.clone()
+    pub fn worker_address(&self, worker_id: WorkerId) -> Multiaddr {
+        self.inner
+            .config
+            .node_info
+            .p2p_info
+            .workers
+            .get(worker_id as usize)
+            .expect("worker id out of range")
+            .network_address
+            .clone()
     }
 }

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -4,7 +4,7 @@ use crate::{ConfigFmt, ConfigTrait, TelcoinDirs};
 use libp2p::{kad::K_VALUE, request_response::ProtocolSupport, StreamProtocol};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, sync::OnceLock, time::Duration};
-use tn_types::Round;
+use tn_types::{Round, WorkerId};
 
 impl ConfigTrait for NetworkConfig {}
 
@@ -138,13 +138,13 @@ impl LibP2pConfig {
     }
 
     /// Return topics for worker.
-    pub fn worker_batch_topic() -> String {
-        String::from("tn-worker")
+    pub fn worker_batch_topic(worker_id: WorkerId) -> String {
+        format!("tn-worker-{worker_id}")
     }
 
     /// Return topics for worker.
-    pub fn worker_txn_topic() -> String {
-        String::from("tn-txn")
+    pub fn worker_txn_topic(worker_id: WorkerId) -> String {
+        format!("tn-txn-{worker_id}")
     }
 
     /// Protocol for identify behavior.

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -64,7 +64,7 @@ where
         match gossip {
             WorkerGossip::Batch(batch_hash) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic(self.id)),
                     WorkerNetworkError::InvalidTopic
                 );
                 // Retrieve the block...
@@ -91,7 +91,7 @@ where
             }
             WorkerGossip::Txn(tx_bytes) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_txn_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_txn_topic(self.id)),
                     WorkerNetworkError::InvalidTopic
                 );
                 if let Some(authority) = self.consensus_config.authority() {

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -73,7 +73,7 @@ impl WorkerNetworkHandle {
     /// Publish a batch digest to the worker network.
     pub(crate) async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Batch(batch_digest));
-        self.handle.publish(tn_config::LibP2pConfig::worker_batch_topic(), data).await?;
+        self.handle.publish(tn_config::LibP2pConfig::worker_batch_topic(0), data).await?;
         Ok(())
     }
 
@@ -81,7 +81,7 @@ impl WorkerNetworkHandle {
     /// Do this when not a committee member so a CVV can include the txn.
     pub(crate) async fn publish_txn(&self, txn: Vec<u8>) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Txn(txn));
-        self.handle.publish("tn-txn".into(), data).await?;
+        self.handle.publish(tn_config::LibP2pConfig::worker_txn_topic(0), data).await?;
         Ok(())
     }
 

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -34,6 +34,8 @@ pub(crate) type Res = WorkerResponse;
 /// The wrapper around worker-specific network calls.
 #[derive(Clone, Debug)]
 pub struct WorkerNetworkHandle {
+    /// Worker id this handle is bound to.
+    worker_id: WorkerId,
     /// The handle to the node's network.
     handle: NetworkHandle<Req, Res>,
     /// The type to spawn tasks.
@@ -45,11 +47,12 @@ pub struct WorkerNetworkHandle {
 impl WorkerNetworkHandle {
     /// Create a new instance of [Self].
     pub fn new(
+        worker_id: WorkerId,
         handle: NetworkHandle<Req, Res>,
         task_spawner: TaskSpawner,
         max_rpc_message_size: usize,
     ) -> Self {
-        Self { handle, task_spawner, max_rpc_message_size }
+        Self { worker_id, handle, task_spawner, max_rpc_message_size }
     }
 
     /// Return a reference to the task spawner.
@@ -62,7 +65,12 @@ impl WorkerNetworkHandle {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test(task_spawner: TaskSpawner) -> Self {
         let (tx, _rx) = tokio::sync::mpsc::channel(5);
-        Self { handle: NetworkHandle::new(tx), task_spawner, max_rpc_message_size: 1024 * 1024 }
+        Self {
+            worker_id: 0,
+            handle: NetworkHandle::new(tx),
+            task_spawner,
+            max_rpc_message_size: 1024 * 1024,
+        }
     }
 
     /// Return a reference to the inner handle.
@@ -73,7 +81,9 @@ impl WorkerNetworkHandle {
     /// Publish a batch digest to the worker network.
     pub(crate) async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Batch(batch_digest));
-        self.handle.publish(tn_config::LibP2pConfig::worker_batch_topic(0), data).await?;
+        self.handle
+            .publish(tn_config::LibP2pConfig::worker_batch_topic(self.worker_id), data)
+            .await?;
         Ok(())
     }
 
@@ -81,7 +91,9 @@ impl WorkerNetworkHandle {
     /// Do this when not a committee member so a CVV can include the txn.
     pub(crate) async fn publish_txn(&self, txn: Vec<u8>) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Txn(txn));
-        self.handle.publish(tn_config::LibP2pConfig::worker_txn_topic(0), data).await?;
+        self.handle
+            .publish(tn_config::LibP2pConfig::worker_txn_topic(self.worker_id), data)
+            .await?;
         Ok(())
     }
 

--- a/crates/consensus/worker/src/test_utils.rs
+++ b/crates/consensus/worker/src/test_utils.rs
@@ -63,6 +63,7 @@ impl TestRequestBatchesNetwork {
         let (tx, mut rx) = mpsc::channel(100);
         let task_manager = TaskManager::default();
         let handle = WorkerNetworkHandle::new(
+            0,
             NetworkHandle::new(tx),
             task_manager.get_spawner(),
             1024 * 1024,

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -55,7 +55,11 @@ pub fn new_worker<DB: Database>(
     info!(target: "worker::worker",
         "Worker {} successfully booted on {}",
         id,
-        consensus_config.config().node_info.p2p_info.worker.network_address
+        consensus_config
+            .config()
+            .node_info
+            .worker_network_address(id)
+            .clone()
     );
 
     batch_provider

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -188,22 +188,22 @@ async fn test_batch_gossip_topics() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
 
     // Test swapped topics, must fail.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
     let bad_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let gossip = WorkerGossip::Txn(vec![]);
     let data = tn_types::encode(&gossip);
     let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
 
     // Use the correct topic for a txn and make sure it works.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
     let good_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
 }
@@ -215,7 +215,7 @@ async fn test_batch_gossip_succeeds() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     task_manager.spawn_task("process-gossip-test", async move {
         handler.pub_process_gossip_for_test(&msg).await.expect("success process gossip");

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -42,6 +42,7 @@ fn create_test_types() -> TestTypes {
     let batch_validator = Arc::new(NoopBatchValidator);
     let (tx, network_commands_rx) = mpsc::channel(10);
     let network_handle = WorkerNetworkHandle::new(
+        worker_id,
         NetworkHandle::new(tx),
         task_manager.get_spawner(),
         config.network_config().libp2p_config().max_rpc_message_size,

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -25,6 +25,7 @@ async fn test_wait_for_quorum_happy_path() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,
@@ -75,6 +76,7 @@ async fn test_batch_rejected_timeout() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,
@@ -128,6 +130,7 @@ async fn test_batch_some_rejected_stake_still_passes() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,
@@ -197,6 +200,7 @@ async fn test_batch_rejected_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,
@@ -257,6 +261,7 @@ async fn test_batch_rejected_antiquorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,
@@ -312,6 +317,7 @@ async fn test_batch_early_anti_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network = WorkerNetworkHandle::new(
+        0,
         NetworkHandle::new(sender),
         task_manager.get_spawner(),
         max_rpc_msg_size,

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -101,8 +101,8 @@ pub(crate) struct EpochManager<P, DB> {
     tn_datadir: P,
     /// Primary network handle.
     primary_network_handle: Option<PrimaryNetworkHandle>,
-    /// Worker network handle.
-    worker_network_handle: Option<WorkerNetworkHandle>,
+    /// Worker network handles keyed by worker id.
+    worker_network_handles: Vec<WorkerNetworkHandle>,
     /// Key config - loaded once for application lifetime.
     key_config: KeyConfig,
     /// The epoch manager's [Notifier] to shutdown all node processes.
@@ -119,8 +119,8 @@ pub(crate) struct EpochManager<P, DB> {
     consensus_db: DB,
     /// ConsensusBus for the application life.
     consensus_bus: ConsensusBus,
-    /// Persistent event stream for worker network events.
-    worker_event_stream: QueChannel<NetworkEvent<WorkerRequest, WorkerResponse>>,
+    /// Persistent event streams for worker network events.
+    worker_event_streams: Vec<QueChannel<NetworkEvent<WorkerRequest, WorkerResponse>>>,
 
     /// The record for a just completed epoch.
     epoch_record: Option<EpochRecord>,
@@ -152,17 +152,12 @@ pub fn catchup_accumulator<DB: TNDatabase>(
     if let Some(block) = reth_env.finalized_header()? {
         let epoch_state = reth_env.epoch_state_from_canonical_tip()?;
 
-        // Note WORKER: In a single worker world this should be suffecient to set the base fee.
-        // In a multi-worker world (furture) this will NOT work and needs updating.
-        gas_accumulator
-            .base_fee(0)
-            .set_base_fee(block.base_fee_per_gas.unwrap_or(MIN_PROTOCOL_BASE_FEE));
-
         let nonce: u64 = block.nonce.into();
         let (current_epoch, last_executed_round) = RethEnv::deconstruct_nonce(nonce);
 
         let blocks =
             reth_env.blocks_for_range(epoch_state.epoch_info.blockHeight..=block.number)?;
+        let mut base_fees = vec![None; gas_accumulator.num_workers()];
 
         // loop through blocks to accumulate gas stats
         for current in blocks {
@@ -173,7 +168,15 @@ pub fn catchup_accumulator<DB: TNDatabase>(
             // `U256::from(payload.batch_index << 16 | payload.worker_id as usize)`
             let lower64 = current.difficulty.into_limbs()[0];
             let worker_id = (lower64 & 0xffff) as u16;
+            if let Some(base_fee) = base_fees.get_mut(worker_id as usize) {
+                *base_fee = Some(current.base_fee_per_gas.unwrap_or(MIN_PROTOCOL_BASE_FEE));
+            }
             gas_accumulator.inc_block(worker_id, gas, limit);
+        }
+        for (worker_id, base_fee) in base_fees.into_iter().enumerate() {
+            if let Some(base_fee) = base_fee {
+                gas_accumulator.base_fee(worker_id as u16).set_base_fee(base_fee);
+            }
         }
 
         // count leaders from consensus db for the current epoch
@@ -541,20 +544,20 @@ where
             // Don't risk keeping the default CVV active mode...
             consensus_bus.node_mode().send_replace(NodeMode::Observer);
         }
-        let worker_event_stream = QueChannel::new();
+        let worker_event_streams = Vec::new();
 
         Self {
             builder,
             tn_datadir,
             primary_network_handle: None,
-            worker_network_handle: None,
+            worker_network_handles: Vec::new(),
             key_config,
             node_shutdown,
             epoch_boundary: Default::default(),
             reth_db,
             consensus_db,
             consensus_bus,
-            worker_event_stream,
+            worker_event_streams,
             epoch_record: None,
         }
     }
@@ -574,9 +577,9 @@ where
         // create channels for engine that survive the lifetime of the node
         let (to_engine, for_engine) = mpsc::channel(1000);
 
-        // Create our epoch gas accumulator, we currently have one worker.
+        // Create our epoch gas accumulator from configured workers.
         // All nodes have to agree on the worker count, do not change this for an existing chain.
-        let gas_accumulator = GasAccumulator::new(1);
+        let gas_accumulator = GasAccumulator::new(self.builder.tn_config.num_workers() as usize);
         // create channel for engine updates to consensus
         let (engine_update_tx, engine_update_rx) = mpsc::channel(64);
 
@@ -700,37 +703,42 @@ where
         // primary network handle
         self.primary_network_handle = Some(PrimaryNetworkHandle::new(primary_network_handle));
 
-        // create long-running network task for worker
-        let worker_network = ConsensusNetwork::new_for_worker(
-            network_config,
-            self.worker_event_stream.clone(),
-            self.key_config.clone(),
-            self.consensus_db.clone(),
-            node_task_spawner.clone(),
-            self.builder.tn_config.node_info.worker_network_address(0).clone(),
-        )?;
-        let worker_network_handle = worker_network.network_handle();
-        let node_shutdown = self.node_shutdown.subscribe();
+        self.worker_network_handles.clear();
+        self.worker_event_streams.clear();
+        let num_workers = self.builder.tn_config.num_workers();
+        for worker_id in 0..num_workers {
+            let worker_event_stream = QueChannel::new();
+            let worker_network = ConsensusNetwork::new_for_worker(
+                network_config,
+                worker_event_stream.clone(),
+                self.key_config.clone(),
+                self.consensus_db.clone(),
+                node_task_spawner.clone(),
+                self.builder.tn_config.node_info.worker_network_address(worker_id).clone(),
+            )?;
+            let worker_network_handle = worker_network.network_handle();
+            let node_shutdown = self.node_shutdown.subscribe();
 
-        // spawn long-running primary network task
-        node_task_spawner.spawn_critical_task("Worker Network", async move {
-            tokio::select!(
-                _ = &node_shutdown => {
-                    Ok(())
-                }
-                res = worker_network.run() => {
-                    warn!(target: "epoch-manager", ?res, "worker network stopped");
-                    res
-                }
-            )
-        });
+            node_task_spawner.spawn_critical_task(format!("Worker Network {worker_id}"), async move {
+                tokio::select!(
+                    _ = &node_shutdown => {
+                        Ok(())
+                    }
+                    res = worker_network.run() => {
+                        warn!(target: "epoch-manager", worker_id, ?res, "worker network stopped");
+                        res
+                    }
+                )
+            });
 
-        // set temporary task spawner - this is updated with each epoch
-        self.worker_network_handle = Some(WorkerNetworkHandle::new(
-            worker_network_handle,
-            node_task_spawner.clone(),
-            network_config.libp2p_config().max_rpc_message_size,
-        ));
+            self.worker_network_handles.push(WorkerNetworkHandle::new(
+                worker_id,
+                worker_network_handle,
+                node_task_spawner.clone(),
+                network_config.libp2p_config().max_rpc_message_size,
+            ));
+            self.worker_event_streams.push(worker_event_stream);
+        }
 
         Ok(())
     }
@@ -982,7 +990,7 @@ where
         let mut consensus_output = self.consensus_bus.subscribe_consensus_output();
 
         // create primary and worker nodes
-        let (primary, worker_node) = self
+        let (primary, worker_nodes) = self
             .create_consensus(
                 engine,
                 &epoch_task_manager,
@@ -995,8 +1003,6 @@ where
         let consensus_shutdown = primary.shutdown_signal().await;
         let epoch_shutdown_rx = consensus_shutdown.subscribe();
 
-        // This needs to be created early so required machinery for other tasks exists when needed.
-        let mut worker = worker_node.new_worker().await?;
         let current_epoch = primary.current_committee().await.epoch();
 
         // Produce a "dummy" epoch 0 EpochRecord if missing.
@@ -1023,22 +1029,33 @@ where
         // start primary
         primary.start(&epoch_task_manager).await?;
 
-        let worker_task_manager_name = worker_task_manager_name(worker_node.id().await);
-        // start batch builder
-        worker.spawn_batch_builder(&worker_task_manager_name, &epoch_task_manager);
-
         let batch_builder_task_spawner = epoch_task_manager.get_spawner();
-        engine
-            .start_batch_builder(
-                worker.id(),
-                worker.batches_tx(),
-                &batch_builder_task_spawner,
-                gas_accumulator.base_fee(worker.id()),
-                current_epoch,
-            )
-            .await?;
+        for worker_node in worker_nodes {
+            // This needs to be created early so required machinery for other tasks exists when
+            // needed.
+            let mut worker = worker_node.new_worker().await?;
+            let worker_id = worker_node.id().await;
+            let worker_task_manager_name = worker_task_manager_name(worker_id);
+            // start batch builder
+            worker.spawn_batch_builder(&worker_task_manager_name, &epoch_task_manager);
 
-        self.orphan_batches(&epoch_task_manager, engine.clone(), worker.clone(), current_epoch)?;
+            engine
+                .start_batch_builder(
+                    worker.id(),
+                    worker.batches_tx(),
+                    &batch_builder_task_spawner,
+                    gas_accumulator.base_fee(worker.id()),
+                    current_epoch,
+                )
+                .await?;
+
+            self.orphan_batches(
+                &epoch_task_manager,
+                engine.clone(),
+                worker.clone(),
+                current_epoch,
+            )?;
+        }
 
         // update tasks
         epoch_task_manager.update_tasks();
@@ -1335,7 +1352,7 @@ where
         network_config: &NetworkConfig,
         initial_epoch: bool,
         gas_accumulator: GasAccumulator,
-    ) -> eyre::Result<(PrimaryNode<DB>, WorkerNode<DB>)> {
+    ) -> eyre::Result<(PrimaryNode<DB>, Vec<WorkerNode<DB>>)> {
         // create config for consensus
         let (consensus_config, preload_keys) =
             self.configure_consensus(engine, network_config).await?;
@@ -1351,8 +1368,7 @@ where
 
         let engine_to_primary =
             EngineToPrimaryRpc::new(primary.consensus_bus().await, self.consensus_db.clone());
-        // only spawns one worker for now
-        let worker = self
+        let workers = self
             .spawn_worker_node_components(
                 &consensus_config,
                 engine,
@@ -1367,11 +1383,13 @@ where
         let prefetches = preload_keys.clone();
         // Attempt to pre-load the next couple of committee's network info.
         let _ = primary_handle.inner_handle().find_authorities(prefetches).await;
-        let worker_handle = worker.network_handle().await;
-        let prefetches = preload_keys.clone();
-        // Attempt to pre-load the next couple of committee's network info.
-        let _ = worker_handle.inner_handle().find_authorities(prefetches).await;
-        Ok((primary, worker))
+        for worker in &workers {
+            let worker_handle = worker.network_handle().await;
+            let prefetches = preload_keys.clone();
+            // Attempt to pre-load the next couple of committee's network info.
+            let _ = worker_handle.inner_handle().find_authorities(prefetches).await;
+        }
+        Ok((primary, workers))
     }
 
     /// Configure consensus for the current epoch.
@@ -1503,59 +1521,66 @@ where
         initial_epoch: bool,
         engine_to_primary: EngineToPrimaryRpc<DB>,
         gas_accumulator: GasAccumulator,
-    ) -> eyre::Result<WorkerNode<DB>> {
-        // only support one worker for now (with id 0) - otherwise, loop here
-        let worker_id = 0;
-        let base_fee = gas_accumulator.base_fee(worker_id);
+    ) -> eyre::Result<Vec<WorkerNode<DB>>> {
+        let num_workers = self.builder.tn_config.num_workers();
+        let mut workers = Vec::with_capacity(num_workers as usize);
+        for worker_id in 0..num_workers {
+            let base_fee = gas_accumulator.base_fee(worker_id);
 
-        // update the network handle's task spawner for reporting batches in the epoch
-        {
-            let network_handle = self
-                .worker_network_handle
-                .as_mut()
-                .ok_or_eyre("worker network handle missing from epoch manager")?;
+            // update the network handle's task spawner for reporting batches in the epoch
+            {
+                let network_handle = self
+                    .worker_network_handles
+                    .get_mut(worker_id as usize)
+                    .ok_or_eyre("worker network handle missing from epoch manager")?;
 
-            network_handle.update_task_spawner(epoch_task_spawner.clone());
-            // initialize worker components on startup
-            // This will use the new epoch_task_spawner on network_handle.
-            if initial_epoch {
-                engine
-                    .initialize_worker_components(
-                        worker_id,
-                        network_handle.clone(),
-                        engine_to_primary,
-                    )
-                    .await?;
-            } else {
-                // We updated our epoch task spawner so make sure worker network tasks are
-                // restarted.
-                engine.respawn_worker_network_tasks(network_handle.clone()).await;
+                network_handle.update_task_spawner(epoch_task_spawner.clone());
+                // initialize worker components on startup
+                // This will use the new epoch_task_spawner on network_handle.
+                if initial_epoch {
+                    engine
+                        .initialize_worker_components(
+                            worker_id,
+                            network_handle.clone(),
+                            engine_to_primary.clone(),
+                        )
+                        .await?;
+                }
             }
+
+            let network_handle = self
+                .worker_network_handles
+                .get(worker_id as usize)
+                .ok_or_eyre("worker network handle missing from epoch manager")?
+                .clone();
+
+            let validator = engine
+                .new_batch_validator(&worker_id, base_fee, consensus_config.committee().epoch())
+                .await;
+            self.spawn_worker_network_for_epoch(
+                consensus_config,
+                &worker_id,
+                validator.clone(),
+                epoch_task_spawner.clone(),
+                &network_handle,
+                initial_epoch,
+            )
+            .await?;
+
+            workers.push(WorkerNode::new(
+                worker_id,
+                consensus_config.clone(),
+                network_handle.clone(),
+                validator,
+            ));
         }
 
-        let network_handle = self
-            .worker_network_handle
-            .as_ref()
-            .ok_or_eyre("worker network handle missing from epoch manager")?
-            .clone();
+        if !initial_epoch {
+            // We updated our epoch task spawner so make sure worker network tasks are restarted.
+            engine.respawn_worker_network_tasks(&self.worker_network_handles).await;
+        }
 
-        let validator = engine
-            .new_batch_validator(&worker_id, base_fee, consensus_config.committee().epoch())
-            .await;
-        self.spawn_worker_network_for_epoch(
-            consensus_config,
-            &worker_id,
-            validator.clone(),
-            epoch_task_spawner,
-            &network_handle,
-            initial_epoch,
-        )
-        .await?;
-
-        let worker =
-            WorkerNode::new(worker_id, consensus_config.clone(), network_handle.clone(), validator);
-
-        Ok(worker)
+        Ok(workers)
     }
 
     /// Create the primary network for the specific epoch.
@@ -1722,8 +1747,12 @@ where
         network_handle: &WorkerNetworkHandle,
         initial_epoch: bool,
     ) -> eyre::Result<()> {
-        // get event streams for the worker network handler
-        let rx_event_stream = self.worker_event_stream.subscribe();
+        // get event stream for this worker network handler
+        let rx_event_stream = self
+            .worker_event_streams
+            .get(*worker_id as usize)
+            .ok_or_eyre("worker event stream missing from epoch manager")?
+            .subscribe();
         debug!(target: "epoch-manager", "spawning worker network for epoch");
 
         let committee_keys: HashSet<BlsPublicKey> = consensus_config
@@ -1750,7 +1779,7 @@ where
                         .committee()
                         .bootstrap_servers()
                         .iter()
-                        .map(|(k, v)| (*k, v.worker.clone()))
+                        .map(|(k, v)| (*k, v.worker_for_id(*worker_id).clone()))
                         .collect(),
                 )
                 .await?;

--- a/crates/telcoin-network-cli/src/keytool/generate.rs
+++ b/crates/telcoin-network-cli/src/keytool/generate.rs
@@ -125,8 +125,17 @@ impl KeygenArgs {
 
         // network keypair for workers
         let network_publickey = key_config.worker_network_public_key();
-        node_info.p2p_info.worker.network_key = network_publickey.clone();
-        node_info.p2p_info.worker.network_address =
+        if node_info.p2p_info.workers.is_empty() {
+            let default_worker = NodeInfo::default()
+                .p2p_info
+                .workers
+                .into_iter()
+                .next()
+                .expect("default node info has a worker entry");
+            node_info.p2p_info.workers.push(default_worker);
+        }
+        node_info.p2p_info.workers[0].network_key = network_publickey.clone();
+        node_info.p2p_info.workers[0].network_address =
             if let Some(worker_addrs) = &self.external_worker_addrs {
                 if let Some(worker_addr) = worker_addrs.first() {
                     worker_addr.clone().with_p2p(network_publickey.into()).map_err(|_| {
@@ -145,7 +154,7 @@ impl KeygenArgs {
                 addr.with(Protocol::P2p(network_publickey.into()))
             };
 
-        info!(target: "tn::generate_keys", worker=?node_info.p2p_info.worker.network_address, "updating worker external network address");
+        info!(target: "tn::generate_keys", worker=?node_info.p2p_info.workers[0].network_address, "updating worker external network address");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Add per-worker swarm handles and network streams for independent worker networking.
- Branch: `stack/555-per-worker-swarms`

Closes #555
