### PR TITLE
Fix all the tests for the new consensus pack data store.

### DIFF
--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -278,7 +278,7 @@ impl<DB: Database> Consensus<DB> {
         consensus_bus: &ConsensusBus,
         protocol: Bullshark,
         task_manager: &TaskManager,
-        mut consensus_chain: ConsensusChain,
+        consensus_chain: ConsensusChain,
     ) {
         let rx_shutdown = consensus_config.shutdown().subscribe();
         // The consensus state (everything else is immutable).
@@ -294,10 +294,9 @@ impl<DB: Database> Consensus<DB> {
 
         // ignore previous epochs
         let latest_sub_dag = consensus_chain
-            .consensus_header_latest()
+            .latest_consensus_header_from_pack(current_epoch)
             .await
             .unwrap_or_default()
-            .filter(|h| h.sub_dag.leader_epoch() >= current_epoch)
             .map(|h| h.sub_dag);
 
         debug!(target: "epoch-manager", ?latest_sub_dag, "recovered latest subdag:");

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -808,6 +808,7 @@ async fn committed_round_after_restart() {
     };
     consensus_chain.new_epoch(previous_epoch, committee.clone()).await.unwrap();
 
+    let mut consensus_number = 0u64;
     for input_round in (1..=11usize).step_by(2) {
         let bullshark = Bullshark::new(
             committee.clone(),
@@ -850,9 +851,10 @@ async fn committed_round_after_restart() {
 
         // There should only be one new item in the output streams.
         if input_round > 1 {
+            consensus_number += 1;
             let committed = rx_output.recv().await.unwrap();
             info!("Received output from consensus, committed_round={}", committed.leader.round());
-            consensus_chain.write_subdag_for_test(input_round as u64, committed).await;
+            consensus_chain.write_subdag_for_test(consensus_number, committed).await;
             let (round, _certs) = rx_primary.recv().await.unwrap();
             info!("Received committed certificates from consensus, committed_round={round}",);
         }

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -784,8 +784,8 @@ async fn missing_leader() {
 
 /// Run for 11 dag rounds in ideal conditions (all nodes reference all other nodes).
 /// Every two rounds (on odd rounds), restart consensus and check consistency.
-//XXXX#[tokio::test]
-async fn _committed_round_after_restart() {
+#[tokio::test]
+async fn committed_round_after_restart() {
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
@@ -799,16 +799,11 @@ async fn _committed_round_after_restart() {
     let config = fixture.authorities().next().unwrap().consensus_config();
     let store = config.node_storage().clone();
     let temp_dir = TempDir::new().unwrap();
-    let mut consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
+    let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
     let previous_epoch = EpochRecord {
         epoch: committee.epoch().saturating_sub(1),
         committee: committee.bls_keys().iter().copied().collect(),
         next_committee: committee.bls_keys().iter().copied().collect(),
-        //XXXXparent_hash: prev_epoch_digest,
-        /*final_consensus: BlockNumHash {
-            number: last.map(|l| l.number).unwrap_or_default(),
-            hash: BlockHash::default(),
-        },*/
         ..Default::default()
     };
     consensus_chain.new_epoch(previous_epoch, committee.clone()).await.unwrap();
@@ -822,10 +817,6 @@ async fn _committed_round_after_restart() {
         );
 
         let cb = ConsensusBus::new();
-        /*XXXXlet mut consensus_chain =
-        ConsensusChain::new_for_test(temp_dir.path().to_owned(), config.committee().clone())
-            .await
-            .unwrap();*/
         let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
         cb.recent_blocks().send_modify(|blocks| {
             blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
@@ -1041,7 +1032,7 @@ async fn restart_with_new_committee() {
     let mut committee: Committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
     let temp_dir = TempDir::new().unwrap();
-    let mut consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
+    let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
     let mut prev_epoch_digest = BlockHash::default();
 
     // Run for a few epochs.

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -27,8 +27,8 @@ use tokio::fs::create_dir_all;
 /// * no certificates re-commit happens
 /// * no certificates are skipped
 /// * no forks created
-//XXXX#[tokio::test]
-async fn _test_consensus_recovery_with_bullshark() {
+#[tokio::test]
+async fn test_consensus_recovery_with_bullshark() {
     // GIVEN
     let num_sub_dags_per_schedule = 3;
 

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -183,13 +183,13 @@ async fn test_consensus_recovery_with_bullshark() {
     // * 4 certificates of round 1
     // * 1 certificate of round 2 (the leader)
     let mut consensus_index_counter = 2;
+    let mut pack_number = 1u64;
     let mut committed_output_before_crash: Vec<Certificate> = Vec::new();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
         assert_eq!(sub_dag.leader.round(), consensus_index_counter);
-        consensus_chain
-            .write_subdag_for_test(consensus_index_counter as u64, sub_dag.clone())
-            .await;
+        consensus_chain.write_subdag_for_test(pack_number, sub_dag.clone()).await;
+        pack_number += 1;
         for output in sub_dag.certificates() {
             assert!(output.round() <= 2);
 
@@ -217,10 +217,6 @@ async fn test_consensus_recovery_with_bullshark() {
     );
 
     let cb = ConsensusBus::new();
-    //let path3 = temp_dir.path().join("3");
-    //create_dir_all(&path3).await.unwrap();
-    //XXXXlet mut consensus_chain = ConsensusChain::new_for_test(path3,
-    // committee.clone()).await.unwrap();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.recent_blocks().send_modify(|blocks| {
         blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
@@ -244,9 +240,8 @@ async fn test_consensus_recovery_with_bullshark() {
     'main: while let Some(sub_dag) = rx_output.recv().await {
         score_with_crash = sub_dag.reputation_score.clone();
         assert_eq!(score_with_crash.total_authorities(), 4);
-        consensus_chain
-            .write_subdag_for_test(consensus_index_counter as u64, sub_dag.clone())
-            .await;
+        consensus_chain.write_subdag_for_test(pack_number, sub_dag.clone()).await;
+        pack_number += 1;
 
         for output in sub_dag.certificates() {
             assert!(output.round() >= 2);
@@ -259,7 +254,6 @@ async fn test_consensus_recovery_with_bullshark() {
                 break 'main;
             }
         }
-        consensus_index_counter += 2;
     }
 
     // THEN compare the output from a non-Crashed consensus to the outputs produced by the

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -85,6 +85,10 @@ where
     /// active. This will put us in a "catch up" mode until we have caught up enough to rejoin
     /// consensus.
     async fn behind_consensus(&self, epoch: Epoch, round: Round, number: Option<u64>) -> bool {
+        // Need to be an active cvv to have fallen behind.
+        if !self.consensus_bus.is_active_cvv() {
+            return false;
+        }
         // Last consensus block we have executed, use this to determine if we are
         // too far behind.
         let (exec_number, exec_epoch, exec_round) = self
@@ -104,7 +108,6 @@ where
         // the current DAG. Trying to ride the GC window exactly can lead to subtle races
         // (allow some time to get going).
         let gc_depth = self.consensus_config.parameters().gc_depth.saturating_sub(10);
-        let active_cvv = self.consensus_bus.is_active_cvv();
         // is our round outside the GC window
         // Will be false when not the same epoch (can't compare rounds) but
         // epoch_behind will work in that case.
@@ -125,9 +128,7 @@ where
         } else {
             epoch > exec_epoch
         };
-        // check if this node is inactive cvv and should be inactive (it is not
-        // caught up enough to be a CVV)
-        if active_cvv && (outside_gc_window || epoch_behind) {
+        if outside_gc_window || epoch_behind {
             // We seem to be too far behind to be an active CVV, try to go
             // inactive to catch up.
             warn!(
@@ -177,7 +178,7 @@ where
                 if let Some(committee) = self.get_committee(epoch) {
                     match cert.verify_cert(&committee) {
                         Ok(()) => {
-                            if self.consensus_bus.is_active_cvv() {
+                            if self.consensus_bus.is_cvv() {
                                 if self.behind_consensus(epoch, cert.header().round, None).await {
                                     warn!(target: "primary", "certificate indicates we are behind, go to catchup mode!");
                                     return Ok(());

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -89,7 +89,6 @@ where
         // too far behind.
         let (exec_number, exec_epoch, exec_round) = self
             .consensus_bus
-            //XXXX.last_consensus_block(Some(epoch), &self.consensus_chain)
             .last_consensus_block(None, &self.consensus_chain)
             .await
             .map(|h| (h.number, h.sub_dag.leader_epoch(), h.sub_dag.leader_round()))
@@ -790,7 +789,6 @@ where
 
     /// Retrieve the consensus header by number.
     async fn get_header_by_number(&self, number: u64) -> PrimaryNetworkResult<ConsensusHeader> {
-        // XXXX- need epoch for completness
         match self.consensus_chain.consensus_header_by_number(None, number).await {
             Ok(Some(header)) => Ok(header),
             _ => Err(PrimaryNetworkError::UnknownConsensusHeaderNumber(number)),
@@ -799,7 +797,6 @@ where
 
     /// Retrieve the consensus header by hash
     async fn get_header_by_hash(&self, hash: BlockHash) -> PrimaryNetworkResult<ConsensusHeader> {
-        // XXXX- need epoch for completness
         match self.consensus_chain.consensus_header_by_digest(None, hash).await {
             Ok(Some(header)) => Ok(header),
             _ => Err(PrimaryNetworkError::UnknownConsensusHeaderDigest(hash)),

--- a/crates/consensus/primary/tests/it/recovery_tests.rs
+++ b/crates/consensus/primary/tests/it/recovery_tests.rs
@@ -33,7 +33,7 @@ async fn test_subdag_persists_restart() {
 
     // Phase 1: Write data
     {
-        let mut consensus_chain =
+        let consensus_chain =
             ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone())
                 .await
                 .unwrap();
@@ -89,7 +89,7 @@ async fn test_subdag_persists_multiple_writes() {
     // Create fixture for epoch 0 (use MemDatabase for certificate generation)
     let fixture_epoch0 = CommitteeFixture::builder(MemDatabase::default).build();
     let committee_epoch0 = fixture_epoch0.committee();
-    let mut consensus_chain =
+    let consensus_chain =
         ConsensusChain::new_for_test(temp_dir.path().to_owned(), fixture_epoch0.committee())
             .await
             .unwrap();
@@ -242,7 +242,7 @@ async fn test_last_committed_persists() {
 
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
-    let mut consensus_chain =
+    let consensus_chain =
         ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone()).await.unwrap();
 
     // Create and commit subdags

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -101,7 +101,7 @@ async fn test_consensus_store_read_latest_final_reputation_scores() {
     let temp_dir = TempDir::new().unwrap();
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
-    let mut consensus_chain =
+    let consensus_chain =
         ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone()).await.unwrap();
     consensus_chain
         .new_epoch(

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -417,6 +417,19 @@ fn test_restartstt() -> eyre::Result<()> {
     do_restarts(2, false, "restarts")
 }
 
+/// Wait for `node` to reach at least `target_block`, polling every second for up to 30 seconds.
+fn wait_for_block(node: &str, target_block: u64) -> eyre::Result<()> {
+    for _ in 0..30 {
+        if let Ok(n) = get_block_number(node) {
+            if n >= target_block {
+                return Ok(());
+            }
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    Err(eyre::eyre!("Node {node} did not reach block {target_block} within 30 seconds"))
+}
+
 /// Run some test to make sure an observer is participating in the network.
 fn run_observer_tests(client_urls: &[String; 4], obs_url: &str) -> eyre::Result<()> {
     network_advancing(client_urls)?;
@@ -428,6 +441,13 @@ fn run_observer_tests(client_urls: &[String; 4], obs_url: &str) -> eyre::Result<
     test_blocks_same(client_urls)?;
     // Send to observer, validator confirms.
     send_and_confirm(obs_url, &client_urls[2], &key, to_account, 0)?;
+
+    // After the first transaction, EL block 1 exists on all validators. Wait for the observer
+    // to sync to that block before reading state from it — the observer starts at genesis and
+    // may not have caught up yet, which would cause the basefee baseline to be 0.
+    let target_block = get_block_number(&client_urls[0])?;
+    wait_for_block(obs_url, target_block)?;
+
     // Send to observer, validator confirms- second time.
     send_and_confirm(obs_url, &client_urls[3], &key, to_account, 1)?;
 

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -337,9 +337,6 @@ where
             let _ = HealthcheckServer::spawn(node_task_manager.get_spawner(), port).await;
         }
 
-        // Subscribe before the select so we don't miss a notification that fires during setup.
-        //XXXXlet node_shutdown_cancel = self.node_shutdown.subscribe();
-
         // await all tasks on epoch-task-manager or node shutdown
         let result = tokio::select! {
             // run long-living node tasks
@@ -352,12 +349,6 @@ where
 
             // loop through short-term epochs
             epoch_result = self.run_epochs(&engine, network_config, to_engine, gas_accumulator) => epoch_result,
-
-            /*XXXX// Cancel run_epochs immediately when node_shutdown fires.
-            // join_until_exit calls notify() early but doesn't return until cleanup finishes
-            // (potentially seconds later), so without this arm run_epoch can continue into
-            // a broken network after the Primary Network channel is closed.
-            _ = node_shutdown_cancel => Ok(()),*/
         };
         self.consensus_chain.persist_current().await?;
         node_task_manager.wait_for_task_shutdown().await;
@@ -873,23 +864,16 @@ where
         // Expect complaints from join so swallow those errors...
         // If we timeout here something is not playing nice and shutting down so return the
         // timeout.
-        let _ = tokio::time::timeout(
+        tokio::time::timeout(
             Duration::from_millis(500),
             epoch_task_manager.wait_for_task_shutdown(),
         )
         .await?;
         if epoch_boundary_reached {
             // The epoch is over now and consensus should be shutdown.
-            // Do a sanity check that no "extra" consensus was produced
-            // past the epoch end and clean the DB if so otherwise we
-            // could produce invalid blocks with it and fork later.
-            // This should not really happen but it is dificult to guarentee
-            // it so deal with it.
-            while let Ok(_output) = consensus_output.try_recv() {
-                if current_epoch == _output.sub_dag().leader_epoch() {
-                    eprintln!("XXXX FOUND BOGUS OUTPUT!");
-                }
-            }
+            // Do a sanity clear of the consensus_output channel.
+            // Note we probably do not need this anymore but not harmful.
+            while let Ok(_output) = consensus_output.try_recv() {}
         } else if let Some(target_hash) =
             self.send_leftover_consensus_output_to_engine(&mut consensus_output, to_engine).await
         {

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -675,7 +675,24 @@ where
                 ..Default::default()
             }
         } else {
-            return Err(eyre::eyre!("Missing previous epoch record"));
+            // The previous epoch record is missing. This can happen when a node restarts while
+            // catching up across multiple epoch boundaries - state sync feeds epoch-boundary
+            // consensus to the engine faster than the epoch record collector fetches the records
+            // from peers. Trigger the collector and wait up to 30 seconds for the record.
+            self.consensus_bus.requested_missing_epoch().send_replace(previous_epoch);
+            warn!(target: "epoch-manager", previous_epoch, current_epoch, "missing previous epoch record, waiting for epoch record collector");
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+            loop {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                if let Ok(Some(rec)) = self.consensus_db.get::<EpochRecords>(&previous_epoch) {
+                    break rec;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(eyre::eyre!(
+                        "Missing previous epoch record for epoch {previous_epoch} after waiting"
+                    ));
+                }
+            }
         };
         self.consensus_chain.new_epoch(previous_epoch_rec, committee).await?;
         Ok(())

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -176,8 +176,8 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
 /// With skip-empty-execution, rounds with no batches and no epoch close skip EVM execution.
 /// This test verifies that `catchup_accumulator` still restores leader counts and gas totals
 /// consistently when empty outputs are present in the committed consensus sequence.
-//#[tokio::test]XXXX
-async fn _test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
+#[tokio::test]
+async fn test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
     let tmp = TempDir::with_prefix("catch_acc_with_out").unwrap();
     let fixture = CommitteeFixture::builder(MemDatabase::default)
         .with_rng(StdRng::seed_from_u64(8991))
@@ -262,10 +262,19 @@ async fn _test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
         }
     }
 
+    // Wait for the subscriber to persist all real outputs so synthetic writes are sequential.
+    let expected = real_outputs.len() as u64;
+    for _ in 0..200 {
+        if consensus_chain.latest_consensus_number() >= expected {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let mut synthetic_number = consensus_chain.latest_consensus_number() + 1;
+
     // Send outputs to engine and inject deterministic empty outputs in between.
     let mut rewards = HashMap::new();
     let mut empty_outputs_seen = 0u32;
-    let mut synthetic_number = 100_000u64;
     for (i, output) in real_outputs.into_iter().enumerate() {
         let leader = output.leader().origin().clone();
         rewards.entry(leader.clone()).and_modify(|count| *count += 1).or_insert(1);
@@ -422,23 +431,6 @@ async fn test_catchup_accumulator_partial_execution() -> eyre::Result<()> {
             }
         }
     }
-
-    // Ensure consensus DB has rounds beyond what execution processed.
-    /*XXXX needs refactor
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        let has_later_rounds = consensus_store
-            .reverse_iter::<ConsensusBlocks>()
-            .any(|(_, header)| header.sub_dag.leader_round() > engine_stop_round as u32);
-        if has_later_rounds {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "timed out waiting for ConsensusBlocks entries beyond round {engine_stop_round}"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }*/
 
     let recovered = GasAccumulator::new(1);
     recovered.rewards_counter().set_committee(fixture.committee());

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -84,7 +84,6 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
 ) -> eyre::Result<()> {
     let rx_shutdown = config.shutdown().subscribe();
     let mut rx_gossip_update = consensus_bus.last_published_consensus_num_hash().subscribe();
-    let mut started_chain = false;
     let (tx, mut rx) = tokio::sync::mpsc::channel(10_000);
     let db = config.node_storage().clone();
     // Get the epoch of our last executed consensus.
@@ -129,12 +128,10 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
                             current_fetch_epoch += 1;
                         }
                     }
-                    // Once we start fetching previous consensus output don't keep doing that.
-                    // Should be self-sustaining once started.
-                    if !started_chain {
-                        let _ = tx.send(next).await;
-                        started_chain = true;
-                    }
+                    // Each gossip event starts a backward traversal from the new tip.
+                    // The traversal terminates naturally when it reaches an already-executed
+                    // or already-cached block, ensuring new consensus blocks are always cached.
+                    let _ = tx.send(next).await;
                 }
             }
 
@@ -144,13 +141,13 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
                 if let Some(next) = get_consensus_header(Some(epoch), number, hash, &config, &consensus_bus, &network, &consensus_chain).await {
                     let _ = tx.send(next).await;
                 } else {
-                    // Chain ended. If it stopped at an unprocessed block (peer fetch failed),
-                    // reset started_chain so the next gossip event restarts the backward traversal.
+                    // Chain ended (either block already executed, or peer fetch failed).
+                    // If it stopped at an unprocessed block, log a warning; the next gossip
+                    // event will start a new traversal from the latest tip.
                     let processed = consensus_bus.recent_blocks().borrow().latest_consensus_block_num_hash().number;
                     if number > processed {
                         warn!(target: "state-sync", ?number, ?epoch, ?processed,
                             "backward chain fetch failed for unprocessed block - will retry on next gossip");
-                        started_chain = false;
                     }
                 }
             }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -143,6 +143,15 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
 
                 if let Some(next) = get_consensus_header(Some(epoch), number, hash, &config, &consensus_bus, &network, &consensus_chain).await {
                     let _ = tx.send(next).await;
+                } else {
+                    // Chain ended. If it stopped at an unprocessed block (peer fetch failed),
+                    // reset started_chain so the next gossip event restarts the backward traversal.
+                    let processed = consensus_bus.recent_blocks().borrow().latest_consensus_block_num_hash().number;
+                    if number > processed {
+                        warn!(target: "state-sync", ?number, ?epoch, ?processed,
+                            "backward chain fetch failed for unprocessed block - will retry on next gossip");
+                        started_chain = false;
+                    }
                 }
             }
 

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -8,6 +8,7 @@ use std::{
     io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     sync::Arc,
+    thread::JoinHandle,
 };
 
 use parking_lot::Mutex;
@@ -32,21 +33,66 @@ enum ConsensusSlot {
     Slot2,
 }
 
-/// Manage and persist the latest consensus state.
-#[derive(Debug, Clone)]
-struct LatestConsensus {
+#[derive(Debug)]
+struct LatestConsensusInner {
     epoch: Epoch,
     number: u64,
     current_slot: ConsensusSlot,
+}
+
+/// Manage and persist the latest consensus state.
+#[derive(Debug, Clone)]
+struct LatestConsensus {
+    state: Arc<Mutex<LatestConsensusInner>>,
     tx: Sender<LatestConsenusCommand>,
+    handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl Drop for LatestConsensus {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.handle) == 1 {
+            // If we are the last ConsensusPack then shutdown thread and wait for it persist and
+            // exit.
+            if let Some(handle) = self.handle.lock().take() {
+                if self.tx.try_send(LatestConsenusCommand::Shutdown).is_ok() {
+                    let _ = handle.join();
+                }
+            }
+        }
+    }
 }
 
 enum LatestConsenusCommand {
-    Update(Epoch, u64, ConsensusSlot),
+    Update(Epoch, Epoch, u64, ConsensusSlot),
     Persist(oneshot::Sender<()>),
+    Shutdown,
 }
 
 impl LatestConsensus {
+    fn read_slot(slot: &mut File) -> Result<(Epoch, u64), ConsensusChainError> {
+        if slot.seek(SeekFrom::End(0))? == 0 {
+            Ok((0, 0))
+        } else {
+            slot.seek(SeekFrom::Start(0))?;
+            let mut buffer32_epoch = [0_u8; 4];
+            let mut buffer32_crc = [0_u8; 4];
+            let mut buffer64 = [0_u8; 8];
+            let _ = slot.read_exact(&mut buffer32_epoch);
+            let _ = slot.read_exact(&mut buffer64);
+            let _ = slot.read_exact(&mut buffer32_crc);
+            let mut crc32_hasher = crc32fast::Hasher::new();
+            crc32_hasher.update(&buffer32_epoch);
+            crc32_hasher.update(&buffer64);
+            let crc32 = crc32_hasher.finalize();
+            let crc32_read = u32::from_le_bytes(buffer32_crc);
+            if crc32 == crc32_read {
+                Ok((u32::from_le_bytes(buffer32_epoch), u64::from_le_bytes(buffer64)))
+            } else {
+                Err(ConsensusChainError::CrcError)
+            }
+        }
+    }
+
     fn new(base_path: &Path) -> Result<Self, ConsensusChainError> {
         let slot1_path = base_path.join("consensus_slot1");
         let slot2_path = base_path.join("consensus_slot2");
@@ -59,104 +105,108 @@ impl LatestConsensus {
         }
         let mut slot1 = OpenOptions::new().read(true).write(true).open(&slot1_path)?;
         let mut slot2 = OpenOptions::new().read(true).write(true).open(&slot2_path)?;
-        let mut buffer32_epoch = [0_u8; 4];
-        let mut buffer32_crc = [0_u8; 4];
-        let mut buffer64 = [0_u8; 8];
-        let _ = slot1.read_exact(&mut buffer32_epoch);
-        let _ = slot1.read_exact(&mut buffer64);
-        let _ = slot1.read_exact(&mut buffer32_crc);
-        let mut crc32_hasher = crc32fast::Hasher::new();
-        crc32_hasher.update(&buffer32_epoch);
-        crc32_hasher.update(&buffer64);
-        let crc32 = crc32_hasher.finalize();
-        let crc32_read = u32::from_le_bytes(buffer32_crc);
-        let (slot1_epoch, slot1_number) = if crc32 == crc32_read {
-            (u32::from_le_bytes(buffer32_epoch), u64::from_le_bytes(buffer64))
-        } else {
-            (0, 0)
-        };
-
-        let _ = slot2.read_exact(&mut buffer32_epoch);
-        let _ = slot2.read_exact(&mut buffer64);
-        let _ = slot2.read_exact(&mut buffer32_crc);
-        let mut crc32_hasher = crc32fast::Hasher::new();
-        crc32_hasher.update(&buffer32_epoch);
-        crc32_hasher.update(&buffer64);
-        let crc32 = crc32_hasher.finalize();
-        let crc32_read = u32::from_le_bytes(buffer32_crc);
-        let (slot2_epoch, slot2_number) = if crc32 == crc32_read {
-            (u32::from_le_bytes(buffer32_epoch), u64::from_le_bytes(buffer64))
-        } else {
-            (0, 0)
-        };
+        let (slot1_epoch, slot1_number) = Self::read_slot(&mut slot1)?;
+        let (slot2_epoch, slot2_number) = Self::read_slot(&mut slot2)?;
 
         let (tx, mut rx) = mpsc::channel(1000);
-        let me = if slot1_epoch == slot2_epoch {
-            if slot1_number > slot2_number {
-                Self {
-                    epoch: slot1_epoch,
-                    number: slot1_number,
-                    current_slot: ConsensusSlot::Slot1,
-                    tx,
-                }
-            } else {
-                Self {
-                    epoch: slot2_epoch,
-                    number: slot2_number,
-                    current_slot: ConsensusSlot::Slot2,
-                    tx,
-                }
-            }
-        } else if slot1_epoch > slot2_epoch {
-            Self {
-                epoch: slot1_epoch,
-                number: slot1_number,
-                current_slot: ConsensusSlot::Slot1,
-                tx,
-            }
-        } else {
-            Self {
-                epoch: slot2_epoch,
-                number: slot2_number,
-                current_slot: ConsensusSlot::Slot2,
-                tx,
-            }
-        };
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             while let Some(com) = rx.blocking_recv() {
                 match com {
-                    LatestConsenusCommand::Update(epoch, number, slot) => {
+                    LatestConsenusCommand::Update(old_epoch, epoch, number, slot) => {
                         let f = match slot {
                             ConsensusSlot::Slot1 => &mut slot1,
                             ConsensusSlot::Slot2 => &mut slot2,
                         };
                         let _ = f.seek(SeekFrom::Start(0));
-                        let _ = f.write_all(&epoch.to_le_bytes());
-                        let _ = f.write_all(&number.to_le_bytes());
+                        let mut buffer = [0_u8; 16];
+                        buffer[0..4].copy_from_slice(&epoch.to_le_bytes());
+                        buffer[4..12].copy_from_slice(&number.to_le_bytes());
                         let mut crc32_hasher = crc32fast::Hasher::new();
                         crc32_hasher.update(&epoch.to_le_bytes());
                         crc32_hasher.update(&number.to_le_bytes());
                         let crc32 = crc32_hasher.finalize();
-                        let _ = f.write_all(&crc32.to_le_bytes());
-                        let _ = f.sync_all();
+                        buffer[12..16].copy_from_slice(&crc32.to_le_bytes());
+                        let _ = f.write_all(&buffer);
+                        if old_epoch != epoch {
+                            let _ = f.sync_all();
+                        }
                     }
                     LatestConsenusCommand::Persist(tx) => {
+                        let _ = slot1.sync_all();
+                        let _ = slot2.sync_all();
                         let _ = tx.send(());
+                    }
+                    LatestConsenusCommand::Shutdown => {
+                        let _ = slot1.sync_all();
+                        let _ = slot2.sync_all();
+                        break;
                     }
                 }
             }
         });
+        let me = if slot1_epoch == slot2_epoch {
+            if slot1_number > slot2_number {
+                Self {
+                    state: Arc::new(Mutex::new(LatestConsensusInner {
+                        epoch: slot1_epoch,
+                        number: slot1_number,
+                        current_slot: ConsensusSlot::Slot1,
+                    })),
+                    tx,
+                    handle: Arc::new(Mutex::new(Some(handle))),
+                }
+            } else {
+                Self {
+                    state: Arc::new(Mutex::new(LatestConsensusInner {
+                        epoch: slot2_epoch,
+                        number: slot2_number,
+                        current_slot: ConsensusSlot::Slot2,
+                    })),
+                    tx,
+                    handle: Arc::new(Mutex::new(Some(handle))),
+                }
+            }
+        } else if slot1_epoch > slot2_epoch {
+            Self {
+                state: Arc::new(Mutex::new(LatestConsensusInner {
+                    epoch: slot1_epoch,
+                    number: slot1_number,
+                    current_slot: ConsensusSlot::Slot1,
+                })),
+                tx,
+                handle: Arc::new(Mutex::new(Some(handle))),
+            }
+        } else {
+            Self {
+                state: Arc::new(Mutex::new(LatestConsensusInner {
+                    epoch: slot2_epoch,
+                    number: slot2_number,
+                    current_slot: ConsensusSlot::Slot2,
+                })),
+                tx,
+                handle: Arc::new(Mutex::new(Some(handle))),
+            }
+        };
         Ok(me)
     }
 
-    async fn update(&mut self, epoch: Epoch, number: u64) {
-        self.epoch = epoch;
-        self.number = number;
-        match self.current_slot {
-            ConsensusSlot::Slot1 => self.current_slot = ConsensusSlot::Slot2,
-            ConsensusSlot::Slot2 => self.current_slot = ConsensusSlot::Slot1,
-        }
-        let _ = self.tx.send(LatestConsenusCommand::Update(epoch, number, self.current_slot)).await;
+    async fn update(&self, epoch: Epoch, number: u64) {
+        let (old_epoch, current_slot) = {
+            let mut state = self.state.lock();
+            let old_epoch = state.epoch;
+            state.epoch = epoch;
+            state.number = number;
+            match state.current_slot {
+                ConsensusSlot::Slot1 => state.current_slot = ConsensusSlot::Slot2,
+                ConsensusSlot::Slot2 => state.current_slot = ConsensusSlot::Slot1,
+            }
+            let current_slot = state.current_slot;
+            (old_epoch, current_slot)
+        };
+        let _ = self
+            .tx
+            .send(LatestConsenusCommand::Update(old_epoch, epoch, number, current_slot))
+            .await;
     }
 
     async fn persist(&self) {
@@ -164,12 +214,25 @@ impl LatestConsensus {
         let _ = self.tx.send(LatestConsenusCommand::Persist(tx)).await;
         let _ = rx.await;
     }
+
+    fn epoch(&self) -> Epoch {
+        self.state.lock().epoch
+    }
+
+    fn number(&self) -> u64 {
+        self.state.lock().number
+    }
+
+    #[cfg(test)]
+    fn current_slot(&self) -> ConsensusSlot {
+        self.state.lock().current_slot
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct ConsensusChain {
     base_path: PathBuf,
-    current_pack: Option<ConsensusPack>,
+    current_pack: Arc<Mutex<Option<ConsensusPack>>>,
     latest_consensus: LatestConsensus,
     recent_packs: Arc<Mutex<VecDeque<ConsensusPack>>>,
 }
@@ -182,8 +245,9 @@ impl ConsensusChain {
     pub async fn new(base_path: PathBuf) -> Result<ConsensusChain, ConsensusChainError> {
         let latest_consensus = LatestConsensus::new(&base_path)?;
         // If we have a pack for the last epoch open it so we can read data early.
-        let current_pack =
-            ConsensusPack::open_append_exists(&base_path, latest_consensus.epoch).ok();
+        let current_pack = Arc::new(Mutex::new(
+            ConsensusPack::open_append_exists(&base_path, latest_consensus.epoch()).ok(),
+        ));
         let recent_packs = Arc::new(Mutex::new(VecDeque::default()));
         Ok(Self { base_path, current_pack, latest_consensus, recent_packs })
     }
@@ -193,7 +257,7 @@ impl ConsensusChain {
         base_path: PathBuf,
         committee: Committee,
     ) -> Result<ConsensusChain, ConsensusChainError> {
-        let mut me = Self::new(base_path).await?;
+        let me = Self::new(base_path).await?;
         me.new_epoch(
             EpochRecord {
                 epoch: 0,
@@ -208,16 +272,15 @@ impl ConsensusChain {
     }
 
     pub async fn new_epoch(
-        &mut self,
+        &self,
         previous_epoch: EpochRecord,
         committee: Committee,
     ) -> Result<(), ConsensusChainError> {
         if previous_epoch.epoch != committee.epoch().saturating_sub(1) {
             return Err(ConsensusChainError::PrevCommitteeEpochMismatch);
         }
-        if let Some(old_pack) = self.current_pack.take() {
+        if let Some(old_pack) = self.current_pack() {
             if old_pack.epoch() == committee.epoch() {
-                self.current_pack = Some(old_pack);
                 return Ok(());
             }
             old_pack.persist().await?;
@@ -229,7 +292,7 @@ impl ConsensusChain {
         }
         let pack = ConsensusPack::open_append(&self.base_path, previous_epoch, committee)?;
         pack.persist().await?; // Surface any open errors.
-        self.current_pack = Some(pack);
+        *self.current_pack.lock() = Some(pack);
         Ok(())
     }
 
@@ -258,21 +321,15 @@ impl ConsensusChain {
     /// Save all the batches and consensus header from the ConsensusOutput the pack file for the
     /// current epoch. This should be called "in-order" as consensus is executed.
     pub async fn save_consensus_output(
-        &mut self,
+        &self,
         consensus: ConsensusOutput,
     ) -> Result<(), ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
-            if consensus.number() > self.latest_consensus.number {
+        if let Some(pack) = &self.current_pack() {
+            if consensus.number() > self.latest_consensus.number() {
                 self.latest_consensus
                     .update(consensus.sub_dag().leader_epoch(), consensus.number())
                     .await;
                 pack.save_consensus_output(consensus).await?;
-            } else {
-                eprintln!(
-                    "XXXX tried to save previous {} on {}",
-                    consensus.number(),
-                    self.latest_consensus.number
-                );
             }
             Ok(())
         } else {
@@ -285,7 +342,7 @@ impl ConsensusChain {
         &self,
         number: u64,
     ) -> Result<ConsensusOutput, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             Ok(pack.get_consensus_output(number).await?)
         } else {
             Err(ConsensusChainError::NoCurrentEpoch)
@@ -298,7 +355,7 @@ impl ConsensusChain {
         epoch: Option<Epoch>,
         digest: B256,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             if let Some(epoch) = epoch {
                 if epoch == pack.epoch() {
                     return Ok(pack.consensus_header_by_digest(digest).await);
@@ -315,7 +372,7 @@ impl ConsensusChain {
                 Ok(None)
             }
         } else {
-            let mut epoch = self.current_pack.as_ref().map(|p| p.epoch());
+            let mut epoch = self.current_pack().as_ref().map(|p| p.epoch());
             while let Some(try_epoch) = epoch {
                 if let Ok(pack) = self.get_static(try_epoch).await {
                     if let Some(header) = pack.consensus_header_by_digest(digest).await {
@@ -334,7 +391,7 @@ impl ConsensusChain {
         epoch: Option<Epoch>,
         number: u64,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             if let Some(epoch) = epoch {
                 if epoch == pack.epoch() {
                     return Ok(Some(pack.consensus_header_by_number(number).await?));
@@ -347,9 +404,7 @@ impl ConsensusChain {
             let pack = self.get_static(epoch).await?;
             Ok(Some(pack.consensus_header_by_number(number).await?))
         } else {
-            let mut epoch = self.current_pack.as_ref().map(|p| p.epoch());
-            // XXXX- TODO this is dumb, we should be able to use epoch records to deduce the epoch
-            // for number.
+            let mut epoch = self.current_pack().as_ref().map(|p| p.epoch());
             while let Some(try_epoch) = epoch {
                 if let Ok(pack) = self.get_static(try_epoch).await {
                     if let Ok(header) = pack.consensus_header_by_number(number).await {
@@ -366,49 +421,55 @@ impl ConsensusChain {
     pub async fn consensus_header_latest(
         &self,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
-            if self.latest_consensus.epoch == pack.epoch() {
-                Ok(Some(pack.consensus_header_by_number(self.latest_consensus.number).await?))
-            } else {
-                let pack = self.get_static(self.latest_consensus.epoch).await?;
-                Ok(Some(pack.consensus_header_by_number(self.latest_consensus.number).await?))
-            }
-        } else {
-            let pack = self.get_static(self.latest_consensus.epoch).await?;
-            Ok(Some(pack.consensus_header_by_number(self.latest_consensus.number).await?))
-        }
+        self.latest_consensus_header_from_pack(self.latest_consensus.epoch()).await
     }
 
     /// Return the last consensus number that was processed.
     pub fn latest_consensus_number(&self) -> u64 {
-        self.latest_consensus.number
+        self.latest_consensus.number()
     }
 
     /// Return the last consensus epoch that was processed.
     pub fn latest_consensus_epoch(&self) -> Epoch {
-        self.latest_consensus.epoch
+        self.latest_consensus.epoch()
     }
 
     /// Resolve when the current epoch is fully persisted to storage.
     pub async fn persist_current(&self) -> Result<(), ConsensusChainError> {
-        if let Some(pack) = &self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             pack.persist().await?;
         }
         self.latest_consensus.persist().await;
         Ok(())
     }
 
-    /// Read the last committed rounds for authorities from an epoch.
-    pub async fn read_last_committed(
-        &mut self,
+    /// Return the latest consensus header for `epoch` by reading directly from the pack index,
+    /// bypassing the slot files (LatestConsensus). This is always consistent with
+    /// read_last_committed and should be used during startup recovery.
+    pub async fn latest_consensus_header_from_pack(
+        &self,
         epoch: Epoch,
-    ) -> HashMap<AuthorityIdentifier, Round> {
-        if let Some(pack) = &mut self.current_pack {
+    ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
+        if let Some(pack) = &self.current_pack() {
+            if pack.epoch() == epoch {
+                return Ok(pack.latest_consensus_header().await);
+            }
+        }
+        if let Ok(pack) = self.get_static(epoch).await {
+            Ok(pack.latest_consensus_header().await)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Read the last committed rounds for authorities from an epoch.
+    pub async fn read_last_committed(&self, epoch: Epoch) -> HashMap<AuthorityIdentifier, Round> {
+        if let Some(pack) = &self.current_pack() {
             if pack.epoch() == epoch {
                 return pack.read_last_committed().await;
             }
         }
-        if let Ok(mut pack) = self.get_static(epoch).await {
+        if let Ok(pack) = self.get_static(epoch).await {
             pack.read_last_committed().await
         } else {
             HashMap::new()
@@ -417,15 +478,15 @@ impl ConsensusChain {
 
     /// Read the final committed sub dag with final reputation scores.
     pub async fn read_latest_commit_with_final_reputation_scores(
-        &mut self,
+        &self,
         epoch: Epoch,
     ) -> Option<Arc<CommittedSubDag>> {
-        if let Some(pack) = &mut self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             if pack.epoch() == epoch {
                 return pack.read_latest_commit_with_final_reputation_scores().await;
             }
         }
-        if let Ok(mut pack) = self.get_static(epoch).await {
+        if let Ok(pack) = self.get_static(epoch).await {
             pack.read_latest_commit_with_final_reputation_scores().await
         } else {
             None
@@ -436,7 +497,7 @@ impl ConsensusChain {
     /// This uses garbage parent hash and number and is ONLY for testing.
     /// As a test only function this will panic if unable to write the sub dag
     /// to the consensus chain
-    pub async fn write_subdag_for_test(&mut self, number: u64, sub_dag: Arc<CommittedSubDag>) {
+    pub async fn write_subdag_for_test(&self, number: u64, sub_dag: Arc<CommittedSubDag>) {
         let output = ConsensusOutput::new(
             sub_dag,
             BlockHash::default(),
@@ -451,8 +512,8 @@ impl ConsensusChain {
     }
 
     /// True if the current epoch pack contains the batch for digest.
-    pub async fn contains_current_batch(&mut self, digest: BlockHash) -> bool {
-        if let Some(pack) = &mut self.current_pack {
+    pub async fn contains_current_batch(&self, digest: BlockHash) -> bool {
+        if let Some(pack) = &self.current_pack() {
             pack.contains_batch(digest).await
         } else {
             false
@@ -462,20 +523,25 @@ impl ConsensusChain {
     /// Count leaders in this pack (in rewards_counter) lower than last_executed_round.
     /// This works on the current epoch/pack.
     pub async fn count_leaders(
-        &mut self,
+        &self,
         last_executed_round: Round,
         rewards_counter: RewardsCounter,
     ) -> Result<(), ConsensusChainError> {
-        if let Some(pack) = &mut self.current_pack {
+        if let Some(pack) = &self.current_pack() {
             Ok(pack.count_leaders(last_executed_round, rewards_counter).await?)
         } else {
             Err(ConsensusChainError::NoCurrentEpoch)
         }
     }
 
+    /// Return a clone of the current pack.
+    fn current_pack(&self) -> Option<ConsensusPack> {
+        self.current_pack.lock().clone()
+    }
+
     /// Get a static pack file from the cache if available or create and cache if not.
     async fn get_static(&self, epoch: Epoch) -> Result<ConsensusPack, PackError> {
-        if let Some(pack) = &self.current_pack {
+        if let Some(pack) = self.current_pack() {
             if pack.epoch() == epoch {
                 return Ok(pack.clone());
             }
@@ -505,6 +571,7 @@ pub enum ConsensusChainError {
     IO(std::io::Error),
     EpochMismatch,
     PrevCommitteeEpochMismatch,
+    CrcError,
 }
 
 impl Error for ConsensusChainError {}
@@ -520,6 +587,7 @@ impl Display for ConsensusChainError {
             ConsensusChainError::PrevCommitteeEpochMismatch => {
                 write!(f, "Current committee epoch and previous epoch not in sync")
             }
+            ConsensusChainError::CrcError => write!(f, "Crc error"),
         }
     }
 }
@@ -556,24 +624,24 @@ mod test {
     #[tokio::test]
     async fn test_consensus_store_latest_consensus() {
         let temp_dir = TempDir::with_prefix("test_latest_consensus").unwrap();
-        let mut latest = LatestConsensus::new(temp_dir.path()).unwrap();
-        assert_eq!(latest.epoch, 0);
-        assert_eq!(latest.number, 0);
-        assert_eq!(latest.current_slot, ConsensusSlot::Slot2);
+        let latest = LatestConsensus::new(temp_dir.path()).unwrap();
+        assert_eq!(latest.epoch(), 0);
+        assert_eq!(latest.number(), 0);
+        assert_eq!(latest.current_slot(), ConsensusSlot::Slot2);
         latest.update(1, 10).await;
-        assert_eq!(latest.epoch, 1);
-        assert_eq!(latest.number, 10);
-        assert_eq!(latest.current_slot, ConsensusSlot::Slot1);
+        assert_eq!(latest.epoch(), 1);
+        assert_eq!(latest.number(), 10);
+        assert_eq!(latest.current_slot(), ConsensusSlot::Slot1);
         latest.update(2, 20).await;
-        assert_eq!(latest.epoch, 2);
-        assert_eq!(latest.number, 20);
-        assert_eq!(latest.current_slot, ConsensusSlot::Slot2);
+        assert_eq!(latest.epoch(), 2);
+        assert_eq!(latest.number(), 20);
+        assert_eq!(latest.current_slot(), ConsensusSlot::Slot2);
         latest.persist().await;
         drop(latest);
         let latest = LatestConsensus::new(temp_dir.path()).unwrap();
-        assert_eq!(latest.epoch, 2);
-        assert_eq!(latest.number, 20);
-        assert_eq!(latest.current_slot, ConsensusSlot::Slot2);
+        assert_eq!(latest.epoch(), 2);
+        assert_eq!(latest.number(), 20);
+        assert_eq!(latest.current_slot(), ConsensusSlot::Slot2);
     }
 
     #[tokio::test]
@@ -591,7 +659,7 @@ mod test {
             ..Default::default()
         };
         // Create and load some data in initial file.
-        let mut consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         let num_outputs = 1000;
@@ -615,7 +683,7 @@ mod test {
         //drop(consensus_chain);
 
         let temp_dir2 = TempDir::with_prefix("test_consensus_pack2").expect("temp dir");
-        let mut consensus_chain2 = ConsensusChain::new(temp_dir2.path().to_owned()).await.unwrap();
+        let consensus_chain2 = ConsensusChain::new(temp_dir2.path().to_owned()).await.unwrap();
         let stream = consensus_chain.get_epoch_stream(0).await.unwrap();
         consensus_chain2.stream_import(stream, 0, previous_epoch.clone()).await.unwrap();
         consensus_chain2.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
@@ -640,7 +708,7 @@ mod test {
             ..Default::default()
         };
         // Create and load some data in initial file.
-        let mut consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         let num_outputs = 100;
@@ -724,7 +792,7 @@ mod test {
 
         consensus_chain.persist_current().await.expect("persist chain");
         drop(consensus_chain);
-        let mut consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).await.unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         // Check that last consenus held over a DB shutdown/restart.

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -99,6 +99,7 @@ enum PackMessage {
     ContainsBatch(B256, oneshot::Sender<bool>),
     Batch(B256, oneshot::Sender<Option<Batch>>),
     CountLeaders(Round, RewardsCounter, oneshot::Sender<Result<(), PackError>>),
+    LatestConsensusHeader(oneshot::Sender<Option<ConsensusHeader>>),
     Shutdown,
 }
 
@@ -164,6 +165,9 @@ fn run_pack_loop(
             }
             PackMessage::CountLeaders(last_executed_round, rewards_counter, tx) => {
                 let _ = tx.send(inner.count_leaders(last_executed_round, &rewards_counter));
+            }
+            PackMessage::LatestConsensusHeader(tx) => {
+                let _ = tx.send(inner.latest_consensus_header());
             }
             PackMessage::Shutdown => {
                 let _ = inner.persist();
@@ -250,7 +254,6 @@ impl ConsensusPack {
         let (tx, rx) = mpsc::channel(1000);
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
-        // XXXX- potential races while this imports, deal with.
         let handle = std::thread::spawn(move || {
             match Inner::stream_import(path, stream, epoch, &previous_epoch) {
                 Ok(inner) => {
@@ -356,7 +359,7 @@ impl ConsensusPack {
     }
 
     /// Read the last committed rounds for authorities from the epoch.
-    pub async fn read_last_committed(&mut self) -> HashMap<AuthorityIdentifier, Round> {
+    pub async fn read_last_committed(&self) -> HashMap<AuthorityIdentifier, Round> {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::ReadLastCommitted(tx)).await;
         rx.await.unwrap_or_default()
@@ -366,11 +369,23 @@ impl ConsensusPack {
     /// ReputationScores are marked as "final". If none exists then this
     /// method returns `None`.
     pub async fn read_latest_commit_with_final_reputation_scores(
-        &mut self,
+        &self,
     ) -> Option<Arc<CommittedSubDag>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::ReadLatestFinalRep(tx)).await;
         rx.await.unwrap_or_default()
+    }
+
+    /// Return the latest consensus header by reading directly from the pack index.
+    /// Unlike consensus_header_latest on ConsensusChain, this does not rely on the
+    /// slot files (LatestConsensus) and is always consistent with read_last_committed.
+    pub async fn latest_consensus_header(&self) -> Option<ConsensusHeader> {
+        let (tx, rx) = oneshot::channel();
+        if self.tx.send(PackMessage::LatestConsensusHeader(tx)).await.is_ok() {
+            rx.await.unwrap_or(None)
+        } else {
+            None
+        }
     }
 
     /// True if the pack contains the batch for digest.
@@ -381,7 +396,7 @@ impl ConsensusPack {
     }
 
     /// Return the Batch for digest if found.
-    pub async fn batch(&mut self, digest: BlockHash) -> Option<Batch> {
+    pub async fn batch(&self, digest: BlockHash) -> Option<Batch> {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::Batch(digest, tx)).await;
         rx.await.unwrap_or_default()
@@ -389,7 +404,7 @@ impl ConsensusPack {
 
     /// Count leaders in this pack (in rewards_counter) lower than last_executed_round.
     pub async fn count_leaders(
-        &mut self,
+        &self,
         last_executed_round: Round,
         rewards_counter: RewardsCounter,
     ) -> Result<(), PackError> {
@@ -764,6 +779,7 @@ impl Inner {
         // Make sure this number is valid before we write anything...
         if (consensus_idx as usize) < self.consensus_idx.len() {
             // If we have saved this output already then ignore it.
+            // Note this can be important when we replay consensus from downloaded pack files.
             return Ok(());
         } else if consensus_idx as usize != self.consensus_idx.len() {
             return Err(PackError::InvalidConsensusNumber(
@@ -926,6 +942,18 @@ impl Inner {
             self.batch_digests.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
         }
         Ok(())
+    }
+
+    /// Return the latest consensus header by reading directly from the pack index,
+    /// bypassing the slot file (LatestConsensus). Used during startup recovery to
+    /// get a ground-truth latest header consistent with read_last_committed.
+    fn latest_consensus_header(&mut self) -> Option<ConsensusHeader> {
+        if self.consensus_idx.is_empty() {
+            return None;
+        }
+        let latest_number =
+            self.epoch_meta.start_consensus_number + self.consensus_idx.len() as u64 - 1;
+        self.consensus_header_by_number(latest_number).ok()
     }
 
     fn read_last_committed(&mut self) -> HashMap<AuthorityIdentifier, Round> {


### PR DESCRIPTION
This should close out the remaining issues for restart tests.  The primary issue was cloning an ConsensusChain did not work correctly (copying critical data vs sharing it).

Also fixing the remaining unit tests.