### PR TITLE
Use a dedicated table for published certs.

### DIFF
--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -9,12 +9,12 @@ use crate::{
 use std::{sync::Arc, time::Duration};
 use tn_config::{ConsensusConfig, KeyConfig};
 use tn_network_libp2p::error::NetworkError;
-use tn_storage::CertificateStore;
+use tn_storage::{tables::ProposedCertificates, CertificateStore};
 use tn_types::{
     ensure,
     error::{DagError, DagResult},
     AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Header, HeaderDigest,
-    Noticer, Notifier, TaskManager, TaskResult, TaskSpawner, TnReceiver, Vote,
+    Noticer, Notifier, TaskError, TaskManager, TaskResult, TaskSpawner, TnReceiver, Vote,
 };
 use tokio::sync::Mutex;
 use tracing::{debug, enabled, error, info, instrument};
@@ -404,7 +404,9 @@ impl<DB: Database> Certifier<DB> {
         // before this call.
         let _guard = self.proposal_lock.lock().await;
         let header_digest = header.digest();
-        if let Ok(Some(cert)) = self.config.node_storage().read(header_digest) {
+        if let Ok(Some(cert)) =
+            self.config.node_storage().get::<ProposedCertificates>(&header_digest)
+        {
             info!(target: "primary::certifier", "asked to propose a header that is already certified {header_digest}, skipping proposal and re-publishing");
             // We have already processed this certificate, doing so again could produce signature
             // equivocation and destroy deterministic randomness (based on the leader
@@ -427,6 +429,10 @@ impl<DB: Database> Certifier<DB> {
             proposal_result = self.propose_header(header) => {
                 match proposal_result {
                     Ok(mut certificate) => {
+                        if let Err(e) = self.config.node_storage().insert::<ProposedCertificates>(&header_digest, &certificate) {
+                            error!(target: "primary::certifier", "error accepting own certificate, unable to save the certificate: {e}");
+                            return Err(TaskError::from_message(e.to_string()));
+                        }
                         // pass to state_sync for internal processing
                         if let Err(e) = self.state_sync.process_own_certificate(&mut certificate).await {
                             error!(target: "primary::certifier", "error accepting own certificate: {e}");

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -32,7 +32,7 @@ use tn_reth::{
 };
 use tn_storage::tables::{
     CertificateDigestByOrigin, CertificateDigestByRound, Certificates, LastProposed,
-    NodeBatchesCache, OurNodeBatchesCache, Payload, Votes,
+    NodeBatchesCache, OurNodeBatchesCache, Payload, ProposedCertificates, Votes,
 };
 use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
@@ -1219,6 +1219,7 @@ where
         self.consensus_db.clear_table::<Certificates>()?;
         self.consensus_db.clear_table::<CertificateDigestByRound>()?;
         self.consensus_db.clear_table::<CertificateDigestByOrigin>()?;
+        self.consensus_db.clear_table::<ProposedCertificates>()?;
         self.consensus_db.clear_table::<Payload>()?;
         self.consensus_db.clear_table::<NodeBatchesCache>()?;
         // Note do not clear OurNodeBatchesCache here- we need to keep those until we process the

--- a/crates/storage/src/composite_db.rs
+++ b/crates/storage/src/composite_db.rs
@@ -24,7 +24,7 @@ impl<DB: Database> CompositeDatabase<DB> {
     pub fn open(epoch_db: DB, kad_db: DB, cache_db: DB) -> Self {
         let epoch_db = LayeredDatabase::open(epoch_db, true);
         let kad_db = LayeredDatabase::open(kad_db, true);
-        let cache_db = LayeredDatabase::open(cache_db, true);
+        let cache_db = LayeredDatabase::open(cache_db, false);
         Self { inner: Arc::new(Inner { epoch_db, kad_db, cache_db }) }
     }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -12,7 +12,7 @@ pub use redb::database::ReDB;
 use tables::{
     CertificateDigestByOrigin, CertificateDigestByRound, Certificates, ConsensusHeaderCache,
     KadProviderRecords, KadRecords, KadWorkerProviderRecords, KadWorkerRecords, LastProposed,
-    NodeBatchesCache, OurNodeBatchesCache, Payload, Votes,
+    NodeBatchesCache, OurNodeBatchesCache, Payload, ProposedCertificates, Votes,
 };
 // Always build redb, we use it as the default for persistant consensus data.
 pub mod archive;
@@ -49,6 +49,7 @@ const VOTES_CF: &str = "votes";
 const CERTIFICATES_CF: &str = "certificates";
 const CERTIFICATE_DIGEST_BY_ROUND_CF: &str = "certificate_digest_by_round";
 const CERTIFICATE_DIGEST_BY_ORIGIN_CF: &str = "certificate_digest_by_origin";
+const PROPOSED_CERTIFICATES_CF: &str = "proposed_certificates";
 const PAYLOAD_CF: &str = "payload";
 const NODE_BATCHES_CACHE_CF: &str = "node_batches_cache";
 const OUR_NODE_BATCHES_CACHE_CF: &str = "our_node_batches_cache";
@@ -88,6 +89,7 @@ pub mod tables {
         Certificates;crate::CERTIFICATES_CF;TableHint::Epoch;<HeaderDigest, Certificate>,  // Cleared every epoch
         CertificateDigestByRound;crate::CERTIFICATE_DIGEST_BY_ROUND_CF;TableHint::Epoch;<(Round, AuthorityIdentifier), HeaderDigest>,  // Cleared every epoch
         CertificateDigestByOrigin;crate::CERTIFICATE_DIGEST_BY_ORIGIN_CF;TableHint::Epoch;<(AuthorityIdentifier, Round), HeaderDigest>,  // Cleared every epoch
+        ProposedCertificates;crate::PROPOSED_CERTIFICATES_CF;TableHint::Epoch;<HeaderDigest, Certificate>,  // Cleared every epoch
         Payload;crate::PAYLOAD_CF;TableHint::Epoch;<(BlockHash, WorkerId), PayloadToken>,  // Cleared every epoch
         // This is a cache to store this nodes batches before consensus, remove once in a ConsensusHeader.
         NodeBatchesCache;crate::NODE_BATCHES_CACHE_CF;TableHint::Cache;<BlockHash, Batch>,
@@ -164,6 +166,7 @@ fn _open_mdbx<P: AsRef<std::path::Path> + Send>(store_path: P) -> CompositeDatab
     db.open_table::<Certificates>().expect("failed to open table!");
     db.open_table::<CertificateDigestByRound>().expect("failed to open table!");
     db.open_table::<CertificateDigestByOrigin>().expect("failed to open table!");
+    db.open_table::<ProposedCertificates>().expect("failed to open table!");
     db.open_table::<Payload>().expect("failed to open table!");
     // Kad tables
     db.open_table::<KadRecords>().expect("failed to open table!");
@@ -193,6 +196,7 @@ fn _open_redb<P: AsRef<std::path::Path> + Send>(store_path: P) -> CompositeDatab
     db.open_table::<Certificates>().expect("failed to open table!");
     db.open_table::<CertificateDigestByRound>().expect("failed to open table!");
     db.open_table::<CertificateDigestByOrigin>().expect("failed to open table!");
+    db.open_table::<ProposedCertificates>().expect("failed to open table!");
     db.open_table::<Payload>().expect("failed to open table!");
     // Kad tables
     db.open_table::<KadRecords>().expect("failed to open table!");

--- a/crates/storage/src/mem_db.rs
+++ b/crates/storage/src/mem_db.rs
@@ -97,6 +97,7 @@ impl Default for MemDatabase {
         let _ = db.open_table::<crate::tables::Certificates>();
         let _ = db.open_table::<crate::tables::CertificateDigestByRound>();
         let _ = db.open_table::<crate::tables::CertificateDigestByOrigin>();
+        let _ = db.open_table::<crate::tables::ProposedCertificates>();
         let _ = db.open_table::<crate::tables::Payload>();
         let _ = db.open_table::<crate::tables::NodeBatchesCache>();
         let _ = db.open_table::<crate::tables::OurNodeBatchesCache>();


### PR DESCRIPTION
Also don't store all cache data in memory.

Closes https://github.com/Telcoin-Association/telcoin-network/issues/651