### PR TITLE
Clean up batch handling and possible race conditions.

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -152,13 +152,7 @@ impl<DB: Database> Subscriber<DB> {
         // This save will essentially mark this consensus output as written in stone (added to the
         // consensus chain). This does NOT imply execution although it will be sent off for
         // execution.
-        save_consensus(
-            self.config.node_storage(),
-            consensus_output.clone(),
-            &self.inner.authority_id,
-            &mut consensus_chain,
-        )
-        .await?;
+        save_consensus(consensus_output.clone(), &mut consensus_chain).await?;
 
         let last_round = consensus_output.leader_round();
 
@@ -327,7 +321,7 @@ impl<DB: Database> Subscriber<DB> {
                     match output {
                         Ok(output) => {
                             debug!(target: "subscriber", output=?output.digest(), "saving next output");
-                            save_consensus(self.config.node_storage(), output.clone(), &self.inner.authority_id, &mut consensus_chain).await?;
+                            save_consensus(output.clone(), &mut consensus_chain).await?;
                             debug!(target: "subscriber", "broadcasting output...");
                             if let Err(e) = self.consensus_bus.consensus_output().send(output).await {
                                 error!(target: "subscriber", "error broadcasting consensus output for authority {:?}: {}", self.inner.authority_id, e);
@@ -353,9 +347,7 @@ impl<DB: Database> Subscriber<DB> {
                             Some(output) = waiting.next() => {
                                 if let Ok(output) = output {
                                     if let Err(e) = save_consensus(
-                                        self.config.node_storage(),
                                         output.clone(),
-                                        &self.inner.authority_id,
                                         &mut consensus_chain,
                                     ).await {
                                         warn!(target: "subscriber", "error saving consensus during shutdown: {e}");

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -8,8 +8,8 @@ use crate::{
     WorkerNetworkError,
 };
 use std::collections::{HashMap, HashSet};
-use tn_storage::tables::NodeBatchesCache;
-use tn_types::{now, Batch, BlockHash, Database, DbTxMut};
+use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
+use tn_types::{now, Batch, BlockHash, Database, DbTxMut, Epoch, B256};
 use tracing::{debug, error, instrument};
 
 #[derive(Debug)]
@@ -19,12 +19,99 @@ pub(crate) struct BatchFetcher<DB> {
     network: WorkerNetworkHandle,
     /// The local database instance.
     batch_store: DB,
+    /// The consensus chain.
+    consensus_chain: ConsensusChain,
+}
+
+/// Retrieve a batch from local storage for batch_digest.
+/// Use this as a helper to fetch a batch from the local cache or the
+/// consensus chain.
+pub(crate) async fn get_batch_local<DB>(
+    epoch: Epoch,
+    batch_digest: B256,
+    store: &DB,
+    consensus_chain: &ConsensusChain,
+) -> WorkerNetworkResult<Option<Batch>>
+where
+    DB: Database,
+{
+    // read from database
+    // look up batches from db
+    if let Some(batch) = store
+        .get::<NodeBatchesCache>(&batch_digest)
+        .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))?
+    {
+        Ok(Some(batch))
+    } else {
+        Ok(consensus_chain.get_batches(epoch, [batch_digest].iter()).await.into_iter().next())
+    }
+}
+
+/// Retrieve a batch from the local cache for batch_digest.
+/// Use this as a helper to fetch a batch from ONLY the local cache.
+pub(crate) fn get_batch_local_cache<DB>(
+    batch_digest: B256,
+    store: &DB,
+) -> WorkerNetworkResult<Option<Batch>>
+where
+    DB: Database,
+{
+    store
+        .get::<NodeBatchesCache>(&batch_digest)
+        .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))
+}
+
+/// Retrieve batches from local storage for the list of batch_digests.
+/// Use this as a helper to fetch batches from the local cache or the
+/// consensus chain.
+pub(crate) async fn get_batches_local<DB>(
+    epoch: Epoch,
+    batch_digests: &[B256],
+    store: &DB,
+    consensus_chain: &ConsensusChain,
+) -> WorkerNetworkResult<Vec<Batch>>
+where
+    DB: Database,
+{
+    // read from database
+    // look up batches from db
+    let mut batches: Vec<_> = store
+        .multi_get::<NodeBatchesCache>(batch_digests.iter())
+        .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))?
+        .into_iter()
+        .flatten() // removes `None`
+        .collect();
+
+    let batches = if batches.is_empty() {
+        // Nothing in cache so get what we can from the consensus chain.
+        consensus_chain.get_batches(epoch, batch_digests.iter()).await
+    } else if batches.len() < batch_digests.len() {
+        // Some not in cache so try to get the rest from the consensus chain.
+        let found_digests: Vec<B256> = batches.iter().map(|b| b.digest()).collect();
+        let mut missing = Vec::new();
+        for digest in batch_digests.iter() {
+            if !found_digests.contains(digest) {
+                missing.push(*digest);
+            }
+        }
+        batches.extend(consensus_chain.get_batches(epoch, missing.iter()).await);
+        batches
+    } else {
+        // All the batches were in the cache.
+        batches
+    };
+
+    Ok(batches)
 }
 
 impl<DB: Database> BatchFetcher<DB> {
     /// Create a new instance of `Self`.
-    pub(crate) fn new(network: WorkerNetworkHandle, batch_store: DB) -> Self {
-        Self { network, batch_store }
+    pub(crate) fn new(
+        network: WorkerNetworkHandle,
+        batch_store: DB,
+        consensus_chain: ConsensusChain,
+    ) -> Self {
+        Self { network, batch_store, consensus_chain }
     }
 
     /// Bulk fetches payload from local storage and remote workers.
@@ -54,7 +141,7 @@ impl<DB: Database> BatchFetcher<DB> {
             }
 
             // 1) fetch from local storage
-            self.fetch_local(&mut missing_digests, &mut fetched_batches)?;
+            self.fetch_local(&mut missing_digests, &mut fetched_batches).await?;
 
             // return if all batches recovered
             if missing_digests.is_empty() {
@@ -103,28 +190,36 @@ impl<DB: Database> BatchFetcher<DB> {
     }
 
     /// Retrieve batches from the local database.
-    fn fetch_local(
+    async fn fetch_local(
         &self,
         missing_digests: &mut HashSet<BlockHash>,
         fetched_batches: &mut HashMap<BlockHash, Batch>,
     ) -> WorkerNetworkResult<()> {
         // read from database
         debug!(target: "batch_fetcher", "Local attempt to fetch {} missing_digests", missing_digests.len());
-        let local_batches = self
-            .batch_store
-            .multi_get::<NodeBatchesCache>(missing_digests.iter())
-            .map_err(|e| WorkerNetworkError::DBRead(format!("Multiget failed: {e}")))?;
-        for (digest, batch) in missing_digests.iter().zip(local_batches) {
-            if let Some(batch) = batch {
-                debug_assert_eq!(*digest, batch.digest());
-                fetched_batches.insert(*digest, batch);
-            }
-        }
+        let missing_vec: Vec<B256> = missing_digests.iter().copied().collect();
+        let local_batches = get_batches_local(
+            self.network.epoch(),
+            &missing_vec,
+            &self.batch_store,
+            &self.consensus_chain,
+        )
+        .await?;
+        fetched_batches.extend(local_batches.into_iter().map(|b| (b.digest(), b)));
 
         // remove fetched batches from missing
         missing_digests.retain(|d| !fetched_batches.contains_key(d));
 
         Ok(())
+    }
+
+    /// Retrieve a batch from the local database.
+    pub(crate) async fn fetch_local_batch(
+        &self,
+        digest: BlockHash,
+    ) -> WorkerNetworkResult<Option<Batch>> {
+        get_batch_local(self.network.epoch(), digest, &self.batch_store, &self.consensus_chain)
+            .await
     }
 
     /// Issue request_batches RPC and verifies response integrity
@@ -150,7 +245,9 @@ mod tests {
     };
     use futures::io::Cursor;
     use std::collections::{HashMap, HashSet};
+    use tempfile::TempDir;
     use tn_network_libp2p::error::NetworkError;
+    use tn_storage::consensus::ConsensusChain;
     use tn_types::{max_batch_size, Batch, BlockHash, TaskManager, B256};
 
     #[tokio::test]
@@ -325,10 +422,15 @@ mod tests {
         let batches = create_test_batches(3);
         let db = setup_batch_db(&batches);
         let digests: HashSet<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+        let temp_dir = TempDir::new().expect("temp dir");
 
         let task_manager = TaskManager::default();
         let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
-        let fetcher = BatchFetcher::new(handle, db);
+        let fetcher = BatchFetcher::new(
+            handle,
+            db,
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+        );
 
         let result = fetcher.fetch_for_primary(digests.clone()).await.expect("fetch local batches");
         assert_eq!(result.len(), batches.len());
@@ -342,10 +444,15 @@ mod tests {
         let batches = create_test_batches(20);
         let db = setup_batch_db(&batches);
         let digests: HashSet<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+        let temp_dir = TempDir::new().expect("temp dir");
 
         let task_manager = TaskManager::default();
         let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
-        let fetcher = BatchFetcher::new(handle, db);
+        let fetcher = BatchFetcher::new(
+            handle,
+            db,
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+        );
 
         let result = fetcher.fetch_for_primary(digests.clone()).await.expect("fetch local batches");
         assert_eq!(result.len(), 20);
@@ -372,15 +479,20 @@ mod tests {
         // only store the first batch locally
         let db = setup_batch_db(&all_batches[..1]);
         let all_digests: HashSet<BlockHash> = all_batches.iter().map(|b| b.digest()).collect();
+        let temp_dir = TempDir::new().expect("temp dir");
 
         let task_manager = TaskManager::default();
         let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
-        let fetcher = BatchFetcher::new(handle.clone(), db);
+        let fetcher = BatchFetcher::new(
+            handle.clone(),
+            db,
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+        );
 
         // step 1: fetch_local finds 1 batch, leaves 4 missing
         let mut missing_digests = all_digests.clone();
         let mut fetched_batches = HashMap::new();
-        fetcher.fetch_local(&mut missing_digests, &mut fetched_batches).unwrap();
+        fetcher.fetch_local(&mut missing_digests, &mut fetched_batches).await.unwrap();
 
         assert_eq!(fetched_batches.len(), 1);
         assert_eq!(missing_digests.len(), 4);

--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -1,6 +1,6 @@
 //! Worker's network-related errors.
 use tn_network_libp2p::{error::NetworkError, Penalty};
-use tn_types::{BatchValidationError, BcsError, BlockHash};
+use tn_types::{BatchValidationError, BcsError, BlockHash, Epoch};
 use tokio::time::error::Elapsed;
 
 /// Result alias for results that possibly return [`WorkerNetworkError`].
@@ -68,6 +68,9 @@ pub enum WorkerNetworkError {
     /// Error reading from DB.
     #[error("DB read Error {0}")]
     DBRead(String),
+    /// Invalid batch epoch.
+    #[error("Got batch from epoch {0} expected {1}")]
+    BatchEpochMismatch(Epoch, Epoch),
 }
 
 impl From<WorkerNetworkError> for Option<Penalty> {
@@ -126,6 +129,7 @@ impl From<WorkerNetworkError> for Option<Penalty> {
             | WorkerNetworkError::DBRead(_)
             | WorkerNetworkError::StreamClosed
             | WorkerNetworkError::Network(_)
+            | WorkerNetworkError::BatchEpochMismatch(_, _)
             | WorkerNetworkError::Internal(_) => None,
         }
     }

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -60,7 +60,7 @@ impl WorkerNetworkHandle {
 
     /// Publish a batch digest to the worker network.
     pub(crate) async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
-        let data = encode(&WorkerGossip::Batch(batch_digest));
+        let data = encode(&WorkerGossip::Batch(self.epoch, batch_digest));
         self.handle.publish(tn_config::LibP2pConfig::worker_batch_topic(), data).await?;
         Ok(())
     }

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -4,7 +4,10 @@ use super::{
     handle::WorkerNetworkHandle,
     message::WorkerGossip,
 };
-use crate::network::{stream_codec, PendingBatchStream};
+use crate::{
+    batch_fetcher::get_batch_local_cache,
+    network::{stream_codec, PendingBatchStream},
+};
 use futures::AsyncWriteExt as _;
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
@@ -62,14 +65,25 @@ where
         let gossip = try_decode(data)?;
 
         match gossip {
-            WorkerGossip::Batch(batch_hash) => {
+            WorkerGossip::Batch(epoch, batch_hash) => {
                 ensure!(
                     topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic()),
                     WorkerNetworkError::InvalidTopic
                 );
+                let my_epoch = self.consensus_config.epoch();
+                // We are probably behind.  Do not bother to fetch and store this Batch now, it will
+                // most likely be removed before we can use it and will be fetched
+                // later when needed.
+                ensure!(my_epoch == epoch, WorkerNetworkError::BatchEpochMismatch(epoch, my_epoch));
                 // Retrieve the batch...
                 let store = self.consensus_config.node_storage();
-                if !matches!(store.get::<NodeBatchesCache>(&batch_hash), Ok(Some(_))) {
+                // Since we are precaching Batches for the current epoch we only need to check if it
+                // is in the local cache. There should not have been an opertunity
+                // for it to be in the consensus chain yet.
+                if !matches!(
+                    get_batch_local_cache(batch_hash, self.consensus_config.node_storage(),),
+                    Ok(Some(_))
+                ) {
                     // If batch is missing from db, then request from peer.
                     // If we are a CVV then we should already have it.
                     // This allows non-CVVs to pre fetch batches they will soon need.

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -10,7 +10,7 @@ use tn_types::{BlockHash, Epoch, SealedBatch};
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WorkerGossip {
     /// A new is available.
-    Batch(BlockHash),
+    Batch(Epoch, BlockHash),
     /// Transaction- published so a committee member can include in a batch.
     Txn(Vec<u8>),
 }

--- a/crates/consensus/worker/src/network/primary.rs
+++ b/crates/consensus/worker/src/network/primary.rs
@@ -19,7 +19,7 @@ pub(crate) struct PrimaryReceiverHandler<DB> {
     /// Synchronize header payloads from other workers.
     pub network: Option<WorkerNetworkHandle>,
     /// Fetch certificate payloads from other workers.
-    pub batch_fetcher: Option<BatchFetcher<DB>>,
+    pub batch_fetcher: BatchFetcher<DB>,
     /// Validate incoming batches
     pub validator: Arc<dyn BatchValidation>,
 }
@@ -35,7 +35,7 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
         let mut missing = HashSet::new();
         for digest in message.digests.iter() {
             // Check if we already have the batch.
-            match self.store.get::<NodeBatchesCache>(digest) {
+            match self.batch_fetcher.fetch_local_batch(*digest).await {
                 Ok(None) => {
                     missing.insert(*digest);
                     debug!("Requesting sync for batch {digest}");
@@ -107,13 +107,6 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
         &self,
         digests: HashSet<BlockHash>,
     ) -> eyre::Result<HashMap<BlockHash, Batch>> {
-        // option approach required for startup - this should never happen
-        let Some(batch_fetcher) = self.batch_fetcher.as_ref() else {
-            return Err(eyre::eyre!(
-                "fetch_batches() is unsupported via RPC interface, please call via local worker handler instead".to_string(),
-            ));
-        };
-
-        Ok(batch_fetcher.fetch_for_primary(digests).await?)
+        Ok(self.batch_fetcher.fetch_for_primary(digests).await?)
     }
 }

--- a/crates/consensus/worker/src/network/stream_codec.rs
+++ b/crates/consensus/worker/src/network/stream_codec.rs
@@ -6,10 +6,12 @@
 //! To start stream, peers exchange `B256` (32-byte) digest at the
 //! beginning of the stream.
 
+use crate::batch_fetcher::get_batches_local;
+
 use super::error::{WorkerNetworkError, WorkerNetworkResult};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use std::collections::HashSet;
-use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
+use tn_storage::consensus::ConsensusChain;
 use tn_types::{max_batch_size, Batch, Database, Epoch, B256};
 
 /// Max number of batch digests per chunk.
@@ -80,42 +82,6 @@ where
     Ok(count)
 }
 
-/// Retrieve batches from the list of batch_digests.
-async fn get_batches<DB>(
-    epoch: Epoch,
-    batch_digests: &[B256],
-    store: &DB,
-    consensus_chain: &ConsensusChain,
-) -> WorkerNetworkResult<Vec<Batch>>
-where
-    DB: Database,
-{
-    // look up batches from db
-    let mut batches: Vec<_> = store
-        .multi_get::<NodeBatchesCache>(batch_digests.iter())
-        .map_err(|e| WorkerNetworkError::Internal(format!("DB error: {e}")))?
-        .into_iter()
-        .flatten() // removes `None`
-        .collect();
-
-    let batches = if batches.is_empty() {
-        consensus_chain.get_batches(epoch, batch_digests.iter()).await
-    } else if batches.len() < batch_digests.len() {
-        let mut missing = Vec::new();
-        for digest in batches.iter().map(|b| b.digest()) {
-            if !batch_digests.contains(&digest) {
-                missing.push(digest);
-            }
-        }
-        batches.extend(consensus_chain.get_batches(epoch, missing.iter()).await);
-        batches
-    } else {
-        batches
-    };
-
-    Ok(batches)
-}
-
 /// Send batches over stream, looking up from database.
 pub(crate) async fn send_batches_over_stream<DB, S>(
     stream: &mut S,
@@ -138,7 +104,7 @@ where
     let digests: Vec<_> = batch_digests.iter().copied().collect();
     for chunk in digests.chunks(BATCH_DIGESTS_READ_CHUNK_SIZE) {
         // look up batches from db
-        let batches: Vec<_> = get_batches(epoch, chunk, store, consensus_chain).await?;
+        let batches: Vec<_> = get_batches_local(epoch, chunk, store, consensus_chain).await?;
 
         // write batch count for this chunk
         let chunk_size = batches.len() as u32;

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -12,7 +12,10 @@ use crate::{
 use std::{sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
 use tn_network_types::{local::LocalNetwork, WorkerOwnBatchMessage, WorkerToPrimaryClient};
-use tn_storage::tables::{NodeBatchesCache, OurNodeBatchesCache};
+use tn_storage::{
+    consensus::ConsensusChain,
+    tables::{NodeBatchesCache, OurNodeBatchesCache},
+};
 use tn_types::{
     error::BlockSealError, BatchReceiver, BatchSender, BatchValidation, Database, DbTxMut as _,
     SealedBatch, TaskManager, WorkerId,
@@ -30,16 +33,20 @@ pub fn new_worker<DB: Database>(
     validator: Arc<dyn BatchValidation>,
     consensus_config: ConsensusConfig<DB>,
     network_handle: WorkerNetworkHandle,
+    consensus_chain: ConsensusChain,
 ) -> Worker<DB, QuorumWaiter> {
     info!(target: "worker::worker", "Boot worker node with id {} key {:?}", id, consensus_config.key_config().primary_public_key());
 
-    let batch_fetcher =
-        BatchFetcher::new(network_handle.clone(), consensus_config.node_storage().clone());
+    let batch_fetcher = BatchFetcher::new(
+        network_handle.clone(),
+        consensus_config.node_storage().clone(),
+        consensus_chain,
+    );
     consensus_config.local_network().set_primary_to_worker_local_handler(Arc::new(
         PrimaryReceiverHandler {
             store: consensus_config.node_storage().clone(),
             network: Some(network_handle.clone()),
-            batch_fetcher: Some(batch_fetcher),
+            batch_fetcher,
             validator,
         },
     ));
@@ -263,6 +270,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             }
             Err(e) => {
                 error!(target: "worker::batch_provider", "Join error attempting batch quorum! {e}");
+                // See remove comment above.
+                let _ = self.store.remove::<OurNodeBatchesCache>(&digest);
                 return Err(BlockSealError::FailedQuorum);
             }
         }
@@ -296,7 +305,6 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         let message = WorkerOwnBatchMessage { worker_id: self.id, digest };
         if let Err(err) = self.client.report_own_batch(message).await {
             error!(target: "worker::batch_provider", "Failed to report our batch: {err:?}");
-            let _ = self.store.remove::<NodeBatchesCache>(&digest);
             Err(BlockSealError::FailedToReport)
         } else {
             Ok(())

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -82,7 +82,7 @@ async fn test_batch_gossip_topics() {
     let TestTypes { network_commands_rx: _, handler, task_manager: _, committee: _ } =
         create_test_types();
     let batch_digest = B256::random();
-    let gossip = WorkerGossip::Batch(batch_digest);
+    let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
     let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
@@ -115,7 +115,7 @@ async fn test_batch_gossip_triggers_stream_request() {
     let TestTypes { mut network_commands_rx, handler, task_manager, committee } =
         create_test_types();
     let batch_digest = B256::random();
-    let gossip = WorkerGossip::Batch(batch_digest);
+    let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
     let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
     let msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
@@ -162,7 +162,7 @@ async fn test_batch_gossip_stream_accepted_opens_stream() {
     let TestTypes { mut network_commands_rx, handler, task_manager, committee } =
         create_test_types();
     let batch_digest = B256::random();
-    let gossip = WorkerGossip::Batch(batch_digest);
+    let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
     let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
     let msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -921,8 +921,13 @@ where
         )
         .await?;
 
-        let worker =
-            WorkerNode::new(worker_id, consensus_config.clone(), network_handle.clone(), validator);
+        let worker = WorkerNode::new(
+            worker_id,
+            consensus_config.clone(),
+            network_handle.clone(),
+            validator,
+            self.consensus_chain.clone(),
+        );
 
         Ok(worker)
     }

--- a/crates/node/src/worker.rs
+++ b/crates/node/src/worker.rs
@@ -2,6 +2,7 @@
 use crate::manager::WORKER_TASK_BASE;
 use std::sync::Arc;
 use tn_config::ConsensusConfig;
+use tn_storage::consensus::ConsensusChain;
 use tn_types::{BatchValidation, Database as ConsensusDatabase, WorkerId};
 use tn_worker::{new_worker, quorum_waiter::QuorumWaiter, Worker, WorkerNetworkHandle};
 use tokio::sync::RwLock;
@@ -17,6 +18,8 @@ pub struct WorkerNodeInner<CDB> {
     network_handle: WorkerNetworkHandle,
     /// The batch validator.
     validator: Arc<dyn BatchValidation>,
+    /// The consensus chain.
+    consensus_chain: ConsensusChain,
 }
 
 impl<CDB: ConsensusDatabase> WorkerNodeInner<CDB> {
@@ -31,6 +34,7 @@ impl<CDB: ConsensusDatabase> WorkerNodeInner<CDB> {
             self.validator.clone(),
             self.consensus_config.clone(),
             self.network_handle.clone(),
+            self.consensus_chain.clone(),
         );
 
         Ok(batch_provider)
@@ -48,8 +52,10 @@ impl<CDB: ConsensusDatabase> WorkerNode<CDB> {
         consensus_config: ConsensusConfig<CDB>,
         network_handle: WorkerNetworkHandle,
         validator: Arc<dyn BatchValidation>,
+        consensus_chain: ConsensusChain,
     ) -> WorkerNode<CDB> {
-        let inner = WorkerNodeInner { id, consensus_config, network_handle, validator };
+        let inner =
+            WorkerNodeInner { id, consensus_config, network_handle, validator, consensus_chain };
 
         Self { internal: Arc::new(RwLock::new(inner)) }
     }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -13,13 +13,9 @@ use tn_test_utils_committee as _;
 use std::time::Duration;
 use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode};
-use tn_storage::{
-    consensus::ConsensusChain,
-    tables::{ConsensusHeaderCache, NodeBatchesCache},
-};
+use tn_storage::{consensus::ConsensusChain, tables::ConsensusHeaderCache};
 use tn_types::{
-    AuthorityIdentifier, BlockHash, ConsensusHeader, ConsensusOutput, Database, Epoch, TaskSpawner,
-    TnSender,
+    BlockHash, ConsensusHeader, ConsensusOutput, Database, Epoch, TaskSpawner, TnSender,
 };
 use tracing::{debug, error, info, warn};
 
@@ -104,30 +100,17 @@ pub fn spawn_state_sync<DB: Database>(
     }
 }
 
-/// Write the consensus header and it's component transaction batches to the consensus DB.
+/// Write the consensus header and it's component transaction batches to the consensus chain.
 ///
 /// An error here indicates a critical node failure.
 /// Note, if this returns an error then the DB could not be written to- this is probably fatal.
-pub async fn save_consensus<DB: Database>(
-    db: &DB,
+pub async fn save_consensus(
     consensus_output: ConsensusOutput,
-    authority_id: &Option<AuthorityIdentifier>,
     consensus_chain: &mut ConsensusChain,
 ) -> eyre::Result<()> {
-    let sub_dag = consensus_output.sub_dag().clone();
     consensus_chain.save_consensus_output(consensus_output).await?;
-    if let Some(authority_id) = authority_id {
-        // If we are a validator we need to clear any of our batches from our cache that are
-        // now part of consensus.
-        for cert in &sub_dag.certificates {
-            if cert.header().author() == authority_id {
-                for batch_hash in cert.header().payload().keys() {
-                    let _ = db.remove::<NodeBatchesCache>(batch_hash);
-                }
-            }
-        }
-    }
-    // Make sure we have persisted the consensus output before we execute.
+    // Note it is ok to leave batches in NodeBatchesCache until the epoch ends (when the table is
+    // cleared). Make sure we have persisted the consensus output before we execute.
     consensus_chain.persist_current().await?;
     Ok(())
 }

--- a/crates/state-sync/tests/it/main.rs
+++ b/crates/state-sync/tests/it/main.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 use tempfile::TempDir;
-use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, open_db};
+use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{CommittedSubDag, ConsensusHeader, ConsensusOutput, ReputationScores, B256};
 
@@ -19,7 +19,6 @@ use tn_types::{CommittedSubDag, ConsensusHeader, ConsensusOutput, ReputationScor
 #[tokio::test]
 async fn test_sync_save_consensus() {
     let temp_dir = TempDir::new().unwrap();
-    let store = open_db(temp_dir.path());
 
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
@@ -41,7 +40,7 @@ async fn test_sync_save_consensus() {
     let output = ConsensusOutput::new(sub_dag, B256::ZERO, 1, false, VecDeque::new(), vec![]);
 
     // Save consensus using state_sync
-    state_sync::save_consensus(&store, output, &None, &mut consensus_chain).await.unwrap();
+    state_sync::save_consensus(output, &mut consensus_chain).await.unwrap();
 
     // Verify the consensus was saved
     let saved = consensus_chain.consensus_header_by_number(1).await.unwrap();
@@ -60,7 +59,6 @@ async fn test_sync_save_consensus() {
 #[tokio::test]
 async fn test_sync_parent_hash_chain() {
     let temp_dir = TempDir::new().unwrap();
-    let store = open_db(temp_dir.path());
 
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
@@ -84,7 +82,7 @@ async fn test_sync_parent_hash_chain() {
         let output =
             ConsensusOutput::new(sub_dag.clone(), parent_hash, i, false, VecDeque::new(), vec![]);
 
-        state_sync::save_consensus(&store, output, &None, &mut consensus_chain).await.unwrap();
+        state_sync::save_consensus(output, &mut consensus_chain).await.unwrap();
 
         // Calculate the digest that was saved
         let digest = ConsensusHeader::digest_from_parts(parent_hash, &sub_dag, i);
@@ -114,7 +112,6 @@ async fn test_sync_parent_hash_chain() {
 #[tokio::test]
 async fn test_sync_lookup_by_hash() {
     let temp_dir = TempDir::new().unwrap();
-    let store = open_db(temp_dir.path());
 
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
@@ -132,7 +129,7 @@ async fn test_sync_lookup_by_hash() {
     let output =
         ConsensusOutput::new(sub_dag.clone(), B256::ZERO, 1, false, VecDeque::new(), vec![]);
 
-    state_sync::save_consensus(&store, output, &None, &mut consensus_chain).await.unwrap();
+    state_sync::save_consensus(output, &mut consensus_chain).await.unwrap();
 
     // Compute the expected digest
     let expected_digest = ConsensusHeader::digest_from_parts(B256::ZERO, &sub_dag, 1);
@@ -207,7 +204,6 @@ async fn test_digest_collision_resistance() {
 #[tokio::test]
 async fn test_digest_mismatch_detection() {
     let temp_dir = TempDir::new().unwrap();
-    let store = open_db(temp_dir.path());
 
     let fixture = CommitteeFixture::builder(MemDatabase::default).build();
     let committee = fixture.committee();
@@ -224,7 +220,7 @@ async fn test_digest_mismatch_detection() {
 
     // Save block 1 with correct parent (ZERO)
     let output1 = ConsensusOutput::new(sub_dag, B256::ZERO, 1, false, VecDeque::new(), vec![]);
-    state_sync::save_consensus(&store, output1, &None, &mut consensus_chain).await.unwrap();
+    state_sync::save_consensus(output1, &mut consensus_chain).await.unwrap();
 
     // Get block 1's digest
     let block1 = consensus_chain.consensus_header_by_number(1).await.unwrap().unwrap();


### PR DESCRIPTION
This attempts to fix the protocol violation that brought down testnet.  It leaves batches in the cache until epoch close.  Clearing the cache early combined with a bug on local batch fetching could lead so a race making a batch unavailable producing the error.

Also try to clean up some other batch handling.  Add an epoch to the gossiped batch hashes so a node can not pre fetch batches for an epoch it is not currently working on (these will most likely be deleted and re-fetched later, wasting network bandwidth).

rebase #632 onto main
closes #631 