### PR TITLE
Fix open_redb test helper for 3-arg CompositeDatabase::open

### DIFF
--- a/crates/storage/src/composite_db.rs
+++ b/crates/storage/src/composite_db.rs
@@ -261,8 +261,7 @@ mod test {
     fn open_redb(path: &Path) -> CompositeDatabase<ReDB> {
         let db = ReDB::open(path.join("redb")).expect("Cannot open database");
 
-        let db =
-            CompositeDatabase::open(db.clone(), db.clone(), db.clone(), db.clone(), db.clone(), db);
+        let db = CompositeDatabase::open(db.clone(), db.clone(), db);
         db.open_table::<TestTable>().expect("failed to open table!");
         db
     }


### PR DESCRIPTION
  ## Summary

  `CompositeDatabase::open` was refactored from 6 args to 3 in #652, but the
  `#[cfg(feature = "redb")]` `open_redb` test helper in `composite_db.rs` was
  missed and still passes 6 cloned dbs.  `make clippy` doesn't pass
  `--all-targets` so it missed this, and default `cargo test` leaves the `redb`
  feature off, but the error surfaces immediately under `cargo clippy
  --all-features --all-targets` or `cargo test --features redb`.

  ## Changes

  - [x] `open_redb` now calls `CompositeDatabase::open(db.clone(), db.clone(),
  db)` to match the `open_mdbx` helper directly below.

  ## Testing

  - `cargo +nightly-2026-03-20 fmt --check` clean
  - `cargo +nightly-2026-03-20 clippy -p tn-storage --all-features --all-targets`
   builds (E0061 gone; 28 pre-existing warnings unrelated)
  - `cargo test -p tn-storage --features redb --lib`