### PR TITLE
Fix observer sync issue.

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -457,7 +457,7 @@ impl PrimaryNetworkHandle {
                 | PackError::ExtraBatches
                 | PackError::MissingBatches
                 | PackError::CorruptPack
-                | PackError::InvalidEpoch => Some(Penalty::Severe),
+                | PackError::InvalidEpoch(_, _) => Some(Penalty::Severe),
                 PackError::IO(_)
                 | PackError::BatchLoad(_)
                 | PackError::EpochLoad(_)

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -562,7 +562,10 @@ impl Inner {
         if let Ok(meta) = data.fetch(DATA_HEADER_BYTES as u64) {
             let meta = meta.into_epoch()?;
             if epoch_meta != meta {
-                return Err(PackError::InvalidEpoch);
+                return Err(PackError::InvalidEpoch(
+                    epoch,
+                    "open append has unexpected meta data".to_string(),
+                ));
             }
         } else {
             data.append(&PackRecord::EpochMeta(epoch_meta.clone()))
@@ -694,23 +697,47 @@ impl Inner {
         epoch_meta: &EpochMeta,
     ) -> Result<(), PackError> {
         if epoch != epoch_meta.epoch {
-            return Err(PackError::InvalidEpoch);
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                format!("meta data epoch is {}", epoch_meta.epoch),
+            ));
         }
         let start_consensus_number =
             if epoch == 0 { 1 } else { previous_epoch.final_consensus.number + 1 };
         if start_consensus_number != epoch_meta.start_consensus_number {
-            return Err(PackError::InvalidEpoch);
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                format!(
+                    "expected start consensus number {start_consensus_number}, got {}",
+                    epoch_meta.start_consensus_number
+                ),
+            ));
         }
         if previous_epoch.final_state != epoch_meta.genesis_exec_state {
-            return Err(PackError::InvalidEpoch);
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                format!(
+                    "expected final state {:?} meta final state {:?}",
+                    previous_epoch.final_state, epoch_meta.genesis_exec_state
+                ),
+            ));
         }
         if previous_epoch.final_consensus != epoch_meta.genesis_consensus {
-            return Err(PackError::InvalidEpoch);
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                format!(
+                    "expected final consensus {:?} meta final consensus {:?}",
+                    previous_epoch.final_consensus, epoch_meta.genesis_consensus
+                ),
+            ));
         }
         let committee: BTreeSet<BlsPublicKey> =
             previous_epoch.next_committee.iter().copied().collect();
         if epoch_meta.committee.bls_keys() != committee {
-            return Err(PackError::InvalidEpoch);
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                "epoch meta has unexpected committee".to_string(),
+            ));
         }
         Ok(())
     }
@@ -1164,7 +1191,7 @@ pub enum PackError {
     InvalidConsensusChain,
     ExtraBatches,
     MissingBatches,
-    InvalidEpoch,
+    InvalidEpoch(Epoch, String),
     SendFailed,
     ReceiveFailed,
     PersistError(String),
@@ -1196,7 +1223,9 @@ impl Display for PackError {
             PackError::InvalidConsensusChain => write!(f, "Broken consensus record chain"),
             PackError::ExtraBatches => write!(f, "Extra batches in pack file"),
             PackError::MissingBatches => write!(f, "Missing batches in pack file"),
-            PackError::InvalidEpoch => write!(f, "Epoch meta data incorrect"),
+            PackError::InvalidEpoch(epoch, msg) => {
+                write!(f, "Epoch meta data incorrect, epoch {epoch}: {msg}")
+            }
             PackError::SendFailed => write!(f, "Internal channel send failed"),
             PackError::ReceiveFailed => write!(f, "Internal channel receive failed"),
             PackError::PersistError(e) => write!(f, "Failed to persist: {e}"),

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -564,7 +564,7 @@ impl Inner {
             if epoch_meta != meta {
                 return Err(PackError::InvalidEpoch(
                     epoch,
-                    "open append has unexpected meta data".to_string(),
+                    format!("open append has unexpected meta data, expected {epoch_meta:?} got {meta:?}"),
                 ));
             }
         } else {

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -130,11 +130,12 @@ impl<'de> Deserialize<'de> for Authority {
 }
 
 /// The committee lists all validators that participate in consensus.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Eq, Default)]
 struct CommitteeInner {
     /// The authorities of epoch.
     authorities: BTreeMap<BlsPublicKey, Authority>,
     /// Keeps and index of the Authorities by their respective identifier
+    /// This is a helper struct, not included in serde or equality.
     #[serde(skip)]
     authorities_by_id: BTreeMap<AuthorityIdentifier, Authority>,
     /// The epoch number of this committee
@@ -146,7 +147,17 @@ struct CommitteeInner {
     #[serde(skip)]
     validity_threshold: VotingPower,
     /// The bootstrap servers to initially join a network (probably the initial committee).
+    /// Note, not included in partial eq since they are not relevand to overall committee equality.
     bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapServer>,
+}
+
+impl PartialEq for CommitteeInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.epoch == other.epoch
+            && self.quorum_threshold == other.validity_threshold
+            && self.validity_threshold == other.validity_threshold
+            && self.authorities.eq(&other.authorities)
+    }
 }
 
 impl CommitteeInner {

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -154,7 +154,7 @@ struct CommitteeInner {
 impl PartialEq for CommitteeInner {
     fn eq(&self, other: &Self) -> bool {
         self.epoch == other.epoch
-            && self.quorum_threshold == other.validity_threshold
+            && self.quorum_threshold == other.quorum_threshold
             && self.validity_threshold == other.validity_threshold
             && self.authorities.eq(&other.authorities)
     }


### PR DESCRIPTION
Updating bootstrap servers in all committees created an inequality in early pack file meta data.
This improves the logging around epoch meta data errors and removes bootstrap servers from committee equality (they are not logically part of the committee anyway).

Closes https://github.com/Telcoin-Association/telcoin-network/issues/691