### PR TITLE
Worker configs

### DIFF
--- a/crates/config/src/genesis.rs
+++ b/crates/config/src/genesis.rs
@@ -36,6 +36,11 @@ pub const GENESIS_ACCOUNT_STATE_YAML: &str =
 pub const GOVERNANCE_SAFE_ADDRESS: Address = address!("00000000000000000000000000000000000007a0");
 /// The default issuance address.
 pub const ISSUANCE_ADDRESS: Address = address!("07a07a07a07a07a07a07a07a07a07a07a07a07a0");
+/// The address for the WorkerConfigs contract.
+pub const WORKER_CONFIGS_ADDRESS: Address = address!("Fee0FEe0fee0fEE0FEe0fee0FEE0fEe0feE0FEe0");
+/// The path to WorkerConfigs json (tn-contracts submodule).
+pub const WORKER_CONFIGS_JSON: &str =
+    include_str!("../../../tn-contracts/artifacts/WorkerConfigs.json");
 
 /// The struct for starting a network at genesis.
 #[derive(Debug)]

--- a/crates/e2e-tests/tests/it/genesis_tests.rs
+++ b/crates/e2e-tests/tests/it/genesis_tests.rs
@@ -214,7 +214,7 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
         stakeVersion,
     } = current_epoch_info;
     assert_eq!(blockHeight, 0);
-    assert_eq!(epochDuration, 86400);
+    assert_eq!(epochDuration, 28800); // 8h
     assert_eq!(epochIssuance, expected_epoch_issuance);
     assert_eq!(stakeVersion, 0);
 

--- a/crates/e2e-tests/tests/it/staking.rs
+++ b/crates/e2e-tests/tests/it/staking.rs
@@ -129,7 +129,7 @@ async fn test_cli_keygen_to_stake() -> eyre::Result<()> {
         epochIssuance: U256::from(parse_ether("20_000_000").unwrap())
             .checked_div(U256::from(28))
             .expect("u256 div"),
-        epochDuration: 86400,
+        epochDuration: 28800,
     };
 
     let genesis = tn_types::test_genesis().extend_accounts([
@@ -148,6 +148,7 @@ async fn test_cli_keygen_to_stake() -> eyre::Result<()> {
         genesis,
         initial_stake_config.clone(),
         governance,
+        vec![(0u8, 30_000_000u64)],
     )?;
 
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());

--- a/crates/telcoin-network-cli/src/genesis/mod.rs
+++ b/crates/telcoin-network-cli/src/genesis/mod.rs
@@ -122,6 +122,7 @@ pub struct GenesisArgs {
         alias = "worker_fee_config",
         help_heading = "Per-worker fee config overrides",
         value_name = "WORKER_ID:STRATEGY:VALUE",
+        default_value = "0:0:18446744073709551615", // u64::MAX
         verbatim_doc_comment
     )]
     pub worker_fee_configs: Vec<String>,

--- a/crates/telcoin-network-cli/src/genesis/mod.rs
+++ b/crates/telcoin-network-cli/src/genesis/mod.rs
@@ -90,7 +90,7 @@ pub struct GenesisArgs {
         long = "epoch-duration-in-secs",
         alias = "epoch_length",
         help_heading = "The length of each epoch in seconds.",
-        default_value_t = 60 * 60 * 24, // 24-hours
+        default_value_t = 60 * 60 * 8, // 8-hours
         verbatim_doc_comment
     )]
     pub epoch_duration: u32,
@@ -110,6 +110,22 @@ pub struct GenesisArgs {
     /// Default is 0x7e1 (2017).
     #[arg(long, default_value_t = 2017, value_parser=maybe_hex)]
     pub chain_id: u64,
+    /// Per-worker fee config overrides at genesis.
+    ///
+    /// Format: WORKER_ID:STRATEGY:VALUE (e.g., 0:0:100000000 for worker 0 with EIP-1559 at 100M
+    /// gas target, or 1:1:200 for worker 1 with static fee of 200 wei).
+    /// Can be specified multiple times for different workers.
+    ///
+    /// See types/src/gas_accumulator.rs for all `WorkerFeeConfig` types.
+    #[arg(
+        long = "worker-fee-config",
+        alias = "worker_fee_config",
+        help_heading = "Per-worker fee config overrides",
+        value_name = "WORKER_ID:STRATEGY:VALUE",
+        verbatim_doc_comment
+    )]
+    pub worker_fee_configs: Vec<String>,
+
     /// YAML file containing accounts to merge into genesis.
     /// This is intended for dev and test nets.
     #[arg(long, value_name = "YAML_FILE", verbatim_doc_comment)]
@@ -135,6 +151,53 @@ pub(crate) fn account_from_word(key_word: &str) -> Address {
 }
 
 impl GenesisArgs {
+    /// Parse `--worker-fee-config` values from `"WORKER_ID:STRATEGY:VALUE"` strings
+    /// into `(strategy, value)` pairs ordered by worker id.
+    ///
+    /// The worker id is validated to match the index position (0, 1, 2, ...).
+    fn parse_worker_fee_configs(&self) -> eyre::Result<Vec<(u8, u64)>> {
+        if self.worker_fee_configs.is_empty() {
+            return Ok(vec![(0u8, 100_000_000_000u64)]);
+        }
+
+        let mut configs: Vec<(u16, u8, u64)> = self
+            .worker_fee_configs
+            .iter()
+            .map(|s| {
+                let parts: Vec<&str> = s.splitn(3, ':').collect();
+                if parts.len() != 3 {
+                    eyre::bail!(
+                        "invalid --worker-fee-config format '{s}': expected WORKER_ID:STRATEGY:VALUE"
+                    );
+                }
+                let worker_id: u16 = parts[0].parse().map_err(|e| {
+                    eyre::eyre!("invalid worker id '{}' in --worker-fee-config: {e}", parts[0])
+                })?;
+                let strategy: u8 = parts[1].parse().map_err(|e| {
+                    eyre::eyre!("invalid strategy '{}' in --worker-fee-config: {e}", parts[1])
+                })?;
+                let value: u64 = parts[2].parse().map_err(|e| {
+                    eyre::eyre!("invalid value '{}' in --worker-fee-config: {e}", parts[2])
+                })?;
+                Ok((worker_id, strategy, value))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+
+        // Sort by worker_id so positional indexing is deterministic.
+        configs.sort_by_key(|(id, _, _)| *id);
+
+        // Validate contiguous worker ids starting from 0.
+        for (expected, (id, _, _)) in configs.iter().enumerate() {
+            if *id as usize != expected {
+                eyre::bail!(
+                    "worker fee configs must be contiguous starting from 0, but worker id {id} found at position {expected}"
+                );
+            }
+        }
+
+        Ok(configs.into_iter().map(|(_, strategy, value)| (strategy, value)).collect())
+    }
+
     /// Execute command
     pub fn execute(&self, data_dir: PathBuf) -> eyre::Result<()> {
         info!(target: "genesis::ceremony", "Creating a new chain genesis with initial validators");
@@ -163,6 +226,8 @@ impl GenesisArgs {
         set_genesis_defaults(&mut genesis);
         genesis.config.chain_id = self.chain_id;
 
+        let worker_fee_configs = self.parse_worker_fee_configs()?;
+
         // try to create a runtime if one doesn't already exist
         // this is a workaround for executing committees pre-genesis during tests and normal CLI
         // operations
@@ -173,6 +238,7 @@ impl GenesisArgs {
                 genesis,
                 initial_stake_config.clone(),
                 self.consensus_registry_owner,
+                worker_fee_configs.clone(),
             )?
         } else {
             // no runtime exists (normal CLI operation)
@@ -186,6 +252,7 @@ impl GenesisArgs {
                     genesis,
                     initial_stake_config,
                     self.consensus_registry_owner,
+                    worker_fee_configs,
                 )
             })?
         };
@@ -235,5 +302,70 @@ impl GenesisArgs {
         Config::write_to_path(data_dir.committee_path(), committee, ConfigFmt::YAML)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tn_types::{Address, U256};
+
+    fn args_with_configs(configs: Vec<&str>) -> GenesisArgs {
+        GenesisArgs {
+            consensus_registry_owner: Address::ZERO,
+            basefee_address: Address::ZERO,
+            initial_stake: U256::ZERO,
+            min_withdrawal: U256::ZERO,
+            epoch_rewards: U256::ZERO,
+            epoch_duration: 0,
+            dev_funded_account: None,
+            max_header_delay_ms: None,
+            min_header_delay_ms: None,
+            chain_id: 2017,
+            worker_fee_configs: configs.into_iter().map(String::from).collect(),
+            accounts: None,
+        }
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_empty_returns_default() {
+        let args = args_with_configs(vec![]);
+        let result = args.parse_worker_fee_configs().unwrap();
+        assert_eq!(result, vec![(0, 100_000_000_000)]);
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_single() {
+        let args = args_with_configs(vec!["0:0:30000000"]);
+        let result = args.parse_worker_fee_configs().unwrap();
+        assert_eq!(result, vec![(0, 30_000_000)]);
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_multiple() {
+        let args = args_with_configs(vec!["0:0:30000000", "1:1:500"]);
+        let result = args.parse_worker_fee_configs().unwrap();
+        assert_eq!(result, vec![(0, 30_000_000), (1, 500)]);
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_sorts_by_worker_id() {
+        let args = args_with_configs(vec!["1:1:500", "0:0:30000000"]);
+        let result = args.parse_worker_fee_configs().unwrap();
+        assert_eq!(result, vec![(0, 30_000_000), (1, 500)]);
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_non_contiguous_errors() {
+        let args = args_with_configs(vec!["0:0:30000000", "2:1:500"]);
+        let result = args.parse_worker_fee_configs();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_worker_fee_configs_bad_format_errors() {
+        let args = args_with_configs(vec!["bad"]);
+        let result = args.parse_worker_fee_configs();
+        assert!(result.is_err());
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -108,18 +108,19 @@ use std::{
 };
 use system_calls::{
     ConsensusRegistry::{self},
-    EpochState, CONSENSUS_REGISTRY_ADDRESS, SYSTEM_ADDRESS,
+    EpochState, WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS, SYSTEM_ADDRESS,
 };
 use tempfile::TempDir;
 use tn_config::{
     NodeInfo, BLSG1_JSON, CONSENSUS_REGISTRY_JSON, GOVERNANCE_SAFE_ADDRESS, ISSUANCE_ADDRESS,
-    ISSUANCE_JSON,
+    ISSUANCE_JSON, WORKER_CONFIGS_ADDRESS, WORKER_CONFIGS_JSON,
 };
 use tn_types::{
-    deconstruct_nonce, gas_accumulator::RewardsCounter, Address, BlockBody, BlockHashOrNumber,
-    BlockNumHash, BlockNumber, EngineUpdate, Epoch, ExecHeader, Genesis, GenesisAccount,
-    RecoveredBlock, Round, SealedBlock, SealedHeader, TaskManager, TaskSpawner, TransactionSigned,
-    B256, ETHEREUM_BLOCK_GAS_LIMIT_30M, U256,
+    deconstruct_nonce,
+    gas_accumulator::{RewardsCounter, WorkerFeeConfig},
+    Address, BlockBody, BlockHashOrNumber, BlockNumHash, BlockNumber, EngineUpdate, Epoch,
+    ExecHeader, Genesis, GenesisAccount, RecoveredBlock, Round, SealedBlock, SealedHeader,
+    TaskManager, TaskSpawner, TransactionSigned, B256, ETHEREUM_BLOCK_GAS_LIMIT_30M, U256,
 };
 use tracing::{debug, error, info, warn};
 use traits::{TNPrimitives, TelcoinNode};
@@ -1079,6 +1080,7 @@ impl RethEnv {
         genesis: Genesis,
         initial_stake_config: ConsensusRegistry::StakeConfig,
         owner_address: Address,
+        worker_configs: Vec<(u8, u64)>,
     ) -> eyre::Result<Genesis> {
         // create temporary reth env for execution
         let tmp_chain: Arc<RethChainSpec> = Arc::new(genesis.clone().into());
@@ -1188,6 +1190,35 @@ impl RethEnv {
             owner_address.create(1)
         };
 
+        // deploy WorkerConfigs contract
+        let tmp_worker_configs_address = {
+            let mut tn_evm = reth_env.inner.evm_config.evm_factory().create_evm(
+                &mut db,
+                reth_env.inner.evm_config.evm_env(&tmp_chain.sealed_genesis_header())?,
+            );
+
+            let (strategies, values): (Vec<u8>, Vec<u64>) = worker_configs.iter().copied().unzip();
+            let constructor_args =
+                WorkerConfigs::constructorCall { strategies, values, owner_: owner_address }
+                    .abi_encode();
+
+            let initcode_binding =
+                Self::fetch_value_from_json_str(WORKER_CONFIGS_JSON, Some("bytecode.object"))?;
+            let initcode =
+                hex::decode(initcode_binding.as_str().ok_or_eyre("invalid worker configs json")?)?;
+            let mut create_worker_configs = initcode;
+            create_worker_configs.extend(constructor_args);
+
+            let ResultAndState { result, state } =
+                tn_evm.transact_pre_genesis_create(owner_address, create_worker_configs.into())?;
+            debug!(target: "engine", "create worker configs result:\n{:#?}", result);
+
+            tn_evm.db_mut().commit(state);
+
+            // Third create tx on tmp chain (after blsg1 at nonce 0 and registry at nonce 1)
+            owner_address.create(2)
+        };
+
         // execute the transactions to get final bundle state
         db.merge_transitions(BundleRetention::PlainState);
         let BundleState { state, contracts, reverts, state_size, reverts_size } = db.take_bundle();
@@ -1210,6 +1241,17 @@ impl RethEnv {
         let registry_runtimecode =
             Self::link_solidity_library(registry_runtimecode_str, &blsg1_address.encode_hex())?;
 
+        let tmp_worker_configs_storage = state.get(&tmp_worker_configs_address).map(|account| {
+            account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
+        });
+        let worker_configs_runtimecode_binding =
+            Self::fetch_value_from_json_str(WORKER_CONFIGS_JSON, Some("deployedBytecode.object"))?;
+        let worker_configs_runtimecode = hex::decode(
+            worker_configs_runtimecode_binding
+                .as_str()
+                .ok_or_eyre("invalid worker configs json")?,
+        )?;
+
         let blsg1_runtimecode_binding =
             Self::fetch_value_from_json_str(BLSG1_JSON, Some("deployedBytecode.object"))?;
         let blsg1_runtimecode =
@@ -1231,6 +1273,12 @@ impl RethEnv {
             (
                 ISSUANCE_ADDRESS,
                 GenesisAccount::default().with_code(Some(issuance_runtimecode.into())),
+            ),
+            (
+                WORKER_CONFIGS_ADDRESS,
+                GenesisAccount::default()
+                    .with_code(Some(worker_configs_runtimecode.into()))
+                    .with_storage(tmp_worker_configs_storage),
             ),
         ]);
 
@@ -1410,6 +1458,100 @@ impl RethEnv {
     {
         let calldata = ConsensusRegistry::getCommitteeValidatorsCall { epoch }.abi_encode().into();
         self.call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(evm, calldata)
+    }
+
+    /// Read fee configs for all workers from the [`WorkerConfigs`] contract at the given header.
+    ///
+    /// Builds an EVM against `header`'s state, calls `numWorkers()`, then makes one
+    /// `getWorkerConfig` call per worker. Returns the on-chain worker count alongside the
+    /// decoded [`WorkerFeeConfig`]s.
+    fn worker_fee_configs_inner(
+        &self,
+        header: &SealedHeader,
+    ) -> eyre::Result<(usize, Vec<WorkerFeeConfig>)> {
+        let state_provider = self.inner.blockchain_provider.state_by_block_hash(header.hash())?;
+        let state = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder().with_database(state).with_bundle_update().build();
+        let mut tn_evm = self
+            .inner
+            .evm_config
+            .evm_factory()
+            .create_evm(&mut db, self.inner.evm_config.evm_env(header)?);
+
+        let num_workers_calldata = WorkerConfigs::numWorkersCall {}.abi_encode().into();
+        let num_workers_state = self.read_state_on_chain(
+            &mut tn_evm,
+            SYSTEM_ADDRESS,
+            WORKER_CONFIGS_ADDRESS,
+            num_workers_calldata,
+        )?;
+        let num_workers_data = match num_workers_state.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            e => eyre::bail!("failed to read num workers: {e:?}"),
+        };
+        let num_workers =
+            <WorkerConfigs::numWorkersCall as alloy::sol_types::SolCall>::abi_decode_returns(
+                &num_workers_data,
+            )? as usize;
+
+        let mut configs = Vec::with_capacity(num_workers);
+        for worker_id in 0..num_workers {
+            let calldata = WorkerConfigs::getWorkerConfigCall { workerId: worker_id as u16 }
+                .abi_encode()
+                .into();
+            let state = self.read_state_on_chain(
+                &mut tn_evm,
+                SYSTEM_ADDRESS,
+                WORKER_CONFIGS_ADDRESS,
+                calldata,
+            )?;
+            let data = match state.result {
+                ExecutionResult::Success { output, .. } => output.into_data(),
+                e => eyre::bail!("failed to read worker config for worker {worker_id}: {e:?}"),
+            };
+            let ret = <WorkerConfigs::getWorkerConfigCall as alloy::sol_types::SolCall>::abi_decode_returns(&data)?;
+            let config = match ret.strategy {
+                0 => WorkerFeeConfig::Eip1559 { target_gas: ret.value },
+                1 => WorkerFeeConfig::Static { fee: ret.value },
+                s => eyre::bail!("unknown fee strategy {s} for worker {worker_id}"),
+            };
+            configs.push(config);
+        }
+
+        Ok((num_workers, configs))
+    }
+
+    /// Read worker fee configs from the [`WorkerConfigs`] contract at the block identified by
+    /// `block_hash`.
+    ///
+    /// Returns the on-chain worker count and one [`WorkerFeeConfig`] per worker. Fails with a
+    /// descriptive error if `block_hash` does not resolve to a sealed header.
+    pub fn get_worker_fee_configs_at_block(
+        &self,
+        block_hash: B256,
+    ) -> eyre::Result<(usize, Vec<WorkerFeeConfig>)> {
+        let header = self
+            .sealed_header_by_hash(block_hash)?
+            .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
+        self.worker_fee_configs_inner(&header)
+    }
+
+    /// Read worker fee configs from the [`WorkerConfigs`] contract at the canonical tip.
+    ///
+    /// `num_workers` is the caller's view of the on-chain worker count. It is compared against
+    /// the value returned by `numWorkers()` at canonical tip; a mismatch indicates governance
+    /// grew/shrank the worker set mid-node-lifetime and the in-memory `GasAccumulator` no longer
+    /// matches the contract. Caller must restart or re-resolve the worker count.
+    pub fn get_worker_fee_configs(&self, num_workers: usize) -> eyre::Result<Vec<WorkerFeeConfig>> {
+        let canonical_tip = self.canonical_tip();
+        let (num_workers_on_chain, configs) = self.worker_fee_configs_inner(&canonical_tip)?;
+        if num_workers != num_workers_on_chain {
+            return Err(eyre::eyre!(
+                "worker count drift: caller={num_workers}, on-chain numWorkers()={num_workers_on_chain}; \
+                 GasAccumulator sized at startup no longer matches WorkerConfigs; node restart required"
+            ));
+        }
+        Ok(configs)
     }
 
     /// Helper function to call `ConsensusRegistry` state on-chain.
@@ -1603,7 +1745,7 @@ mod tests {
         let tmp_genesis = tn_types::test_genesis().extend_accounts([
             (
                 governance,
-                GenesisAccount::default().with_balance(U256::from((50_000_000 * 10) ^ 18)), // 50mil TEL
+                GenesisAccount::default().with_balance(U256::from(parse_ether("50_000_000")?)), // 50mil TEL
             ),
             (
                 new_validator_eoa.address(),
@@ -1626,6 +1768,7 @@ mod tests {
             tmp_genesis,
             initial_stake_config.clone(),
             governance,
+            vec![(0u8, 30_000_000u64)],
         )?;
 
         // update genesis again to include stake for new validator
@@ -2005,5 +2148,74 @@ mod tests {
                 assert!(mods.remove(&r));
             }
         };
+    }
+
+    #[tokio::test]
+    async fn test_get_worker_fee_configs() -> eyre::Result<()> {
+        // minimal validator set (5 validators)
+        let all_validators: Vec<Address> =
+            (1..=5).map(|i| Address::from_slice(&[i * 0x11; 20])).collect();
+
+        let validators: Vec<_> = all_validators
+            .iter()
+            .enumerate()
+            .map(|(i, addr)| {
+                let mut rng = StdRng::seed_from_u64(i as u64);
+                let bls = BlsKeypair::generate(&mut rng);
+                let bls_pubkey = bls.public();
+                let pop = generate_proof_of_possession_bls_for_test(&bls, addr)
+                    .expect("pop generation failed");
+                NodeInfo {
+                    name: format!("validator-{i}"),
+                    bls_public_key: *bls_pubkey,
+                    p2p_info: NodeP2pInfo::default(),
+                    execution_address: *addr,
+                    proof_of_possession: pop,
+                }
+            })
+            .collect();
+
+        let initial_stake_config = ConsensusRegistry::StakeConfig {
+            stakeAmount: U256::from(parse_ether("1_000_000").unwrap()),
+            minWithdrawAmount: U256::from(parse_ether("1_000").unwrap()),
+            epochIssuance: U256::from(parse_ether("20_000_000").unwrap())
+                .checked_div(U256::from(28))
+                .expect("u256 div checked"),
+            epochDuration: 28800,
+        };
+
+        let governance_multisig =
+            TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+        let governance = governance_multisig.address();
+        let tmp_genesis = tn_types::test_genesis().extend_accounts([(
+            governance,
+            GenesisAccount::default().with_balance(U256::from((50_000_000 * 10) ^ 18)),
+        )]);
+
+        // deploy with 2 workers: worker 0 = EIP-1559 (strategy 0, target 30M),
+        // worker 1 = Static (strategy 1, fee 500)
+        let worker_configs = vec![(0u8, 30_000_000u64), (1u8, 500u64)];
+        let genesis = RethEnv::create_consensus_registry_genesis_accounts(
+            validators.clone(),
+            tmp_genesis,
+            initial_stake_config.clone(),
+            governance,
+            worker_configs,
+        )?;
+
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Worker Fee Config Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+                .unwrap();
+
+        // read back worker configs from chain state
+        let configs = reth_env.get_worker_fee_configs(2)?;
+        assert_eq!(configs.len(), 2);
+        assert_eq!(configs[0], WorkerFeeConfig::Eip1559 { target_gas: 30_000_000 });
+        assert_eq!(configs[1], WorkerFeeConfig::Static { fee: 500 });
+
+        Ok(())
     }
 }

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -181,7 +181,22 @@ sol!(
         function getRewards(address validatorAddress) public view virtual returns (uint256);
         /// Returns the next committee size
         function getNextCommitteeSize() external view returns (uint16);
+    }
 
+    /// Worker fee configs for base fee adjustment.
+    #[sol(rpc)]
+    contract WorkerConfigs {
+        /// Initialize with per-worker configs and owner.
+        constructor(uint8[] memory strategies, uint64[] memory values, address owner_);
+        /// Get the stored fee config for a worker.
+        function getWorkerConfig(uint16 workerId) external view returns (uint8 strategy, uint64 value);
+        /// Set the number of workers for the next epoch.
+        function setNumWorkers(uint16 numWorkers_) external;
+        /// Set the config for a worker by worker id.
+        /// NOTE: this must be called before calling `setNumWorkers`.
+        function setWorkerConfig(uint16 workerId, uint8 strategy, uint64 value) external;
+        /// Retrieve the number of workers for the protocol.
+        function numWorkers() external view returns (uint16);
     }
 );
 

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -25,6 +25,20 @@
 //!    skipped or double-counted. State is updated through the normal path (payload_builder).
 
 use crate::{AuthorityIdentifier, Committee, WorkerId};
+
+/// Fee strategy for a worker, read from the WorkerConfigs contract each epoch.
+/// Adding a new strategy = new contract constant + new enum variant + match arm in
+/// adjust_base_fees.
+///
+/// NOTE: these are mapped in `tn-reth/src/lib.rs:worker_fee_configs_inner`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerFeeConfig {
+    /// Adjust fee +/-12.5% per epoch based on gas utilization vs target.
+    Eip1559 { target_gas: u64 },
+    /// Fixed fee set by governance, no utilization-based adjustment.
+    Static { fee: u64 },
+}
+
 use alloy::{
     eips::eip1559::MIN_PROTOCOL_BASE_FEE,
     primitives::Address,
@@ -216,11 +230,16 @@ pub struct GasAccumulator {
 impl GasAccumulator {
     /// Create a new [`GasAccumulator`] with `workers` slots, all zeroed.
     pub fn new(workers: usize) -> Self {
+        Self::new_with_rewards(workers, RewardsCounter::default())
+    }
+
+    /// Create a new [`GasAccumulator`] with `workers` slots and a pre-built [`RewardsCounter`].
+    pub fn new_with_rewards(workers: usize, rewards: RewardsCounter) -> Self {
         let mut inner = Vec::with_capacity(workers);
         for _ in 0..workers {
             inner.push(Accumulated::default());
         }
-        Self { inner: Arc::new(inner), rewards_counter: RewardsCounter::default() }
+        Self { inner: Arc::new(inner), rewards_counter: rewards }
     }
 
     /// Increment the block count, gas used, and gas limit for `worker_id`.
@@ -285,8 +304,135 @@ impl GasAccumulator {
     }
 }
 
+/// EIP-1559-style base fee adjustment computed once per epoch.
+///
+/// Compares `gas_used` (total gas consumed by a single worker during the epoch)
+/// against `target_gas` (governance-set target for the epoch) and nudges the
+/// base fee up or down by at most 12.5 % (denominator = 8).
+///
+/// The result is clamped to `[MIN_PROTOCOL_BASE_FEE, u64::MAX]`.
+pub fn compute_next_base_fee_eip1559(current_base_fee: u64, gas_used: u64, target_gas: u64) -> u64 {
+    // Guard: if target is zero, keep current fee unchanged.
+    // The contract reverts for target `0` so this should never happen
+    if target_gas == 0 {
+        return current_base_fee;
+    }
+
+    let new_base_fee = match gas_used.cmp(&target_gas) {
+        core::cmp::Ordering::Equal => current_base_fee,
+        core::cmp::Ordering::Greater => {
+            let excess = (gas_used - target_gas).min(target_gas);
+            let delta =
+                (current_base_fee as u128).saturating_mul(excess as u128) / target_gas as u128 / 8;
+            let delta = delta.max(1);
+            current_base_fee.saturating_add(delta.min(u64::MAX as u128) as u64)
+        }
+        core::cmp::Ordering::Less => {
+            let deficit = (target_gas - gas_used).min(target_gas);
+            let delta =
+                (current_base_fee as u128).saturating_mul(deficit as u128) / target_gas as u128 / 8;
+            current_base_fee.saturating_sub(delta.min(u64::MAX as u128) as u64)
+        }
+    };
+
+    new_base_fee.max(MIN_PROTOCOL_BASE_FEE)
+}
+
 impl Default for GasAccumulator {
     fn default() -> Self {
         Self::new(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::eips::eip1559::MIN_PROTOCOL_BASE_FEE;
+
+    #[test]
+    fn gas_at_target_no_change() {
+        // When gas_used == target_gas, delta is 0, fee unchanged
+        assert_eq!(compute_next_base_fee_eip1559(1000, 500, 500), 1000);
+    }
+
+    #[test]
+    fn gas_over_target_increases_fee() {
+        // gas_used = 2 * target → delta = 1000 * 1.0 / 8 = 125
+        assert_eq!(compute_next_base_fee_eip1559(1000, 1000, 500), 1125);
+    }
+
+    #[test]
+    fn gas_under_target_decreases_fee() {
+        // gas_used = 0 → delta = 1000 * 1.0 / 8 = 125
+        assert_eq!(compute_next_base_fee_eip1559(1000, 0, 500), 875);
+    }
+
+    #[test]
+    fn floor_at_min_protocol_base_fee() {
+        // Large decrease should floor at MIN_PROTOCOL_BASE_FEE (7)
+        // base=8, gas_used=0, target=1 → delta = 8 * 1 / 1 / 8 = 1, result = 7
+        assert_eq!(compute_next_base_fee_eip1559(8, 0, 1), MIN_PROTOCOL_BASE_FEE);
+    }
+
+    #[test]
+    fn zero_target_returns_current() {
+        assert_eq!(compute_next_base_fee_eip1559(1000, 500, 0), 1000);
+    }
+
+    #[test]
+    fn overflow_safety_large_values() {
+        // u64::MAX base fee with high gas usage should not panic
+        let result = compute_next_base_fee_eip1559(u64::MAX, u64::MAX, 1);
+        assert_eq!(result, u64::MAX); // saturating_add caps at MAX
+    }
+
+    #[test]
+    fn max_increase_is_12_5_percent() {
+        // Even with huge gas overshoot, increase is capped at base_fee/8
+        // excess = min(u64::MAX - 1, 1) = 1, delta = 1_000_000 * 1 / 1 / 8 = 125_000
+        let base = 1_000_000u64;
+        let result = compute_next_base_fee_eip1559(base, u64::MAX, 1);
+        assert_eq!(result, base + base / 8);
+    }
+
+    #[test]
+    fn max_decrease_is_12_5_percent() {
+        // Even with zero gas usage, decrease is capped at base_fee/8
+        // deficit = min(1, 1) = 1, delta = 1_000_000 * 1 / 1 / 8 = 125_000
+        let base = 1_000_000u64;
+        let result = compute_next_base_fee_eip1559(base, 0, 1);
+        assert_eq!(result, base - base / 8);
+    }
+
+    #[test]
+    fn small_values() {
+        // Very small base fee
+        assert_eq!(
+            compute_next_base_fee_eip1559(MIN_PROTOCOL_BASE_FEE, 0, 100),
+            MIN_PROTOCOL_BASE_FEE
+        );
+    }
+
+    #[test]
+    fn partial_utilization() {
+        // 75% utilization → 25% under target → decrease by 25%/8 = 3.125%
+        // base=1000, delta = 1000 * 250 / 1000 / 8 = 31
+        assert_eq!(compute_next_base_fee_eip1559(1000, 750, 1000), 969);
+    }
+
+    #[test]
+    fn slight_over_target() {
+        // 110% utilization → 10% over → increase by 10%/8 = 1.25%
+        // base=1000, delta = 1000 * 100 / 1000 / 8 = 12 (integer division)
+        assert_eq!(compute_next_base_fee_eip1559(1000, 1100, 1000), 1012);
+    }
+
+    #[test]
+    fn min_base_fee_still_increases_over_target() {
+        // At MIN_PROTOCOL_BASE_FEE (7), integer 7/8 = 0 but delta is floored at 1
+        assert_eq!(
+            compute_next_base_fee_eip1559(MIN_PROTOCOL_BASE_FEE, 200, 100),
+            MIN_PROTOCOL_BASE_FEE + 1
+        );
     }
 }


### PR DESCRIPTION
- `RethEnv::get_worker_fee_configs(num_workers)` reads from canonical tip and rejects worker-count drift; `get_worker_fee_configs_at_block(hash)` reads at a specific header for replay paths.
- CLI: `--worker-fee-config WORKER_ID:STRATEGY:VALUE` (repeatable). Parser sorts by worker id, validates contiguous ids starting from 0, errors on bad format. Default when omitted: one EIP-1559 worker, 100M target gas.
- `compute_next_base_fee_eip1559` in `tn-types::gas_accumulator` — ±12.5% bound, `MIN_PROTOCOL_BASE_FEE` floor, saturating arithmetic. 11 unit tests cover at-target, over/under, overflow, min-fee floor, and partial utilization.
- Default epoch duration: 24h → 8h. `genesis_tests` and `staking` updated to match.
- `tn-contracts` submodule bumped to pull in the `WorkerConfigs` contract
- `GasAccumulator::new_with_rewards` constructor so callers can hand in a pre-built `RewardsCounter` instead of always starting from default.

precursor for #614 
unblocks #657