### PR TITLE
Reduce penalties to prevent ban cascades on WAN

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -437,8 +437,15 @@ impl Default for ScoreConfig {
             min_application_score_before_ban: -60.0,
             max_score: 100.0,
             min_score: -100.0,
-            score_halflife: 600.0,
-            banned_before_decay_secs: 12 * 3600, // 12 hours
+            // 5-minute halflife: transient WAN penalties (peer flap, slow request) decay
+            // out within a couple of half-lives so they do not accumulate across the
+            // observer-join window.
+            score_halflife: 300.0,
+            // Short lockout so a peer that crosses the ban threshold can recover within
+            // one operator-attention window. DoS protection comes from the ban threshold
+            // itself, not from the lockout duration — a peer that keeps misbehaving will
+            // simply hit the threshold again.
+            banned_before_decay_secs: 30 * 60, // 30 minutes
             min_score_before_disconnect: -20.0,
             min_score_before_ban: -50.0,
         }

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -112,8 +112,10 @@ impl From<&PrimaryNetworkError> for Option<Penalty> {
                 | CertManagerError::ChannelClosed
                 | CertManagerError::TNSend(_) => None,
             },
-            | PrimaryNetworkError::InvalidRequest(_)
-            | PrimaryNetworkError::UnknownConsensusHeaderDigest(_)
+            // Benign "miss": observers legitimately request not-yet-served headers.
+            // No penalty so honest sync flows are not banned during catch-up.
+            PrimaryNetworkError::UnknownConsensusHeaderDigest(_) => None,
+            PrimaryNetworkError::InvalidRequest(_)
             | PrimaryNetworkError::UnknownStreamRequest(_)
             | PrimaryNetworkError::UnknownConsensusHeaderCert(_) => Some(Penalty::Mild),
             PrimaryNetworkError::InvalidEpochRequest

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -711,13 +711,14 @@ where
             tokio::select! {
                 header =
                     request_handler.retrieve_consensus_header(number, hash) => {
-                        // Penalize peer's reputation for bad request.
-                        // This could happen now and then and not be malicious so use a Mild only
-                        // to close any DOS attack.
+                        // A peer asking for a header we cannot return is not a misbehavior
+                        // signal — observers legitimately request headers that have not yet
+                        // been served. Log the miss and respond with the error; do not
+                        // penalize. DoS protection is provided by req_res concurrency limits
+                        // and gossipsub rate limits, not by penalizing sync requests.
                         if let Err(e) = &header {
                             let my_number = request_handler.consensus_chain().latest_consensus_number();
-                            tracing::warn!(target: "primary::network", ?e, ?my_number, ?number, ?hash, ?peer,  "applying penalty for failed consesus header request");
-                            network_handle.handle.report_penalty(peer, Penalty::Mild).await;
+                            tracing::debug!(target: "primary::network", ?e, ?my_number, ?number, ?hash, ?peer, "consensus header request could not be served");
                         }
                         let response = header.into_response();
                         let _ = network_handle.handle.send_response(response, channel).await;

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -711,14 +711,21 @@ where
             tokio::select! {
                 header =
                     request_handler.retrieve_consensus_header(number, hash) => {
-                        // A peer asking for a header we cannot return is not a misbehavior
-                        // signal — observers legitimately request headers that have not yet
-                        // been served. Log the miss and respond with the error; do not
-                        // penalize. DoS protection is provided by req_res concurrency limits
-                        // and gossipsub rate limits, not by penalizing sync requests.
-                        if let Err(e) = &header {
+                        // Route through the central PrimaryNetworkError → Penalty mapping
+                        // so every handler in this file applies penalties consistently.
+                        // The only reachable variant from this path is
+                        // UnknownConsensusHeaderDigest, which the central table now maps
+                        // to None — observers legitimately request not-yet-served headers.
+                        if let Err(ref e) = header {
+                            if let Some(penalty) = e.into() {
+                                network_handle.report_penalty(peer, penalty).await;
+                            }
                             let my_number = request_handler.consensus_chain().latest_consensus_number();
-                            tracing::debug!(target: "primary::network", ?e, ?my_number, ?number, ?hash, ?peer, "consensus header request could not be served");
+                            tracing::debug!(
+                                target: "primary::network",
+                                ?e, ?my_number, ?number, ?hash, ?peer,
+                                "consensus header request could not be served"
+                            );
                         }
                         let response = header.into_response();
                         let _ = network_handle.handle.send_response(response, channel).await;

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -24,7 +24,7 @@ use libp2p::{
     kad::{self, store::RecordStore, Mode, QueryId},
     request_response::{
         self, Codec, Event as ReqResEvent, InboundFailure as ReqResInboundFailure,
-        InboundRequestId, OutboundRequestId,
+        InboundRequestId, OutboundFailure as ReqResOutboundFailure, OutboundRequestId,
     },
     swarm::{NetworkBehaviour, SwarmEvent},
     Multiaddr, PeerId, Swarm, SwarmBuilder,
@@ -936,8 +936,30 @@ where
                     return Ok(());
                 }
 
-                // apply penalty
-                self.swarm.behaviour_mut().peer_manager.process_penalty(peer, Penalty::Medium);
+                // Differentiate transport-level failures (peer disconnect, dial fail) from
+                // protocol-level violations. Transport failures are common on WAN and should
+                // not contribute to ban score; otherwise N in-flight requests at disconnect
+                // time cause N * Medium = instant ban.
+                match &error {
+                    ReqResOutboundFailure::DialFailure
+                    | ReqResOutboundFailure::ConnectionClosed
+                    | ReqResOutboundFailure::Io(_) => {
+                        // transport-level: no penalty
+                    }
+                    ReqResOutboundFailure::Timeout => {
+                        self.swarm
+                            .behaviour_mut()
+                            .peer_manager
+                            .process_penalty(peer, Penalty::Mild);
+                    }
+                    ReqResOutboundFailure::UnsupportedProtocols => {
+                        warn!(target: "network", ?peer, ?request_id, "outbound failure: unsupported protocol");
+                        self.swarm
+                            .behaviour_mut()
+                            .peer_manager
+                            .process_penalty(peer, Penalty::Severe);
+                    }
+                }
 
                 // try to forward error to original caller
                 let _ = self.outbound_requests.remove(&(peer, request_id)).map(|ack| {
@@ -949,28 +971,28 @@ where
                 debug!(target: "network", my_id=?self.swarm.local_peer_id(), "this node");
                 match error {
                     ReqResInboundFailure::Io(e) => {
-                        // penalize peer since this is an attack surface
+                        // attack surface, but the common cause is a peer disconnecting
+                        // mid-request on a flaky WAN link. Treat as Mild so it can accumulate
+                        // for repeat offenders without insta-banning on a single drop.
                         warn!(target: "network", ?e, ?peer, ?request_id, "inbound IO failure");
                         self.swarm
                             .behaviour_mut()
                             .peer_manager
-                            .process_penalty(peer, Penalty::Medium);
+                            .process_penalty(peer, Penalty::Mild);
                     }
                     ReqResInboundFailure::UnsupportedProtocols => {
                         warn!(target: "network", ?peer, ?request_id, ?error, "inbound failure: unsupported protocol");
 
                         // the local peer supports none of the protocols requested by the remote
+                        // Severe (not Fatal) so version skew during rolling upgrades does not
+                        // instantly ban a peer that is otherwise well-behaved.
                         self.swarm
                             .behaviour_mut()
                             .peer_manager
-                            .process_penalty(peer, Penalty::Fatal);
+                            .process_penalty(peer, Penalty::Severe);
                     }
                     ReqResInboundFailure::Timeout | ReqResInboundFailure::ConnectionClosed => {
-                        // penalty for potentially malicious request
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Mild);
+                        // peer dropped or stalled mid-request — expected on WAN, no penalty
                     }
                     ReqResInboundFailure::ResponseOmission => { /* ignore local error */ }
                 }
@@ -1395,9 +1417,10 @@ where
                 trace!(target: "network-kad", "Got record {key} {value:?}");
                 self.swarm.behaviour_mut().peer_manager.add_known_peer(key, value.info);
             } else {
-                // mild punishment for old record
-                trace!(target: "network-kad", ?source, "processing mild penalty for old record");
-                self.swarm.behaviour_mut().peer_manager.process_penalty(source, Penalty::Mild);
+                // A peer republishing a slightly stale (but signature-valid) record is
+                // expected after restarts and benign — the local store keeps the newer
+                // version. Log only; no penalty.
+                trace!(target: "network-kad", ?source, "ignoring stale but valid kad record");
             }
         } else {
             warn!(target: "network-kad", "Received invalid peer record!");

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -31,6 +31,7 @@ use libp2p::{
 };
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    io::ErrorKind,
     time::Duration,
 };
 use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
@@ -942,16 +943,40 @@ where
                 // time cause N * Medium = instant ban.
                 match &error {
                     ReqResOutboundFailure::DialFailure
-                    | ReqResOutboundFailure::ConnectionClosed
-                    | ReqResOutboundFailure::Io(_) => {
+                    | ReqResOutboundFailure::ConnectionClosed => {
                         // transport-level: no penalty
                     }
+                    ReqResOutboundFailure::Io(e) => match e.kind() {
+                        ErrorKind::ConnectionReset
+                        | ErrorKind::ConnectionAborted
+                        | ErrorKind::TimedOut
+                        | ErrorKind::UnexpectedEof
+                        | ErrorKind::BrokenPipe
+                        | ErrorKind::Interrupted => {
+                            // transport flap on WAN — no penalty
+                        }
+                        _ => {
+                            warn!(
+                                target: "network",
+                                ?e, ?peer, ?request_id,
+                                "outbound IO failure (likely codec violation)"
+                            );
+                            self.swarm
+                                .behaviour_mut()
+                                .peer_manager
+                                .process_penalty(peer, Penalty::Medium);
+                        }
+                    },
                     ReqResOutboundFailure::Timeout => {
                         self.swarm
                             .behaviour_mut()
                             .peer_manager
                             .process_penalty(peer, Penalty::Mild);
                     }
+                    // Severe = 5 strikes covers the typical rolling-upgrade window where
+                    // a peer sees <=5 req-res handshakes per halflife. Demote to Medium
+                    // if telemetry shows version-skewed peers banned during normal
+                    // upgrades.
                     ReqResOutboundFailure::UnsupportedProtocols => {
                         warn!(target: "network", ?peer, ?request_id, "outbound failure: unsupported protocol");
                         self.swarm
@@ -969,17 +994,32 @@ where
             ReqResEvent::InboundFailure { peer, request_id, error, connection_id: _ } => {
                 debug!(target: "network", ?peer, ?error, pending=?self.inbound_requests, "Inbound failure for req/res");
                 debug!(target: "network", my_id=?self.swarm.local_peer_id(), "this node");
-                match error {
-                    ReqResInboundFailure::Io(e) => {
-                        // attack surface, but the common cause is a peer disconnecting
-                        // mid-request on a flaky WAN link. Treat as Mild so it can accumulate
-                        // for repeat offenders without insta-banning on a single drop.
-                        warn!(target: "network", ?e, ?peer, ?request_id, "inbound IO failure");
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Mild);
-                    }
+                match &error {
+                    ReqResInboundFailure::Io(e) => match e.kind() {
+                        ErrorKind::ConnectionReset
+                        | ErrorKind::ConnectionAborted
+                        | ErrorKind::TimedOut
+                        | ErrorKind::UnexpectedEof
+                        | ErrorKind::BrokenPipe
+                        | ErrorKind::Interrupted => {
+                            // transport flap on WAN — no penalty
+                        }
+                        _ => {
+                            warn!(
+                                target: "network",
+                                ?e, ?peer, ?request_id,
+                                "inbound IO failure (likely codec violation)"
+                            );
+                            self.swarm
+                                .behaviour_mut()
+                                .peer_manager
+                                .process_penalty(peer, Penalty::Medium);
+                        }
+                    },
+                    // Severe = 5 strikes covers the typical rolling-upgrade window where
+                    // a peer sees <=5 req-res handshakes per halflife. Demote to Medium
+                    // if telemetry shows version-skewed peers banned during normal
+                    // upgrades.
                     ReqResInboundFailure::UnsupportedProtocols => {
                         warn!(target: "network", ?peer, ?request_id, ?error, "inbound failure: unsupported protocol");
 

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -13,7 +13,7 @@ use libp2p::{
 use std::{collections::HashSet, net::IpAddr, time::Instant};
 use tn_config::PeerConfig;
 use tn_types::{BlsPublicKey, NetworkPublicKey};
-use tracing::error;
+use tracing::{error, warn};
 
 /// Information about a given connected peer.
 /// Note that bls_public_key and network_key are Optional.
@@ -156,7 +156,20 @@ impl Peer {
 
     /// Apply a penalty to the peer's score.
     pub(super) fn apply_penalty(&mut self, penalty: Penalty) -> Reputation {
-        if !self.is_trusted {
+        if self.is_trusted {
+            // Trusted peers (current-epoch committee, configured allowlist) bypass
+            // the score model entirely. Severe/Fatal suppressions are operationally
+            // significant: they hint that a committee member is misbehaving in ways
+            // that would normally ban an untrusted peer. Surface as a warn! so ops
+            // can correlate downstream issues with the original signal.
+            if matches!(penalty, Penalty::Severe | Penalty::Fatal) {
+                warn!(
+                    target: "peer-manager",
+                    ?penalty,
+                    "skipping severe/fatal penalty for trusted peer"
+                );
+            }
+        } else {
             self.score.apply_penalty(penalty);
         }
 

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -44,14 +44,19 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 
 ### 3.2 Req/Res events (`process_reqres_event`, L851)
 
-| Location                                     | Trigger                                                                     | Severity |
-| -------------------------------------------- | --------------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:946` | `ReqResEvent::OutboundFailure` after PX-disconnect skip guard               | `Medium` |
-| `crates/network-libp2p/src/consensus.rs:963` | `ReqResInboundFailure::Io(e)`                                               | `Medium` |
-| `crates/network-libp2p/src/consensus.rs:972` | `ReqResInboundFailure::UnsupportedProtocols`                                | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:979` | `ReqResInboundFailure::Timeout` or `ReqResInboundFailure::ConnectionClosed` | `Mild`   |
+| Location                                     | Trigger                                                                                            | Severity |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:943` | `OutboundFailure::DialFailure` / `OutboundFailure::ConnectionClosed`                               | `None`   |
+| `crates/network-libp2p/src/consensus.rs:946` | `OutboundFailure::Io(e)` with transport-flap `e.kind()` (Reset/Aborted/Timed/EOF/Pipe/Interrupted) | `None`   |
+| `crates/network-libp2p/src/consensus.rs:946` | `OutboundFailure::Io(e)` other kinds (codec violation, e.g. `io::Error::other`)                    | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:961` | `OutboundFailure::Timeout`                                                                         | `Mild`   |
+| `crates/network-libp2p/src/consensus.rs:973` | `OutboundFailure::UnsupportedProtocols`                                                            | `Severe` |
+| `crates/network-libp2p/src/consensus.rs:973` | `InboundFailure::Io(e)` with transport-flap `e.kind()`                                             | `None`   |
+| `crates/network-libp2p/src/consensus.rs:973` | `InboundFailure::Io(e)` other kinds (codec violation)                                              | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:992` | `InboundFailure::UnsupportedProtocols`                                                             | `Severe` |
+| `crates/network-libp2p/src/consensus.rs:995` | `InboundFailure::Timeout` / `InboundFailure::ConnectionClosed`                                     | `None`   |
 
-`ReqResInboundFailure::ResponseOmission` is explicitly a no-op (local error). See restraint invariants below.
+`InboundFailure::ResponseOmission` is explicitly a no-op (local error). See restraint invariants below.
 
 ### 3.3 Kademlia outbound `GetRecord` query (`process_kad_event`, L1208)
 
@@ -64,7 +69,7 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 | Location                                      | Trigger                                                                               | Severity |
 | --------------------------------------------- | ------------------------------------------------------------------------------------- | -------- |
 | `crates/network-libp2p/src/consensus.rs:1383` | record was rejected AND `record.publisher.is_none()` (publisher-less record)          | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:1406` | `peer_record_valid(&record).is_some()` but `!is_newer_record(&record)` (stale record) | `Mild`   |
+| `crates/network-libp2p/src/consensus.rs:1406` | `peer_record_valid(&record).is_some()` but `!is_newer_record(&record)` (stale record — trace log only; kad routinely replays put-records to refresh TTLs) | `None`   |
 | `crates/network-libp2p/src/consensus.rs:1413` | `peer_record_valid(&record).is_none()` (invalid signature / wrong network key)        | `Fatal`  |
 
 A rejected record from a banned source/publisher with a publisher present does
@@ -133,7 +138,7 @@ Source: `crates/consensus/worker/src/network/error.rs:76-138`.
 | ------------------------------------------------- | ------------------------------------------ | -------------------------------------------------- |
 | `crates/consensus/primary/src/network/mod.rs:421` | `stream_import` (epoch pack download)      | `Self::consensus_chain_error_to_penalty(&err)`     |
 | `crates/consensus/primary/src/network/mod.rs:682` | `retrieve_missing_certs`                   | `(&PrimaryNetworkError).into() -> Option<Penalty>` |
-| `crates/consensus/primary/src/network/mod.rs:719` | `retrieve_consensus_header` (any err)      | hard-coded `Penalty::Mild`                         |
+| `crates/consensus/primary/src/network/mod.rs:719` | `retrieve_consensus_header`                | `(&PrimaryNetworkError).into()` — only reachable variant `UnknownConsensusHeaderDigest` → `None` |
 | `crates/consensus/primary/src/network/mod.rs:751` | `retrieve_epoch_record`                    | `(&PrimaryNetworkError).into()`                    |
 | `crates/consensus/primary/src/network/mod.rs:835` | `process_epoch_stream` response-err branch | `(&PrimaryNetworkError).into()`                    |
 | `crates/consensus/primary/src/network/mod.rs:863` | `process_gossip`                           | `(&PrimaryNetworkError).into()`                    |
@@ -158,7 +163,7 @@ Source: `crates/consensus/primary/src/error/network.rs:70-132`.
 | `Certificate(CertManagerError::UnverifiedSignature(_))`                                                                                                                                                                                                                                                                                  | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:97`      |
 | `Certificate(CertManagerError::*)` operational variants (`PendingCertificateNotFound`, `PendingParentsMismatch`, `CertificateManagerOneshot`, `FatalForwardAcceptedCertificate`, `NoCertificateFetched`, `FatalAppendParent`, `GC`, `JoinError`, `Pending`, `Storage`, `RequestBounds`, `Timeout`, `Network`, `ChannelClosed`, `TNSend`) | None                                     | `crates/consensus/primary/src/error/network.rs:99-113`  |
 | `InvalidRequest(_)`                                                                                                                                                                                                                                                                                                                      | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
-| `UnknownConsensusHeaderDigest(_)`                                                                                                                                                                                                                                                                                                        | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
+| `UnknownConsensusHeaderDigest(_)`                                                                                                                                                                                                                                                                                                        | `None`                                   | `crates/consensus/primary/src/error/network.rs:115-117` |
 | `UnknownStreamRequest(_)`                                                                                                                                                                                                                                                                                                                | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
 | `UnknownConsensusHeaderCert(_)`                                                                                                                                                                                                                                                                                                          | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
 | `InvalidEpochRequest`                                                                                                                                                                                                                                                                                                                    | `Medium`                                 | `crates/consensus/primary/src/error/network.rs:119-120` |
@@ -233,7 +238,7 @@ Source: `crates/consensus/primary/src/network/mod.rs:448-489`.
 These are deliberate tolerances for benign failures. Changing any of these from
 `None` to a real penalty risks banning honest peers during normal operation.
 
-- `ReqResInboundFailure::ResponseOmission` — local error, no peer fault. `crates/network-libp2p/src/consensus.rs:981`.
+- `InboundFailure::ResponseOmission` — local error, no peer fault. `crates/network-libp2p/src/consensus.rs:981`.
 - PX-disconnect outbound failures — `pending_px_disconnects` short-circuit before penalty. `crates/network-libp2p/src/consensus.rs:940-943`.
 - `WorkerNetworkError::Timeout` / `DBInsert` / `DBCommit` / `DBRead` / `StreamClosed` / `Network` / `BatchEpochMismatch` / `Internal` — local failures or epoch-boundary races. `crates/consensus/worker/src/network/error.rs:128-135`.
 - `PrimaryNetworkError::UnavailableEpoch` / `UnavailableEpochDigest` — a peer "might not have this yet" during sync. `crates/consensus/primary/src/error/network.rs:123-124`.
@@ -257,7 +262,7 @@ What happens when a peer's score crosses `min_score_before_ban` (`-50.0`):
 4. `PeerManager::apply_peer_action` matches `PeerAction::Ban` and invokes `process_ban`, which pushes `PeerEvent::Banned(peer_id)`. `crates/network-libp2p/src/peers/manager.rs:287-292,389-401`.
 5. `ConsensusNetwork::process_peer_manager_event` consumes `PeerEvent::Banned`, blacklists the peer in gossipsub, and removes it from the kad routing table. `crates/network-libp2p/src/consensus.rs:1152-1158`.
 6. Future inbound/outbound connection attempts are denied by `handle_established_inbound_connection` / `handle_established_outbound_connection` via `peer_banned`. `crates/network-libp2p/src/peers/behavior.rs:73-107`.
-7. The score does not decay during the `banned_before_decay` window (12h by default). After expiry, `Score::update_at` resumes exponential decay using the halflife constant. `crates/network-libp2p/src/peers/score.rs:115-135`.
+7. The score does not decay during the `banned_before_decay` window (30 min by default). After expiry, `Score::update_at` resumes exponential decay using the halflife constant. `crates/network-libp2p/src/peers/score.rs:115-135`.
 
 ## 8. Open Questions / Notes
 
@@ -265,5 +270,5 @@ What happens when a peer's score crosses `min_score_before_ban` (`-50.0`):
 - `Penalty::Severe` never appears as a literal in `crates/network-libp2p/src/consensus.rs`. It only reaches `process_penalty` via app-layer error mappings: `BatchValidationError::RecoverTransaction`, `HeaderError::{InvalidTimestamp, InvalidParentRound}`, `PackError::{InvalidConsensusChain, ExtraBatches, MissingBatches, CorruptPack, InvalidEpoch}`, and `ConsensusChainError::{EmptyImport, InvalidImport}`.
 - `PeerAction::DisconnectWithPX` adds the peer to `temporarily_banned` and emits `DisconnectPeerX`. This is a soft ban that bypasses the score model and does not produce a `PeerEvent::Banned`. `crates/network-libp2p/src/peers/manager.rs:295-303`.
 - The trusted-peer short-circuit in `Peer::apply_penalty` (`crates/network-libp2p/src/peers/peer.rs:158-161`) is the only mechanism preventing scored bans of locally configured peers. There is no allowlist applied at the network-layer call sites.
-- `retrieve_consensus_header` hard-codes `Penalty::Mild` regardless of error kind (`crates/consensus/primary/src/network/mod.rs:719`). All other primary call sites route through `(&PrimaryNetworkError).into()` so changes to the error mapping propagate automatically; this site is the lone exception and must be updated by hand.
+- `retrieve_consensus_header` (`crates/consensus/primary/src/network/mod.rs:711-725`) now routes through `(&PrimaryNetworkError).into()` like the other primary call sites. The only reachable variant from this code path is `UnknownConsensusHeaderDigest`, which the central mapping now maps to `None` (observers legitimately request not-yet-served headers).
 - Penalty application is not debounced. A peer that produces many `Mild` errors in quick succession (e.g. during a sync flap) can still cross the ban threshold (`-50.0`) in fewer than ~50 events if its score has already drifted negative.

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -1,0 +1,269 @@
+# Peer Penalty System — Invariants Reference
+
+This document is the single source of truth for the telcoin-network peer penalty system.
+Every penalty severity, score-model invariant, and every site that applies a penalty is listed here with a source citation.
+Treat each entry as an assertion to verify against the code.
+
+## 1. Penalty Severity Levels
+
+`Penalty` is defined in `crates/network-libp2p/src/peers/types.rs:69-86`.
+Score deltas are applied in `crates/network-libp2p/src/peers/score.rs:84-100`.
+
+| Variant           | Score Delta              | Effect                                                  | Source                                                       |
+| ----------------- | ------------------------ | ------------------------------------------------------- | ------------------------------------------------------------ |
+| `Penalty::Mild`   | `-1.0`                   | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:90`                |
+| `Penalty::Medium` | `-5.0`                   | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:91`                |
+| `Penalty::Severe` | `-10.0`                  | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:92`                |
+| `Penalty::Fatal`  | sets score to `min_score` (`-100.0`) | Immediate ban — score jumps below `min_score_before_ban` (`-50.0`) | `crates/network-libp2p/src/peers/score.rs:93`     |
+
+## 2. Score Model Invariants
+
+- Score range: `[min_score, max_score]` = `[-100.0, 100.0]`. `crates/config/src/network.rs:438-439`.
+- Default starting score: `0.0`. `crates/config/src/network.rs:436`.
+- Ban threshold (`min_score_before_ban`): `-50.0`. `crates/config/src/network.rs:443`.
+- Disconnect threshold (`min_score_before_disconnect`): `-20.0`. `crates/config/src/network.rs:442`.
+- Score halflife: `600.0` seconds; decay factor is `e^(-ln(2)/halflife * dt)`. `crates/config/src/network.rs:440`, `crates/network-libp2p/src/peers/score.rs:130-132`.
+- `banned_before_decay_secs`: `12 * 3600` (12 hours). When a peer crosses the ban threshold, `last_updated` is pushed forward by this duration so the score does not decay during the lockout. `crates/config/src/network.rs:441`, `crates/network-libp2p/src/peers/score.rs:149-154`.
+- Trusted peers skip penalty application entirely — `Peer::apply_penalty` short-circuits when `self.is_trusted`. `crates/network-libp2p/src/peers/peer.rs:158-161`.
+- Penalty application has no debouncing: every `process_penalty` call evaluates reputation immediately and may produce a ban on the same call. `crates/network-libp2p/src/peers/all_peers.rs:111-147`.
+- Bans surface to the rest of the swarm as `PeerEvent::Banned`, pushed by `process_ban`. `crates/network-libp2p/src/peers/manager.rs:389-401`.
+- `Penalty::Fatal` always crosses the ban threshold on the first call because `min_score` (`-100`) is less than `min_score_before_ban` (`-50`). `crates/network-libp2p/src/peers/score.rs:93`, `crates/config/src/network.rs:439,443`.
+- Only the `Banned`/`Disconnected`/`Trusted` reputation transitions trigger a `PeerAction`. If the new reputation equals the prior reputation, `process_penalty` returns `PeerAction::NoAction`. `crates/network-libp2p/src/peers/all_peers.rs:117-119`.
+
+## 3. Penalty Application Sites — Network Layer
+
+All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::ReportPenalty` (L700-707) is the external entry from the app layer; everything below is internal.
+
+### 3.1 Gossip events (`process_gossip_event`, L781)
+
+| Location                                              | Trigger (immediate guard)                                          | Severity |
+| ----------------------------------------------------- | ------------------------------------------------------------------ | -------- |
+| `crates/network-libp2p/src/consensus.rs:828`          | `verify_gossip` rejected (`!valid`) — invalid topic or unauthorized publisher | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:839`          | `GossipEvent::GossipsubNotSupported { peer_id }`                   | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:843`          | `GossipEvent::SlowPeer { peer_id, failed_messages }`               | `Mild`   |
+
+### 3.2 Req/Res events (`process_reqres_event`, L851)
+
+| Location                                              | Trigger                                                                   | Severity |
+| ----------------------------------------------------- | ------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:946`          | `ReqResEvent::OutboundFailure` after PX-disconnect skip guard             | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:963`          | `ReqResInboundFailure::Io(e)`                                             | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:972`          | `ReqResInboundFailure::UnsupportedProtocols`                              | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:979`          | `ReqResInboundFailure::Timeout` or `ReqResInboundFailure::ConnectionClosed` | `Mild` |
+
+`ReqResInboundFailure::ResponseOmission` is explicitly a no-op (local error). See restraint invariants below.
+
+### 3.3 Kademlia outbound `GetRecord` query (`process_kad_event`, L1208)
+
+| Location                                              | Trigger                                                                                                       | Severity |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:1267`         | `kad::QueryResult::GetRecord(Ok(FoundRecord))` but `peer_record_valid` returned `None` (bad sig / key mismatch) | `Fatal`  |
+
+### 3.4 Kad put-record handler (`process_kad_put_request`, L1362)
+
+| Location                                              | Trigger                                                                              | Severity |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
+| `crates/network-libp2p/src/consensus.rs:1383`         | record was rejected AND `record.publisher.is_none()` (publisher-less record)         | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:1406`         | `peer_record_valid(&record).is_some()` but `!is_newer_record(&record)` (stale record) | `Mild`   |
+| `crates/network-libp2p/src/consensus.rs:1413`         | `peer_record_valid(&record).is_none()` (invalid signature / wrong network key)        | `Fatal`  |
+
+A rejected record from a banned source/publisher with a publisher present does
+NOT incur an extra penalty here — only the missing-publisher case is fatal. The
+ban itself was applied elsewhere.
+
+### 3.5 Kad query-result post-processing (`process_kad_query_result`, L1450)
+
+| Location                                              | Trigger                                                                | Severity |
+| ----------------------------------------------------- | ---------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:1479`         | record valid but `query.request != key` (returned key does not match request) | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:1488`         | `peer_record_valid(&record).is_none()` on the late-step path           | `Fatal`  |
+
+## 4. Penalty Application Sites — Worker Layer
+
+### 4.1 `crates/consensus/worker/src/network/mod.rs` call sites
+
+| Location                                                          | Handler                          | Source of penalty                              |
+| ----------------------------------------------------------------- | -------------------------------- | ---------------------------------------------- |
+| `crates/consensus/worker/src/network/mod.rs:246`                  | `process_report_batch`           | `WorkerNetworkError::into() -> Option<Penalty>` |
+| `crates/consensus/worker/src/network/mod.rs:271`                  | `process_gossip`                 | `WorkerNetworkError::penalty()`                |
+| `crates/consensus/worker/src/network/mod.rs:379`                  | `process_request_batches_stream` response-error branch | `WorkerNetworkError::into() -> Option<Penalty>` |
+| `crates/consensus/worker/src/network/mod.rs:435`                  | `process_inbound_stream`         | `WorkerNetworkError::penalty()`                |
+
+### 4.2 `WorkerNetworkError::penalty()` mapping
+
+Source: `crates/consensus/worker/src/network/error.rs:76-138`.
+
+| Error variant                                                          | Severity | Source                                                  |
+| ---------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
+| `BatchValidation(CanonicalChain { .. })`                               | `Mild`   | `crates/consensus/worker/src/network/error.rs:86`       |
+| `BatchValidation(InvalidEpoch { .. })`                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`    |
+| `BatchValidation(InvalidTx4844(_))`                                    | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`    |
+| `BatchValidation(RecoverTransaction(..))`                              | `Severe` | `crates/consensus/worker/src/network/error.rs:91`       |
+| `BatchValidation(EmptyBatch)`                                          | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(InvalidBaseFee { .. })`                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(InvalidWorkerId { .. })`                              | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(InvalidDigest)`                                       | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(GasOverflow)`                                         | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(CalculateMaxPossibleGas)`                             | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(HeaderMaxGasExceedsGasLimit { .. })`                  | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `BatchValidation(HeaderTransactionBytesExceedsMax(_))`                 | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
+| `InvalidRequest(_)`                                                    | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106`  |
+| `UnknownStreamRequest(_)`                                              | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106`  |
+| `StdIo(io_err)` kind `ConnectionReset`/`ConnectionAborted`/`TimedOut`/`Interrupted` | `Mild` | `crates/consensus/worker/src/network/error.rs:108-114`  |
+| `StdIo(io_err)` other kinds                                            | `Medium` | `crates/consensus/worker/src/network/error.rs:115`      |
+| `NonCommitteeBatch`                                                    | `Medium` | `crates/consensus/worker/src/network/error.rs:119`      |
+| `InvalidTopic`                                                         | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `Bcs(_)`                                                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `TooManyBatches { .. }`                                                | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `UnexpectedBatch(_)`                                                   | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `DuplicateBatch(_)`                                                    | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `RequestHashMismatch`                                                  | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
+| `Timeout(_)`                                                           | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| `DBInsert(_)` / `DBCommit(_)` / `DBRead(_)`                            | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| `StreamClosed`                                                         | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| `Network(_)`                                                           | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| `BatchEpochMismatch(_, _)`                                             | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| `Internal(_)`                                                          | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+
+## 5. Penalty Application Sites — Primary Layer
+
+### 5.1 `crates/consensus/primary/src/network/mod.rs` call sites
+
+| Location                                                          | Handler                              | Source of penalty                                                         |
+| ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `crates/consensus/primary/src/network/mod.rs:421`                 | `stream_import` (epoch pack download) | `Self::consensus_chain_error_to_penalty(&err)`                            |
+| `crates/consensus/primary/src/network/mod.rs:682`                 | `retrieve_missing_certs`             | `(&PrimaryNetworkError).into() -> Option<Penalty>`                         |
+| `crates/consensus/primary/src/network/mod.rs:719`                 | `retrieve_consensus_header` (any err) | hard-coded `Penalty::Mild`                                                |
+| `crates/consensus/primary/src/network/mod.rs:751`                 | `retrieve_epoch_record`              | `(&PrimaryNetworkError).into()`                                           |
+| `crates/consensus/primary/src/network/mod.rs:835`                 | `process_epoch_stream` response-err branch | `(&PrimaryNetworkError).into()`                                       |
+| `crates/consensus/primary/src/network/mod.rs:863`                 | `process_gossip`                     | `(&PrimaryNetworkError).into()`                                           |
+| `crates/consensus/primary/src/network/mod.rs:912`                 | `process_inbound_stream`             | `(&PrimaryNetworkError).into()`                                           |
+
+### 5.2 `From<&PrimaryNetworkError> for Option<Penalty>`
+
+Source: `crates/consensus/primary/src/error/network.rs:70-132`.
+
+| Variant                                                           | Severity | Source                                                       |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `InvalidHeader(header_error)`                                     | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:76-78` |
+| `Certificate(CertManagerError::Certificate(CertificateError::Header(h)))` | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:81-83` |
+| `Certificate(CertManagerError::Certificate(CertificateError::TooOld(..)))` | `Mild`   | `crates/consensus/primary/src/error/network.rs:85`            |
+| `Certificate(CertManagerError::Certificate(CertificateError::RecoverBlsAggregateSignatureBytes))` | `Fatal`  | `crates/consensus/primary/src/error/network.rs:87-90`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::Unsigned))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::Inquorate { .. }))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::InvalidSignature))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::ResChannelClosed(_)))` | None    | `crates/consensus/primary/src/error/network.rs:92-94`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::TooNew(..)))` | None     | `crates/consensus/primary/src/error/network.rs:92-94`         |
+| `Certificate(CertManagerError::Certificate(CertificateError::Storage(_)))` | None     | `crates/consensus/primary/src/error/network.rs:92-94`         |
+| `Certificate(CertManagerError::UnverifiedSignature(_))`           | `Fatal`  | `crates/consensus/primary/src/error/network.rs:97`            |
+| `Certificate(CertManagerError::*)` operational variants (`PendingCertificateNotFound`, `PendingParentsMismatch`, `CertificateManagerOneshot`, `FatalForwardAcceptedCertificate`, `NoCertificateFetched`, `FatalAppendParent`, `GC`, `JoinError`, `Pending`, `Storage`, `RequestBounds`, `Timeout`, `Network`, `ChannelClosed`, `TNSend`) | None | `crates/consensus/primary/src/error/network.rs:99-113` |
+| `InvalidRequest(_)`                                               | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
+| `UnknownConsensusHeaderDigest(_)`                                 | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
+| `UnknownStreamRequest(_)`                                         | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
+| `UnknownConsensusHeaderCert(_)`                                   | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
+| `InvalidEpochRequest`                                             | `Medium` | `crates/consensus/primary/src/error/network.rs:119-120`       |
+| `StdIo(_)`                                                        | `Medium` | `crates/consensus/primary/src/error/network.rs:119-120`       |
+| `InvalidTopic`                                                    | `Fatal`  | `crates/consensus/primary/src/error/network.rs:121-122`       |
+| `Decode(_)`                                                       | `Fatal`  | `crates/consensus/primary/src/error/network.rs:121-122`       |
+| `UnavailableEpoch(_)`                                             | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `UnavailableEpochDigest(_)`                                       | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `PeerNotInCommittee(_)`                                           | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `Storage(_)`                                                      | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `Timeout(_)`                                                      | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `StreamUnavailable(_)`                                            | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| `Internal(_)`                                                     | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+
+### 5.3 `penalty_from_header_error`
+
+Source: `crates/consensus/primary/src/error/network.rs:137-171`.
+
+| `HeaderError` variant                                             | Severity | Source                                                       |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `SyncBatches(_)`                                                  | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
+| `TooNew { .. }`                                                   | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
+| `Storage(_)`                                                      | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
+| `UnknownExecutionResult(_)`                                       | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
+| `InvalidParents`                                                  | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
+| `WrongNumberOfParents(_, _)`                                      | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
+| `TooOld { .. }`                                                   | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
+| `InvalidTimestamp { .. }`                                         | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151`       |
+| `InvalidParentRound`                                              | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151`       |
+| `AlreadyVotedForLaterRound { .. }`                                | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `AlreadyVoted(_, _)`                                              | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `DuplicateParents`                                                | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `TooManyParents(_, _)`                                            | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `UnknownNetworkKey(_)`                                            | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `PeerNotAuthor`                                                   | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `InvalidGenesisParent(_)`                                         | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `ParentMissingSignature`                                          | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `InvalidParentTimestamp { .. }`                                   | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `UnkownWorkerId`                                                  | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `InvalidHeaderDigest`                                             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `UnknownAuthority(_)`                                             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
+| `PendingCertificateOneshot`                                       | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
+| `TNSend(_)`                                                       | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
+| `InvalidEpoch { .. }`                                             | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
+| `ClosedWatchChannel`                                              | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
+
+### 5.4 `consensus_chain_error_to_penalty`
+
+Source: `crates/consensus/primary/src/network/mod.rs:448-489`.
+
+| Variant                                                           | Severity | Source                                                       |
+| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `PackError(PackError::MissingBatch)`                              | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
+| `PackError(PackError::NotConsensus)`                              | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
+| `PackError(PackError::NotBatch)`                                  | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
+| `PackError(PackError::NotEpoch)`                                  | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
+| `PackError(PackError::InvalidConsensusChain)`                     | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
+| `PackError(PackError::ExtraBatches)`                              | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
+| `PackError(PackError::MissingBatches)`                            | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
+| `PackError(PackError::CorruptPack)`                               | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
+| `PackError(PackError::InvalidEpoch)`                              | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
+| `PackError` operational variants (`IO`, `BatchLoad`, `EpochLoad`, `Append`, `IndexAppend`, `Fetch`, `Open`, `ReadOnly`, `ReadError`, `MissingAuthority`, `SendFailed`, `ReceiveFailed`, `PersistError`, `InvalidConsensusNumber`, `ConsensusNumberAlreadyAdded`, `ConsensusNumberTooLow`, `ConsensusNumberTooHigh`) | None | `crates/consensus/primary/src/network/mod.rs:460-476` |
+| `EpochMismatch`                                                   | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
+| `PrevCommitteeEpochMismatch`                                      | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
+| `CrcError`                                                        | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
+| `EmptyImport`                                                     | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483`        |
+| `InvalidImport`                                                   | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483`        |
+| `StreamUnavailable` / `NoCurrentEpoch` / `EpochDbError(_)` / `IO(_)` | None  | `crates/consensus/primary/src/network/mod.rs:484-487`        |
+
+## 6. Restraint Invariants (no-penalty cases)
+
+These are deliberate tolerances for benign failures. Changing any of these from
+`None` to a real penalty risks banning honest peers during normal operation.
+
+- `ReqResInboundFailure::ResponseOmission` — local error, no peer fault. `crates/network-libp2p/src/consensus.rs:981`.
+- PX-disconnect outbound failures — `pending_px_disconnects` short-circuit before penalty. `crates/network-libp2p/src/consensus.rs:940-943`.
+- `WorkerNetworkError::Timeout` / `DBInsert` / `DBCommit` / `DBRead` / `StreamClosed` / `Network` / `BatchEpochMismatch` / `Internal` — local failures or epoch-boundary races. `crates/consensus/worker/src/network/error.rs:128-135`.
+- `PrimaryNetworkError::UnavailableEpoch` / `UnavailableEpochDigest` — a peer "might not have this yet" during sync. `crates/consensus/primary/src/error/network.rs:123-124`.
+- `PrimaryNetworkError::PeerNotInCommittee` — left to `None` to avoid penalizing during epoch transitions. `crates/consensus/primary/src/error/network.rs:125`.
+- `PrimaryNetworkError::Storage` / `Timeout` / `StreamUnavailable` / `Internal` — local failures. `crates/consensus/primary/src/error/network.rs:126-129`.
+- `CertManagerError::Certificate(CertificateError::TooNew(..))` — request races ahead of local state. `crates/consensus/primary/src/error/network.rs:92-94`.
+- All `CertManagerError` operational variants (pending lookups, GC, oneshot drops, channel closures, internal storage / network errors). `crates/consensus/primary/src/error/network.rs:99-113`.
+- `HeaderError::InvalidEpoch { .. }` — explicitly `None`; epoch boundary mismatch is not penalized. `crates/consensus/primary/src/error/network.rs:166-169`.
+- `HeaderError::PendingCertificateOneshot` / `TNSend` / `ClosedWatchChannel` — local channel/task failures. `crates/consensus/primary/src/error/network.rs:166-169`.
+- All `PackError` IO/load/persist/internal variants — local failures. `crates/consensus/primary/src/network/mod.rs:460-476`.
+- `ConsensusChainError::StreamUnavailable` / `NoCurrentEpoch` / `EpochDbError` / `IO` — local failures during epoch pack streaming. `crates/consensus/primary/src/network/mod.rs:484-487`.
+- A rejected kad put record from a banned source/publisher with `record.publisher.is_some()` — no extra penalty is stacked on top of the existing ban. `crates/network-libp2p/src/consensus.rs:1375-1388`.
+
+## 7. Ban Lifecycle
+
+What happens when a peer's score crosses `min_score_before_ban` (`-50.0`):
+
+1. `Score::apply_penalty` writes the new `telcoin_score` and calls `Score::update_score`. `crates/network-libp2p/src/peers/score.rs:84-100`.
+2. `update_score` observes `!already_banned && self.is_banned()` and pushes `last_updated` forward by `banned_before_decay` so the score does not decay during the lockout. `crates/network-libp2p/src/peers/score.rs:141-154`.
+3. `AllPeers::process_penalty` sees `new_reputation == Reputation::Banned` and calls `update_connection_status(peer_id, NewConnectionStatus::Banned)`, returning `PeerAction::Ban(_)`. `crates/network-libp2p/src/peers/all_peers.rs:121-127`.
+4. `PeerManager::apply_peer_action` matches `PeerAction::Ban` and invokes `process_ban`, which pushes `PeerEvent::Banned(peer_id)`. `crates/network-libp2p/src/peers/manager.rs:287-292,389-401`.
+5. `ConsensusNetwork::process_peer_manager_event` consumes `PeerEvent::Banned`, blacklists the peer in gossipsub, and removes it from the kad routing table. `crates/network-libp2p/src/consensus.rs:1152-1158`.
+6. Future inbound/outbound connection attempts are denied by `handle_established_inbound_connection` / `handle_established_outbound_connection` via `peer_banned`. `crates/network-libp2p/src/peers/behavior.rs:73-107`.
+7. The score does not decay during the `banned_before_decay` window (12h by default). After expiry, `Score::update_at` resumes exponential decay using the halflife constant. `crates/network-libp2p/src/peers/score.rs:115-135`.
+
+## 8. Open Questions / Notes
+
+- `NetworkCommand::ReportPenalty` (`crates/network-libp2p/src/consensus.rs:700-707`) is the external entry point from the application layer. Worker and primary call sites all route through this command via `report_penalty` on the network handle (`crates/network-libp2p/src/types.rs:548`).
+- `Penalty::Severe` never appears as a literal in `crates/network-libp2p/src/consensus.rs`. It only reaches `process_penalty` via app-layer error mappings: `BatchValidationError::RecoverTransaction`, `HeaderError::{InvalidTimestamp, InvalidParentRound}`, `PackError::{InvalidConsensusChain, ExtraBatches, MissingBatches, CorruptPack, InvalidEpoch}`, and `ConsensusChainError::{EmptyImport, InvalidImport}`.
+- `PeerAction::DisconnectWithPX` adds the peer to `temporarily_banned` and emits `DisconnectPeerX`. This is a soft ban that bypasses the score model and does not produce a `PeerEvent::Banned`. `crates/network-libp2p/src/peers/manager.rs:295-303`.
+- The trusted-peer short-circuit in `Peer::apply_penalty` (`crates/network-libp2p/src/peers/peer.rs:158-161`) is the only mechanism preventing scored bans of locally configured peers. There is no allowlist applied at the network-layer call sites.
+- `retrieve_consensus_header` hard-codes `Penalty::Mild` regardless of error kind (`crates/consensus/primary/src/network/mod.rs:719`). All other primary call sites route through `(&PrimaryNetworkError).into()` so changes to the error mapping propagate automatically; this site is the lone exception and must be updated by hand.
+- Penalty application is not debounced. A peer that produces many `Mild` errors in quick succession (e.g. during a sync flap) can still cross the ban threshold (`-50.0`) in fewer than ~50 events if its score has already drifted negative.

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -9,12 +9,12 @@ Treat each entry as an assertion to verify against the code.
 `Penalty` is defined in `crates/network-libp2p/src/peers/types.rs:69-86`.
 Score deltas are applied in `crates/network-libp2p/src/peers/score.rs:84-100`.
 
-| Variant           | Score Delta              | Effect                                                  | Source                                                       |
-| ----------------- | ------------------------ | ------------------------------------------------------- | ------------------------------------------------------------ |
-| `Penalty::Mild`   | `-1.0`                   | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:90`                |
-| `Penalty::Medium` | `-5.0`                   | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:91`                |
-| `Penalty::Severe` | `-10.0`                  | Clamped to `[min_score, max_score]`                     | `crates/network-libp2p/src/peers/score.rs:92`                |
-| `Penalty::Fatal`  | sets score to `min_score` (`-100.0`) | Immediate ban — score jumps below `min_score_before_ban` (`-50.0`) | `crates/network-libp2p/src/peers/score.rs:93`     |
+| Variant           | Score Delta                          | Effect                                                             | Source                                        |
+| ----------------- | ------------------------------------ | ------------------------------------------------------------------ | --------------------------------------------- |
+| `Penalty::Mild`   | `-1.0`                               | Clamped to `[min_score, max_score]`                                | `crates/network-libp2p/src/peers/score.rs:90` |
+| `Penalty::Medium` | `-5.0`                               | Clamped to `[min_score, max_score]`                                | `crates/network-libp2p/src/peers/score.rs:91` |
+| `Penalty::Severe` | `-10.0`                              | Clamped to `[min_score, max_score]`                                | `crates/network-libp2p/src/peers/score.rs:92` |
+| `Penalty::Fatal`  | sets score to `min_score` (`-100.0`) | Immediate ban — score jumps below `min_score_before_ban` (`-50.0`) | `crates/network-libp2p/src/peers/score.rs:93` |
 
 ## 2. Score Model Invariants
 
@@ -22,8 +22,8 @@ Score deltas are applied in `crates/network-libp2p/src/peers/score.rs:84-100`.
 - Default starting score: `0.0`. `crates/config/src/network.rs:436`.
 - Ban threshold (`min_score_before_ban`): `-50.0`. `crates/config/src/network.rs:443`.
 - Disconnect threshold (`min_score_before_disconnect`): `-20.0`. `crates/config/src/network.rs:442`.
-- Score halflife: `600.0` seconds; decay factor is `e^(-ln(2)/halflife * dt)`. `crates/config/src/network.rs:440`, `crates/network-libp2p/src/peers/score.rs:130-132`.
-- `banned_before_decay_secs`: `12 * 3600` (12 hours). When a peer crosses the ban threshold, `last_updated` is pushed forward by this duration so the score does not decay during the lockout. `crates/config/src/network.rs:441`, `crates/network-libp2p/src/peers/score.rs:149-154`.
+- Score halflife: `300.0` seconds; decay factor is `e^(-ln(2)/halflife * dt)`. `crates/config/src/network.rs:440`, `crates/network-libp2p/src/peers/score.rs:130-132`.
+- `banned_before_decay_secs`: `30 * 60` (30 min). When a peer crosses the ban threshold, `last_updated` is pushed forward by this duration so the score does not decay during the lockout. `crates/config/src/network.rs:441`, `crates/network-libp2p/src/peers/score.rs:149-154`.
 - Trusted peers skip penalty application entirely — `Peer::apply_penalty` short-circuits when `self.is_trusted`. `crates/network-libp2p/src/peers/peer.rs:158-161`.
 - Penalty application has no debouncing: every `process_penalty` call evaluates reputation immediately and may produce a ban on the same call. `crates/network-libp2p/src/peers/all_peers.rs:111-147`.
 - Bans surface to the rest of the swarm as `PeerEvent::Banned`, pushed by `process_ban`. `crates/network-libp2p/src/peers/manager.rs:389-401`.
@@ -36,36 +36,36 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 
 ### 3.1 Gossip events (`process_gossip_event`, L781)
 
-| Location                                              | Trigger (immediate guard)                                          | Severity |
-| ----------------------------------------------------- | ------------------------------------------------------------------ | -------- |
-| `crates/network-libp2p/src/consensus.rs:828`          | `verify_gossip` rejected (`!valid`) — invalid topic or unauthorized publisher | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:839`          | `GossipEvent::GossipsubNotSupported { peer_id }`                   | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:843`          | `GossipEvent::SlowPeer { peer_id, failed_messages }`               | `Mild`   |
+| Location                                     | Trigger (immediate guard)                                                     | Severity |
+| -------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:828` | `verify_gossip` rejected (`!valid`) — invalid topic or unauthorized publisher | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:839` | `GossipEvent::GossipsubNotSupported { peer_id }`                              | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:843` | `GossipEvent::SlowPeer { peer_id, failed_messages }`                          | `Mild`   |
 
 ### 3.2 Req/Res events (`process_reqres_event`, L851)
 
-| Location                                              | Trigger                                                                   | Severity |
-| ----------------------------------------------------- | ------------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:946`          | `ReqResEvent::OutboundFailure` after PX-disconnect skip guard             | `Medium` |
-| `crates/network-libp2p/src/consensus.rs:963`          | `ReqResInboundFailure::Io(e)`                                             | `Medium` |
-| `crates/network-libp2p/src/consensus.rs:972`          | `ReqResInboundFailure::UnsupportedProtocols`                              | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:979`          | `ReqResInboundFailure::Timeout` or `ReqResInboundFailure::ConnectionClosed` | `Mild` |
+| Location                                     | Trigger                                                                     | Severity |
+| -------------------------------------------- | --------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:946` | `ReqResEvent::OutboundFailure` after PX-disconnect skip guard               | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:963` | `ReqResInboundFailure::Io(e)`                                               | `Medium` |
+| `crates/network-libp2p/src/consensus.rs:972` | `ReqResInboundFailure::UnsupportedProtocols`                                | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:979` | `ReqResInboundFailure::Timeout` or `ReqResInboundFailure::ConnectionClosed` | `Mild`   |
 
 `ReqResInboundFailure::ResponseOmission` is explicitly a no-op (local error). See restraint invariants below.
 
 ### 3.3 Kademlia outbound `GetRecord` query (`process_kad_event`, L1208)
 
-| Location                                              | Trigger                                                                                                       | Severity |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:1267`         | `kad::QueryResult::GetRecord(Ok(FoundRecord))` but `peer_record_valid` returned `None` (bad sig / key mismatch) | `Fatal`  |
+| Location                                      | Trigger                                                                                                         | Severity |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:1267` | `kad::QueryResult::GetRecord(Ok(FoundRecord))` but `peer_record_valid` returned `None` (bad sig / key mismatch) | `Fatal`  |
 
 ### 3.4 Kad put-record handler (`process_kad_put_request`, L1362)
 
-| Location                                              | Trigger                                                                              | Severity |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
-| `crates/network-libp2p/src/consensus.rs:1383`         | record was rejected AND `record.publisher.is_none()` (publisher-less record)         | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:1406`         | `peer_record_valid(&record).is_some()` but `!is_newer_record(&record)` (stale record) | `Mild`   |
-| `crates/network-libp2p/src/consensus.rs:1413`         | `peer_record_valid(&record).is_none()` (invalid signature / wrong network key)        | `Fatal`  |
+| Location                                      | Trigger                                                                               | Severity |
+| --------------------------------------------- | ------------------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:1383` | record was rejected AND `record.publisher.is_none()` (publisher-less record)          | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:1406` | `peer_record_valid(&record).is_some()` but `!is_newer_record(&record)` (stale record) | `Mild`   |
+| `crates/network-libp2p/src/consensus.rs:1413` | `peer_record_valid(&record).is_none()` (invalid signature / wrong network key)        | `Fatal`  |
 
 A rejected record from a banned source/publisher with a publisher present does
 NOT incur an extra penalty here — only the missing-publisher case is fatal. The
@@ -73,160 +73,160 @@ ban itself was applied elsewhere.
 
 ### 3.5 Kad query-result post-processing (`process_kad_query_result`, L1450)
 
-| Location                                              | Trigger                                                                | Severity |
-| ----------------------------------------------------- | ---------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:1479`         | record valid but `query.request != key` (returned key does not match request) | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:1488`         | `peer_record_valid(&record).is_none()` on the late-step path           | `Fatal`  |
+| Location                                      | Trigger                                                                       | Severity |
+| --------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
+| `crates/network-libp2p/src/consensus.rs:1479` | record valid but `query.request != key` (returned key does not match request) | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:1488` | `peer_record_valid(&record).is_none()` on the late-step path                  | `Fatal`  |
 
 ## 4. Penalty Application Sites — Worker Layer
 
 ### 4.1 `crates/consensus/worker/src/network/mod.rs` call sites
 
-| Location                                                          | Handler                          | Source of penalty                              |
-| ----------------------------------------------------------------- | -------------------------------- | ---------------------------------------------- |
-| `crates/consensus/worker/src/network/mod.rs:246`                  | `process_report_batch`           | `WorkerNetworkError::into() -> Option<Penalty>` |
-| `crates/consensus/worker/src/network/mod.rs:271`                  | `process_gossip`                 | `WorkerNetworkError::penalty()`                |
-| `crates/consensus/worker/src/network/mod.rs:379`                  | `process_request_batches_stream` response-error branch | `WorkerNetworkError::into() -> Option<Penalty>` |
-| `crates/consensus/worker/src/network/mod.rs:435`                  | `process_inbound_stream`         | `WorkerNetworkError::penalty()`                |
+| Location                                         | Handler                                                | Source of penalty                               |
+| ------------------------------------------------ | ------------------------------------------------------ | ----------------------------------------------- |
+| `crates/consensus/worker/src/network/mod.rs:246` | `process_report_batch`                                 | `WorkerNetworkError::into() -> Option<Penalty>` |
+| `crates/consensus/worker/src/network/mod.rs:271` | `process_gossip`                                       | `WorkerNetworkError::penalty()`                 |
+| `crates/consensus/worker/src/network/mod.rs:379` | `process_request_batches_stream` response-error branch | `WorkerNetworkError::into() -> Option<Penalty>` |
+| `crates/consensus/worker/src/network/mod.rs:435` | `process_inbound_stream`                               | `WorkerNetworkError::penalty()`                 |
 
 ### 4.2 `WorkerNetworkError::penalty()` mapping
 
 Source: `crates/consensus/worker/src/network/error.rs:76-138`.
 
-| Error variant                                                          | Severity | Source                                                  |
-| ---------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
-| `BatchValidation(CanonicalChain { .. })`                               | `Mild`   | `crates/consensus/worker/src/network/error.rs:86`       |
-| `BatchValidation(InvalidEpoch { .. })`                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`    |
-| `BatchValidation(InvalidTx4844(_))`                                    | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`    |
-| `BatchValidation(RecoverTransaction(..))`                              | `Severe` | `crates/consensus/worker/src/network/error.rs:91`       |
-| `BatchValidation(EmptyBatch)`                                          | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(InvalidBaseFee { .. })`                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(InvalidWorkerId { .. })`                              | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(InvalidDigest)`                                       | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(GasOverflow)`                                         | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(CalculateMaxPossibleGas)`                             | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(HeaderMaxGasExceedsGasLimit { .. })`                  | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `BatchValidation(HeaderTransactionBytesExceedsMax(_))`                 | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`   |
-| `InvalidRequest(_)`                                                    | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106`  |
-| `UnknownStreamRequest(_)`                                              | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106`  |
-| `StdIo(io_err)` kind `ConnectionReset`/`ConnectionAborted`/`TimedOut`/`Interrupted` | `Mild` | `crates/consensus/worker/src/network/error.rs:108-114`  |
-| `StdIo(io_err)` other kinds                                            | `Medium` | `crates/consensus/worker/src/network/error.rs:115`      |
-| `NonCommitteeBatch`                                                    | `Medium` | `crates/consensus/worker/src/network/error.rs:119`      |
-| `InvalidTopic`                                                         | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `Bcs(_)`                                                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `TooManyBatches { .. }`                                                | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `UnexpectedBatch(_)`                                                   | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `DuplicateBatch(_)`                                                    | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `RequestHashMismatch`                                                  | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126`  |
-| `Timeout(_)`                                                           | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
-| `DBInsert(_)` / `DBCommit(_)` / `DBRead(_)`                            | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
-| `StreamClosed`                                                         | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
-| `Network(_)`                                                           | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
-| `BatchEpochMismatch(_, _)`                                             | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
-| `Internal(_)`                                                          | None     | `crates/consensus/worker/src/network/error.rs:128-135`  |
+| Error variant                                                                       | Severity | Source                                                 |
+| ----------------------------------------------------------------------------------- | -------- | ------------------------------------------------------ |
+| `BatchValidation(CanonicalChain { .. })`                                            | `Mild`   | `crates/consensus/worker/src/network/error.rs:86`      |
+| `BatchValidation(InvalidEpoch { .. })`                                              | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`   |
+| `BatchValidation(InvalidTx4844(_))`                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`   |
+| `BatchValidation(RecoverTransaction(..))`                                           | `Severe` | `crates/consensus/worker/src/network/error.rs:91`      |
+| `BatchValidation(EmptyBatch)`                                                       | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(InvalidBaseFee { .. })`                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(InvalidWorkerId { .. })`                                           | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(InvalidDigest)`                                                    | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(GasOverflow)`                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(CalculateMaxPossibleGas)`                                          | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(HeaderMaxGasExceedsGasLimit { .. })`                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `BatchValidation(HeaderTransactionBytesExceedsMax(_))`                              | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
+| `InvalidRequest(_)`                                                                 | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106` |
+| `UnknownStreamRequest(_)`                                                           | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106` |
+| `StdIo(io_err)` kind `ConnectionReset`/`ConnectionAborted`/`TimedOut`/`Interrupted` | `Mild`   | `crates/consensus/worker/src/network/error.rs:108-114` |
+| `StdIo(io_err)` other kinds                                                         | `Medium` | `crates/consensus/worker/src/network/error.rs:115`     |
+| `NonCommitteeBatch`                                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:119`     |
+| `InvalidTopic`                                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `Bcs(_)`                                                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `TooManyBatches { .. }`                                                             | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `UnexpectedBatch(_)`                                                                | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `DuplicateBatch(_)`                                                                 | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `RequestHashMismatch`                                                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
+| `Timeout(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `DBInsert(_)` / `DBCommit(_)` / `DBRead(_)`                                         | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `StreamClosed`                                                                      | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `Network(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `BatchEpochMismatch(_, _)`                                                          | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `Internal(_)`                                                                       | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
 
 ## 5. Penalty Application Sites — Primary Layer
 
 ### 5.1 `crates/consensus/primary/src/network/mod.rs` call sites
 
-| Location                                                          | Handler                              | Source of penalty                                                         |
-| ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
-| `crates/consensus/primary/src/network/mod.rs:421`                 | `stream_import` (epoch pack download) | `Self::consensus_chain_error_to_penalty(&err)`                            |
-| `crates/consensus/primary/src/network/mod.rs:682`                 | `retrieve_missing_certs`             | `(&PrimaryNetworkError).into() -> Option<Penalty>`                         |
-| `crates/consensus/primary/src/network/mod.rs:719`                 | `retrieve_consensus_header` (any err) | hard-coded `Penalty::Mild`                                                |
-| `crates/consensus/primary/src/network/mod.rs:751`                 | `retrieve_epoch_record`              | `(&PrimaryNetworkError).into()`                                           |
-| `crates/consensus/primary/src/network/mod.rs:835`                 | `process_epoch_stream` response-err branch | `(&PrimaryNetworkError).into()`                                       |
-| `crates/consensus/primary/src/network/mod.rs:863`                 | `process_gossip`                     | `(&PrimaryNetworkError).into()`                                           |
-| `crates/consensus/primary/src/network/mod.rs:912`                 | `process_inbound_stream`             | `(&PrimaryNetworkError).into()`                                           |
+| Location                                          | Handler                                    | Source of penalty                                  |
+| ------------------------------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `crates/consensus/primary/src/network/mod.rs:421` | `stream_import` (epoch pack download)      | `Self::consensus_chain_error_to_penalty(&err)`     |
+| `crates/consensus/primary/src/network/mod.rs:682` | `retrieve_missing_certs`                   | `(&PrimaryNetworkError).into() -> Option<Penalty>` |
+| `crates/consensus/primary/src/network/mod.rs:719` | `retrieve_consensus_header` (any err)      | hard-coded `Penalty::Mild`                         |
+| `crates/consensus/primary/src/network/mod.rs:751` | `retrieve_epoch_record`                    | `(&PrimaryNetworkError).into()`                    |
+| `crates/consensus/primary/src/network/mod.rs:835` | `process_epoch_stream` response-err branch | `(&PrimaryNetworkError).into()`                    |
+| `crates/consensus/primary/src/network/mod.rs:863` | `process_gossip`                           | `(&PrimaryNetworkError).into()`                    |
+| `crates/consensus/primary/src/network/mod.rs:912` | `process_inbound_stream`                   | `(&PrimaryNetworkError).into()`                    |
 
 ### 5.2 `From<&PrimaryNetworkError> for Option<Penalty>`
 
 Source: `crates/consensus/primary/src/error/network.rs:70-132`.
 
-| Variant                                                           | Severity | Source                                                       |
-| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
-| `InvalidHeader(header_error)`                                     | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:76-78` |
-| `Certificate(CertManagerError::Certificate(CertificateError::Header(h)))` | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:81-83` |
-| `Certificate(CertManagerError::Certificate(CertificateError::TooOld(..)))` | `Mild`   | `crates/consensus/primary/src/error/network.rs:85`            |
-| `Certificate(CertManagerError::Certificate(CertificateError::RecoverBlsAggregateSignatureBytes))` | `Fatal`  | `crates/consensus/primary/src/error/network.rs:87-90`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::Unsigned))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::Inquorate { .. }))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::InvalidSignature))` | `Fatal` | `crates/consensus/primary/src/error/network.rs:87-90`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::ResChannelClosed(_)))` | None    | `crates/consensus/primary/src/error/network.rs:92-94`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::TooNew(..)))` | None     | `crates/consensus/primary/src/error/network.rs:92-94`         |
-| `Certificate(CertManagerError::Certificate(CertificateError::Storage(_)))` | None     | `crates/consensus/primary/src/error/network.rs:92-94`         |
-| `Certificate(CertManagerError::UnverifiedSignature(_))`           | `Fatal`  | `crates/consensus/primary/src/error/network.rs:97`            |
-| `Certificate(CertManagerError::*)` operational variants (`PendingCertificateNotFound`, `PendingParentsMismatch`, `CertificateManagerOneshot`, `FatalForwardAcceptedCertificate`, `NoCertificateFetched`, `FatalAppendParent`, `GC`, `JoinError`, `Pending`, `Storage`, `RequestBounds`, `Timeout`, `Network`, `ChannelClosed`, `TNSend`) | None | `crates/consensus/primary/src/error/network.rs:99-113` |
-| `InvalidRequest(_)`                                               | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
-| `UnknownConsensusHeaderDigest(_)`                                 | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
-| `UnknownStreamRequest(_)`                                         | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
-| `UnknownConsensusHeaderCert(_)`                                   | `Mild`   | `crates/consensus/primary/src/error/network.rs:115-118`       |
-| `InvalidEpochRequest`                                             | `Medium` | `crates/consensus/primary/src/error/network.rs:119-120`       |
-| `StdIo(_)`                                                        | `Medium` | `crates/consensus/primary/src/error/network.rs:119-120`       |
-| `InvalidTopic`                                                    | `Fatal`  | `crates/consensus/primary/src/error/network.rs:121-122`       |
-| `Decode(_)`                                                       | `Fatal`  | `crates/consensus/primary/src/error/network.rs:121-122`       |
-| `UnavailableEpoch(_)`                                             | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `UnavailableEpochDigest(_)`                                       | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `PeerNotInCommittee(_)`                                           | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `Storage(_)`                                                      | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `Timeout(_)`                                                      | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `StreamUnavailable(_)`                                            | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
-| `Internal(_)`                                                     | None     | `crates/consensus/primary/src/error/network.rs:123-129`       |
+| Variant                                                                                                                                                                                                                                                                                                                                  | Severity                                 | Source                                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------- |
+| `InvalidHeader(header_error)`                                                                                                                                                                                                                                                                                                            | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:76-78`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::Header(h)))`                                                                                                                                                                                                                                                                | delegates to `penalty_from_header_error` | `crates/consensus/primary/src/error/network.rs:81-83`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::TooOld(..)))`                                                                                                                                                                                                                                                               | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:85`      |
+| `Certificate(CertManagerError::Certificate(CertificateError::RecoverBlsAggregateSignatureBytes))`                                                                                                                                                                                                                                        | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:87-90`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::Unsigned))`                                                                                                                                                                                                                                                                 | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:87-90`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::Inquorate { .. }))`                                                                                                                                                                                                                                                         | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:87-90`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::InvalidSignature))`                                                                                                                                                                                                                                                         | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:87-90`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::ResChannelClosed(_)))`                                                                                                                                                                                                                                                      | None                                     | `crates/consensus/primary/src/error/network.rs:92-94`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::TooNew(..)))`                                                                                                                                                                                                                                                               | None                                     | `crates/consensus/primary/src/error/network.rs:92-94`   |
+| `Certificate(CertManagerError::Certificate(CertificateError::Storage(_)))`                                                                                                                                                                                                                                                               | None                                     | `crates/consensus/primary/src/error/network.rs:92-94`   |
+| `Certificate(CertManagerError::UnverifiedSignature(_))`                                                                                                                                                                                                                                                                                  | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:97`      |
+| `Certificate(CertManagerError::*)` operational variants (`PendingCertificateNotFound`, `PendingParentsMismatch`, `CertificateManagerOneshot`, `FatalForwardAcceptedCertificate`, `NoCertificateFetched`, `FatalAppendParent`, `GC`, `JoinError`, `Pending`, `Storage`, `RequestBounds`, `Timeout`, `Network`, `ChannelClosed`, `TNSend`) | None                                     | `crates/consensus/primary/src/error/network.rs:99-113`  |
+| `InvalidRequest(_)`                                                                                                                                                                                                                                                                                                                      | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
+| `UnknownConsensusHeaderDigest(_)`                                                                                                                                                                                                                                                                                                        | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
+| `UnknownStreamRequest(_)`                                                                                                                                                                                                                                                                                                                | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
+| `UnknownConsensusHeaderCert(_)`                                                                                                                                                                                                                                                                                                          | `Mild`                                   | `crates/consensus/primary/src/error/network.rs:115-118` |
+| `InvalidEpochRequest`                                                                                                                                                                                                                                                                                                                    | `Medium`                                 | `crates/consensus/primary/src/error/network.rs:119-120` |
+| `StdIo(_)`                                                                                                                                                                                                                                                                                                                               | `Medium`                                 | `crates/consensus/primary/src/error/network.rs:119-120` |
+| `InvalidTopic`                                                                                                                                                                                                                                                                                                                           | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:121-122` |
+| `Decode(_)`                                                                                                                                                                                                                                                                                                                              | `Fatal`                                  | `crates/consensus/primary/src/error/network.rs:121-122` |
+| `UnavailableEpoch(_)`                                                                                                                                                                                                                                                                                                                    | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `UnavailableEpochDigest(_)`                                                                                                                                                                                                                                                                                                              | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `PeerNotInCommittee(_)`                                                                                                                                                                                                                                                                                                                  | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `Storage(_)`                                                                                                                                                                                                                                                                                                                             | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `Timeout(_)`                                                                                                                                                                                                                                                                                                                             | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `StreamUnavailable(_)`                                                                                                                                                                                                                                                                                                                   | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
+| `Internal(_)`                                                                                                                                                                                                                                                                                                                            | None                                     | `crates/consensus/primary/src/error/network.rs:123-129` |
 
 ### 5.3 `penalty_from_header_error`
 
 Source: `crates/consensus/primary/src/error/network.rs:137-171`.
 
-| `HeaderError` variant                                             | Severity | Source                                                       |
-| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
-| `SyncBatches(_)`                                                  | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
-| `TooNew { .. }`                                                   | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
-| `Storage(_)`                                                      | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
-| `UnknownExecutionResult(_)`                                       | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143`       |
-| `InvalidParents`                                                  | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
-| `WrongNumberOfParents(_, _)`                                      | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
-| `TooOld { .. }`                                                   | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147`       |
-| `InvalidTimestamp { .. }`                                         | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151`       |
-| `InvalidParentRound`                                              | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151`       |
-| `AlreadyVotedForLaterRound { .. }`                                | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `AlreadyVoted(_, _)`                                              | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `DuplicateParents`                                                | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `TooManyParents(_, _)`                                            | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `UnknownNetworkKey(_)`                                            | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `PeerNotAuthor`                                                   | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `InvalidGenesisParent(_)`                                         | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `ParentMissingSignature`                                          | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `InvalidParentTimestamp { .. }`                                   | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `UnkownWorkerId`                                                  | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `InvalidHeaderDigest`                                             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `UnknownAuthority(_)`                                             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164`       |
-| `PendingCertificateOneshot`                                       | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
-| `TNSend(_)`                                                       | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
-| `InvalidEpoch { .. }`                                             | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
-| `ClosedWatchChannel`                                              | None     | `crates/consensus/primary/src/error/network.rs:166-169`       |
+| `HeaderError` variant              | Severity | Source                                                  |
+| ---------------------------------- | -------- | ------------------------------------------------------- |
+| `SyncBatches(_)`                   | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143` |
+| `TooNew { .. }`                    | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143` |
+| `Storage(_)`                       | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143` |
+| `UnknownExecutionResult(_)`        | `Mild`   | `crates/consensus/primary/src/error/network.rs:140-143` |
+| `InvalidParents`                   | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147` |
+| `WrongNumberOfParents(_, _)`       | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147` |
+| `TooOld { .. }`                    | `Medium` | `crates/consensus/primary/src/error/network.rs:145-147` |
+| `InvalidTimestamp { .. }`          | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151` |
+| `InvalidParentRound`               | `Severe` | `crates/consensus/primary/src/error/network.rs:149-151` |
+| `AlreadyVotedForLaterRound { .. }` | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `AlreadyVoted(_, _)`               | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `DuplicateParents`                 | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `TooManyParents(_, _)`             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `UnknownNetworkKey(_)`             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `PeerNotAuthor`                    | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `InvalidGenesisParent(_)`          | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `ParentMissingSignature`           | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `InvalidParentTimestamp { .. }`    | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `UnkownWorkerId`                   | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `InvalidHeaderDigest`              | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `UnknownAuthority(_)`              | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `PendingCertificateOneshot`        | None     | `crates/consensus/primary/src/error/network.rs:166-169` |
+| `TNSend(_)`                        | None     | `crates/consensus/primary/src/error/network.rs:166-169` |
+| `InvalidEpoch { .. }`              | None     | `crates/consensus/primary/src/error/network.rs:166-169` |
+| `ClosedWatchChannel`               | None     | `crates/consensus/primary/src/error/network.rs:166-169` |
 
 ### 5.4 `consensus_chain_error_to_penalty`
 
 Source: `crates/consensus/primary/src/network/mod.rs:448-489`.
 
-| Variant                                                           | Severity | Source                                                       |
-| ----------------------------------------------------------------- | -------- | ------------------------------------------------------------ |
-| `PackError(PackError::MissingBatch)`                              | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
-| `PackError(PackError::NotConsensus)`                              | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
-| `PackError(PackError::NotBatch)`                                  | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
-| `PackError(PackError::NotEpoch)`                                  | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454`        |
-| `PackError(PackError::InvalidConsensusChain)`                     | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
-| `PackError(PackError::ExtraBatches)`                              | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
-| `PackError(PackError::MissingBatches)`                            | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
-| `PackError(PackError::CorruptPack)`                               | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
-| `PackError(PackError::InvalidEpoch)`                              | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459`        |
-| `PackError` operational variants (`IO`, `BatchLoad`, `EpochLoad`, `Append`, `IndexAppend`, `Fetch`, `Open`, `ReadOnly`, `ReadError`, `MissingAuthority`, `SendFailed`, `ReceiveFailed`, `PersistError`, `InvalidConsensusNumber`, `ConsensusNumberAlreadyAdded`, `ConsensusNumberTooLow`, `ConsensusNumberTooHigh`) | None | `crates/consensus/primary/src/network/mod.rs:460-476` |
-| `EpochMismatch`                                                   | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
-| `PrevCommitteeEpochMismatch`                                      | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
-| `CrcError`                                                        | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480`        |
-| `EmptyImport`                                                     | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483`        |
-| `InvalidImport`                                                   | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483`        |
-| `StreamUnavailable` / `NoCurrentEpoch` / `EpochDbError(_)` / `IO(_)` | None  | `crates/consensus/primary/src/network/mod.rs:484-487`        |
+| Variant                                                                                                                                                                                                                                                                                                             | Severity | Source                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
+| `PackError(PackError::MissingBatch)`                                                                                                                                                                                                                                                                                | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454` |
+| `PackError(PackError::NotConsensus)`                                                                                                                                                                                                                                                                                | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454` |
+| `PackError(PackError::NotBatch)`                                                                                                                                                                                                                                                                                    | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454` |
+| `PackError(PackError::NotEpoch)`                                                                                                                                                                                                                                                                                    | `Medium` | `crates/consensus/primary/src/network/mod.rs:451-454` |
+| `PackError(PackError::InvalidConsensusChain)`                                                                                                                                                                                                                                                                       | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459` |
+| `PackError(PackError::ExtraBatches)`                                                                                                                                                                                                                                                                                | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459` |
+| `PackError(PackError::MissingBatches)`                                                                                                                                                                                                                                                                              | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459` |
+| `PackError(PackError::CorruptPack)`                                                                                                                                                                                                                                                                                 | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459` |
+| `PackError(PackError::InvalidEpoch)`                                                                                                                                                                                                                                                                                | `Severe` | `crates/consensus/primary/src/network/mod.rs:455-459` |
+| `PackError` operational variants (`IO`, `BatchLoad`, `EpochLoad`, `Append`, `IndexAppend`, `Fetch`, `Open`, `ReadOnly`, `ReadError`, `MissingAuthority`, `SendFailed`, `ReceiveFailed`, `PersistError`, `InvalidConsensusNumber`, `ConsensusNumberAlreadyAdded`, `ConsensusNumberTooLow`, `ConsensusNumberTooHigh`) | None     | `crates/consensus/primary/src/network/mod.rs:460-476` |
+| `EpochMismatch`                                                                                                                                                                                                                                                                                                     | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480` |
+| `PrevCommitteeEpochMismatch`                                                                                                                                                                                                                                                                                        | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480` |
+| `CrcError`                                                                                                                                                                                                                                                                                                          | `Mild`   | `crates/consensus/primary/src/network/mod.rs:478-480` |
+| `EmptyImport`                                                                                                                                                                                                                                                                                                       | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483` |
+| `InvalidImport`                                                                                                                                                                                                                                                                                                     | `Severe` | `crates/consensus/primary/src/network/mod.rs:481-483` |
+| `StreamUnavailable` / `NoCurrentEpoch` / `EpochDbError(_)` / `IO(_)`                                                                                                                                                                                                                                                | None     | `crates/consensus/primary/src/network/mod.rs:484-487` |
 
 ## 6. Restraint Invariants (no-penalty cases)
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -498,10 +498,18 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
 
     // Capture the malicious peer's view of the honest responder before the request.
-    // The contract under test: a failed OutboundFailure caused by codec mismatch /
-    // transport-level errors must NOT penalize the responder — otherwise a peer who
-    // cannot satisfy a request would be banned by every requester, which is the
-    // ban-cascade that breaks observer joins on WAN.
+    //
+    // The contract under test: when a malformed *request* arrives at the responder,
+    // libp2p's `read_request` fails inside the codec and the responder drops the
+    // substream WITHOUT emitting `InboundFailure::Io` (see libp2p request-response
+    // 0.29 `lib.rs:1011-1014`). From the requester's side the failure surfaces as
+    // either `OutboundFailure::ConnectionClosed` or `OutboundFailure::Io` with a
+    // transport-flap `ErrorKind` (e.g. `UnexpectedEof`) — both are no-penalty
+    // under the new policy.
+    //
+    // The `Penalty::Medium` codec-violation path requires the malformed bytes to
+    // be a *response* (read_response on the requester returns `io::Error::other`).
+    // That is exercised separately by `test_outbound_failure_malicious_response`.
     let malicious_view_before = malicious_peer.peer_score(honest_peer_id).await?.unwrap();
 
     // honest peer returns `OutboundFailure` error
@@ -515,7 +523,10 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
     // Allow time for any penalty propagation
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Malicious peer's view of the honest peer should be unchanged.
+    // Responder's score (from the requester's view) is unchanged: a transport-level
+    // OutboundFailure for a malformed-request scenario must not penalize the
+    // responder. Otherwise a peer who cannot satisfy a request would be banned by
+    // every requester — the ban-cascade that breaks observer joins on WAN.
     let malicious_view_after = malicious_peer.peer_score(honest_peer_id).await?.unwrap();
     assert_eq!(
         malicious_view_before, malicious_view_after,
@@ -523,8 +534,9 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
     );
 
     // Note: honest peer's penalty of the malicious requester via InboundFailure is
-    // tracked separately — see Issue #250. libp2p does not reliably surface
-    // InboundFailure events for every codec mismatch scenario.
+    // NOT exercised here. libp2p request-response 0.29 does not emit
+    // InboundFailure::Io when read_request fails — see lib.rs:1011-1014.
+    // Dispatch-layer coverage for that path is tracked in Issue #250.
 
     Ok(())
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -471,7 +471,6 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
     malicious_peer.start_listening(config_1.primary_address()).await?;
     honest_peer.start_listening(config_2.primary_address()).await?;
 
-    let malicious_peer_id = malicious_peer.local_peer_id().await?;
     let honest_peer_id = honest_peer.local_peer_id().await?;
     let honest_peer_addr = config_2.primary_address();
     let honest_peer_net = config_2.primary_networkkey();
@@ -498,7 +497,12 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
     // sleep for heartbeat
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
 
-    let peer_score_before_msg = honest_peer.peer_score(malicious_peer_id).await?.unwrap();
+    // Capture the malicious peer's view of the honest responder before the request.
+    // The contract under test: a failed OutboundFailure caused by codec mismatch /
+    // transport-level errors must NOT penalize the responder — otherwise a peer who
+    // cannot satisfy a request would be banned by every requester, which is the
+    // ban-cascade that breaks observer joins on WAN.
+    let malicious_view_before = malicious_peer.peer_score(honest_peer_id).await?.unwrap();
 
     // honest peer returns `OutboundFailure` error
     let response_from_peer = malicious_peer.send_request(malicious_msg, honest_bls).await?;
@@ -508,15 +512,19 @@ async fn test_outbound_failure_malicious_request() -> eyre::Result<()> {
 
     assert_matches!(res, Err(NetworkError::Outbound(_)));
 
-    // Allow time for penalty to be applied
+    // Allow time for any penalty propagation
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // TODO: the honest peer penalize the malicious requestor. see Issue #250
-    //
-    // assert honest peer's score is lower - penalties are applied immediately
-    // however, it should be the case that honest peer penalizes the malicious peer
-    let peer_score_after_msg = malicious_peer.peer_score(honest_peer_id).await?.unwrap();
-    assert!(peer_score_before_msg > peer_score_after_msg);
+    // Malicious peer's view of the honest peer should be unchanged.
+    let malicious_view_after = malicious_peer.peer_score(honest_peer_id).await?.unwrap();
+    assert_eq!(
+        malicious_view_before, malicious_view_after,
+        "requester must not penalize responder on transport-level OutboundFailure (before={malicious_view_before}, after={malicious_view_after})"
+    );
+
+    // Note: honest peer's penalty of the malicious requester via InboundFailure is
+    // tracked separately — see Issue #250. libp2p does not reliably surface
+    // InboundFailure events for every codec mismatch scenario.
 
     Ok(())
 }


### PR DESCRIPTION
- Split outbound-failure handling by kind: transport-level errors (`DialFailure`, `ConnectionClosed`, `Io`) no longer penalize. `Timeout` stays `Mild`; `UnsupportedProtocols` is `Severe` (not `Fatal`, so rolling upgrades do not insta-ban).
- Inbound failures: `Io` drops from `Medium` to `Mild`; `Timeout` and `ConnectionClosed` are no-ops; `UnsupportedProtocols` is `Severe` instead of `Fatal`. Fixes the N-in-flight-requests-at-disconnect insta-ban.
- Drop the hard-coded `Mild` on failed `retrieve_consensus_header` — observers legitimately request headers ahead of local state during sync. Logged at debug instead.
- Drop the `Mild` on stale-but-valid kad records — republication after a peer restart is expected and the local store keeps the newer version.
- Tighten score-model defaults: `score_halflife` 600s → 300s, `banned_before_decay_secs` 12h → 30m. DoS protection still comes from the ban threshold, not the lockout duration.
- Add `crates/network-libp2p/src/peers/penalty.md` as the single source of truth for severities, score-model invariants, and every penalty call site with a source citation.
- Re-enable `test_outbound_failure_malicious_request` and flip its assertion to the new contract: a transport-level `OutboundFailure` must not penalize the responder. Issue #250 tracks the separate inbound side.
