### PR TITLE
Fixes some observer issues.

### DIFF
--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -33,7 +33,7 @@ async fn get_consensus_header<DB: TNDatabase>(
     consensus_bus: &ConsensusBusApp,
     network: &PrimaryNetworkHandle,
     consensus_chain: &ConsensusChain,
-) -> Option<(Epoch, u64, B256)> {
+) -> Option<(u64, B256)> {
     // Use the persisted ConsensusChain DB number as the cutoff, not the in-memory
     // recent_blocks tracker. The in-memory tracker can advance during a brief CvvActive
     // phase (local Bullshark commits) before the node transitions to CvvInactive, causing
@@ -43,15 +43,7 @@ async fn get_consensus_header<DB: TNDatabase>(
         return None;
     }
     if let Ok(Some(block)) = db.get::<ConsensusHeaderCache>(&number) {
-        return if block.number > 0 {
-            Some((
-                consensus_chain.epochs().number_to_epoch(block.number - 1),
-                block.number - 1,
-                block.parent_hash,
-            ))
-        } else {
-            None
-        };
+        return if block.number > 0 { Some((block.number - 1, block.parent_hash)) } else { None };
     }
     // request consensus from any peer
     match network.request_consensus(number, hash).await {
@@ -72,8 +64,7 @@ async fn get_consensus_header<DB: TNDatabase>(
                 // Update our last seen valid consensus header if it is newer.
                 consensus_bus.last_consensus_header().send_replace(Some(header));
             }
-            let epoch = consensus_chain.epochs().number_to_epoch(parent_number);
-            Some((epoch, parent_number, parent))
+            Some((parent_number, parent))
         }
         Err(e) => {
             warn!(
@@ -86,8 +77,7 @@ async fn get_consensus_header<DB: TNDatabase>(
             // Return the failed data so we try again.
             // We will not be able to progress without this info so pause and keep trying...
             tokio::time::sleep(Duration::from_secs(5)).await;
-            let epoch = consensus_chain.epochs().number_to_epoch(number);
-            Some((epoch, number, hash))
+            Some((number, hash))
         }
     }
 }
@@ -289,7 +279,6 @@ pub async fn spawn_fetch_consensus(
 
 /// Retrieve a consensus headers from a peer.
 /// Start at number/hash and work backwards to end number.
-#[allow(clippy::too_many_arguments)]
 async fn get_consensus_header_range<DB: TNDatabase>(
     number: u64,
     hash: B256,
@@ -297,22 +286,21 @@ async fn get_consensus_header_range<DB: TNDatabase>(
     consensus_bus: &ConsensusBusApp,
     network: &PrimaryNetworkHandle,
     consensus_chain: &ConsensusChain,
-    fetch_epoch: Epoch,
     end_number: u64,
 ) {
     if number < end_number {
         return;
     }
-    info!(target: "state-sync", ?number, ?hash, ?end_number, ?fetch_epoch, "fetching consensus from peer");
+    info!(target: "state-sync", ?number, ?hash, ?end_number, "fetching consensus from peer");
     let mut number = number;
     let mut hash = hash;
     let mut count = 1;
-    while let Some((epoch, next_number, next_hash)) =
+    while let Some((next_number, next_hash)) =
         get_consensus_header(number, hash, db, consensus_bus, network, consensus_chain).await
     {
         number = next_number;
         hash = next_hash;
-        if number < end_number || epoch < fetch_epoch {
+        if number < end_number {
             break;
         }
         if consensus_chain.consensus_header_by_number(number).await.unwrap_or_default().is_some() {
@@ -320,7 +308,7 @@ async fn get_consensus_header_range<DB: TNDatabase>(
             break;
         }
         if count % 10 == 0 {
-            info!(target: "state-sync", ?number, ?hash, ?end_number, ?fetch_epoch, "fetching consensus from peer");
+            info!(target: "state-sync", ?number, ?hash, ?end_number, "fetching consensus from peer");
         }
         count += 1;
     }
@@ -364,7 +352,6 @@ async fn manage_new_consensus<DB: TNDatabase>(
                     &consensus_bus_clone,
                     &network_clone,
                     &consensus_chain_clone,
-                    epoch,
                     0,
                 )
                 .await;
@@ -381,7 +368,6 @@ async fn manage_new_consensus<DB: TNDatabase>(
         if task_num < 6 {
             let end_number = last_number.unwrap_or_default();
             *last_number = Some(number + 1);
-            let min_epoch = first_gossipped_epoch.unwrap_or_default();
             let tasks_clone = tasks.clone();
             tasks.fetch_add(1, Ordering::Relaxed);
             task_spawner.spawn_task(
@@ -394,7 +380,6 @@ async fn manage_new_consensus<DB: TNDatabase>(
                         &consensus_bus_clone,
                         &network_clone,
                         &consensus_chain_clone,
-                        min_epoch,
                         end_number,
                     )
                     .await;
@@ -428,7 +413,9 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
     // should not hurt and can clear up an issue if something interferes with eviction.
     // Note, on longer shutdowns this will have no real effect but could lead to churn
     // if a node is being restarted relatively quickly.
-    let _ = db.clear_table::<ConsensusHeaderCache>();
+    if let Err(e) = db.clear_table::<ConsensusHeaderCache>() {
+        error!(target: "state-sync", ?e, "Error clearing consensus header cache, ignoring...");
+    }
     // Get the epoch of our last executed consensus.
     let mut current_fetch_epoch = consensus_chain.latest_consensus_epoch();
     let mut first_gossipped_epoch = None; // Track the first epoch we see via gossip.

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -423,6 +423,12 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
     task_spawner: TaskSpawner,
     mut rx_consensus_request: impl TnReceiver<(Epoch, u64, B256)>,
 ) {
+    // Attempt to clear the consensus header cache on startup.
+    // This should not really be needed (records are evicted as they are processed) but
+    // should not hurt and can clear up an issue if something interferes with eviction.
+    // Note, on longer shutdowns this will have no real effect but could lead to churn
+    // if a node is being restarted relatively quickly.
+    let _ = db.clear_table::<ConsensusHeaderCache>();
     // Get the epoch of our last executed consensus.
     let mut current_fetch_epoch = consensus_chain.latest_consensus_epoch();
     let mut first_gossipped_epoch = None; // Track the first epoch we see via gossip.

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -303,11 +303,13 @@ async fn catch_up_consensus_from_to<DB: Database>(
         let mut remove_cache = false;
         // Check if we already have this consensus output in our local DB.
         // We will be verifying and loading these records elsewhere.
-        let consensus_header = if number == max_consensus_height {
-            max_consensus.clone()
-        } else if let Ok(Some(header)) = db.get::<ConsensusHeaderCache>(&number) {
+        let consensus_header = if let Ok(Some(header)) = db.get::<ConsensusHeaderCache>(&number) {
+            // Always check the cache first, even if on max_consesus_height so we evict this record
+            // if cached.
             remove_cache = true;
             header
+        } else if number == max_consensus_height {
+            max_consensus.clone()
         } else if let Ok(Some(header)) = consensus_chain.consensus_header_by_number(number).await {
             // Block already in local ConsensusChain DB (e.g., processed before a restart).
             // Use it to advance the parent-chain verification; execution will be skipped below

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -285,15 +285,6 @@ async fn catch_up_consensus_from_to<DB: Database>(
     let last_consensus_height = from.number;
     let max_consensus_height = max_consensus.number;
     let catchup_distance = max_consensus_height.saturating_sub(last_consensus_height);
-    if catchup_distance > 0 {
-        info!(
-            target: "tn::observer",
-            last_consensus_height,
-            max_consensus_height,
-            catchup_distance,
-            "catching up consensus blocks"
-        );
-    }
     if last_consensus_height >= max_consensus_height {
         return Ok(from);
     }
@@ -306,6 +297,9 @@ async fn catch_up_consensus_from_to<DB: Database>(
         let consensus_header = if let Ok(Some(header)) = db.get::<ConsensusHeaderCache>(&number) {
             // Always check the cache first, even if on max_consesus_height so we evict this record
             // if cached.
+            // Note that the consensus header at number must be consenstent (consensus was reached)
+            // so this is fine. In other words it would be a protocol violation to have
+            // different ConsensusHeaders at the same number.
             remove_cache = true;
             header
         } else if number == max_consensus_height {
@@ -316,11 +310,15 @@ async fn catch_up_consensus_from_to<DB: Database>(
             // since number <= consensus_chain.latest_consensus_number().
             header
         } else {
-            warn!(
-                target: "tn::observer",
-                block_number = number,
-                "Could not find header"
-            );
+            if number > last_consensus_height + 1 {
+                // Only log the warning after we start and hit a missing header.
+                // I.e. We don't want a ton of warnings when we are starting to catch up.
+                warn!(
+                    target: "tn::observer",
+                    block_number = number,
+                    "Could not find header (We may be catching up)"
+                );
+            }
             // We should have all the required headers in local storage by now...
             return Ok(result_header);
         };
@@ -330,6 +328,16 @@ async fn catch_up_consensus_from_to<DB: Database>(
         }
         if remove_cache {
             let _ = db.remove::<ConsensusHeaderCache>(&number); // Should be done with this now.
+        }
+        if number == last_consensus_height + 1 {
+            // We only want to log this once and only when we are doing something.
+            info!(
+                target: "tn::observer",
+                last_consensus_height,
+                max_consensus_height,
+                catchup_distance,
+                "catching up consensus blocks"
+            );
         }
         let parent_hash = last_parent;
         last_parent =

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -807,6 +807,7 @@ impl Inner {
             previous_epoch.final_consensus.hash
         };
         let mut batches = HashSet::new();
+        let mut referenced_batches = HashSet::new();
         while let Some(record) = next(&mut stream_iter, timeout).await? {
             match record {
                 PackRecord::EpochMeta(_epoch_meta) => {
@@ -829,24 +830,24 @@ impl Inner {
                     if consensus_header.parent_hash != parent_digest {
                         return Err(PackError::InvalidConsensusChain);
                     }
-                    let mut batch_count = 0;
                     for header in &consensus_header.sub_dag.headers {
                         for (digest, _) in header.payload().iter() {
                             if !batches.contains(digest) {
                                 return Err(PackError::MissingBatches);
                             }
-                            batch_count += 1;
+                            referenced_batches.insert(*digest);
                         }
                     }
-                    // batches.len() will generally equal batch_count but if it is greater than we
-                    // had batches that were not accounted for. Note, we do >
-                    // not == because it is possible for a batch to be in more than one subdag (at
-                    // least at time of writing). This is also why we don't just
+                    // batches.len() will generally equal referenced_batches.len() but if it is
+                    // greater than we had batches that were not accounted for.
+                    // It is possible (at time of writing) for a batch to
+                    // be in more than one subdag.  This is also why we don't just
                     // remove batches as we check above.
-                    if batches.len() > batch_count {
+                    if batches.len() > referenced_batches.len() {
                         return Err(PackError::ExtraBatches);
                     }
                     batches.clear();
+                    referenced_batches.clear();
                     let consensus_digest = consensus_header.digest();
                     parent_digest = consensus_digest;
                     let consensus_number = consensus_header.number;

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -829,16 +829,24 @@ impl Inner {
                     if consensus_header.parent_hash != parent_digest {
                         return Err(PackError::InvalidConsensusChain);
                     }
+                    let mut batch_count = 0;
                     for header in &consensus_header.sub_dag.headers {
                         for (digest, _) in header.payload().iter() {
-                            if !batches.remove(digest) {
+                            if !batches.contains(digest) {
                                 return Err(PackError::MissingBatches);
                             }
+                            batch_count += 1;
                         }
                     }
-                    if !batches.is_empty() {
+                    // batches.len() will generally equal batch_count but if it is greater than we
+                    // had batches that were not accounted for. Note, we do >
+                    // not == because it is possible for a batch to be in more than one subdag (at
+                    // least at time of writing). This is also why we don't just
+                    // remove batches as we check above.
+                    if batches.len() > batch_count {
                         return Err(PackError::ExtraBatches);
                     }
+                    batches.clear();
                     let consensus_digest = consensus_header.digest();
                     parent_digest = consensus_digest;
                     let consensus_number = consensus_header.number;

--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -129,12 +129,12 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
             DBMessage::Insert(ins) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = ins.insert_txn(txn) {
-                        tracing::error!(target: "layered_db_runner", "DB TXN Insert: {e}")
+                        tracing::error!(target: "layered_db_runner", "DB TXN Insert {}: {e}", ins.name())
                     }
                     committed_inserts.push(ins);
                 } else {
                     if let Err(e) = ins.insert(&db) {
-                        tracing::error!(target: "layered_db_runner", "DB Insert: {e}");
+                        tracing::error!(target: "layered_db_runner", "DB Insert {}: {e}", ins.name());
                     }
                     if let Some(mem_db) = mem_db.as_ref() {
                         ins.clear_insert_mem(mem_db);
@@ -144,19 +144,19 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
             DBMessage::Remove(rm) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = rm.remove_txn(txn) {
-                        tracing::error!(target: "layered_db_runner", "DB TXN Remove: {e}")
+                        tracing::error!(target: "layered_db_runner", "DB TXN Remove {}: {e}", rm.name())
                     }
                 } else if let Err(e) = rm.remove(&db) {
-                    tracing::error!(target: "layered_db_runner", "DB Remove: {e}")
+                    tracing::error!(target: "layered_db_runner", "DB Remove {}: {e}", rm.name())
                 }
             }
             DBMessage::Clear(clr) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = clr.clear_table_txn(txn) {
-                        tracing::error!(target: "layered_db_runner", "DB TXN Clear table: {e}")
+                        tracing::error!(target: "layered_db_runner", "DB TXN Clear table {}: {e}", clr.name())
                     }
                 } else if let Err(e) = clr.clear_table(&db) {
-                    tracing::error!(target: "layered_db_runner", "DB Clear: {e}")
+                    tracing::error!(target: "layered_db_runner", "DB Clear {}: {e}", clr.name())
                 }
             }
             DBMessage::CaughtUp(tx) => {
@@ -382,6 +382,7 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
 }
 
 trait InsertTrait<DB: Database>: Send + 'static {
+    fn name(&self) -> &str;
     fn insert(&self, db: &DB) -> eyre::Result<()>;
     fn insert_txn(&self, txn: &mut DB::TXMut<'_>) -> eyre::Result<()>;
     /// Clear the inserted data from the memdb if present.
@@ -389,11 +390,13 @@ trait InsertTrait<DB: Database>: Send + 'static {
 }
 
 trait RemoveTrait<DB: Database>: Send + 'static {
+    fn name(&self) -> &str;
     fn remove(&self, db: &DB) -> eyre::Result<()>;
     fn remove_txn(&self, txn: &mut DB::TXMut<'_>) -> eyre::Result<()>;
 }
 
 trait ClearTrait<DB: Database>: Send + 'static {
+    fn name(&self) -> &str;
     fn clear_table(&self, db: &DB) -> eyre::Result<()>;
     fn clear_table_txn(&self, txn: &mut DB::TXMut<'_>) -> eyre::Result<()>;
 }
@@ -422,6 +425,9 @@ impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
         // Best effort to avoid memory growing forever.
         let _ = mem_db.remove::<T>(&self.key);
     }
+    fn name(&self) -> &str {
+        &T::NAME
+    }
 }
 
 impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemove<T> {
@@ -432,6 +438,10 @@ impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemove<T> {
     fn remove_txn(&self, txn: &mut <DB as Database>::TXMut<'_>) -> eyre::Result<()> {
         txn.remove::<T>(&self.key)
     }
+
+    fn name(&self) -> &str {
+        &T::NAME
+    }
 }
 
 impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
@@ -441,6 +451,10 @@ impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
 
     fn clear_table_txn(&self, txn: &mut <DB as Database>::TXMut<'_>) -> eyre::Result<()> {
         txn.clear_table::<T>()
+    }
+
+    fn name(&self) -> &str {
+        &T::NAME
     }
 }
 

--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -426,7 +426,7 @@ impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
         let _ = mem_db.remove::<T>(&self.key);
     }
     fn name(&self) -> &str {
-        &T::NAME
+        T::NAME
     }
 }
 
@@ -440,7 +440,7 @@ impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemove<T> {
     }
 
     fn name(&self) -> &str {
-        &T::NAME
+        T::NAME
     }
 }
 
@@ -454,7 +454,7 @@ impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
     }
 
     fn name(&self) -> &str {
-        &T::NAME
+        T::NAME
     }
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -144,7 +144,7 @@ fn _open_mdbx<P: AsRef<std::path::Path> + Send>(store_path: P) -> CompositeDatab
             const GROWTH: usize = 4 * MEGABYTE;
             const CACHE_GROWTH: usize = 8 * MEGABYTE;
         } else {
-            const EPOCH_MAX: usize = 128 * MEGABYTE;
+            const EPOCH_MAX: usize = 512 * MEGABYTE;
             const KAD_MAX: usize = 64 * MEGABYTE;
             const CACHE_MAX: usize = 1024 * MEGABYTE;
             const GROWTH: usize = 8 * MEGABYTE;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -146,7 +146,7 @@ fn _open_mdbx<P: AsRef<std::path::Path> + Send>(store_path: P) -> CompositeDatab
         } else {
             const EPOCH_MAX: usize = 128 * MEGABYTE;
             const KAD_MAX: usize = 64 * MEGABYTE;
-            const CACHE_MAX: usize = 512 * MEGABYTE;
+            const CACHE_MAX: usize = 1024 * MEGABYTE;
             const GROWTH: usize = 8 * MEGABYTE;
             const CACHE_GROWTH: usize = 64 * MEGABYTE;
         }

--- a/crates/telcoin-network-cli/src/cli.rs
+++ b/crates/telcoin-network-cli/src/cli.rs
@@ -109,11 +109,12 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     ///     pub enable: bool,
     /// }
     ///
-    /// if let Err(err) = telcoin_network_cli::cli::Cli::<MyArgs>::parse()
-    ///     .run(None, |builder, _, tn_datadir, passphrase| {
-    ///         launch_node(builder, tn_datadir, passphrase)
-    ///     })
-    /// {
+    /// if let Err(err) = telcoin_network_cli::cli::Cli::<MyArgs>::parse().run(
+    ///     None,
+    ///     |builder, _, tn_datadir, passphrase, version| {
+    ///         launch_node(builder, tn_datadir, passphrase, version)
+    ///     },
+    /// ) {
     ///     eprintln!("Error: {err:?}");
     ///     std::process::exit(1);
     /// }


### PR DESCRIPTION
- Improves some of the DB failure logs for debugging.
- Clears the consensus header cache on a restart.
- Closes a hole that could leak consensus headers in the cache (never remove them).
- Allow a pack file with the same batch in multiple subdags to stream.
- Increase the max size of some of the mdmx DBs.
- Focus some of the catch up logs to be cleaner.