### PR TITLE
Only store headers not entire certs in subdags.

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -644,7 +644,7 @@ mod tests {
         let mut leader_cert = Certificate::default();
         leader_cert.header_mut_for_test().author = leader;
         let mut subdag = CommittedSubDag::default();
-        subdag.leader = leader_cert;
+        subdag.headers.push(leader_cert.header.clone());
         let output = ConsensusOutput::new_with_subdag(Arc::new(subdag), BlockHash::default(), 0);
 
         // receive new blocks and return non-fatal errors

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -8,8 +8,8 @@ use std::{
 };
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
-    Authority, AuthorityIdentifier, BlsPublicKey, Certificate, CertificateDigest, Committee,
-    Database, Epoch, Hash as _, Multiaddr, NetworkPublicKey, Notifier,
+    Authority, AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Epoch,
+    Hash as _, HeaderDigest, Multiaddr, NetworkPublicKey, Notifier,
 };
 use tracing::info;
 
@@ -22,7 +22,7 @@ struct ConsensusConfigInner<DB> {
     authority: Option<Authority>,
     local_network: LocalNetwork,
     network_config: NetworkConfig,
-    genesis: HashMap<CertificateDigest, Certificate>,
+    genesis: HashMap<HeaderDigest, Certificate>,
 }
 
 /// The configuration for consensus.
@@ -147,7 +147,7 @@ where
     ///
     /// Genesis certificates establish the initial state and authority set
     /// for the consensus protocol to produce the first primary `Header`.
-    pub fn genesis(&self) -> &HashMap<CertificateDigest, Certificate> {
+    pub fn genesis(&self) -> &HashMap<HeaderDigest, Certificate> {
         &self.inner.genesis
     }
 

--- a/crates/consensus/executor/src/errors.rs
+++ b/crates/consensus/executor/src/errors.rs
@@ -7,7 +7,7 @@
 use std::fmt::Debug;
 use thiserror::Error;
 use tn_storage::StoreError;
-use tn_types::{AuthorityIdentifier, BlockHash, CertificateDigest, WorkerId};
+use tn_types::{AuthorityIdentifier, BlockHash, HeaderDigest, WorkerId};
 
 /// Returns an error if the given condition is false.
 ///
@@ -64,7 +64,7 @@ pub enum SubscriberError {
     /// a certificate, which prevents the certificate from being executed. The certificate
     /// digest and error details are included for debugging.
     #[error("Error occurred while retrieving certificate {0} payload: {1}")]
-    PayloadRetrieveError(CertificateDigest, String),
+    PayloadRetrieveError(HeaderDigest, String),
 
     /// Consensus output referenced a worker ID that doesn't exist in the committee.
     ///

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -14,7 +14,7 @@ use tn_primary::{
     network::{ConsensusResult, PrimaryNetworkHandle},
     ConsensusBus, ConsensusBusApp, NodeMode,
 };
-use tn_storage::{consensus::ConsensusChain, CertificateStore};
+use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     encode, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash, BlsSigner as _,
     CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusOutput, Database,
@@ -152,10 +152,6 @@ impl<DB: Database> Subscriber<DB> {
                 consensus_header.number,
             )
             .await?;
-
-        // If we want to rejoin consensus eventually then save certs.
-        let _ = self.config.node_storage().write(consensus_output.sub_dag().leader.clone());
-        let _ = self.config.node_storage().write_all(consensus_output.sub_dag().certificates());
 
         let mut consensus_chain = self.inner.consensus_chain.clone();
         // This save will essentially mark this consensus output as written in stone (added to the
@@ -409,7 +405,7 @@ impl<DB: Database> Subscriber<DB> {
         parent_hash: B256,
         number: u64,
     ) -> SubscriberResult<ConsensusOutput> {
-        let num_blocks = sub_dag.num_primary_blocks();
+        let num_blocks = sub_dag.num_primary_batches();
         let num_certs = sub_dag.len();
 
         if num_blocks == 0 {
@@ -420,8 +416,8 @@ impl<DB: Database> Subscriber<DB> {
         let mut batch_set: BTreeSet<BlockHash> = BTreeSet::new();
 
         let mut batch_digests = VecDeque::with_capacity(num_certs);
-        for cert in sub_dag.certificates() {
-            for (digest, _) in cert.header().payload().iter() {
+        for header in sub_dag.headers() {
+            for (digest, _) in header.payload().iter() {
                 batch_set.insert(*digest);
                 batch_digests.push_back(*digest);
             }
@@ -433,12 +429,12 @@ impl<DB: Database> Subscriber<DB> {
 
         let mut batches = Vec::with_capacity(num_certs);
         // map all fetched batches to their respective certificates for applying block rewards
-        for cert in sub_dag.certificates() {
+        for header in sub_dag.headers() {
             // create collection of batches to execute for this certificate
-            let mut cert_batches = Vec::with_capacity(cert.header().payload().len());
+            let mut cert_batches = Vec::with_capacity(header.payload().len());
 
             // retrieve fetched batch by digest
-            for digest in cert.header().payload().keys() {
+            for digest in header.payload().keys() {
                 let batch = fetched_batches.remove(digest).ok_or(SubscriberError::MissingFetchedBatch(*digest)).inspect_err(|_| {
                     error!(target: "subscriber", "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
                 })?;
@@ -446,14 +442,14 @@ impl<DB: Database> Subscriber<DB> {
                 debug!(
                     target: "subscriber",
                     "Adding fetched batch {digest} from certificate {} to consensus output",
-                    cert.digest()
+                    header.digest()
                 );
                 cert_batches.push(batch);
             }
 
             // main collection for execution
             batches.push(CertifiedBatch {
-                address: self.authority_execution_address(cert.origin())?,
+                address: self.authority_execution_address(header.author())?,
                 batches: cert_batches,
             });
         }

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -13,7 +13,7 @@ use tn_storage::CertificateStore;
 use tn_types::{
     ensure,
     error::{DagError, DagResult},
-    AuthorityIdentifier, BlsPublicKey, Certificate, CertificateDigest, Committee, Database, Header,
+    AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Header, HeaderDigest,
     Noticer, Notifier, TaskManager, TaskResult, TaskSpawner, TnReceiver, Vote,
 };
 use tracing::{debug, enabled, error, info, instrument};
@@ -120,7 +120,7 @@ impl<DB: Database> Certifier<DB> {
         committee: Committee,
         cancel_proposal: Noticer,
     ) -> DagResult<Vote> {
-        let mut missing_parents: Option<Vec<CertificateDigest>> = None;
+        let mut missing_parents: Option<Vec<HeaderDigest>> = None;
         let mut attempt: u32 = 0;
         debug!(target: "primary::certifier", ?authority, ?header, "requesting vote for header...");
 

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -6,7 +6,7 @@ use crate::{
     state_sync::StateSynchronizer,
     ConsensusBus,
 };
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tn_config::{ConsensusConfig, KeyConfig};
 use tn_network_libp2p::error::NetworkError;
 use tn_storage::CertificateStore;
@@ -16,6 +16,7 @@ use tn_types::{
     AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Header, HeaderDigest,
     Noticer, Notifier, TaskManager, TaskResult, TaskSpawner, TnReceiver, Vote,
 };
+use tokio::sync::Mutex;
 use tracing::{debug, enabled, error, info, instrument};
 
 #[cfg(test)]
@@ -47,6 +48,10 @@ pub(crate) struct Certifier<DB> {
     task_spawner: TaskSpawner,
     /// Notifier to cancel pending proposals and vote requests if new header is received.
     new_proposal: Notifier,
+    /// Lock to make sure we are only in one header proposal at a time.
+    /// Should not generally happen but can lead to leader cert equivocation
+    /// if it does so be really sure.
+    proposal_lock: Arc<Mutex<()>>,
 }
 
 impl<DB: Database> Certifier<DB> {
@@ -100,6 +105,7 @@ impl<DB: Database> Certifier<DB> {
                 network: primary_network,
                 task_spawner,
                 new_proposal: Notifier::new(),
+                proposal_lock: Arc::new(Mutex::new(())),
             }
             .run(rx_headers)
             .await;
@@ -391,6 +397,22 @@ impl<DB: Database> Certifier<DB> {
     /// The method returns once enough votes are processed to certify the proposal,
     /// or if a new proposal arrives.
     async fn spawn_header_proposal(self, header: Header) -> TaskResult {
+        // Make sure other proposal's are shutdown and done before we check if
+        // this header is already certified.  Any existing proposals should have been cancelled
+        // before this call.
+        let _guard = self.proposal_lock.lock().await;
+        let header_digest = header.digest();
+        if let Ok(Some(cert)) = self.config.node_storage().read(header_digest) {
+            info!(target: "primary::certifier", "asked to propose a header that is already certified {header_digest}, skipping proposal and re-publishing");
+            // We have already processed this certificate, doing so again could produce signature
+            // equivocation and destroy deterministic randomness (based on the leader
+            // signature). Since we got here try to re-publish the certificate on gossip
+            // network
+            if let Err(e) = self.network.publish_certificate(cert).await {
+                error!(target: "primary::certifier", ?e, "failed to re-gossip certificate");
+            }
+            return Ok(());
+        }
         tokio::select! {
             // listen for new_proposal notification to exit
             // NOTE: sub here is okay bc no loop

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -397,6 +397,8 @@ impl<DB: Database> Certifier<DB> {
     /// The method returns once enough votes are processed to certify the proposal,
     /// or if a new proposal arrives.
     async fn spawn_header_proposal(self, header: Header) -> TaskResult {
+        // Grab this before the lock so quick exit after the lock if need to.
+        let new_proposal_noticer = self.new_proposal.subscribe();
         // Make sure other proposal's are shutdown and done before we check if
         // this header is already certified.  Any existing proposals should have been cancelled
         // before this call.
@@ -416,7 +418,7 @@ impl<DB: Database> Certifier<DB> {
         tokio::select! {
             // listen for new_proposal notification to exit
             // NOTE: sub here is okay bc no loop
-            _ = self.new_proposal.subscribe() => {
+            _ = new_proposal_noticer => {
                 debug!(target: "primary::certifier", "new proposal notification received");
                 Ok(())
             },

--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -79,8 +79,8 @@ impl Bullshark {
         // update the score for the previous leader. If no previous leader exists,
         // then this is the first time we commit a leader, so no score update takes place
         if let Some(last_committed_sub_dag) = state.last_committed_sub_dag.as_ref() {
-            let leader_digest = last_committed_sub_dag.leader.digest();
-            let leader_round = last_committed_sub_dag.leader.round();
+            let leader_digest = last_committed_sub_dag.leader().digest();
+            let leader_round = last_committed_sub_dag.leader().round();
             for certificate in committed_sequence.iter().filter(|c| c.round() == leader_round + 1) {
                 if certificate.header().parents().contains(&leader_digest) {
                     reputation_score.add_score(certificate.origin(), 1);
@@ -221,18 +221,15 @@ impl Bullshark {
             debug!("Leader {:?} has enough support", leader);
 
             let mut min_round = leader.round();
-            let mut sequence = Vec::new();
+            let sequence = utils::order_dag(&leader, state);
 
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
-            for x in utils::order_dag(&leader, state) {
+            for x in &sequence {
                 // Update and clean up internal state.
-                state.update(&x);
+                state.update(x);
 
                 // For logging.
                 min_round = min_round.min(x.round());
-
-                // Add the certificate to the sequence.
-                sequence.push(x);
             }
             let num_certificates = sequence.len();
             debug!(min_round, "Subdag has {} certificates", num_certificates);

--- a/crates/consensus/primary/src/consensus/mod.rs
+++ b/crates/consensus/primary/src/consensus/mod.rs
@@ -12,7 +12,7 @@ pub use crate::consensus::{
 };
 use thiserror::Error;
 use tn_storage::StoreError;
-use tn_types::{Certificate, CertificateDigest};
+use tn_types::{Certificate, HeaderDigest};
 
 /// The default channel size used in the consensus and subscriber logic.
 pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
@@ -32,7 +32,7 @@ pub enum ConsensusError {
     ShuttingDown,
 
     #[error("Parent digest {0:?} not found in DAG for {1:?}!")]
-    MissingParent(CertificateDigest, Box<Certificate>),
+    MissingParent(HeaderDigest, Box<Certificate>),
 
     #[error("Parent round not found in DAG for {0:?}!")]
     MissingParentRound(Box<Certificate>),

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -13,8 +13,8 @@ use std::{
 use tn_config::ConsensusConfig;
 use tn_storage::{consensus::ConsensusChain, CertificateStore};
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Committee, Database,
-    Hash as _, Noticer, Round, TaskManager, TnReceiver, TnSender,
+    AuthorityIdentifier, Certificate, CommittedSubDag, Committee, Database, Hash as _,
+    HeaderDigest, Noticer, Round, TaskManager, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument};
 
@@ -23,7 +23,7 @@ use tracing::{debug, error, info, instrument};
 mod consensus_tests;
 
 /// The representation of the DAG in memory.
-pub type Dag = BTreeMap<Round, HashMap<AuthorityIdentifier, (CertificateDigest, Certificate)>>;
+pub type Dag = BTreeMap<Round, HashMap<AuthorityIdentifier, (HeaderDigest, Certificate)>>;
 
 /// The state that needs to be persisted for crash-recovery.
 #[derive(Debug)]
@@ -194,7 +194,7 @@ impl ConsensusState {
             return Ok(());
         }
         if let Some(round_table) = dag.get(&(round - 1)) {
-            let store_parents: BTreeSet<&CertificateDigest> =
+            let store_parents: BTreeSet<&HeaderDigest> =
                 round_table.iter().map(|(_, (digest, _))| digest).collect();
             for parent_digest in certificate.header().parents() {
                 if !store_parents.contains(parent_digest) {
@@ -392,7 +392,7 @@ impl<DB: Database> Consensus<DB> {
                 // This will force the follow function to not outrun execution...  this is probably
                 // fine. Also once we can follow gossiped consensus output this will not really be
                 // an issue (except during initial catch up).
-                let base_execution_block = committed_sub_dag.leader.header.latest_execution_block;
+                let base_execution_block = committed_sub_dag.leader().latest_execution_block;
                 if self.consensus_bus.app().wait_for_execution(base_execution_block).await.is_err()
                 {
                     // This seems to be a bogus sub dag, we are out of sync...
@@ -407,9 +407,9 @@ impl<DB: Database> Consensus<DB> {
                     return Ok(());
                 }
 
-                tracing::debug!(target: "telcoin::consensus_state", "Commit in Sequence {:?}", committed_sub_dag.leader.nonce());
+                tracing::debug!(target: "telcoin::consensus_state", "Commit in Sequence {:?}", committed_sub_dag.leader().nonce());
 
-                for certificate in &committed_sub_dag.certificates {
+                for certificate in &committed_sub_dag.headers {
                     committed_certificates.push(certificate.clone());
                 }
 

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -114,7 +114,7 @@ async fn commit_one_with_leader() {
 
             if outcome == Outcome::Commit {
                 for sub_dag in &committed {
-                    assert_eq!(sub_dag.leader.origin(), &expected_leaders.pop_front().unwrap())
+                    assert_eq!(sub_dag.leader().author(), &expected_leaders.pop_front().unwrap())
                 }
             }
 
@@ -250,7 +250,7 @@ async fn not_enough_support_with_leader_schedule_change() {
 
                 assert_eq!(committed_dag_14.leader_round(), 14);
 
-                assert_eq!(committed_dag_14.leader.origin(), ids.get(2).unwrap());
+                assert_eq!(committed_dag_14.leader().author(), ids.get(2).unwrap());
             }
         }
     }
@@ -353,18 +353,18 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
 
                 //
                 // We are still using a swap table with no bad list...
-                assert_eq!(committed_dag_6.leader.origin(), ids.get(2).unwrap());
-                assert_eq!(committed_dag_8.leader.origin(), ids.get(3).unwrap());
-                assert_eq!(committed_dag_10.leader.origin(), ids.get(0).unwrap());
-                assert_eq!(committed_dag_12.leader.origin(), ids.get(1).unwrap());
-                assert_eq!(committed_dag_14.leader.origin(), ids.get(2).unwrap());
+                assert_eq!(committed_dag_6.leader().author(), ids.get(2).unwrap());
+                assert_eq!(committed_dag_8.leader().author(), ids.get(3).unwrap());
+                assert_eq!(committed_dag_10.leader().author(), ids.get(0).unwrap());
+                assert_eq!(committed_dag_12.leader().author(), ids.get(1).unwrap());
+                assert_eq!(committed_dag_14.leader().author(), ids.get(2).unwrap());
                 // Note that round 16 (when committed) would be auth 3 except it now has a bad rep.
 
                 // The leaders of round 12 & 14 shouldn't change from the "original" schedule
                 let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
-                assert_eq!(committed_dag_12.leader.origin(), &schedule.leader(12).id());
-                assert_eq!(committed_dag_14.leader.origin(), &schedule.leader(14).id());
+                assert_eq!(committed_dag_12.leader().author(), &schedule.leader(12).id());
+                assert_eq!(committed_dag_14.leader().author(), &schedule.leader(14).id());
 
                 assert_eq!(outcome, Outcome::Commit);
             }
@@ -382,7 +382,7 @@ async fn test_long_period_of_asynchrony_for_leader_schedule_change() {
                 // update happened the leader schedule changed and now the Authority
                 // 3 is flagged as low score and it will be swapped with Authority
                 // 0.
-                assert_eq!(committed_dag.leader.origin(), ids.get(0).unwrap());
+                assert_eq!(committed_dag.leader().author(), ids.get(0).unwrap());
                 break;
             }
         }
@@ -451,12 +451,12 @@ async fn commit_one() {
     // Ensure the first 4 ordered certificates are from round 1 (they are the parents of the
     // committed leader); then the leader's certificate should be committed.
     let committed_sub_dag: Arc<CommittedSubDag> = rx_output.recv().await.unwrap();
-    let mut sequence = committed_sub_dag.certificates.iter();
+    let mut sequence = committed_sub_dag.headers.iter();
     for _ in 1..=4 {
         let output = sequence.next().unwrap();
         assert_eq!(output.round(), 1);
     }
-    let output = sequence.next().unwrap();
+    let output = sequence.next().unwrap(); // The first element is the leader so skip it to get to round 1 headers.
     assert_eq!(output.round(), 2);
 
     // AND the reputation scores have not been updated
@@ -464,7 +464,7 @@ async fn commit_one() {
     assert!(committed_sub_dag.reputation_score.all_zero());
 }
 
-/// Run for 11 dag rounds with one dead node node (that is not a leader). We should commit the
+/// Run for 11 dag rounds with one dead node (that is not a leader). We should commit the
 /// leaders of rounds 2, 4, 6 and 10. The leader of round 8 will be missing, but eventually the
 /// leader 10 will get committed.
 #[tokio::test]
@@ -523,7 +523,8 @@ async fn dead_node() {
     let mut committed_sub_dags: Vec<Arc<CommittedSubDag>> = Vec::new();
     for _commit_rounds in 1..=4 {
         let committed_sub_dag = rx_output.recv().await.unwrap();
-        committed.extend(committed_sub_dag.certificates.clone());
+        let headers = committed_sub_dag.headers.clone();
+        committed.extend(headers);
         committed_sub_dags.push(committed_sub_dag);
     }
 
@@ -657,7 +658,7 @@ async fn not_enough_support() {
 
     // We should commit 2 leaders (rounds 2 and 4).
     let committed_sub_dag: Arc<CommittedSubDag> = rx_output.recv().await.unwrap();
-    let mut sequence = committed_sub_dag.certificates.iter();
+    let mut sequence = committed_sub_dag.headers.iter();
     for _ in 1..=3 {
         let output = sequence.next().unwrap();
         assert_eq!(output.round(), 1);
@@ -670,7 +671,7 @@ async fn not_enough_support() {
     assert!(committed_sub_dag.reputation_score.all_zero());
 
     let committed_sub_dag: Arc<CommittedSubDag> = rx_output.recv().await.unwrap();
-    let mut sequence = committed_sub_dag.certificates.iter();
+    let mut sequence = committed_sub_dag.headers.iter();
     for _ in 1..=3 {
         let output = sequence.next().unwrap();
         assert_eq!(output.round(), 2);
@@ -762,7 +763,7 @@ async fn missing_leader() {
 
     // Ensure the commit sequence is as expected.
     let committed_sub_dag: Arc<CommittedSubDag> = rx_output.recv().await.unwrap();
-    let mut sequence = committed_sub_dag.certificates.iter();
+    let mut sequence = committed_sub_dag.headers.iter();
     for _ in 1..=3 {
         let output = sequence.next().unwrap();
         assert_eq!(output.round(), 1);
@@ -853,7 +854,7 @@ async fn committed_round_after_restart() {
         if input_round > 1 {
             consensus_number += 1;
             let committed = rx_output.recv().await.unwrap();
-            info!("Received output from consensus, committed_round={}", committed.leader.round());
+            info!("Received output from consensus, committed_round={}", committed.leader().round());
             consensus_chain.write_subdag_for_test(consensus_number, committed).await;
             let (round, _certs) = rx_primary.recv().await.unwrap();
             info!("Received committed certificates from consensus, committed_round={round}",);
@@ -1001,7 +1002,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
     // ensure the leaders of rounds 2 and 4 have been committed
     let mut current_score = 0;
     for sub_dag in all_subdags {
-        if (sub_dag.leader.round() / 2) % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
+        if (sub_dag.leader().round() / 2) % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
             // On every 5th commit we reset the scores and count from the beginning with
             // scores updated to 1, as we expect now every node to have voted for the previous
             // leader.
@@ -1018,7 +1019,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
             // for every commit.
             current_score += 1;
 
-            if ((sub_dag.leader.round() / 2) + 1) % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
+            if ((sub_dag.leader().round() / 2) + 1) % NUM_SUB_DAGS_PER_SCHEDULE == 0 {
                 // if this is going to be the last score update for the current schedule, then
                 // make sure that the `final_of_schedule` will be true
                 assert!(sub_dag.reputation_score.final_of_schedule);
@@ -1122,7 +1123,7 @@ async fn restart_with_new_committee() {
         // Ensure the first 4 ordered certificates are from round 1 (they are the parents of the
         // committed leader); then the leader's certificate should be committed.
         let committed_sub_dag = rx_output.recv().await.unwrap();
-        let mut sequence = committed_sub_dag.certificates.iter();
+        let mut sequence = committed_sub_dag.headers.iter();
         for _ in 1..=4 {
             let output = sequence.next().unwrap();
             assert_eq!(output.epoch(), epoch);
@@ -1187,13 +1188,13 @@ async fn garbage_collection_basic() {
         sub_dags.iter().for_each(|sub_dag| {
             // ensure nothing has been committed for authority 4
             assert!(
-                !sub_dag.certificates.iter().any(|c| c.header().author() == &slow_node),
+                !sub_dag.headers.iter().any(|c| c.author() == &slow_node),
                 "Slow authority shouldn't be amongst the committed ones"
             );
 
             // Once leader of round 6 is committed then we know that garbage
             // collection has run. In this case no certificate of round 1 should exist.
-            if sub_dag.leader.round() == 6 {
+            if sub_dag.leader().round() == 6 {
                 assert_eq!(
                     state.dag.iter().filter(|(round, _)| **round <= 2).count(),
                     0,
@@ -1208,7 +1209,7 @@ async fn garbage_collection_basic() {
             // leader.round() - 1, except for the latest leader which should be
             // leader.round().
             for (_round, certificates) in
-                state.dag.iter().filter(|(round, _)| **round <= sub_dag.leader.round())
+                state.dag.iter().filter(|(round, _)| **round <= sub_dag.leader().round())
             {
                 assert_eq!(certificates.len(), 4, "We expect to have all the certificates");
             }
@@ -1308,7 +1309,7 @@ async fn slow_node() {
 
                 let sub_dag = sub_dags.first().unwrap();
 
-                for committed in &sub_dag.certificates {
+                for committed in &sub_dag.headers {
                     assert!(
                         committed.round() >= 2,
                         "We don't expect to see any certificate below round 2 because of gc"
@@ -1316,7 +1317,7 @@ async fn slow_node() {
                 }
 
                 let slow_node_total =
-                    sub_dag.certificates.iter().filter(|c| c.origin() == &slow_node).count();
+                    sub_dag.headers.iter().filter(|c| c.author() == &slow_node).count();
 
                 assert_eq!(slow_node_total, 4);
 
@@ -1453,11 +1454,11 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
                     // we expect now to commit two sub dags, those with leader 6 and 2.
                     assert_eq!(sub_dags.len(), 2);
 
-                    assert_eq!(sub_dags[0].leader.round(), 2);
-                    assert_eq!(sub_dags[1].leader.round(), 6);
+                    assert_eq!(sub_dags[0].leader().round(), 2);
+                    assert_eq!(sub_dags[1].leader().round(), 6);
 
-                    assert_eq!(sub_dags[0].certificates.len(), 4);
-                    assert_eq!(sub_dags[1].certificates.len(), 10);
+                    assert_eq!(sub_dags[0].headers.len(), 4);
+                    assert_eq!(sub_dags[1].headers.len(), 10);
 
                     // And GC has collected everything up to round 5.
                     assert_eq!(state.dag.len(), 5);

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    BlockNumHash, Certificate, CertificateDigest, ExecHeader, Hash as _, ReputationScores,
+    BlockNumHash, Certificate, ExecHeader, Hash as _, Header, HeaderDigest, ReputationScores,
     SealedHeader, TaskManager, TnReceiver, TnSender, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::fs::create_dir_all;
@@ -94,16 +94,16 @@ async fn test_consensus_recovery_with_bullshark() {
 
     // hold all the certificates that get committed when consensus runs
     // without any crash.
-    let mut committed_output_no_crash: Vec<Certificate> = Vec::new();
+    let mut committed_output_no_crash: Vec<Header> = Vec::new();
     let mut score_no_crash: ReputationScores = ReputationScores::default();
 
     let mut idx = 1;
     'main: while let Some(sub_dag) = rx_output.recv().await {
         score_no_crash = sub_dag.reputation_score.clone();
-        assert_eq!(sub_dag.leader.round(), consensus_index_counter);
+        assert_eq!(sub_dag.leader().round(), consensus_index_counter);
         consensus_chain.write_subdag_for_test(idx, sub_dag.clone()).await;
         idx += 1;
-        for output in sub_dag.certificates() {
+        for output in sub_dag.headers() {
             assert!(output.round() <= 6);
 
             committed_output_no_crash.push(output.clone());
@@ -184,13 +184,13 @@ async fn test_consensus_recovery_with_bullshark() {
     // * 1 certificate of round 2 (the leader)
     let mut consensus_index_counter = 2;
     let mut pack_number = 1u64;
-    let mut committed_output_before_crash: Vec<Certificate> = Vec::new();
+    let mut committed_output_before_crash: Vec<Header> = Vec::new();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
-        assert_eq!(sub_dag.leader.round(), consensus_index_counter);
+        assert_eq!(sub_dag.leader().round(), consensus_index_counter);
         consensus_chain.write_subdag_for_test(pack_number, sub_dag.clone()).await;
         pack_number += 1;
-        for output in sub_dag.certificates() {
+        for output in sub_dag.headers() {
             assert!(output.round() <= 2);
 
             committed_output_before_crash.push(output.clone());
@@ -234,7 +234,7 @@ async fn test_consensus_recovery_with_bullshark() {
     }
 
     // AND capture the committed output
-    let mut committed_output_after_crash: Vec<Certificate> = Vec::new();
+    let mut committed_output_after_crash: Vec<Header> = Vec::new();
     let mut score_with_crash: ReputationScores = ReputationScores::default();
 
     'main: while let Some(sub_dag) = rx_output.recv().await {
@@ -243,7 +243,7 @@ async fn test_consensus_recovery_with_bullshark() {
         consensus_chain.write_subdag_for_test(pack_number, sub_dag.clone()).await;
         pack_number += 1;
 
-        for output in sub_dag.certificates() {
+        for output in sub_dag.headers() {
             assert!(output.round() >= 2);
 
             committed_output_after_crash.push(output.clone());
@@ -290,7 +290,7 @@ async fn test_dag_rejects_certificate_with_missing_parents() {
     let mut state = ConsensusState::new(gc_depth);
 
     // Get genesis digests
-    let genesis: BTreeSet<CertificateDigest> =
+    let genesis: BTreeSet<HeaderDigest> =
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect();
 
     // Create round 1 certificates with valid genesis parents
@@ -305,7 +305,7 @@ async fn test_dag_rejects_certificate_with_missing_parents() {
     // Create a fake parent digest that doesn't exist
     let mut fake_parent_bytes = [0u8; 32];
     fake_parent_bytes[31] = 0xFF;
-    let fake_parent = CertificateDigest::new(fake_parent_bytes);
+    let fake_parent = HeaderDigest::new(fake_parent_bytes);
 
     // Create certificate with fake parent (that doesn't exist in DAG)
     let mut fake_parents = round1_digests.clone();
@@ -337,7 +337,7 @@ async fn test_dag_rejects_certificate_at_gc_boundary() {
     let gc_depth = 5;
     let mut state = ConsensusState::new(gc_depth);
 
-    let genesis: BTreeSet<CertificateDigest> =
+    let genesis: BTreeSet<HeaderDigest> =
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect();
 
     // Build DAG from round 1 to 10
@@ -382,7 +382,7 @@ async fn test_dag_detects_equivocation_same_round_different_cert() {
     let gc_depth = 10;
     let mut state = ConsensusState::new(gc_depth);
 
-    let genesis: BTreeSet<CertificateDigest> =
+    let genesis: BTreeSet<HeaderDigest> =
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect();
 
     // Create first certificate from authority 0 at round 1
@@ -430,7 +430,7 @@ async fn test_dag_accepts_duplicate_certificate_insertion() {
     let gc_depth = 10;
     let mut state = ConsensusState::new(gc_depth);
 
-    let genesis: BTreeSet<CertificateDigest> =
+    let genesis: BTreeSet<HeaderDigest> =
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect();
 
     let (_, cert) = mock_certificate(&committee, ids[0].clone(), 1, genesis);
@@ -457,7 +457,7 @@ async fn test_dag_rejects_certificate_with_missing_parent_round() {
     let gc_depth = 10;
     let mut state = ConsensusState::new(gc_depth);
 
-    let genesis: BTreeSet<CertificateDigest> =
+    let genesis: BTreeSet<HeaderDigest> =
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect();
 
     // Create round 1 certificates

--- a/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
@@ -431,7 +431,8 @@ async fn test_leader_schedule_from_store() {
         scores.add_score(&id, score as u64);
     }
 
-    let sub_dag = Arc::new(CommittedSubDag::new(vec![], Certificate::default(), 0, scores, None));
+    let cert = Certificate::default();
+    let sub_dag = Arc::new(CommittedSubDag::new(vec![cert.clone()], cert, 0, scores, None));
 
     consensus_chain.write_subdag_for_test(1, sub_dag).await;
 

--- a/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/randomized_tests.rs
@@ -20,7 +20,7 @@ use tn_primary::test_utils::mock_certificate_with_rand;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    Authority, AuthorityIdentifier, Certificate, CertificateDigest, Committee, Hash as _, Round,
+    Authority, AuthorityIdentifier, Certificate, Committee, Hash as _, HeaderDigest, Round,
     VotingPower,
 };
 use tokio::sync::mpsc::channel;
@@ -310,7 +310,7 @@ fn make_certificates_with_parameters(
     let mut certificates = VecDeque::new();
     let mut parents = initial_parents;
     let mut next_parents = Vec::new();
-    let mut certificate_digests: HashSet<CertificateDigest> =
+    let mut certificate_digests: HashSet<HeaderDigest> =
         parents.iter().map(|c| c.digest()).collect();
 
     for round in range {
@@ -347,7 +347,7 @@ fn make_certificates_with_parameters(
                 .map(|(a, inclusion_probability)| (a.id(), *inclusion_probability))
                 .collect();
 
-            let mut parent_digests: BTreeSet<CertificateDigest> = this_cert_parents_with_slow_nodes(
+            let mut parent_digests: BTreeSet<HeaderDigest> = this_cert_parents_with_slow_nodes(
                 &authority.id(),
                 current_parents.clone(),
                 ids.as_slice(),
@@ -366,7 +366,7 @@ fn make_certificates_with_parameters(
                 None
             };
 
-            let mut parent_digests: Vec<CertificateDigest> = parent_digests.into_iter().collect();
+            let mut parent_digests: Vec<HeaderDigest> = parent_digests.into_iter().collect();
 
             // Step 4 -- references to previous round
             // Now from the rest of current_parents, pick a random number - uniform - to how many
@@ -378,7 +378,7 @@ fn make_certificates_with_parameters(
             parent_digests.shuffle(&mut rand);
 
             // now keep only the num_of_parents_to_pick
-            let mut parents_digests: Vec<CertificateDigest> =
+            let mut parents_digests: Vec<HeaderDigest> =
                 parent_digests.into_iter().take(num_of_parents_to_pick as usize).collect();
 
             // Now swap one if necessary with our own
@@ -395,8 +395,7 @@ fn make_certificates_with_parameters(
                 "Failed on seed {seed}. At least 2f+1 parents are needed."
             );
 
-            let parents_digests: BTreeSet<CertificateDigest> =
-                parents_digests.into_iter().collect();
+            let parents_digests: BTreeSet<HeaderDigest> = parents_digests.into_iter().collect();
 
             // Now create the certificate with the provided parents
             let (_, certificate) = mock_certificate_with_rand(
@@ -493,7 +492,7 @@ fn generate_and_run_execution_plans(
             let (_outcome, committed_sub_dags) =
                 bullshark.process_certificate(&mut state, c).unwrap();
             for sub_dag in committed_sub_dags {
-                plan_committed_certificates.extend(sub_dag.certificates().iter().cloned());
+                plan_committed_certificates.extend(sub_dag.headers().iter().cloned());
             }
         }
 
@@ -534,7 +533,7 @@ fn create_execution_plan(
     let mut rand = rand::rngs::StdRng::seed_from_u64(seed);
 
     // Create a map of digest -> certificate
-    let digest_to_certificate: HashMap<CertificateDigest, Certificate> =
+    let digest_to_certificate: HashMap<HeaderDigest, Certificate> =
         certificates.clone().into_iter().map(|c| (c.digest(), c)).collect();
 
     // To model the DAG in form of edges and vertexes build an adjacency matrix.
@@ -542,8 +541,7 @@ fn create_execution_plan(
     // certificates. This is important because the algorithm ensures that no children will be
     // added to the final list unless all their dependencies (parent certificates) have first
     // been added earlier - so we respect the causal order.
-    let mut adjacency_parent_to_children: HashMap<CertificateDigest, Vec<CertificateDigest>> =
-        HashMap::new();
+    let mut adjacency_parent_to_children: HashMap<HeaderDigest, Vec<HeaderDigest>> = HashMap::new();
 
     // The nodes that have no incoming edges/dependencies (parent certificates) - initially are the
     // certificates of round 1 (we have no parents)

--- a/crates/consensus/primary/src/consensus/utils.rs
+++ b/crates/consensus/primary/src/consensus/utils.rs
@@ -48,8 +48,10 @@ pub(crate) fn order_dag(leader: &Certificate, state: &ConsensusState) -> Vec<Cer
         }
     }
 
-    // Ordering the output by round is not really necessary but it makes the commit sequence
-    // prettier.
+    // Ordering the output by round is necessary to make sure batches from early rounds go in before
+    // later rounds and to put the leader at the end plus it makes the commit sequence prettier.
+    // Note, the leader should be a single certificate with the highest round, it will sort last-
+    // this marks it as the leader.
     ordered.sort_by_key(|x| x.round());
     ordered
 }

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -580,7 +580,7 @@ struct ConsensusBusEpochInner {
     /// only if it already sent us its whole history.
     new_certificates: QueChannel<Certificate>,
     /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
-    committed_certificates: QueChannel<(Round, Vec<Certificate>)>,
+    committed_headers: QueChannel<(Round, Vec<Header>)>,
 
     /// Sends missing certificates to the `CertificateFetcher`.
     /// Receives certificates with missing parents from the `Synchronizer`.
@@ -609,7 +609,7 @@ impl ConsensusBusEpochInner {
     fn new() -> Self {
         Self {
             new_certificates: QueChannel::new(),
-            committed_certificates: QueChannel::new(),
+            committed_headers: QueChannel::new(),
             certificate_fetcher: QueChannel::new(),
             parents: QueChannel::new(),
             our_digests: QueChannel::new(),
@@ -686,8 +686,8 @@ impl ConsensusBus {
 
     /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
     /// Can only be subscribed to once.
-    pub fn committed_certificates(&self) -> &impl TnSender<(Round, Vec<Certificate>)> {
-        &self.inner_epoch.committed_certificates
+    pub fn committed_certificates(&self) -> &impl TnSender<(Round, Vec<Header>)> {
+        &self.inner_epoch.committed_headers
     }
 
     /// Missing certificates.
@@ -780,8 +780,8 @@ impl ConsensusBus {
     }
 
     /// Subscribe to the sequence of ordered certificates to the primary (for cleanup and feedback).
-    pub fn subscribe_committed_certificates(&self) -> impl TnReceiver<(Round, Vec<Certificate>)> {
-        self.inner_epoch.committed_certificates.subscribe()
+    pub fn subscribe_committed_certificates(&self) -> impl TnReceiver<(Round, Vec<Header>)> {
+        self.inner_epoch.committed_headers.subscribe()
     }
 
     /// Subscribe to certificates with missing parents from the `Synchronizer`.

--- a/crates/consensus/primary/src/error/cert_manager.rs
+++ b/crates/consensus/primary/src/error/cert_manager.rs
@@ -2,7 +2,7 @@
 
 use tn_network_libp2p::error::NetworkError;
 use tn_storage::StoreError;
-use tn_types::{error::CertificateError, CertificateDigest, SendError};
+use tn_types::{error::CertificateError, HeaderDigest, SendError};
 
 use super::GarbageCollectorError;
 
@@ -20,13 +20,13 @@ pub(crate) enum CertManagerError {
     GC(#[from] GarbageCollectorError),
     /// The certificate's signature verification state is unverified.
     #[error("Unverified signature verification state {0}")]
-    UnverifiedSignature(CertificateDigest),
+    UnverifiedSignature(HeaderDigest),
     /// Oneshot channel dropped for certificate manager.
     #[error("Failed to return certificate manager's result.")]
     CertificateManagerOneshot,
     /// The pending certificate is unexpectedly missing. This should not happen.
     #[error("Pending certificate not found by digest: {0}")]
-    PendingCertificateNotFound(CertificateDigest),
+    PendingCertificateNotFound(HeaderDigest),
     /// The certificate was verified, accepted, and stored in storage.
     /// However, an error occurred adding it to the collection of parents.
     /// This is the only way to advance the round and is fatal.
@@ -42,13 +42,13 @@ pub(crate) enum CertManagerError {
     JoinError,
     /// The certificate is pending acceptance due to missing parents.
     #[error("The certificate {0} is pending acceptance due to missing parents.")]
-    Pending(CertificateDigest),
+    Pending(HeaderDigest),
     /// Error retrieving value from storage.
     #[error("Storage failure: {0}")]
     Storage(#[from] StoreError),
     /// A duplicate certificate was received but it has different missing parents.
     #[error("The certificate {0} was already pending, but now it has different missing parents.")]
-    PendingParentsMismatch(CertificateDigest),
+    PendingParentsMismatch(HeaderDigest),
 
     /// mpsc sender dropped while processig the certificate
     #[error("Failed to process certificate - TN sender error: {0}")]

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -24,9 +24,8 @@ use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
     now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlsPublicKey, Certificate,
-    CertificateDigest, ConsensusHeader, Database, Epoch, EpochCertificate, EpochRecord, Hash as _,
-    Header, HeaderDigest, ProtocolSignature, Round, SignatureVerificationState, TnSender as _,
-    Vote, B256,
+    ConsensusHeader, Database, Epoch, EpochCertificate, EpochRecord, Hash as _, Header,
+    HeaderDigest, ProtocolSignature, Round, SignatureVerificationState, TnSender as _, Vote, B256,
 };
 use tokio::{io::AsyncReadExt, sync::Mutex as TokioMutex, time::timeout};
 use tracing::{debug, error, info, warn};
@@ -58,7 +57,7 @@ pub(crate) struct RequestHandler<DB> {
     /// for missing parents. The values are associated with the first authority that proposed a
     /// header with these parents. The node keeps track of requested Certificates to prevent
     /// unsolicited certificate attacks.
-    requested_parents: Arc<Mutex<BTreeMap<(Round, CertificateDigest), AuthorityIdentifier>>>,
+    requested_parents: Arc<Mutex<BTreeMap<(Round, HeaderDigest), AuthorityIdentifier>>>,
     /// Map of the last epoch and round each authority requested a vote for.
     /// Used to stop validator equivocation early.
     auth_last_vote: Arc<AuthEquivocationMap>,
@@ -187,7 +186,7 @@ where
 
     /// Process gossip from the committee.
     ///
-    /// Peers gossip the CertificateDigest so peers can request the Certificate. This waits until
+    /// Peers gossip the HeaderDigest so peers can request the Certificate. This waits until
     /// the certificate can be retrieved and timesout after some time. It's important to give up
     /// after enough time to limit the DoS attack surface. Peers who timeout must lose reputation.
     pub(super) async fn process_gossip(&self, msg: &GossipMessage) -> PrimaryNetworkResult<()> {
@@ -218,6 +217,14 @@ where
                                     return Ok(());
                                 }
                                 self.state_sync.process_peer_certificate(&mut cert).await?;
+                            }
+                            if !self.consensus_bus.is_cvv_inactive()
+                                && self.consensus_config.committee().epoch() == cert.epoch()
+                            {
+                                // If we are catching up and this is for our current epoch save in
+                                // cache so we will be able
+                                // to rejoin consensus later when caught up.
+                                let _ = self.consensus_config.node_storage().write((*cert).clone());
                             }
                         }
                         Err(e) => warn!(target: "primary", "Recieved invalid cert {e}"),
@@ -702,10 +709,7 @@ where
     ///
     /// Certificates are considered "known" if they are in local storage, pending, or already
     /// requested from a peer.
-    async fn check_for_missing_parents(
-        &self,
-        header: &Header,
-    ) -> HeaderResult<Vec<CertificateDigest>> {
+    async fn check_for_missing_parents(&self, header: &Header) -> HeaderResult<Vec<HeaderDigest>> {
         // identify parents that are neither in storage nor pending
         let mut unknown_certs = self.state_sync.identify_unkown_parents(header).await?;
 

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -218,7 +218,7 @@ where
                                 }
                                 self.state_sync.process_peer_certificate(&mut cert).await?;
                             }
-                            if !self.consensus_bus.is_cvv_inactive()
+                            if self.consensus_bus.is_cvv_inactive()
                                 && self.consensus_config.committee().epoch() == cert.epoch()
                             {
                                 // If we are catching up and this is for our current epoch save in

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -10,8 +10,8 @@ use std::{
 use tn_network_libp2p::{types::IntoRpcError, PeerExchangeMap, TNMessage};
 use tn_types::{
     error::HeaderError, AuthorityIdentifier, BlockHash, BlsPublicKey, BlsSignature, Certificate,
-    CertificateDigest, ConsensusHeader, Epoch, EpochCertificate, EpochRecord, EpochVote, Header,
-    Round, Vote, B256,
+    ConsensusHeader, Epoch, EpochCertificate, EpochRecord, EpochVote, Header, HeaderDigest, Round,
+    Vote, B256,
 };
 
 /// Info that is published (via gossip) by validators once they reach consensus.
@@ -28,7 +28,7 @@ pub struct ConsensusResult {
     /// the validator that produced this result
     pub validator: BlsPublicKey,
     /// the signature of the validator publishing this record
-    /// see digest() below, this is a signature over the has of the epoch, round, number and hash
+    /// see digest() below, this is a signature over the hash of the epoch, round, number and hash
     /// fields
     pub signature: BlsSignature,
 }
@@ -228,7 +228,7 @@ pub enum PrimaryResponse {
     ///
     /// If the peer was unable to verify parents for a proposed header, they respond requesting
     /// the missing certificate by digest.
-    MissingParents(Vec<CertificateDigest>),
+    MissingParents(Vec<HeaderDigest>),
     /// The requested consensus header.
     ConsensusHeader(Arc<ConsensusHeader>),
     /// The requested epoch record and certificate.

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -34,9 +34,9 @@ use tn_storage::{
     PayloadStore,
 };
 use tn_types::{
-    encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, CertificateDigest, ConsensusHeader,
-    Database, Epoch, EpochCertificate, EpochRecord, EpochVote, Header, Round, TaskError,
-    TaskSpawner, TnReceiver, TnSender, Vote, B256,
+    encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader, Database, Epoch,
+    EpochCertificate, EpochRecord, EpochVote, Header, HeaderDigest, Round, TaskError, TaskSpawner,
+    TnReceiver, TnSender, Vote, B256,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -959,5 +959,5 @@ pub enum RequestVoteResult {
     ///
     /// If the peer was unable to verify parents for a proposed header, they respond requesting
     /// the missing certificate by digest.
-    MissingParents(Vec<CertificateDigest>),
+    MissingParents(Vec<HeaderDigest>),
 }

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -210,7 +210,7 @@ impl<DB: Database> Proposer<DB> {
             current_round,
             current_epoch,
             digests.iter().map(|m| (m.digest, m.worker_id)).collect(),
-            parents.iter().map(|x| x.digest()).collect(),
+            parents.iter().map(|x| x.header().digest()).collect(),
             consensus_bus.app().latest_execution_block_num_hash(),
         );
 

--- a/crates/consensus/primary/src/state_handler.rs
+++ b/crates/consensus/primary/src/state_handler.rs
@@ -2,7 +2,7 @@
 
 use crate::ConsensusBus;
 use tn_types::{
-    AuthorityIdentifier, Certificate, Noticer, Round, TaskManager, TaskResult, TnReceiver, TnSender,
+    AuthorityIdentifier, Header, Noticer, Round, TaskManager, TaskResult, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument};
 
@@ -33,13 +33,13 @@ impl StateHandler {
     }
 
     #[instrument(level = "debug", skip_all, fields(commit_round, num_certs = certificates.len()))]
-    async fn handle_sequenced(&mut self, commit_round: Round, certificates: Vec<Certificate>) {
+    async fn handle_sequenced(&mut self, commit_round: Round, certificates: Vec<Header>) {
         // Now we are going to signal which of our own batches have been committed.
         let own_rounds_committed: Vec<_> = certificates
             .iter()
-            .filter_map(|cert| {
-                if cert.header().author() == &self.authority_id {
-                    Some(cert.header().round())
+            .filter_map(|header| {
+                if header.author() == &self.authority_id {
+                    Some(header.round())
                 } else {
                     None
                 }
@@ -61,13 +61,13 @@ impl StateHandler {
 
     async fn run(
         mut self,
-        mut rx_committed_certificates: impl TnReceiver<(Round, Vec<Certificate>)>,
+        mut rx_committed_certificates: impl TnReceiver<(Round, Vec<Header>)>,
     ) -> TaskResult {
         info!(target: "primary::state_handler", "StateHandler on node {} has started successfully.", self.authority_id);
         loop {
             tokio::select! {
-                Some((commit_round, certificates)) = rx_committed_certificates.recv() => {
-                    self.handle_sequenced(commit_round, certificates).await;
+                Some((commit_round, headers)) = rx_committed_certificates.recv() => {
+                    self.handle_sequenced(commit_round, headers).await;
                 },
 
                 _ = &self.rx_shutdown => {

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -179,7 +179,6 @@ where
     ///
     /// NOTE: `self::process_verified_certificates` checks the verification status, so all
     /// certificates managed here are verified.
-    // synchronizer::accept_certificate_internal
     async fn accept_verified_certificates(
         &mut self,
         certificates: VecDeque<Certificate>,

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -19,7 +19,7 @@ use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
     error::{CertificateError, HeaderError},
-    Certificate, CertificateDigest, Database, Hash as _, Round, TnReceiver, TnSender as _,
+    Certificate, Database, Hash as _, HeaderDigest, Round, TnReceiver, TnSender as _,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, error};
@@ -132,7 +132,7 @@ where
     async fn get_missing_parents(
         &self,
         certificate: &Certificate,
-    ) -> CertManagerResult<HashSet<CertificateDigest>> {
+    ) -> CertManagerResult<HashSet<HeaderDigest>> {
         // handle genesis cert
         if certificate.round() == 1 {
             debug!(target: "primary::cert_manager", ?certificate, "cert round 1");
@@ -332,8 +332,8 @@ pub(crate) enum CertificateManagerCommand {
     /// This is used to vote on headers.
     FilterUnkownDigests {
         /// The collection of digests not found in local storage.
-        unknown: Vec<CertificateDigest>,
+        unknown: Vec<HeaderDigest>,
         /// Return the result to the header validator.
-        reply: oneshot::Sender<Vec<CertificateDigest>>,
+        reply: oneshot::Sender<Vec<HeaderDigest>>,
     },
 }

--- a/crates/consensus/primary/src/state_sync/cert_validator.rs
+++ b/crates/consensus/primary/src/state_sync/cert_validator.rs
@@ -12,7 +12,7 @@ use std::{collections::HashSet, sync::Arc};
 use tn_config::ConsensusConfig;
 use tn_storage::CertificateStore;
 use tn_types::{
-    error::CertificateError, Certificate, CertificateDigest, Database, Hash as _, Round,
+    error::CertificateError, Certificate, Database, Hash as _, HeaderDigest, Round,
     SignatureVerificationState, TaskSpawner, TnSender as _,
 };
 use tokio::sync::oneshot;
@@ -301,7 +301,7 @@ where
     fn requires_direct_verification(
         &self,
         cert: &Certificate,
-        all_parents: &HashSet<CertificateDigest>,
+        all_parents: &HashSet<HeaderDigest>,
     ) -> bool {
         !all_parents.contains(&cert.digest())
             || cert.header().round().is_multiple_of(

--- a/crates/consensus/primary/src/state_sync/header_validator.rs
+++ b/crates/consensus/primary/src/state_sync/header_validator.rs
@@ -9,7 +9,7 @@ use tn_network_types::{PrimaryToWorkerClient as _, WorkerSynchronizeMessage};
 use tn_storage::{CertificateStore, PayloadStore};
 use tn_types::{
     error::{DagError, HeaderError, HeaderResult},
-    Certificate, CertificateDigest, Database, Header, Round, TnSender as _,
+    Certificate, Database, Header, HeaderDigest, Round, TnSender as _,
 };
 use tokio::sync::oneshot;
 use tracing::debug;
@@ -198,7 +198,7 @@ where
     pub(super) async fn identify_unkown_parents(
         &self,
         header: &Header,
-    ) -> HeaderResult<Vec<CertificateDigest>> {
+    ) -> HeaderResult<Vec<HeaderDigest>> {
         // handle genesis
         if header.round() == 1 {
             for digest in header.parents() {

--- a/crates/consensus/primary/src/state_sync/mod.rs
+++ b/crates/consensus/primary/src/state_sync/mod.rs
@@ -5,7 +5,7 @@ use cert_validator::CertificateValidator;
 use header_validator::HeaderValidator;
 use tn_config::ConsensusConfig;
 use tn_types::{
-    error::HeaderResult, Certificate, CertificateDigest, Database, Header, Round, TaskManager,
+    error::HeaderResult, Certificate, Database, Header, HeaderDigest, Round, TaskManager,
     TaskSpawner,
 };
 mod cert_collector;
@@ -116,7 +116,7 @@ where
     pub(crate) async fn identify_unkown_parents(
         &self,
         header: &Header,
-    ) -> HeaderResult<Vec<CertificateDigest>> {
+    ) -> HeaderResult<Vec<HeaderDigest>> {
         self.header_validator.identify_unkown_parents(header).await
     }
 }

--- a/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{CertManagerError, CertManagerResult};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use tn_types::{Certificate, CertificateDigest, Hash as _, Round};
+use tn_types::{Certificate, Hash as _, HeaderDigest, Round};
 use tracing::debug;
 
 /// A certificate that is missing parents and pending approval.
@@ -17,12 +17,12 @@ struct PendingCertificate {
     certificate: Certificate,
     /// The certificate's missing parents that must be retrieved before the pending certificate is
     /// accepted.
-    missing_parent_digests: HashSet<CertificateDigest>,
+    missing_parent_digests: HashSet<HeaderDigest>,
 }
 
 impl PendingCertificate {
     /// Create a new instance of Self.
-    fn new(certificate: Certificate, missing_parents: HashSet<CertificateDigest>) -> Self {
+    fn new(certificate: Certificate, missing_parents: HashSet<HeaderDigest>) -> Self {
         Self { certificate, missing_parent_digests: missing_parents }
     }
 }
@@ -38,12 +38,12 @@ pub(super) struct PendingCertificateManager {
     /// Each certificate entry tracks both the certificate itself and its dependency state
     ///
     /// Pending certificates that cannot be accepted yet.
-    pending: HashMap<CertificateDigest, PendingCertificate>,
+    pending: HashMap<HeaderDigest, PendingCertificate>,
     /// Map of a the missing certificate digests and the pending certificates that are blocked by
     /// them.
     ///
     /// The keys are (round, digest) to enable garbage collection by round.
-    missing_for_pending: BTreeMap<(Round, CertificateDigest), HashSet<CertificateDigest>>,
+    missing_for_pending: BTreeMap<(Round, HeaderDigest), HashSet<HeaderDigest>>,
 }
 
 impl PendingCertificateManager {
@@ -58,7 +58,7 @@ impl PendingCertificateManager {
     pub(super) fn insert_pending(
         &mut self,
         certificate: Certificate,
-        missing_parents: HashSet<CertificateDigest>,
+        missing_parents: HashSet<HeaderDigest>,
     ) -> CertManagerResult<()> {
         let digest = certificate.digest();
         let parent_round = certificate.round() - 1;
@@ -85,7 +85,7 @@ impl PendingCertificateManager {
     pub(super) fn update_pending(
         &mut self,
         round: Round,
-        digest: CertificateDigest,
+        digest: HeaderDigest,
     ) -> CertManagerResult<VecDeque<Certificate>> {
         let mut ready_certificates = VecDeque::new();
         let mut certificates_to_process = VecDeque::new();
@@ -134,10 +134,7 @@ impl PendingCertificateManager {
     ///
     /// This is useful for iterating through all missing certificates that are blocking pending
     /// certificates from being accepted.
-    pub(super) fn next_for_gc_round(
-        &mut self,
-        gc_round: Round,
-    ) -> Option<(Round, CertificateDigest)> {
+    pub(super) fn next_for_gc_round(&mut self, gc_round: Round) -> Option<(Round, HeaderDigest)> {
         let (round, digest) = self
             .missing_for_pending
             .first_key_value()
@@ -159,7 +156,7 @@ impl PendingCertificateManager {
     }
 
     /// Returns whether a certificate is being tracked
-    pub(super) fn is_pending(&self, digest: &CertificateDigest) -> bool {
+    pub(super) fn is_pending(&self, digest: &HeaderDigest) -> bool {
         self.pending.contains_key(digest)
     }
 
@@ -172,7 +169,7 @@ impl PendingCertificateManager {
     /// Filter parents that are pending in place.
     ///
     /// This is used when voting for headers.
-    pub(super) fn filter_unknown_digests(&self, unknown: &mut Vec<CertificateDigest>) {
+    pub(super) fn filter_unknown_digests(&self, unknown: &mut Vec<HeaderDigest>) {
         unknown.retain(|digest| !self.pending.contains_key(digest));
     }
 }

--- a/crates/consensus/primary/src/test_utils/helpers.rs
+++ b/crates/consensus/primary/src/test_utils/helpers.rs
@@ -18,8 +18,8 @@ use tn_reth::{
 };
 use tn_types::{
     test_chain_spec_arc, test_genesis, to_intent_message, Address, AuthorityIdentifier, Batch,
-    BlockHash, BlsKeypair, BlsSignature, Bytes, Certificate, CertificateDigest, Committee, Epoch,
-    ExecHeader, Hash as _, HeaderBuilder, ProtocolSignature, Round, VotingPower, WorkerId, U256,
+    BlockHash, BlsKeypair, BlsSignature, Bytes, Certificate, Committee, Epoch, ExecHeader,
+    Hash as _, HeaderBuilder, HeaderDigest, ProtocolSignature, Round, VotingPower, WorkerId, U256,
 };
 
 pub fn temp_dir() -> TempDir {
@@ -107,27 +107,27 @@ pub fn batch_with_rand<R: Rng + ?Sized>(rand: &mut R, worker_id: WorkerId) -> Ba
 pub fn make_optimal_certificates(
     committee: &Committee,
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     ids: &[AuthorityIdentifier],
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     make_certificates(committee, range, initial_parents, ids, 0.0)
 }
 
 /// Outputs rounds worth of certificates with optimal parents that are signed.
 pub fn make_optimal_signed_certificates(
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     committee: &Committee,
     keys: &[(AuthorityIdentifier, BlsKeypair)],
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     make_signed_certificates(range, initial_parents, committee, keys, 0.0)
 }
 
 /// Bernoulli-samples from a set of ancestors passed as a argument,
 fn this_cert_parents(
-    ancestors: &BTreeSet<CertificateDigest>,
+    ancestors: &BTreeSet<HeaderDigest>,
     failure_prob: f64,
-) -> BTreeSet<CertificateDigest> {
+) -> BTreeSet<HeaderDigest> {
     std::iter::from_fn(|| {
         let f: f64 = rand::rng().random();
         Some(f > failure_prob)
@@ -143,15 +143,15 @@ fn this_cert_parents(
 /// `make_one_certificate` argument
 fn rounds_of_certificates(
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     ids: &[AuthorityIdentifier],
     failure_probability: f64,
     make_one_certificate: impl Fn(
         AuthorityIdentifier,
         Round,
-        BTreeSet<CertificateDigest>,
-    ) -> (CertificateDigest, Certificate),
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+        BTreeSet<HeaderDigest>,
+    ) -> (HeaderDigest, Certificate),
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     let mut certificates = VecDeque::new();
     let mut parents = initial_parents.iter().cloned().collect::<BTreeSet<_>>();
     let mut next_parents = BTreeSet::new();
@@ -174,10 +174,10 @@ fn rounds_of_certificates(
 pub fn make_certificates(
     committee: &Committee,
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     ids: &[AuthorityIdentifier],
     failure_probability: f64,
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     let generator = |pk, round, parents| mock_certificate(committee, pk, round, parents);
 
     rounds_of_certificates(range, initial_parents, ids, failure_probability, generator)
@@ -265,10 +265,10 @@ pub struct TestLeaderConfiguration {
 pub fn make_certificates_with_leader_configuration(
     committee: &Committee,
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     names: &[AuthorityIdentifier],
     leader_configurations: HashMap<Round, TestLeaderConfiguration>,
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     for round in leader_configurations.keys() {
         assert_eq!(round % 2, 0, "Leaders are elected only on even rounds");
     }
@@ -365,7 +365,7 @@ pub fn this_cert_parents_with_slow_nodes(
     slow_nodes: &[(AuthorityIdentifier, f64)],
     rand: &mut StdRng,
     committee: &Committee,
-) -> BTreeSet<CertificateDigest> {
+) -> BTreeSet<HeaderDigest> {
     let mut parents = BTreeSet::new();
     let mut not_included = Vec::new();
     let mut total_stake = 0;
@@ -420,9 +420,9 @@ pub fn make_certificates_with_epoch(
     committee: &Committee,
     range: RangeInclusive<Round>,
     epoch: Epoch,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     keys: &[AuthorityIdentifier],
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     let mut certificates = VecDeque::new();
     let mut parents = initial_parents.iter().cloned().collect::<BTreeSet<_>>();
     let mut next_parents = BTreeSet::new();
@@ -443,11 +443,11 @@ pub fn make_certificates_with_epoch(
 /// make rounds worth of signed certificates with the sampled number of parents
 pub fn make_signed_certificates(
     range: RangeInclusive<Round>,
-    initial_parents: &BTreeSet<CertificateDigest>,
+    initial_parents: &BTreeSet<HeaderDigest>,
     committee: &Committee,
     keys: &[(AuthorityIdentifier, BlsKeypair)],
     failure_probability: f64,
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>) {
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>) {
     let ids = keys.iter().map(|(authority, _)| authority.clone()).collect::<Vec<_>>();
     let generator = |pk, round, parents| signed_cert_for_test(keys, pk, round, parents, committee);
 
@@ -458,9 +458,9 @@ pub fn mock_certificate_with_rand<R: RngCore + ?Sized>(
     committee: &Committee,
     origin: AuthorityIdentifier,
     round: Round,
-    parents: BTreeSet<CertificateDigest>,
+    parents: BTreeSet<HeaderDigest>,
     rand: &mut R,
-) -> (CertificateDigest, Certificate) {
+) -> (HeaderDigest, Certificate) {
     let header_builder = HeaderBuilder::default();
     let header = header_builder
         .author(origin)
@@ -479,8 +479,8 @@ pub fn mock_certificate(
     committee: &Committee,
     origin: AuthorityIdentifier,
     round: Round,
-    parents: BTreeSet<CertificateDigest>,
-) -> (CertificateDigest, Certificate) {
+    parents: BTreeSet<HeaderDigest>,
+) -> (HeaderDigest, Certificate) {
     mock_certificate_with_epoch(committee, origin, round, 0, parents)
 }
 
@@ -491,8 +491,8 @@ pub fn mock_certificate_with_epoch(
     origin: AuthorityIdentifier,
     round: Round,
     epoch: Epoch,
-    parents: BTreeSet<CertificateDigest>,
-) -> (CertificateDigest, Certificate) {
+    parents: BTreeSet<HeaderDigest>,
+) -> (HeaderDigest, Certificate) {
     let header_builder = HeaderBuilder::default();
     let header = header_builder
         .author(origin)
@@ -510,9 +510,9 @@ pub fn signed_cert_for_test(
     signers: &[(AuthorityIdentifier, BlsKeypair)],
     origin: AuthorityIdentifier,
     round: Round,
-    parents: BTreeSet<CertificateDigest>,
+    parents: BTreeSet<HeaderDigest>,
     committee: &Committee,
-) -> (CertificateDigest, Certificate) {
+) -> (HeaderDigest, Certificate) {
     let header = HeaderBuilder::default()
         .author(origin)
         .payload(fixture_payload(1))

--- a/crates/consensus/primary/src/tests/certificate_processing_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_processing_tests.rs
@@ -12,8 +12,8 @@ use tn_primary::test_utils::{make_optimal_signed_certificates, signed_cert_for_t
 use tn_storage::{mem_db::MemDatabase, CertificateStore};
 use tn_test_utils_committee::{AuthorityFixture, CommitteeFixture};
 use tn_types::{
-    error::CertificateError, Certificate, CertificateDigest, Database, Hash as _, Round,
-    TaskManager, TnReceiver as _,
+    error::CertificateError, Certificate, Database, Hash as _, HeaderDigest, Round, TaskManager,
+    TnReceiver as _,
 };
 use tokio::time::timeout;
 
@@ -72,7 +72,7 @@ fn create_core_test_types<DB: Database>(
 }
 
 /// Helper to sort certificates by digest
-fn sort_by_digest(a: &CertificateDigest, b: &CertificateDigest) -> core::cmp::Ordering {
+fn sort_by_digest(a: &HeaderDigest, b: &HeaderDigest) -> core::cmp::Ordering {
     a.cmp(b)
 }
 
@@ -323,7 +323,7 @@ async fn test_node_restart_syncs_state() -> eyre::Result<()> {
     assert!(rx_parents_first_recovery.try_recv().is_err());
 
     // send remaining 2 certs to reach quorum
-    let mut last_digest = CertificateDigest::default();
+    let mut last_digest = HeaderDigest::default();
     for cert in certs.clone().iter_mut().take(2) {
         last_digest = cert.digest();
         validator_first_recovery.process_peer_certificate(cert).await.unwrap();

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -24,7 +24,7 @@ use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
-    BlsPublicKey, Certificate, CertificateDigest, EpochVote, ExecHeader, Hash as _, SealedHeader,
+    BlsPublicKey, Certificate, EpochVote, ExecHeader, Hash as _, HeaderDigest, SealedHeader,
     TaskManager, B256,
 };
 use tracing::debug;
@@ -199,7 +199,7 @@ async fn test_vote_fails_invalid_genesis_parent() -> eyre::Result<()> {
     // start with the expected parents in genesis
     let mut expected_parents: Vec<_> =
         Certificate::genesis(&committee.committee()).iter().map(|x| x.digest()).collect();
-    let extra_parent = CertificateDigest::new(BlockHash::random().0);
+    let extra_parent = HeaderDigest::new(BlockHash::random().0);
     expected_parents.pop();
     expected_parents.push(extra_parent);
     let wrong_genesis: BTreeSet<_> = expected_parents.into_iter().collect();

--- a/crates/consensus/primary/tests/it/bullshark_commit_tests.rs
+++ b/crates/consensus/primary/tests/it/bullshark_commit_tests.rs
@@ -256,7 +256,7 @@ async fn test_commit_order_oldest_first() {
     // Verify leaders are committed in ascending round order
     let mut last_leader_round = 0;
     for subdag in &all_committed {
-        let leader_round = subdag.leader.round();
+        let leader_round = subdag.leader().round();
         assert!(
             leader_round > last_leader_round,
             "Leaders should be committed in ascending round order: {} > {}",

--- a/crates/consensus/primary/tests/it/recovery_tests.rs
+++ b/crates/consensus/primary/tests/it/recovery_tests.rs
@@ -29,7 +29,7 @@ async fn test_subdag_persists_restart() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader_digest = certificates.first().unwrap().digest();
+    let leader_digest = certificates.last().unwrap().header().digest();
 
     // Phase 1: Write data
     {
@@ -40,7 +40,7 @@ async fn test_subdag_persists_restart() {
 
         // Create and persist subdags with sequential indices
         for idx in 0..5u64 {
-            let leader = certificates.first().cloned().unwrap();
+            let leader = certificates.last().cloned().unwrap();
             let reputation = ReputationScores::new(&committee);
             let subdag =
                 Arc::new(CommittedSubDag::new(certificates.clone(), leader, idx, reputation, None));
@@ -69,15 +69,11 @@ async fn test_subdag_persists_restart() {
 
         // Verify subdag content persisted correctly
         assert_eq!(
-            latest_subdag.leader.digest(),
+            latest_subdag.leader().digest(),
             leader_digest,
             "Leader should persist across restart"
         );
-        assert_eq!(
-            latest_subdag.certificates.len(),
-            certificates.len(),
-            "Certificates should persist"
-        );
+        assert_eq!(latest_subdag.headers.len(), certificates.len(), "Certificates should persist");
     }
 }
 
@@ -101,7 +97,7 @@ async fn test_subdag_persists_multiple_writes() {
 
     // Write subdags for epoch 0 with indices 0, 1, 2
     for idx in 0..3u64 {
-        let leader = certs_epoch0.first().cloned().unwrap();
+        let leader = certs_epoch0.last().cloned().unwrap();
         let reputation = ReputationScores::new(&committee_epoch0);
         let subdag =
             Arc::new(CommittedSubDag::new(certs_epoch0.clone(), leader, idx, reputation, None));
@@ -121,11 +117,11 @@ async fn test_subdag_persists_multiple_writes() {
     let genesis1: BTreeSet<_> = fixture_epoch1.genesis().collect();
     let (_, headers1) = fixture_epoch1.headers_round(0, &genesis1);
     let certs_epoch1: Vec<_> = headers1.iter().map(|h| fixture_epoch1.certificate(h)).collect();
-    let epoch1_leader_digest = certs_epoch1.first().unwrap().digest();
+    let epoch1_leader_digest = certs_epoch1.last().unwrap().header().digest();
 
     // Continue with indices 3, 4, 5
     for idx in 3..6u64 {
-        let leader = certs_epoch1.first().cloned().unwrap();
+        let leader = certs_epoch1.last().cloned().unwrap();
         let reputation = ReputationScores::new(&committee_epoch1);
         let subdag =
             Arc::new(CommittedSubDag::new(certs_epoch1.clone(), leader, idx, reputation, None));
@@ -137,7 +133,7 @@ async fn test_subdag_persists_multiple_writes() {
     let latest_after_epoch1 =
         consensus_chain.consensus_header_latest().await.unwrap().unwrap().sub_dag;
     assert_eq!(
-        latest_after_epoch1.leader.digest(),
+        latest_after_epoch1.leader().digest(),
         epoch1_leader_digest,
         "Latest subdag should be from second batch"
     );

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -19,8 +19,8 @@ use tn_storage::{
 };
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Database, EpochRecord,
-    Hash as _, Header, HeaderBuilder, ReputationScores, Round,
+    AuthorityIdentifier, Certificate, CommittedSubDag, Database, EpochRecord, Hash as _, Header,
+    HeaderBuilder, HeaderDigest, ReputationScores, Round,
 };
 
 fn create_header_for_round(round: Round) -> Header {
@@ -32,7 +32,7 @@ fn create_header_for_round(round: Round) -> Header {
         .author(id)
         .round(round)
         .epoch(fixture.committee().epoch())
-        .parents([CertificateDigest::default()].iter().cloned().collect())
+        .parents([HeaderDigest::default()].iter().cloned().collect())
         .with_payload_batch(fixture_batch_with_transactions(10), 0)
         .build()
 }
@@ -118,9 +118,10 @@ async fn test_consensus_store_read_latest_final_reputation_scores() {
 
     // AND we add some commits without any final scores
     for sequence_number in 0..10 {
+        let cert = Certificate::default();
         let sub_dag = Arc::new(CommittedSubDag::new(
-            vec![],
-            Certificate::default(),
+            vec![cert.clone()],
+            cert,
             sequence_number,
             ReputationScores::new(&committee),
             None,
@@ -145,13 +146,9 @@ async fn test_consensus_store_read_latest_final_reputation_scores() {
             scores.final_of_schedule = true;
         }
 
-        let sub_dag = Arc::new(CommittedSubDag::new(
-            vec![],
-            Certificate::default(),
-            sequence_number,
-            scores,
-            None,
-        ));
+        let cert = Certificate::default();
+        let sub_dag =
+            Arc::new(CommittedSubDag::new(vec![cert.clone()], cert, sequence_number, scores, None));
 
         consensus_chain.write_subdag_for_test(sequence_number, sub_dag).await;
     }
@@ -219,7 +216,7 @@ async fn test_write_all_and_read_all_by_store_type<DB: CertificateStore>(store: 
     // GIVEN
     // create certificates for 10 rounds
     let certs = certificates(10);
-    let ids = certs.iter().map(|c| c.digest()).collect::<Vec<CertificateDigest>>();
+    let ids = certs.iter().map(|c| c.digest()).collect::<Vec<HeaderDigest>>();
 
     // store them in both main and secondary index
     store.write_all(certs.iter()).unwrap();
@@ -393,7 +390,7 @@ async fn test_certificate_store_notify_read() {
     // run the tests a few times
     for _ in 0..10 {
         let mut certs = certificates(3);
-        let mut ids = certs.iter().map(|c| c.digest()).collect::<Vec<CertificateDigest>>();
+        let mut ids = certs.iter().map(|c| c.digest()).collect::<Vec<HeaderDigest>>();
 
         let cloned_store = store.clone();
 

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -36,9 +36,11 @@ pub fn execute_consensus_output(
     let batches = output.flatten_batches();
 
     let span = info_span!(target: "telcoin", "execute-consensus", epoch,
+        consensus_number = output.number(),
         consensus_hash = output_digest.to_string(),
-        parent_number = canonical_header.number,
-        parent_hash = canonical_header.hash().to_string(),
+        parent_consensus_hash = output.parent_hash().to_string(),
+        parent_exec_number = canonical_header.number,
+        parent_exec_hash = canonical_header.hash().to_string(),
         executed_blocks = field::Empty,
         batches = batches.len(),
     );

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -27,7 +27,7 @@ pub fn execute_consensus_output(
     // rename canonical header for clarity
     let BuildArguments { reth_env, output, parent_header } = args;
     let mut canonical_header = parent_header; // Last canonical header executed.
-    gas_accumulator.rewards_counter().inc_leader_count(output.leader().origin());
+    gas_accumulator.rewards_counter().inc_leader_count(output.leader().author());
     let epoch = output.leader().epoch();
     // output digest returns the `ConsensusHeader` digest
     let output_digest: B256 = output.digest().into();
@@ -76,7 +76,7 @@ pub fn execute_consensus_output(
         // Use parent values for next block (these values would come from the worker's block).
         let base_fee_per_gas = canonical_header.base_fee_per_gas.unwrap_or_default();
         let gas_limit = canonical_header.gas_limit;
-        let leader = output.leader().origin();
+        let leader = output.leader().author();
         let beneficiary = gas_accumulator
             .get_authority_address(leader)
             .ok_or(TnEngineError::UnknownAuthority(leader.clone()))

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -709,7 +709,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     let previous_sub_dag = None;
     let mut batch_digests_1: VecDeque<BlockHash> = batches_1.iter().map(|b| b.digest()).collect();
     let subdag_1 = Arc::new(CommittedSubDag::new(
-        vec![leader_1.clone(), Certificate::default()],
+        vec![Certificate::default(), leader_1.clone()],
         leader_1,
         sub_dag_index_1,
         reputation_scores,
@@ -735,7 +735,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     let previous_sub_dag = Some(subdag_1.clone());
     let batch_digests_2: VecDeque<BlockHash> = batches_2.iter().map(|b| b.digest()).collect();
     let subdag_2 = CommittedSubDag::new(
-        vec![leader_2.clone(), Certificate::default()],
+        vec![Certificate::default(), leader_2.clone()],
         leader_2,
         sub_dag_index_2,
         reputation_scores,
@@ -1220,7 +1220,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     let mut cert_1 = Certificate::default();
     cert_1.header.round = 1;
     let subdag_1 = Arc::new(CommittedSubDag::new(
-        vec![cert_1],
+        vec![leader_1.clone()],
         leader_1,
         sub_dag_index_1,
         reputation_scores,
@@ -1248,7 +1248,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     let mut cert_2 = Certificate::default();
     cert_2.header.round = 2;
     let subdag_2: Arc<CommittedSubDag> = CommittedSubDag::new(
-        vec![cert_2],
+        vec![leader_2.clone()],
         leader_2,
         sub_dag_index_2,
         reputation_scores,
@@ -1601,7 +1601,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     let previous_sub_dag = None;
     let batch_digests_1: VecDeque<BlockHash> = batches_1.iter().map(|b| b.digest()).collect();
     let subdag_1 = Arc::new(CommittedSubDag::new(
-        vec![Certificate::default()],
+        vec![leader_1.clone()],
         leader_1,
         sub_dag_index_1,
         reputation_scores,
@@ -1626,7 +1626,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     let previous_sub_dag = Some(subdag_1.clone());
     let batch_digests_2: VecDeque<BlockHash> = batches_2.iter().map(|b| b.digest()).collect();
     let subdag_2: Arc<CommittedSubDag> = CommittedSubDag::new(
-        vec![Certificate::default()],
+        vec![Certificate::default(), leader_2.clone()],
         leader_2,
         sub_dag_index_2,
         reputation_scores,
@@ -1837,7 +1837,7 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
     let batch_digest = batch.digest();
     let batch_digests = VecDeque::from([batch_digest]);
     let subdag = Arc::new(CommittedSubDag::new(
-        vec![leader.clone(), Certificate::default()],
+        vec![Certificate::default(), leader.clone()],
         leader,
         sub_dag_index,
         reputation_scores,
@@ -2142,7 +2142,7 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
     let batch_digest = batch.digest();
     let batch_digests = VecDeque::from([batch_digest]);
     let subdag = Arc::new(CommittedSubDag::new(
-        vec![leader.clone(), Certificate::default()],
+        vec![Certificate::default(), leader.clone()],
         leader,
         sub_dag_index,
         reputation_scores,

--- a/crates/network-libp2p/src/tests/codec_tests.rs
+++ b/crates/network-libp2p/src/tests/codec_tests.rs
@@ -6,7 +6,7 @@ use crate::{
     TNCodec,
 };
 use libp2p::StreamProtocol;
-use tn_types::{Certificate, CertificateDigest, Header};
+use tn_types::{Certificate, Header, HeaderDigest};
 
 #[tokio::test]
 async fn test_encode_decode_same_message() {
@@ -32,7 +32,7 @@ async fn test_encode_decode_same_message() {
 
     // encode response
     let mut encoded = Vec::new();
-    let response = TestPrimaryResponse::MissingParents(vec![CertificateDigest::new([b'a'; 32])]);
+    let response = TestPrimaryResponse::MissingParents(vec![HeaderDigest::new([b'a'; 32])]);
     codec
         .write_response(&protocol, &mut encoded, response.clone())
         .await

--- a/crates/network-libp2p/src/tests/common.rs
+++ b/crates/network-libp2p/src/tests/common.rs
@@ -9,7 +9,7 @@ use std::{
     sync::{Arc, Once},
 };
 use tn_config::ScoreConfig;
-use tn_types::{BlockHash, Certificate, CertificateDigest, Header, SealedBatch, Vote};
+use tn_types::{BlockHash, Certificate, Header, HeaderDigest, SealedBatch, Vote};
 
 /// Default heartbeat for tests.
 #[allow(dead_code)] // used in network_tests.rs
@@ -93,7 +93,7 @@ pub(super) enum TestPrimaryRequest {
 pub(super) enum TestPrimaryResponse {
     Vote(Vote),
     MissingCertificates(Vec<Certificate>),
-    MissingParents(Vec<CertificateDigest>),
+    MissingParents(Vec<HeaderDigest>),
 }
 
 impl From<PeerExchangeMap> for TestWorkerRequest {

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -127,7 +127,7 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
             // forward output from consensus to engine
             Some(output) = consensus_output.recv() => {
                 debug!(target: "gas-test", output=?output.leader(), round=output.leader().round(), "received output");
-                let leader = output.leader().origin().clone();
+                let leader = output.leader().author().clone();
                 // manually track values as well
                 rewards.entry(leader).and_modify(|count| *count += 1).or_insert(1);
                 to_engine.send(output).await?;
@@ -278,7 +278,7 @@ async fn test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
     let mut rewards = HashMap::new();
     let mut empty_outputs_seen = 0u32;
     for (i, output) in real_outputs.into_iter().enumerate() {
-        let leader = output.leader().origin().clone();
+        let leader = output.leader().author().clone();
         rewards.entry(leader.clone()).and_modify(|count| *count += 1).or_insert(1);
         to_engine.send(output.clone()).await?;
 
@@ -420,7 +420,7 @@ async fn test_catchup_accumulator_partial_execution() -> eyre::Result<()> {
     loop {
         tokio::select! {
             Some(output) = consensus_output.recv() => {
-                let leader = output.leader().origin().clone();
+                let leader = output.leader().author().clone();
                 let round = output.leader().round();
                 if round <= engine_stop_round as u32 {
                     executed_rewards.entry(leader).and_modify(|c| *c += 1).or_insert(1u32);

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -341,7 +341,7 @@ async fn catch_up_consensus_from_to<DB: Database>(
             continue;
         }
 
-        let base_execution_block = consensus_header.sub_dag.leader.header().latest_execution_block;
+        let base_execution_block = consensus_header.sub_dag.leader().latest_execution_block;
         // We need to make sure execution has caught up so we can verify we have not
         // forked. This will force the follow function to not outrun
         // execution...  this is probably fine. Also once we can

--- a/crates/state-sync/tests/it/main.rs
+++ b/crates/state-sync/tests/it/main.rs
@@ -29,7 +29,7 @@ async fn test_sync_save_consensus() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
 
     // Create a CommittedSubDag
     let reputation = ReputationScores::new(&committee);
@@ -49,7 +49,7 @@ async fn test_sync_save_consensus() {
     let saved_header = saved.unwrap();
     assert_eq!(saved_header.number, 1, "Consensus number should be 1");
     assert_eq!(
-        saved_header.sub_dag.certificates.len(),
+        saved_header.sub_dag.headers.len(),
         certificates.len(),
         "Should have same number of certificates"
     );
@@ -74,7 +74,7 @@ async fn test_sync_parent_hash_chain() {
     let mut saved_digests: Vec<B256> = vec![B256::ZERO]; // Genesis parent
 
     for i in 1..=3u64 {
-        let leader = certificates.first().cloned().unwrap();
+        let leader = certificates.last().cloned().unwrap();
         let reputation = ReputationScores::new(&committee);
         let sub_dag =
             Arc::new(CommittedSubDag::new(certificates.clone(), leader, i - 1, reputation, None));
@@ -121,7 +121,7 @@ async fn test_sync_lookup_by_hash() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
 
     let reputation = ReputationScores::new(&committee);
     let sub_dag = Arc::new(CommittedSubDag::new(certificates, leader, 0, reputation, None));
@@ -149,7 +149,7 @@ async fn test_digest_determinism() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
 
     let reputation = ReputationScores::new(&committee);
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
@@ -175,7 +175,7 @@ async fn test_digest_collision_resistance() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
 
     let reputation = ReputationScores::new(&committee);
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
@@ -213,7 +213,7 @@ async fn test_digest_mismatch_detection() {
     let genesis: BTreeSet<_> = fixture.genesis().collect();
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
 
     let reputation = ReputationScores::new(&committee);
     let sub_dag = Arc::new(CommittedSubDag::new(certificates, leader, 0, reputation, None));

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -788,8 +788,8 @@ impl Inner {
                     if consensus_header.parent_hash != parent_digest {
                         return Err(PackError::InvalidConsensusChain);
                     }
-                    for cert in &consensus_header.sub_dag.certificates {
-                        for (digest, _) in cert.header().payload().iter() {
+                    for header in &consensus_header.sub_dag.headers {
+                        for (digest, _) in header.payload().iter() {
                             if !batches.remove(digest) {
                                 return Err(PackError::MissingBatches);
                             }
@@ -901,7 +901,7 @@ impl Inner {
             .into_consensus()?;
         let parent_hash = header.parent_hash;
         let deliver = header.sub_dag;
-        let num_blocks = deliver.num_primary_blocks();
+        let num_blocks = deliver.num_primary_batches();
         let num_certs = deliver.len();
 
         let sub_dag = deliver;
@@ -912,8 +912,8 @@ impl Inner {
         let mut batch_set: HashSet<BlockHash> = HashSet::new();
 
         let mut batch_digests = VecDeque::with_capacity(num_certs);
-        for cert in sub_dag.certificates() {
-            for (digest, _) in cert.header().payload().iter() {
+        for header in sub_dag.headers() {
+            for (digest, _) in header.payload().iter() {
                 batch_set.insert(*digest);
                 batch_digests.push_back(*digest);
             }
@@ -921,12 +921,12 @@ impl Inner {
 
         // map all fetched batches to their respective certificates for applying block rewards
         let mut batches = Vec::with_capacity(num_certs);
-        for cert in &sub_dag.certificates {
+        for header in &sub_dag.headers {
             // create collection of batches to execute for this certificate
-            let mut cert_batches = Vec::with_capacity(cert.header().payload().len());
+            let mut cert_batches = Vec::with_capacity(header.payload().len());
 
             // retrieve fetched batch by digest
-            for digest in cert.header().payload().keys() {
+            for digest in header.payload().keys() {
                 let position = self
                     .batch_digests
                     .load(*digest)
@@ -940,7 +940,7 @@ impl Inner {
             }
 
             let address =
-                self.epoch_meta.committee.authority(cert.origin()).map(|a| a.execution_address());
+                self.epoch_meta.committee.authority(header.author()).map(|a| a.execution_address());
             if let Some(address) = address {
                 // main collection for execution
                 batches.push(CertifiedBatch { address, batches: cert_batches });
@@ -1032,14 +1032,14 @@ impl Inner {
                 let block = self.data.fetch(pos);
                 block.ok().map(|b| b.into_consensus().ok()).unwrap_or_default()
             }) {
-                let id = block.sub_dag.leader.origin().clone();
+                let id = block.sub_dag.leader().author().clone();
                 let round = block.sub_dag.leader_round();
-                let certs = block.sub_dag.certificates();
+                let headers = block.sub_dag.headers();
                 res.entry(id).and_modify(|r| *r = max(*r, round)).or_insert_with(|| round);
-                for c in certs {
-                    res.entry(c.origin().clone())
-                        .and_modify(|r| *r = max(*r, c.round()))
-                        .or_insert_with(|| c.round());
+                for h in headers {
+                    res.entry(h.author().clone())
+                        .and_modify(|r| *r = max(*r, h.round()))
+                        .or_insert_with(|| h.round());
                 }
             }
         }
@@ -1125,7 +1125,7 @@ impl Inner {
                 continue;
             }
 
-            rewards_counter.inc_leader_count(header.sub_dag.leader.origin());
+            rewards_counter.inc_leader_count(header.sub_dag.leader().author());
         }
         Ok(())
     }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -78,16 +78,16 @@ macro_rules! tables {
 pub mod tables {
     use super::{PayloadToken, ProposerKey};
     use tn_types::{
-        AuthorityIdentifier, Batch, BlockHash, Certificate, CertificateDigest, ConsensusHeader,
-        Header, Round, TableHint, VoteInfo, WorkerId,
+        AuthorityIdentifier, Batch, BlockHash, Certificate, ConsensusHeader, Header, HeaderDigest,
+        Round, TableHint, VoteInfo, WorkerId,
     };
 
     tables!(
         LastProposed;crate::LAST_PROPOSED_CF;TableHint::Epoch;<ProposerKey, Header>,  // Cleared every epoch
         Votes;crate::VOTES_CF;TableHint::Epoch;<AuthorityIdentifier, VoteInfo>,  // Cleared every epoch
-        Certificates;crate::CERTIFICATES_CF;TableHint::Epoch;<CertificateDigest, Certificate>,  // Cleared every epoch
-        CertificateDigestByRound;crate::CERTIFICATE_DIGEST_BY_ROUND_CF;TableHint::Epoch;<(Round, AuthorityIdentifier), CertificateDigest>,  // Cleared every epoch
-        CertificateDigestByOrigin;crate::CERTIFICATE_DIGEST_BY_ORIGIN_CF;TableHint::Epoch;<(AuthorityIdentifier, Round), CertificateDigest>,  // Cleared every epoch
+        Certificates;crate::CERTIFICATES_CF;TableHint::Epoch;<HeaderDigest, Certificate>,  // Cleared every epoch
+        CertificateDigestByRound;crate::CERTIFICATE_DIGEST_BY_ROUND_CF;TableHint::Epoch;<(Round, AuthorityIdentifier), HeaderDigest>,  // Cleared every epoch
+        CertificateDigestByOrigin;crate::CERTIFICATE_DIGEST_BY_ORIGIN_CF;TableHint::Epoch;<(AuthorityIdentifier, Round), HeaderDigest>,  // Cleared every epoch
         Payload;crate::PAYLOAD_CF;TableHint::Epoch;<(BlockHash, WorkerId), PayloadToken>,  // Cleared every epoch
         // This is a cache to store this nodes batches before consensus, remove once in a ConsensusHeader.
         NodeBatchesCache;crate::NODE_BATCHES_CACHE_CF;TableHint::Cache;<BlockHash, Batch>,

--- a/crates/storage/src/stores/certificate_store.rs
+++ b/crates/storage/src/stores/certificate_store.rs
@@ -12,11 +12,11 @@ use crate::{
     StoreResult, ROUNDS_TO_KEEP,
 };
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, Database, DbTx, DbTxMut, Hash, Round,
+    AuthorityIdentifier, Certificate, Database, DbTx, DbTxMut, Hash, HeaderDigest, Round,
 };
 use tn_utils::NotifyRead;
 
-static NOTIFY_SUBSCRIBERS: LazyLock<NotifyRead<CertificateDigest, Certificate>> =
+static NOTIFY_SUBSCRIBERS: LazyLock<NotifyRead<HeaderDigest, Certificate>> =
     LazyLock::new(NotifyRead::new);
 
 /// The main storage trait when we have to deal with certificates.
@@ -51,7 +51,7 @@ pub trait CertificateStore {
 
     /// Retrieves a certificate from the store. If not found
     /// then None is returned as result.
-    fn read(&self, id: CertificateDigest) -> StoreResult<Option<Certificate>>;
+    fn read(&self, id: HeaderDigest) -> StoreResult<Option<Certificate>>;
 
     /// Retrieves a certificate from the store by round and authority.
     /// If not found, None is returned as result.
@@ -62,27 +62,27 @@ pub trait CertificateStore {
     ) -> StoreResult<Option<Certificate>>;
 
     /// Check database for certificate.
-    fn contains(&self, digest: &CertificateDigest) -> StoreResult<bool>;
+    fn contains(&self, digest: &HeaderDigest) -> StoreResult<bool>;
 
     /// Check database for multiple certificates.
     fn multi_contains<'a>(
         &self,
-        digests: impl Iterator<Item = &'a CertificateDigest>,
+        digests: impl Iterator<Item = &'a HeaderDigest>,
     ) -> StoreResult<Vec<bool>>;
 
     /// Retrieves multiple certificates by their provided ids. The results
     /// are returned in the same sequence as the provided keys.
     fn read_all(
         &self,
-        ids: impl IntoIterator<Item = CertificateDigest>,
+        ids: impl IntoIterator<Item = HeaderDigest>,
     ) -> StoreResult<Vec<Option<Certificate>>>;
 
     /// Waits to get notified until the requested certificate becomes available
     // Use de-sugared async fn to specify trait bounds and avoid clippy warnings.
-    fn notify_read(&self, id: CertificateDigest) -> impl Future<Output = StoreResult<Certificate>>;
+    fn notify_read(&self, id: HeaderDigest) -> impl Future<Output = StoreResult<Certificate>>;
 
     /// Deletes a single certificate by its digest.
-    fn delete(&self, id: CertificateDigest) -> StoreResult<()>;
+    fn delete(&self, id: HeaderDigest) -> StoreResult<()>;
 
     /// Retrieves all the certificates with round >= the provided round.
     /// The result is returned with certificates sorted in round asc order
@@ -128,7 +128,7 @@ pub trait CertificateStore {
 /// Save a cert using an open txn.
 fn save_cert<TX: DbTxMut>(
     txn: &mut TX,
-    digest: CertificateDigest,
+    digest: HeaderDigest,
     certificate: &Certificate,
 ) -> StoreResult<()> {
     txn.insert::<Certificates>(&digest, certificate)?;
@@ -210,7 +210,7 @@ impl<DB: Database> CertificateStore for DB {
 
     /// Retrieves a certificate from the store. If not found
     /// then None is returned as result.
-    fn read(&self, id: CertificateDigest) -> StoreResult<Option<Certificate>> {
+    fn read(&self, id: HeaderDigest) -> StoreResult<Option<Certificate>> {
         self.get::<Certificates>(&id)
     }
 
@@ -227,13 +227,13 @@ impl<DB: Database> CertificateStore for DB {
         }
     }
 
-    fn contains(&self, digest: &CertificateDigest) -> StoreResult<bool> {
+    fn contains(&self, digest: &HeaderDigest) -> StoreResult<bool> {
         self.contains_key::<Certificates>(digest)
     }
 
     fn multi_contains<'a>(
         &self,
-        digests: impl Iterator<Item = &'a CertificateDigest>,
+        digests: impl Iterator<Item = &'a HeaderDigest>,
     ) -> StoreResult<Vec<bool>> {
         digests.map(|digest| self.contains_key::<Certificates>(digest)).collect()
     }
@@ -242,13 +242,13 @@ impl<DB: Database> CertificateStore for DB {
     /// are returned in the same sequence as the provided keys.
     fn read_all(
         &self,
-        ids: impl IntoIterator<Item = CertificateDigest>,
+        ids: impl IntoIterator<Item = HeaderDigest>,
     ) -> StoreResult<Vec<Option<Certificate>>> {
         ids.into_iter().map(|digest| self.get::<Certificates>(&digest)).collect()
     }
 
     /// Waits to get notified until the requested certificate becomes available
-    async fn notify_read(&self, id: CertificateDigest) -> StoreResult<Certificate> {
+    async fn notify_read(&self, id: HeaderDigest) -> StoreResult<Certificate> {
         // we register our interest to be notified with the value
         let receiver = NOTIFY_SUBSCRIBERS.register_one(&id);
 
@@ -269,7 +269,7 @@ impl<DB: Database> CertificateStore for DB {
     }
 
     /// Deletes a single certificate by its digest.
-    fn delete(&self, id: CertificateDigest) -> StoreResult<()> {
+    fn delete(&self, id: HeaderDigest) -> StoreResult<()> {
         let mut txn = self.write_txn()?;
         // first read the certificate to get the round - we'll need in order
         // to delete the secondary index

--- a/crates/test-utils-committee/src/committee.rs
+++ b/crates/test-utils-committee/src/committee.rs
@@ -4,8 +4,8 @@ use super::{AuthorityFixture, Builder};
 use std::collections::{BTreeMap, BTreeSet};
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, Committee, Database, Hash as _, Header,
-    HeaderBuilder, Round, Vote,
+    AuthorityIdentifier, Certificate, Committee, Database, Hash as _, Header, HeaderBuilder,
+    HeaderDigest, Round, Vote,
 };
 
 /// Fixture representing a committee to reach consensus.
@@ -109,7 +109,7 @@ impl<DB: Database> CommitteeFixture<DB> {
     pub fn headers_round(
         &self,
         prior_round: Round,
-        parents: &BTreeSet<CertificateDigest>,
+        parents: &BTreeSet<HeaderDigest>,
     ) -> (Round, Vec<Header>) {
         let round = prior_round + 1;
         let next_headers = self
@@ -176,7 +176,7 @@ impl<DB: Database> CommitteeFixture<DB> {
     }
 
     /// Create the genesis certificates for the committe.
-    pub fn genesis(&self) -> impl Iterator<Item = CertificateDigest> {
+    pub fn genesis(&self) -> impl Iterator<Item = HeaderDigest> {
         Certificate::genesis(&self.committee()).into_iter().map(|x| x.digest())
     }
 }

--- a/crates/test-utils/src/consensus.rs
+++ b/crates/test-utils/src/consensus.rs
@@ -7,8 +7,8 @@ use std::{
     ops::RangeInclusive,
 };
 use tn_types::{
-    now, test_chain_spec_arc, AuthorityIdentifier, Batch, BlockHash, Certificate,
-    CertificateDigest, Database, Hash as _, HeaderBuilder, Round, WorkerId,
+    now, test_chain_spec_arc, AuthorityIdentifier, Batch, BlockHash, Certificate, Database,
+    Hash as _, HeaderBuilder, HeaderDigest, Round, WorkerId,
 };
 
 /// Create a random number of batches with signed transactions.
@@ -36,9 +36,9 @@ fn random_batches(
 fn signed_cert<DB>(
     origin: AuthorityIdentifier,
     round: Round,
-    parents: BTreeSet<CertificateDigest>,
+    parents: BTreeSet<HeaderDigest>,
     committee: &CommitteeFixture<DB>,
-) -> (CertificateDigest, Certificate, HashMap<BlockHash, Batch>)
+) -> (HeaderDigest, Certificate, HashMap<BlockHash, Batch>)
 where
     DB: Database,
 {
@@ -60,9 +60,9 @@ where
 fn signed_cert_empty<DB>(
     origin: AuthorityIdentifier,
     round: Round,
-    parents: BTreeSet<CertificateDigest>,
+    parents: BTreeSet<HeaderDigest>,
     committee: &CommitteeFixture<DB>,
-) -> (CertificateDigest, Certificate)
+) -> (HeaderDigest, Certificate)
 where
     DB: Database,
 {
@@ -86,7 +86,7 @@ pub fn create_signed_certificates_for_rounds<DB>(
     range: RangeInclusive<Round>,
     fixture: &CommitteeFixture<DB>,
     empty_rounds: &[Round],
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>, HashMap<BlockHash, Batch>)
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>, HashMap<BlockHash, Batch>)
 where
     DB: Database,
 {
@@ -129,7 +129,7 @@ pub fn create_signed_certificates_with_empty_rounds<DB>(
     range: RangeInclusive<Round>,
     fixture: &CommitteeFixture<DB>,
     empty_rounds: &[Round],
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>, HashMap<BlockHash, Batch>)
+) -> (VecDeque<Certificate>, BTreeSet<HeaderDigest>, HashMap<BlockHash, Batch>)
 where
     DB: Database,
 {

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1500,7 +1500,7 @@ mod tests {
         let reputation_scores = ReputationScores::default();
         let previous_sub_dag = None;
         let sub_dag = Arc::new(CommittedSubDag::new(
-            vec![leader.clone(), Certificate::default()],
+            vec![Certificate::default(), leader.clone()],
             leader,
             subdag_index,
             reputation_scores,

--- a/crates/tn-reth/tests/it/pipeline_helpers.rs
+++ b/crates/tn-reth/tests/it/pipeline_helpers.rs
@@ -446,7 +446,7 @@ fn consensus_output_for_test(
     let reputation_scores = ReputationScores::default();
     let previous_sub_dag = None;
     let sub_dag = Arc::new(CommittedSubDag::new(
-        vec![leader.clone(), Certificate::default()],
+        vec![Certificate::default(), leader.clone()],
         leader,
         subdag_index,
         reputation_scores,

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -1,8 +1,8 @@
 //! Error types whenn validating types during consensus.
 
 use crate::{
-    crypto, BlockNumHash, BlsPublicKey, CertificateDigest, Digest, Epoch, HeaderDigest, Round,
-    SendError, TimestampSec, VoteDigest, WorkerId,
+    crypto, BlockNumHash, BlsPublicKey, Digest, Epoch, HeaderDigest, Round, SendError,
+    TimestampSec, VoteDigest, WorkerId,
 };
 use thiserror::Error;
 
@@ -117,7 +117,7 @@ pub enum DagError {
     InvalidTimestamp { created_time: TimestampSec, local_time: TimestampSec },
 
     #[error("Invalid parent {0} (not found in genesis)")]
-    InvalidGenesisParent(CertificateDigest),
+    InvalidGenesisParent(HeaderDigest),
 
     #[error("No peer can be reached for fetching certificates! Check if network is healthy.")]
     NoCertificateFetched,
@@ -237,7 +237,7 @@ pub enum HeaderError {
     UnknownExecutionResult(BlockNumHash),
     /// Invalid parent for genesis.
     #[error("Invalid parent for genesis: {0}")]
-    InvalidGenesisParent(CertificateDigest),
+    InvalidGenesisParent(HeaderDigest),
     /// Error retrieving value from storage.
     #[error("Storage failure: {0}")]
     Storage(#[from] StoreError),
@@ -302,10 +302,10 @@ pub enum CertificateError {
     InvalidSignature,
     /// The certificates's round is too far behind.
     #[error("Certificate {0} for round {1} is too old for GC round {2}")]
-    TooOld(CertificateDigest, Round, Round),
+    TooOld(HeaderDigest, Round, Round),
     /// The certificate is too far in the future for this node.
     #[error("Certificate {0} for round {1} is too new for this primary at round {2}")]
-    TooNew(CertificateDigest, Round, Round),
+    TooNew(HeaderDigest, Round, Round),
     /// Oneshot channel dropped while processing the certificate.
     #[error("Failed to process certificate - oneshot sender error")]
     ResChannelClosed(String),

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -58,9 +58,10 @@ impl ConsensusHeader {
 
 impl Default for ConsensusHeader {
     fn default() -> Self {
+        let cert = Certificate::default();
         let sub_dag = Arc::new(CommittedSubDag::new(
-            vec![],
-            Certificate::default(),
+            vec![cert.clone()],
+            cert,
             0,
             crate::ReputationScores::default(),
             None,

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -12,7 +12,7 @@ use crate::{
     ensure,
     error::{CertificateError, CertificateResult, DagError, DagResult, HeaderError},
     serde::RoaringBitmapSerde,
-    Authority, AuthorityIdentifier, BlockHash, Committee, Digest, Epoch, Hash, Header, Round,
+    Authority, AuthorityIdentifier, Committee, Epoch, Hash, Header, HeaderDigest, Round,
     VotingPower,
 };
 use serde::{Deserialize, Serialize};
@@ -448,54 +448,11 @@ pub fn validate_fetched_certificate(
     Ok(certificate)
 }
 
-/// Certificate digest.
-#[derive(
-    Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
-pub struct CertificateDigest(Digest<{ crypto::DIGEST_LENGTH }>);
-
-impl CertificateDigest {
-    /// Create a new instance of CertificateDigest.
-    pub fn new(digest: [u8; crypto::DIGEST_LENGTH]) -> Self {
-        CertificateDigest(Digest { digest })
-    }
-}
-
-impl AsRef<[u8]> for CertificateDigest {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.digest
-    }
-}
-
-impl From<CertificateDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
-    fn from(hd: CertificateDigest) -> Self {
-        hd.0
-    }
-}
-
-impl fmt::Debug for CertificateDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for CertificateDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0.to_string().get(0..16).ok_or(fmt::Error)?)
-    }
-}
-
 impl Hash<{ crypto::DIGEST_LENGTH }> for Certificate {
-    type TypedDigest = CertificateDigest;
+    type TypedDigest = HeaderDigest;
 
-    fn digest(&self) -> CertificateDigest {
-        CertificateDigest(Digest { digest: self.header.digest().into() })
-    }
-}
-
-impl From<CertificateDigest> for BlockHash {
-    fn from(value: CertificateDigest) -> Self {
-        Self::from(value.0.digest)
+    fn digest(&self) -> HeaderDigest {
+        self.header.digest()
     }
 }
 

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -1,8 +1,8 @@
 use crate::{
     crypto, encode,
     error::{HeaderError, HeaderResult},
-    now, AuthorityIdentifier, Batch, BlockHash, BlockNumHash, CertificateDigest, Committee, Digest,
-    Epoch, Hash, Round, TimestampSec, VoteDigest, WorkerId,
+    now, AuthorityIdentifier, Batch, BlockHash, BlockNumHash, Committee, Digest, Epoch, Hash,
+    Round, TimestampSec, VoteDigest, WorkerId,
 };
 use derive_builder::Builder;
 use indexmap::IndexMap;
@@ -26,7 +26,7 @@ pub struct Header {
     #[serde(with = "indexmap::map::serde_seq")]
     pub payload: IndexMap<BlockHash, WorkerId>,
     /// Parent certificates for this Header.
-    pub parents: BTreeSet<CertificateDigest>,
+    pub parents: BTreeSet<HeaderDigest>,
     /// Hash and number of the latest known execution block when this Header was build.
     /// This may be our parent block or may not but it does include our latest
     /// execution result in a signed and validated structure which validates
@@ -44,7 +44,7 @@ impl Header {
         round: Round,
         epoch: Epoch,
         payload: IndexMap<BlockHash, WorkerId>,
-        parents: BTreeSet<CertificateDigest>,
+        parents: BTreeSet<HeaderDigest>,
         latest_execution_block: BlockNumHash,
     ) -> Self {
         let header = Self {
@@ -122,7 +122,7 @@ impl Header {
         &self.payload
     }
     /// The parents for the header.
-    pub fn parents(&self) -> &BTreeSet<CertificateDigest> {
+    pub fn parents(&self) -> &BTreeSet<HeaderDigest> {
         &self.parents
     }
 
@@ -150,12 +150,6 @@ impl Header {
     /// The nonce of this header used during execution.
     pub fn nonce(&self) -> u64 {
         ((self.epoch as u64) << 32) | self.round as u64
-    }
-}
-
-impl From<Header> for CertificateDigest {
-    fn from(value: Header) -> Self {
-        Self::new(value.digest().into())
     }
 }
 

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -264,7 +264,7 @@ impl Display for ConsensusOutput {
 /// Note it stores Headers without certificates, all validation
 /// should be complete.  Future validation can be done by verifying
 /// the consensus chain against signed checkpoints (like epoch records).
-#[derive(PartialEq, Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(PartialEq, Serialize, Deserialize, Clone, Debug)]
 pub struct CommittedSubDag {
     /// The sequence of committed certificates.
     /// Note the last element MUST be the leader.
@@ -279,6 +279,19 @@ pub struct CommittedSubDag {
     commit_timestamp: TimestampSec,
     /// Randomness derived from the leaders BLS aggregate signature.
     randomness: B256,
+}
+
+impl Default for CommittedSubDag {
+    fn default() -> Self {
+        // Override default so we have one default header (the leader)
+        // so a default value won't panic when used.
+        Self {
+            headers: vec![Header::default()],
+            reputation_score: Default::default(),
+            commit_timestamp: Default::default(),
+            randomness: Default::default(),
+        }
+    }
 }
 
 impl CommittedSubDag {
@@ -300,7 +313,8 @@ impl CommittedSubDag {
             warn!(sub_dag_index = ?sub_dag_index, "Leader timestamp {} is older than previously committed sub dag timestamp {}. Auto-correcting to max {}.",
                 leader.header().created_at(), previous_sub_dag_ts, commit_timestamp);
         }
-        // Make sure the leader is at index 0.
+        // Make sure the leader is the LAST certificate.
+        //
         assert_eq!(leader.digest(), certificates.last().map(|c| c.digest()).unwrap_or_default());
         let randomness = leader.aggregated_signature().unwrap_or_else(|| {
                 error!(target: "engine", "BLS signature missing for leader - using default for closing epoch");

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -308,7 +308,6 @@ impl CommittedSubDag {
             });
         let randomness = keccak256(randomness.to_bytes());
         let headers = certificates.into_iter().map(|c| c.header).collect();
-
         Self { headers, reputation_score, commit_timestamp, randomness }
     }
 

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -4,7 +4,7 @@
 use super::ConsensusHeader;
 use crate::{
     crypto, encode, Address, Batch, BlockHash, BlockNumHash, BlsSignature, Certificate, Digest,
-    Epoch, Hash, ReputationScores, Round, SealedHeader, TimestampSec, B256,
+    Epoch, Hash, Header, ReputationScores, Round, SealedHeader, TimestampSec, B256,
 };
 use alloy::primitives::keccak256;
 use once_cell::sync::OnceCell;
@@ -135,8 +135,8 @@ impl ConsensusOutput {
     }
 
     /// The leader for the round
-    pub fn leader(&self) -> &Certificate {
-        &self.inner.sub_dag.leader
+    pub fn leader(&self) -> &Header {
+        self.inner.sub_dag.leader()
     }
 
     /// The round for the [CommittedSubDag].
@@ -151,7 +151,7 @@ impl ConsensusOutput {
 
     /// The leader's `nonce`.
     pub fn nonce(&self) -> SequenceNumber {
-        self.inner.sub_dag.leader.nonce()
+        self.inner.sub_dag.leader().nonce()
     }
 
     /// Return the batch digest for index idx or None if not available.
@@ -229,11 +229,7 @@ impl ConsensusOutput {
     /// NOTE: this cannot fail - uses [BlsSignature::default] and is considered acceptable with
     /// permissioned validator set, but should never happen.
     pub fn keccak_leader_sigs(&self) -> B256 {
-        let randomness = self.leader().aggregated_signature().unwrap_or_else(|| {
-            error!(target: "engine", ?self, "BLS signature missing for leader - using default for closing epoch");
-            BlsSignature::default()
-        });
-        keccak256(randomness.to_bytes())
+        self.inner.sub_dag.randomness
     }
 
     /// The parent hash for this output.
@@ -256,20 +252,23 @@ impl Display for ConsensusOutput {
         write!(
             f,
             "ConsensusOutput(epoch={:?}, round={:?}, timestamp={:?}, digest={:?})",
-            self.inner.sub_dag.leader.epoch(),
-            self.inner.sub_dag.leader.round(),
+            self.inner.sub_dag.leader().epoch(),
+            self.inner.sub_dag.leader().round(),
             self.inner.sub_dag.commit_timestamp(),
             self.digest()
         )
     }
 }
 
+/// Contains the committed output from Bullshark consensus.
+/// Note it stores Headers without certificates, all validation
+/// should be complete.  Future validation can be done by verifying
+/// the consensus chain against signed checkpoints (like epoch records).
 #[derive(PartialEq, Serialize, Deserialize, Clone, Debug, Default)]
 pub struct CommittedSubDag {
     /// The sequence of committed certificates.
-    pub certificates: Vec<Certificate>,
-    /// The leader certificate responsible for committing this sub-dag.
-    pub leader: Certificate,
+    /// Note the last element MUST be the leader.
+    pub headers: Vec<Header>,
     /// The so far calculated reputation score for nodes
     pub reputation_score: ReputationScores,
     /// The timestamp that should identify this commit. This is guaranteed to be monotonically
@@ -278,9 +277,13 @@ pub struct CommittedSubDag {
     /// Property is explicitly private so the method commit_timestamp() should be used instead
     /// which bears additional resolution logic.
     commit_timestamp: TimestampSec,
+    /// Randomness derived from the leaders BLS aggregate signature.
+    randomness: B256,
 }
 
 impl CommittedSubDag {
+    /// Create a new CommittedSubDag.
+    /// Note that leader MUST be the first element or certificates or this will panic.
     pub fn new(
         certificates: Vec<Certificate>,
         leader: Certificate,
@@ -295,36 +298,48 @@ impl CommittedSubDag {
 
         if previous_sub_dag_ts > *leader.header().created_at() {
             warn!(sub_dag_index = ?sub_dag_index, "Leader timestamp {} is older than previously committed sub dag timestamp {}. Auto-correcting to max {}.",
-            leader.header().created_at(), previous_sub_dag_ts, commit_timestamp);
+                leader.header().created_at(), previous_sub_dag_ts, commit_timestamp);
         }
+        // Make sure the leader is at index 0.
+        assert_eq!(leader.digest(), certificates.last().map(|c| c.digest()).unwrap_or_default());
+        let randomness = leader.aggregated_signature().unwrap_or_else(|| {
+                error!(target: "engine", "BLS signature missing for leader - using default for closing epoch");
+                BlsSignature::default()
+            });
+        let randomness = keccak256(randomness.to_bytes());
+        let headers = certificates.into_iter().map(|c| c.header).collect();
 
-        Self { certificates, leader, reputation_score, commit_timestamp }
+        Self { headers, reputation_score, commit_timestamp, randomness }
     }
 
+    /// How many consensus headers are in this sub dag (including the leader).
     pub fn len(&self) -> usize {
-        self.certificates.len()
+        self.headers.len()
     }
 
+    /// Is this empty (i.e. contains no headers).
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    pub fn num_primary_blocks(&self) -> usize {
-        self.certificates.iter().map(|x| x.header().payload().len()).sum()
+    /// Number of batches contained in the sub dag.
+    pub fn num_primary_batches(&self) -> usize {
+        self.headers.iter().map(|x| x.payload().len()).sum()
     }
 
-    pub fn is_last(&self, output: &Certificate) -> bool {
-        self.certificates.iter().last().map_or_else(|| false, |x| x == output)
+    /// The leader header responsible for committing this sub-dag.
+    pub fn leader(&self) -> &Header {
+        self.headers.last().expect("sub dag MUST have a leader")
     }
 
     /// The Certificate's round.
     pub fn leader_round(&self) -> Round {
-        self.leader.round()
+        self.leader().round()
     }
 
     /// The Certificate's epoch.
     pub fn leader_epoch(&self) -> Epoch {
-        self.leader.epoch()
+        self.leader().epoch()
     }
 
     /// Return the leaders commit timestamp.
@@ -333,14 +348,14 @@ impl CommittedSubDag {
         // replaying this commit and field is never initialised. It's safe to fallback on leader's
         // timestamp.
         if self.commit_timestamp == 0 {
-            return *self.leader.header().created_at();
+            return *self.leader().created_at();
         }
         self.commit_timestamp
     }
 
     /// Return the Certificates for this SubDag.
-    pub fn certificates(&self) -> &[Certificate] {
-        &self.certificates
+    pub fn headers(&self) -> &[Header] {
+        &self.headers
     }
 }
 
@@ -351,12 +366,12 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for CommittedSubDag {
         let mut hasher = crypto::DefaultHashFunction::new();
         // Instead of hashing serialized CommittedSubDag, hash the certificate digests instead.
         // Signatures in the certificates are not part of the commitment.
-        for cert in &self.certificates {
+        for cert in &self.headers {
             hasher.update(cert.digest().as_ref());
         }
-        hasher.update(self.leader.digest().as_ref());
         hasher.update(encode(&self.reputation_score).as_ref());
         hasher.update(encode(&self.commit_timestamp).as_ref());
+        hasher.update(self.randomness.as_ref());
         ConsensusDigest(Digest { digest: hasher.finalize().into() })
     }
 }

--- a/crates/types/tests/it/serde_tests.rs
+++ b/crates/types/tests/it/serde_tests.rs
@@ -69,7 +69,7 @@ fn test_committed_subdag_serde_roundtrip() {
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
 
     // Create a CommittedSubDag
-    let leader = certificates.first().cloned().unwrap();
+    let leader = certificates.last().cloned().unwrap();
     let reputation = ReputationScores::new(&committee);
 
     let original_subdag =
@@ -82,12 +82,10 @@ fn test_committed_subdag_serde_roundtrip() {
     let recovered_subdag: CommittedSubDag = decode(&bytes);
 
     // Compare leader and certificates
-    assert_eq!(original_subdag.leader.digest(), recovered_subdag.leader.digest());
-    assert_eq!(original_subdag.certificates.len(), recovered_subdag.certificates.len());
+    assert_eq!(original_subdag.leader().digest(), recovered_subdag.leader().digest());
+    assert_eq!(original_subdag.headers.len(), recovered_subdag.headers.len());
 
-    for (orig, recov) in
-        original_subdag.certificates.iter().zip(recovered_subdag.certificates.iter())
-    {
+    for (orig, recov) in original_subdag.headers.iter().zip(recovered_subdag.headers.iter()) {
         assert_eq!(orig.digest(), recov.digest());
     }
 }


### PR DESCRIPTION
This reduces storage and makes it easier to validate pack files (no need to verify all certs from a peer).