### PR TITLE
Kad improvements

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -113,6 +113,15 @@ pub struct LibP2pConfig {
     pub px_disconnect_timeout: Duration,
     /// The k-bucket size for kademlia.
     pub k_bucket_size: NonZeroUsize,
+    /// The TTL applied to kademlia records — both the libp2p record TTL and the
+    /// local store's `expires` timestamp. Drives eviction of records that are
+    /// never refreshed. Also used for provider record TTL.
+    pub kad_record_ttl: Duration,
+    /// How often this node republishes its own kademlia records.
+    ///
+    /// Must be < `kad_record_ttl`, otherwise records expire before they are
+    /// refreshed.
+    pub kad_publication_interval: Duration,
 }
 
 impl LibP2pConfig {
@@ -165,6 +174,8 @@ impl Default for LibP2pConfig {
             max_px_disconnects: 10,
             px_disconnect_timeout: Duration::from_secs(3),
             k_bucket_size: K_VALUE,
+            kad_record_ttl: Duration::from_secs(48 * 60 * 60),
+            kad_publication_interval: Duration::from_secs(12 * 60 * 60),
         }
     }
 }

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -31,7 +31,7 @@ use libp2p::{
 };
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
 use tn_types::{
@@ -257,15 +257,14 @@ where
         let mut kad_config = libp2p::kad::Config::new(DEFAULT_KAD_PROTO_NAME);
         // manually add peers
         kad_config.set_kbucket_inserts(kad::BucketInserts::Manual);
-        kad_config.set_kbucket_size(network_config.libp2p_config().k_bucket_size);
-        let two_days = Some(Duration::from_secs(48 * 60 * 60));
-        let twelve_hours = Some(Duration::from_secs(12 * 60 * 60));
+        let libp2p = network_config.libp2p_config();
+        kad_config.set_kbucket_size(libp2p.k_bucket_size);
         kad_config
-            .set_record_ttl(two_days)
+            .set_record_ttl(Some(libp2p.kad_record_ttl))
             .set_record_filtering(kad::StoreInserts::FilterBoth)
-            .set_publication_interval(twelve_hours)
+            .set_publication_interval(Some(libp2p.kad_publication_interval))
             .set_query_timeout(Duration::from_secs(60))
-            .set_provider_record_ttl(two_days);
+            .set_provider_record_ttl(Some(libp2p.kad_record_ttl));
         let kad_store = KadStore::new(db.clone(), &key_config, kad_type);
         let kademlia = kad::Behaviour::with_config(peer_id, kad_store.clone(), kad_config);
 
@@ -357,11 +356,14 @@ where
     /// Return None if we don't have any confirmed external addresses yet.
     fn get_peer_record(&self) -> kad::Record {
         let key = kad::RecordKey::new(&self.key_config.primary_public_key());
+        // libp2p's `set_record_ttl` drives republish, not eviction — the local store
+        // can only evict rows that carry an `expires`.
+        let expires = Instant::now().checked_add(self.config.kad_record_ttl);
         kad::Record {
             key: key.clone(),
             value: encode(&self.node_record),
             publisher: Some(*self.swarm.local_peer_id()),
-            expires: None, // never expire
+            expires,
         }
     }
 

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -166,6 +166,14 @@ where
     ///
     /// The external address is self-reported and unconfirmed.
     node_record: NodeRecord,
+    /// Peers we have already pushed our [NodeRecord] to.
+    ///
+    /// A peer connecting for the first time needs our record before it can resolve
+    /// our BLS key, so we push it on `PeerConnected`. A peer that reconnects (or that
+    /// flaps repeatedly, as observed with banned peers in adiri testnet) should already have
+    /// the record in their persistent kad store. This list is per-process-lifetime in case nodes
+    /// restart.
+    published_to_peers: HashSet<PeerId>,
 }
 
 impl<Req, Res, DB, Events> ConsensusNetwork<Req, Res, DB, Events>
@@ -333,6 +341,7 @@ where
             key_config,
             task_spawner,
             node_record,
+            published_to_peers: HashSet::new(),
         })
     }
 
@@ -405,8 +414,11 @@ where
         }
     }
 
-    /// Publish our network addresses and peer id AND to the network under our BLS public key for
-    /// discovery.
+    /// Push our [NodeRecord] to a specific peer and to the DHT.
+    ///
+    /// Used on first-time connections so the remote peer can resolve our BLS key
+    /// without waiting for the kad publication interval (12h). Callers must
+    /// short-circuit on reconnects - see [`Self::published_to_peers`]
     fn publish_our_data_to_peer(&mut self, peer: PeerId) {
         let record = self.get_peer_record();
         info!(target: "network-kad", "Publishing our record to kademlia");
@@ -461,9 +473,13 @@ where
                 TNBehaviorEvent::Kademlia(event) => self.process_kad_event(event)?,
                 TNBehaviorEvent::Stream(event) => self.process_stream_event(event)?,
             },
-            SwarmEvent::ExternalAddrConfirmed { address: _ } => {
-                // New confirmed address so lets publish/update or kademlia address rocord.
-                self.provide_our_data();
+            SwarmEvent::ExternalAddrConfirmed { address } => {
+                // protocol expects static IP address
+                // emit warning if peers report different external address
+                let expected = &self.node_record.info().multiaddrs;
+                if !expected.contains(&address) {
+                    warn!(target: "network", ?expected, reported=?address, "peer reporting different external addr:")
+                }
             }
             SwarmEvent::ExpiredListenAddr { address, .. } => {
                 debug!(
@@ -1081,12 +1097,32 @@ where
                 self.connected_peers.retain(|peer| *peer != peer_id);
             }
             PeerEvent::PeerConnected(peer_id, addr) => {
+                // Defense in depth: even if the peer-manager `handle_established_*_connection`
+                // path lets a banned peer reach this event (observed in adiri testnet logs),
+                // refuse to register the connection with kademlia/gossipsub. Otherwise the
+                // banned peer ends up in the kad routing table and triggers a redial loop.
+                if self.swarm.behaviour().peer_manager.peer_banned(&peer_id) {
+                    debug!(
+                        target: "network",
+                        ?peer_id,
+                        "PeerConnected for banned peer — refusing to register"
+                    );
+                    let _ = self.swarm.disconnect_peer_id(peer_id);
+                    return Ok(());
+                }
+
                 // register peer for request-response behaviour
                 // NOTE: gossipsub handles `FromSwarm::ConnectionEstablished`
                 self.swarm.add_peer_address(peer_id, addr.clone());
                 // add as a kademlia peer
                 self.swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
-                self.publish_our_data_to_peer(peer_id);
+
+                // First-time connections need a direct record push so the peer can resolve
+                // our BLS key without waiting for the next kad publication interval. Skip
+                // on reconnects to avoid amplifying the local kad store on flapping peers
+                if self.published_to_peers.insert(peer_id) {
+                    self.publish_our_data_to_peer(peer_id);
+                }
 
                 // manage connected peers for
                 self.connected_peers.push_back(peer_id);

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -1259,9 +1259,6 @@ where
                     kad::QueryResult::GetRecord(Ok(
                         kad::GetRecordOk::FinishedWithNoAdditionalRecord { cache_candidates },
                     )) => {
-                        // TODO: configure caching and see issue #301
-                        // self.swarm.behaviour_mut().kademlia.put_record_to(record, peers, quorum);
-
                         debug!(target: "network-kad", ?cache_candidates, "FinishedWithNoAdditionalRecord - failed to find record");
                         self.close_kad_query(&query_id);
                     }
@@ -1282,7 +1279,7 @@ where
                         );
                     }
                     kad::QueryResult::PutRecord(Err(err)) => {
-                        error!(target: "network-kad", "Failed to put record: {err:?}");
+                        debug!(target: "network-kad", "Failed to put record: {err:?}");
                     }
                     kad::QueryResult::StartProviding(Ok(kad::AddProviderOk { key })) => {
                         debug!(

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -756,6 +756,18 @@ where
                 // without any intermediate tracking.
                 self.swarm.behaviour_mut().stream.open_stream(peer_id, reply);
             }
+            #[cfg(test)]
+            NetworkCommand::KadStoreGet { key, reply } => {
+                let record_key = kad::RecordKey::new(&key);
+                let record = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .get(&record_key)
+                    .map(|cow| cow.into_owned());
+                let _ = reply.send(record);
+            }
         }
 
         Ok(())

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -31,7 +31,7 @@ use libp2p::{
 };
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    time::{Duration, Instant},
+    time::Duration,
 };
 use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
 use tn_types::{
@@ -365,14 +365,15 @@ where
     /// Return None if we don't have any confirmed external addresses yet.
     fn get_peer_record(&self) -> kad::Record {
         let key = kad::RecordKey::new(&self.key_config.primary_public_key());
-        // libp2p's `set_record_ttl` drives republish, not eviction — the local store
-        // can only evict rows that carry an `expires`.
-        let expires = Instant::now().checked_add(self.config.kad_record_ttl);
+        // Leave `expires: None` for our OWN record so libp2p's PutRecordJob
+        // recomputes a fresh `now + kad_record_ttl` on every replication snapshot
+        // (see libp2p-kad jobs.rs:217-221). The configured `kad_record_ttl` still
+        // drives the wire-level expiry that remote peers store.
         kad::Record {
             key: key.clone(),
             value: encode(&self.node_record),
             publisher: Some(*self.swarm.local_peer_id()),
-            expires,
+            expires: None,
         }
     }
 

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -422,6 +422,9 @@ impl<DB: Database> RecordStore for KadStore<DB> {
                 }
             }
             if !found {
+                // prune expired entries before checking the cap
+                let now = SystemTime::now();
+                recs.retain(|r| !r.is_expired(now));
                 if recs.len() >= self.config.max_providers_per_key {
                     return Err(Error::MaxProvidedKeys);
                 }

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -56,6 +56,20 @@ impl fmt::Debug for KadRecord {
     }
 }
 
+impl KadRecord {
+    /// Returns true if the record carries an expiry that has already passed.
+    fn is_expired(&self, now: SystemTime) -> bool {
+        matches!(self.expires, Some(exp) if exp <= now)
+    }
+}
+
+impl KadProviderRecord {
+    /// Returns true if the provider record carries an expiry that has already passed.
+    fn is_expired(&self, now: SystemTime) -> bool {
+        matches!(self.expires, Some(exp) if exp <= now)
+    }
+}
+
 impl From<Record> for KadRecord {
     fn from(value: Record) -> Self {
         let expires = instant_to_system(&value.expires);
@@ -199,6 +213,78 @@ impl<DB: Database> KadStore<DB> {
         h.update(encode(key).as_ref());
         BlockHash::from_slice(h.finalize().as_bytes())
     }
+
+    /// Scan the records table and remove any rows whose expiry has passed.
+    /// Returns the number of rows actually removed and updates `num_records`.
+    fn evict_expired_records(&mut self) -> usize {
+        let now = SystemTime::now();
+        let expired_keys: Vec<BlockHash> = match self.kad_type {
+            KadStoreType::Primary => self
+                .db
+                .iter::<KadRecords>()
+                .filter_map(|(k, v)| {
+                    let r: KadRecord = decode(v.as_ref());
+                    r.is_expired(now).then_some(k)
+                })
+                .collect(),
+            KadStoreType::Worker => self
+                .db
+                .iter::<KadWorkerRecords>()
+                .filter_map(|(k, v)| {
+                    let r: KadRecord = decode(v.as_ref());
+                    r.is_expired(now).then_some(k)
+                })
+                .collect(),
+        };
+        let mut evicted = 0;
+        for k in &expired_keys {
+            let ok = match self.kad_type {
+                KadStoreType::Primary => self.db.remove::<KadRecords>(k).is_ok(),
+                KadStoreType::Worker => self.db.remove::<KadWorkerRecords>(k).is_ok(),
+            };
+            if ok {
+                evicted += 1;
+            }
+        }
+        self.num_records = self.num_records.saturating_sub(evicted);
+        evicted
+    }
+
+    /// Scan provider records and drop any key whose entire `Vec<KadProviderRecord>` has expired.
+    /// Returns the number of keys removed and updates `num_providers`.
+    fn evict_expired_providers(&mut self) -> usize {
+        let now = SystemTime::now();
+        let drop_keys: Vec<BlockHash> = match self.kad_type {
+            KadStoreType::Primary => self
+                .db
+                .iter::<KadProviderRecords>()
+                .filter_map(|(k, v)| {
+                    let recs: Vec<KadProviderRecord> = decode(v.as_ref());
+                    (!recs.is_empty() && recs.iter().all(|r| r.is_expired(now))).then_some(k)
+                })
+                .collect(),
+            KadStoreType::Worker => self
+                .db
+                .iter::<KadWorkerProviderRecords>()
+                .filter_map(|(k, v)| {
+                    let recs: Vec<KadProviderRecord> = decode(v.as_ref());
+                    (!recs.is_empty() && recs.iter().all(|r| r.is_expired(now))).then_some(k)
+                })
+                .collect(),
+        };
+        let mut evicted = 0;
+        for k in &drop_keys {
+            let ok = match self.kad_type {
+                KadStoreType::Primary => self.db.remove::<KadProviderRecords>(k).is_ok(),
+                KadStoreType::Worker => self.db.remove::<KadWorkerProviderRecords>(k).is_ok(),
+            };
+            if ok {
+                evicted += 1;
+            }
+        }
+        self.num_providers = self.num_providers.saturating_sub(evicted);
+        evicted
+    }
 }
 
 /// Iterator of KAD records.
@@ -216,10 +302,15 @@ impl<'a> Iterator for RecordIter<'a> {
     type Item = Cow<'a, Record>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(_, r)| {
-            let r: KadRecord = decode(r.as_ref());
-            Cow::Owned(r.into())
-        })
+        let now = SystemTime::now();
+        loop {
+            let (_, raw) = self.iter.next()?;
+            let r: KadRecord = decode(raw.as_ref());
+            if r.is_expired(now) {
+                continue;
+            }
+            return Some(Cow::Owned(r.into()));
+        }
     }
 }
 
@@ -237,10 +328,12 @@ impl<DB: Database> RecordStore for KadStore<DB> {
             KadStoreType::Primary => self.db.get::<KadRecords>(&key).ok()?,
             KadStoreType::Worker => self.db.get::<KadWorkerRecords>(&key).ok()?,
         };
-        record.map(|r| {
-            let r: KadRecord = decode(r.as_ref());
-            Cow::Owned(r.into())
-        })
+        let raw = record?;
+        let r: KadRecord = decode(raw.as_ref());
+        if r.is_expired(SystemTime::now()) {
+            return None;
+        }
+        Some(Cow::Owned(r.into()))
     }
 
     fn put(&mut self, r: Record) -> libp2p::kad::store::Result<()> {
@@ -263,10 +356,13 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         // Should be safe since a failure to insert indicates a fatal DB condition.
         if new_record {
             if self.num_records >= self.config.max_records {
-                return Err(Error::MaxRecords);
-            } else {
-                self.num_records += 1;
+                // Try to free a slot by evicting any records whose TTL has passed.
+                self.evict_expired_records();
+                if self.num_records >= self.config.max_records {
+                    return Err(Error::MaxRecords);
+                }
             }
+            self.num_records += 1;
         }
         match self.kad_type {
             KadStoreType::Primary => self
@@ -303,8 +399,12 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     }
 
     fn add_provider(&mut self, record: ProviderRecord) -> libp2p::kad::store::Result<()> {
-        if self.config.max_provided_keys == self.num_providers {
-            return Err(Error::MaxProvidedKeys);
+        if self.num_providers >= self.config.max_provided_keys {
+            // Try to free a slot by evicting fully-expired provider key groups.
+            self.evict_expired_providers();
+            if self.num_providers >= self.config.max_provided_keys {
+                return Err(Error::MaxProvidedKeys);
+            }
         }
         let key = self.key_to_hash(&record.key);
         let kr: KadProviderRecord = record.into();
@@ -356,9 +456,13 @@ impl<DB: Database> RecordStore for KadStore<DB> {
             KadStoreType::Primary => self.db.get::<KadProviderRecords>(&key),
             KadStoreType::Worker => self.db.get::<KadWorkerProviderRecords>(&key),
         } {
+            let now = SystemTime::now();
             let records: Vec<KadProviderRecord> = decode(&recs);
-            let records: Vec<ProviderRecord> = records.into_iter().map(|r| r.into()).collect();
             records
+                .into_iter()
+                .filter(|r| !r.is_expired(now))
+                .map(|r| r.into())
+                .collect()
         } else {
             vec![]
         }
@@ -733,6 +837,49 @@ mod test {
         assert_eq!(kad_store_worker.num_providers, 1);
         kad_store_worker.remove_provider(&provider_rec3.key, &provider_rec3.provider);
         assert_eq!(kad_store_worker.num_providers, 0);
+    }
+
+    /// Expired records must be filtered from `get()` and `records()` even though
+    /// they remain on disk until `put()` triggers eviction.
+    #[test]
+    fn test_kad_expired_records_filtered_on_read() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config =
+            KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
+        let mut kad_store = KadStore::new(db, &key_config, KadStoreType::Primary);
+
+        let expired = test_record(true);
+        kad_store.put(expired.clone()).expect("put expired record");
+        assert_eq!(kad_store.num_records, 1, "row was written to disk");
+
+        assert!(kad_store.get(&expired.key).is_none(), "get filters expired");
+        assert_eq!(kad_store.records().count(), 0, "records() filters expired");
+    }
+
+    /// When the store is full of expired records, a new put should evict them and succeed.
+    #[test]
+    fn test_kad_put_evicts_expired_when_full() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config =
+            KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
+        let mut kad_store = KadStore::new(db, &key_config, KadStoreType::Primary);
+
+        let config = MemoryStoreConfig::default();
+
+        // Saturate the store with already-expired records.
+        for _ in 0..config.max_records {
+            let rec = test_record(true);
+            kad_store.put(rec).expect("put expired record");
+        }
+        assert_eq!(kad_store.num_records, config.max_records);
+
+        // A live record under a brand-new key must succeed: the put path evicts expired rows.
+        let fresh = test_record(false);
+        kad_store.put(fresh.clone()).expect("eviction must make room");
+        assert_eq!(kad_store.num_records, 1, "only the fresh row should remain");
+        assert!(kad_store.get(&fresh.key).is_some(), "fresh record retained");
     }
 
     /// Test that we do not count duplicate puts against our max records.

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -458,11 +458,7 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         } {
             let now = SystemTime::now();
             let records: Vec<KadProviderRecord> = decode(&recs);
-            records
-                .into_iter()
-                .filter(|r| !r.is_expired(now))
-                .map(|r| r.into())
-                .collect()
+            records.into_iter().filter(|r| !r.is_expired(now)).map(|r| r.into()).collect()
         } else {
             vec![]
         }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1719,7 +1719,11 @@ async fn test_newer_kad_record_replaced() -> eyre::Result<()> {
         .store_mut()
         .get(&peer2_new_record.key)
         .expect("peer2 record in local kad store");
-    assert_eq!(old_kad_record, *store_record);
+    // Records carry an `Instant` `expires`, which loses precision across the
+    // SystemTime <-> Instant round-trip in `KadRecord`. Compare the stable fields.
+    assert_eq!(old_kad_record.key, store_record.key);
+    assert_eq!(old_kad_record.value, store_record.value);
+    assert_eq!(old_kad_record.publisher, store_record.publisher);
 
     // process new put request with newer record
     network
@@ -1732,7 +1736,9 @@ async fn test_newer_kad_record_replaced() -> eyre::Result<()> {
         .store_mut()
         .get(&peer2_new_record.key)
         .expect("peer2 record in local kad store");
-    assert_eq!(*store_record, peer2_new_record);
+    assert_eq!(store_record.key, peer2_new_record.key);
+    assert_eq!(store_record.value, peer2_new_record.value);
+    assert_eq!(store_record.publisher, peer2_new_record.publisher);
 
     Ok(())
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -70,6 +70,10 @@ fn create_test_peers<Req: TNMessage, Res: TNMessage>(
     (target, peers, task_manager)
 }
 
+/// ConsensusNetwork backed by in-memory kad store.
+type ConsensusNetworkMemoryDB<Req, Res> =
+    ConsensusNetwork<Req, Res, MemDatabase, mpsc::Sender<NetworkEvent<Req, Res>>>;
+
 /// A peer on TN
 struct TestPeer<Req, Res, DB = MemDatabase>
 where
@@ -83,8 +87,7 @@ where
     /// Network handle to send commands.
     network_handle: NetworkHandle<Req, Res>,
     /// The network task.
-    #[allow(clippy::type_complexity)]
-    network: Option<ConsensusNetwork<Req, Res, MemDatabase, mpsc::Sender<NetworkEvent<Req, Res>>>>,
+    network: Option<ConsensusNetworkMemoryDB<Req, Res>>,
 }
 /// A peer on TN
 struct NetworkPeer<Req, Res, DB = MemDatabase>
@@ -123,8 +126,21 @@ where
     Req: TNMessage,
     Res: TNMessage,
 {
+    create_test_types_with_config::<Req, Res>(NetworkConfig::default())
+}
+
+/// Variant of [`create_test_types`] that lets a caller customize [`NetworkConfig`]
+/// (e.g. shrink `kad_record_ttl` for a regression test).
+///
+/// The heartbeat-interval override applied by `create_test_types` is preserved here
+/// so callers can opt into a custom kad TTL without having to also remember the
+/// short heartbeat the peer manager needs in tests.
+fn create_test_types_with_config<Req, Res>(mut network_config: NetworkConfig) -> TestTypes<Req, Res>
+where
+    Req: TNMessage,
+    Res: TNMessage,
+{
     // custom network config with short heartbeat interval for peer manager
-    let mut network_config = NetworkConfig::default();
     network_config.peer_config_mut().heartbeat_interval = TEST_HEARTBEAT_INTERVAL;
 
     let all_nodes =
@@ -1688,6 +1704,104 @@ async fn test_node_record_validation() {
     // assert publisher mismatch fails
     peer_record.publisher = Some(peer2.network.swarm.local_peer_id().clone());
     assert!(network.peer_record_valid(&peer_record).is_none());
+}
+
+#[tokio::test]
+async fn test_local_record_has_no_expiry() {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let record = peer1.network.get_peer_record();
+    // Must be `None`. libp2p's PutRecordJob::poll only refreshes `expires` via
+    // `.or_else(...)`, so a `Some(_)` value here causes the local RecordIter to
+    // filter our row after `kad_record_ttl` and the node goes invisible. See
+    // get_peer_record() for the full reasoning.
+    assert!(
+        record.expires.is_none(),
+        "local record must have expires: None (see nemesis-1 in security-eval-kad-table-bug.md)"
+    );
+}
+
+/// End-to-end check on the nemesis-1 fix: peer 1's *own* record must survive
+/// past `kad_record_ttl` (because `get_peer_record` sets `expires: None` and
+/// libp2p's `PutRecordJob` keeps refreshing it), while peer 1's *copy of peer
+/// 2's* record must drop off the read path once `expires: Some(_)` (filled in
+/// by peer 2's libp2p before sending) lapses with no further republishes.
+#[tokio::test]
+async fn test_killed_peer_record_expires_local_record_survives() -> eyre::Result<()> {
+    // Short TTL keeps the test fast. Publication interval is the libp2p check
+    // cadence for record refresh — must be < TTL.
+    let short_ttl = Duration::from_secs(2);
+    let mut network_config = NetworkConfig::default();
+    network_config.libp2p_config_mut().kad_record_ttl = short_ttl;
+    network_config.libp2p_config_mut().kad_publication_interval = Duration::from_millis(500);
+
+    let TestTypes { peer1, peer2, _task_manager } =
+        create_test_types_with_config::<TestWorkerRequest, TestWorkerResponse>(network_config);
+
+    let NetworkPeer {
+        config: config_1, network_handle: peer1_handle, network: peer1_network, ..
+    } = peer1;
+    let NetworkPeer {
+        config: config_2, network_handle: peer2_handle, network: peer2_network, ..
+    } = peer2;
+
+    let peer1_bls = config_1.key_config().primary_public_key();
+    let peer2_bls = config_2.key_config().primary_public_key();
+    let peer2_net = config_2.primary_networkkey();
+    let peer2_addr = config_2.primary_address();
+
+    let peer1_task = tokio::spawn(async move { peer1_network.run().await });
+    let peer2_task = tokio::spawn(async move { peer2_network.run().await });
+
+    peer1_handle.start_listening(config_1.primary_address()).await?;
+    peer2_handle.start_listening(peer2_addr.clone()).await?;
+
+    // Wire peer1 -> peer2 and wait for kad cross-publication.
+    peer1_handle.add_trusted_peer_and_dial(peer2_bls, peer2_net, peer2_addr).await?;
+    wait_for_peer_discovery(&peer1_handle, peer2_bls, Duration::from_secs(5)).await?;
+
+    // Poll until peer1 has stored peer2's record. `publish_our_data_to_peer`
+    // fires on PeerConnected, but the actual record-store write only lands
+    // after a round trip.
+    let kad_recv_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if peer1_handle.kad_store_get(peer2_bls).await?.is_some() {
+            break;
+        }
+        if tokio::time::Instant::now() >= kad_recv_deadline {
+            return Err(eyre!("timed out waiting for peer1 to receive peer2's kad record"));
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Sanity: peer1's own record also present before peer2 dies.
+    assert!(
+        peer1_handle.kad_store_get(peer1_bls).await?.is_some(),
+        "own record present after startup"
+    );
+
+    // Kill peer2 — no more republishes can refresh peer1's stored copy.
+    peer2_task.abort();
+    let _ = peer2_task.await;
+
+    // Wait past kad_record_ttl. Buffer covers SystemTime/Instant rounding.
+    tokio::time::sleep(short_ttl + Duration::from_secs(1)).await;
+
+    // Invariant 1: peer1's own record (expires: None) is still readable.
+    assert!(
+        peer1_handle.kad_store_get(peer1_bls).await?.is_some(),
+        "local record must survive past kad_record_ttl (regression on nemesis-1 fix)"
+    );
+
+    // Invariant 2: peer1's copy of peer2's record (expires: Some(_)) is filtered on read.
+    assert!(
+        peer1_handle.kad_store_get(peer2_bls).await?.is_none(),
+        "expired peer record must not be returned from kad store"
+    );
+
+    peer1_task.abort();
+    let _ = peer1_task.await;
+    drop(_task_manager);
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -309,6 +309,17 @@ where
         /// Channel for returning the established stream to application layer.
         reply: oneshot::Sender<NetworkResult<Stream>>,
     },
+    /// Read a single record from the local kad store by BLS key.
+    ///
+    /// Test-only observation hook used to assert local-store eviction
+    /// behavior from a spawned-network test. See `kad_store_get`.
+    #[cfg(test)]
+    KadStoreGet {
+        /// The BLS public key the record is stored under.
+        key: BlsPublicKey,
+        /// Reply with the record if one exists in the local store.
+        reply: oneshot::Sender<Option<libp2p::kad::Record>>,
+    },
 }
 
 /// Wrap a network response.
@@ -725,5 +736,20 @@ where
         let (reply, to_caller) = oneshot::channel();
         self.sender.send(NetworkCommand::SendRequestDirect { peer, request, reply }).await?;
         Ok(to_caller)
+    }
+
+    /// Read a single record from the local kad store by BLS key.
+    ///
+    /// Test-only observation hook so a spawned-network test can assert on
+    /// kad store contents that are otherwise unreachable once the network is
+    /// running on its own task.
+    #[cfg(test)]
+    pub(crate) async fn kad_store_get(
+        &self,
+        key: BlsPublicKey,
+    ) -> NetworkResult<Option<libp2p::kad::Record>> {
+        let (reply, rx) = oneshot::channel();
+        self.sender.send(NetworkCommand::KadStoreGet { key, reply }).await?;
+        rx.await.map_err(Into::into)
     }
 }


### PR DESCRIPTION
- Set `expires = now + kad_record_ttl` on our own `NodeRecord` so the local store can actually evict it; libp2p's record TTL only drives republish, not eviction.
- Move `kad_record_ttl` (48h) and `kad_publication_interval` (12h) from hardcoded `ConsensusNetwork::new` constants into `LibP2pConfig` so operators can tune them.
- `KadStore` now filters expired records on `get` / `records` / `providers` and opportunistically sweeps expired rows on `put` / `add_provider` when at capacity, so a saturated store of stale rows self-heals on the next put instead of returning `MaxRecords`. Provider keys drop only when all providers under the key have expired.
- Track `published_to_peers` per process and skip the direct record push on reconnects — the remote already has it in its persistent kad store. Cuts amplification from flapping/banned peers seen in adiri.
- `ExternalAddrConfirmed` no longer re-publishes; the external address is static, so a mismatch just warns.
- `PeerConnected` now re-checks `peer_manager.peer_banned` and refuses to register banned peers with kad/gossipsub, backstopping the upstream peer-manager guard.
- `PutRecord` failures drop from `error!` to `debug!` (routine when peers are unreachable, was flooding logs).
- Two new unit tests cover (1) expired records being filtered from reads and (2) `put` evicting expired rows when the store is full. One existing test loosened to compare stable fields only, because `Instant`-encoded `expires` doesn't survive the `SystemTime` ↔ `Instant` round-trip exactly.

closes #682 