### PR TITLE
use serde default to deserialize missing fields on network config

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -10,6 +10,7 @@ impl ConfigTrait for NetworkConfig {}
 
 /// The container for all network configurations.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[serde(default)]
 pub struct NetworkConfig {
     /// The configurations for libp2p library.
     ///
@@ -78,6 +79,7 @@ impl NetworkConfig {
 
 /// Configurations for libp2p library.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct LibP2pConfig {
     /// The supported inbound/outbound protocols for request/response behavior.
     /// - ex) "/telcoin-network/mainnet/0.0.1"
@@ -182,6 +184,7 @@ impl Default for LibP2pConfig {
 
 /// Configuration for state syncing operations.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct SyncConfig {
     /// Maximum number of rounds that can be skipped for a single authority when requesting missing
     /// certificates.
@@ -253,6 +256,7 @@ impl Default for SyncConfig {
 
 /// Configure the quic transport for libp2p.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct QuicConfig {
     /// Timeout for the initial handshake when establishing a connection.
     /// The actual timeout is the minimum of this and the [`Config::max_idle_timeout`].
@@ -294,6 +298,7 @@ impl Default for QuicConfig {
 
 /// Configurations for network peers.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(default)]
 pub struct PeerConfig {
     /// The interval (secs) for updating peer status.
     pub heartbeat_interval: u64,
@@ -404,6 +409,7 @@ impl PeerConfig {
 
 /// Configuration for peer scoring parameters
 #[derive(Serialize, Deserialize, Clone, Debug, Copy)]
+#[serde(default)]
 pub struct ScoreConfig {
     /// The default score for new peers.
     pub default_score: f64,
@@ -511,5 +517,96 @@ mod protocol_vec {
                 Ok((protocol, support))
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_yaml_deserializes_to_default() {
+        let parsed: NetworkConfig = serde_yaml::from_str("{}").expect("empty mapping deserializes");
+        let default = NetworkConfig::default();
+
+        assert_eq!(parsed.hostname, default.hostname);
+        assert_eq!(parsed.libp2p_config.kad_record_ttl, default.libp2p_config.kad_record_ttl);
+        assert_eq!(
+            parsed.libp2p_config.kad_publication_interval,
+            default.libp2p_config.kad_publication_interval
+        );
+        assert_eq!(parsed.peer_config.target_num_peers, default.peer_config.target_num_peers);
+        assert_eq!(
+            parsed.sync_config.max_skip_rounds_for_missing_certs,
+            default.sync_config.max_skip_rounds_for_missing_certs
+        );
+        assert_eq!(parsed.quic_config.max_idle_timeout, default.quic_config.max_idle_timeout);
+    }
+
+    #[test]
+    fn partial_yaml_uses_defaults_for_missing_fields() {
+        // libp2p_config provided with only a subset of fields; the two new kad
+        // fields (and others) are absent and must fall back to defaults.
+        let yaml = r#"
+libp2p_config:
+  supported_req_res_protocols:
+    - - /telcoin-network/0.0.0
+      - full
+  max_rpc_message_size: 2097152
+  max_gossip_message_size: 12000
+  max_idle_connection_timeout:
+    secs: 65
+    nanos: 0
+  max_px_disconnects: 10
+  px_disconnect_timeout:
+    secs: 3
+    nanos: 0
+  k_bucket_size: 20
+hostname: "my-validator"
+"#;
+        let parsed: NetworkConfig =
+            serde_yaml::from_str(yaml).expect("partial config deserializes");
+        let default = LibP2pConfig::default();
+
+        // explicitly-set field is preserved
+        assert_eq!(parsed.libp2p_config.max_rpc_message_size, 2 * 1024 * 1024);
+        assert_eq!(parsed.hostname, "my-validator");
+
+        // missing new fields fall back to defaults
+        assert_eq!(parsed.libp2p_config.kad_record_ttl, default.kad_record_ttl);
+        assert_eq!(parsed.libp2p_config.kad_publication_interval, default.kad_publication_interval);
+
+        // entirely-missing sub-sections also default
+        assert_eq!(parsed.peer_config.target_num_peers, PeerConfig::default().target_num_peers);
+    }
+
+    #[test]
+    fn legacy_libp2p_config_without_kad_fields_deserializes() {
+        let default = LibP2pConfig::default();
+        let serialized = serde_yaml::to_string(&default).expect("serialize default");
+
+        // Round-trip through serde_yaml::Value so we can drop the two new
+        // kad fields cleanly without depending on their serialized layout
+        // (Duration serializes as a multi-line mapping).
+        let mut value: serde_yaml::Value =
+            serde_yaml::from_str(&serialized).expect("serialized default re-parses");
+        let mapping = value.as_mapping_mut().expect("libp2p config is a mapping");
+        assert!(
+            mapping.remove(&serde_yaml::Value::String("kad_record_ttl".into())).is_some(),
+            "kad_record_ttl must be present in the default serialization"
+        );
+        assert!(
+            mapping.remove(&serde_yaml::Value::String("kad_publication_interval".into())).is_some(),
+            "kad_publication_interval must be present in the default serialization"
+        );
+        let legacy = serde_yaml::to_string(&value).expect("serialize stripped value");
+
+        let parsed: LibP2pConfig =
+            serde_yaml::from_str(&legacy).expect("legacy yaml without kad fields parses");
+
+        assert_eq!(parsed.kad_record_ttl, default.kad_record_ttl);
+        assert_eq!(parsed.kad_publication_interval, default.kad_publication_interval);
+        assert_eq!(parsed.max_rpc_message_size, default.max_rpc_message_size);
+        assert_eq!(parsed.k_bucket_size, default.k_bucket_size);
     }
 }


### PR DESCRIPTION
- use serde default for network config
- add regression test for network config

closes #685 