### PR TITLE
Fix a couple of edge cases from testing.

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -190,7 +190,13 @@ impl<DB: Database> Subscriber<DB> {
             if let Some(last_consensus_header) =
                 self.consensus_bus.last_consensus_header().borrow().as_ref()
             {
-                if consensus_header_number == last_consensus_header.number {
+                // If we seem to be on the same number also make sure this is not a stale record.
+                // If that happens during a catch up it will lead to premature cvv active when not
+                // caught up.
+                if consensus_header_number == last_consensus_header.number
+                    && last_consensus_header.sub_dag.commit_timestamp().elapsed()
+                        < Duration::from_secs(5)
+                {
                     // We are caught up enough so try to jump back into consensus
                     info!(target: "subscriber", "attempting to rejoin consensus, consensus block height {consensus_header_number}");
                     self.consensus_bus.node_mode().send_replace(NodeMode::CvvActive);

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -206,6 +206,10 @@ where
         // Long-running tasks for the lifetime of the node.
         let mut node_task_manager = TaskManager::new(NODE_TASK_MANAGER);
         let node_task_spawner = node_task_manager.get_spawner();
+        // Prime the last forwarded consensus number at startup.
+        // Normally this is not needed but is a layer of safety in case
+        // run_epoch() does not process any output for some reason.
+        self.last_forwarded_consensus_number = self.consensus_chain.latest_consensus_number();
 
         info!(target: "epoch-manager", "starting node and launching first epoch");
 

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -100,7 +100,6 @@ where
         // channels.
         let consensus_bus = ConsensusBus::new_with_app(self.consensus_bus.clone());
         self.last_consensus_header = None;
-        self.last_forwarded_consensus_number = 0;
         // We have not created this epoch's primary yet (no committee) so get it from chain
         // ourselves... Note, any consensus output to replay should be in the same epoch...
         let (committee, epoch_info, epoch_start) =


### PR DESCRIPTION
This adds a time component to switching back to cvv active so we don't do so on stale data.

Also manages the last forwarded output per epoch better to close bug caused when not producing output in an epoch (the first problem led to the second).

Closes https://github.com/Telcoin-Association/telcoin-network/issues/658