### PR TITLE
update worker network handle at epoch boundary

### DIFF
--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -892,8 +892,9 @@ where
                 .ok_or_eyre("worker network handle missing from epoch manager")?;
 
             network_handle.update_task_spawner(epoch_task_spawner.clone());
+            network_handle.update_epoch(consensus_config.committee().epoch());
             // initialize worker components on startup
-            // This will use the new epoch_task_spawner on network_handle.
+            // This will use the new epoch_task_spawner and epoch on network_handle.
             // Also initialize if workers are empty: this happens when the first epoch returns
             // early from replay_missed_consensus (epoch boundary hit) before create_consensus
             // is reached, leaving workers uninitialized.


### PR DESCRIPTION
- Adds a single `network_handle.update_epoch(consensus_config.committee().epoch())` next to the existing `update_task_spawner` call in `spawn_worker_node_components`, before workers are initialized or their network tasks respawned

closes #649 