### PR TITLE
Tighten some of consensus chain data.

### DIFF
--- a/crates/consensus/primary/src/consensus/leader_schedule.rs
+++ b/crates/consensus/primary/src/consensus/leader_schedule.rs
@@ -248,7 +248,7 @@ impl LeaderSchedule {
     }
 
     /// Restores the LeaderSchedule by using the storage. It will attempt to retrieve the last
-    /// committed "final" ReputationScores and use them to create build a LeaderSwapTable to use
+    /// committed "final" ReputationScores and use them to build a LeaderSwapTable to use
     /// for the LeaderSchedule.
     pub async fn from_store(
         committee: Committee,

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -14,7 +14,7 @@ use tn_config::ConsensusConfig;
 use tn_storage::{consensus::ConsensusChain, CertificateStore};
 use tn_types::{
     AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Committee, Database,
-    Hash as _, Noticer, Round, TaskManager, Timestamp, TnReceiver, TnSender,
+    Hash as _, Noticer, Round, TaskManager, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument};
 
@@ -166,12 +166,9 @@ impl ConsensusState {
             .or_insert_with(|| certificate.round());
         self.last_round = self.last_round.update(certificate.round(), self.gc_depth);
 
-        let commit_latency_ms = certificate.created_at().elapsed().as_millis() as u64;
-
         // Metric: certificate_commit_latency_ms - time from certificate creation to commit
         info!(
             target: "consensus::metrics",
-            certificate_commit_latency_ms = commit_latency_ms,
             round = certificate.round(),
             origin = ?certificate.origin(),
             digest = ?certificate.digest(),

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -700,10 +700,8 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     // are randomly generated
     //
     // for each tx, seed address with funds in genesis
-    let timestamp = now();
     let mut leader_1 = Certificate::default();
     // update cert
-    leader_1.update_created_at_for_test(timestamp);
     leader_1.header_mut_for_test().author = authority_1;
     let sub_dag_index_1 = 1;
     leader_1.header.round = sub_dag_index_1 as u32;
@@ -730,7 +728,6 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     let mut leader_2 = Certificate::default();
     let leader_2_epoch = leader_2.epoch();
     // update cert
-    leader_2.update_created_at_for_test(timestamp + 2);
     leader_2.header_mut_for_test().author = authority_2;
     let sub_dag_index_2 = 2;
     leader_2.header.round = sub_dag_index_2 as u32;
@@ -1212,10 +1209,8 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     // are randomly generated
     //
     // for each tx, seed address with funds in genesis
-    let timestamp = now();
     let mut leader_1 = Certificate::default();
     // update timestamp
-    leader_1.update_created_at_for_test(timestamp);
     leader_1.header_mut_for_test().author = authority_1;
     let sub_dag_index_1: u64 = 1;
     leader_1.header.round = sub_dag_index_1 as u32;
@@ -1244,7 +1239,6 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     let mut leader_2 = Certificate::default();
     let leader_2_epoch = leader_2.epoch();
     // update timestamp
-    leader_2.update_created_at_for_test(timestamp + 2);
     leader_2.header_mut_for_test().author = authority_2;
     let sub_dag_index_2 = 2;
     leader_2.header.round = sub_dag_index_2 as u32;
@@ -1599,10 +1593,8 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     // are randomly generated
     //
     // for each tx, seed address with funds in genesis
-    let timestamp = now();
     let mut leader_1 = Certificate::default();
     // update timestamp
-    leader_1.update_created_at_for_test(timestamp);
     let sub_dag_index_1 = 1;
     leader_1.header.round = sub_dag_index_1 as u32;
     let reputation_scores = ReputationScores::default();
@@ -1628,7 +1620,6 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     // create second output
     let mut leader_2 = Certificate::default();
     // update timestamp
-    leader_2.update_created_at_for_test(timestamp + 2);
     let sub_dag_index_2 = 2;
     leader_2.header.round = sub_dag_index_2 as u32;
     let reputation_scores = ReputationScores::default();
@@ -1836,10 +1827,8 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
     // are randomly generated
     //
     // for each tx, seed address with funds in genesis
-    let timestamp = now();
     let mut leader = Certificate::default();
     // update cert
-    leader.update_created_at_for_test(timestamp);
     leader.header_mut_for_test().author = authority_1;
     let sub_dag_index = 1;
     leader.header.round = sub_dag_index as u32;
@@ -2144,9 +2133,7 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
     execute_test_batch(&mut batch);
 
     // consensus output
-    let timestamp = now();
     let mut leader = Certificate::default();
-    leader.update_created_at_for_test(timestamp);
     leader.header_mut_for_test().author = authority_1;
     let sub_dag_index = 1;
     leader.header.round = sub_dag_index as u32;

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1236,7 +1236,7 @@ pub(crate) mod test {
     use tn_reth::RethChainSpec;
     use tn_test_utils::CommitteeFixture;
     use tn_types::{
-        now, test_genesis, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
+        test_genesis, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
         ConsensusOutput, EpochRecord, Hash, ReputationScores,
     };
 
@@ -1264,10 +1264,8 @@ pub(crate) mod test {
             .expect("authority in committee")
             .execution_address();
 
-        let timestamp = now();
         let mut leader_1 = Certificate::default();
         // update cert
-        leader_1.update_created_at_for_test(timestamp);
         leader_1.header_mut_for_test().author = authority_1;
         for batch in &batches_1 {
             leader_1.header.payload.insert(batch.digest(), 0_u16);

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -49,6 +49,9 @@ impl ConsensusHeader {
         hasher.update(parent_hash.as_slice());
         hasher.update(sub_dag.digest().as_ref());
         hasher.update(number.to_le_bytes().as_ref());
+        // Include the extra field.
+        // Not using this yet but include the default in the hash in prep when we do.
+        hasher.update(B256::default().as_slice());
         BlockHash::from_slice(hasher.finalize().as_bytes())
     }
 }

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -11,10 +11,9 @@ use crate::{
     },
     ensure,
     error::{CertificateError, CertificateResult, DagError, DagResult, HeaderError},
-    now,
     serde::RoaringBitmapSerde,
     Authority, AuthorityIdentifier, BlockHash, Committee, Digest, Epoch, Hash, Header, Round,
-    TimestampSec, VotingPower,
+    VotingPower,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -35,10 +34,6 @@ pub struct Certificate {
     /// Bitmap that indicates which authorities from committee signed this certificate.
     #[serde_as(as = "RoaringBitmapSerde")]
     signed_authorities: roaring::RoaringBitmap,
-    /// Timestamp for certificate creation.
-    ///
-    /// This is only used for performance metrics. Consensus relies on the header's timestamp.
-    created_at: TimestampSec,
 }
 
 impl Certificate {
@@ -160,12 +155,7 @@ impl Certificate {
             SignatureVerificationState::Unverified(bls_signature)
         };
 
-        Ok(Certificate {
-            header,
-            signature_verification_state,
-            signed_authorities,
-            created_at: now(),
-        })
+        Ok(Certificate { header, signature_verification_state, signed_authorities })
     }
 
     /// Return the group of authorities that signed this certificate.
@@ -346,13 +336,6 @@ impl Certificate {
         &self.signature_verification_state
     }
 
-    /// The time (sec) when the certificate was created.
-    ///
-    /// This is only used for performance metrics. Consensus relies on the header's timestamp.
-    pub fn created_at(&self) -> &TimestampSec {
-        &self.created_at
-    }
-
     /// Set the state of the Signature verification.
     pub fn set_signature_verification_state(&mut self, state: SignatureVerificationState) {
         self.signature_verification_state = state;
@@ -389,13 +372,6 @@ impl Certificate {
     /// Only Used for testing.
     pub fn header_mut_for_test(&mut self) -> &mut Header {
         &mut self.header
-    }
-
-    /// Change the certificate's created_at timestamp.
-    ///
-    /// Only Used for testing.
-    pub fn update_created_at_for_test(&mut self, timestamp: TimestampSec) {
-        self.created_at = timestamp;
     }
 }
 

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -355,7 +355,7 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for CommittedSubDag {
             hasher.update(cert.digest().as_ref());
         }
         hasher.update(self.leader.digest().as_ref());
-        // skip reputation for stable hashes
+        hasher.update(encode(&self.reputation_score).as_ref());
         hasher.update(encode(&self.commit_timestamp).as_ref());
         ConsensusDigest(Digest { digest: hasher.finalize().into() })
     }

--- a/crates/types/src/primary/reputation.rs
+++ b/crates/types/src/primary/reputation.rs
@@ -2,14 +2,14 @@
 
 use crate::{AuthorityIdentifier, Committee};
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, collections::HashMap};
+use std::{cmp::Ordering, collections::BTreeMap};
 
 /// The reputation scores for authorities participating in consensus.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct ReputationScores {
     /// Holds the score for every authority. If an authority is not amongst
     /// the records of the map then we assume that its score is zero.
-    pub scores_per_authority: HashMap<AuthorityIdentifier, u64>,
+    pub scores_per_authority: BTreeMap<AuthorityIdentifier, u64>,
     /// When true it notifies us that those scores will be the last updated scores of the
     /// current schedule before they get reset for the next schedule and start
     /// scoring from the beginning. In practice we can leverage this information to


### PR DESCRIPTION
Closes https://github.com/Telcoin-Association/telcoin-network/issues/638

Make sure we include rep scores in digests and remove created_at from certs (not really needed so save the 8 bytes).
