### PR TITLE
Dont use eyre for task errors.

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -163,10 +163,9 @@ impl BatchBuilder {
             // forward to worker and wait for ack that quorum was reached
             if let Err(e) = to_worker.send((batch, ack)).await {
                 error!(target: "worker::batch_builder", ?e, "failed to send next batch to worker");
-                let res_err = Err(eyre::eyre!("{e}"));
                 // try to return error if worker channel closed
-                let _ = result.send(Err(e.into()));
-                return res_err;
+                let _ = result.send(Err(BatchBuilderError::WorkerChannelClosed));
+                return Err(e.into());
             }
 
             // wait for worker to ack quorum reached then update pool with mined transactions

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -21,7 +21,6 @@ state-sync = { workspace = true }
 tn-types = { workspace = true }
 tn-config = { workspace = true }
 tn-primary = { workspace = true }
-eyre = { workspace = true }
 
 [dev-dependencies]
 eyre = { workspace = true }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -91,7 +91,7 @@ pub fn spawn_subscriber<DB: Database>(
                 info!(target: "subscriber", "Starting subscriber: CVV");
                 if let Err(e) = subscriber.run(rx_shutdown, rx_sequence, consensus_chain).await {
                     error!(target: "subscriber", "Error subscriber consensus: {e}");
-                    Err(eyre::eyre!("{e}"))
+                    Err(e.into())
                 } else {
                     Ok(())
                 }
@@ -106,7 +106,7 @@ pub fn spawn_subscriber<DB: Database>(
                     info!(target: "subscriber", "Starting subscriber: Catch up and rejoin");
                     if let Err(e) = subscriber.catch_up_rejoin_consensus(clone).await {
                         error!(target: "subscriber", "Error catching up consensus: {e}");
-                        Err(eyre::eyre!("{e}"))
+                        Err(e.into())
                     } else {
                         Ok(())
                     }
@@ -120,7 +120,7 @@ pub fn spawn_subscriber<DB: Database>(
                 info!(target: "subscriber", "Starting subscriber: Follower");
                 if let Err(e) = subscriber.follow_consensus(clone).await {
                     error!(target: "subscriber", "Error following consensus: {e}");
-                    Err(eyre::eyre!("{e}"))
+                    Err(e.into())
                 } else {
                     Ok(())
                 }

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -112,7 +112,7 @@ impl<DB: Database> CertificateFetcher<DB> {
             .await
             .map_err(|e| {
                 error!(target: "primary::cert_fetcher", ?e, "cert fetcher shutting down");
-                eyre::eyre!("{e}")
+                e.into()
             })
         });
     }

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -406,7 +406,7 @@ impl<DB: Database> Certifier<DB> {
                         // pass to state_sync for internal processing
                         if let Err(e) = self.state_sync.process_own_certificate(&mut certificate).await {
                             error!(target: "primary::certifier", "error accepting own certificate: {e}");
-                            return Err(eyre::eyre!("{e}"));
+                            return Err(e.into());
                         }
 
                         // try to publish the certificate on gossip network
@@ -434,7 +434,7 @@ impl<DB: Database> Certifier<DB> {
                                     auth=?self.authority_id,
                                     "Certifier error on proposed header task: {e}"
                                 );
-                                Err(eyre::eyre!("{e}"))
+                                Err(e.into())
                             }
                         }
                     }

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -340,7 +340,7 @@ impl<DB: Database> Consensus<DB> {
             // Subscribe before spawning so the channel is active before any messages are sent.
             let rx_new_certificates = consensus_bus.subscribe_new_certificates();
             task_manager.spawn_critical_task("consensus task", async move {
-                s.run(rx_new_certificates).await.map_err(|e| eyre::eyre!("{e}"))
+                Ok(s.run(rx_new_certificates).await?)
             });
         }
     }

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -28,8 +28,8 @@ use tn_network_types::{WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerTo
 use tn_storage::{consensus::ConsensusChain, PayloadStore};
 use tn_types::{
     encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, CertificateDigest, ConsensusHeader,
-    Database, Epoch, EpochCertificate, EpochRecord, EpochVote, Header, Round, TaskSpawner,
-    TnReceiver, TnSender, Vote, B256,
+    Database, Epoch, EpochCertificate, EpochRecord, EpochVote, Header, Round, TaskError,
+    TaskSpawner, TnReceiver, TnSender, Vote, B256,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -468,7 +468,7 @@ where
                             }
                             None => {
                                 warn!(target: "worker::network", "critical worker network events channel dropped");
-                                break Err(eyre::eyre!("critical worker network events channel dropped"));
+                                break Err(TaskError::from_message("critical worker network events channel dropped"));
                             }
                         }
                     }
@@ -752,12 +752,11 @@ where
         self.task_spawner.spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "primary::network", ?e, "process_gossip");
-                let res_err = Err(eyre::eyre!("{e}"));
                 // convert error into penalty to lower peer score
                 if let Some(penalty) = (&e).into() {
                     network_handle.report_penalty(propagation_source, penalty).await;
                 }
-                res_err
+                Err(e.into())
             } else {
                 Ok(())
             }
@@ -783,11 +782,11 @@ where
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
                     warn!(target: "worker::network", %peer, ?e, "failed to read request digest from stream");
-                    return Err(eyre::eyre!("{e}"));
+                    return Err(e.into());
                 }
                 Err(e) => {
                     warn!(target: "worker::network", %peer, "timeout reading request digest from stream");
-                    return Err(eyre::eyre!("{e}"));
+                    return Err(e.into());
                 }
             }
             let request_digest = B256::from(digest_buf);
@@ -803,11 +802,10 @@ where
                 .await {
                     // apply applicable penalty for error
                     warn!(target: "worker::network", ?err, "error processing request batches stream");
-                    let res_err = Err(eyre::eyre!("{err}"));
                     if let Some(penalty) = (&err).into() {
                         network_handle.report_penalty(peer, penalty).await;
                     }
-                    res_err
+                    Err(err.into())
                 } else {
                     Ok(())
                 }

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -646,9 +646,7 @@ impl<DB: Database> Proposer<DB> {
             let rx_committed_own_headers = self.consensus_bus.subscribe_committed_own_headers();
             task_manager.spawn_critical_task("proposer task", async move {
                 info!(target: "primary::proposer", "Starting proposer");
-                self.run(rx_our_digests, rx_parents, rx_committed_own_headers)
-                    .await
-                    .map_err(|e| eyre::eyre!("{e}"))
+                Ok(self.run(rx_our_digests, rx_parents, rx_committed_own_headers).await?)
             });
         }
         // If not an active CVV then don't propose anything.

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -183,13 +183,8 @@ where
             // NOTE: this should be okay bc header is already certified by quorum of signatures
             self.task_spawner.spawn_task("sync header batches", async move {
                 let sync_header = HeaderValidator::new(config, bus);
-                let res = sync_header.sync_header_batches(&header, true, max_age).await;
-                if let Err(e) = res {
-                    error!(target: "primary::cert_validator", ?e, ?header, ?max_age, "error syncing batches for certified header");
-                    Err(eyre::eyre!("{e}"))
-                } else {
-                    Ok(())
-                }
+                Ok(sync_header.sync_header_batches(&header, true, max_age).await
+                    .inspect_err(|e| error!(target: "primary::cert_validator", ?e, ?header, ?max_age, "error syncing batches for certified header"))?)
             });
 
             // trigger certificate fetching if cert is too far ahead of this node

--- a/crates/consensus/primary/src/state_sync/mod.rs
+++ b/crates/consensus/primary/src/state_sync/mod.rs
@@ -54,7 +54,7 @@ where
         // Subscribe before spawning so the channel is active before any messages are sent.
         let rx = self.certificate_validator.consensus_bus().subscribe_certificate_manager();
         task_manager.spawn_critical_task("certificate-manager", async move {
-            certificate_manager.run(rx).await.map_err(|e| eyre::eyre!("{e}"))
+            Ok(certificate_manager.run(rx).await?)
         });
     }
 

--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -73,12 +73,13 @@ pub enum WorkerNetworkError {
     BatchEpochMismatch(Epoch, Epoch),
 }
 
-impl From<WorkerNetworkError> for Option<Penalty> {
-    fn from(val: WorkerNetworkError) -> Self {
+impl WorkerNetworkError {
+    /// Return the penalty for this error if it causes one (None if no penalty).
+    pub fn penalty(&self) -> Option<Penalty> {
         //
         // explicitly match every error type to ensure penalties are updated with changes
         //
-        match val {
+        match self {
             WorkerNetworkError::BatchValidation(batch_validation_error) => {
                 match batch_validation_error {
                     // mild
@@ -132,5 +133,11 @@ impl From<WorkerNetworkError> for Option<Penalty> {
             | WorkerNetworkError::BatchEpochMismatch(_, _)
             | WorkerNetworkError::Internal(_) => None,
         }
+    }
+}
+
+impl From<WorkerNetworkError> for Option<Penalty> {
+    fn from(val: WorkerNetworkError) -> Self {
+        val.penalty()
     }
 }

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -15,7 +15,7 @@ use tn_config::ConsensusConfig;
 use tn_network_libp2p::{types::NetworkEvent, GossipMessage, ResponseChannel, Stream};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
-    BatchValidation, BlockHash, BlsPublicKey, Database, Epoch, SealedBatch, TaskSpawner,
+    BatchValidation, BlockHash, BlsPublicKey, Database, Epoch, SealedBatch, TaskError, TaskSpawner,
     TnReceiver, WorkerId, B256,
 };
 use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
@@ -161,7 +161,7 @@ where
                             }
                             None => {
                                 warn!(target: "worker::network", "critical worker network events channel dropped");
-                                break Err(eyre::eyre!("critical worker network events channel dropped"));
+                                break Err(TaskError::from_message("critical worker network events channel dropped"));
                             }
                         }
                     }
@@ -261,12 +261,11 @@ where
         self.network_handle.get_task_spawner().spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "worker::network", ?e, "process_gossip");
-                let res_err = Err(eyre::eyre!("{e}"));
                 // convert error into penalty to lower peer score
-                if let Some(penalty) = e.into() {
+                if let Some(penalty) = e.penalty() {
                     network_handle.report_penalty(propagation_source, penalty).await;
                 }
-                res_err
+                Err(e.into())
             } else {
                 Ok(())
             }
@@ -385,11 +384,11 @@ where
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
                     warn!(target: "worker::network", %peer, ?e, "failed to read request digest from stream");
-                    return Err(eyre::eyre!("{e}"));
+                    return Err(e.into());
                 }
                 Err(e) => {
                     warn!(target: "worker::network", %peer, "timeout reading request digest from stream");
-                    return Err(eyre::eyre!("{e}"));
+                    return Err(e.into());
                 }
             }
             let request_digest = B256::from(digest_buf);
@@ -405,11 +404,10 @@ where
                 .await {
                     // apply applicable penalty for error
                     warn!(target: "worker::network", ?err, "error processing request batches stream");
-                    let res_err = Err(eyre::eyre!("{err}"));
-                    if let Some(penalty) = err.into() {
+                    if let Some(penalty) = err.penalty() {
                         network_handle.report_penalty(peer, penalty).await;
                     }
-                    res_err
+                    Err(err.into())
                 } else {
                     Ok(())
                 }

--- a/crates/consensus/worker/src/quorum_waiter.rs
+++ b/crates/consensus/worker/src/quorum_waiter.rs
@@ -236,7 +236,7 @@ impl QuorumWaiterTrait for QuorumWaiter {
 
             // forward result
             let _ = tx.send(res.clone());
-            res.map_err(|e| eyre::eyre!({ e }))
+            Ok(res?)
         });
         rx
     }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -76,16 +76,15 @@ impl ExecutionNodeInner {
         self.reth_env.get_task_spawner().spawn_critical_task("consensus engine", async move {
             info!("Engine stated from block {block_num}/{block_hash}, consensus output {consensus_header:?}");
             let res = tn_engine.await;
-            match res {
+            match &res {
                 Ok(_) => {
                     info!(target: "engine", "TN Engine exited gracefully");
-                    Ok(())
                 }
                 Err(e) => {
                     error!(target: "engine", ?e, "TN Engine error");
-                    Err(eyre::eyre!("{e}"))
                 }
             }
+            Ok(res?)
         });
 
         Ok(())

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -18,7 +18,7 @@ use tn_reth::{system_calls::EpochState, RethDb, RethEnv};
 use tn_storage::{consensus::ConsensusChain, open_db, DatabaseType};
 use tn_types::{
     deconstruct_nonce, gas_accumulator::GasAccumulator, BlockNumHash, ConsensusHeader,
-    ConsensusOutput, Database as TNDatabase, EngineUpdate, Epoch, Notifier, TaskManager,
+    ConsensusOutput, Database as TNDatabase, EngineUpdate, Epoch, Notifier, TaskError, TaskManager,
     TaskSpawner, TimestampSec, MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::{WorkerNetworkHandle, WorkerRequest, WorkerResponse};
@@ -286,15 +286,23 @@ where
         // spawn three critical workers that will fetch epoch pack files from an epoch work queue.
         // Note, these workers will just go dormant once we have caught up- that's ok.
         for i in 0..3 {
+            let shutdown = self.node_shutdown.subscribe();
+            let consensus_bus = self.consensus_bus.clone();
+            let primary_network_handle = primary_network_handle.clone();
+            let consensus_chain = self.consensus_chain.clone();
             node_task_manager.spawn_critical_task(
                 format!("epoch-consensus-worker-{i}"),
-                spawn_fetch_consensus(
-                    self.node_shutdown.subscribe(),
-                    self.consensus_bus.clone(),
-                    primary_network_handle.clone(),
-                    i,
-                    self.consensus_chain.clone(),
-                ),
+                async move {
+                    spawn_fetch_consensus(
+                        shutdown,
+                        consensus_bus,
+                        primary_network_handle,
+                        i,
+                        consensus_chain,
+                    )
+                    .await;
+                    Ok(())
+                },
             );
         }
 
@@ -498,7 +506,7 @@ where
                 });
             }
             error!(target: "engine", "engine updates ended, node will exit");
-            Err(eyre::eyre!("engine updates ended, node will exit"))
+            Err(TaskError::from_message("engine updates ended, node will exit"))
         });
     }
 }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -83,7 +83,7 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
     consensus_bus: ConsensusBusApp,
     network: PrimaryNetworkHandle,
     consensus_chain: ConsensusChain,
-) -> eyre::Result<()> {
+) {
     let rx_shutdown = config.shutdown().subscribe();
     let mut rx_gossip_update = consensus_bus.last_published_consensus_num_hash().subscribe();
     let (tx, mut rx) = tokio::sync::mpsc::channel(10_000);
@@ -141,7 +141,7 @@ pub(crate) async fn spawn_track_recent_consensus<DB: TNDatabase>(
             }
 
             _ = &rx_shutdown => {
-                return Ok(())
+                return;
             }
         }
     }
@@ -158,7 +158,7 @@ pub async fn spawn_fetch_consensus(
     network: PrimaryNetworkHandle,
     task_index: u32, // Task index for logging.
     consensus_chain: ConsensusChain,
-) -> eyre::Result<()> {
+) {
     async fn next_epoch<'s>(
         consensus_bus: &ConsensusBusApp,
         next_sem: &'s Arc<Semaphore>,
@@ -190,7 +190,7 @@ pub async fn spawn_fetch_consensus(
                             _ = &rx_shutdown => {
                                 info!(target: "state-sync",
                                     "epoch consensus fetcher {task_index} shutting down during pack fetch");
-                                return Ok(());
+                                return;
                             }
                         }
                     }
@@ -199,7 +199,7 @@ pub async fn spawn_fetch_consensus(
                 }
             }
             _ = &rx_shutdown => {
-                return Ok(())
+                break;
             }
         }
     }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -15,7 +15,7 @@ use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusHeaderCache};
 use tn_types::{
-    BlockHash, ConsensusHeader, ConsensusOutput, Database, Epoch, TaskSpawner, TnSender,
+    BlockHash, ConsensusHeader, ConsensusOutput, Database, Epoch, TaskError, TaskSpawner, TnSender,
 };
 use tracing::{debug, error, info, warn};
 
@@ -74,19 +74,13 @@ pub fn spawn_state_sync<DB: Database>(
                 "state sync: track latest consensus header from peers",
                 async move {
                     info!(target: "state-sync", "Starting state sync: track latest consensus header from peers");
-                    if let Err(e) = spawn_track_recent_consensus(
+                    spawn_track_recent_consensus(
                         config_clone,
                         consensus_bus_clone,
                         network,
                         consensus_chain_clone,
-                    )
-                    .await
-                    {
-                        error!(target: "state-sync", "Error tracking latest consensus headers: {e}");
-                        Err(eyre::eyre!("{e}"))
-                    } else {
-                        Ok(())
-                    }
+                    ).await;
+                    Ok(())
                 },
             );
             task_spawner.spawn_task(
@@ -95,7 +89,7 @@ pub fn spawn_state_sync<DB: Database>(
                     info!(target: "state-sync", "Starting state sync: stream consensus header from peers");
                     if let Err(e) = spawn_stream_consensus_headers(config, consensus_bus, consensus_chain).await {
                         error!(target: "state-sync", "Error streaming consensus headers: {e}");
-                        Err(eyre::eyre!("{e}"))
+                        Err(TaskError::from_message(e))
                     } else {
                         Ok(())
                     }

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -23,8 +23,8 @@ use reth_transaction_pool::{
 };
 use std::{sync::Arc, time::Instant};
 use tn_types::{
-    Address, EnvKzgSettings, Recovered, SealedBlock, TaskSpawner, TransactionSigned, TxHash,
-    MIN_PROTOCOL_BASE_FEE,
+    Address, EnvKzgSettings, Recovered, SealedBlock, TaskError, TaskSpawner, TransactionSigned,
+    TxHash, MIN_PROTOCOL_BASE_FEE,
 };
 use tracing::{debug, info, trace};
 
@@ -135,7 +135,9 @@ impl WorkerTxPool {
                     _ => unreachable!("TN reorgs are impossible"),
                 }
             }
-            Err(eyre::eyre!("canonical txn pool task ended because state_stream closed"))
+            Err(TaskError::from_message(
+                "canonical txn pool task ended because state_stream closed",
+            ))
         });
         Ok(this)
     }

--- a/crates/types/src/task_manager.rs
+++ b/crates/types/src/task_manager.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::{Debug, Display},
     future::Future,
     pin::pin,
+    sync::Arc,
     task::Poll,
     time::Duration,
 };
@@ -15,8 +16,57 @@ use tokio::{
     task::{JoinError, JoinHandle},
 };
 
-/// The error type for tasks.
-pub type TaskError = eyre::Report;
+/// Trait that encompasses the required traits for a TaskError.
+pub trait TaskErrorTrait: std::error::Error + Send + Sync + 'static {}
+
+impl<E: std::error::Error + Send + Sync + 'static> TaskErrorTrait for E {}
+
+/// Used internally to wrap a simple message error when there is nothing better to wrap.
+#[derive(Clone, Debug)]
+struct TaskStrErr(String);
+
+impl std::error::Error for TaskStrErr {}
+impl Display for TaskStrErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Error type for tasks.
+/// Reports an error happened and gets it's string.
+/// Wraps the original error.
+#[derive(Clone, Debug)]
+pub struct TaskError {
+    error: Arc<dyn TaskErrorTrait>,
+}
+
+impl TaskError {
+    /// Retrun a reference to the contained error.
+    pub fn error(&self) -> &dyn TaskErrorTrait {
+        &*self.error
+    }
+
+    /// Produce a TaskError from a String.
+    /// We can not just implement From because of the
+    /// generic implementation (even though it does not work for a String...).
+    pub fn from_message(message: impl ToString) -> Self {
+        let err = TaskStrErr(message.to_string());
+        err.into()
+    }
+}
+
+impl<E: std::error::Error + Send + Sync + 'static> From<E> for TaskError {
+    fn from(error: E) -> Self {
+        Self { error: Arc::new(error) }
+    }
+}
+
+impl Display for TaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
 /// Result type for all tasks.
 pub type TaskResult = Result<(), TaskError>;
 
@@ -587,7 +637,7 @@ mod test {
 
     use tokio::sync::mpsc::{self, Receiver, Sender};
 
-    use crate::{Notifier, TaskJoinError, TaskManager};
+    use crate::{Notifier, TaskError, TaskJoinError, TaskManager};
 
     struct Ping {
         ping_rx: Receiver<u32>,
@@ -749,7 +799,8 @@ mod test {
             tokio::time::sleep(Duration::from_secs(10)).await;
             Ok(())
         });
-        task_manager.spawn_critical_task("Crit 2", async move { Err(eyre::eyre!("BOOM!")) });
+        task_manager
+            .spawn_critical_task("Crit 2", async move { Err(TaskError::from_message("BOOM!")) });
         match task_manager.join(Notifier::default()).await {
             Ok(_) => {}
             Err(TaskJoinError::CriticalExitOk(_name)) => panic!("should not be OK"),


### PR DESCRIPTION
Use a custom error type to clean up the task error code (not using eyre).