### PR TITLE
Handle duplicate batch digests in a committed sub-DAG

### DIFF
--- a/crates/consensus/executor/src/errors.rs
+++ b/crates/consensus/executor/src/errors.rs
@@ -135,6 +135,6 @@ pub enum SubscriberError {
     /// This is a protocol violation that occurs when consensus references a batch
     /// but it's not present in the fetched results. This should not happen if workers
     /// are behaving correctly and may indicate either a worker bug or data corruption.
-    #[error("A fetched batch is missing from the collection.")]
+    #[error("A fetched batch is missing from the collection: {0}")]
     MissingFetchedBatch(BlockHash),
 }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -4,7 +4,7 @@ use crate::{errors::SubscriberResult, SubscriberError};
 use futures::{stream::FuturesOrdered, StreamExt};
 use state_sync::{last_consensus_parent, save_consensus, spawn_state_sync};
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
     sync::Arc,
     time::Duration,
 };
@@ -430,6 +430,7 @@ impl<DB: Database> Subscriber<DB> {
         // SAFETY: 10-node committees * 6-round commit max * 5 batch max = 300 max batch digests
         // possible 32bytes * 300 = 9.6 kb => well within 1MB max message size
         let mut fetched_batches = self.fetch_batches_from_peers(batch_set).await?;
+        let fetched_digests: HashSet<BlockHash> = fetched_batches.keys().copied().collect();
 
         let mut batches = Vec::with_capacity(num_certs);
         // map all fetched batches to their respective certificates for applying block rewards
@@ -455,10 +456,9 @@ impl<DB: Database> Subscriber<DB> {
 
                     cert_batches.push(batch);
                 } else {
-                    warn!(target: "subscriber", ?digest, ?batch_digests, "railed to remove fetched batch - possible duplicate");
-
                     // if the batch is a duplicate, the engine will ignore
-                    if !batch_digests.contains(digest) {
+                    warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - possible duplicate");
+                    if !fetched_digests.contains(digest) {
                         error!(target: "subscriber", ?digest, "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
                         return Err(SubscriberError::MissingFetchedBatch(*digest));
                     }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -439,16 +439,30 @@ impl<DB: Database> Subscriber<DB> {
 
             // retrieve fetched batch by digest
             for digest in header.payload().keys() {
-                let batch = fetched_batches.remove(digest).ok_or(SubscriberError::MissingFetchedBatch(*digest)).inspect_err(|_| {
-                    error!(target: "subscriber", "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
-                })?;
-
                 debug!(
                     target: "subscriber",
-                    "Adding fetched batch {digest} from certificate {} to consensus output",
-                    header.digest()
+                    ?digest,
+                    "fetching batch",
                 );
-                cert_batches.push(batch);
+
+                let batch = fetched_batches.remove(digest);
+                if let Some(batch) = batch {
+                    debug!(
+                        target: "subscriber",
+                        "Adding fetched batch {digest} from certificate {} to consensus output",
+                        header.digest()
+                    );
+
+                    cert_batches.push(batch);
+                } else {
+                    warn!(target: "subscriber", ?digest, ?batch_digests, "railed to remove fetched batch - possible duplicate");
+
+                    // if the batch is a duplicate, the engine will ignore
+                    if !batch_digests.contains(digest) {
+                        error!(target: "subscriber", ?digest, "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
+                        return Err(SubscriberError::MissingFetchedBatch(*digest));
+                    }
+                }
             }
 
             // main collection for execution

--- a/crates/consensus/executor/tests/it/main.rs
+++ b/crates/consensus/executor/tests/it/main.rs
@@ -2,7 +2,10 @@
 
 #![allow(unused_crate_dependencies)]
 
-use std::sync::Arc;
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 use tempfile::TempDir;
 use tn_executor::subscriber::spawn_subscriber;
 use tn_network_libp2p::types::{MessageId, NetworkCommand};
@@ -15,7 +18,8 @@ use tn_primary::{
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils::{create_signed_certificates_for_rounds, CommitteeFixture};
 use tn_types::{
-    BlockNumHash, ExecHeader, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, B256,
+    now, test_chain_spec_arc, Batch, BlockHash, BlockNumHash, ExecHeader, Hash as _, HeaderBuilder,
+    HeaderDigest, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, WorkerId, B256,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::sync::mpsc;
@@ -345,6 +349,195 @@ async fn test_executor_batch_fetching() -> eyre::Result<()> {
         total_batches_received,
         batch_count
     );
+
+    Ok(())
+}
+
+/// Creates a random payload with the given number of batches.
+///
+/// Returns the payload map for a header and the batch map for the mock client.
+fn random_payload(count: usize) -> (HashMap<BlockHash, Batch>, Vec<(Batch, WorkerId)>) {
+    let chain = test_chain_spec_arc();
+    let mut batch_map = HashMap::new();
+    let mut payload_entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let batch = tn_reth::test_utils::batch(chain.clone());
+        let d = batch.digest();
+        batch_map.insert(d, batch.clone());
+        payload_entries.push((batch, 0));
+    }
+    (batch_map, payload_entries)
+}
+
+/// Test that duplicate batch digests within a single committed SubDag are handled gracefully.
+///
+/// Constructs a DAG where one authority includes the same batch digest in certificates at two
+/// different rounds. When Bullshark commits a SubDag containing both certificates, the
+/// subscriber must not crash with `MissingFetchedBatch` on the second occurrence.
+#[tokio::test]
+async fn test_duplicate_batch_digest() -> eyre::Result<()> {
+    let num_sub_dags_per_schedule = 100;
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let config = primary.consensus_config().clone();
+    let task_manager = TaskManager::new("duplicate batch tests");
+    let rx_shutdown = config.shutdown().subscribe();
+    let consensus_bus = ConsensusBus::new();
+    let temp_dir = TempDir::with_prefix("test_duplicate_batch_digest").unwrap();
+    let mut consensus_chain =
+        ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone()).await.unwrap();
+
+    let mut consensus_output = consensus_bus.app().subscribe_consensus_output();
+
+    // network mock to handle publish commands
+    let (tx, mut rx) = mpsc::channel(5);
+    tokio::spawn(async move {
+        while let Some(com) = rx.recv().await {
+            if let NetworkCommand::Publish { topic: _, msg: _, reply } = com {
+                reply.send(Ok(MessageId::new(&[0]))).unwrap();
+            }
+        }
+    });
+    let network = PrimaryNetworkHandle::new_for_test(tx);
+
+    spawn_subscriber(
+        config.clone(),
+        rx_shutdown,
+        consensus_bus.clone(),
+        &task_manager,
+        network,
+        consensus_chain.clone(),
+        u64::max_value(),
+    );
+    tokio::task::yield_now().await;
+
+    // collect authority ids in order
+    let authorities: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
+
+    // the batch that will appear in two different certificates (authority[2], rounds 2 and 3)
+    let chain = test_chain_spec_arc();
+    let shared_batch = tn_reth::test_utils::batch(chain);
+    let shared_digest = shared_batch.digest();
+
+    // accumulate all batches for the mock client
+    let mut all_batches: HashMap<BlockHash, Batch> = HashMap::new();
+    all_batches.insert(shared_digest, shared_batch.clone());
+
+    // genesis parents for round 1
+    let mut parents: BTreeSet<HeaderDigest> = fixture.genesis().collect();
+    let mut all_certificates = Vec::new();
+
+    // build 5 rounds of certificates
+    for round in 1u32..=5 {
+        let mut round_digests = BTreeSet::new();
+
+        for (idx, auth_id) in authorities.iter().enumerate() {
+            // authority[2] gets the shared batch in rounds 2 and 3
+            let use_shared = idx == 2 && (round == 2 || round == 3);
+
+            let (batch_map, payload_entries) = if use_shared {
+                // include the shared batch plus some random ones
+                let (mut bmap, mut entries) = random_payload(2);
+                bmap.insert(shared_digest, shared_batch.clone());
+                entries.push((shared_batch.clone(), 0));
+                (bmap, entries)
+            } else {
+                random_payload(3)
+            };
+
+            all_batches.extend(batch_map);
+
+            // build header using with_payload_batch for each batch
+            let mut builder = HeaderBuilder::default()
+                .author(auth_id.clone())
+                .round(round)
+                .epoch(0)
+                .parents(parents.clone())
+                .created_at(now());
+
+            for (batch, worker_id) in payload_entries {
+                builder = builder.with_payload_batch(batch, worker_id);
+            }
+
+            let header = builder.build();
+            let cert = fixture.certificate(&header);
+            round_digests.insert(cert.digest());
+            all_certificates.push(cert);
+        }
+
+        parents = round_digests;
+    }
+
+    // set up mock worker with all batches
+    let mock_client = Arc::new(MockPrimaryToWorkerClient { batches: all_batches });
+    config.local_network().set_primary_to_worker_local_handler(mock_client);
+
+    let leader_schedule = LeaderSchedule::from_store(
+        committee.clone(),
+        &mut consensus_chain,
+        DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    )
+    .await;
+    let bullshark = Bullshark::new(
+        committee.clone(),
+        num_sub_dags_per_schedule,
+        leader_schedule,
+        DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    );
+
+    let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
+    consensus_bus.app().recent_blocks().send_modify(|blocks| {
+        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+    });
+    let task_manager2 = TaskManager::default();
+    Consensus::spawn(
+        config.clone(),
+        &consensus_bus,
+        bullshark,
+        &task_manager2,
+        consensus_chain,
+        None,
+    )
+    .await;
+
+    // feed all certificates to trigger subdag commits
+    for certificate in all_certificates.iter() {
+        consensus_bus.new_certificates().send(certificate.clone()).await.unwrap();
+    }
+
+    // collect outputs with a timeout to avoid hanging
+    let expected_outputs = 2;
+    let mut outputs_received = 0;
+    let mut found_shared_digest = false;
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        while let Some(output) = consensus_output.recv().await {
+            // check if any output contains the shared digest
+            for digest in output.batch_digests() {
+                if *digest == shared_digest {
+                    found_shared_digest = true;
+                }
+            }
+
+            outputs_received += 1;
+            if outputs_received >= expected_outputs {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Timed out waiting for consensus outputs — subscriber may have crashed"
+    );
+    assert!(
+        outputs_received >= expected_outputs,
+        "Expected at least {expected_outputs} outputs, got {outputs_received}"
+    );
+    assert!(found_shared_digest, "The shared batch digest should appear in at least one output");
 
     Ok(())
 }

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -2,9 +2,11 @@
 
 use super::*;
 use crate::consensus::LeaderSwapTable;
+use indexmap::IndexMap;
+use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
-use tn_types::B256;
+use tn_types::{now, HeaderBuilder, B256};
 
 #[tokio::test]
 async fn test_empty_proposal() {
@@ -128,5 +130,145 @@ async fn test_equivocation_protection_after_restart() {
     let new_header = rx_headers.recv().await.unwrap();
     if new_header.round() == header.round() {
         assert_eq!(header, new_header);
+    }
+}
+
+/// Helper to build a header with the given author, round, and payload digests.
+fn build_test_header(author: &AuthorityIdentifier, round: Round, digests: &[BlockHash]) -> Header {
+    let mut payload = IndexMap::new();
+    for &d in digests {
+        payload.insert(d, 0u16);
+    }
+    HeaderBuilder::default()
+        .author(author.clone())
+        .round(round)
+        .epoch(0)
+        .parents(BTreeSet::new())
+        .created_at(now())
+        .payload(payload)
+        .build()
+}
+
+#[tokio::test]
+async fn test_process_committed_headers() {
+    // -- shared setup helper --
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let author = primary.id();
+
+    // --- Scenario A: header at round > max_committed_round is NOT re-queued ---
+    {
+        let cb = ConsensusBus::new();
+        let task_manager = TaskManager::default();
+        let mut proposer = Proposer::new(
+            primary.consensus_config(),
+            primary.consensus_config().authority_id().expect("authority"),
+            cb.clone(),
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+            task_manager.get_spawner(),
+        );
+
+        // insert headers at rounds 4, 5, 6 with distinct digests
+        let d4 = B256::random();
+        let d5 = B256::random();
+        let d6 = B256::random();
+        proposer.proposed_headers.insert(4, build_test_header(&author, 4, &[d4]));
+        proposer.proposed_headers.insert(5, build_test_header(&author, 5, &[d5]));
+        proposer.proposed_headers.insert(6, build_test_header(&author, 6, &[d6]));
+
+        // commit rounds 4 and 5 => max_committed_round = 5
+        // round 6 > 5 so it should NOT be re-queued
+        proposer.process_committed_headers(6, vec![4, 5]);
+
+        // nothing re-queued because the only uncommitted header (round 6) is above
+        // max_committed_round
+        assert!(proposer.digests.is_empty(), "round 6 should not be re-queued");
+
+        // rounds 4, 5 removed as committed; only round 6 remains
+        assert_eq!(proposer.proposed_headers.len(), 1);
+        assert!(
+            proposer.proposed_headers.contains_key(&6),
+            "round 6 header should still be in proposed_headers"
+        );
+    }
+
+    // --- Scenario B: header at round <= max_committed_round IS re-queued ---
+    {
+        let cb = ConsensusBus::new();
+        let task_manager = TaskManager::default();
+        let mut proposer = Proposer::new(
+            primary.consensus_config(),
+            primary.consensus_config().authority_id().expect("authority"),
+            cb.clone(),
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+            task_manager.get_spawner(),
+        );
+
+        // insert headers at rounds 3, 4, 5
+        let d3a = B256::random();
+        let d3b = B256::random();
+        let d4 = B256::random();
+        let d5 = B256::random();
+        proposer.proposed_headers.insert(3, build_test_header(&author, 3, &[d3a, d3b]));
+        proposer.proposed_headers.insert(4, build_test_header(&author, 4, &[d4]));
+        proposer.proposed_headers.insert(5, build_test_header(&author, 5, &[d5]));
+
+        // commit rounds 4 and 5 => max_committed_round = 5
+        // round 3 <= 5 and NOT in committed list => its digests are re-queued
+        proposer.process_committed_headers(5, vec![4, 5]);
+
+        // round 3's digests should have been prepended to self.digests
+        assert!(!proposer.digests.is_empty(), "round 3 digests should be re-queued");
+        assert_eq!(proposer.digests.len(), 2, "round 3 had two digests");
+
+        // verify the re-queued digests match round 3's payload
+        let requeued: Vec<BlockHash> = proposer.digests.iter().map(|pd| pd.digest).collect();
+        assert!(requeued.contains(&d3a), "d3a should be re-queued");
+        assert!(requeued.contains(&d3b), "d3b should be re-queued");
+
+        // round 3 should also be removed from proposed_headers
+        assert!(
+            !proposer.proposed_headers.contains_key(&3),
+            "round 3 should be removed after re-queue"
+        );
+
+        // committed rounds 4, 5 also removed
+        assert!(proposer.proposed_headers.is_empty(), "all headers should be removed");
+    }
+
+    // --- Scenario C: empty committed headers ---
+    {
+        let cb = ConsensusBus::new();
+        let task_manager = TaskManager::default();
+        let mut proposer = Proposer::new(
+            primary.consensus_config(),
+            primary.consensus_config().authority_id().expect("authority"),
+            cb.clone(),
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+            task_manager.get_spawner(),
+        );
+
+        // insert headers at rounds 4, 5, 6
+        let d4 = B256::random();
+        let d5 = B256::random();
+        let d6 = B256::random();
+        proposer.proposed_headers.insert(4, build_test_header(&author, 4, &[d4]));
+        proposer.proposed_headers.insert(5, build_test_header(&author, 5, &[d5]));
+        proposer.proposed_headers.insert(6, build_test_header(&author, 6, &[d6]));
+
+        // empty committed list => max_committed_round = 0
+        // all rounds > 0 so nothing is re-queued
+        proposer.process_committed_headers(6, vec![]);
+
+        assert!(proposer.digests.is_empty(), "no digests should be re-queued");
+        assert_eq!(
+            proposer.proposed_headers.len(),
+            3,
+            "all headers should remain in proposed_headers"
+        );
+        assert!(proposer.proposed_headers.contains_key(&4));
+        assert!(proposer.proposed_headers.contains_key(&5));
+        assert!(proposer.proposed_headers.contains_key(&6));
     }
 }


### PR DESCRIPTION
* `fetch_batches` no longer crashes when a batch digest appears in more than one certificate of a committed sub-DAG. A `None` from `fetched_batches.remove` is now checked against the sub-DAG's full digest list: a known duplicate is skipped (the engine ignores the repeat), and only a digest absent from the sub-DAG returns `MissingFetchedBatch`.
* `MissingFetchedBatch` now includes the offending `BlockHash` so the fatal case is diagnosable from logs.
* Added `test_duplicate_batch_digest`: builds a DAG where one authority reuses the same batch digest across two rounds, commits both in one sub-DAG, and asserts the subscriber produces output instead of shutting down.
* Added `test_process_committed_headers` for the proposer's re-queue logic — the source of the duplicate: headers at or below `max_committed_round` that weren't committed get their digests re-queued, while headers above it do not. Covers the re-queue, no-re-queue, and empty-committed cases.

The duplicate originates in the proposer re-queue path and only became fatal in the subscriber, so both sides are covered.

closes #700 