### PR TITLE
Make consensus headers cheap to clone.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -2670,16 +2670,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2700,20 +2690,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -2722,7 +2698,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -2736,19 +2712,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2889,32 +2854,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro 0.12.0",
-]
-
-[[package]]
-name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
- "derive_builder_macro 0.20.2",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -2931,21 +2875,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core 0.12.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core 0.20.2",
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -11184,12 +11118,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -11889,7 +11817,6 @@ dependencies = [
  "blst",
  "bs58",
  "clap",
- "derive_builder 0.12.0",
  "eyre",
  "futures",
  "hex",
@@ -12602,7 +12529,7 @@ checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",
- "derive_builder 0.20.2",
+ "derive_builder",
  "regex",
  "rustversion",
  "time",
@@ -12616,7 +12543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.2",
+ "derive_builder",
  "git2",
  "rustversion",
  "time",
@@ -12631,7 +12558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.2",
+ "derive_builder",
  "rustversion",
 ]
 

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -644,7 +644,7 @@ mod tests {
         let mut leader_cert = Certificate::default();
         leader_cert.update_header_author_for_test(leader);
         let mut subdag = CommittedSubDag::default();
-        subdag.headers.push((*leader_cert.header).clone());
+        subdag.headers.push(leader_cert.header().clone());
         let output = ConsensusOutput::new_with_subdag(Arc::new(subdag), BlockHash::default(), 0);
 
         // receive new blocks and return non-fatal errors

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -419,7 +419,7 @@ impl<DB: Database> Consensus<DB> {
                 // This will force the follow function to not outrun execution...  this is probably
                 // fine. Also once we can follow gossiped consensus output this will not really be
                 // an issue (except during initial catch up).
-                let base_execution_block = committed_sub_dag.leader().latest_execution_block;
+                let base_execution_block = committed_sub_dag.leader().latest_execution_block();
                 if self.consensus_bus.app().wait_for_execution(base_execution_block).await.is_err()
                 {
                     // This seems to be a bogus sub dag, we are out of sync...

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -162,7 +162,6 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         | HeaderError::ParentMissingSignature
         | HeaderError::InvalidParentTimestamp { .. }
         | HeaderError::UnkownWorkerId
-        | HeaderError::InvalidHeaderDigest
         | HeaderError::UnknownAuthority(_) => Some(Penalty::Fatal),
         // ignore
         HeaderError::PendingCertificateOneshot

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -207,14 +207,14 @@ where
                 // process certificate
                 cert.validate_received().map_err(CertManagerError::from)?;
 
-                let epoch = cert.header().epoch;
+                let epoch = cert.header().epoch();
                 // Early verify so we can detect we are behind.
                 // The verification is cached in the cert so this should not be too expensive.
                 if let Some(committee) = self.get_committee(epoch).await {
                     match cert.verify_cert(&committee) {
                         Ok(()) => {
                             if self.consensus_bus.is_cvv() {
-                                if self.behind_consensus(epoch, cert.header().round, None).await {
+                                if self.behind_consensus(epoch, cert.header().round(), None).await {
                                     warn!(target: "primary", "certificate indicates we are behind, go to catchup mode!");
                                     return Ok(());
                                 }
@@ -346,7 +346,7 @@ where
         // This should keep a malicious validator from corrupting another
         // nodes vote cache.
         // This relies on libp2p to manage peer ids that are used to get the bls key.
-        let committee_peer = header.author.clone();
+        let committee_peer = header.author().clone();
         let auth_id: AuthorityIdentifier = peer.into();
         if let Some(auth) = self.consensus_config.committee().authority(&committee_peer) {
             // We err on the side of caution here, if auths peer id is not known fail but we
@@ -497,14 +497,14 @@ where
         // if peer is ahead, wait for execution to catch up
         // NOTE: this doesn't hurt since this node shouldn't vote until execution is caught up
         // ensure execution results match if this succeeds.
-        if self.consensus_bus.wait_for_execution(header.latest_execution_block).await.is_err() {
+        if self.consensus_bus.wait_for_execution(header.latest_execution_block()).await.is_err() {
             error!(
                 target: "primary",
-                peer_hash = ?header.latest_execution_block,
+                peer_hash = ?header.latest_execution_block(),
                 expected = ?self.consensus_bus.latest_execution_block_num_hash(),
                 "unexpected execution result received"
             );
-            return Err(HeaderError::UnknownExecutionResult(header.latest_execution_block).into());
+            return Err(HeaderError::UnknownExecutionResult(header.latest_execution_block()).into());
         }
         debug!(target: "primary", ?header, round = header.round(), "Processing vote request from peer");
 
@@ -575,7 +575,7 @@ where
                 header.created_at() >= parent.header().created_at(),
                 HeaderError::InvalidParentTimestamp {
                     header: *header.created_at(),
-                    parent: *parent.header.created_at()
+                    parent: *parent.header().created_at()
                 }
                 .into()
             );

--- a/crates/consensus/primary/src/state_sync/header_validator.rs
+++ b/crates/consensus/primary/src/state_sync/header_validator.rs
@@ -180,7 +180,7 @@ where
                     committed_round = *rx_committed_round_updates.borrow_and_update();
                     debug!(target: "primary::header_validator", ?committed_round, "committed round update");
 
-                    if header.round < committed_round.saturating_sub(max_age) {
+                    if header.round() < committed_round.saturating_sub(max_age) {
                         return Err(HeaderError::TooOld{
                             digest: header.digest(),
                             header_round: header.round(),

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -17,7 +17,7 @@ use tn_network_libp2p::{
 use tn_storage::{mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    test_utils::init_test_tracing, BlsSignature, Certificate, Hash as _, Header,
+    test_utils::init_test_tracing, BlsSignature, Certificate, Hash as _, Header, HeaderBuilder,
     SignatureVerificationState, TaskManager, TnSender as _,
 };
 use tokio::{
@@ -320,9 +320,8 @@ async fn test_fetch_certificates_basic() {
                     let mut certs = Vec::new();
                     // Add cert missing parent info.
                     let mut cert = certificates[num_written].clone();
-                    let mut ch = cert.header().clone();
-                    ch.clear_parents_for_test();
-                    cert.update_header_for_test(ch);
+                    let ch_builder = HeaderBuilder::from_header(cert.header());
+                    cert.update_header_for_test(ch_builder.parents(BTreeSet::default()).build());
                     certs.push(cert);
                     // Add cert with incorrect digest.
                     let mut cert = certificates[num_written].clone();
@@ -353,7 +352,7 @@ async fn test_fetch_certificates_basic() {
     verify_certificates_not_in_store(&certificate_store, &certificates[num_written..target_index]);
 
     assert!(!synchronizer
-        .identify_unkown_parents(&certificates[target_index].header)
+        .identify_unkown_parents(certificates[target_index].header())
         .await
         .unwrap()
         .is_empty());
@@ -398,7 +397,7 @@ async fn test_fetch_certificates_basic() {
     verify_certificates_not_in_store(&certificate_store, &certificates[num_written..target_index]);
 
     assert!(!synchronizer
-        .identify_unkown_parents(&certificates[target_index].header)
+        .identify_unkown_parents(certificates[target_index].header())
         .await
         .unwrap()
         .is_empty());

--- a/crates/consensus/primary/src/tests/header_validator_tests.rs
+++ b/crates/consensus/primary/src/tests/header_validator_tests.rs
@@ -27,7 +27,7 @@ async fn test_sync_batches_drops_old_rounds() -> eyre::Result<()> {
         .map(|a| {
             let header = a
                 .header_builder(&committee)
-                .with_payload_batch(fixture_batch_with_transactions(10), 0)
+                .with_payload_batch(&fixture_batch_with_transactions(10), 0)
                 .build();
             let cert = fixture.certificate(&header);
             let digest = cert.digest();
@@ -44,7 +44,7 @@ async fn test_sync_batches_drops_old_rounds() -> eyre::Result<()> {
         .header_builder(&fixture.committee())
         .round(2)
         .parents(certs.keys().cloned().collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // update round

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -316,27 +316,6 @@ async fn test_vote_fails_unknown_execution_result() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_vote_fails_invalid_header_digest() -> eyre::Result<()> {
-    // common types
-    let temp_dir = TempDir::new().unwrap();
-    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
-        create_test_types(temp_dir.path()).await;
-
-    let parents = Vec::new();
-
-    // create header proposed by last peer in the committee for round 1
-    let mut header = committee.header_from_last_authority();
-    // change values so digest doesn't match
-    header.latest_execution_block = BlockNumHash::new(0, BlockHash::random());
-    let peer = *committee.last_authority().authority().protocol_key();
-
-    // process vote
-    let res = handler.vote(peer, header, parents).await;
-    assert_matches!(res, Err(PrimaryNetworkError::InvalidHeader(HeaderError::InvalidHeaderDigest)));
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_vote_fails_invalid_timestamp() -> eyre::Result<()> {
     // common types
     let temp_dir = TempDir::new().unwrap();

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -75,7 +75,7 @@ async fn test_request_vote_too_new() {
         .round(100) // Need to be bigger than the gc window
         .latest_execution_block(BlockNumHash::default()) // dummy_hash would be correct here but this is the test...
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Trying to build on off of a missing execution block, will be an error.
@@ -143,7 +143,7 @@ async fn test_request_vote_has_missing_execution_block() {
         .round(3)
         .latest_execution_block(BlockNumHash::default()) // dummy_hash would be correct here but this is the test...
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
@@ -237,7 +237,7 @@ async fn test_request_vote_older_execution_block() {
         .round(3)
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
@@ -315,7 +315,7 @@ async fn test_request_vote_has_missing_parents() {
         .round(2)
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Write some certificates from round 2 into the store, and leave out the rest to test
@@ -431,7 +431,7 @@ async fn test_request_vote_accept_missing_parents() {
         .round(3)
         .parents(round_2_certs.iter().map(|c| c.digest()).collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Populate all round 1 certificates and some round 2 certificates into the storage.
@@ -519,7 +519,7 @@ async fn test_request_vote_missing_batches() {
     for primary in fixture.authorities().filter(|a| a.id() != authority_id) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(&fixture_batch_with_transactions(10), 0)
             .build();
 
         let certificate = fixture.certificate(&header);
@@ -536,7 +536,7 @@ async fn test_request_vote_missing_batches() {
         .round(2)
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     // Set up mock worker.
@@ -595,7 +595,7 @@ async fn test_request_vote_already_voted() {
     for primary in fixture.authorities().filter(|a| a.id() != id) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(&fixture_batch_with_transactions(10), 0)
             .build();
 
         let certificate = fixture.certificate(&header);
@@ -619,7 +619,7 @@ async fn test_request_vote_already_voted() {
         .round(2)
         .parents(certificates.keys().cloned().collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     cb.app().committed_round_updates().send_replace(1);
@@ -652,7 +652,7 @@ async fn test_request_vote_already_voted() {
         .round(2)
         .parents(certificates.keys().cloned().collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build();
 
     let response = handler.vote(author_peer, test_header, Vec::new()).await;
@@ -842,7 +842,7 @@ async fn test_request_vote_created_at_in_future() {
     for primary in fixture.authorities().filter(|a| a.id() != id) {
         let header = primary
             .header_builder(&fixture.committee())
-            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(&fixture_batch_with_transactions(10), 0)
             .build();
 
         let certificate = fixture.certificate(&header);
@@ -870,7 +870,7 @@ async fn test_request_vote_created_at_in_future() {
         .round(2)
         .parents(certificates.keys().cloned().collect())
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .created_at(created_at)
         .build();
 
@@ -886,7 +886,7 @@ async fn test_request_vote_created_at_in_future() {
         let header = primary
             .header_builder(&fixture.committee())
             .round(2)
-            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .with_payload_batch(&fixture_batch_with_transactions(10), 0)
             .build();
 
         let certificate = fixture.certificate(&header);
@@ -907,7 +907,7 @@ async fn test_request_vote_created_at_in_future() {
         .round(3)
         .latest_execution_block(BlockNumHash::new(0, dummy_hash))
         .parents(certificates.keys().cloned().collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .created_at(created_at)
         .build();
 

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -33,7 +33,7 @@ fn create_header_for_round(round: Round) -> Header {
         .round(round)
         .epoch(fixture.committee().epoch())
         .parents([HeaderDigest::default()].iter().cloned().collect())
-        .with_payload_batch(fixture_batch_with_transactions(10), 0)
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
         .build()
 }
 

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -346,7 +346,7 @@ async fn catch_up_consensus_from_to<DB: Database>(
             continue;
         }
 
-        let base_execution_block = consensus_header.sub_dag.leader().latest_execution_block;
+        let base_execution_block = consensus_header.sub_dag.leader().latest_execution_block();
         // We need to make sure execution has caught up so we can verify we have not
         // forked. This will force the follow function to not outrun
         // execution...  this is probably fine. Also once we can

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1280,7 +1280,7 @@ pub(crate) mod test {
     use tn_test_utils::CommitteeFixture;
     use tn_types::{
         test_genesis, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
-        ConsensusHeader, ConsensusOutput, EpochRecord, Hash, ReputationScores,
+        ConsensusHeader, ConsensusOutput, EpochRecord, Hash, HeaderBuilder, ReputationScores,
     };
 
     use crate::{
@@ -1311,9 +1311,9 @@ pub(crate) mod test {
         // update cert
         leader_1.update_header_author_for_test(authority_1);
         for batch in &batches_1 {
-            let mut ch = leader_1.header().clone();
-            ch.payload.insert(batch.digest(), 0_u16);
-            leader_1.update_header_for_test(ch);
+            let mut builder = HeaderBuilder::from_header(leader_1.header());
+            builder = builder.with_payload_batch(&batch, 0_u16);
+            leader_1.update_header_for_test(builder.build());
         }
         let sub_dag_index_1 = 1;
         leader_1.update_header_round_for_test(sub_dag_index_1 as u32);

--- a/crates/test-utils-committee/src/committee.rs
+++ b/crates/test-utils-committee/src/committee.rs
@@ -122,7 +122,7 @@ impl<DB: Database> CommitteeFixture<DB> {
                     .round(round)
                     .epoch(0)
                     .parents(parents.clone())
-                    .with_payload_batch(fixture_batch_with_transactions(10), 0)
+                    .with_payload_batch(&fixture_batch_with_transactions(10), 0)
                     .build()
             })
             .collect();

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -18,7 +18,6 @@ bincode = { workspace = true }
 reth-primitives = { workspace = true }
 reth-chainspec = { workspace = true }
 reth-tasks = { workspace = true }
-derive_builder = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 rand = { workspace = true }

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -205,9 +205,6 @@ pub enum HeaderError {
     /// Invalid header request
     #[error("Invalid epoch. Peer proposed epoch {theirs}, but expected {ours})")]
     InvalidEpoch { theirs: Epoch, ours: Epoch },
-    /// The expected digest does not match the peer's sealed header.
-    #[error("Invalid header digest")]
-    InvalidHeaderDigest,
     /// The author is not in the current committee.
     #[error("Received message from unknown authority {0}")]
     UnknownAuthority(String),

--- a/crates/types/src/primary/certificate.rs
+++ b/crates/types/src/primary/certificate.rs
@@ -12,15 +12,14 @@ use crate::{
     ensure,
     error::{CertificateError, CertificateResult, DagError, DagResult, HeaderError},
     serde::RoaringBitmapSerde,
-    Authority, AuthorityIdentifier, Committee, Epoch, Hash, Header, HeaderDigest, Round,
-    TimestampSec, VotingPower,
+    Authority, AuthorityIdentifier, Committee, Epoch, Hash, Header, HeaderBuilder, HeaderDigest,
+    Round, TimestampSec, VotingPower,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
-    sync::Arc,
 };
 
 /// Certificates are the output of consensus.
@@ -29,28 +28,31 @@ use std::{
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Certificate {
     /// Certificate's header.
-    /// Wrapped in an Arc to make cloning cheaper and to discourage changing the header and
-    /// invalidating the cert.
-    pub header: Arc<Header>,
+    /// Header uses an inner Arc and is immutable (so cert can't be invalidated trivially).
+    header: Header,
     /// Container for [BlsAggregateSignatureBytes].
-    pub signature_verification_state: SignatureVerificationState,
+    signature_verification_state: SignatureVerificationState,
     /// Bitmap that indicates which authorities from committee signed this certificate.
     #[serde_as(as = "RoaringBitmapSerde")]
     signed_authorities: roaring::RoaringBitmap,
 }
 
 impl Certificate {
+    /// Consume the cert and return the contained Header.
+    pub fn into_header(self) -> Header {
+        self.header
+    }
+
     /// Create a genesis certificate with empty payload.
     pub fn genesis(committee: &Committee) -> Vec<Self> {
         committee
             .authorities()
             .iter()
             .map(|authority| Self {
-                header: Arc::new(Header {
-                    author: authority.id(),
-                    epoch: committee.epoch(),
-                    ..Default::default()
-                }),
+                header: HeaderBuilder::default()
+                    .author(authority.id())
+                    .epoch(committee.epoch())
+                    .build(),
                 ..Self::default()
             })
             .collect()
@@ -158,11 +160,7 @@ impl Certificate {
             SignatureVerificationState::Unverified(bls_signature)
         };
 
-        Ok(Certificate {
-            header: Arc::new(header),
-            signature_verification_state,
-            signed_authorities,
-        })
+        Ok(Certificate { header, signature_verification_state, signed_authorities })
     }
 
     /// Return the group of authorities that signed this certificate.
@@ -371,35 +369,31 @@ impl Certificate {
     ///
     /// Only Used for testing.
     pub fn update_header_for_test(&mut self, header: Header) {
-        self.header = Arc::new(header);
+        self.header = header;
     }
 
     /// Update the headers author for a test- not for production code.
     pub fn update_header_author_for_test(&mut self, author: AuthorityIdentifier) {
-        let mut header = (*self.header).clone();
-        header.author = author;
-        self.header = Arc::new(header);
+        let header_builder = HeaderBuilder::from_header(&self.header);
+        self.header = header_builder.author(author).build();
     }
 
     /// Update the headers round for a test- not for production code.
     pub fn update_header_round_for_test(&mut self, round: Round) {
-        let mut header = (*self.header).clone();
-        header.round = round;
-        self.header = Arc::new(header);
+        let header_builder = HeaderBuilder::from_header(&self.header);
+        self.header = header_builder.round(round).build();
     }
 
     /// Update the headers epoch for a test- not for production code.
     pub fn update_header_epoch_for_test(&mut self, epoch: Epoch) {
-        let mut header = (*self.header).clone();
-        header.epoch = epoch;
-        self.header = Arc::new(header);
+        let header_builder = HeaderBuilder::from_header(&self.header);
+        self.header = header_builder.epoch(epoch).build();
     }
 
     /// Update the headers created_at for a test- not for production code.
     pub fn update_header_created_at_for_test(&mut self, created_at: TimestampSec) {
-        let mut header = (*self.header).clone();
-        header.created_at = created_at;
-        self.header = Arc::new(header);
+        let header_builder = HeaderBuilder::from_header(&self.header);
+        self.header = header_builder.created_at(created_at).build();
     }
 }
 

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -113,7 +113,8 @@ impl Header {
 
         // Note that self.digest() MUST be set correctly so no need to check.  We could add a panic
         // here but it is inexpressable outside of a bug in this module so no need to calc
-        // the digest.
+        // the digest.  Use a debug assert just in case on debug builds.
+        debug_assert_eq!(Hash::digest(&*self.inner), self.inner.digest);
 
         // Ensure authority is in the current committee.
         committee
@@ -374,7 +375,6 @@ mod test {
 
     use alloy::{eips::BlockNumHash, primitives::BlockHash};
     use indexmap::IndexMap;
-    use once_cell::sync::OnceCell;
     use serde::{Deserialize, Serialize};
 
     use crate::{
@@ -403,14 +403,11 @@ mod test {
         /// execution result in a signed and validated structure which validates
         /// this execution block as well.
         pub latest_execution_block: BlockNumHash,
-        /// The [HeaderDigest].
-        #[serde(skip)]
-        pub digest: OnceCell<HeaderDigest>,
     }
 
     /// Simple test to make sure that moving to the inner Arc on Header will not
     /// change the serialized data.  If this test breaks it may indicate a fork
-    /// was introduced.
+    /// was introduced.  This test may also outlive it's usefulness.
     #[test]
     fn test_header_serde() {
         let mut test_header = HeaderData::default();

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -4,37 +4,64 @@ use crate::{
     now, AuthorityIdentifier, Batch, BlockHash, BlockNumHash, Committee, Digest, Epoch, Hash,
     Round, TimestampSec, VoteDigest, WorkerId,
 };
-use derive_builder::Builder;
 use indexmap::IndexMap;
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, fmt};
+use std::{collections::BTreeSet, fmt, sync::Arc};
 
-/// `Header` type for consensus layer.
-#[derive(Builder, Clone, Deserialize, Serialize, Default)]
-#[builder(pattern = "owned", build_fn(skip))]
-pub struct Header {
+/// `Header` inner data type for consensus layer.
+#[derive(Deserialize, Serialize)]
+struct HeaderInner {
     /// Primary that created the header. Must be the same primary that broadcasted the header.
-    pub author: AuthorityIdentifier,
+    author: AuthorityIdentifier,
     /// The round for this header
-    pub round: Round,
+    round: Round,
     /// The epoch this Header was created in.
-    pub epoch: Epoch,
+    epoch: Epoch,
     /// The timestamp for when the header was requested to be created.
-    pub created_at: TimestampSec,
+    created_at: TimestampSec,
     /// IndexMap of the [BatchDigest] to the [WorkerId]
     #[serde(with = "indexmap::map::serde_seq")]
-    pub payload: IndexMap<BlockHash, WorkerId>,
+    payload: IndexMap<BlockHash, WorkerId>,
     /// Parent certificates for this Header.
-    pub parents: BTreeSet<HeaderDigest>,
+    parents: BTreeSet<HeaderDigest>,
     /// Hash and number of the latest known execution block when this Header was build.
     /// This may be our parent block or may not but it does include our latest
     /// execution result in a signed and validated structure which validates
     /// this execution block as well.
-    pub latest_execution_block: BlockNumHash,
+    latest_execution_block: BlockNumHash,
     /// The [HeaderDigest].
+    /// This is cached to avoid calculating frequently (but not serialized).
+    /// Note, this struct is private and this field MUST always be set on creation in this module.
+    /// Failure to do so is undefined behaviour (not being set and not matching the struct is
+    /// inexpressable outside of a bug in this module).
     #[serde(skip)]
-    pub digest: OnceCell<HeaderDigest>,
+    digest: HeaderDigest,
+}
+
+impl Default for HeaderInner {
+    fn default() -> Self {
+        // Override this so we can make sure to set the digest (avoid a future foot-gun).
+        let mut inner = Self {
+            author: Default::default(),
+            round: Default::default(),
+            epoch: Default::default(),
+            created_at: Default::default(),
+            payload: Default::default(),
+            parents: Default::default(),
+            latest_execution_block: Default::default(),
+            digest: Default::default(),
+        };
+
+        let digest = Hash::digest(&inner);
+        inner.digest = digest;
+        inner
+    }
+}
+
+/// `Header` type for consensus layer.
+#[derive(Clone, Default)]
+pub struct Header {
+    inner: Arc<HeaderInner>,
 }
 
 impl Header {
@@ -47,24 +74,24 @@ impl Header {
         parents: BTreeSet<HeaderDigest>,
         latest_execution_block: BlockNumHash,
     ) -> Self {
-        let header = Self {
+        let mut inner = HeaderInner {
             author,
             round,
             epoch,
             created_at: now(),
             payload,
             parents,
-            digest: OnceCell::default(),
+            digest: HeaderDigest::default(),
             latest_execution_block,
         };
-        let digest = Hash::digest(&header);
-        header.digest.set(digest).expect("digest oncecell empty for new header");
-        header
+        let digest = Hash::digest(&inner);
+        inner.digest = digest;
+        Self { inner: Arc::new(inner) }
     }
 
     /// Hashed digest for Header
     pub fn digest(&self) -> HeaderDigest {
-        *self.digest.get_or_init(|| Hash::digest(self))
+        self.inner.digest
     }
 
     /// Ensure the header is valid based on the current committee and workercache.
@@ -72,27 +99,29 @@ impl Header {
     /// The digest is calculated with the sealed header, so the EL data is also verified.
     pub fn validate(&self, committee: &Committee) -> HeaderResult<()> {
         // Ensure the header is from the correct epoch.
-        if self.epoch != committee.epoch() {
-            return Err(HeaderError::InvalidEpoch { theirs: self.epoch, ours: committee.epoch() });
+        if self.inner.epoch != committee.epoch() {
+            return Err(HeaderError::InvalidEpoch {
+                theirs: self.inner.epoch,
+                ours: committee.epoch(),
+            });
         }
 
         // Ensure we don't have too many parents.
-        if self.parents.len() > committee.size() {
-            return Err(HeaderError::TooManyParents(self.parents.len(), committee.size()));
+        if self.inner.parents.len() > committee.size() {
+            return Err(HeaderError::TooManyParents(self.inner.parents.len(), committee.size()));
         }
 
-        // Ensure the header digest is well formed.
-        if Hash::digest(self) != self.digest() {
-            return Err(HeaderError::InvalidHeaderDigest);
-        }
+        // Note that self.digest() MUST be set correctly so no need to check.  We could add a panic
+        // here but it is inexpressable outside of a bug in this module so no need to calc
+        // the digest.
 
         // Ensure authority is in the current committee.
         committee
-            .authority(&self.author)
-            .ok_or(HeaderError::UnknownAuthority(self.author.to_string()))?;
+            .authority(&self.inner.author)
+            .ok_or(HeaderError::UnknownAuthority(self.inner.author.to_string()))?;
 
         // Ensure all worker ids are correct.
-        for worker_id in self.payload.values() {
+        for worker_id in self.inner.payload.values() {
             if *worker_id as usize >= committee.number_of_workers() {
                 return Err(HeaderError::UnkownWorkerId);
             }
@@ -103,86 +132,152 @@ impl Header {
 
     /// The [AuthorityIdentifier] that produced the header.
     pub fn author(&self) -> &AuthorityIdentifier {
-        &self.author
+        &self.inner.author
     }
     /// The [Round] for the header.
     pub fn round(&self) -> Round {
-        self.round
+        self.inner.round
     }
     /// The [Epoch] for the header.
     pub fn epoch(&self) -> Epoch {
-        self.epoch
+        self.inner.epoch
     }
     /// The [TimestampSec] for the header.
     pub fn created_at(&self) -> &TimestampSec {
-        &self.created_at
+        &self.inner.created_at
     }
     /// The payload for the header.
     pub fn payload(&self) -> &IndexMap<BlockHash, WorkerId> {
-        &self.payload
+        &self.inner.payload
     }
     /// The parents for the header.
     pub fn parents(&self) -> &BTreeSet<HeaderDigest> {
-        &self.parents
+        &self.inner.parents
     }
-
-    // Used for testing.
-
-    /// Replace the header's payload with a new one.
-    ///
-    /// Only used for testing.
-    pub fn update_payload_for_test(&mut self, new_payload: IndexMap<BlockHash, WorkerId>) {
-        self.payload = new_payload;
-    }
-
-    /// Replace the header's round with a new one.
-    ///
-    /// Only used for testing.
-    pub fn update_round_for_test(&mut self, new_round: Round) {
-        self.round = new_round;
-    }
-
-    /// Clear the header's parents.
-    pub fn clear_parents_for_test(&mut self) {
-        self.parents.clear();
+    /// Return the latest executioin block for this header.
+    pub fn latest_execution_block(&self) -> BlockNumHash {
+        self.inner.latest_execution_block
     }
 
     /// The nonce of this header used during execution.
     pub fn nonce(&self) -> u64 {
-        ((self.epoch as u64) << 32) | self.round as u64
+        ((self.inner.epoch as u64) << 32) | self.inner.round as u64
     }
 }
 
+impl Serialize for Header {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let ok = self.inner.serialize(serializer)?;
+        Ok(ok)
+    }
+}
+
+impl<'de> Deserialize<'de> for Header {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut inner = HeaderInner::deserialize(deserializer)?;
+        let digest = Hash::digest(&inner);
+        inner.digest = digest;
+        Ok(Self { inner: Arc::new(inner) })
+    }
+}
+
+/// Builder for `Header` data type for consensus layer.
+#[derive(Default, Debug)]
+pub struct HeaderBuilder {
+    /// Primary that created the header. Must be the same primary that broadcasted the header.
+    author: AuthorityIdentifier,
+    /// The round for this header
+    round: Round,
+    /// The epoch this Header was created in.
+    epoch: Epoch,
+    /// The timestamp for when the header was requested to be created.
+    created_at: TimestampSec,
+    /// IndexMap of the [BatchDigest] to the [WorkerId]
+    payload: IndexMap<BlockHash, WorkerId>,
+    /// Parent certificates for this Header.
+    parents: BTreeSet<HeaderDigest>,
+    /// Hash and number of the latest known execution block when this Header was build.
+    latest_execution_block: BlockNumHash,
+}
+
 impl HeaderBuilder {
+    /// Build a new builder using the values from header as the defaults.
+    pub fn from_header(header: &Header) -> Self {
+        Self {
+            author: header.inner.author.clone(),
+            round: header.inner.round,
+            epoch: header.inner.epoch,
+            created_at: header.inner.created_at,
+            payload: header.inner.payload.clone(),
+            parents: header.inner.parents.clone(),
+            latest_execution_block: header.inner.latest_execution_block,
+        }
+    }
+
     /// "Build" the header by taking all fields and calculating the hash.
     /// This is used for tests, if used for "real" code then at least latest_execution_block will
     /// need to be visited.
     pub fn build(self) -> Header {
-        let h = Header {
-            author: self.author.expect("author set for header builder"),
-            round: self.round.expect("round set for header builder"),
-            epoch: self.epoch.expect("epoch set for header builder"),
-            created_at: self.created_at.unwrap_or(0),
-            payload: self.payload.unwrap_or_default(),
-            parents: self.parents.expect("parents set for header builder"),
-            digest: OnceCell::default(),
-            latest_execution_block: self.latest_execution_block.unwrap_or_default(),
+        let mut inner = HeaderInner {
+            author: self.author,
+            round: self.round,
+            epoch: self.epoch,
+            created_at: self.created_at,
+            payload: self.payload,
+            parents: self.parents,
+            digest: HeaderDigest::default(),
+            latest_execution_block: self.latest_execution_block,
         };
 
-        h.digest.set(Hash::digest(&h)).expect("digest oncecell empty for new header");
+        inner.digest = Hash::digest(&inner);
 
-        h
+        Header { inner: Arc::new(inner) }
     }
 
+    /// Set the author on the builder.
+    pub fn author(mut self, author: AuthorityIdentifier) -> Self {
+        self.author = author;
+        self
+    }
+    /// Set the round on the builder.
+    pub fn round(mut self, round: Round) -> Self {
+        self.round = round;
+        self
+    }
+    /// Set the epoch on the builder.
+    pub fn epoch(mut self, epoch: Epoch) -> Self {
+        self.epoch = epoch;
+        self
+    }
+    /// Set the created_at on the builder.
+    pub fn created_at(mut self, created_at: TimestampSec) -> Self {
+        self.created_at = created_at;
+        self
+    }
+    /// Set the payload on the builder.
+    pub fn payload(mut self, payload: IndexMap<BlockHash, WorkerId>) -> Self {
+        self.payload = payload;
+        self
+    }
+    /// Set the parents on the builder.
+    pub fn parents(mut self, parents: BTreeSet<HeaderDigest>) -> Self {
+        self.parents = parents;
+        self
+    }
+    /// Set the latest_execution_block on the builder.
+    pub fn latest_execution_block(mut self, latest_execution_block: BlockNumHash) -> Self {
+        self.latest_execution_block = latest_execution_block;
+        self
+    }
     /// Helper method to directly set values of the payload
-    pub fn with_payload_batch(mut self, batch: Batch, worker_id: WorkerId) -> Self {
-        if self.payload.is_none() {
-            self.payload = Some(Default::default());
-        }
-        let payload = self.payload.as_mut().unwrap();
-
-        payload.insert(batch.digest(), worker_id);
-
+    pub fn with_payload_batch(mut self, batch: &Batch, worker_id: WorkerId) -> Self {
+        self.payload.insert(batch.digest(), worker_id);
         self
     }
 }
@@ -236,7 +331,7 @@ impl fmt::Display for HeaderDigest {
     }
 }
 
-impl Hash<{ crypto::DIGEST_LENGTH }> for Header {
+impl Hash<{ crypto::DIGEST_LENGTH }> for HeaderInner {
     type TypedDigest = HeaderDigest;
 
     fn digest(&self) -> HeaderDigest {
@@ -256,7 +351,7 @@ impl fmt::Debug for Header {
             self.author(),
             self.epoch(),
             self.payload().len(),
-            self.latest_execution_block,
+            self.latest_execution_block(),
         )
     }
 }
@@ -270,5 +365,61 @@ impl fmt::Display for Header {
 impl PartialEq for Header {
     fn eq(&self, other: &Self) -> bool {
         self.digest() == other.digest()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeSet;
+
+    use alloy::{eips::BlockNumHash, primitives::BlockHash};
+    use indexmap::IndexMap;
+    use once_cell::sync::OnceCell;
+    use serde::{Deserialize, Serialize};
+
+    use crate::{
+        decode, encode, AuthorityIdentifier, Epoch, Header, HeaderDigest, Round, TimestampSec,
+        WorkerId,
+    };
+
+    /// `Header` type for consensus layer- use this to make sure serde is ignoring the inner Arc....
+    #[derive(Clone, Deserialize, Serialize, Default, Debug, PartialEq)]
+    struct HeaderData {
+        /// Primary that created the header. Must be the same primary that broadcasted the header.
+        pub author: AuthorityIdentifier,
+        /// The round for this header
+        pub round: Round,
+        /// The epoch this Header was created in.
+        pub epoch: Epoch,
+        /// The timestamp for when the header was requested to be created.
+        pub created_at: TimestampSec,
+        /// IndexMap of the [BatchDigest] to the [WorkerId]
+        #[serde(with = "indexmap::map::serde_seq")]
+        pub payload: IndexMap<BlockHash, WorkerId>,
+        /// Parent certificates for this Header.
+        pub parents: BTreeSet<HeaderDigest>,
+        /// Hash and number of the latest known execution block when this Header was build.
+        /// This may be our parent block or may not but it does include our latest
+        /// execution result in a signed and validated structure which validates
+        /// this execution block as well.
+        pub latest_execution_block: BlockNumHash,
+        /// The [HeaderDigest].
+        #[serde(skip)]
+        pub digest: OnceCell<HeaderDigest>,
+    }
+
+    /// Simple test to make sure that moving to the inner Arc on Header will not
+    /// change the serialized data.  If this test breaks it may indicate a fork
+    /// was introduced.
+    #[test]
+    fn test_header_serde() {
+        let mut test_header = HeaderData::default();
+        test_header.payload.insert(BlockHash::default(), 0);
+        test_header.parents.insert(HeaderDigest::default());
+        let test_enc = encode(&test_header);
+        let header: Header = decode(&test_enc);
+        let test_enc = encode(&header);
+        let test_header2: HeaderData = decode(&test_enc);
+        assert_eq!(test_header, test_header2, "Header mismatch");
     }
 }

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -321,7 +321,7 @@ impl CommittedSubDag {
                 BlsSignature::default()
             });
         let randomness = keccak256(randomness.to_bytes());
-        let headers = certificates.into_iter().map(|c| Arc::unwrap_or_clone(c.header)).collect();
+        let headers = certificates.into_iter().map(|c| c.into_header()).collect();
         Self { headers, reputation_score, commit_timestamp, randomness }
     }
 


### PR DESCRIPTION
Moved to an internal Arc pattern and made fields private.  The cached digest can not be inconsistent anymore outside of a bug in header.rs.  Also removed the now unnecessary Arc from Certificate and also made its fields private to discourage invalidating certs.  Removed an error and test for invalid digests on headers- this is not expressible anymore.  Added a test to make sure the Header changes do not change the serialize format.