### PR TITLE
patch: worker network race condition

### DIFF
--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -15,7 +15,6 @@ use tn_network_libp2p::{
 use tn_types::{
     encode, max_batch_size, Batch, BlockHash, BlsPublicKey, Epoch, SealedBatch, TaskSpawner, B256,
 };
-use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
 use crate::{
@@ -75,7 +74,7 @@ impl WorkerNetworkHandle {
     }
 
     /// Report a new batch to a peer.
-    async fn report_batch(
+    pub(crate) async fn report_batch(
         &self,
         peer_bls: BlsPublicKey,
         sealed_batch: SealedBatch,
@@ -93,34 +92,6 @@ impl WorkerNetworkHandle {
             )),
             WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
         }
-    }
-
-    /// Report a new batch to peers.
-    ///
-    /// QuorumWaiter uses this to reach quorum for new batches.
-    pub(crate) fn report_batch_to_peers(
-        &self,
-        peers: &[BlsPublicKey],
-        sealed_batch: SealedBatch,
-    ) -> Vec<oneshot::Receiver<NetworkResult<()>>> {
-        let mut result = vec![];
-        // loop through committee peers
-        for peer in peers {
-            let handle = self.clone();
-            let batch = sealed_batch.clone();
-            let task_name = format!("ReportBatchToPeer-{peer}");
-            let (tx, rx) = oneshot::channel();
-            let peer = *peer;
-            self.task_spawner.spawn_task(task_name, async move {
-                let res = handle.report_batch(peer, batch).await;
-                // ignore error bc quorum waiter will move on once quorum is reached
-                let _ = tx.send(res);
-            });
-
-            result.push(rx);
-        }
-
-        result
     }
 
     /// Request a group of batches by hashes using stream-based transfer.

--- a/crates/consensus/worker/src/quorum_waiter.rs
+++ b/crates/consensus/worker/src/quorum_waiter.rs
@@ -12,6 +12,12 @@ use tn_types::{Authority, BlsPublicKey, Committee, SealedBatch, TaskSpawner, Vot
 use tokio::sync::oneshot;
 use tracing::debug;
 
+/// Maximum number of retry attempts for reporting a batch to a single peer.
+const MAX_BATCH_REPORT_ATTEMPTS: u32 = 3;
+
+/// Base backoff duration for retrying batch reports (doubles each attempt).
+const BATCH_REPORT_RETRY_BACKOFF: Duration = Duration::from_millis(200);
+
 /// Interface to QuorumWaiter, exists primarily for tests.
 pub trait QuorumWaiterTrait: Send + Sync + Clone + Unpin + 'static {
     /// Send a batch to committee peers in an attempt to get quorum on it's validity.
@@ -56,35 +62,41 @@ impl QuorumWaiter {
         Self { inner: Arc::new(QuorumWaiterInner { authority, committee, network }) }
     }
 
-    /// Helper function. It waits for a future to complete and then delivers a value.
+    /// Report a batch to a single peer with retry-and-backoff for transient network errors.
+    ///
+    /// - `Ok(deliver)` — peer accepted the batch
+    /// - `Err(Rejected)` — peer explicitly rejected (RPCError), no retry
+    /// - `Err(Network)` — all retry attempts exhausted
     async fn waiter(
         bls: BlsPublicKey,
-        wait_for: oneshot::Receiver<Result<(), NetworkError>>,
+        network: WorkerNetworkHandle,
+        sealed_batch: SealedBatch,
         deliver: VotingPower,
     ) -> Result<VotingPower, WaiterError> {
-        match wait_for.await {
-            Ok(r) => {
-                match r {
-                    Ok(_) => Ok(deliver),
-                    Err(NetworkError::RPCError(msg)) => {
-                        tracing::error!(
-                            target = "worker::quorum_waiter",
-                            "RPCError, peer {bls}: {msg}"
-                        );
-                        Err(WaiterError::Rejected(deliver))
-                    }
-                    // Non-exhaustive enum...
-                    Err(err) => {
-                        tracing::error!(
-                            target = "worker::quorum_waiter",
-                            "Network error, peer {bls}: {err:?}"
-                        );
-                        Err(WaiterError::Network(deliver))
+        for attempt in 0..MAX_BATCH_REPORT_ATTEMPTS {
+            match network.report_batch(bls, sealed_batch.clone()).await {
+                Ok(()) => return Ok(deliver),
+                Err(NetworkError::RPCError(msg)) => {
+                    tracing::error!(
+                        target = "worker::quorum_waiter",
+                        "RPCError, peer {bls}: {msg}"
+                    );
+                    return Err(WaiterError::Rejected(deliver));
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target = "worker::quorum_waiter",
+                        attempt = attempt + 1,
+                        max_attempts = MAX_BATCH_REPORT_ATTEMPTS,
+                        "Network error, peer {bls}: {err:?}, retrying..."
+                    );
+                    if attempt + 1 < MAX_BATCH_REPORT_ATTEMPTS {
+                        tokio::time::sleep(BATCH_REPORT_RETRY_BACKOFF * 2u32.pow(attempt)).await;
                     }
                 }
             }
-            Err(_) => Err(WaiterError::Network(deliver)),
         }
+        Err(WaiterError::Network(deliver))
     }
 }
 
@@ -105,9 +117,8 @@ impl QuorumWaiterTrait for QuorumWaiter {
                 // Broadcast the batch to the other workers.
                 let peers: Vec<_> =
                     inner.committee.others_keys_except(inner.authority.protocol_key());
-                let handlers = inner.network.report_batch_to_peers(&peers, sealed_batch);
 
-                // Collect all the handlers to receive acknowledgements.
+                // Spawn per-peer retry tasks that report the batch with backoff.
                 let mut wait_for_quorum: FuturesUnordered<
                     oneshot::Receiver<Result<VotingPower, WaiterError>>,
                 > = FuturesUnordered::new();
@@ -116,22 +127,18 @@ impl QuorumWaiterTrait for QuorumWaiter {
                 let mut available_stake = 0;
                 // Stake from a committee member that has rejected this batch.
                 let mut rejected_stake = 0;
-                peers
-                    .into_iter()
-                    .zip(handlers.into_iter().enumerate())
-                    .map(|(name, (i, handler))| {
-                        let stake = inner.committee.voting_power(&name);
-                        available_stake += stake;
-                        let (tx, rx) = oneshot::channel();
-                        let task_name = format!("qw-peer-{i}");
-                        spawner_clone.spawn_task(task_name, async move {
-                            // forward result through oneshot channel
-                            let res = Self::waiter(name, handler, stake).await;
-                            let _ = tx.send(res);
-                        });
-                        rx
-                    })
-                    .for_each(|f| wait_for_quorum.push(f));
+                for (i, name) in peers.into_iter().enumerate() {
+                    let stake = inner.committee.voting_power(&name);
+                    available_stake += stake;
+                    let (tx, rx) = oneshot::channel();
+                    let network = inner.network.clone();
+                    let batch = sealed_batch.clone();
+                    spawner_clone.spawn_task(format!("qw-peer-{i}"), async move {
+                        let res = Self::waiter(name, network, batch, stake).await;
+                        let _ = tx.send(res);
+                    });
+                    wait_for_quorum.push(rx);
+                }
 
                 // Wait for the first 2f nodes to send back an Ack. Then we consider the batch
                 // delivered and we send its digest to the primary (that will include it into
@@ -211,8 +218,6 @@ impl QuorumWaiterTrait for QuorumWaiter {
                         break Err(QuorumWaiterError::QuorumRejected);
                     }
                     if total_stake + available_stake < threshold {
-                        // It is no longer possible to reach quorum...
-                        // This is likely because of network/rpc errors and may not be permanent.
                         break Err(QuorumWaiterError::AntiQuorum);
                     }
                 }

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -1,12 +1,12 @@
 //! Unit tests for the worker's quorum waiter.
 
 use assert_matches::assert_matches;
-use std::{num::NonZeroUsize, time::Duration};
+use std::{collections::HashMap, num::NonZeroUsize, time::Duration};
 use tn_network_libp2p::types::{NetworkCommand, NetworkHandle};
 use tn_reth::test_utils::batch;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::{test_chain_spec_arc, TaskManager};
+use tn_types::{test_chain_spec_arc, BlsPublicKey, TaskManager};
 use tn_worker::{
     quorum_waiter::{QuorumWaiter, QuorumWaiterError, QuorumWaiterTrait as _},
     WorkerNetworkHandle, WorkerRPCError, WorkerRequest, WorkerResponse,
@@ -249,24 +249,20 @@ async fn test_batch_rejected_antiquorum() {
     let attest_handle =
         quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
 
-    // 1/2 of committee byzantine
-    let threshold = committee.size() / 2;
-    for _i in 0..threshold {
-        match network_rx.recv().await {
-            Some(NetworkCommand::SendRequest {
-                peer: _,
-                request: WorkerRequest::ReportBatch { sealed_batch: in_batch },
-                reply,
-            }) => {
-                assert_eq!(in_batch, sealed_batch);
-                drop(reply);
+    // Background handler: drop all replies to simulate network errors.
+    // With retries, peers will send multiple requests - drop them all.
+    tokio::spawn(async move {
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { reply, .. } => {
+                    drop(reply);
+                }
+                _ => panic!("unexpected network command!"),
             }
-            Some(_) => panic!("unexpected network command!"),
-            None => panic!("failed to get a batch!"),
         }
-    }
+    });
 
-    // expect timeout error
+    // All peers exhaust retries → all return WaiterError::Network → AntiQuorum
     assert_matches!(attest_handle.await.unwrap(), Err(QuorumWaiterError::AntiQuorum));
 }
 
@@ -299,34 +295,203 @@ async fn test_batch_early_anti_quorum() {
     let attest_handle =
         quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
 
-    // send three accepts, three rejects and drop the rest (network error) for batch
-    // This will create an anti-quorum, make sure we produce the error without waiting the 10 second
-    // timeout.
-    for i in 0..8 {
-        match network_rx.recv().await {
-            Some(NetworkCommand::SendRequest {
-                peer: _,
-                request: WorkerRequest::ReportBatch { sealed_batch: in_batch },
-                reply,
-            }) => {
-                assert_eq!(in_batch, sealed_batch);
-                match i {
-                    0 | 1 | 2 => reply.send(Ok(WorkerResponse::ReportBatch)).unwrap(),
-                    3 | 4 | 5 => reply
-                        .send(Ok(WorkerResponse::Error(WorkerRPCError("REJECTED!!!".to_string()))))
-                        .unwrap(),
-                    _ => drop(reply), // These will produce network errors in the QW.
+    // Background handler that tracks per-peer behavior:
+    // - First 3 unique peers: accept
+    // - Next 3 unique peers: reject (RPCError)
+    // - Rest: always drop (network error, retries also dropped)
+    // This creates an anti-quorum once the dropped peers exhaust retries.
+    tokio::spawn(async move {
+        let mut peer_behavior: HashMap<BlsPublicKey, u8> = HashMap::new();
+        let mut next_index = 0u8;
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { peer, reply, .. } => {
+                    let behavior = *peer_behavior.entry(peer).or_insert_with(|| {
+                        let idx = next_index;
+                        next_index += 1;
+                        idx
+                    });
+                    match behavior {
+                        0..=2 => {
+                            let _ = reply.send(Ok(WorkerResponse::ReportBatch));
+                        }
+                        3..=5 => {
+                            let _ = reply.send(Ok(WorkerResponse::Error(WorkerRPCError(
+                                "REJECTED!!!".to_string(),
+                            ))));
+                        }
+                        _ => drop(reply),
+                    }
                 }
+                _ => panic!("unexpected network command!"),
             }
-            Some(_) => panic!("unexpected network command!"),
-            None => panic!("failed to get a batch!"),
         }
-    }
+    });
 
-    // expect to NOT timeout, note this timeout must be much lower than the verify_batch timeout for
-    // this test
-    match tokio::time::timeout(Duration::from_secs(2), attest_handle).await {
+    // expect to NOT timeout - anti-quorum should be detected early.
+    // Retries add ~600ms max, well within the 3-second window.
+    match tokio::time::timeout(Duration::from_secs(3), attest_handle).await {
         Err(_) => panic!("should not timeout, should reach anti-quorum early"),
+        Ok(Ok(r)) => assert_matches!(r, Err(QuorumWaiterError::AntiQuorum)),
+        Ok(Err(_)) => panic!("unexpected recv error!"),
+    }
+}
+
+/// Verify that retries allow quorum to be reached after initial network failures.
+#[tokio::test]
+async fn test_network_error_retry_then_quorum() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .build();
+    let committee = fixture.committee();
+    let my_primary = fixture.authorities().next().unwrap();
+    let task_manager = TaskManager::default();
+
+    // setup network
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network =
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+    let quorum_waiter =
+        QuorumWaiter::new(my_primary.authority().clone(), committee.clone(), network);
+
+    // Make a batch.
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain).seal_slow();
+
+    let timeout = Duration::from_secs(10);
+    let attest_handle =
+        quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
+
+    // Background handler: all peers fail first attempt, succeed on retry
+    tokio::spawn(async move {
+        let mut attempt_count: HashMap<BlsPublicKey, u32> = HashMap::new();
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { peer, reply, .. } => {
+                    let count = attempt_count.entry(peer).or_insert(0);
+                    *count += 1;
+                    if *count == 1 {
+                        drop(reply);
+                    } else {
+                        let _ = reply.send(Ok(WorkerResponse::ReportBatch));
+                    }
+                }
+                _ => panic!("unexpected network command!"),
+            }
+        }
+    });
+
+    // All peers succeed on retry → quorum reached
+    assert!(attest_handle.await.unwrap().is_ok());
+}
+
+/// Verify that partial retry success can achieve quorum.
+#[tokio::test]
+async fn test_network_error_partial_retry_success() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(10).unwrap())
+        .build();
+    let committee = fixture.committee();
+    let my_primary = fixture.authorities().next().unwrap();
+    let task_manager = TaskManager::default();
+
+    // setup network
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network =
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+    let quorum_waiter =
+        QuorumWaiter::new(my_primary.authority().clone(), committee.clone(), network);
+
+    // Make a batch.
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain).seal_slow();
+
+    let timeout = Duration::from_secs(10);
+    let attest_handle =
+        quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
+
+    // Background handler:
+    // - First 3 unique peers: succeed immediately
+    // - Next 3 unique peers: fail first, succeed on retry
+    // - Rest: always fail (drop)
+    tokio::spawn(async move {
+        let mut peer_order: HashMap<BlsPublicKey, u8> = HashMap::new();
+        let mut next_index = 0u8;
+        let mut attempt_count: HashMap<BlsPublicKey, u32> = HashMap::new();
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { peer, reply, .. } => {
+                    let order = *peer_order.entry(peer).or_insert_with(|| {
+                        let idx = next_index;
+                        next_index += 1;
+                        idx
+                    });
+                    let count = attempt_count.entry(peer).or_insert(0);
+                    *count += 1;
+                    match order {
+                        0..=2 => {
+                            let _ = reply.send(Ok(WorkerResponse::ReportBatch));
+                        }
+                        3..=5 => {
+                            if *count == 1 {
+                                drop(reply);
+                            } else {
+                                let _ = reply.send(Ok(WorkerResponse::ReportBatch));
+                            }
+                        }
+                        _ => drop(reply),
+                    }
+                }
+                _ => panic!("unexpected network command!"),
+            }
+        }
+    });
+
+    // 3 immediate + 3 on retry + self = 7 stake >= threshold
+    assert!(attest_handle.await.unwrap().is_ok());
+}
+
+/// Verify that bounded retries produce AntiQuorum, not Timeout.
+#[tokio::test]
+async fn test_network_error_all_retries_exhausted() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .build();
+    let committee = fixture.committee();
+    let my_primary = fixture.authorities().next().unwrap();
+    let task_manager = TaskManager::default();
+
+    // setup network
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network =
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+    let quorum_waiter =
+        QuorumWaiter::new(my_primary.authority().clone(), committee.clone(), network);
+
+    // Make a batch.
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain).seal_slow();
+
+    let timeout = Duration::from_secs(10);
+    let attest_handle =
+        quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
+
+    // Background handler: always drop replies
+    tokio::spawn(async move {
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { reply, .. } => drop(reply),
+                _ => panic!("unexpected network command!"),
+            }
+        }
+    });
+
+    // All retries exhausted → AntiQuorum (not Timeout), well within 5 seconds
+    match tokio::time::timeout(Duration::from_secs(5), attest_handle).await {
+        Err(_) => panic!("should not timeout waiting for quorum waiter"),
         Ok(Ok(r)) => assert_matches!(r, Err(QuorumWaiterError::AntiQuorum)),
         Ok(Err(_)) => panic!("unexpected recv error!"),
     }

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use eyre::{eyre, OptionExt};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -37,8 +37,8 @@ use tn_storage::tables::{
 use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
     Committee, CommitteeBuilder, ConsensusOutput, Database as TNDatabase, Epoch, EpochRecord,
-    Multiaddr, NetworkPublicKey, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
-    B256,
+    Multiaddr, NetworkPublicKey, Notifier, P2pNode, TaskJoinError, TaskManager, TaskSpawner,
+    TnReceiver, B256,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -960,27 +960,22 @@ where
             .map(|a| *a.protocol_key())
             .collect();
 
-        if initial_epoch {
-            // Make sure we at least hove bootstrap peers on first epoch.
-            network_handle
-                .inner_handle()
-                .add_bootstrap_peers(
-                    consensus_config
-                        .committee()
-                        .bootstrap_servers()
-                        .iter()
-                        .map(|(k, v)| (*k, v.primary.clone()))
-                        .collect(),
-                )
-                .await?;
-        }
-
-        network_handle.inner_handle().new_epoch(committee_keys.clone()).await?;
-        debug!(target: "epoch-manager", auth=?consensus_config.authority_id(), "event stream updated!");
+        let bootstrap_peers = consensus_config
+            .committee()
+            .bootstrap_servers()
+            .iter()
+            .map(|(k, v)| (*k, v.primary.clone()))
+            .collect();
+        Self::init_network_for_epoch(
+            network_handle.inner_handle(),
+            bootstrap_peers,
+            committee_keys.clone(),
+            initial_epoch,
+        )
+        .await?;
 
         // start listening if the network needs to be initialized
         if initial_epoch {
-            // start listening for p2p messages
             let primary_address = Self::parse_listener_address_for_swarm(
                 "PRIMARY_LISTENER_MULTIADDR",
                 consensus_config.primary_networkkey(),
@@ -999,8 +994,9 @@ where
             )
             .await?;
 
-        let mut peers = network_handle.connected_peers_count().await.unwrap_or(0);
-        if peers == 0 || self.consensus_bus.is_cvv() {
+        if network_handle.connected_peers_count().await.unwrap_or(0) == 0
+            || self.consensus_bus.is_cvv()
+        {
             // always dial peers for the new epoch
             // do this if a CVV (may need to connect to the other CVVs) or if we don't have any
             // peers if we are not a committee member and have peers then do not pester
@@ -1017,26 +1013,7 @@ where
             }
         }
 
-        // wait until the primary has connected with at least 1 peer
-        let mut retries = 0;
-        while peers == 0 {
-            retries += 1;
-            if retries > 240 {
-                // If we could not get on the network in about 2 minutes then trigger node exit.
-                // This indicates a fundemental problem (maybe no network access?) that should be
-                // addressed. Since this is a blockchain there is nothing useful for a
-                // node to do without being on the network.
-                return Err(eyre::eyre!(
-                    "Unable to join telcoin network, can not connect to any peers!"
-                ));
-            }
-            if retries % 10 == 0 {
-                // Log error about every 5 seconds.
-                error!(target: "epoch-manager", "failed to join the network!")
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            peers = network_handle.connected_peers_count().await.unwrap_or(0);
-        }
+        Self::wait_for_network_peers(network_handle.inner_handle(), "primary network").await?;
 
         // spawn primary network
         PrimaryNetwork::new(
@@ -1112,7 +1089,20 @@ where
             .into_iter()
             .map(|a| *a.protocol_key())
             .collect();
-        network_handle.inner_handle().new_epoch(committee_keys.clone()).await?;
+
+        let bootstrap_peers = consensus_config
+            .committee()
+            .bootstrap_servers()
+            .iter()
+            .map(|(k, v)| (*k, v.worker.clone()))
+            .collect();
+        Self::init_network_for_epoch(
+            network_handle.inner_handle(),
+            bootstrap_peers,
+            committee_keys.clone(),
+            initial_epoch,
+        )
+        .await?;
 
         // start listening if the network needs to be initialized
         if initial_epoch {
@@ -1122,18 +1112,6 @@ where
                 consensus_config.worker_address(),
             )?;
             network_handle.inner_handle().start_listening(worker_address).await?;
-            // Make sure we at least hove bootstrap peers on first epoch.
-            network_handle
-                .inner_handle()
-                .add_bootstrap_peers(
-                    consensus_config
-                        .committee()
-                        .bootstrap_servers()
-                        .iter()
-                        .map(|(k, v)| (*k, v.worker.clone()))
-                        .collect(),
-                )
-                .await?;
         }
 
         let worker_address = consensus_config.worker_address();
@@ -1152,6 +1130,8 @@ where
                 epoch_task_spawner.clone(),
             );
         }
+
+        Self::wait_for_network_peers(network_handle.inner_handle(), "worker network").await?;
 
         // update the authorized publishers for gossip every epoch
         network_handle
@@ -1263,5 +1243,46 @@ where
                     })
             })
             .unwrap_or(Ok(fallback))
+    }
+
+    /// Initialize a network handle for a new epoch: register bootstrap peers (on first epoch)
+    /// then update the epoch committee.
+    ///
+    /// Bootstrap peers must be added BEFORE `new_epoch()` so that `known_peers` is populated
+    /// when `new_epoch()` builds `current_committee` from it.
+    async fn init_network_for_epoch<Req: TNMessage, Res: TNMessage>(
+        handle: &NetworkHandle<Req, Res>,
+        bootstrap_peers: BTreeMap<BlsPublicKey, P2pNode>,
+        committee_keys: HashSet<BlsPublicKey>,
+        initial_epoch: bool,
+    ) -> eyre::Result<()> {
+        if initial_epoch {
+            handle.add_bootstrap_peers(bootstrap_peers).await?;
+        }
+        handle.new_epoch(committee_keys).await?;
+        Ok(())
+    }
+
+    /// Block until the network has connected to at least one peer, with retries.
+    async fn wait_for_network_peers<Req: TNMessage, Res: TNMessage>(
+        handle: &NetworkHandle<Req, Res>,
+        network_name: &str,
+    ) -> eyre::Result<()> {
+        let mut peers = handle.connected_peer_count().await.unwrap_or(0);
+        let mut retries = 0;
+        while peers == 0 {
+            retries += 1;
+            if retries > 240 {
+                return Err(eyre::eyre!(
+                    "{network_name} unable to join, cannot connect to any peers!"
+                ));
+            }
+            if retries % 10 == 0 {
+                error!(target: "epoch-manager", "failed to join the {network_name}!");
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            peers = handle.connected_peer_count().await.unwrap_or(0);
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Overview

Fixes a race condition in worker network startup by aligning its initialization sequence with the primary, and adds retry-with-backoff to the quorum waiter so transient network errors don't cause premature batch failures.

## Changes

### Epoch node startup consolidation (`epoch.rs`)
- Extracted `init_network_for_epoch()` — shared helper that adds bootstrap peers *before* `new_epoch()`, ensuring `known_peers` is populated when the committee is built
- Extracted `wait_for_network_peers()` — shared helper that blocks until at least one peer is connected, with 240-retry budget and periodic error logging
- Worker network now calls both helpers, matching the primary's initialization order
- Worker network now waits for peer connections before proceeding to consensus, eliminating the startup race
- Removed duplicated bootstrap-peer and peer-wait logic from the primary path in favor of the shared helpers

### Quorum waiter retry logic (`quorum_waiter.rs`, `handle.rs`)
- `waiter()` now owns the full per-peer lifecycle: sends the batch, retries on transient network errors (up to 3 attempts with exponential backoff starting at 200ms), and returns immediately on explicit RPC rejection
- Removed the `report_batch_to_peers()` bulk wrapper from `WorkerNetworkHandle` — each peer task now calls `report_batch()` directly
- Made `report_batch()` `pub(crate)` so quorum waiter tasks can call it
- Removed the `oneshot::Receiver` indirection that previously sat between the network call and the waiter

### Quorum waiter tests (`quorum_waiter_tests.rs`)
- Rewrote `test_batch_rejected_antiquorum` and `test_batch_early_anti_quorum` to use background handler tasks that process retried requests correctly
- Added `test_network_error_retry_then_quorum` — all peers fail once then succeed on retry, quorum reached
- Added `test_network_error_partial_retry_success` — mix of immediate success, retry success, and permanent failure still reaches quorum
- Added `test_network_error_all_retries_exhausted` — all peers fail all attempts, confirms `AntiQuorum` is returned within bounded time (not timeout)

closes #612 
blocked by #571 