### PR TITLE
Exex2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -118,9 +118,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f312b60857fb4f8e0c723a17ae9c687c0e83a3c6b7940a30d4d5a26af091"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e56cae3909bcb2347f77c0f318ef5eb7e131ea6d0a94d31f8bfb6e4c5e3c7c7"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4394690a8a64757316c57c57f2c663bf8395febb4c4baa049a058ebd122b668"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa68d4b6fbbf44b9597684f27509573c5de3ef897907122376157f25b1f378e"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b97433ffdb356d11b6c89b08c69a787b9f55d787cdeee733c12fdf85d465ef1"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6173ced325833e40ccb781bb372c720df638a966bad6ed6733682b6bff63d855"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464d9c2c5bca3ff3f020f2ab502629043486a1b3645c5c11613c1dade4eb6f5e"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2158d382ef9743ae7185c9fcd33cd9a99967419fdcd5eebc83ff7c0e79cad2bc"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -458,7 +458,7 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b08405e82effb4985f7cbe83d5067730e79893c8699793c1e113043ffeac9d"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f39b713fb8fd7abb6ee7601d467f71d2c2541b7799dd02d3a8f9f650d1d3f6d"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96846729dd095dd5a87bf5bd8efea2345ca41ceab6dda212c49f5c8ca6e2a536"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20059ff046049aae59f6e19d96462214ad3290cf9920394309dd7ffc284390"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3468c7d973491c4c02a373a29273cb747aa4a99cf2e54a6178b564d97462db50"
+checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aca954ee74bb38b24399da5bd861a2511fb76d40cca7ae700d2289ff96fb90"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b71da7e5cdd0d5ffebc459f5987888fd3380969c2f94f8cb652ad91ae51bba"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3569433bc2cddd4f00b1dd533a38a07512b55e62d11f662fde20930b613b57"
+checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
+checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f083328dbf7aa5abfe5c0a7758ec9acc86a45bfbcfb45c54186c6caa78036f2a"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1641df7ef4d15cd43843d399252c90a95abf465a67e2a2b2fd76f4e93cc60e15"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b6ca72affc6669e0a456af7d3c15d6b2edf75797d7906bc3900a8b1e094348"
+checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00e2d5ab1f7310c7ecd69962af8c99d2557335ff8cf1baf39c8ff6eec9c171d"
+checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154695f4a24dd749368fd46a4bdac1ec806b4376abc40112e3028018fee5b593"
+checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c2c0b5f024814f1c04ae76ff71862d06c836e7d67102daf8a557e5056be68"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f59de30d9d3b13ce6a1b90e85270dc086e4e4733aaa12b250fb30e1eb35849"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e64733ea58cfb393c901047638e9ff6890c0a45dc5855bfa077f8bace0f9f9"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -823,7 +823,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9c680a7ee0879aa27ea2e347f14e3a973a262e4325964fa1ab062b8a796064"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74911eda4fd7ef12f446b1661f11787f9fb31bde4ab4a0a68efcac9b98cfdf"
+checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130762ef3e6c0fb7dc1b855d4f359eb8ea6f2df2f800f40aa52d27737bf640f1"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3684226a2220bb6e84a5ab74877e66628882336ecfba97482c9d473aa2b1cc"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1759,16 +1759,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1804,24 +1804,24 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
  "bitflags 2.11.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "num-bigint",
  "rustc-hash",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -1844,7 +1844,7 @@ dependencies = [
  "futures-lite",
  "hashbrown 0.16.1",
  "icu_normalizer",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "intrusive-collections",
  "itertools 0.14.0",
  "num-bigint",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -1883,14 +1883,14 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36418a46544b152632c141b0a0b7a453cd69ca150caeef83aee9e2f4b48b7d"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
  "bitflags 2.11.0",
  "boa_ast",
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce9d7aa5563a2e14eab111e2ae1a06a69a812f6c0c3d843196c9d03fbef440"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -2115,7 +2115,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform 0.1.9",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2129,7 +2129,7 @@ checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform 0.3.2",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2404,7 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2508,6 +2508,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2648,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -3367,7 +3376,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring",
  "sha2",
 ]
@@ -3461,6 +3470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "exex-lifecycle"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "tn-exex",
+ "tn-types",
+ "tracing",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,9 +3497,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -3965,7 +3984,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4234,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4249,7 +4268,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4349,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4408,9 +4426,9 @@ checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4578,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -4694,9 +4712,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -4797,10 +4815,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5024,14 +5044,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5071,9 +5091,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
@@ -5476,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -5488,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5519,9 +5539,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -5683,7 +5703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5756,9 +5776,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -6672,7 +6692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6685,9 +6705,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -7230,9 +7250,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redb"
-version = "3.1.1"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef99362319c782aa4639ad3a306b64c3bb90e12874e99b8df124cb679d988611"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
  "libc",
 ]
@@ -10368,9 +10388,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -10405,7 +10425,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -10745,9 +10765,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -10816,7 +10836,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
@@ -10837,9 +10857,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -10882,7 +10902,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10944,7 +10964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10955,7 +10975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10971,9 +10991,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11046,9 +11066,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -11494,7 +11514,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11531,9 +11550,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -11654,6 +11673,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tn-exex"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "futures",
+ "reth-execution-types",
+ "reth-provider",
+ "tn-reth",
+ "tn-types",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "tn-network-libp2p"
 version = "0.1.0"
 dependencies = [
@@ -11708,6 +11742,7 @@ dependencies = [
  "tn-config",
  "tn-engine",
  "tn-executor",
+ "tn-exex",
  "tn-network-libp2p",
  "tn-network-types",
  "tn-primary",
@@ -11731,7 +11766,7 @@ dependencies = [
  "backoff",
  "eyre",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "parking_lot",
  "proptest",
  "rand 0.9.2",
@@ -11852,7 +11887,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "eyre",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "telcoin-network-cli",
  "tempfile",
  "tn-config",
@@ -11887,7 +11922,7 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "libp2p",
  "once_cell",
  "parking_lot",
@@ -11947,9 +11982,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -11964,9 +11999,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12032,7 +12067,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -12052,39 +12087,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -12132,7 +12167,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12551,9 +12586,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -12687,9 +12722,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12700,23 +12735,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12724,9 +12755,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12737,9 +12768,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -12761,7 +12792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12787,8 +12818,8 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.13.1",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -12807,9 +12838,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13261,9 +13292,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -13296,7 +13327,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -13327,7 +13358,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -13346,9 +13377,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -13364,9 +13395,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13470,9 +13501,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13481,9 +13512,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13493,18 +13524,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13513,18 +13544,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13554,20 +13585,21 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -13577,9 +13609,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bin/telcoin-network",
     "crates/config",
     "crates/engine",
+    "crates/exex",
     "crates/node",
     "crates/storage",
     "crates/test-utils",
@@ -21,6 +22,9 @@ members = [
     "crates/consensus/executor",
     "crates/consensus/primary",
     "crates/consensus/worker",
+
+    # examples
+    "examples/exex-lifecycle",
 
     # execution
     "crates/batch-builder",
@@ -133,6 +137,7 @@ alloy-evm = { version = "0.27.2" }
 
 tn-batch-validator = { path = "crates/batch-validator" }
 tn-engine = { path = "crates/engine" }
+tn-exex = { path = "crates/exex" }
 
 # batch maker
 tn-batch-builder = { path = "crates/batch-builder" }

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -85,11 +85,17 @@ pub struct LibP2pConfig {
     pub supported_req_res_protocols: Vec<(StreamProtocol, ProtocolSupport)>,
     /// Maximum message size between request/response network messages in bytes.
     pub max_rpc_message_size: usize,
-    /// Maximum message size for gossipped network messages in bytes.
+    /// Maximum message size for gossipped messages request/response network messages in bytes.
     ///
-    /// The largest gossip message is likely a `Certificate`.
-    /// The default of 12,000 bytes should be enough for legit gossip.
-    /// Large messages should not be gossipped
+    /// The largest gossip message is the `ConsensusHeader`, which influenced the default max.
+    ///
+    /// Consensus headers are created based on subdag commits which can be several rounds deep.
+    /// More benchmarking is needed, but this should be a safe number for a 4-member committee.
+    /// - 6 round max between commits
+    /// - 4 certificate max per round
+    /// - ~300 bytes size per empty certificate
+    /// - 5 batch digests max per certificate (32 bytes each)
+    /// - (6 * 4)(300 + (5 * 32)) = 11,040
     pub max_gossip_message_size: usize,
     /// The maximum duration to keep an idle connection alive between peers.
     ///

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -47,6 +47,8 @@ pub(crate) struct Certifier<DB> {
     task_spawner: TaskSpawner,
     /// Notifier to cancel pending proposals and vote requests if new header is received.
     new_proposal: Notifier,
+    /// Consensus bus for ExEx notifications.
+    consensus_bus: ConsensusBus,
 }
 
 impl<DB: Database> Certifier<DB> {
@@ -100,6 +102,7 @@ impl<DB: Database> Certifier<DB> {
                 network: primary_network,
                 task_spawner,
                 new_proposal: Notifier::new(),
+                consensus_bus,
             }
             .run(rx_headers)
             .await;
@@ -405,6 +408,9 @@ impl<DB: Database> Certifier<DB> {
                             error!(target: "primary::certifier", "error accepting own certificate: {e}");
                             return;
                         }
+
+                        // notify ExEx subscribers about own certificate
+                        let _ = self.consensus_bus.app().exex_own_certificates().send(certificate.clone());
 
                         // try to publish the certificate on gossip network
                         if let Err(e) = self.network.publish_certificate(certificate).await {

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -414,6 +414,13 @@ impl<DB: Database> Consensus<DB> {
                     committed_certificates.push(certificate.clone());
                 }
 
+                // notify ExEx subscribers about committed sub-DAG
+                let _ = self
+                    .consensus_bus
+                    .app()
+                    .exex_committed_sub_dags()
+                    .send(committed_sub_dag.clone());
+
                 // NOTE: The size of the sub-dag can be arbitrarily large (depending on the network
                 // condition and Byzantine leaders).
                 self.consensus_bus

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -223,6 +223,17 @@ pub struct ConsensusBusAppInner {
     /// Broadcast the latest output from consensus after committing to the subdag.
     /// Engine consumes and executes to extend canonical chain.
     consensus_output: broadcast::Sender<ConsensusOutput>,
+
+    /// Broadcast channel for own certificates (ExEx).
+    /// Sent after our header is certified.
+    exex_own_certificates: broadcast::Sender<Certificate>,
+    /// Broadcast channel for peer certificates (ExEx).
+    /// Sent when a peer certificate is accepted and forwarded to consensus.
+    exex_peer_certificates: broadcast::Sender<Certificate>,
+    /// Broadcast channel for committed sub-DAGs (ExEx).
+    /// Sent when Bullshark commits a sub-DAG.
+    exex_committed_sub_dags: broadcast::Sender<Arc<CommittedSubDag>>,
+
     /// Status of sync?
     tx_sync_status: watch::Sender<NodeMode>,
 
@@ -269,6 +280,10 @@ impl ConsensusBusApp {
         let (consensus_header, _rx_consensus_header) = broadcast::channel(CHANNEL_CAPACITY);
         let (consensus_output, _rx_consensus_output) = broadcast::channel(100);
 
+        let (exex_own_certificates, _) = broadcast::channel(CHANNEL_CAPACITY);
+        let (exex_peer_certificates, _) = broadcast::channel(CHANNEL_CAPACITY);
+        let (exex_committed_sub_dags, _) = broadcast::channel(CHANNEL_CAPACITY);
+
         let (tx_epoch_record, _) = watch::channel(None);
 
         Self {
@@ -282,6 +297,9 @@ impl ConsensusBusApp {
                 tx_last_published_consensus_num_hash,
                 consensus_header,
                 consensus_output,
+                exex_own_certificates,
+                exex_peer_certificates,
+                exex_committed_sub_dags,
                 tx_sync_status,
                 new_epoch_votes: QueChannel::new(),
                 tx_epoch_record,
@@ -451,6 +469,36 @@ impl ConsensusBusApp {
     /// Provide a subscription(Receiver) to consensus_headers.
     pub fn subscribe_consensus_header(&self) -> impl TnReceiver<ConsensusHeader> {
         self.inner.consensus_header.subscribe()
+    }
+
+    /// Broadcast sender for own certificates (ExEx).
+    pub fn exex_own_certificates(&self) -> &broadcast::Sender<Certificate> {
+        &self.inner.exex_own_certificates
+    }
+
+    /// Broadcast sender for peer certificates (ExEx).
+    pub fn exex_peer_certificates(&self) -> &broadcast::Sender<Certificate> {
+        &self.inner.exex_peer_certificates
+    }
+
+    /// Broadcast sender for committed sub-DAGs (ExEx).
+    pub fn exex_committed_sub_dags(&self) -> &broadcast::Sender<Arc<CommittedSubDag>> {
+        &self.inner.exex_committed_sub_dags
+    }
+
+    /// Subscribe to own certificate notifications (ExEx).
+    pub fn subscribe_exex_own_certificates(&self) -> broadcast::Receiver<Certificate> {
+        self.inner.exex_own_certificates.subscribe()
+    }
+
+    /// Subscribe to peer certificate notifications (ExEx).
+    pub fn subscribe_exex_peer_certificates(&self) -> broadcast::Receiver<Certificate> {
+        self.inner.exex_peer_certificates.subscribe()
+    }
+
+    /// Subscribe to committed sub-DAG notifications (ExEx).
+    pub fn subscribe_exex_committed_sub_dags(&self) -> broadcast::Receiver<Arc<CommittedSubDag>> {
+        self.inner.exex_committed_sub_dags.subscribe()
     }
 
     /// Will resolve once we have executed block.

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -204,6 +204,9 @@ where
                 })
                 .map_err(|_| CertManagerError::FatalAppendParent)?;
 
+            // notify ExEx subscribers about peer certificate
+            let _ = self.consensus_bus.app().exex_peer_certificates().send(cert.clone());
+
             // send to consensus for processing into the DAG
             self.consensus_bus.new_certificates().send(cert).await.inspect_err(|e| {
                 error!(target: "primary::cert_manager", ?e, "failed to forward accepted certificate to consensus");

--- a/crates/exex/Cargo.toml
+++ b/crates/exex/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tn-exex"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Execution Extensions (ExEx) plugin system for Telcoin Network."
+
+[dependencies]
+tn-reth = { workspace = true }
+tn-types = { workspace = true }
+reth-execution-types = { workspace = true }
+reth-provider = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+eyre = { workspace = true }
+futures = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -1,0 +1,61 @@
+//! The context provided to each ExEx at launch.
+
+use crate::{replay::ReplayStream, TnExExEvent, TnExExNotification};
+use tn_reth::RethEnv;
+use tn_types::BlockNumber;
+use tokio::sync::mpsc;
+
+/// Everything an ExEx needs to operate, provided at launch.
+///
+/// Each ExEx receives its own context with:
+/// - A notification stream covering the full transaction lifecycle
+/// - An event channel to report processing progress
+/// - Access to reth's blockchain provider for querying chain state
+#[derive(Debug)]
+pub struct TnExExContext {
+    /// Async stream of lifecycle notifications (certificates, commits, executions).
+    pub notifications: mpsc::Receiver<TnExExNotification>,
+    /// Channel to send events (e.g., FinishedHeight) back to the manager.
+    pub events: mpsc::UnboundedSender<TnExExEvent>,
+    /// Access to reth's blockchain provider for querying chain state/history.
+    pub reth_env: RethEnv,
+}
+
+impl TnExExContext {
+    /// Replay historical blocks from `start_block` to the current chain tip.
+    ///
+    /// Returns a stream of `TnExExNotification::ChainExecuted` for each historical block.
+    /// After the stream is exhausted, the ExEx should switch to `self.notifications` for
+    /// live data.
+    pub fn replay_from(&self, start_block: BlockNumber) -> ReplayStream {
+        let tip = self.reth_env.last_block_number().unwrap_or(0);
+        ReplayStream::new(self.reth_env.clone(), start_block, tip)
+    }
+
+    /// Convenience: replay from `start_block` then seamlessly chain with live notifications.
+    ///
+    /// This is the recommended way for stateful ExExes to initialize:
+    /// ```rust,ignore
+    /// let mut stream = ctx.replay_and_subscribe(last_indexed_block + 1);
+    /// while let Some(notification) = stream.next().await {
+    ///     // Process identically — no distinction between replay and live
+    /// }
+    /// ```
+    ///
+    /// Note: this consumes `self` because the live notification stream is moved
+    /// into the returned combined stream.
+    pub fn replay_and_subscribe(
+        self,
+        start_block: BlockNumber,
+    ) -> impl futures::Stream<Item = eyre::Result<TnExExNotification>> {
+        use futures::StreamExt;
+        use tokio_stream::wrappers::ReceiverStream;
+
+        let tip = self.reth_env.last_block_number().unwrap_or(0);
+        let replay = ReplayStream::new(self.reth_env, start_block, tip);
+
+        // Chain replay stream with live notifications (wrapped as Ok)
+        let live = ReceiverStream::new(self.notifications).map(Ok);
+        replay.chain(live)
+    }
+}

--- a/crates/exex/src/event.rs
+++ b/crates/exex/src/event.rs
@@ -1,0 +1,16 @@
+//! Events sent from ExExes back to the manager.
+
+use tn_types::BlockNumber;
+
+/// Event sent from an ExEx back to the manager.
+///
+/// ExExes use these events to communicate processing progress back to the
+/// node, enabling coordination for data pruning.
+#[derive(Debug, Clone)]
+pub enum TnExExEvent {
+    /// Signal that the ExEx has durably processed all blocks up to this height.
+    ///
+    /// Used for pruning coordination — the node won't prune data below the
+    /// minimum finished height across all ExExes.
+    FinishedHeight(BlockNumber),
+}

--- a/crates/exex/src/lib.rs
+++ b/crates/exex/src/lib.rs
@@ -1,0 +1,52 @@
+//! Execution Extensions (ExEx) plugin system for Telcoin Network.
+//!
+//! ExEx provides a full-lifecycle plugin system that allows external modules to
+//! react to chain state changes in real-time. Unlike reth's execution-only ExEx,
+//! TN's version covers the entire transaction lifecycle:
+//!
+//! 1. **Certificate accepted** — a header is certified (own or peer)
+//! 2. **Consensus committed** — a sub-DAG is committed by Bullshark
+//! 3. **Chain executed** — blocks are executed and finalized
+//!
+//! This enables bridges, wallets, and dapps to track transactions from consensus
+//! inclusion through finality to execution.
+//!
+//! TN uses Bullshark BFT consensus with immediate finality. There are no reorgs,
+//! no WAL, and no reorg handling needed.
+
+#![doc(
+    html_logo_url = "https://www.telco.in/logos/TEL.svg",
+    html_favicon_url = "https://www.telco.in/logos/TEL.svg",
+    issue_tracker_base_url = "https://github.com/telcoin-association/telcoin-network/issues/"
+)]
+#![warn(missing_debug_implementations, missing_docs, unreachable_pub, rustdoc::all)]
+#![deny(unused_must_use, rust_2018_idioms)]
+
+mod context;
+mod event;
+/// ExEx manager for notification fan-out.
+pub mod manager;
+mod notification;
+/// Historical block replay for ExEx catch-up.
+pub mod replay;
+
+pub use context::TnExExContext;
+pub use event::TnExExEvent;
+pub use manager::{exex_channel_capacity, TnExExManager, TnExExManagerHandle};
+pub use notification::{Chain, TnExExNotification};
+pub use replay::ReplayStream;
+
+use std::{future::Future, pin::Pin};
+
+/// Type for ExEx install functions.
+///
+/// The function receives a [`TnExExContext`] and returns a future that runs
+/// for the lifetime of the ExEx. The outer function handles initialization,
+/// the returned future is the long-running ExEx task.
+///
+/// Reference: reth's `LaunchExEx` trait uses the same pattern.
+pub type ExExInstallFn = Box<
+    dyn FnOnce(TnExExContext) -> Pin<Box<dyn Future<Output = eyre::Result<()>> + Send>>
+        + Send
+        + Sync,
+>;

--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -1,0 +1,248 @@
+//! ExEx Manager — fans out lifecycle notifications to all registered ExExes.
+//!
+//! The manager subscribes to 4 sources:
+//! 1. Own certificates (from ConsensusBus)
+//! 2. Peer certificates (from ConsensusBus)
+//! 3. Committed sub-DAGs (from ConsensusBus)
+//! 4. Canonical state notifications (from reth's BlockchainProvider)
+//!
+//! It wraps each into the appropriate [`TnExExNotification`] variant and fans out
+//! to all registered ExExes using non-blocking `try_send`.
+
+use crate::{TnExExEvent, TnExExNotification};
+use futures::StreamExt;
+use reth_provider::CanonStateNotification;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tn_reth::CanonStateNotificationStream;
+use tn_types::{BlockNumber, Certificate, CommittedSubDag};
+use tokio::sync::{broadcast, mpsc, watch};
+use tokio_stream::wrappers::BroadcastStream;
+use tracing::{debug, error, warn};
+
+/// Notification channel capacity per ExEx.
+const EXEX_CHANNEL_CAPACITY: usize = 64;
+
+/// The ExEx manager fans out lifecycle notifications to all registered ExExes.
+///
+/// It implements [`Future`] following the same pattern as `ExecutorEngine`.
+/// The manager runs for the lifetime of the node (spawned on `node_task_manager`).
+pub struct TnExExManager {
+    /// Subscription to canonical state notifications from reth's BlockchainProvider.
+    canon_state_stream: CanonStateNotificationStream,
+    /// Stream of own certificates from ConsensusBus.
+    own_certs_stream: BroadcastStream<Certificate>,
+    /// Stream of peer certificates from ConsensusBus.
+    peer_certs_stream: BroadcastStream<Certificate>,
+    /// Stream of committed sub-DAGs from ConsensusBus.
+    committed_sub_dags_stream: BroadcastStream<Arc<CommittedSubDag>>,
+    /// Per-ExEx notification senders (one per registered ExEx).
+    exex_txs: Vec<(String, mpsc::Sender<TnExExNotification>)>,
+    /// Per-ExEx event receivers for FinishedHeight reporting.
+    event_rxs: Vec<mpsc::UnboundedReceiver<TnExExEvent>>,
+    /// Per-ExEx finished heights.
+    finished_heights: Vec<Option<BlockNumber>>,
+    /// Watch sender for the minimum finished height across all ExExes.
+    min_finished_height_tx: watch::Sender<Option<BlockNumber>>,
+}
+
+impl TnExExManager {
+    /// Create a new ExEx manager.
+    pub fn new(
+        canon_state_stream: CanonStateNotificationStream,
+        rx_own_certs: broadcast::Receiver<Certificate>,
+        rx_peer_certs: broadcast::Receiver<Certificate>,
+        rx_committed_sub_dags: broadcast::Receiver<Arc<CommittedSubDag>>,
+        exex_txs: Vec<(String, mpsc::Sender<TnExExNotification>)>,
+        event_rxs: Vec<mpsc::UnboundedReceiver<TnExExEvent>>,
+    ) -> (Self, TnExExManagerHandle) {
+        let num_exexes = exex_txs.len();
+        let (min_finished_height_tx, min_finished_height_rx) = watch::channel(None);
+
+        let manager = Self {
+            canon_state_stream,
+            own_certs_stream: BroadcastStream::new(rx_own_certs),
+            peer_certs_stream: BroadcastStream::new(rx_peer_certs),
+            committed_sub_dags_stream: BroadcastStream::new(rx_committed_sub_dags),
+            exex_txs,
+            event_rxs,
+            finished_heights: vec![None; num_exexes],
+            min_finished_height_tx,
+        };
+
+        let handle = TnExExManagerHandle { min_finished_height: min_finished_height_rx };
+
+        (manager, handle)
+    }
+
+    /// Fan out a notification to all registered ExExes.
+    fn fan_out(&self, notification: &TnExExNotification) {
+        for (name, tx) in &self.exex_txs {
+            if let Err(e) = tx.try_send(notification.clone()) {
+                match e {
+                    mpsc::error::TrySendError::Full(_) => {
+                        warn!(
+                            target: "exex::manager",
+                            exex = %name,
+                            "ExEx notification channel full, dropping notification"
+                        );
+                    }
+                    mpsc::error::TrySendError::Closed(_) => {
+                        error!(
+                            target: "exex::manager",
+                            exex = %name,
+                            "ExEx notification channel closed"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Poll all event receivers for FinishedHeight updates.
+    fn poll_events(&mut self, cx: &mut Context<'_>) {
+        for (i, rx) in self.event_rxs.iter_mut().enumerate() {
+            while let Poll::Ready(Some(event)) = rx.poll_recv(cx) {
+                match event {
+                    TnExExEvent::FinishedHeight(height) => {
+                        self.finished_heights[i] = Some(height);
+                    }
+                }
+            }
+        }
+
+        // Compute minimum finished height: None if any ExEx hasn't reported yet
+        let min_height = self
+            .finished_heights
+            .iter()
+            .try_fold(None, |acc: Option<BlockNumber>, h| {
+                let height = (*h)?;
+                Some(Some(acc.map_or(height, |a: BlockNumber| a.min(height))))
+            })
+            .flatten();
+
+        self.min_finished_height_tx.send_replace(min_height);
+    }
+}
+
+impl futures::Future for TnExExManager {
+    type Output = eyre::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // Poll own certificates stream
+        loop {
+            match this.own_certs_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(cert))) => {
+                    let notification =
+                        TnExExNotification::CertificateAccepted { certificate: Box::new(cert), is_own: true };
+                    this.fan_out(&notification);
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    warn!(target: "exex::manager", ?e, "own certificates stream error");
+                }
+                Poll::Ready(None) => {
+                    debug!(target: "exex::manager", "own certificates stream ended");
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll peer certificates stream
+        loop {
+            match this.peer_certs_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(cert))) => {
+                    let notification = TnExExNotification::CertificateAccepted {
+                        certificate: Box::new(cert),
+                        is_own: false,
+                    };
+                    this.fan_out(&notification);
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    warn!(target: "exex::manager", ?e, "peer certificates stream error");
+                }
+                Poll::Ready(None) => {
+                    debug!(target: "exex::manager", "peer certificates stream ended");
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll committed sub-DAGs stream
+        loop {
+            match this.committed_sub_dags_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(sub_dag))) => {
+                    let notification = TnExExNotification::ConsensusCommitted { sub_dag };
+                    this.fan_out(&notification);
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    warn!(target: "exex::manager", ?e, "committed sub-dags stream error");
+                }
+                Poll::Ready(None) => {
+                    debug!(target: "exex::manager", "committed sub-dags stream ended");
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll canonical state stream
+        loop {
+            match this.canon_state_stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(notification)) => match notification {
+                    CanonStateNotification::Commit { new } => {
+                        let notification = TnExExNotification::ChainExecuted { new };
+                        this.fan_out(&notification);
+                    }
+                    _ => unreachable!("TN reorgs are impossible"),
+                },
+                Poll::Ready(None) => {
+                    debug!(target: "exex::manager", "canonical state stream ended");
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll ExEx events
+        this.poll_events(cx);
+
+        Poll::Pending
+    }
+}
+
+impl std::fmt::Debug for TnExExManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TnExExManager")
+            .field("num_exexes", &self.exex_txs.len())
+            .field("finished_heights", &self.finished_heights)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Cheaply cloneable handle for querying ExEx manager state.
+#[derive(Clone, Debug)]
+pub struct TnExExManagerHandle {
+    /// The minimum finished height across all ExExes.
+    min_finished_height: watch::Receiver<Option<BlockNumber>>,
+}
+
+impl TnExExManagerHandle {
+    /// Returns the current minimum finished height across all ExExes.
+    ///
+    /// Returns `None` if any ExEx hasn't reported a finished height yet.
+    pub fn min_finished_height(&self) -> Option<BlockNumber> {
+        *self.min_finished_height.borrow()
+    }
+}
+
+/// Returns the ExEx notification channel capacity.
+pub const fn exex_channel_capacity() -> usize {
+    EXEX_CHANNEL_CAPACITY
+}

--- a/crates/exex/src/notification.rs
+++ b/crates/exex/src/notification.rs
@@ -1,0 +1,55 @@
+//! ExEx notification types for the full transaction lifecycle.
+//!
+//! TN's ExEx system covers the entire transaction lifecycle:
+//! certificate accepted → consensus committed → chain executed.
+//!
+//! TN uses Bullshark BFT consensus with immediate finality, so there are no
+//! reorgs — all committed state is immediately final.
+
+use std::sync::Arc;
+use tn_types::{Certificate, CommittedSubDag};
+
+/// Re-export the Chain type from reth.
+pub use reth_execution_types::Chain;
+
+/// Notification sent to ExExes covering the full transaction lifecycle.
+///
+/// TN's ExEx system tracks transactions through three stages:
+/// 1. **Certificate accepted** — a header has been certified (own or peer)
+/// 2. **Consensus committed** — a sub-DAG has been committed by Bullshark
+/// 3. **Chain executed** — blocks have been executed and added to the canonical chain
+///
+/// All stages produce final, irrevocable state thanks to BFT consensus.
+#[derive(Debug, Clone)]
+pub enum TnExExNotification {
+    /// A certificate has been accepted (either our own or a peer's).
+    ///
+    /// This is the earliest signal that a header's batches are included
+    /// in the consensus DAG.
+    CertificateAccepted {
+        /// The accepted certificate.
+        certificate: Box<Certificate>,
+        /// Whether this certificate was produced by the local node.
+        is_own: bool,
+    },
+
+    /// A sub-DAG has been committed by the Bullshark consensus protocol.
+    ///
+    /// This means the certificates in the sub-DAG are ordered and will
+    /// be executed. The committed sub-DAG includes the leader certificate
+    /// and all certificates it commits.
+    ConsensusCommitted {
+        /// The committed sub-DAG containing ordered certificates.
+        sub_dag: Arc<CommittedSubDag>,
+    },
+
+    /// New blocks have been executed and added to the canonical chain.
+    ///
+    /// This is the final stage — the transactions have been executed by the
+    /// EVM and the resulting state changes are finalized. TN's BFT consensus
+    /// guarantees immediate finality with no reorgs.
+    ChainExecuted {
+        /// The new chain segment containing blocks, receipts, and state changes.
+        new: Arc<Chain>,
+    },
+}

--- a/crates/exex/src/replay.rs
+++ b/crates/exex/src/replay.rs
@@ -1,0 +1,67 @@
+//! Historical block replay for ExEx catch-up.
+//!
+//! When an ExEx starts (or restarts after a crash), it may need to catch up
+//! to the current chain tip. Since TN has no reorgs, this is simply reading
+//! finalized blocks from the database in ascending order.
+
+use crate::TnExExNotification;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tn_reth::RethEnv;
+use tn_types::BlockNumber;
+
+/// Stream that replays historical blocks from the database as ExEx notifications.
+///
+/// Reads finalized blocks from `current_block` to `end_block` (inclusive) and yields
+/// `TnExExNotification::ChainExecuted` for each block.
+///
+/// If `current_block > end_block`, the stream is immediately empty.
+#[derive(Debug)]
+pub struct ReplayStream {
+    reth_env: RethEnv,
+    current_block: BlockNumber,
+    end_block: BlockNumber,
+}
+
+impl ReplayStream {
+    /// Create a new replay stream from `start_block` to `end_block` (inclusive).
+    pub fn new(reth_env: RethEnv, start_block: BlockNumber, end_block: BlockNumber) -> Self {
+        Self { reth_env, current_block: start_block, end_block }
+    }
+}
+
+impl futures::Stream for ReplayStream {
+    type Item = eyre::Result<TnExExNotification>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.current_block > this.end_block {
+            return Poll::Ready(None);
+        }
+
+        let block_number = this.current_block;
+        this.current_block += 1;
+
+        match this.reth_env.replay_block_as_chain(block_number) {
+            Ok(Some(chain)) => {
+                Poll::Ready(Some(Ok(TnExExNotification::ChainExecuted { new: chain })))
+            }
+            Ok(None) => Poll::Ready(Some(Err(eyre::eyre!(
+                "block {block_number} not found in database during replay"
+            )))),
+            Err(e) => Poll::Ready(Some(Err(e.into()))),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.current_block > self.end_block {
+            (0, Some(0))
+        } else {
+            let remaining = (self.end_block - self.current_block + 1) as usize;
+            (remaining, Some(remaining))
+        }
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -26,6 +26,7 @@ tn-rpc = { workspace = true }
 eyre = { workspace = true }
 tn-network-libp2p = { workspace = true }
 tn-reth = { workspace = true }
+tn-exex = { workspace = true }
 state-sync = { workspace = true }
 tn-engine = { workspace = true }
 tn-batch-builder = { workspace = true }

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -12,8 +12,9 @@
 
 use self::inner::ExecutionNodeInner;
 use builder::ExecutionNodeBuilder;
-use std::{net::SocketAddr, sync::Arc};
+use std::{future::Future, net::SocketAddr, sync::Arc};
 use tn_config::Config;
+use tn_exex::ExExInstallFn;
 use tn_reth::{
     system_calls::EpochState, CanonStateNotificationStream, RethConfig, RethDb, RethEnv,
     WorkerTxPool,
@@ -34,7 +35,6 @@ pub use tn_reth::worker::*;
 ///
 /// Used to build the node until upstream reth supports
 /// broader node customization.
-#[derive(Clone, Debug)]
 pub struct TnBuilder {
     /// The node configuration.
     pub node_config: RethConfig,
@@ -54,6 +54,39 @@ pub struct TnBuilder {
     pub healthcheck: Option<u16>,
     /// A reference to the long lived reth DB for the node.
     pub reth_db: RethDb,
+    /// Registered ExEx install functions.
+    ///
+    /// Each entry is a `(name, install_fn)` pair. These are consumed during node
+    /// startup to spawn ExEx tasks on the node-level task manager.
+    pub exex_fns: Vec<(String, ExExInstallFn)>,
+}
+
+impl TnBuilder {
+    /// Register an Execution Extension (ExEx) plugin.
+    ///
+    /// ExExes are long-running tasks that receive notifications about the full
+    /// transaction lifecycle: certificate accepted, consensus committed, and
+    /// chain executed.
+    pub fn install_exex<F, Fut>(&mut self, name: impl Into<String>, install_fn: F) -> &mut Self
+    where
+        F: FnOnce(tn_exex::TnExExContext) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = eyre::Result<()>> + Send + 'static,
+    {
+        self.exex_fns.push((name.into(), Box::new(|ctx| Box::pin(install_fn(ctx)))));
+        self
+    }
+}
+
+impl std::fmt::Debug for TnBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TnBuilder")
+            .field("node_config", &self.node_config)
+            .field("tn_config", &self.tn_config)
+            .field("metrics", &self.metrics)
+            .field("healthcheck", &self.healthcheck)
+            .field("exex_count", &self.exex_fns.len())
+            .finish_non_exhaustive()
+    }
 }
 
 /// Wrapper for the inner execution node components.

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -273,6 +273,69 @@ where
         // spawn task to update the latest execution results for consensus
         self.spawn_engine_update_task(engine_update_rx, &node_task_manager);
 
+        // Spawn ExEx manager and ExEx tasks if any are registered
+        if !self.builder.exex_fns.is_empty() {
+            let reth_env = engine.get_reth_env().await;
+            let canon_stream = reth_env.canonical_block_stream();
+
+            // Subscribe to ConsensusBus broadcast channels for ExEx
+            let rx_own_certs = self.consensus_bus.subscribe_exex_own_certificates();
+            let rx_peer_certs = self.consensus_bus.subscribe_exex_peer_certificates();
+            let rx_committed_sub_dags = self.consensus_bus.subscribe_exex_committed_sub_dags();
+
+            let mut exex_txs = Vec::new();
+            let mut event_rxs = Vec::new();
+
+            for (name, install_fn) in self.builder.exex_fns.drain(..) {
+                let (notif_tx, notif_rx) = mpsc::channel(tn_exex::exex_channel_capacity());
+                let (event_tx, event_rx) = mpsc::unbounded_channel();
+
+                let ctx = tn_exex::TnExExContext {
+                    notifications: notif_rx,
+                    events: event_tx,
+                    reth_env: reth_env.clone(),
+                };
+
+                let exex_fut = install_fn(ctx);
+                let exex_name = name.clone();
+                node_task_manager.get_spawner().spawn_critical_task(
+                    format!("exex-{name}"),
+                    async move {
+                        if let Err(e) = exex_fut.await {
+                            tracing::error!(
+                                target: "exex",
+                                exex = %exex_name,
+                                ?e,
+                                "ExEx task failed"
+                            );
+                        }
+                    },
+                );
+
+                exex_txs.push((name, notif_tx));
+                event_rxs.push(event_rx);
+            }
+
+            let (manager, _handle) = tn_exex::TnExExManager::new(
+                canon_stream,
+                rx_own_certs,
+                rx_peer_certs,
+                rx_committed_sub_dags,
+                exex_txs,
+                event_rxs,
+            );
+            node_task_manager.get_spawner().spawn_critical_task("exex-manager", async move {
+                if let Err(e) = manager.await {
+                    tracing::error!(
+                        target: "exex",
+                        ?e,
+                        "ExEx manager failed"
+                    );
+                }
+            });
+            info!(target: "epoch-manager", "ExEx manager and tasks spawned");
+        }
+
         node_task_manager.update_tasks();
 
         info!(target: "epoch-manager", tasks=?node_task_manager, "NODE TASKS\n");

--- a/crates/telcoin-network-cli/src/node.rs
+++ b/crates/telcoin-network-cli/src/node.rs
@@ -169,7 +169,8 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
 
         // create dbs to survive between sync state transitions
         let reth_db = tn_reth::RethEnv::new_database(&node_config, tn_datadir.reth_db_path())?;
-        let builder = TnBuilder { node_config, tn_config, metrics, healthcheck, reth_db };
+        let builder =
+            TnBuilder { node_config, tn_config, metrics, healthcheck, reth_db, exex_fns: vec![] };
 
         Ok(launcher(builder, ext, tn_datadir, key_config))
     }

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -90,7 +90,8 @@ fn execution_builder<CliExt: clap::Args + fmt::Debug>(
         RethConfig::new(reth_command, instance, tmp_dir, true, Arc::new(tn_config.chain_spec()));
     // create engine node
     let reth_db = RethEnv::new_database(&node_config, tmp_dir.join("db"))?;
-    let builder = TnBuilder { node_config, tn_config, metrics: None, healthcheck, reth_db };
+    let builder =
+        TnBuilder { node_config, tn_config, metrics: None, healthcheck, reth_db, exex_fns: vec![] };
 
     Ok((builder, ext))
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -82,9 +82,9 @@ use reth_node_core::node_config::DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB;
 use reth_provider::{
     providers::{BlockchainProvider, StaticFileProvider},
     BlockIdReader as _, BlockNumReader, BlockReader, CanonChainTracker,
-    CanonStateSubscriptions as _, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
-    DatabaseProviderFactory, HeaderProvider as _, ProviderFactory, StateProviderBox,
-    StateProviderFactory, TransactionVariant,
+    CanonStateSubscriptions as _, Chain, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
+    DatabaseProviderFactory, ExecutionOutcome, HeaderProvider as _, ProviderFactory,
+    ReceiptProvider as _, StateProviderBox, StateProviderFactory, TransactionVariant,
 };
 use reth_revm::{
     cached::CachedReads,
@@ -909,6 +909,43 @@ impl RethEnv {
         range: RangeInclusive<BlockNumber>,
     ) -> TnRethResult<Vec<SealedHeader>> {
         Ok(self.inner.blockchain_provider.sealed_headers_range(range)?)
+    }
+
+    /// Build a [`Chain`] from a historical block in the database.
+    ///
+    /// Reads the block with recovered senders and its receipts, then constructs
+    /// a `Chain` suitable for ExEx replay notifications.
+    ///
+    /// Returns `None` if the block does not exist in the database.
+    pub fn replay_block_as_chain(
+        &self,
+        block_number: BlockNumber,
+    ) -> TnRethResult<Option<Arc<reth_provider::Chain>>> {
+        // Read block with senders
+        let Some(block) = self.inner.blockchain_provider.sealed_block_with_senders(
+            BlockHashOrNumber::Number(block_number),
+            TransactionVariant::NoHash,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        // Read receipts for this block
+        let receipts = self
+            .inner
+            .blockchain_provider
+            .receipts_by_block(BlockHashOrNumber::Number(block_number))?
+            .unwrap_or_default();
+
+        // Construct a minimal ExecutionOutcome with receipts only (no bundle state)
+        let execution_outcome = ExecutionOutcome::new(
+            Default::default(), // empty BundleState — state already committed to DB
+            vec![receipts],
+            block_number,
+            Vec::new(), // no requests
+        );
+
+        Ok(Some(Arc::new(Chain::new(vec![block], execution_outcome, Default::default()))))
     }
 
     /// Return the head header from the reth db.

--- a/examples/exex-lifecycle/Cargo.toml
+++ b/examples/exex-lifecycle/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "exex-lifecycle"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Example ExEx that tracks transactions through the full lifecycle."
+
+[dependencies]
+tn-exex = { path = "../../crates/exex" }
+tn-types = { path = "../../crates/types" }
+eyre = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/exex-lifecycle/src/main.rs
+++ b/examples/exex-lifecycle/src/main.rs
@@ -1,0 +1,107 @@
+//! Example ExEx: Transaction Lifecycle Tracker
+//!
+//! This ExEx demonstrates all three notification types in TN's ExEx system:
+//! 1. **CertificateAccepted** — a header is certified (own or peer)
+//! 2. **ConsensusCommitted** — a sub-DAG is committed by Bullshark
+//! 3. **ChainExecuted** — blocks are executed and finalized
+//!
+//! It logs each stage so you can see transactions flow through the full lifecycle.
+//!
+//! # Registration
+//!
+//! ```rust,ignore
+//! builder.install_exex("lifecycle-tracker", lifecycle_tracker_exex);
+//! ```
+
+use tn_exex::{TnExExContext, TnExExEvent, TnExExNotification};
+use tn_types::BlockHeader as _;
+use tracing::{debug, info};
+
+/// The lifecycle tracker ExEx.
+///
+/// Receives notifications covering the full transaction lifecycle and logs
+/// each stage. In a real application, this could feed a block explorer,
+/// analytics pipeline, or bridge monitoring system.
+async fn lifecycle_tracker_exex(mut ctx: TnExExContext) -> eyre::Result<()> {
+    info!(target: "exex::lifecycle", "Lifecycle tracker ExEx started");
+
+    while let Some(notification) = ctx.notifications.recv().await {
+        match notification {
+            TnExExNotification::CertificateAccepted { certificate, is_own } => {
+                // Stage 1: A header has been certified.
+                // The certificate's batches are now included in the consensus DAG.
+                let origin = if is_own { "own" } else { "peer" };
+                info!(
+                    target: "exex::lifecycle",
+                    round = certificate.round(),
+                    origin = origin,
+                    num_batches = certificate.header().payload.len(),
+                    "Certificate accepted"
+                );
+            }
+
+            TnExExNotification::ConsensusCommitted { sub_dag } => {
+                // Stage 2: A sub-DAG has been committed by Bullshark.
+                // The certificates are now ordered and will be executed.
+                info!(
+                    target: "exex::lifecycle",
+                    leader_round = sub_dag.leader.round(),
+                    num_certificates = sub_dag.certificates.len(),
+                    "Consensus committed sub-DAG"
+                );
+            }
+
+            TnExExNotification::ChainExecuted { new } => {
+                // Stage 3: Blocks have been executed and added to the canonical chain.
+                // This is the final stage — transactions are now finalized.
+                let mut total_txs = 0u64;
+                let mut total_gas = 0u64;
+
+                for block in new.blocks().values() {
+                    let tx_count = block.body().transactions().count() as u64;
+                    let gas_used = block.header().gas_used();
+                    total_txs += tx_count;
+                    total_gas += gas_used;
+                    debug!(
+                        target: "exex::lifecycle",
+                        block_number = block.number(),
+                        tx_count,
+                        gas_used,
+                        "Block executed"
+                    );
+                }
+
+                let tip = new.tip();
+                let tip_number = tip.number();
+                info!(
+                    target: "exex::lifecycle",
+                    tip_number,
+                    num_blocks = new.blocks().len(),
+                    total_txs,
+                    total_gas,
+                    "Chain executed"
+                );
+
+                // Report finished height so the node knows we've processed up to here
+                ctx.events.send(TnExExEvent::FinishedHeight(tip_number))?;
+            }
+        }
+    }
+
+    info!(target: "exex::lifecycle", "Lifecycle tracker ExEx shutting down");
+    Ok(())
+}
+
+fn main() {
+    // This example is meant to be used as a library, registered via:
+    //   builder.install_exex("lifecycle-tracker", lifecycle_tracker_exex);
+    //
+    // It cannot run standalone since it needs a TnExExContext from the node.
+    println!("This is a library example. Register it with TnBuilder::install_exex().");
+    println!();
+    println!("Example usage:");
+    println!("  builder.install_exex(\"lifecycle-tracker\", lifecycle_tracker_exex);");
+
+    // Prevent unused function warning
+    let _ = lifecycle_tracker_exex;
+}


### PR DESCRIPTION
- New `tn-exex` crate with a plugin system that covers the full transaction lifecycle: certificate acceptance, consensus commit, and chain execution (reth only supports execution canonical updates)
- `TnExExManager` subscribes to ConsensusBus broadcast channels and reth's canonical state stream, fans out `TnExExNotification` variants to all registered ExExes
- Three new broadcast channels on `ConsensusBusApp`: `exex_own_certificates`, `exex_peer_certificates`, `exex_committed_sub_dags` — plumbed from certifier, cert_manager, and consensus state respectively
- `TnBuilder::install_exex()` registers plugins at startup; node manager spawns manager + ExEx tasks on the critical task set
- `ReplayStream` and `TnExExContext::replay_and_subscribe()` let ExExes catch up from a historical block to the live tip seamlessly
- `RethEnv::replay_block_as_chain()` reconstructs a `Chain` from a stored block + receipts for replay
- Example in `examples/exex-lifecycle` demonstrates all three notification types with structured logging
- Updated `max_gossip_message_size` doc comments with ConsensusHeader size derivation

closes #618 