### PR TITLE
Remove unused UpdateAuthorizedPublishers network command

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -518,11 +518,6 @@ where
     /// Process commands for the network.
     fn process_command(&mut self, command: NetworkCommand<Req, Res>) -> NetworkResult<()> {
         match command {
-            NetworkCommand::UpdateAuthorizedPublishers { authorities, reply } => {
-                // this value should be updated at the start of each epoch
-                self.authorized_publishers = authorities;
-                send_or_log_error!(reply, Ok(()), "UpdateAuthorizedPublishers");
-            }
             NetworkCommand::StartListening { multiaddr, reply } => {
                 let res = self.swarm.listen_on(multiaddr);
                 send_or_log_error!(reply, res, "StartListening");

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -737,7 +737,7 @@ async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<
     }
 
     // remove cvv from whitelist and try to publish again
-    nvv.update_authorized_publishers(HashMap::new()).await?;
+    nvv.subscribe_with_publishers(TEST_TOPIC.into(), HashSet::new()).await?;
 
     let random_block = fixture_batch_with_transactions(10);
     let sealed_block = random_block.seal_slow();

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -94,16 +94,6 @@ where
     Req: TNMessage,
     Res: TNMessage,
 {
-    /// Update the list of authorized publishers.
-    ///
-    /// This list is used to verify messages came from an authorized source.
-    /// Only valid for Subscriber implementations.
-    UpdateAuthorizedPublishers {
-        /// The unique set of authorized peers by topic.
-        authorities: HashMap<String, Option<HashSet<BlsPublicKey>>>,
-        /// The acknowledgement that the set was updated.
-        reply: oneshot::Sender<NetworkResult<()>>,
-    },
     /// Start listening on the provided multiaddr.
     ///
     /// Return the result to caller.
@@ -362,16 +352,6 @@ where
     pub fn new_for_test() -> Self {
         let (sender, _) = mpsc::channel(100);
         Self { sender }
-    }
-
-    /// Update the list of authorized publishers.
-    pub async fn update_authorized_publishers(
-        &self,
-        authorities: HashMap<String, Option<HashSet<BlsPublicKey>>>,
-    ) -> NetworkResult<()> {
-        let (reply, ack) = oneshot::channel();
-        self.sender.send(NetworkCommand::UpdateAuthorizedPublishers { authorities, reply }).await?;
-        ack.await?
     }
 
     /// Start swarm listening on the given address. Returns an error if the address is not


### PR DESCRIPTION
- Drop `NetworkCommand::UpdateAuthorizedPublishers`, the matching dispatcher arm in `consensus.rs`, and the `update_authorized_publishers` helper on the subscriber handle — no production caller remains.
- Authorization is already set per topic via `subscribe_with_publishers` at each epoch boundary, so this removes a second, now-redundant path for mutating the publisher whitelist.
- Update the one affected test (`test_msg_verification_ignores_unauthorized_publisher`) to clear the whitelist by re-subscribing with an empty publisher set instead of calling the removed helper.

closes #703 