### PR TITLE
Pull batches from both the cache and the consensus chain.

### DIFF
--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -10,7 +10,7 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{GossipMessage, Stream};
 use tn_network_types::{WorkerOthersBatchMessage, WorkerToPrimaryClient};
-use tn_storage::tables::NodeBatchesCache;
+use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
 use tn_types::{
     ensure, now, try_decode, BatchValidation, BlsPublicKey, Database, SealedBatch, WorkerId, B256,
 };
@@ -152,6 +152,7 @@ where
         pending_request: Option<PendingBatchStream>,
         mut stream: Stream,
         request_digest: B256,
+        consensus_chain: &ConsensusChain,
     ) -> WorkerNetworkResult<()> {
         // `None` indicates unexpected request
         let Some(request) = pending_request else {
@@ -182,6 +183,7 @@ where
             stream_codec::send_batches_over_stream(
                 &mut stream,
                 store,
+                consensus_chain,
                 &request.batch_digests,
                 request.epoch,
             ),
@@ -239,7 +241,15 @@ where
         stream: Stream,
         pending_request: Option<PendingBatchStream>,
         request_digest: B256,
+        consensus_chain: &ConsensusChain,
     ) -> WorkerNetworkResult<()> {
-        self.process_request_batches_stream(peer, pending_request, stream, request_digest).await
+        self.process_request_batches_stream(
+            peer,
+            pending_request,
+            stream,
+            request_digest,
+            consensus_chain,
+        )
+        .await
     }
 }

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{types::NetworkEvent, GossipMessage, ResponseChannel, Stream};
+use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     BatchValidation, BlockHash, BlsPublicKey, Database, Epoch, SealedBatch, TaskSpawner,
     TnReceiver, WorkerId, B256,
@@ -115,6 +116,8 @@ pub struct WorkerNetwork<DB, Events> {
     pending_batch_requests: Arc<Mutex<HashMap<PendingBatchRequestKey, PendingBatchStream>>>,
     /// Semaphore bounding total concurrent batch stream operations (pending + active).
     batch_stream_semaphore: Arc<Semaphore>,
+    /// Access to the consensus chain.
+    consensus_chain: ConsensusChain,
 }
 
 impl<DB, Events> WorkerNetwork<DB, Events>
@@ -129,6 +132,7 @@ where
         consensus_config: ConsensusConfig<DB>,
         id: WorkerId,
         validator: Arc<dyn BatchValidation>,
+        consensus_chain: ConsensusChain,
     ) -> Self {
         let request_handler =
             RequestHandler::new(id, validator, consensus_config, network_handle.clone());
@@ -138,6 +142,7 @@ where
             request_handler,
             pending_batch_requests: Arc::new(Mutex::new(HashMap::new())),
             batch_stream_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_BATCH_STREAMS)),
+            consensus_chain,
         }
     }
 
@@ -362,6 +367,7 @@ where
         let network_handle = self.network_handle.clone();
         let pending_map = self.pending_batch_requests.clone();
         let task_name = format!("stream-requested-batches-{peer}");
+        let consensus_chain = self.consensus_chain.clone();
         self.network_handle.get_task_spawner().spawn_task(task_name, async move {
             // read the request digest (32-bytes) from the stream with timeout
             let mut digest_buf = [0u8; tn_types::DIGEST_LENGTH];
@@ -388,7 +394,7 @@ where
 
             // process stream
             if let Err(err) = request_handler
-                .process_request_batches_stream(peer, opt_pending_req, stream, request_digest)
+                .process_request_batches_stream(peer, opt_pending_req, stream, request_digest, &consensus_chain)
                 .await {
                     // apply applicable penalty for error
                     warn!(target: "worker::network", ?err, "error processing request batches stream");

--- a/crates/consensus/worker/src/network/stream_codec.rs
+++ b/crates/consensus/worker/src/network/stream_codec.rs
@@ -9,7 +9,7 @@
 use super::error::{WorkerNetworkError, WorkerNetworkResult};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use std::collections::HashSet;
-use tn_storage::tables::NodeBatchesCache;
+use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
 use tn_types::{max_batch_size, Batch, Database, Epoch, B256};
 
 /// Max number of batch digests per chunk.
@@ -80,10 +80,47 @@ where
     Ok(count)
 }
 
+/// Retrieve batches from the list of batch_digests.
+async fn get_batches<DB>(
+    epoch: Epoch,
+    batch_digests: &[B256],
+    store: &DB,
+    consensus_chain: &ConsensusChain,
+) -> WorkerNetworkResult<Vec<Batch>>
+where
+    DB: Database,
+{
+    // look up batches from db
+    let mut batches: Vec<_> = store
+        .multi_get::<NodeBatchesCache>(batch_digests.iter())
+        .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))?
+        .into_iter()
+        .flatten() // removes `None`
+        .collect();
+
+    let batches = if batches.is_empty() {
+        consensus_chain.get_batches(epoch, batch_digests.iter()).await
+    } else if batches.len() < batch_digests.len() {
+        let mut missing = Vec::new();
+        for digest in batches.iter().map(|b| b.digest()) {
+            if !batch_digests.contains(&digest) {
+                missing.push(digest);
+            }
+        }
+        batches.extend(consensus_chain.get_batches(epoch, missing.iter()).await);
+        batches
+    } else {
+        batches
+    };
+
+    Ok(batches)
+}
+
 /// Send batches over stream, looking up from database.
 pub(crate) async fn send_batches_over_stream<DB, S>(
     stream: &mut S,
     store: &DB,
+    consensus_chain: &ConsensusChain,
     batch_digests: &HashSet<B256>,
     epoch: Epoch,
 ) -> WorkerNetworkResult<()>
@@ -101,12 +138,7 @@ where
     let digests: Vec<_> = batch_digests.iter().copied().collect();
     for chunk in digests.chunks(BATCH_DIGESTS_READ_CHUNK_SIZE) {
         // look up batches from db
-        let batches: Vec<_> = store
-            .multi_get::<NodeBatchesCache>(chunk.iter())
-            .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))?
-            .into_iter()
-            .flatten() // removes `None`
-            .collect();
+        let batches: Vec<_> = get_batches(epoch, chunk, store, consensus_chain).await?;
 
         // write batch count for this chunk
         let chunk_size = batches.len() as u32;
@@ -135,6 +167,7 @@ mod tests {
     use futures::io::Cursor;
     use snap::read::FrameDecoder;
     use std::io::Read;
+    use tempfile::TempDir;
     use tn_types::{max_batch_size, TaskManager};
 
     /// Helper to write batch to buffer and return it
@@ -302,13 +335,18 @@ mod tests {
     async fn test_send_batches_over_stream_roundtrip() {
         let batches = create_test_batches(3);
         let db = setup_batch_db(&batches);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
 
         // collect digests
         let digests: HashSet<B256> = batches.iter().map(|b| b.digest()).collect();
 
         // send batches over a Vec<u8> buffer
         let mut output = Vec::new();
-        send_batches_over_stream(&mut output, &db, &digests, 0).await.expect("send batches");
+        send_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0)
+            .await
+            .expect("send batches");
 
         // read back: chunk_count then each batch
         let mut cursor = Cursor::new(output);
@@ -337,12 +375,18 @@ mod tests {
         let batches = create_test_batches(3);
         // only insert first 2 batches into DB
         let db = setup_batch_db(&batches[..2]);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+        consensus_chain.persist_current().await.expect("clean open");
 
         // request all 3 digests
         let digests: HashSet<B256> = batches.iter().map(|b| b.digest()).collect();
 
         let mut output = Vec::new();
-        send_batches_over_stream(&mut output, &db, &digests, 0).await.expect("send batches");
+        send_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0)
+            .await
+            .expect("send batches");
 
         // chunk count should reflect only found batches (2)
         let mut cursor = Cursor::new(output);
@@ -354,9 +398,14 @@ mod tests {
     async fn test_send_batches_over_stream_empty_digests() {
         let db = setup_batch_db(&[]);
         let digests: HashSet<B256> = HashSet::new();
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
 
         let mut output = Vec::new();
-        send_batches_over_stream(&mut output, &db, &digests, 0).await.expect("send batches");
+        send_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0)
+            .await
+            .expect("send batches");
 
         // empty digests → no output (no chunks written)
         assert!(output.is_empty());
@@ -370,13 +419,18 @@ mod tests {
         let batch_count = BATCH_DIGESTS_READ_CHUNK_SIZE + 50;
         let batches = create_test_batches(batch_count);
         let db = setup_batch_db(&batches);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
 
         let digests: HashSet<B256> = batches.iter().map(|b| b.digest()).collect();
         assert_eq!(digests.len(), batch_count);
 
         // send batches (will chunk into 200 + 50)
         let mut output = Vec::new();
-        send_batches_over_stream(&mut output, &db, &digests, 0).await.expect("send batches");
+        send_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0)
+            .await
+            .expect("send batches");
 
         // read back using the handle's multi-chunk reader
         let mut cursor = Cursor::new(output);

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -1175,6 +1175,7 @@ where
             consensus_config.clone(),
             *worker_id,
             validator,
+            self.consensus_chain.clone(),
         )
         .spawn(&epoch_task_spawner);
 

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -13,8 +13,8 @@ use std::{
 
 use parking_lot::Mutex;
 use tn_types::{
-    gas_accumulator::RewardsCounter, AuthorityIdentifier, BlockHash, BlockNumHash, CommittedSubDag,
-    Committee, ConsensusHeader, ConsensusOutput, Epoch, EpochRecord, Round, B256,
+    gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, BlockNumHash,
+    CommittedSubDag, Committee, ConsensusHeader, ConsensusOutput, Epoch, EpochRecord, Round, B256,
 };
 use tokio::{
     fs::File as AsyncFile,
@@ -544,6 +544,23 @@ impl ConsensusChain {
         } else {
             false
         }
+    }
+
+    /// Return a vector of batches matching the provided digests (if found).
+    pub async fn get_batches(
+        &self,
+        epoch: Epoch,
+        digests: impl Iterator<Item = &BlockHash>,
+    ) -> Vec<Batch> {
+        let mut result = Vec::new();
+        if let Ok(pack) = self.get_static(epoch).await {
+            for digest in digests {
+                if let Some(batch) = pack.batch(*digest).await {
+                    result.push(batch);
+                }
+            }
+        }
+        result
     }
 
     /// Count leaders in this pack (in rewards_counter) lower than last_executed_round.


### PR DESCRIPTION
Expose the consensus chain DB to the worker network and use both the batch cache and consensus chain to find requested batches.