### PR TITLE
Regression tests for observer epoch-0 sync + stale prior-epoch vote

### DIFF
--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::PrimaryNetworkError,
     network::{
-        message::{ConsensusResult, PrimaryGossip},
+        message::{ConsensusResult, PrimaryGossip, PrimaryResponse},
         MissingCertificatesRequest, PendingEpochStream, RequestHandler,
         MAX_CONCURRENT_EPOCH_STREAMS, PENDING_REQUEST_TIMEOUT,
     },
@@ -20,12 +20,12 @@ use std::{
 use tempfile::TempDir;
 use tn_config::Parameters;
 use tn_network_libp2p::{GossipMessage, TopicHash};
-use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
+use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
-    BlsPublicKey, Certificate, EpochVote, ExecHeader, Hash as _, HeaderDigest, SealedHeader,
-    TaskManager, B256,
+    BlsPublicKey, Certificate, Database, Epoch, EpochVote, ExecHeader, Hash as _, HeaderDigest,
+    SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -113,6 +113,41 @@ async fn create_test_types(path: &Path) -> TestTypes {
     create_test_types_with_params(path, None).await
 }
 
+/// Helper function to create an instance of [RequestHandler] for the first authority of a
+/// committee at the supplied epoch. Mirrors [`create_test_types_with_params`] but threads the
+/// epoch through the [`CommitteeFixture`] builder so that the handler's view of the committee
+/// reports `epoch` rather than the default `0`.
+async fn create_test_types_at_epoch(path: &Path, epoch: Epoch) -> TestTypes {
+    let committee = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .epoch(epoch)
+        .build();
+    let authority = committee.first_authority();
+    let config = authority.consensus_config();
+    let cb = ConsensusBus::new();
+
+    // spawn the synchronizer
+    let task_manager = TaskManager::default();
+    let synchronizer =
+        StateSynchronizer::new(config.clone(), cb.clone(), task_manager.get_spawner());
+    synchronizer.spawn(&task_manager);
+
+    // last execution result
+    let parent = SealedHeader::seal_slow(ExecHeader::default());
+
+    // set the latest execution result to genesis - test headers are proposed for round 1
+    let mut recent = RecentBlocks::new(1);
+    recent.push_latest(0, BlockNumHash::new(0, B256::default()), Some(parent.clone()));
+    cb.app().recent_blocks().send_replace(recent);
+
+    let consensus_chain =
+        ConsensusChain::new_for_test(path.to_owned(), committee.committee()).await.unwrap();
+    let consensus_bus = cb.app().clone();
+    let handler =
+        RequestHandler::new(config.clone(), cb.app().clone(), synchronizer, consensus_chain);
+    TestTypes { committee, handler, parent, consensus_bus, task_manager }
+}
+
 #[tokio::test]
 async fn test_vote_succeeds() -> eyre::Result<()> {
     // common types
@@ -134,6 +169,45 @@ async fn test_vote_succeeds() -> eyre::Result<()> {
     let res = handler.vote(peer, header, parents).await;
     debug!(target: "primary::handler_tests", ?res);
     assert!(res.is_ok());
+    Ok(())
+}
+
+/// Regression test: a stale `VoteInfo` from a prior epoch left over in the `Votes` table must
+/// not block a vote on a header from the current epoch. Without the explicit
+/// `header.epoch() > vote_info.epoch()` branch in the vote handler, an older entry's `round`
+/// would short-circuit the equivocation check and reject the new header as a duplicate vote.
+#[tokio::test]
+async fn test_vote_succeeds_with_stale_prior_epoch_vote_info() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types_at_epoch(temp_dir.path(), 1).await;
+
+    // Seed the Votes table with a stale entry from epoch 0 keyed under the authority that
+    // will submit the current-epoch header. F3 should clear this row on epoch close, so the
+    // scenario is theoretically impossible — but the new branch defends against the row
+    // leaking, and the regression test pins that defence in place.
+    let author_id = committee.last_authority().id();
+    let stale = VoteInfo { epoch: 0, round: 5, vote_digest: VoteDigest::default() };
+    committee.first_authority().consensus_config().node_storage().insert::<Votes>(&author_id, &stale)?;
+
+    // current-epoch (epoch=1) header from the same author at round 1
+    let header = committee
+        .header_builder_last_authority()
+        .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
+        .created_at(1) // parent is 0
+        .build();
+    let peer = *committee.last_authority().authority().protocol_key();
+
+    let res = handler.vote(peer, header, vec![]).await?;
+    assert_matches!(res, PrimaryResponse::Vote(_));
+
+    // The stale row must have been overwritten with a current-epoch entry.
+    let stored: Option<VoteInfo> =
+        committee.first_authority().consensus_config().node_storage().get::<Votes>(&author_id)?;
+    let stored = stored.expect("vote info written");
+    assert_eq!(stored.epoch, committee.committee().epoch());
+    assert_eq!(stored.round, 1);
+
     Ok(())
 }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -118,10 +118,8 @@ async fn create_test_types(path: &Path) -> TestTypes {
 /// epoch through the [`CommitteeFixture`] builder so that the handler's view of the committee
 /// reports `epoch` rather than the default `0`.
 async fn create_test_types_at_epoch(path: &Path, epoch: Epoch) -> TestTypes {
-    let committee = CommitteeFixture::builder(MemDatabase::default)
-        .randomize_ports(true)
-        .epoch(epoch)
-        .build();
+    let committee =
+        CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).epoch(epoch).build();
     let authority = committee.first_authority();
     let config = authority.consensus_config();
     let cb = ConsensusBus::new();
@@ -188,7 +186,11 @@ async fn test_vote_succeeds_with_stale_prior_epoch_vote_info() -> eyre::Result<(
     // leaking, and the regression test pins that defence in place.
     let author_id = committee.last_authority().id();
     let stale = VoteInfo { epoch: 0, round: 5, vote_digest: VoteDigest::default() };
-    committee.first_authority().consensus_config().node_storage().insert::<Votes>(&author_id, &stale)?;
+    committee
+        .first_authority()
+        .consensus_config()
+        .node_storage()
+        .insert::<Votes>(&author_id, &stale)?;
 
     // current-epoch (epoch=1) header from the same author at round 1
     let header = committee

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -67,6 +67,18 @@ pub fn config_local_testnet(
     passphrase: Option<String>,
     accounts: Option<Vec<(Address, GenesisAccount)>>,
 ) -> eyre::Result<()> {
+    config_local_testnet_with_epoch_duration(temp_path, passphrase, accounts, None)
+}
+
+/// Like [`config_local_testnet`], but lets the caller override the epoch duration in seconds.
+/// Pass `None` to use the genesis CLI default (8 hours). Useful for tests that need to
+/// observe an epoch boundary within the test budget.
+pub fn config_local_testnet_with_epoch_duration(
+    temp_path: &Path,
+    passphrase: Option<String>,
+    accounts: Option<Vec<(Address, GenesisAccount)>>,
+    epoch_duration_secs: Option<u32>,
+) -> eyre::Result<()> {
     let validators = [
         ("validator-1", "0x1111111111111111111111111111111111111111"),
         ("validator-2", "0x2222222222222222222222222222222222222222"),
@@ -94,19 +106,24 @@ pub fn config_local_testnet(
     create_observer_info(dir, passphrase.clone())?;
 
     // create committee from shared genesis dir
-    let create_committee_command = CommandParser::<GenesisArgs>::parse_from([
-        "tn",
-        "--basefee-address",
-        "0x9999999999999999999999999999999999999999",
-        "--consensus-registry-owner",
-        "0x00000000000000000000000000000000000007a0",
-        "--dev-funded-account",
-        "test-source",
-        "--max-header-delay-ms",
-        "1000",
-        "--min-header-delay-ms",
-        "500",
-    ]);
+    let mut genesis_args: Vec<String> = vec![
+        "tn".into(),
+        "--basefee-address".into(),
+        "0x9999999999999999999999999999999999999999".into(),
+        "--consensus-registry-owner".into(),
+        "0x00000000000000000000000000000000000007a0".into(),
+        "--dev-funded-account".into(),
+        "test-source".into(),
+        "--max-header-delay-ms".into(),
+        "1000".into(),
+        "--min-header-delay-ms".into(),
+        "500".into(),
+    ];
+    if let Some(duration) = epoch_duration_secs {
+        genesis_args.push("--epoch-duration-in-secs".into());
+        genesis_args.push(duration.to_string());
+    }
+    let create_committee_command = CommandParser::<GenesisArgs>::parse_from(genesis_args);
     create_committee_command.args.execute(shared_genesis_dir.clone())?;
     // If provided optional accounts then hack them into genesis now...
     if let Some(accounts) = accounts {

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -2,6 +2,10 @@
 //!
 //! Process management, cleanup guards, and helpers used across all test modules.
 
+use e2e_tests::setup_log_dir;
+use escargot::CargoRun;
+use ethereum_tx_sign::{LegacyTransaction, Transaction};
+use eyre::Report;
 use jsonrpsee::{
     core::{client::ClientT as _, DeserializeOwned},
     http_client::HttpClientBuilder,
@@ -11,15 +15,19 @@ use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
+use secp256k1::{Keypair, Secp256k1, SecretKey};
 use serde_json::Value;
 use std::{
     collections::HashMap,
     fmt::Debug,
+    path::Path,
     process::Child,
     sync::{Condvar, Mutex},
     time::Duration,
 };
-use tn_types::test_utils::init_test_tracing;
+use tn_types::{
+    address, get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address,
+};
 use tokio::runtime::Builder;
 use tracing::{error, info};
 
@@ -28,6 +36,9 @@ use tracing::{error, info};
 const MAX_CONCURRENT_TESTS: usize = 2;
 
 static TEST_SEMAPHORE: TestSemaphore = TestSemaphore::new(MAX_CONCURRENT_TESTS);
+
+/// One unit of TEL (10^18) measured in wei.
+pub(crate) const WEI_PER_TEL: u128 = 1_000_000_000_000_000_000;
 
 /// Acquire a permit to run an e2e test. Blocks until a slot is available.
 /// The returned guard releases the permit on drop. Also ensure test tracing.
@@ -275,4 +286,325 @@ where
             .block_on(call_rpc_inner(node, command, params, retries, debug_params)),
     };
     Ok(resp?)
+}
+
+/// Check if the network is advancing (query all nodes).
+pub(crate) fn network_advancing(client_urls: &[String; 4]) -> eyre::Result<()> {
+    // Wait for all nodes to respond to RPC.
+    // With skip-empty-execution, blocks are only produced when transactions
+    // exist or an epoch closes, so we cannot rely on block_number advancing
+    // during idle periods. Actual block production is verified later by
+    // send_and_confirm().
+    let mut i = 0;
+    loop {
+        let mut all_responsive = true;
+        for url in client_urls {
+            if get_block_number(url).is_err() {
+                all_responsive = false;
+                break;
+            }
+        }
+        if all_responsive {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+        i += 1;
+        if i > 45 {
+            return Err(eyre::eyre!("Network not responding within 45 seconds!"));
+        }
+    }
+}
+
+/// Start a process running a validator node.
+pub(crate) fn start_validator(
+    instance: usize,
+    bin: &'static CargoRun,
+    base_dir: &Path,
+    rpc_port: u16,
+    test: &str,
+    run: u32,
+) -> Child {
+    let data_dir = base_dir.join(format!("validator-{}", instance + 1));
+    let ws_port = get_available_tcp_port("127.0.0.1").expect("ws port");
+    // IPC: use temp-dir-based path to avoid cross-test conflicts
+    let ipc_path = base_dir.join(format!("validator-{}.ipc", instance + 1));
+    let mut command = bin.command();
+
+    command
+        .env("TN_BLS_PASSPHRASE", "restart_test")
+        .arg("node")
+        .arg("--datadir")
+        .arg(&*data_dir.to_string_lossy())
+        .arg("--http")
+        .arg("--http.port")
+        .arg(format!("{rpc_port}"))
+        .arg("--ws")
+        .arg("--ws.port")
+        .arg(format!("{ws_port}"))
+        .arg("--ipcpath")
+        .arg(ipc_path.to_string_lossy().as_ref())
+        .arg("--node-name")
+        .arg(format!("{test}-node{instance}"));
+
+    setup_log_dir(&mut command, instance, test, run);
+
+    command.spawn().expect("failed to execute")
+}
+
+/// Start a process running an observer node.
+pub(crate) fn start_observer(
+    instance: usize,
+    bin: &'static CargoRun,
+    base_dir: &Path,
+    rpc_port: u16,
+    test: &str,
+    run: u32,
+) -> Child {
+    let data_dir = base_dir.join("observer");
+    let ws_port = get_available_tcp_port("127.0.0.1").expect("ws port");
+    // IPC: use temp-dir-based path to avoid cross-test conflicts
+    let ipc_path = base_dir.join("observer.ipc");
+    let mut command = bin.command();
+    command
+        .env("TN_BLS_PASSPHRASE", "restart_test")
+        .arg("node")
+        .arg("--observer")
+        .arg("--datadir")
+        .arg(&*data_dir.to_string_lossy())
+        .arg("--http")
+        .arg("--http.port")
+        .arg(format!("{rpc_port}"))
+        .arg("--ws")
+        .arg("--ws.port")
+        .arg(format!("{ws_port}"))
+        .arg("--ipcpath")
+        .arg(ipc_path.to_string_lossy().as_ref())
+        .arg("--node-name")
+        .arg(format!("{test}-node{instance}"));
+
+    setup_log_dir(&mut command, instance, test, run);
+
+    command.spawn().expect("failed to execute")
+}
+
+/// Retrieve "latest" execution block and parse the number (block height).
+pub(crate) fn get_block_number(node: &str) -> eyre::Result<u64> {
+    let block = get_block(node, None)?;
+    Ok(u64::from_str_radix(&block["number"].as_str().unwrap_or("0x100_000")[2..], 16)?)
+}
+
+/// If key starts with 0x then return it otherwise generate the key from the key string.
+pub(crate) fn get_key(key: &str) -> String {
+    if key.starts_with("0x") {
+        key.to_string()
+    } else {
+        let (_, _, key) = account_from_word(key);
+        key
+    }
+}
+
+/// Return the (account, public key, secret key) generated from key_word.
+fn account_from_word(key_word: &str) -> (String, String, String) {
+    let seed = keccak256(key_word.as_bytes());
+    let mut rand =
+        <secp256k1::rand::rngs::StdRng as secp256k1::rand::SeedableRng>::from_seed(seed.0);
+    let secp = Secp256k1::new();
+    let (secret_key, public_key) = secp.generate_keypair(&mut rand);
+    let keypair = Keypair::from_secret_key(&secp, &secret_key);
+    // strip out the first byte because that should be the SECP256K1_TAG_PUBKEY_UNCOMPRESSED
+    // tag returned by libsecp's uncompressed pubkey serialization
+    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
+    let address = Address::from_slice(&hash[12..]);
+    let pubkey = keypair.public_key().serialize();
+    let secret = keypair.secret_bytes();
+    (address.to_string(), const_hex::encode(pubkey), const_hex::encode(secret))
+}
+
+/// Retrieve a node's latest consensus header.
+pub(crate) fn get_latest_consensus_header(node: &str) -> eyre::Result<HashMap<String, Value>> {
+    call_rpc(node, "tn_latestConsensusHeader", rpc_params![], 10, "tn_latestConsensusHeader")
+}
+
+/// Query a node's highest consensus chain block height.
+/// NOTE: consensus chain is required to grow to detect byzantine validators.
+pub(crate) fn get_latest_consensus_header_number(node: &str) -> eyre::Result<u64> {
+    let header = get_latest_consensus_header(node)?;
+    let value = header
+        .get("number")
+        .ok_or_else(|| Report::msg("tn_latestConsensusHeader missing `number` field"))?;
+
+    match value {
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| Report::msg("tn_latestConsensusHeader number is not u64-compatible")),
+        Value::String(s) if s.starts_with("0x") => {
+            u64::from_str_radix(s.trim_start_matches("0x"), 16)
+                .map_err(|e| Report::msg(format!("failed to parse consensus number hex: {e}")))
+        }
+        Value::String(s) => s
+            .parse::<u64>()
+            .map_err(|e| Report::msg(format!("failed to parse consensus number: {e}"))),
+        _ => Err(Report::msg("tn_latestConsensusHeader number has unexpected type")),
+    }
+}
+
+/// Take a string and return the deterministic account derived from it.  This is be used
+/// with similiar functionality in the test client to allow easy testing using simple strings
+/// for accounts.
+pub(crate) fn address_from_word(key_word: &str) -> Address {
+    let seed = keccak256(key_word.as_bytes());
+    let mut rand =
+        <secp256k1::rand::rngs::StdRng as secp256k1::rand::SeedableRng>::from_seed(seed.0);
+    let secp = Secp256k1::new();
+    let (_, public_key) = secp.generate_keypair(&mut rand);
+    // strip out the first byte because that should be the SECP256K1_TAG_PUBKEY_UNCOMPRESSED
+    // tag returned by libsecp's uncompressed pubkey serialization
+    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
+    Address::from_slice(&hash[12..])
+}
+
+/// Send native tokens and confirm the account balance changed.
+pub(crate) fn send_and_confirm(
+    node: &str,
+    node_test: &str,
+    key: &str,
+    to_account: Address,
+    nonce: u128,
+) -> eyre::Result<()> {
+    let basefee_address = address!("0x9999999999999999999999999999999999999999");
+    let current = get_balance(node_test, &to_account.to_string(), 1)?;
+    let current_basefee = get_balance(node_test, &basefee_address.to_string(), 1)?;
+    let amount = 10 * WEI_PER_TEL; // 10 TEL
+    let expected = current + amount;
+    send_tel(node, key, to_account, amount, 250, 21000, nonce)?;
+
+    // sleep
+    std::thread::sleep(Duration::from_millis(1000));
+    info!(target: "restart-test", "calling get_positive_balance_with_retry...");
+
+    // get positive bal and kill child2 if error
+    let bal = get_balance_above_with_retry(node_test, &to_account.to_string(), expected - 1)?;
+
+    if expected != bal {
+        error!(target: "restart-test", "{expected} != {bal} - returning error!");
+        return Err(Report::msg(format!("Expected a balance of {expected} got {bal}!")));
+    }
+    let bal =
+        get_balance_above_with_retry(node_test, &basefee_address.to_string(), current_basefee)?;
+    let expected_bal = if nonce > 0 { current_basefee + (current_basefee / (nonce)) } else { 0 };
+    if nonce > 0 && bal < expected_bal {
+        error!(target: "restart-test", ?bal, ?expected_bal, "basefee error!");
+        return Err(Report::msg("Expected a basefee increment!".to_string()));
+    }
+    Ok(())
+}
+
+/// Send an RPC call to node to get the latest balance for address.
+/// Return a tuple of the TEL and remainder (any value left after dividing by 1_e18).
+/// Note, balance is in wei and must fit in an u128.
+pub(crate) fn get_balance(node: &str, address: &str, retries: usize) -> eyre::Result<u128> {
+    let res_str: String =
+        call_rpc(node, "eth_getBalance", rpc_params!(address, "latest"), retries, address)?;
+    info!(target: "restart-test", "get_balance for {node}: parsing string {res_str}");
+    let tel = u128::from_str_radix(&res_str[2..], 16)?;
+    info!(target: "restart-test", "get_balance for {node}: {tel:?}");
+    Ok(tel)
+}
+
+/// Retry up to 10 times to retrieve an account balance > 0.
+pub(crate) fn get_positive_balance_with_retry(node: &str, address: &str) -> eyre::Result<u128> {
+    get_balance_above_with_retry(node, address, 0)
+}
+
+/// Retry up to 45 times to retrieve an account balance > above.
+pub(crate) fn get_balance_above_with_retry(
+    node: &str,
+    address: &str,
+    above: u128,
+) -> eyre::Result<u128> {
+    let mut bal = get_balance(node, address, 5)?;
+    let mut i = 0;
+    while i < 45 && bal <= above {
+        std::thread::sleep(Duration::from_millis(1200));
+        i += 1;
+        bal = get_balance(node, address, 5)?;
+    }
+    if i == 45 && bal <= above {
+        error!(target:"restart-test", "get_balance_above_with_retry i == 30 - returning error!!");
+        Err(Report::msg(format!("Failed to get a balance {bal} for {address} above {above}")))
+    } else {
+        Ok(bal)
+    }
+}
+
+/// Create, sign and submit a TXN to transfer TEL from key's account to to_account.
+pub(crate) fn send_tel(
+    node: &str,
+    key: &str,
+    to_account: Address,
+    amount: u128,
+    gas_price: u128,
+    gas: u128,
+    nonce: u128,
+) -> eyre::Result<()> {
+    let mut to_addr = [0_u8; 20];
+    //const_hex::decode_to_slice(to_account, &mut to_addr[..])?;
+    to_addr.copy_from_slice(to_account.as_slice());
+    let (from_account, _, _) = decode_key(key)?;
+    let new_transaction = LegacyTransaction {
+        chain: 0x7e1,
+        nonce,
+        to: Some(to_addr),
+        value: amount,
+        gas_price,
+        gas,
+        data: vec![/* contract code or other data */],
+    };
+    let decoded = const_hex::decode(key)?;
+    let secret_key = SecretKey::from_byte_array(decoded.as_slice().try_into()?)?;
+    let ecdsa = new_transaction
+        .ecdsa(&secret_key.secret_bytes())
+        .map_err(|_| Report::msg("Failed to get ecdsa"))?;
+    let transaction_bytes = new_transaction.sign(&ecdsa);
+    let res_str: String = call_rpc(
+        node,
+        "eth_sendRawTransaction",
+        rpc_params!(const_hex::encode(&transaction_bytes)),
+        1,
+        transaction_bytes,
+    )?;
+    info!(target: "restart-test", "Submitted TEL transfer from {from_account} to {to_account} for {amount}: {res_str}");
+    Ok(())
+}
+
+/// Decode a secret key into it's public key and account.
+/// Returns a tuple of (account, public_key, public_key_long) as hex encoded strings.
+pub(crate) fn decode_key(key: &str) -> eyre::Result<(String, String, String)> {
+    match const_hex::decode(key) {
+        Ok(key) => {
+            let key_array: [u8; 32] = key
+                .as_slice()
+                .try_into()
+                .map_err(|e: std::array::TryFromSliceError| Report::msg(e.to_string()))?;
+            match SecretKey::from_byte_array(key_array) {
+                Ok(secret_key) => {
+                    let secp = Secp256k1::new();
+                    let keypair = Keypair::from_secret_key(&secp, &secret_key);
+                    let public_key = keypair.public_key();
+                    // strip out the first byte because that should be the
+                    // SECP256K1_TAG_PUBKEY_UNCOMPRESSED tag returned by
+                    // libsecp's uncompressed pubkey serialization
+                    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
+                    let address = Address::from_slice(&hash[12..]);
+                    Ok((
+                        address.to_string(),
+                        const_hex::encode(public_key.serialize()),
+                        const_hex::encode(public_key.serialize_uncompressed()),
+                    ))
+                }
+                Err(err) => Err(Report::msg(err.to_string())),
+            }
+        }
+        Err(err) => Err(Report::msg(err.to_string())),
+    }
 }

--- a/crates/e2e-tests/tests/it/main.rs
+++ b/crates/e2e-tests/tests/it/main.rs
@@ -10,5 +10,6 @@ mod faucet;
 mod genesis_tests;
 mod restarts;
 mod staking;
+mod sync;
 
 fn main() {}

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -1,60 +1,21 @@
-use alloy::primitives::address;
-use e2e_tests::{config_local_testnet, setup_log_dir};
+//! E2e tests for nodes crashing and rejoining and active network.
+
+use super::common::{kill_child, ProcessGuard};
+use crate::common::{
+    address_from_word, get_balance, get_balance_above_with_retry, get_block, get_block_number,
+    get_key, get_latest_consensus_header_number, get_positive_balance_with_retry,
+    network_advancing, send_and_confirm, send_tel, start_observer, start_validator, WEI_PER_TEL,
+};
+use e2e_tests::config_local_testnet;
 use escargot::CargoRun;
-use ethereum_tx_sign::{LegacyTransaction, Transaction};
 use eyre::Report;
-use jsonrpsee::rpc_params;
 use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
-use secp256k1::{Keypair, Secp256k1, SecretKey};
-use serde_json::Value;
-use std::{collections::HashMap, path::Path, process::Child, time::Duration};
-use tn_types::{get_available_tcp_port, keccak256, Address};
+use std::{path::Path, process::Child, time::Duration};
+use tn_types::get_available_tcp_port;
 use tracing::{error, info};
-
-use crate::common::{call_rpc, get_block};
-
-use super::common::{kill_child, ProcessGuard};
-
-/// One unit of TEL (10^18) measured in wei.
-const WEI_PER_TEL: u128 = 1_000_000_000_000_000_000;
-
-fn send_and_confirm(
-    node: &str,
-    node_test: &str,
-    key: &str,
-    to_account: Address,
-    nonce: u128,
-) -> eyre::Result<()> {
-    let basefee_address = address!("0x9999999999999999999999999999999999999999");
-    let current = get_balance(node_test, &to_account.to_string(), 1)?;
-    let current_basefee = get_balance(node_test, &basefee_address.to_string(), 1)?;
-    let amount = 10 * WEI_PER_TEL; // 10 TEL
-    let expected = current + amount;
-    send_tel(node, key, to_account, amount, 250, 21000, nonce)?;
-
-    // sleep
-    std::thread::sleep(Duration::from_millis(1000));
-    info!(target: "restart-test", "calling get_positive_balance_with_retry...");
-
-    // get positive bal and kill child2 if error
-    let bal = get_balance_above_with_retry(node_test, &to_account.to_string(), expected - 1)?;
-
-    if expected != bal {
-        error!(target: "restart-test", "{expected} != {bal} - returning error!");
-        return Err(Report::msg(format!("Expected a balance of {expected} got {bal}!")));
-    }
-    let bal =
-        get_balance_above_with_retry(node_test, &basefee_address.to_string(), current_basefee)?;
-    let expected_bal = if nonce > 0 { current_basefee + (current_basefee / (nonce)) } else { 0 };
-    if nonce > 0 && bal < expected_bal {
-        error!(target: "restart-test", ?bal, ?expected_bal, "basefee error!");
-        return Err(Report::msg("Expected a basefee increment!".to_string()));
-    }
-    Ok(())
-}
 
 /// Run the first part tests, broken up like this to allow more robust node shutdown.
 fn run_restart_tests1(
@@ -238,32 +199,6 @@ fn run_restart_tests2(client_urls: &[String; 4]) -> eyre::Result<()> {
     }
     test_blocks_same(client_urls)?;
     Ok(())
-}
-
-fn network_advancing(client_urls: &[String; 4]) -> eyre::Result<()> {
-    // Wait for all nodes to respond to RPC.
-    // With skip-empty-execution, blocks are only produced when transactions
-    // exist or an epoch closes, so we cannot rely on block_number advancing
-    // during idle periods. Actual block production is verified later by
-    // send_and_confirm().
-    let mut i = 0;
-    loop {
-        let mut all_responsive = true;
-        for url in client_urls {
-            if get_block_number(url).is_err() {
-                all_responsive = false;
-                break;
-            }
-        }
-        if all_responsive {
-            return Ok(());
-        }
-        std::thread::sleep(Duration::from_secs(1));
-        i += 1;
-        if i > 45 {
-            return Err(eyre::eyre!("Network not responding within 45 seconds!"));
-        }
-    }
 }
 
 fn do_restarts(delay: u64, lagged: bool, test: &str) -> eyre::Result<()> {
@@ -456,78 +391,6 @@ fn test_restarts_lagged_delayed() -> eyre::Result<()> {
     do_restarts(70, true, "restarts_lagged_delayed")
 }
 
-/// Start a process running a validator node.
-fn start_validator(
-    instance: usize,
-    bin: &'static CargoRun,
-    base_dir: &Path,
-    rpc_port: u16,
-    test: &str,
-    run: u32,
-) -> Child {
-    let data_dir = base_dir.join(format!("validator-{}", instance + 1));
-    let ws_port = get_available_tcp_port("127.0.0.1").expect("ws port");
-    // IPC: use temp-dir-based path to avoid cross-test conflicts
-    let ipc_path = base_dir.join(format!("validator-{}.ipc", instance + 1));
-    let mut command = bin.command();
-
-    command
-        .env("TN_BLS_PASSPHRASE", "restart_test")
-        .arg("node")
-        .arg("--datadir")
-        .arg(&*data_dir.to_string_lossy())
-        .arg("--http")
-        .arg("--http.port")
-        .arg(format!("{rpc_port}"))
-        .arg("--ws")
-        .arg("--ws.port")
-        .arg(format!("{ws_port}"))
-        .arg("--ipcpath")
-        .arg(ipc_path.to_string_lossy().as_ref())
-        .arg("--node-name")
-        .arg(format!("{test}-node{instance}"));
-
-    setup_log_dir(&mut command, instance, test, run);
-
-    command.spawn().expect("failed to execute")
-}
-
-/// Start a process running an observer node.
-fn start_observer(
-    instance: usize,
-    bin: &'static CargoRun,
-    base_dir: &Path,
-    rpc_port: u16,
-    test: &str,
-    run: u32,
-) -> Child {
-    let data_dir = base_dir.join("observer");
-    let ws_port = get_available_tcp_port("127.0.0.1").expect("ws port");
-    // IPC: use temp-dir-based path to avoid cross-test conflicts
-    let ipc_path = base_dir.join("observer.ipc");
-    let mut command = bin.command();
-    command
-        .env("TN_BLS_PASSPHRASE", "restart_test")
-        .arg("node")
-        .arg("--observer")
-        .arg("--datadir")
-        .arg(&*data_dir.to_string_lossy())
-        .arg("--http")
-        .arg("--http.port")
-        .arg(format!("{rpc_port}"))
-        .arg("--ws")
-        .arg("--ws.port")
-        .arg(format!("{ws_port}"))
-        .arg("--ipcpath")
-        .arg(ipc_path.to_string_lossy().as_ref())
-        .arg("--node-name")
-        .arg(format!("{test}-node{instance}"));
-
-    setup_log_dir(&mut command, instance, test, run);
-
-    command.spawn().expect("failed to execute")
-}
-
 fn test_blocks_same(client_urls: &[String; 4]) -> eyre::Result<()> {
     info!(target: "restart-test", "calling get_block for {:?}", &client_urls[0]);
     let block0 = get_block(&client_urls[0], None)?;
@@ -558,184 +421,6 @@ fn test_blocks_same(client_urls: &[String; 4]) -> eyre::Result<()> {
     }
     info!(target: "restart-test", "all rpcs returned same block hash");
     Ok(())
-}
-
-/// Send an RPC call to node to get the latest balance for address.
-/// Return a tuple of the TEL and remainder (any value left after dividing by 1_e18).
-/// Note, balance is in wei and must fit in an u128.
-fn get_balance(node: &str, address: &str, retries: usize) -> eyre::Result<u128> {
-    let res_str: String =
-        call_rpc(node, "eth_getBalance", rpc_params!(address, "latest"), retries, address)?;
-    info!(target: "restart-test", "get_balance for {node}: parsing string {res_str}");
-    let tel = u128::from_str_radix(&res_str[2..], 16)?;
-    info!(target: "restart-test", "get_balance for {node}: {tel:?}");
-    Ok(tel)
-}
-
-/// Retry up to 10 times to retrieve an account balance > 0.
-fn get_positive_balance_with_retry(node: &str, address: &str) -> eyre::Result<u128> {
-    get_balance_above_with_retry(node, address, 0)
-}
-
-/// Retry up to 45 times to retrieve an account balance > above.
-fn get_balance_above_with_retry(node: &str, address: &str, above: u128) -> eyre::Result<u128> {
-    let mut bal = get_balance(node, address, 5)?;
-    let mut i = 0;
-    while i < 45 && bal <= above {
-        std::thread::sleep(Duration::from_millis(1200));
-        i += 1;
-        bal = get_balance(node, address, 5)?;
-    }
-    if i == 45 && bal <= above {
-        error!(target:"restart-test", "get_balance_above_with_retry i == 30 - returning error!!");
-        Err(Report::msg(format!("Failed to get a balance {bal} for {address} above {above}")))
-    } else {
-        Ok(bal)
-    }
-}
-
-/// If key starts with 0x then return it otherwise generate the key from the key string.
-fn get_key(key: &str) -> String {
-    if key.starts_with("0x") {
-        key.to_string()
-    } else {
-        let (_, _, key) = account_from_word(key);
-        key
-    }
-}
-
-fn get_block_number(node: &str) -> eyre::Result<u64> {
-    let block = get_block(node, None)?;
-    Ok(u64::from_str_radix(&block["number"].as_str().unwrap_or("0x100_000")[2..], 16)?)
-}
-
-fn get_latest_consensus_header(node: &str) -> eyre::Result<HashMap<String, Value>> {
-    call_rpc(node, "tn_latestConsensusHeader", rpc_params![], 10, "tn_latestConsensusHeader")
-}
-
-fn get_latest_consensus_header_number(node: &str) -> eyre::Result<u64> {
-    let header = get_latest_consensus_header(node)?;
-    let value = header
-        .get("number")
-        .ok_or_else(|| Report::msg("tn_latestConsensusHeader missing `number` field"))?;
-
-    match value {
-        Value::Number(n) => n
-            .as_u64()
-            .ok_or_else(|| Report::msg("tn_latestConsensusHeader number is not u64-compatible")),
-        Value::String(s) if s.starts_with("0x") => {
-            u64::from_str_radix(s.trim_start_matches("0x"), 16)
-                .map_err(|e| Report::msg(format!("failed to parse consensus number hex: {e}")))
-        }
-        Value::String(s) => s
-            .parse::<u64>()
-            .map_err(|e| Report::msg(format!("failed to parse consensus number: {e}"))),
-        _ => Err(Report::msg("tn_latestConsensusHeader number has unexpected type")),
-    }
-}
-
-/// Take a string and return the deterministic account derived from it.  This is be used
-/// with similiar functionality in the test client to allow easy testing using simple strings
-/// for accounts.
-fn address_from_word(key_word: &str) -> Address {
-    let seed = keccak256(key_word.as_bytes());
-    let mut rand =
-        <secp256k1::rand::rngs::StdRng as secp256k1::rand::SeedableRng>::from_seed(seed.0);
-    let secp = Secp256k1::new();
-    let (_, public_key) = secp.generate_keypair(&mut rand);
-    // strip out the first byte because that should be the SECP256K1_TAG_PUBKEY_UNCOMPRESSED
-    // tag returned by libsecp's uncompressed pubkey serialization
-    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
-    Address::from_slice(&hash[12..])
-}
-
-/// Return the (account, public key, secret key) generated from key_word.
-fn account_from_word(key_word: &str) -> (String, String, String) {
-    let seed = keccak256(key_word.as_bytes());
-    let mut rand =
-        <secp256k1::rand::rngs::StdRng as secp256k1::rand::SeedableRng>::from_seed(seed.0);
-    let secp = Secp256k1::new();
-    let (secret_key, public_key) = secp.generate_keypair(&mut rand);
-    let keypair = Keypair::from_secret_key(&secp, &secret_key);
-    // strip out the first byte because that should be the SECP256K1_TAG_PUBKEY_UNCOMPRESSED
-    // tag returned by libsecp's uncompressed pubkey serialization
-    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
-    let address = Address::from_slice(&hash[12..]);
-    let pubkey = keypair.public_key().serialize();
-    let secret = keypair.secret_bytes();
-    (address.to_string(), const_hex::encode(pubkey), const_hex::encode(secret))
-}
-
-/// Create, sign and submit a TXN to transfer TEL from key's account to to_account.
-fn send_tel(
-    node: &str,
-    key: &str,
-    to_account: Address,
-    amount: u128,
-    gas_price: u128,
-    gas: u128,
-    nonce: u128,
-) -> eyre::Result<()> {
-    let mut to_addr = [0_u8; 20];
-    //const_hex::decode_to_slice(to_account, &mut to_addr[..])?;
-    to_addr.copy_from_slice(to_account.as_slice());
-    let (from_account, _, _) = decode_key(key)?;
-    let new_transaction = LegacyTransaction {
-        chain: 0x7e1,
-        nonce,
-        to: Some(to_addr),
-        value: amount,
-        gas_price,
-        gas,
-        data: vec![/* contract code or other data */],
-    };
-    let decoded = const_hex::decode(key)?;
-    let secret_key = SecretKey::from_byte_array(decoded.as_slice().try_into()?)?;
-    let ecdsa = new_transaction
-        .ecdsa(&secret_key.secret_bytes())
-        .map_err(|_| Report::msg("Failed to get ecdsa"))?;
-    let transaction_bytes = new_transaction.sign(&ecdsa);
-    let res_str: String = call_rpc(
-        node,
-        "eth_sendRawTransaction",
-        rpc_params!(const_hex::encode(&transaction_bytes)),
-        1,
-        transaction_bytes,
-    )?;
-    info!(target: "restart-test", "Submitted TEL transfer from {from_account} to {to_account} for {amount}: {res_str}");
-    Ok(())
-}
-
-/// Decode a secret key into it's public key and account.
-/// Returns a tuple of (account, public_key, public_key_long) as hex encoded strings.
-fn decode_key(key: &str) -> eyre::Result<(String, String, String)> {
-    match const_hex::decode(key) {
-        Ok(key) => {
-            let key_array: [u8; 32] = key
-                .as_slice()
-                .try_into()
-                .map_err(|e: std::array::TryFromSliceError| Report::msg(e.to_string()))?;
-            match SecretKey::from_byte_array(key_array) {
-                Ok(secret_key) => {
-                    let secp = Secp256k1::new();
-                    let keypair = Keypair::from_secret_key(&secp, &secret_key);
-                    let public_key = keypair.public_key();
-                    // strip out the first byte because that should be the
-                    // SECP256K1_TAG_PUBKEY_UNCOMPRESSED tag returned by
-                    // libsecp's uncompressed pubkey serialization
-                    let hash = keccak256(&public_key.serialize_uncompressed()[1..]);
-                    let address = Address::from_slice(&hash[12..]);
-                    Ok((
-                        address.to_string(),
-                        const_hex::encode(public_key.serialize()),
-                        const_hex::encode(public_key.serialize_uncompressed()),
-                    ))
-                }
-                Err(err) => Err(Report::msg(err.to_string())),
-            }
-        }
-        Err(err) => Err(Report::msg(err.to_string())),
-    }
 }
 
 /// Test that an observer started AFTER validators have already produced blocks

--- a/crates/e2e-tests/tests/it/sync.rs
+++ b/crates/e2e-tests/tests/it/sync.rs
@@ -1,0 +1,179 @@
+//! E2e tests for syncing a new node to an existing network.
+
+use alloy::providers::{Provider, ProviderBuilder};
+use e2e_tests::config_local_testnet_with_epoch_duration;
+use std::time::Duration;
+use tn_reth::system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS};
+use tn_types::{get_available_tcp_port, EpochCertificate, EpochRecord};
+use tokio::time::Instant;
+use tracing::info;
+
+use crate::common::{
+    address_from_word, get_key, get_latest_consensus_header_number, network_advancing,
+    send_and_confirm, start_observer, start_validator, ProcessGuard,
+};
+
+/// Epoch duration (in seconds) used by the pack-import test. Mirrors the value used by
+/// `epochs.rs::EPOCH_DURATION` so that epoch boundaries occur on the same cadence under
+/// test-utils.
+const PACK_IMPORT_EPOCH_DURATION: u64 = 10;
+
+/// Regression test: an observer joining after epoch 0 has been closed and certified must
+/// successfully import the epoch-0 pack rather than failing with
+/// `PackError::InvalidConsensusChain` (Finding F2 in `report.md`).
+///
+/// Without the `consensus_pack::stream_import` parent-hash convention fix, the observer's
+/// first record in the epoch-0 pack expects `parent_hash == ConsensusHeader::default().digest()`
+/// but the validator's send-side computed `parent_hash` from a synthesised previous-epoch
+/// sentinel. The mismatch surfaces as a "Broken consensus record chain" error and the
+/// observer never advances past genesis.
+#[test]
+#[ignore = "should not run with a default cargo test, run restart tests as seperate step"]
+fn test_observer_pack_imports_after_epoch_close() -> eyre::Result<()> {
+    let _permit = super::common::acquire_test_permit();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("tokio runtime");
+    rt.block_on(test_observer_pack_imports_after_epoch_close_inner())
+}
+
+async fn test_observer_pack_imports_after_epoch_close_inner() -> eyre::Result<()> {
+    info!(target: "restart-test", "test_observer_pack_imports_after_epoch_close");
+    let tmp_guard =
+        tempfile::TempDir::with_prefix("observer_pack_import").expect("tempdir is okay");
+    let temp_path = tmp_guard.path().to_path_buf();
+    config_local_testnet_with_epoch_duration(
+        &temp_path,
+        Some("restart_test".to_string()),
+        None,
+        Some(PACK_IMPORT_EPOCH_DURATION as u32),
+    )
+    .expect("failed to config");
+
+    let bin = e2e_tests::get_telcoin_network_binary();
+
+    // Start 4 validators (no observer yet)
+    let mut guard = ProcessGuard::empty();
+    let mut client_urls = [
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+        "http://127.0.0.1".to_string(),
+    ];
+    for i in 0..4 {
+        let rpc_port = get_available_tcp_port("127.0.0.1")
+            .expect("Failed to get an ephemeral rpc port for child!");
+        client_urls[i].push_str(&format!(":{rpc_port}"));
+        guard.push(start_validator(i, &bin, &temp_path, rpc_port, "observer_pack_import", 0));
+    }
+
+    // Wait for validators to start serving RPC.
+    network_advancing(&client_urls)?;
+
+    // Wait until epoch 0 has fully closed AND a certified epoch-0 record is on disk.
+    // The observer can only be forced down the pack-import path once a complete persisted
+    // epoch-0 pack exists on the validator side.
+    let provider = ProviderBuilder::new().connect_http(client_urls[0].parse()?);
+    let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, &provider);
+
+    // (a) wait for epoch 0 to close
+    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 4);
+    loop {
+        let info = registry.getCurrentEpochInfo().call().await?;
+        if info.epochId > 0 {
+            info!(target: "restart-test", current_epoch = info.epochId, "epoch 0 closed");
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(eyre::eyre!(
+                "epoch 0 did not close within {}s",
+                PACK_IMPORT_EPOCH_DURATION * 4
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // (b) wait for tn_epochRecord(0) to return a certified record
+    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3);
+    let validator_record_0: (EpochRecord, EpochCertificate) = loop {
+        match provider
+            .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+            .await
+        {
+            Ok(rec) => break rec,
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => return Err(eyre::eyre!("epoch 0 record never certified: {e}")),
+        }
+    };
+    assert!(
+        validator_record_0.0.verify_with_cert(&validator_record_0.1),
+        "validator-side epoch-0 record fails self-verify"
+    );
+
+    // Now start the observer fresh from genesis. With epoch 0 already on disk, any sync
+    // must take the consensus_pack::stream_import path for that epoch.
+    let obs_rpc_port = get_available_tcp_port("127.0.0.1")
+        .expect("Failed to get an ephemeral rpc port for observer!");
+    let obs_url = format!("http://127.0.0.1:{obs_rpc_port}");
+    guard.push(start_observer(4, &bin, &temp_path, obs_rpc_port, "observer_pack_import", 0));
+
+    // Wait for the observer to catch up. We compare consensus header heights to avoid
+    // racing with EVM execution lag. The deadline allows pack download + verify + apply
+    // on top of normal observer startup.
+    let validator_height = get_latest_consensus_header_number(&client_urls[0])?;
+    let max_secs = (PACK_IMPORT_EPOCH_DURATION * 6).max(60) as i32;
+    let mut caught_up = false;
+    for _ in 0..max_secs {
+        if let Ok(obs_height) = get_latest_consensus_header_number(&obs_url) {
+            if obs_height >= validator_height {
+                info!(target: "restart-test", obs_height, validator_height, "observer caught up via pack import");
+                caught_up = true;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    assert!(
+        caught_up,
+        "observer did not catch up within {max_secs}s — pack import likely failed. Check logs in test_logs/observer_pack_import/"
+    );
+
+    // The observer must reconstruct the epoch-0 pack chain: ask for tn_epochRecord(0)
+    // and confirm it self-verifies and matches the validator's record byte-for-byte.
+    let obs_provider = ProviderBuilder::new().connect_http(obs_url.parse()?);
+    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3);
+    let observer_record_0: (EpochRecord, EpochCertificate) = loop {
+        match obs_provider
+            .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+            .await
+        {
+            Ok(rec) => break rec,
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => return Err(eyre::eyre!("observer epoch 0 record never available: {e}")),
+        }
+    };
+    assert!(
+        observer_record_0.0.verify_with_cert(&observer_record_0.1),
+        "observer epoch-0 record fails self-verify after pack import"
+    );
+    assert_eq!(
+        observer_record_0.0, validator_record_0.0,
+        "observer epoch-0 record diverges from validator after pack import"
+    );
+
+    // Final liveness check: a transaction submitted to the observer is confirmed by a
+    // validator. This proves the observer is fully synced post-pack-import and not just
+    // serving stale state.
+    let key = get_key("test-source");
+    let to_account = address_from_word("observer-pack-import-target");
+    send_and_confirm(&obs_url, &client_urls[1], &key, to_account, 0)?;
+
+    guard.kill_all();
+    Ok(())
+}

--- a/crates/test-utils-committee/src/builder.rs
+++ b/crates/test-utils-committee/src/builder.rs
@@ -165,7 +165,7 @@ where
         // Make the committee so we can give it the AuthorityFixtures below.
         let committee = Committee::new_for_test(
             authorities.into_iter().map(|(k, (_, _, a))| (k, a)).collect(),
-            0,
+            self.epoch,
             bootstrap_servers,
         );
         let genesis = test_genesis();


### PR DESCRIPTION
- Adds `test_observer_pack_imports_after_epoch_close` (e2e): starts 4 validators with a 10s epoch duration, waits for epoch 0 to close and certify on the validator side, then starts a fresh observer so the only catch-up path is `consensus_pack::stream_import`. Asserts the observer reaches the validator's consensus height, returns a self-verifying epoch-0 record that matches the validator's byte-for-byte, and confirms a transaction submitted to the observer — pinning down the parent-hash convention fix from #674 (Finding F2).
- Adds `test_vote_succeeds_with_stale_prior_epoch_vote_info` (primary unit): seeds the `Votes` table with an epoch-0 entry, submits an epoch-1 header from the same author, and asserts the handler returns `PrimaryResponse::Vote` and overwrites the stale row — pinning down the `header.epoch() > vote_info.epoch()` defensive branch from #674 (Findings F1 / F6).
- Threads `CommitteeFixture::epoch` through to `Committee::new_for_test` so fixtures actually report the requested epoch (was hardcoded to `0`); needed by the new vote test.
- Adds `config_local_testnet_with_epoch_duration` so e2e tests can override the genesis 8-hour epoch default; original `config_local_testnet` is preserved as a thin wrapper.
- Moves shared process / key / balance / tx helpers from `restarts.rs` into `common.rs` so both `restarts.rs` and the new `sync.rs` module can use them. No behaviour change in `restarts.rs`.

closes #675