### PR TITLE
idempotent request replacement

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -684,10 +684,16 @@ where
                     let mut hasher = tn_types::DefaultHashFunction::new();
                     hasher.update(&epoch.to_le_bytes());
                     let request_digest = B256::from_slice(hasher.finalize().as_bytes());
-                    let pending = PendingEpochStream::new(epoch, permit);
-                    // If the same peer requests the same epoch then replace request.
-                    // If the peer tries to stream twice the second attempt will be
-                    // punished as a protocol violation.
+                    // If the same peer re-requests the same epoch while a prior entry
+                    // is still pending, preserve the original `created_at` so the
+                    // cleanup timer is not rearmed. Without this, a peer could hold a
+                    // slot indefinitely by re-requesting before the 30s timeout.
+                    // A second stream open is still punished as a protocol violation.
+                    let created_at = pending_map
+                        .get(&(peer, request_digest))
+                        .map(|p| p.created_at)
+                        .unwrap_or_else(Instant::now);
+                    let pending = PendingEpochStream { epoch, created_at, _permit: permit };
                     if pending_map.insert((peer, request_digest), pending).is_some() {
                         debug!(
                             target: "primary::network",

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -4,16 +4,18 @@ use crate::{
     error::PrimaryNetworkError,
     network::{
         message::{ConsensusResult, PrimaryGossip},
-        MissingCertificatesRequest, RequestHandler,
+        MissingCertificatesRequest, PendingEpochStream, RequestHandler,
+        MAX_CONCURRENT_EPOCH_STREAMS, PENDING_REQUEST_TIMEOUT,
     },
     state_sync::StateSynchronizer,
     ConsensusBus, ConsensusBusApp, NodeMode, RecentBlocks,
 };
 use assert_matches::assert_matches;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::Path,
-    time::Duration,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 use tempfile::TempDir;
 use tn_config::Parameters;
@@ -695,4 +697,61 @@ async fn test_behind_consensus_genuinely_behind() {
 
     let result = handler.behind_consensus(0, 60, None).await;
     assert!(result, "genuinely behind node should be detected");
+}
+
+/// A peer that re-requests the same epoch while an entry is already pending must not be
+/// able to reset the cleanup timer. If the replacement path rearmed `created_at`, a peer
+/// could re-request every 20s and hold a slot forever. This test exercises the
+/// preservation logic used by `process_epoch_stream` and verifies the entry is evicted on
+/// schedule relative to the *original* insertion time.
+#[tokio::test]
+async fn test_pending_epoch_stream_replacement_preserves_created_at() {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EPOCH_STREAMS));
+    let mut pending_map: HashMap<(BlsPublicKey, B256), PendingEpochStream> = HashMap::new();
+
+    let peer = BlsPublicKey::default();
+    let digest = B256::random();
+    let key = (peer, digest);
+    let epoch: u32 = 7;
+
+    // initial insertion at T0, where T0 is just past the cleanup horizon so we can
+    // assert eviction without waiting on wall-clock time
+    let t0 = Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1);
+    let permit = semaphore.clone().try_acquire_owned().expect("permit available");
+    pending_map.insert(key, PendingEpochStream::new_with_created_at(epoch, permit, t0));
+
+    // simulate a re-request: production code looks up the existing entry's
+    // `created_at` and reuses it when building the replacement
+    let new_permit = semaphore.clone().try_acquire_owned().expect("permit available");
+    let preserved_created_at =
+        pending_map.get(&key).map(|p| p.created_at).unwrap_or_else(Instant::now);
+    let replacement =
+        PendingEpochStream { epoch, created_at: preserved_created_at, _permit: new_permit };
+    assert!(pending_map.insert(key, replacement).is_some(), "expected replacement");
+
+    // the replacement must carry the original `created_at`, not a fresh one
+    let after = pending_map.get(&key).expect("entry present after replacement");
+    assert_eq!(
+        after.created_at, t0,
+        "replacement must preserve original created_at to prevent cleanup-timer reset"
+    );
+
+    // cleanup mirrors `PrimaryNetwork::cleanup_stale_pending_requests`: entries whose
+    // age >= PENDING_REQUEST_TIMEOUT must be evicted. Since created_at is t0 (stale),
+    // the entry must drop.
+    let now = Instant::now();
+    pending_map
+        .retain(|_, pending| now.duration_since(pending.created_at) < PENDING_REQUEST_TIMEOUT);
+
+    assert!(
+        pending_map.is_empty(),
+        "stale entry must be evicted by cleanup even though it was 'replaced' moments ago"
+    );
+
+    // and the permit must have returned to the semaphore
+    assert_eq!(
+        semaphore.available_permits(),
+        MAX_CONCURRENT_EPOCH_STREAMS,
+        "dropping the evicted pending entry must release its semaphore permit"
+    );
 }

--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -98,7 +98,9 @@ impl From<WorkerNetworkError> for Option<Penalty> {
                     }
                 }
             }
-            WorkerNetworkError::InvalidRequest(_) => Some(Penalty::Mild),
+            WorkerNetworkError::InvalidRequest(_) | WorkerNetworkError::UnknownStreamRequest(_) => {
+                Some(Penalty::Mild)
+            }
             WorkerNetworkError::StdIo(ref io_err) => {
                 // separate legitimate failures like connection resets from suspicious behavior
                 match io_err.kind() {
@@ -117,7 +119,6 @@ impl From<WorkerNetworkError> for Option<Penalty> {
             | WorkerNetworkError::TooManyBatches { .. }
             | WorkerNetworkError::UnexpectedBatch(_)
             | WorkerNetworkError::DuplicateBatch(_)
-            | WorkerNetworkError::UnknownStreamRequest(_)
             | WorkerNetworkError::RequestHashMismatch => Some(Penalty::Fatal),
             // ignore
             WorkerNetworkError::Timeout(_)

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -98,6 +98,11 @@ impl PendingBatchStream {
     ) -> Self {
         Self { batch_digests, epoch, created_at, _permit: permit }
     }
+
+    /// Read the `created_at` timestamp for testing the cleanup / replacement behavior.
+    pub fn created_at(&self) -> Instant {
+        self.created_at
+    }
 }
 
 /// Handle inter-node communication between primaries.
@@ -318,8 +323,30 @@ where
                     } else {
                         let request_digest =
                             self.network_handle.generate_batch_request_id(&batch_digests);
-                        let pending = PendingBatchStream::new(batch_digests, epoch, permit);
-                        pending_map.insert((peer, request_digest), pending);
+                        // If the same peer re-requests the same batch set while a prior
+                        // entry is still pending, preserve the original `created_at` so
+                        // the cleanup timer is not rearmed. Without this, a peer could
+                        // hold a slot indefinitely by re-requesting before the 30s
+                        // timeout. A second stream open is still punished as a protocol
+                        // violation.
+                        let created_at = pending_map
+                            .get(&(peer, request_digest))
+                            .map(|p| p.created_at)
+                            .unwrap_or_else(Instant::now);
+                        let pending = PendingBatchStream {
+                            batch_digests,
+                            epoch,
+                            created_at,
+                            _permit: permit,
+                        };
+                        if pending_map.insert((peer, request_digest), pending).is_some() {
+                            debug!(
+                                target: "worker::network",
+                                %peer,
+                                ?request_digest,
+                                "pending batch stream request replaced with identical batch request"
+                            );
+                        }
                         debug!(
                             target: "worker::network",
                             %peer,

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -738,3 +738,77 @@ async fn test_request_batches_peer_fallback_preserves_digests() {
     // all peers rejected → error
     assert!(result.is_err());
 }
+
+/// A peer that re-requests the same batch set while an entry is already pending must not
+/// be able to reset the cleanup timer. If the replacement path rearmed `created_at`, a
+/// peer could re-request every 20s and hold a slot forever. This test exercises the
+/// preservation logic used by `process_request_batches_stream` and verifies the entry is
+/// evicted on schedule relative to the *original* insertion time.
+#[tokio::test]
+async fn test_pending_batch_stream_replacement_preserves_created_at() {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_BATCH_STREAMS));
+    let mut pending_map: std::collections::HashMap<(BlsPublicKey, B256), PendingBatchStream> =
+        std::collections::HashMap::new();
+
+    let task_manager = TaskManager::default();
+    let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
+
+    let peer = BlsPublicKey::default();
+    let batch_digests: HashSet<B256> = HashSet::from([B256::random(), B256::random()]);
+    let request_digest = handle.pub_generate_batch_request_id(&batch_digests);
+    let key = (peer, request_digest);
+    let epoch = 7u32;
+
+    // initial insertion at T0, where T0 is just past the cleanup horizon so we can
+    // assert eviction without waiting on wall-clock time
+    let t0 =
+        std::time::Instant::now() - PENDING_REQUEST_TIMEOUT - std::time::Duration::from_secs(1);
+    let permit = semaphore.clone().try_acquire_owned().expect("permit available");
+    pending_map.insert(
+        key,
+        PendingBatchStream::new_with_created_at(batch_digests.clone(), epoch, permit, t0),
+    );
+
+    // simulate a re-request: production code looks up the existing entry's
+    // `created_at` and reuses it when building the replacement
+    let new_permit = semaphore.clone().try_acquire_owned().expect("permit available");
+    let preserved_created_at = pending_map
+        .get(&key)
+        .map(|p| p.created_at())
+        .unwrap_or_else(std::time::Instant::now);
+    let replacement = PendingBatchStream::new_with_created_at(
+        batch_digests.clone(),
+        epoch,
+        new_permit,
+        preserved_created_at,
+    );
+    assert!(pending_map.insert(key, replacement).is_some(), "expected replacement");
+
+    // the replacement must carry the original `created_at`, not a fresh one
+    let after = pending_map.get(&key).expect("entry present after replacement");
+    assert_eq!(
+        after.created_at(),
+        t0,
+        "replacement must preserve original created_at to prevent cleanup-timer reset"
+    );
+
+    // cleanup mirrors `WorkerNetwork::cleanup_stale_pending_requests`: entries whose
+    // age >= PENDING_REQUEST_TIMEOUT must be evicted. Since created_at is t0 (stale),
+    // the entry must drop.
+    let now = std::time::Instant::now();
+    pending_map.retain(|_, pending| {
+        now.duration_since(pending.created_at()) < PENDING_REQUEST_TIMEOUT
+    });
+
+    assert!(
+        pending_map.is_empty(),
+        "stale entry must be evicted by cleanup even though it was 'replaced' moments ago"
+    );
+
+    // and the permit must have returned to the semaphore
+    assert_eq!(
+        semaphore.available_permits(),
+        MAX_CONCURRENT_BATCH_STREAMS,
+        "dropping the evicted pending entry must release its semaphore permit"
+    );
+}


### PR DESCRIPTION
- Primary and worker pending-request replacement now preserves `created_at`, so a peer re-requesting the same epoch / batch set cannot rearm the 30s cleanup timer and squat a slot indefinitely
- Worker's `UnknownStreamRequest` drops from `Penalty::Fatal` to `Penalty::Mild`, matching the primary. The error fires when a stream open races the sweeper — a transient network condition, not a malicious act
- Worker gets a `debug!` log on replacement, mirroring the primary's existing hook for squat-detection telemetry
- Unit tests on both paths assert: replacement preserves the original `created_at`, the stale entry is evicted on schedule, and the semaphore permit is returned
