### PR TITLE
Fsync parent directory after file create and rename in archive

### DIFF
--- a/crates/storage/src/archive/data_file.rs
+++ b/crates/storage/src/archive/data_file.rs
@@ -12,6 +12,18 @@ use crate::archive::error::rename::RenameError;
 const READ_BUFFER_SIZE: usize = 16 * 1024; // 16kb
 const WRITE_BUFFER_SIZE: usize = 16 * 1024; // 16kb
 
+/// Fsync a directory so recent directory-entry changes (file creates, renames)
+/// are durable on Unix.
+///
+/// `File::sync_all` on a regular file does not flush the parent directory entry
+/// that names it.  A crash between a create/rename and a subsequent directory
+/// fsync can leave the filesystem with the entry missing even though the file's
+/// own data and metadata are durable.  Calling this on the parent directory
+/// closes that gap.
+pub(crate) fn fsync_directory(path: &Path) -> Result<(), io::Error> {
+    File::open(path)?.sync_all()
+}
+
 /// Wrapper around a file that implements read and write buffers and manages
 /// them seamlessly via standard IO traits.
 #[derive(Debug)]
@@ -38,7 +50,12 @@ impl DataFile {
             // If we are opening for write then make sure the file exists.
             // This function will create it if it does not exist or produce
             // an error if it does so ignore the errors.
-            let _ = File::create_new(path);
+            if File::create_new(path).is_ok() {
+                // New file was created; fsync the parent so the directory entry is durable.
+                if let Some(parent) = path.parent() {
+                    let _ = fsync_directory(parent);
+                }
+            }
         }
         let mut data_file = OpenOptions::new().read(true).append(!read_only).open(path)?;
         let data_file_end = data_file.seek(SeekFrom::End(0))?;
@@ -164,9 +181,21 @@ impl DataFile {
         if path.exists() {
             return Err(RenameError::FilesExist);
         }
+        let old_parent = self.data_file_path.parent().map(Path::to_owned);
         let res = fs::rename(&self.data_file_path, path);
         if res.is_ok() {
             self.data_file_path = path.to_owned();
+            // Fsync the new path's parent so the rename is durable on the entry side.
+            if let Some(new_parent) = path.parent() {
+                fsync_directory(new_parent).map_err(RenameError::RenameIO)?;
+            }
+            // If the source was in a different directory, fsync that too so the old entry's
+            // removal is durable.
+            if let Some(old_parent) = &old_parent {
+                if path.parent() != Some(old_parent.as_path()) {
+                    fsync_directory(old_parent).map_err(RenameError::RenameIO)?;
+                }
+            }
         }
         res.map_err(RenameError::RenameIO)
     }

--- a/crates/storage/src/archive/data_file.rs
+++ b/crates/storage/src/archive/data_file.rs
@@ -20,6 +20,12 @@ const WRITE_BUFFER_SIZE: usize = 16 * 1024; // 16kb
 /// fsync can leave the filesystem with the entry missing even though the file's
 /// own data and metadata are durable.  Calling this on the parent directory
 /// closes that gap.
+///
+/// # Precondition
+///
+/// `path` must refer to a directory.  Passing a regular file silently fsyncs
+/// that file's contents instead of providing the directory-entry durability
+/// guarantee callers expect, so all in-crate call sites pass a directory.
 pub(crate) fn fsync_directory(path: &Path) -> Result<(), io::Error> {
     File::open(path)?.sync_all()
 }

--- a/crates/storage/src/archive/digest_index/index.rs
+++ b/crates/storage/src/archive/digest_index/index.rs
@@ -335,6 +335,9 @@ impl<const KSIZE: usize, S: BuildHasher + Default> HdxIndex<KSIZE, S> {
                 hdx_file.write_all(&chunk[..n * bucket_size])?;
                 remaining -= n;
             }
+            // Header and initial buckets were just written; fsync the directory so the index.hdx
+            // entry is durable.
+            let _ = fsync_directory(dir);
             (header, bloom)
         } else {
             let header = HdxHeader::load_header(&mut hdx_file)?;
@@ -359,11 +362,6 @@ impl<const KSIZE: usize, S: BuildHasher + Default> HdxIndex<KSIZE, S> {
             let bloom: Bloom = bloom_bits.try_into()?;
             (header, bloom)
         };
-        if file_end == 0 {
-            // Header and initial buckets were just written; fsync the directory so the index.hdx
-            // entry is durable.
-            let _ = fsync_directory(dir);
-        }
         let (odx_file, _odx_header) = OdxHeader::open_odx_file(
             header.version(),
             header.uid(),

--- a/crates/storage/src/archive/digest_index/index.rs
+++ b/crates/storage/src/archive/digest_index/index.rs
@@ -4,6 +4,7 @@ use tn_types::B256;
 
 use crate::archive::{
     crc::{add_crc32, check_crc},
+    data_file::fsync_directory,
     digest_index::{
         bloom::{Bloom, BLOOM_SIZE_BYTES},
         bucket_iter::BucketIter,
@@ -292,7 +293,13 @@ impl<const KSIZE: usize, S: BuildHasher + Default> HdxIndex<KSIZE, S> {
         read_only: bool,
     ) -> Result<HdxIndex<KSIZE, S>, LoadHeaderError> {
         let dir = dir.as_ref();
-        let _ = fs::create_dir(dir);
+        let dir_created = fs::create_dir(dir).is_ok();
+        if dir_created {
+            // The index directory is brand new; fsync the parent so the entry survives a crash.
+            if let Some(parent) = dir.parent() {
+                let _ = fsync_directory(parent);
+            }
+        }
         let mut hdx_file = if read_only {
             OpenOptions::new().read(true).write(false).open(dir.join("index.hdx"))?
         } else {
@@ -352,6 +359,11 @@ impl<const KSIZE: usize, S: BuildHasher + Default> HdxIndex<KSIZE, S> {
             let bloom: Bloom = bloom_bits.try_into()?;
             (header, bloom)
         };
+        if file_end == 0 {
+            // Header and initial buckets were just written; fsync the directory so the index.hdx
+            // entry is durable.
+            let _ = fsync_directory(dir);
+        }
         let (odx_file, _odx_header) = OdxHeader::open_odx_file(
             header.version(),
             header.uid(),

--- a/crates/storage/src/archive/digest_index/odx_header.rs
+++ b/crates/storage/src/archive/digest_index/odx_header.rs
@@ -51,6 +51,11 @@ impl OdxHeader {
             }
             let header = OdxHeader::new(version, uid, appnum, read_only);
             header.write_header(&mut file)?;
+            // New odx file was just created and its header written; fsync the parent so the entry
+            // is durable.
+            if let Some(parent) = path.parent() {
+                let _ = fsync_directory(parent);
+            }
             header
         } else {
             let header = OdxHeader::load_header(&mut file, read_only)?;
@@ -66,13 +71,6 @@ impl OdxHeader {
             }
             header
         };
-        if file_end == 0 {
-            // New odx file was just created and its header written; fsync the parent so the entry
-            // is durable.
-            if let Some(parent) = path.parent() {
-                let _ = fsync_directory(parent);
-            }
-        }
         Ok((file, header))
     }
 

--- a/crates/storage/src/archive/digest_index/odx_header.rs
+++ b/crates/storage/src/archive/digest_index/odx_header.rs
@@ -2,6 +2,7 @@
 
 use crate::archive::{
     crc::{add_crc32, check_crc},
+    data_file::fsync_directory,
     error::load_header::LoadHeaderError,
 };
 use std::{
@@ -65,6 +66,13 @@ impl OdxHeader {
             }
             header
         };
+        if file_end == 0 {
+            // New odx file was just created and its header written; fsync the parent so the entry
+            // is durable.
+            if let Some(parent) = path.parent() {
+                let _ = fsync_directory(parent);
+            }
+        }
         Ok((file, header))
     }
 

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -140,6 +140,9 @@ impl PositionIndex {
             }
             let mut header = PdxHeader::from_data_header(data_header);
             header.write_header(&mut pdx_file)?;
+            // index.pdx was just created and its header written; fsync the directory so the entry
+            // is durable.
+            let _ = fsync_directory(dir);
             header
         } else {
             let header = PdxHeader::load_header(&mut pdx_file)?;
@@ -155,11 +158,6 @@ impl PositionIndex {
             }
             header
         };
-        if was_empty {
-            // index.pdx was just created and its header written; fsync the directory so the entry
-            // is durable.
-            let _ = fsync_directory(dir);
-        }
         Ok(Self { _header: header, pdx_file, _index_dir: dir.to_owned() })
     }
 

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::archive::{
     crc::{add_crc32, check_crc},
-    data_file::DataFile,
+    data_file::{fsync_directory, DataFile},
     error::{
         commit::CommitError, fetch::FetchError, insert::AppendError, load_header::LoadHeaderError,
     },
@@ -124,10 +124,17 @@ impl PositionIndex {
         read_only: bool,
     ) -> Result<PositionIndex, LoadHeaderError> {
         let dir = dir.as_ref();
-        let _ = fs::create_dir(dir);
+        let dir_created = fs::create_dir(dir).is_ok();
+        if dir_created {
+            // The index directory is brand new; fsync the parent so the entry survives a crash.
+            if let Some(parent) = dir.parent() {
+                let _ = fsync_directory(parent);
+            }
+        }
         let mut pdx_file = DataFile::open(dir.join("index.pdx"), read_only)?;
 
-        let header = if pdx_file.is_empty() {
+        let was_empty = pdx_file.is_empty();
+        let header = if was_empty {
             if read_only {
                 return Err(LoadHeaderError::ReadOnlyEmpty);
             }
@@ -148,6 +155,11 @@ impl PositionIndex {
             }
             header
         };
+        if was_empty {
+            // index.pdx was just created and its header written; fsync the directory so the entry
+            // is durable.
+            let _ = fsync_directory(dir);
+        }
         Ok(Self { _header: header, pdx_file, _index_dir: dir.to_owned() })
     }
 


### PR DESCRIPTION
  ## Summary

  Adds `fsync` on parent directories after file creates and renames in the
  archive module, closing a durability gap on Unix where `File::sync_all` alone
  does not flush the directory entry that names a file.

  ## Changes

  - [x] New helper `fsync_directory(path)` in `archive::data_file`.
  - [x] `DataFile::open`: fsync parent after successful `File::create_new`.
  - [x] `DataFile::rename`: fsync new (and old, if different) parent after
  `fs::rename`; errors propagate via `RenameError::RenameIO`.
  - [x] `HdxIndex::open_hdx_file`: fsync parent when the index directory is
  freshly created; fsync the index directory after initial header + bucket
  writes.
  - [x] `OdxHeader::open_odx_file`: fsync parent after the new header is written.
  - [x] `PositionIndex::open_pdx_file`: fsync parent when the index directory is
  freshly created; fsync the index directory after the new header is written.

  Closes #551.  Related: #510.

  ## Testing

  Existing archive tests (`test_archive_hdx_index`, `test_archive_pdx_index`,
  `test_consensus_pack`) exercise the create/open/rename paths and surface any
  `io::Error` from the new fsync calls.  No new tests added; per the issue,
  directory fsync correctness is a kernel guarantee.

  Local: `cargo +nightly-2026-03-20 fmt` clean, `cargo +nightly-2026-03-20 clippy
   -p tn-storage --all-features` clean, `cargo test -p tn-storage --lib`