### PR TITLE
Track previous/current/next committees in the network layer

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -709,21 +709,30 @@ where
                 let peers = self.swarm.behaviour_mut().peer_manager.peers_for_exchange();
                 send_or_log_error!(reply, peers, "PeersForExchange");
             }
-            NetworkCommand::NewEpoch { committee } => {
-                // at the start of a new epoch, each node needs to know:
-                // - the current committee
-                // - all staked nodes who will vote at the end of the epoch
-                //      - only synced nodes can vote
+            NetworkCommand::InitializeCommittees { current, next } => {
+                // The network mirrors three of the on-chain registry's committees: previous,
+                // current, and next. Peers in any of the three count as validators so the
+                // just-completed committee is not pruned while late gossip may still arrive and
+                // next-epoch peers are protected before they begin voting. (NVV support and
+                // late-gossip acceptance remain future work.)
                 //
-                // once a node stakes and tries to sync, it would be nice
-                // if it could receive priority on the network for syncing
-                // state
-                //
-                // for now, this only supports the current committee for the epoch
-
-                info!(target: "network", this_node=?self.swarm.local_peer_id(), "network update for next committee - ensuring no committee members are banned");
-                // ensure that the next committee isn't banned
-                self.swarm.behaviour_mut().peer_manager.new_epoch(committee);
+                // On the initial epoch the previous slot is empty; seed current and next here.
+                info!(target: "network", this_node=?self.swarm.local_peer_id(), "initializing previous/current/next committees");
+                self.swarm.behaviour_mut().peer_manager.initialize_committees(current, next);
+            }
+            NetworkCommand::NextCommittee { next_committee, epoch_end_timestamp } => {
+                // Rotate the committees forward (previous <- current, current <- next, next <- arg)
+                // and record when the just-completed epoch ended.
+                info!(target: "network", this_node=?self.swarm.local_peer_id(), ?epoch_end_timestamp, "rotating committees for next epoch");
+                self.swarm
+                    .behaviour_mut()
+                    .peer_manager
+                    .next_committee(next_committee, epoch_end_timestamp);
+            }
+            NetworkCommand::PrepareCommitteeDial { committee } => {
+                // Deadlock-breaker pre-dial: forgive bans so the committee can be dialed without
+                // mutating the committee slots (the real slot update follows shortly after).
+                self.swarm.behaviour_mut().peer_manager.prepare_committee_dial(committee);
             }
             NetworkCommand::FindAuthorities { bls_keys } => {
                 // this will trigger a PeerEvent to fetch records through kad if not in the peer map

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -709,25 +709,24 @@ where
                 let peers = self.swarm.behaviour_mut().peer_manager.peers_for_exchange();
                 send_or_log_error!(reply, peers, "PeersForExchange");
             }
-            NetworkCommand::InitializeCommittees { current, next } => {
+            NetworkCommand::UpdateCommittees { previous, current, next, epoch_end_timestamp } => {
                 // The network mirrors three of the on-chain registry's committees: previous,
                 // current, and next. Peers in any of the three count as validators so the
                 // just-completed committee is not pruned while late gossip may still arrive and
                 // next-epoch peers are protected before they begin voting. (NVV support and
                 // late-gossip acceptance remain future work.)
                 //
-                // On the initial epoch the previous slot is empty; seed current and next here.
-                info!(target: "network", this_node=?self.swarm.local_peer_id(), "initializing previous/current/next committees");
-                self.swarm.behaviour_mut().peer_manager.initialize_committees(current, next);
-            }
-            NetworkCommand::NextCommittee { next_committee, epoch_end_timestamp } => {
-                // Rotate the committees forward (previous <- current, current <- next, next <- arg)
-                // and record when the just-completed epoch ended.
-                info!(target: "network", this_node=?self.swarm.local_peer_id(), ?epoch_end_timestamp, "rotating committees for next epoch");
-                self.swarm
-                    .behaviour_mut()
-                    .peer_manager
-                    .next_committee(next_committee, epoch_end_timestamp);
+                // All three slots are set directly from authoritative state every epoch (no
+                // positional rotation), so current/previous self-correct against on-chain state and
+                // any peer that exits the three-slot window is demoted. The just-completed epoch's
+                // end timestamp is recorded.
+                info!(target: "network", this_node=?self.swarm.local_peer_id(), ?epoch_end_timestamp, "updating previous/current/next committees");
+                self.swarm.behaviour_mut().peer_manager.update_committees(
+                    previous,
+                    current,
+                    next,
+                    epoch_end_timestamp,
+                );
             }
             NetworkCommand::PrepareCommitteeDial { committee } => {
                 // Deadlock-breaker pre-dial: forgive bans so the committee can be dialed without

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -709,7 +709,7 @@ where
                 let peers = self.swarm.behaviour_mut().peer_manager.peers_for_exchange();
                 send_or_log_error!(reply, peers, "PeersForExchange");
             }
-            NetworkCommand::UpdateCommittees { previous, current, next, epoch_end_timestamp } => {
+            NetworkCommand::UpdateCommittees { previous, current, next } => {
                 // The network mirrors three of the on-chain registry's committees: previous,
                 // current, and next. Peers in any of the three count as validators so the
                 // just-completed committee is not pruned while late gossip may still arrive and
@@ -718,15 +718,9 @@ where
                 //
                 // All three slots are set directly from authoritative state every epoch (no
                 // positional rotation), so current/previous self-correct against on-chain state and
-                // any peer that exits the three-slot window is demoted. The just-completed epoch's
-                // end timestamp is recorded.
-                info!(target: "network", this_node=?self.swarm.local_peer_id(), ?epoch_end_timestamp, "updating previous/current/next committees");
-                self.swarm.behaviour_mut().peer_manager.update_committees(
-                    previous,
-                    current,
-                    next,
-                    epoch_end_timestamp,
-                );
+                // any peer that exits the three-slot window is demoted.
+                info!(target: "network", this_node=?self.swarm.local_peer_id(), "updating previous/current/next committees");
+                self.swarm.behaviour_mut().peer_manager.update_committees(previous, current, next);
             }
             NetworkCommand::PrepareCommitteeDial { committee } => {
                 // Deadlock-breaker pre-dial: forgive bans so the committee can be dialed without

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -734,20 +734,6 @@ impl AllPeers {
         }
     }
 
-    /// Boolean indicating if this peer is in the current committee of voting validators.
-    ///
-    /// This is the narrow current-only check; [`Self::is_peer_validator`] widens membership to the
-    /// previous and next committees as well. Kept as the building block for future NVV support.
-    #[allow(dead_code)]
-    fn is_peer_cvv(&self, peer_id: &PeerId) -> bool {
-        match self.identity_for(peer_id) {
-            PeerIdentity::Confirmed(bls_public_key) => {
-                self.current_committee.contains(&bls_public_key)
-            }
-            PeerIdentity::Unidentified(_) => false,
-        }
-    }
-
     /// Boolean indicating if the ip address is associated with a banned peer.
     pub(super) fn ip_banned(&self, ip: &IpAddr) -> bool {
         self.banned_peers.ip_banned(ip)

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -37,16 +37,17 @@ pub(super) struct AllPeers {
     peers: HashMap<PeerId, Peer>,
     /// Peers in the previous epoch's committee.
     ///
-    /// Retained for one rotation so late gossip from the just-completed committee still counts as
-    /// validator traffic and those peers are not pruned mid-rotation.
+    /// Set every epoch from authoritative state so late gossip from the just-completed committee
+    /// still counts as validator traffic and those peers are not pruned mid-rotation.
     previous_committee: HashSet<PeerId>,
     /// Peers in the current epoch's committee.
     current_committee: HashSet<PeerId>,
     /// Peers in the next epoch's committee, pre-emptively trusted so they are not banned before
     /// they begin voting.
     next_committee: HashSet<PeerId>,
-    /// Timestamp (sec) at which the previous epoch closed. Recorded on every rotation; the `0`
-    /// sentinel means no previous epoch boundary has been observed yet (initial epoch).
+    /// Timestamp (sec) at which the previous epoch closed. Set every epoch from authoritative
+    /// state; the `0` sentinel means no previous epoch boundary has been observed yet (initial
+    /// epoch).
     ///
     /// Stored ahead of its consumer: a future PR reads this to accept late gossipsub messages from
     /// the previous committee within a grace window.
@@ -831,55 +832,71 @@ impl AllPeers {
         }
     }
 
-    /// Seed the committee slots on the initial epoch.
+    /// Set the previous/current/next committee slots directly from authoritative state.
     ///
-    /// The previous slot is empty (no epoch has closed yet); `current` and `next` are recorded so
-    /// peers in either committee count as validators. Banned or disconnecting members of either
-    /// committee are forgiven, their advertised addresses refreshed, and they are marked `trusted`.
-    /// Peers that appear in both committees are processed once.
-    pub(super) fn initialize_committees(
+    /// Called every epoch with the three committees read from the persisted epoch records. All
+    /// three slots are overwritten (no positional rotation), so `current` and `previous` are always
+    /// re-validated against authoritative state rather than derived from a prior prediction. The
+    /// just-completed epoch's end timestamp is recorded.
+    ///
+    /// Any peer that was tracked in one of the three slots before this update but is absent from all
+    /// three afterward is demoted via [`Peer::make_untrusted`], bounding committee-derived trust to
+    /// the three-slot window. Members of the new committees are forgiven any bans, have their
+    /// advertised addresses refreshed, and are marked `trusted`; peers appearing in more than one
+    /// committee are processed once. The demote and re-trust sets are disjoint by construction, so
+    /// no peer is demoted then re-trusted in a single call.
+    pub(super) fn update_committees(
         &mut self,
+        previous: Vec<(BlsPublicKey, NetworkInfo)>,
         current: Vec<(BlsPublicKey, NetworkInfo)>,
         next: Vec<(BlsPublicKey, NetworkInfo)>,
+        epoch_end_timestamp: TimestampSec,
     ) -> Vec<(PeerId, PeerAction)> {
-        self.previous_committee = HashSet::new();
+        // capture the peers tracked across all three slots before the overwrite
+        let previously_tracked: HashSet<PeerId> = self
+            .previous_committee
+            .iter()
+            .chain(self.current_committee.iter())
+            .chain(self.next_committee.iter())
+            .copied()
+            .collect();
+
+        // overwrite all three slots directly from authoritative state
+        self.previous_committee = previous.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
         self.current_committee = current.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
         self.next_committee = next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
+        self.epoch_end_timestamp = epoch_end_timestamp;
 
-        // unban + trust every member once (peers in both committees are handled a single time)
+        // demote any peer that fell out of all three slots, returning it to the normal score model
+        let still_tracked: HashSet<PeerId> = self
+            .previous_committee
+            .iter()
+            .chain(self.current_committee.iter())
+            .chain(self.next_committee.iter())
+            .copied()
+            .collect();
+        for peer_id in previously_tracked.difference(&still_tracked) {
+            if let Some(peer) = self.peers.get_mut(peer_id) {
+                peer.make_untrusted();
+            }
+        }
+
+        // unban + trust every member once (peers in multiple committees are handled a single time)
         let mut processed: HashSet<PeerId> = HashSet::new();
-        let members: Vec<(BlsPublicKey, NetworkInfo)> = current
+        let members: Vec<(BlsPublicKey, NetworkInfo)> = previous
             .into_iter()
+            .chain(current)
             .chain(next)
             .filter(|(_, ni)| processed.insert(ni.pubkey.clone().into()))
             .collect();
         self.apply_committee_membership(members)
     }
 
-    /// Rotate the committee slots forward at an epoch boundary.
-    ///
-    /// `previous <- current`, `current <- next`, `next <- new_next`, and the timestamp at which the
-    /// just-completed epoch ended is recorded. Only the incoming `next` committee is run through the
-    /// unban + trust loop: `Peer::make_trusted` is a one-way ratchet, so peers that already passed
-    /// through the committee in a prior rotation keep their trust, and re-applying it to the
-    /// previous or current slots is wasted work.
-    pub(super) fn rotate_to_next_epoch(
-        &mut self,
-        new_next: Vec<(BlsPublicKey, NetworkInfo)>,
-        epoch_end_timestamp: TimestampSec,
-    ) -> Vec<(PeerId, PeerAction)> {
-        self.previous_committee = std::mem::take(&mut self.current_committee);
-        self.current_committee = std::mem::take(&mut self.next_committee);
-        self.next_committee = new_next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
-        self.epoch_end_timestamp = epoch_end_timestamp;
-        self.apply_committee_membership(new_next)
-    }
-
     /// Forgive bans and refresh trust for a committee WITHOUT touching the committee slots.
     ///
     /// Used only by the deadlock-breaker pre-dial path: it unbans committee peers so a subsequent
     /// dial loop can connect, but leaves previous/current/next untouched because the real slot
-    /// update follows shortly after via `initialize_committees` / `rotate_to_next_epoch`.
+    /// update follows shortly after via `update_committees`.
     pub(super) fn mark_committee_for_dial(
         &mut self,
         committee: Vec<(BlsPublicKey, NetworkInfo)>,

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -939,9 +939,9 @@ impl AllPeers {
     ///
     /// The complete committee sets are stored directly, keyed by [BlsPublicKey]. Committee
     /// membership is a consensus-domain fact that is always known, so a member whose libp2p
-    /// [PeerId] has not been discovered yet is still retained in its slot and counts as a validator;
-    /// the unban/trust pass for it then runs lazily once discovery confirms its network identity
-    /// (see [`Self::apply_membership_if_committee`]).
+    /// [PeerId] has not been discovered yet is still retained in its slot and counts as a
+    /// validator; the unban/trust pass for it then runs lazily once discovery confirms its
+    /// network identity (see [`Self::apply_membership_if_committee`]).
     ///
     /// Any member that was tracked in one of the three slots before this update but is absent from
     /// all three afterward is demoted via [`Peer::make_untrusted`] when a `Confirmed` record exists
@@ -1001,11 +1001,11 @@ impl AllPeers {
 
     /// Lazily apply committee trust to a single member the moment its network identity is learned.
     ///
-    /// Called from the discovery path ([`super::manager::PeerManager::add_known_peer`]) after a peer
-    /// is re-keyed onto its `Confirmed` identity. If the member belongs to any tracked committee
-    /// slot it is unbanned/trusted immediately, closing the trust window for members that were
-    /// tracked by [`Self::update_committees`] before their [PeerId] was known. A no-op for peers
-    /// that are not in any tracked committee.
+    /// Called from the discovery path ([`super::manager::PeerManager::add_known_peer`]) after a
+    /// peer is re-keyed onto its `Confirmed` identity. If the member belongs to any tracked
+    /// committee slot it is unbanned/trusted immediately, closing the trust window for members
+    /// that were tracked by [`Self::update_committees`] before their [PeerId] was known. A
+    /// no-op for peers that are not in any tracked committee.
     pub(super) fn apply_membership_if_committee(
         &mut self,
         bls_key: BlsPublicKey,

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -21,7 +21,7 @@ use std::{
     net::IpAddr,
     time::{Duration, Instant},
 };
-use tn_types::{BlsPublicKey, NetworkPublicKey, TimestampSec};
+use tn_types::{BlsPublicKey, NetworkPublicKey};
 use tokio::sync::oneshot;
 use tracing::{debug, error, warn};
 #[cfg(test)]
@@ -45,14 +45,6 @@ pub(super) struct AllPeers {
     /// Peers in the next epoch's committee, pre-emptively trusted so they are not banned before
     /// they begin voting.
     next_committee: HashSet<PeerId>,
-    /// Timestamp (sec) at which the previous epoch closed. Set every epoch from authoritative
-    /// state; the `0` sentinel means no previous epoch boundary has been observed yet (initial
-    /// epoch).
-    ///
-    /// Stored ahead of its consumer: a future PR reads this to accept late gossipsub messages from
-    /// the previous committee within a grace window.
-    #[allow(dead_code)]
-    epoch_end_timestamp: TimestampSec,
     /// Information for peers that scored poorly enough to become banned.
     banned_peers: BannedPeers,
     /// The number of peers that have disconnected from this node.
@@ -79,7 +71,6 @@ impl AllPeers {
             previous_committee: Default::default(),
             current_committee: Default::default(),
             next_committee: Default::default(),
-            epoch_end_timestamp: Default::default(),
             banned_peers: Default::default(),
             disconnected_peers: 0,
             pending_dials: Default::default(),
@@ -836,8 +827,7 @@ impl AllPeers {
     ///
     /// Called every epoch with the three committees read from the persisted epoch records. All
     /// three slots are overwritten (no positional rotation), so `current` and `previous` are always
-    /// re-validated against authoritative state rather than derived from a prior prediction. The
-    /// just-completed epoch's end timestamp is recorded.
+    /// re-validated against authoritative state rather than derived from a prior prediction.
     ///
     /// Any peer that was tracked in one of the three slots before this update but is absent from
     /// all three afterward is demoted via [`Peer::make_untrusted`], bounding committee-derived
@@ -850,7 +840,6 @@ impl AllPeers {
         previous: Vec<(BlsPublicKey, NetworkInfo)>,
         current: Vec<(BlsPublicKey, NetworkInfo)>,
         next: Vec<(BlsPublicKey, NetworkInfo)>,
-        epoch_end_timestamp: TimestampSec,
     ) -> Vec<(PeerId, PeerAction)> {
         // capture the peers tracked across all three slots before the overwrite
         let previously_tracked: HashSet<PeerId> = self
@@ -865,7 +854,6 @@ impl AllPeers {
         self.previous_committee = previous.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
         self.current_committee = current.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
         self.next_committee = next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
-        self.epoch_end_timestamp = epoch_end_timestamp;
 
         // demote any peer that fell out of all three slots, returning it to the normal score model
         let still_tracked: HashSet<PeerId> = self

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -167,7 +167,7 @@ impl AllPeers {
                 peer.update_net(bls_public_key, network_key, addrs);
                 peer
             }
-            None => Peer::new(bls_public_key, network_key),
+            None => Peer::new(bls_public_key, network_key, addrs),
         };
         self.bls_by_peer_id.insert(peer_id, bls_public_key);
         self.peers.insert(PeerIdentity::Confirmed(bls_public_key), peer);

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -833,13 +833,13 @@ impl AllPeers {
     /// all three afterward is demoted via [`Peer::make_untrusted`], bounding committee-derived
     /// trust to the three-slot window. Members of the new committees are forgiven any bans,
     /// have their advertised addresses refreshed, and are marked `trusted`; peers appearing in
-    /// more than one committee are processed once. The demote and re-trust sets are disjoint by
-    /// construction, so no peer is demoted then re-trusted in a single call.
+    /// more than one committee are processed once by map construction. The demote and re-trust
+    /// sets are disjoint by construction, so no peer is demoted then re-trusted in a single call.
     pub(super) fn update_committees(
         &mut self,
-        previous: Vec<(BlsPublicKey, NetworkInfo)>,
-        current: Vec<(BlsPublicKey, NetworkInfo)>,
-        next: Vec<(BlsPublicKey, NetworkInfo)>,
+        previous: HashMap<PeerId, (BlsPublicKey, NetworkInfo)>,
+        current: HashMap<PeerId, (BlsPublicKey, NetworkInfo)>,
+        next: HashMap<PeerId, (BlsPublicKey, NetworkInfo)>,
     ) -> Vec<(PeerId, PeerAction)> {
         // capture the peers tracked across all three slots before the overwrite
         let previously_tracked: HashSet<PeerId> = self
@@ -851,32 +851,26 @@ impl AllPeers {
             .collect();
 
         // overwrite all three slots directly from authoritative state
-        self.previous_committee = previous.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
-        self.current_committee = current.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
-        self.next_committee = next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
+        self.previous_committee = previous.keys().copied().collect();
+        self.current_committee = current.keys().copied().collect();
+        self.next_committee = next.keys().copied().collect();
+
+        // merge the three committees; duplicates across slots collapse via map semantics
+        let mut members = previous;
+        members.extend(current);
+        members.extend(next);
 
         // demote any peer that fell out of all three slots, returning it to the normal score model
-        let still_tracked: HashSet<PeerId> = self
-            .previous_committee
-            .iter()
-            .chain(self.current_committee.iter())
-            .chain(self.next_committee.iter())
-            .copied()
-            .collect();
-        for peer_id in previously_tracked.difference(&still_tracked) {
-            if let Some(peer) = self.peers.get_mut(peer_id) {
-                peer.make_untrusted();
+        // (members.keys() is the union of the three new slots)
+        for peer_id in &previously_tracked {
+            if !members.contains_key(peer_id) {
+                if let Some(peer) = self.peers.get_mut(peer_id) {
+                    peer.make_untrusted();
+                }
             }
         }
 
-        // unban + trust every member once (peers in multiple committees are handled a single time)
-        let mut processed: HashSet<PeerId> = HashSet::new();
-        let members: Vec<(BlsPublicKey, NetworkInfo)> = previous
-            .into_iter()
-            .chain(current)
-            .chain(next)
-            .filter(|(_, ni)| processed.insert(ni.pubkey.clone().into()))
-            .collect();
+        // unban + trust every member once
         self.apply_committee_membership(members)
     }
 
@@ -887,7 +881,7 @@ impl AllPeers {
     /// update follows shortly after via `update_committees`.
     pub(super) fn mark_committee_for_dial(
         &mut self,
-        committee: Vec<(BlsPublicKey, NetworkInfo)>,
+        committee: HashMap<PeerId, (BlsPublicKey, NetworkInfo)>,
     ) -> Vec<(PeerId, PeerAction)> {
         self.apply_committee_membership(committee)
     }
@@ -900,11 +894,10 @@ impl AllPeers {
     /// manager to apply; the committee slots are owned by the callers.
     fn apply_committee_membership(
         &mut self,
-        committee: Vec<(BlsPublicKey, NetworkInfo)>,
+        committee: HashMap<PeerId, (BlsPublicKey, NetworkInfo)>,
     ) -> Vec<(PeerId, PeerAction)> {
         let mut actions = Vec::with_capacity(committee.len());
-        for (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. }) in committee {
-            let peer_id: PeerId = pubkey.clone().into();
+        for (peer_id, (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. })) in committee {
             // the NewConnectionStatus doesn't affect this call
             let status = self.ensure_peer_exists(&peer_id, &NewConnectionStatus::Unbanned);
             // We have all our network settings so go ahead and make sure they are set.

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -839,12 +839,12 @@ impl AllPeers {
     /// re-validated against authoritative state rather than derived from a prior prediction. The
     /// just-completed epoch's end timestamp is recorded.
     ///
-    /// Any peer that was tracked in one of the three slots before this update but is absent from all
-    /// three afterward is demoted via [`Peer::make_untrusted`], bounding committee-derived trust to
-    /// the three-slot window. Members of the new committees are forgiven any bans, have their
-    /// advertised addresses refreshed, and are marked `trusted`; peers appearing in more than one
-    /// committee are processed once. The demote and re-trust sets are disjoint by construction, so
-    /// no peer is demoted then re-trusted in a single call.
+    /// Any peer that was tracked in one of the three slots before this update but is absent from
+    /// all three afterward is demoted via [`Peer::make_untrusted`], bounding committee-derived
+    /// trust to the three-slot window. Members of the new committees are forgiven any bans,
+    /// have their advertised addresses refreshed, and are marked `trusted`; peers appearing in
+    /// more than one committee are processed once. The demote and re-trust sets are disjoint by
+    /// construction, so no peer is demoted then re-trusted in a single call.
     pub(super) fn update_committees(
         &mut self,
         previous: Vec<(BlsPublicKey, NetworkInfo)>,

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -21,7 +21,7 @@ use std::{
     net::IpAddr,
     time::{Duration, Instant},
 };
-use tn_types::{BlsPublicKey, NetworkPublicKey};
+use tn_types::{BlsPublicKey, NetworkPublicKey, TimestampSec};
 use tokio::sync::oneshot;
 use tracing::{debug, error, warn};
 #[cfg(test)]
@@ -35,11 +35,23 @@ mod peers;
 pub(super) struct AllPeers {
     /// The collection of known connected peers, their status and reputation
     peers: HashMap<PeerId, Peer>,
-    /// The collection of staked current_committee at the beginning of each epoch.
+    /// Peers in the previous epoch's committee.
+    ///
+    /// Retained for one rotation so late gossip from the just-completed committee still counts as
+    /// validator traffic and those peers are not pruned mid-rotation.
+    previous_committee: HashSet<PeerId>,
+    /// Peers in the current epoch's committee.
     current_committee: HashSet<PeerId>,
-    /// The collection of staked current_committee pub key to peerid at the beginning of each
-    /// epoch.
-    current_committee_keys: HashMap<BlsPublicKey, Option<PeerId>>,
+    /// Peers in the next epoch's committee, pre-emptively trusted so they are not banned before
+    /// they begin voting.
+    next_committee: HashSet<PeerId>,
+    /// Timestamp (sec) at which the previous epoch closed. Recorded on every rotation; the `0`
+    /// sentinel means no previous epoch boundary has been observed yet (initial epoch).
+    ///
+    /// Stored ahead of its consumer: a future PR reads this to accept late gossipsub messages from
+    /// the previous committee within a grace window.
+    #[allow(dead_code)]
+    epoch_end_timestamp: TimestampSec,
     /// Information for peers that scored poorly enough to become banned.
     banned_peers: BannedPeers,
     /// The number of peers that have disconnected from this node.
@@ -63,8 +75,10 @@ impl AllPeers {
     ) -> Self {
         Self {
             peers: Default::default(),
+            previous_committee: Default::default(),
             current_committee: Default::default(),
-            current_committee_keys: Default::default(),
+            next_committee: Default::default(),
+            epoch_end_timestamp: Default::default(),
             banned_peers: Default::default(),
             disconnected_peers: 0,
             pending_dials: Default::default(),
@@ -632,15 +646,15 @@ impl AllPeers {
         self.peers.get(peer_id)
     }
 
-    /// Boolean indicating if this peer is a validator.
-    /// This method will be updated to include nvvs as well.
+    /// Boolean indicating if this peer is a validator in the previous, current, or next committee.
+    ///
+    /// Membership spans all three tracked committees so peers from the just-completed epoch are not
+    /// pruned while late gossip may still arrive, and next-epoch peers are protected before they
+    /// begin voting. (NVV support remains future work.)
     pub(super) fn is_peer_validator(&self, peer_id: &PeerId) -> bool {
-        self.is_peer_cvv(peer_id)
-    }
-
-    /// Boolean indicating if this peer is in the current committee of voting validators.
-    fn is_peer_cvv(&self, peer_id: &PeerId) -> bool {
-        self.current_committee.contains(peer_id)
+        self.previous_committee.contains(peer_id)
+            || self.current_committee.contains(peer_id)
+            || self.next_committee.contains(peer_id)
     }
 
     /// Boolean indicating if the ip address is associated with a banned peer.
@@ -817,26 +831,75 @@ impl AllPeers {
         }
     }
 
-    /// Update committee for the new epoch.
+    /// Seed the committee slots on the initial epoch.
     ///
-    /// The committee is tracked to ensure priority on the network.
-    /// The banned status of any committee peer is forgiven and IPs
-    /// associated with the committee node are reset. The advertised
-    /// listening addresses are updated and the peer is marked `trusted`
-    /// so it won't incur any additional penalties.
-    pub(super) fn new_epoch(
+    /// The previous slot is empty (no epoch has closed yet); `current` and `next` are recorded so
+    /// peers in either committee count as validators. Banned or disconnecting members of either
+    /// committee are forgiven, their advertised addresses refreshed, and they are marked `trusted`.
+    /// Peers that appear in both committees are processed once.
+    pub(super) fn initialize_committees(
+        &mut self,
+        current: Vec<(BlsPublicKey, NetworkInfo)>,
+        next: Vec<(BlsPublicKey, NetworkInfo)>,
+    ) -> Vec<(PeerId, PeerAction)> {
+        self.previous_committee = HashSet::new();
+        self.current_committee = current.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
+        self.next_committee = next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
+
+        // unban + trust every member once (peers in both committees are handled a single time)
+        let mut processed: HashSet<PeerId> = HashSet::new();
+        let members: Vec<(BlsPublicKey, NetworkInfo)> = current
+            .into_iter()
+            .chain(next)
+            .filter(|(_, ni)| processed.insert(ni.pubkey.clone().into()))
+            .collect();
+        self.apply_committee_membership(members)
+    }
+
+    /// Rotate the committee slots forward at an epoch boundary.
+    ///
+    /// `previous <- current`, `current <- next`, `next <- new_next`, and the timestamp at which the
+    /// just-completed epoch ended is recorded. Only the incoming `next` committee is run through the
+    /// unban + trust loop: `Peer::make_trusted` is a one-way ratchet, so peers that already passed
+    /// through the committee in a prior rotation keep their trust, and re-applying it to the
+    /// previous or current slots is wasted work.
+    pub(super) fn rotate_to_next_epoch(
+        &mut self,
+        new_next: Vec<(BlsPublicKey, NetworkInfo)>,
+        epoch_end_timestamp: TimestampSec,
+    ) -> Vec<(PeerId, PeerAction)> {
+        self.previous_committee = std::mem::take(&mut self.current_committee);
+        self.current_committee = std::mem::take(&mut self.next_committee);
+        self.next_committee = new_next.iter().map(|(_, ni)| ni.pubkey.clone().into()).collect();
+        self.epoch_end_timestamp = epoch_end_timestamp;
+        self.apply_committee_membership(new_next)
+    }
+
+    /// Forgive bans and refresh trust for a committee WITHOUT touching the committee slots.
+    ///
+    /// Used only by the deadlock-breaker pre-dial path: it unbans committee peers so a subsequent
+    /// dial loop can connect, but leaves previous/current/next untouched because the real slot
+    /// update follows shortly after via `initialize_committees` / `rotate_to_next_epoch`.
+    pub(super) fn mark_committee_for_dial(
         &mut self,
         committee: Vec<(BlsPublicKey, NetworkInfo)>,
     ) -> Vec<(PeerId, PeerAction)> {
-        // update current committee
-        self.current_committee.clear();
-        self.current_committee_keys.clear();
+        self.apply_committee_membership(committee)
+    }
 
+    /// Forgive bans, refresh advertised addresses, and mark each committee peer `trusted`.
+    ///
+    /// The banned status of any committee peer is forgiven and IPs associated with the committee
+    /// node are reset. The advertised listening addresses are updated and the peer is marked
+    /// `trusted` so it won't incur any additional penalties. Returns the unban actions for the
+    /// manager to apply; the committee slots are owned by the callers.
+    fn apply_committee_membership(
+        &mut self,
+        committee: Vec<(BlsPublicKey, NetworkInfo)>,
+    ) -> Vec<(PeerId, PeerAction)> {
         let mut actions = Vec::with_capacity(committee.len());
         for (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. }) in committee {
             let peer_id: PeerId = pubkey.clone().into();
-            self.current_committee.insert(peer_id);
-            self.current_committee_keys.insert(bls_key, Some(peer_id));
             // the NewConnectionStatus doesn't affect this call
             let status = self.ensure_peer_exists(&peer_id, &NewConnectionStatus::Unbanned);
             // We have all our network settings so go ahead and make sure they are set.

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -22,7 +22,7 @@ use std::{
     task::Context,
 };
 use tn_config::PeerConfig;
-use tn_types::BlsPublicKey;
+use tn_types::{BlsPublicKey, TimestampSec};
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
 
@@ -326,9 +326,9 @@ impl PeerManager {
 
     /// Returns a boolean if the peer is a known validator.
     ///
-    /// `AllPeers` only tracks CVVs for now. (current voting validators)
-    ///
-    /// This method will be extended to support any staked validator.
+    /// Membership spans the previous, current, and next committees tracked by `AllPeers`, so peers
+    /// from the just-completed epoch and the upcoming epoch both count. (NVV support remains future
+    /// work.)
     pub(super) fn is_peer_validator(&self, peer_id: &PeerId) -> bool {
         self.peers.is_peer_validator(peer_id)
     }
@@ -608,11 +608,61 @@ impl PeerManager {
             || self.peers.get_peer(peer_id).map(|p| p.is_trusted()).unwrap_or_default()
     }
 
-    /// Update the committee for the new epoch.
-    pub(crate) fn new_epoch(&mut self, committee: HashSet<BlsPublicKey>) {
-        // remove from temporary banned and warn if validator was banned
-        let mut exp_committee = Vec::default();
-        for bls_key in &committee {
+    /// Seed the previous/current/next committees on the initial epoch.
+    ///
+    /// `current` and `next` are resolved to known network info and handed to the peer store, which
+    /// records both as validators and forgives any bans. Unknown `next` keys trigger a kad lookup
+    /// (see [`Self::trigger_missing_authorities`]) since the next committee is the most likely
+    /// source of peers we have never connected to.
+    pub(crate) fn initialize_committees(
+        &mut self,
+        current: HashSet<BlsPublicKey>,
+        next: HashSet<BlsPublicKey>,
+    ) {
+        let current = self.resolve_committee(&current);
+        let resolved_next = self.resolve_committee(&next);
+        self.trigger_missing_authorities(&next);
+        let unban_actions = self.peers.initialize_committees(current, resolved_next);
+        self.apply_unban_actions(unban_actions);
+    }
+
+    /// Rotate the committees forward at an epoch boundary: `previous <- current`,
+    /// `current <- next`, `next <- new_next`, recording the just-closed epoch's end timestamp.
+    ///
+    /// Only the incoming `next` committee is resolved and run through the unban loop. Unknown `next`
+    /// keys trigger a kad lookup.
+    pub(crate) fn next_committee(
+        &mut self,
+        next: HashSet<BlsPublicKey>,
+        epoch_end_timestamp: TimestampSec,
+    ) {
+        let resolved_next = self.resolve_committee(&next);
+        self.trigger_missing_authorities(&next);
+        let unban_actions = self.peers.rotate_to_next_epoch(resolved_next, epoch_end_timestamp);
+        self.apply_unban_actions(unban_actions);
+    }
+
+    /// Pre-dial recovery: forgive bans for a committee so a subsequent dial loop can connect,
+    /// WITHOUT mutating the committee slots.
+    ///
+    /// Used by the deadlock-breaker path while waiting for an epoch record; the real slot update
+    /// follows shortly after via [`Self::initialize_committees`] or [`Self::next_committee`].
+    pub(crate) fn prepare_committee_dial(&mut self, committee: HashSet<BlsPublicKey>) {
+        let committee = self.resolve_committee(&committee);
+        let unban_actions = self.peers.mark_committee_for_dial(committee);
+        self.apply_unban_actions(unban_actions);
+    }
+
+    /// Resolve committee bls keys to known network info, forgiving temporary bans along the way.
+    ///
+    /// Keys with no known network info are skipped with a warning; callers that need to chase them
+    /// down should also call [`Self::trigger_missing_authorities`].
+    fn resolve_committee(
+        &mut self,
+        committee: &HashSet<BlsPublicKey>,
+    ) -> Vec<(BlsPublicKey, NetworkInfo)> {
+        let mut exp_committee = Vec::with_capacity(committee.len());
+        for bls_key in committee {
             if let Some(NetworkInfo { pubkey, multiaddrs: multiaddr, timestamp }) =
                 self.known_peers.get(bls_key)
             {
@@ -633,12 +683,22 @@ impl PeerManager {
                 warn!(target: "peer-manager", "unknown committee member with key {bls_key}");
             }
         }
+        exp_committee
+    }
 
-        // add trusted peer record
-        let unban_actions = self.peers.new_epoch(exp_committee);
+    /// Emit a [`PeerEvent::MissingAuthorities`] for any committee keys with no known network info so
+    /// kad discovery can chase them.
+    fn trigger_missing_authorities(&mut self, committee: &HashSet<BlsPublicKey>) {
+        let missing: Vec<BlsPublicKey> =
+            committee.iter().filter(|k| !self.known_peers.contains_key(k)).copied().collect();
+        if !missing.is_empty() {
+            self.events.push_back(PeerEvent::MissingAuthorities(missing));
+        }
+    }
 
-        // apply unban for any banned validators
-        for (peer_id, action) in unban_actions {
+    /// Apply unban actions returned by the peer store.
+    fn apply_unban_actions(&mut self, actions: Vec<(PeerId, PeerAction)>) {
+        for (peer_id, action) in actions {
             self.apply_peer_action(peer_id, action);
         }
     }

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -22,7 +22,7 @@ use std::{
     task::Context,
 };
 use tn_config::PeerConfig;
-use tn_types::{BlsPublicKey, TimestampSec};
+use tn_types::BlsPublicKey;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
 
@@ -623,19 +623,14 @@ impl PeerManager {
         previous: HashSet<BlsPublicKey>,
         current: HashSet<BlsPublicKey>,
         next: HashSet<BlsPublicKey>,
-        epoch_end_timestamp: TimestampSec,
     ) {
         self.trigger_missing_authorities(&current);
         self.trigger_missing_authorities(&next);
         let resolved_previous = self.resolve_committee(&previous);
         let resolved_current = self.resolve_committee(&current);
         let resolved_next = self.resolve_committee(&next);
-        let unban_actions = self.peers.update_committees(
-            resolved_previous,
-            resolved_current,
-            resolved_next,
-            epoch_end_timestamp,
-        );
+        let unban_actions =
+            self.peers.update_committees(resolved_previous, resolved_current, resolved_next);
         self.apply_unban_actions(unban_actions);
     }
 

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -608,40 +608,34 @@ impl PeerManager {
             || self.peers.get_peer(peer_id).map(|p| p.is_trusted()).unwrap_or_default()
     }
 
-    /// Seed the previous/current/next committees on the initial epoch.
+    /// Set the previous/current/next committees directly from authoritative state, every epoch.
     ///
-    /// `current` and `next` are resolved to known network info and handed to the peer store, which
-    /// records both as validators and forgives any bans. Unknown keys in either committee trigger a
-    /// kad lookup (see [`Self::trigger_missing_authorities`]). The `next` committee is the most
-    /// likely source of peers we have never connected to, but `current` members may also be unknown
-    /// when a restart seeds the committees late (the initial epoch returned early before network
-    /// setup), so chase both.
-    pub(crate) fn initialize_committees(
+    /// All three committees are resolved to known network info and handed to the peer store, which
+    /// overwrites the three slots, demotes any peer that fell out of the window, records both new
+    /// members as validators, and forgives any bans. Unknown keys in `current` and `next` trigger a
+    /// kad lookup (see [`Self::trigger_missing_authorities`]) — but **not** `previous`, whose peers
+    /// are rotating out and are only resolved so already-known previous members still get
+    /// unban/refresh. The `next` committee is the most likely source of peers we have never
+    /// connected to, but `current` members may also be unknown when a restart seeds the committees
+    /// late (the initial epoch returned early before network setup), so chase both.
+    pub(crate) fn update_committees(
         &mut self,
+        previous: HashSet<BlsPublicKey>,
         current: HashSet<BlsPublicKey>,
-        next: HashSet<BlsPublicKey>,
-    ) {
-        self.trigger_missing_authorities(&current);
-        self.trigger_missing_authorities(&next);
-        let resolved_current = self.resolve_committee(&current);
-        let resolved_next = self.resolve_committee(&next);
-        let unban_actions = self.peers.initialize_committees(resolved_current, resolved_next);
-        self.apply_unban_actions(unban_actions);
-    }
-
-    /// Rotate the committees forward at an epoch boundary: `previous <- current`,
-    /// `current <- next`, `next <- new_next`, recording the just-closed epoch's end timestamp.
-    ///
-    /// Only the incoming `next` committee is resolved and run through the unban loop. Unknown `next`
-    /// keys trigger a kad lookup.
-    pub(crate) fn next_committee(
-        &mut self,
         next: HashSet<BlsPublicKey>,
         epoch_end_timestamp: TimestampSec,
     ) {
-        let resolved_next = self.resolve_committee(&next);
+        self.trigger_missing_authorities(&current);
         self.trigger_missing_authorities(&next);
-        let unban_actions = self.peers.rotate_to_next_epoch(resolved_next, epoch_end_timestamp);
+        let resolved_previous = self.resolve_committee(&previous);
+        let resolved_current = self.resolve_committee(&current);
+        let resolved_next = self.resolve_committee(&next);
+        let unban_actions = self.peers.update_committees(
+            resolved_previous,
+            resolved_current,
+            resolved_next,
+            epoch_end_timestamp,
+        );
         self.apply_unban_actions(unban_actions);
     }
 
@@ -649,7 +643,7 @@ impl PeerManager {
     /// WITHOUT mutating the committee slots.
     ///
     /// Used by the deadlock-breaker path while waiting for an epoch record; the real slot update
-    /// follows shortly after via [`Self::initialize_committees`] or [`Self::next_committee`].
+    /// follows shortly after via [`Self::update_committees`].
     pub(crate) fn prepare_committee_dial(&mut self, committee: HashSet<BlsPublicKey>) {
         let committee = self.resolve_committee(&committee);
         let unban_actions = self.peers.mark_committee_for_dial(committee);

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -683,8 +683,8 @@ impl PeerManager {
         exp_committee
     }
 
-    /// Emit a [`PeerEvent::MissingAuthorities`] for any committee keys with no known network info so
-    /// kad discovery can chase them.
+    /// Emit a [`PeerEvent::MissingAuthorities`] for any committee keys with no known network info
+    /// so kad discovery can chase them.
     fn trigger_missing_authorities(&mut self, committee: &HashSet<BlsPublicKey>) {
         let missing: Vec<BlsPublicKey> =
             committee.iter().filter(|k| !self.known_peers.contains_key(k)).copied().collect();

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -605,17 +605,19 @@ impl PeerManager {
 
     /// Set the previous/current/next committees directly from authoritative state, every epoch.
     ///
-    /// The three committees are handed to the peer store keyed by [`BlsPublicKey`], which overwrites
-    /// the three slots with the complete sets, demotes any member that fell out of the window,
-    /// records every member as a validator (even those whose network identity is not yet known),
-    /// and forgives any bans for members already discovered. Unknown keys in `current` and `next`
-    /// trigger a kad lookup (see [`Self::trigger_missing_authorities`]) — but **not** `previous`,
-    /// whose peers are rotating out. The `next` committee is the most likely source of peers we have
-    /// never connected to, but `current` members may also be unknown when a restart seeds the
-    /// committees late (the initial epoch returned early before network setup), so chase both.
+    /// The three committees are handed to the peer store keyed by [`BlsPublicKey`], which
+    /// overwrites the three slots with the complete sets, demotes any member that fell out of
+    /// the window, records every member as a validator (even those whose network identity is
+    /// not yet known), and forgives any bans for members already discovered. Unknown keys in
+    /// `current` and `next` trigger a kad lookup (see [`Self::trigger_missing_authorities`]) —
+    /// but **not** `previous`, whose peers are rotating out. The `next` committee is the most
+    /// likely source of peers we have never connected to, but `current` members may also be
+    /// unknown when a restart seeds the committees late (the initial epoch returned early
+    /// before network setup), so chase both.
     ///
-    /// Members are also lifted out of the manager's temporary-ban cache so a follow-up dial loop can
-    /// reach them; members discovered only later are forgiven lazily by [`Self::add_known_peer`].
+    /// Members are also lifted out of the manager's temporary-ban cache so a follow-up dial loop
+    /// can reach them; members discovered only later are forgiven lazily by
+    /// [`Self::add_known_peer`].
     pub(crate) fn update_committees(
         &mut self,
         previous: HashSet<BlsPublicKey>,
@@ -647,7 +649,8 @@ impl PeerManager {
     ///
     /// The temporary-ban cache is a network-layer reconnection guard kept separate from peer state;
     /// committee members must bypass it so they can be (re)dialed. Members with no known network
-    /// info yet are skipped here and forgiven lazily once discovered (see [`Self::add_known_peer`]).
+    /// info yet are skipped here and forgiven lazily once discovered (see
+    /// [`Self::add_known_peer`]).
     fn forgive_temporarily_banned(&mut self, committee: &HashSet<BlsPublicKey>) {
         for bls_key in committee {
             if let Some((peer_id, _)) = self.auth_to_peer(*bls_key) {
@@ -681,10 +684,10 @@ impl PeerManager {
         trace!(target: "peer-manager", ?bls_key, "adding known peer");
         self.peers.upsert_peer(bls_key, info.pubkey.clone(), info.multiaddrs.clone());
         self.known_peers.insert(bls_key, info);
-        // FULL FIX: if this newly-discovered peer belongs to a tracked committee, unban/trust it now
+        // if this newly-discovered peer belongs to a tracked committee, unban/trust it now
         // (closing the trust window) instead of waiting for the next epoch's `update_committees`.
-        // `upsert_peer` just re-keyed it onto its `Confirmed` identity, so the trust pass can resolve
-        // its peer id immediately.
+        // `upsert_peer` just re-keyed it onto its `Confirmed` identity, so the trust pass can
+        // resolve its peer id immediately.
         let unban_actions = self.peers.apply_membership_if_committee(bls_key);
         self.apply_unban_actions(unban_actions);
     }

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -652,8 +652,8 @@ impl PeerManager {
     fn resolve_committee(
         &mut self,
         committee: &HashSet<BlsPublicKey>,
-    ) -> Vec<(BlsPublicKey, NetworkInfo)> {
-        let mut exp_committee = Vec::with_capacity(committee.len());
+    ) -> HashMap<PeerId, (BlsPublicKey, NetworkInfo)> {
+        let mut exp_committee = HashMap::with_capacity(committee.len());
         for bls_key in committee {
             if let Some(NetworkInfo { pubkey, multiaddrs: multiaddr, timestamp }) =
                 self.known_peers.get(bls_key)
@@ -663,14 +663,17 @@ impl PeerManager {
                 if self.temporarily_banned.remove(&peer_id) {
                     warn!(target: "peer-manager", ?peer_id, "removed committee member from temporarily banned list");
                 }
-                exp_committee.push((
-                    *bls_key,
-                    NetworkInfo {
-                        pubkey: pubkey.clone(),
-                        multiaddrs: multiaddr.clone(),
-                        timestamp: *timestamp,
-                    },
-                ));
+                exp_committee.insert(
+                    peer_id,
+                    (
+                        *bls_key,
+                        NetworkInfo {
+                            pubkey: pubkey.clone(),
+                            multiaddrs: multiaddr.clone(),
+                            timestamp: *timestamp,
+                        },
+                    ),
+                );
             } else {
                 warn!(target: "peer-manager", "unknown committee member with key {bls_key}");
             }

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -611,18 +611,21 @@ impl PeerManager {
     /// Seed the previous/current/next committees on the initial epoch.
     ///
     /// `current` and `next` are resolved to known network info and handed to the peer store, which
-    /// records both as validators and forgives any bans. Unknown `next` keys trigger a kad lookup
-    /// (see [`Self::trigger_missing_authorities`]) since the next committee is the most likely
-    /// source of peers we have never connected to.
+    /// records both as validators and forgives any bans. Unknown keys in either committee trigger a
+    /// kad lookup (see [`Self::trigger_missing_authorities`]). The `next` committee is the most
+    /// likely source of peers we have never connected to, but `current` members may also be unknown
+    /// when a restart seeds the committees late (the initial epoch returned early before network
+    /// setup), so chase both.
     pub(crate) fn initialize_committees(
         &mut self,
         current: HashSet<BlsPublicKey>,
         next: HashSet<BlsPublicKey>,
     ) {
-        let current = self.resolve_committee(&current);
-        let resolved_next = self.resolve_committee(&next);
+        self.trigger_missing_authorities(&current);
         self.trigger_missing_authorities(&next);
-        let unban_actions = self.peers.initialize_committees(current, resolved_next);
+        let resolved_current = self.resolve_committee(&current);
+        let resolved_next = self.resolve_committee(&next);
+        let unban_actions = self.peers.initialize_committees(resolved_current, resolved_next);
         self.apply_unban_actions(unban_actions);
     }
 

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -66,15 +66,19 @@ impl Peer {
         }
     }
 
-    /// Create a new trusted peer.
-    pub(super) fn new(bls_public_key: BlsPublicKey, network_key: NetworkPublicKey) -> Peer {
+    /// Create a new peer with its known multiaddrs.
+    pub(super) fn new(
+        bls_public_key: BlsPublicKey,
+        network_key: NetworkPublicKey,
+        addrs: Vec<Multiaddr>,
+    ) -> Peer {
         Self {
             bls_public_key: Some(bls_public_key),
             network_key: Some(network_key),
             score: Score::default(),
             is_trusted: false,
             config: Default::default(),
-            multiaddrs: Default::default(),
+            multiaddrs: addrs.into_iter().collect(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
             routable: false,

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -333,6 +333,19 @@ impl Peer {
         }
     }
 
+    /// Revoke a peer's trusted status, returning it to the normal score model.
+    ///
+    /// Called when a peer rotates out of all three committee slots. Only the flag is cleared;
+    /// the score is left as-is so the demoted peer gets a soft landing (heartbeat decay and
+    /// penalties resume immediately now that `is_trusted` is false).
+    ///
+    /// NOTE: `is_trusted` currently conflates committee-derived trust with operator-allowlist
+    /// trust (`new_trusted`/`add_trusted_peer`); demoting clears both for a peer that was in a
+    /// committee. Splitting the two provenances is tracked as a follow-up.
+    pub(super) fn make_untrusted(&mut self) {
+        self.is_trusted = false;
+    }
+
     /// Update multiaddrs for the peer.
     ///
     /// Returns a boolean indicating if the multiaddr was newly recorded.

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -341,7 +341,7 @@ impl Peer {
     ///
     /// NOTE: `is_trusted` currently conflates committee-derived trust with operator-allowlist
     /// trust (`new_trusted`/`add_trusted_peer`); demoting clears both for a peer that was in a
-    /// committee. Splitting the two provenances is tracked as a follow-up.
+    /// committee.
     pub(super) fn make_untrusted(&mut self) {
         self.is_trusted = false;
     }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1344,9 +1344,14 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
     let handle = peer1.clone();
     tokio::spawn(async move {
         handle
-            .initialize_committees(committee, Default::default())
+            .update_committees(
+                Default::default(),
+                committee,
+                Default::default(),
+                Default::default(),
+            )
             .await
-            .expect("Failed to send InitializeCommittees command");
+            .expect("Failed to send UpdateCommittees command");
     })
     .await?;
 
@@ -1468,7 +1473,10 @@ async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
         .into_iter()
         .collect();
 
-    target_peer.network_handle.initialize_committees(committee, Default::default()).await?;
+    target_peer
+        .network_handle
+        .update_committees(Default::default(), committee, Default::default(), Default::default())
+        .await?;
 
     // wait for connection to establish
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
@@ -1548,9 +1556,14 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
     let handle = peer1.clone();
     tokio::spawn(async move {
         handle
-            .initialize_committees(committee, Default::default())
+            .update_committees(
+                Default::default(),
+                committee,
+                Default::default(),
+                Default::default(),
+            )
             .await
-            .expect("Failed to send InitializeCommittees command");
+            .expect("Failed to send UpdateCommittees command");
     })
     .await?;
 
@@ -1614,14 +1627,28 @@ async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()
     );
 
     // peer2 is in the CURRENT committee for this epoch
-    peer1.initialize_committees(vec![peer2_bls].into_iter().collect(), Default::default()).await?;
+    peer1
+        .update_committees(
+            Default::default(),
+            vec![peer2_bls].into_iter().collect(),
+            Default::default(),
+            0,
+        )
+        .await?;
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
 
-    // Rotate to the next epoch whose `next` committee does NOT contain peer2:
-    // previous <- current ({peer2}), current <- next ({}), next <- {}. peer2 drops out of
-    // `current` into `previous` and must NOT be disconnected, since it still counts as a validator
-    // (is_peer_validator spans the previous committee).
-    peer1.next_committee(Default::default(), 1234).await?;
+    // Update to the next epoch where peer2 has rotated out of `current` into `previous`: it is
+    // placed explicitly in the previous slot and absent from current/next. peer2 must NOT be
+    // disconnected, since it still counts as a validator (is_peer_validator spans the previous
+    // committee).
+    peer1
+        .update_committees(
+            vec![peer2_bls].into_iter().collect(),
+            Default::default(),
+            Default::default(),
+            1234,
+        )
+        .await?;
 
     // Let several heartbeats run so any pruning of non-validator peers would take effect.
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL * 3)).await;
@@ -1630,7 +1657,8 @@ async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()
         peer1.connected_peer_ids().await?.contains(&peer2_id),
         "peer2 must stay connected after rotating into the previous committee"
     );
-    // peer2 was made trusted when it entered the committee; trust (and max score) survive rotation.
+    // peer2 stays trusted because it is still inside the three-slot window (now in `previous`), so
+    // it keeps the validator (max) score it was given on entering the committee.
     let peer2_score = peer1.peer_score(peer2_id).await?.expect("peer2 score");
     assert_eq!(
         peer2_score,
@@ -1681,7 +1709,12 @@ async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()>
         )
         .await?;
     publisher
-        .initialize_committees(Default::default(), vec![next_bls].into_iter().collect())
+        .update_committees(
+            Default::default(),
+            Default::default(),
+            vec![next_bls].into_iter().collect(),
+            0,
+        )
         .await?;
 
     // peer2 subscribes with peer1 as the authorized publisher and dials peer1.

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1344,12 +1344,7 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
     let handle = peer1.clone();
     tokio::spawn(async move {
         handle
-            .update_committees(
-                Default::default(),
-                committee,
-                Default::default(),
-                Default::default(),
-            )
+            .update_committees(Default::default(), committee, Default::default())
             .await
             .expect("Failed to send UpdateCommittees command");
     })
@@ -1475,7 +1470,7 @@ async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
 
     target_peer
         .network_handle
-        .update_committees(Default::default(), committee, Default::default(), Default::default())
+        .update_committees(Default::default(), committee, Default::default())
         .await?;
 
     // wait for connection to establish
@@ -1556,12 +1551,7 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
     let handle = peer1.clone();
     tokio::spawn(async move {
         handle
-            .update_committees(
-                Default::default(),
-                committee,
-                Default::default(),
-                Default::default(),
-            )
+            .update_committees(Default::default(), committee, Default::default())
             .await
             .expect("Failed to send UpdateCommittees command");
     })
@@ -1632,7 +1622,6 @@ async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()
             Default::default(),
             vec![peer2_bls].into_iter().collect(),
             Default::default(),
-            0,
         )
         .await?;
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
@@ -1646,7 +1635,6 @@ async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()
             vec![peer2_bls].into_iter().collect(),
             Default::default(),
             Default::default(),
-            1234,
         )
         .await?;
 
@@ -1713,7 +1701,6 @@ async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()>
             Default::default(),
             Default::default(),
             vec![next_bls].into_iter().collect(),
-            0,
         )
         .await?;
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1340,10 +1340,13 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
         .into_iter()
         .collect();
 
-    // Send NewEpoch command to peer1
+    // Seed peer1's committee with peer2
     let handle = peer1.clone();
     tokio::spawn(async move {
-        handle.new_epoch(committee).await.expect("Failed to send NewEpoch command");
+        handle
+            .initialize_committees(committee, Default::default())
+            .await
+            .expect("Failed to send InitializeCommittees command");
     })
     .await?;
 
@@ -1465,7 +1468,7 @@ async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
         .into_iter()
         .collect();
 
-    target_peer.network_handle.new_epoch(committee).await?;
+    target_peer.network_handle.initialize_committees(committee, Default::default()).await?;
 
     // wait for connection to establish
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
@@ -1541,10 +1544,13 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
         .into_iter()
         .collect();
 
-    // Send NewEpoch command to peer1
+    // Seed peer1's committee with peer2
     let handle = peer1.clone();
     tokio::spawn(async move {
-        handle.new_epoch(committee).await.expect("Failed to send NewEpoch command");
+        handle
+            .initialize_committees(committee, Default::default())
+            .await
+            .expect("Failed to send InitializeCommittees command");
     })
     .await?;
 
@@ -1567,6 +1573,151 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
     // Verify connection is established
     let connected_peers_after = peer1.connected_peer_ids().await?;
     assert!(connected_peers_after.contains(&peer2_id), "Peer2 should be connected after new epoch");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()> {
+    // Start with two peers
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { config: config_1, network_handle: peer1, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    let NetworkPeer { config: config_2, network_handle: peer2, network, .. } = peer2;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    peer1.start_listening(config_1.primary_address()).await?;
+    peer2.start_listening(config_2.primary_address()).await?;
+
+    let peer2_id = peer2.local_peer_id().await?;
+    let peer2_bls = config_2.key_config().primary_public_key();
+
+    // Connect peer1 -> peer2
+    peer1
+        .add_explicit_peer(
+            peer2_bls,
+            config_2.key_config().primary_network_public_key(),
+            config_2.primary_address(),
+        )
+        .await?;
+    peer1.dial_by_bls(peer2_bls).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        peer1.connected_peer_ids().await?.contains(&peer2_id),
+        "peer2 should be connected before rotation"
+    );
+
+    // peer2 is in the CURRENT committee for this epoch
+    peer1.initialize_committees(vec![peer2_bls].into_iter().collect(), Default::default()).await?;
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+
+    // Rotate to the next epoch whose `next` committee does NOT contain peer2:
+    // previous <- current ({peer2}), current <- next ({}), next <- {}. peer2 drops out of
+    // `current` into `previous` and must NOT be disconnected, since it still counts as a validator
+    // (is_peer_validator spans the previous committee).
+    peer1.next_committee(Default::default(), 1234).await?;
+
+    // Let several heartbeats run so any pruning of non-validator peers would take effect.
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL * 3)).await;
+
+    assert!(
+        peer1.connected_peer_ids().await?.contains(&peer2_id),
+        "peer2 must stay connected after rotating into the previous committee"
+    );
+    // peer2 was made trusted when it entered the committee; trust (and max score) survive rotation.
+    let peer2_score = peer1.peer_score(peer2_id).await?.expect("peer2 score");
+    assert_eq!(
+        peer2_score,
+        config_1.network_config().peer_config().score_config.max_score,
+        "previous-committee peer should retain validator (max) score"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()> {
+    // peer1 publishes; peer2 only ever appears in peer1's `next` committee and receives gossip.
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { config: config_1, network_handle: publisher, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    let NetworkPeer {
+        config: config_2,
+        network_handle: next_peer,
+        network_events: mut next_peer_events,
+        network,
+    } = peer2;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    publisher.start_listening(config_1.primary_address()).await?;
+    next_peer.start_listening(config_2.primary_address()).await?;
+    let publisher_addr =
+        publisher.listeners().await?.first().expect("publisher listen addr").clone();
+
+    let next_bls = config_2.key_config().primary_public_key();
+    let next_id = next_peer.local_peer_id().await?;
+
+    // Register peer2's network info with peer1, then place peer2 ONLY in peer1's `next` committee
+    // (peer1 never had peer2 in `current`). When peer2 connects, peer1's PeerConnected handler must
+    // treat it as important (is_peer_validator now spans `next`) and add it as a gossipsub explicit
+    // peer, so gossip reaches it.
+    publisher
+        .add_explicit_peer(
+            next_bls,
+            config_2.key_config().primary_network_public_key(),
+            config_2.primary_address(),
+        )
+        .await?;
+    publisher
+        .initialize_committees(Default::default(), vec![next_bls].into_iter().collect())
+        .await?;
+
+    // peer2 subscribes with peer1 as the authorized publisher and dials peer1.
+    next_peer
+        .subscribe_with_publishers(
+            TEST_TOPIC.into(),
+            vec![config_1.key_config().primary_public_key()].into_iter().collect(),
+        )
+        .await?;
+    next_peer
+        .add_trusted_peer_and_dial(
+            config_1.key_config().primary_public_key(),
+            config_1.key_config().primary_network_public_key(),
+            publisher_addr,
+        )
+        .await?;
+
+    // Allow the connection to establish and gossipsub to graft.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert!(
+        publisher.connected_peer_ids().await?.contains(&next_id),
+        "next-committee peer should be connected to the publisher"
+    );
+
+    // Publish and confirm the next-committee peer receives the gossip.
+    let block = fixture_batch_with_transactions(10).seal_slow();
+    let expected = Vec::from(&block);
+    publisher.publish(TEST_TOPIC.into(), expected.clone()).await?;
+    let event =
+        timeout(Duration::from_secs(2), next_peer_events.recv()).await?.expect("gossip received");
+    if let NetworkEvent::Gossip(msg, _) = event {
+        assert_eq!(msg.data, expected);
+    } else {
+        panic!("unexpected network event received");
+    }
 
     Ok(())
 }
@@ -1734,7 +1885,7 @@ async fn test_node_record_validation() {
     assert!(network.peer_record_valid(&peer_record).is_none());
 
     // assert publisher mismatch fails
-    peer_record.publisher = Some(peer2.network.swarm.local_peer_id().clone());
+    peer_record.publisher = Some(*peer2.network.swarm.local_peer_id());
     assert!(network.peer_record_valid(&peer_record).is_none());
 }
 

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -640,9 +640,10 @@ async fn test_prepare_committee_dial_unbans_without_touching_slots() {
 #[tokio::test]
 async fn test_add_known_peer_closes_validator_gap_on_discovery() {
     // GAP FIX (full): a committee member set by bls before its network identity is known is tracked
-    // in the slot but does not yet resolve to a validator by its libp2p id. The moment kad discovery
-    // confirms the identity via `add_known_peer`, the lazy-trust hook makes it a validator and marks
-    // it important -- without waiting for the next epoch's `update_committees`.
+    // in the slot but does not yet resolve to a validator by its libp2p id. The moment kad
+    // discovery confirms the identity via `add_known_peer`, the lazy-trust hook makes it a
+    // validator and marks it important -- without waiting for the next epoch's
+    // `update_committees`.
     let mut peer_manager = create_test_peer_manager(None);
 
     // a committee member whose network identity is not yet known to this node

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -561,7 +561,7 @@ async fn test_is_validator() {
 
     // set the current committee (no previous/next committee for this test)
     let committee = config.committee_pub_keys();
-    peer_manager.update_committees(HashSet::new(), committee, HashSet::new(), 0);
+    peer_manager.update_committees(HashSet::new(), committee, HashSet::new());
 
     // Verify the registered committee member is a validator
     assert!(peer_manager.is_peer_validator(&validator_peer_id));
@@ -578,12 +578,7 @@ async fn test_update_committees_triggers_missing_authorities_for_unknown_next_ke
     let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
 
     // update with a next committee that contains the unknown key
-    peer_manager.update_committees(
-        HashSet::new(),
-        HashSet::new(),
-        HashSet::from([unknown_bls]),
-        100,
-    );
+    peer_manager.update_committees(HashSet::new(), HashSet::new(), HashSet::from([unknown_bls]));
 
     // exactly one MissingAuthorities event referencing the unknown key should be emitted
     let events = collect_all_events(&mut peer_manager);
@@ -603,12 +598,7 @@ async fn test_update_committees_does_not_trigger_for_unknown_previous() {
     let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
 
     // the unknown key appears ONLY in the previous committee (peers rotating out are not chased)
-    peer_manager.update_committees(
-        HashSet::from([unknown_bls]),
-        HashSet::new(),
-        HashSet::new(),
-        100,
-    );
+    peer_manager.update_committees(HashSet::from([unknown_bls]), HashSet::new(), HashSet::new());
 
     // no MissingAuthorities event should be emitted for a previous-only unknown key
     let events = collect_all_events(&mut peer_manager);

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -559,9 +559,9 @@ async fn test_is_validator() {
     };
     peer_manager.add_known_peer(validator, info);
 
-    // seed the current committee (no next committee for this test)
+    // set the current committee (no previous/next committee for this test)
     let committee = config.committee_pub_keys();
-    peer_manager.initialize_committees(committee, HashSet::new());
+    peer_manager.update_committees(HashSet::new(), committee, HashSet::new(), 0);
 
     // Verify the registered committee member is a validator
     assert!(peer_manager.is_peer_validator(&validator_peer_id));
@@ -571,14 +571,19 @@ async fn test_is_validator() {
 }
 
 #[tokio::test]
-async fn test_next_committee_triggers_missing_authorities_for_unknown_next_keys() {
+async fn test_update_committees_triggers_missing_authorities_for_unknown_next_keys() {
     let mut peer_manager = create_test_peer_manager(None);
 
     // generate a bls key that was never registered via add_known_peer
     let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
 
-    // rotate to a next committee that contains the unknown key
-    peer_manager.next_committee(HashSet::from([unknown_bls]), 100);
+    // update with a next committee that contains the unknown key
+    peer_manager.update_committees(
+        HashSet::new(),
+        HashSet::new(),
+        HashSet::from([unknown_bls]),
+        100,
+    );
 
     // exactly one MissingAuthorities event referencing the unknown key should be emitted
     let events = collect_all_events(&mut peer_manager);
@@ -587,6 +592,30 @@ async fn test_next_committee_triggers_missing_authorities_for_unknown_next_keys(
     assert_matches!(
         missing_events.first().unwrap(),
         PeerEvent::MissingAuthorities(missing) if missing.contains(&unknown_bls)
+    );
+}
+
+#[tokio::test]
+async fn test_update_committees_does_not_trigger_for_unknown_previous() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // generate a bls key that was never registered via add_known_peer
+    let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
+
+    // the unknown key appears ONLY in the previous committee (peers rotating out are not chased)
+    peer_manager.update_committees(
+        HashSet::from([unknown_bls]),
+        HashSet::new(),
+        HashSet::new(),
+        100,
+    );
+
+    // no MissingAuthorities event should be emitted for a previous-only unknown key
+    let events = collect_all_events(&mut peer_manager);
+    let missing_events = extract_events(&events, |e| matches!(e, PeerEvent::MissingAuthorities(_)));
+    assert!(
+        missing_events.is_empty(),
+        "previous-committee-only unknown keys must not trigger MissingAuthorities"
     );
 }
 

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -549,6 +549,7 @@ async fn test_is_validator() {
     let config = authority_1.consensus_config();
     let mut peer_manager = PeerManager::new(config.network_config().peer_config());
     let validator = *authority_1.authority().protocol_key();
+    let validator_peer_id: PeerId = config.key_config().primary_network_public_key().into();
     let random_peer_id = PeerId::random();
 
     let info = NetworkInfo {
@@ -558,12 +559,63 @@ async fn test_is_validator() {
     };
     peer_manager.add_known_peer(validator, info);
 
-    // update epoch with random multiaddr
+    // seed the current committee (no next committee for this test)
     let committee = config.committee_pub_keys();
-    peer_manager.new_epoch(committee);
+    peer_manager.initialize_committees(committee, HashSet::new());
+
+    // Verify the registered committee member is a validator
+    assert!(peer_manager.is_peer_validator(&validator_peer_id));
 
     // Verify random peer is not a validator
     assert!(!peer_manager.is_peer_validator(&random_peer_id));
+}
+
+#[tokio::test]
+async fn test_next_committee_triggers_missing_authorities_for_unknown_next_keys() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // generate a bls key that was never registered via add_known_peer
+    let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
+
+    // rotate to a next committee that contains the unknown key
+    peer_manager.next_committee(HashSet::from([unknown_bls]), 100);
+
+    // exactly one MissingAuthorities event referencing the unknown key should be emitted
+    let events = collect_all_events(&mut peer_manager);
+    let missing_events = extract_events(&events, |e| matches!(e, PeerEvent::MissingAuthorities(_)));
+    assert!(missing_events.len() == 1, "Expect one missing authorities event");
+    assert_matches!(
+        missing_events.first().unwrap(),
+        PeerEvent::MissingAuthorities(missing) if missing.contains(&unknown_bls)
+    );
+}
+
+#[tokio::test]
+async fn test_prepare_committee_dial_unbans_without_touching_slots() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // build a known committee member
+    let mut rng = StdRng::from_seed([3; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    let netkey: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let peer_id: PeerId = netkey.clone().into();
+    let info =
+        NetworkInfo { pubkey: netkey, multiaddrs: vec![create_multiaddr(None)], timestamp: now() };
+    peer_manager.add_known_peer(bls, info);
+
+    // manually temp-ban the peer
+    peer_manager.temporarily_banned.insert(peer_id);
+    assert!(peer_manager.peer_banned(&peer_id));
+
+    // prepare the committee for dialing
+    peer_manager.prepare_committee_dial(HashSet::from([bls]));
+
+    // the peer is unbanned but the committee slots remain untouched
+    assert!(!peer_manager.peer_banned(&peer_id), "prepare_committee_dial should unban the peer");
+    assert!(
+        !peer_manager.is_peer_validator(&peer_id),
+        "prepare_committee_dial must not populate committee slots"
+    );
 }
 
 #[tokio::test]

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -638,26 +638,46 @@ fn committee_member(rng: &mut StdRng) -> (BlsPublicKey, NetworkInfo, PeerId) {
     (bls, info, peer_id)
 }
 
+/// Build a committee of `size` distinct members plus the set of their derived peer ids.
+fn random_committee(
+    rng: &mut StdRng,
+    size: usize,
+) -> (Vec<(BlsPublicKey, NetworkInfo)>, HashSet<PeerId>) {
+    let members: Vec<(BlsPublicKey, NetworkInfo, PeerId)> =
+        (0..size).map(|_| committee_member(rng)).collect();
+    let ids: HashSet<PeerId> = members.iter().map(|(_, _, id)| *id).collect();
+    let committee = members.into_iter().map(|(b, i, _)| (b, i)).collect();
+    (committee, ids)
+}
+
 #[test]
-fn test_initialize_committees_seeds_current_and_next() {
+fn test_update_committees_sets_all_three_slots() {
     let mut rng = StdRng::from_seed([10; 32]);
     let mut all_peers = create_all_peers(None);
 
+    let (p_bls, p_info, p_peer_id) = committee_member(&mut rng);
     let (c_bls, c_info, c_peer_id) = committee_member(&mut rng);
     let (n_bls, n_info, n_peer_id) = committee_member(&mut rng);
 
-    all_peers.initialize_committees(vec![(c_bls, c_info)], vec![(n_bls, n_info)]);
+    all_peers.update_committees(
+        vec![(p_bls, p_info)],
+        vec![(c_bls, c_info)],
+        vec![(n_bls, n_info)],
+        7,
+    );
 
+    assert!(all_peers.previous_committee.contains(&p_peer_id));
     assert!(all_peers.current_committee.contains(&c_peer_id));
     assert!(all_peers.next_committee.contains(&n_peer_id));
-    assert!(all_peers.previous_committee.is_empty());
+    assert_eq!(all_peers.epoch_end_timestamp, 7);
+    assert!(all_peers.is_peer_validator(&p_peer_id));
     assert!(all_peers.is_peer_validator(&c_peer_id));
     assert!(all_peers.is_peer_validator(&n_peer_id));
     assert!(!all_peers.is_peer_validator(&PeerId::random()));
 }
 
 #[test]
-fn test_rotate_to_next_epoch_shifts_queue() {
+fn test_update_committees_overwrites_slots_directly() {
     let mut rng = StdRng::from_seed([11; 32]);
     let mut all_peers = create_all_peers(None);
 
@@ -665,62 +685,80 @@ fn test_rotate_to_next_epoch_shifts_queue() {
     let (b_bls, b_info, b_id) = committee_member(&mut rng);
     let (c_bls, c_info, c_id) = committee_member(&mut rng);
     let (d_bls, d_info, d_id) = committee_member(&mut rng);
+    let (e_bls, e_info, e_id) = committee_member(&mut rng);
+    let (f_bls, f_info, f_id) = committee_member(&mut rng);
 
-    // initialize with current={A}, next={B}
-    all_peers.initialize_committees(vec![(a_bls, a_info)], vec![(b_bls, b_info)]);
-
-    // rotate: previous <- current({A}), current <- next({B}), next <- {C}
-    all_peers.rotate_to_next_epoch(vec![(c_bls, c_info)], 1);
+    // first update: previous={A}, current={B}, next={C}
+    all_peers.update_committees(
+        vec![(a_bls, a_info)],
+        vec![(b_bls, b_info)],
+        vec![(c_bls, c_info)],
+        1,
+    );
     assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
     assert_eq!(all_peers.next_committee, HashSet::from([c_id]));
 
-    // rotate again: previous <- current({B}), current <- next({C}), next <- {D}
-    all_peers.rotate_to_next_epoch(vec![(d_bls, d_info)], 2);
-    assert_eq!(all_peers.previous_committee, HashSet::from([b_id]));
-    assert_eq!(all_peers.current_committee, HashSet::from([c_id]));
-    assert_eq!(all_peers.next_committee, HashSet::from([d_id]));
+    // second update: each slot is set directly from its arg, NOT positionally shifted from the
+    // prior round (otherwise current would be the prior next, {C}).
+    all_peers.update_committees(
+        vec![(d_bls, d_info)],
+        vec![(e_bls, e_info)],
+        vec![(f_bls, f_info)],
+        2,
+    );
+    assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
+    assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
+    assert_eq!(all_peers.next_committee, HashSet::from([f_id]));
 }
 
 #[test]
-fn test_rotate_records_epoch_end_timestamp() {
+fn test_update_committees_records_epoch_end_timestamp() {
     let mut rng = StdRng::from_seed([12; 32]);
     let mut all_peers = create_all_peers(None);
 
     let (c_bls, c_info, _) = committee_member(&mut rng);
     let (n_bls, n_info, _) = committee_member(&mut rng);
-    all_peers.initialize_committees(vec![(c_bls, c_info)], vec![(n_bls, n_info)]);
-
-    let (m_bls, m_info, _) = committee_member(&mut rng);
-    all_peers.rotate_to_next_epoch(vec![(m_bls, m_info)], 4242);
+    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![(n_bls, n_info)], 4242);
     assert_eq!(all_peers.epoch_end_timestamp, 4242);
 
-    let (m2_bls, m2_info, _) = committee_member(&mut rng);
-    all_peers.rotate_to_next_epoch(vec![(m2_bls, m2_info)], 5000);
+    let (m_bls, m_info, _) = committee_member(&mut rng);
+    all_peers.update_committees(vec![], vec![(m_bls, m_info)], vec![], 5000);
     assert_eq!(all_peers.epoch_end_timestamp, 5000);
 }
 
 #[test]
-fn test_rotate_committees_no_change() {
+fn test_update_committees_no_change() {
     let mut rng = StdRng::from_seed([13; 32]);
     let mut all_peers = create_all_peers(None);
 
     let (x_bls, x_info, x_id) = committee_member(&mut rng);
 
     // X is in both current and next
-    all_peers.initialize_committees(vec![(x_bls, x_info.clone())], vec![(x_bls, x_info.clone())]);
+    all_peers.update_committees(
+        vec![],
+        vec![(x_bls, x_info.clone())],
+        vec![(x_bls, x_info.clone())],
+        1,
+    );
 
-    // rotate with X again as the incoming next
-    all_peers.rotate_to_next_epoch(vec![(x_bls, x_info.clone())], 1);
+    // repeat the same membership next epoch
+    all_peers.update_committees(
+        vec![],
+        vec![(x_bls, x_info.clone())],
+        vec![(x_bls, x_info.clone())],
+        2,
+    );
 
-    // full overlap keeps X a validator and present in both current and next
+    // full overlap keeps X a validator, present in both current and next, never demoted
     assert!(all_peers.is_peer_validator(&x_id));
     assert!(all_peers.current_committee.contains(&x_id));
     assert!(all_peers.next_committee.contains(&x_id));
+    assert!(all_peers.get_peer(&x_id).unwrap().is_trusted());
 }
 
 #[test]
-fn test_rotate_committees_full_turnover() {
+fn test_update_committees_full_turnover() {
     let mut rng = StdRng::from_seed([14; 32]);
     let mut all_peers = create_all_peers(None);
 
@@ -728,43 +766,32 @@ fn test_rotate_committees_full_turnover() {
     let (b_bls, b_info, b_id) = committee_member(&mut rng);
     let (c_bls, c_info, c_id) = committee_member(&mut rng);
 
-    // initialize with current={A}, next={B}
-    all_peers.initialize_committees(vec![(a_bls, a_info)], vec![(b_bls, b_info)]);
-
-    // rotate in disjoint C: three disjoint slots placed correctly
-    all_peers.rotate_to_next_epoch(vec![(c_bls, c_info)], 1);
-    assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
-    assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
-    assert_eq!(all_peers.next_committee, HashSet::from([c_id]));
-}
-
-#[test]
-fn test_rotate_on_never_seeded_slots_leaves_current_empty() {
-    // Guards the regression fixed by `EpochManager::network_initialized`. Rotation is positional
-    // (previous <- current <- next <- new_next): rotating before the slots were ever seeded by
-    // `initialize_committees` carries the empty seed forward, leaving `current` empty for a full
-    // epoch. The epoch manager must therefore SEED on the first network setup -- never ROTATE --
-    // even when that setup happens late on a post-restart `NewEpoch` iteration. Seeding (shown
-    // second) populates `current` immediately; rotating (shown first) does not.
-    let mut rng = StdRng::from_seed([99; 32]);
-
-    // rotate-on-never-seeded: the incoming committee lands in `next`, `current` stays empty.
-    let mut rotated = create_all_peers(None);
-    let (n_bls, n_info, n_id) = committee_member(&mut rng);
-    rotated.rotate_to_next_epoch(vec![(n_bls, n_info)], 1);
-    assert_eq!(rotated.next_committee, HashSet::from([n_id]));
-    assert!(
-        rotated.current_committee.is_empty(),
-        "rotating before seeding must leave current empty (the bug the epoch-manager fix avoids)"
+    // initialize with previous={A}, current={B}, next={C}
+    all_peers.update_committees(
+        vec![(a_bls, a_info)],
+        vec![(b_bls, b_info)],
+        vec![(c_bls, c_info)],
+        1,
     );
 
-    // seed-on-first-init: `current` is populated immediately and recognized as a validator.
-    let mut seeded = create_all_peers(None);
-    let (c_bls, c_info, c_id) = committee_member(&mut rng);
-    let (x_bls, x_info, _x_id) = committee_member(&mut rng);
-    seeded.initialize_committees(vec![(c_bls, c_info)], vec![(x_bls, x_info)]);
-    assert!(seeded.current_committee.contains(&c_id));
-    assert!(seeded.is_peer_validator(&c_id));
+    // a fully disjoint set replaces every slot directly
+    let (d_bls, d_info, d_id) = committee_member(&mut rng);
+    let (e_bls, e_info, e_id) = committee_member(&mut rng);
+    let (f_bls, f_info, f_id) = committee_member(&mut rng);
+    all_peers.update_committees(
+        vec![(d_bls, d_info)],
+        vec![(e_bls, e_info)],
+        vec![(f_bls, f_info)],
+        2,
+    );
+    assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
+    assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
+    assert_eq!(all_peers.next_committee, HashSet::from([f_id]));
+
+    // every member of the fully-replaced window is gone
+    assert!(!all_peers.is_peer_validator(&a_id));
+    assert!(!all_peers.is_peer_validator(&b_id));
+    assert!(!all_peers.is_peer_validator(&c_id));
 }
 
 #[test]
@@ -786,88 +813,154 @@ fn test_is_peer_validator_returns_true_for_all_three_slots() {
 }
 
 #[test]
-fn test_rotate_does_not_re_apply_unban_to_previous() {
-    let mut rng = StdRng::from_seed([15; 32]);
-    let mut all_peers = create_all_peers(None);
-
-    // P is placed directly in the current committee, then driven to banned
-    let (_p_bls, _p_info, p_id) = committee_member(&mut rng);
-    all_peers.current_committee.insert(p_id);
-    all_peers.update_connection_status(&p_id, NewConnectionStatus::Disconnected);
-    all_peers.update_connection_status(&p_id, NewConnectionStatus::Banned);
-    assert!(all_peers.peer_banned(&p_id));
-
-    // Q is the disjoint incoming next committee
-    let (q_bls, q_info, _q_id) = committee_member(&mut rng);
-    let actions = all_peers.rotate_to_next_epoch(vec![(q_bls, q_info)], 1);
-
-    // P moved current -> previous and is NOT in the incoming set, so it stays banned
-    assert!(all_peers.peer_banned(&p_id));
-    // rotate only unbans the incoming `next`, so no action targets P
-    assert!(!actions.iter().any(|(id, _)| *id == p_id));
-}
-
-#[test]
-fn test_rotate_preserves_existing_trust() {
+fn test_update_committees_in_window_peer_stays_trusted() {
     let mut rng = StdRng::from_seed([16; 32]);
     let mut all_peers = create_all_peers(None);
 
-    // M is in the current committee and made trusted by initialize_committees
+    // M starts in the current committee and is made trusted by update_committees
     let (m_bls, m_info, m_id) = committee_member(&mut rng);
-    all_peers.initialize_committees(vec![(m_bls, m_info)], vec![]);
+    all_peers.update_committees(vec![], vec![(m_bls, m_info.clone())], vec![], 1);
     assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
 
-    // rotate in a disjoint member; M moves current -> previous
+    // next epoch: M moves to the previous slot (still in-window) alongside a disjoint current
     let (other_bls, other_info, _other_id) = committee_member(&mut rng);
-    all_peers.rotate_to_next_epoch(vec![(other_bls, other_info)], 1);
+    all_peers.update_committees(vec![(m_bls, m_info)], vec![(other_bls, other_info)], vec![], 2);
 
-    // make_trusted is a one-way ratchet, so M remains trusted after demotion
+    // M is still inside the three-slot window (now in previous), so it stays trusted -- not via a
+    // one-way ratchet, but because it is still a tracked committee member.
+    assert!(all_peers.previous_committee.contains(&m_id));
+    assert!(all_peers.is_peer_validator(&m_id));
     assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
 }
 
 #[test]
-fn test_rotation_invariants_under_random_committees() {
+fn test_update_committees_demotes_peer_that_exits_window() {
+    let mut rng = StdRng::from_seed([22; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    // E starts trusted as a current-committee member
+    let (e_bls, e_info, e_id) = committee_member(&mut rng);
+    all_peers.update_committees(vec![], vec![(e_bls, e_info)], vec![], 1);
+    assert!(all_peers.get_peer(&e_id).unwrap().is_trusted());
+    assert!(all_peers.is_peer_validator(&e_id));
+
+    // next epoch's three slots do not include E at all
+    let (f_bls, f_info, _f_id) = committee_member(&mut rng);
+    all_peers.update_committees(vec![], vec![(f_bls, f_info)], vec![], 2);
+
+    // E fell out of the window: demoted to untrusted and no longer counts as a validator
+    assert!(!all_peers.get_peer(&e_id).unwrap().is_trusted());
+    assert!(!all_peers.is_peer_validator(&e_id));
+}
+
+#[test]
+fn test_update_committees_does_not_demote_operator_trusted_peer_never_in_committee() {
+    let mut rng = StdRng::from_seed([23; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    // operator-allowlisted trusted peer that is never part of any committee
+    let op_bls = *BlsKeypair::generate(&mut rng).public();
+    let op_net: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let op_id: PeerId = op_net.clone().into();
+    all_peers.add_trusted_peer(op_bls, op_net, vec![create_multiaddr(None)]);
+    assert!(all_peers.get_peer(&op_id).unwrap().is_trusted());
+
+    // a committee update that does not involve the operator peer
+    let (c_bls, c_info, _c_id) = committee_member(&mut rng);
+    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![], 1);
+
+    // the operator peer was never tracked in a committee slot, so demotion does not touch it
+    assert!(all_peers.get_peer(&op_id).unwrap().is_trusted());
+}
+
+#[test]
+fn test_update_committees_current_is_authoritative() {
+    // Finding #2: `current` is set directly from authoritative state, never carried over from the
+    // previously-predicted `next`. When the new `current` differs from the prior `next`, the slot
+    // must reflect the authoritative arg rather than the stale prediction.
+    let mut rng = StdRng::from_seed([20; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (predicted_bls, predicted_info, predicted_id) = committee_member(&mut rng);
+    let (actual_bls, actual_info, actual_id) = committee_member(&mut rng);
+
+    // epoch N predicts next = {predicted}
+    all_peers.update_committees(vec![], vec![], vec![(predicted_bls, predicted_info)], 1);
+    assert_eq!(all_peers.next_committee, HashSet::from([predicted_id]));
+
+    // epoch N+1's authoritative current is {actual}, which differs from the prediction
+    all_peers.update_committees(vec![], vec![(actual_bls, actual_info)], vec![], 2);
+
+    // current matches the authoritative arg, not the stale prediction
+    assert_eq!(all_peers.current_committee, HashSet::from([actual_id]));
+    assert!(!all_peers.current_committee.contains(&predicted_id));
+}
+
+#[test]
+fn test_update_committees_populates_previous() {
+    // Finding #4: a non-empty `previous` arg lands in the slot. After a restart the previous
+    // committee is read from authoritative state rather than reset to empty, so just-rotated-out
+    // peers keep validator protection for the duration of the window.
+    let mut rng = StdRng::from_seed([21; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (p_bls, p_info, p_id) = committee_member(&mut rng);
+    let (c_bls, c_info, _c_id) = committee_member(&mut rng);
+
+    all_peers.update_committees(vec![(p_bls, p_info)], vec![(c_bls, c_info)], vec![], 9);
+
+    assert_eq!(all_peers.previous_committee, HashSet::from([p_id]));
+    assert!(all_peers.is_peer_validator(&p_id));
+    assert!(all_peers.get_peer(&p_id).unwrap().is_trusted());
+}
+
+#[test]
+fn test_update_committees_invariants_under_random_committees() {
     // Property-style coverage without a proptest dependency: across many epochs with random
-    // committee sizes, the queue must always shift correctly (previous <- current <- next <-
-    // new_next), each slot stays bounded by the committee size that produced it, and
-    // epoch_end_timestamp records the last timestamp passed in (monotonic as timestamps increase).
+    // committees in each slot, every slot must equal exactly the set it was given,
+    // epoch_end_timestamp records the last timestamp passed in, every union member is trusted, and
+    // every peer tracked last round but absent this round is demoted to untrusted.
     let mut rng = StdRng::from_seed([42; 32]);
     let mut all_peers = create_all_peers(None);
 
-    // Mirror of the expected `current`/`next` slot contents (which carry across rounds) and the
-    // committee sizes that produced them. The initial AllPeers slots are all empty.
-    let mut current: HashSet<PeerId> = HashSet::new();
-    let mut next: HashSet<PeerId> = HashSet::new();
-    let mut prev_size = 0usize;
-    let mut curr_size = 0usize;
+    let mut prev_union: HashSet<PeerId> = HashSet::new();
 
     for round in 0..32u64 {
-        let size = rng.random_range(0..=5usize);
-        let members: Vec<(BlsPublicKey, NetworkInfo, PeerId)> =
-            (0..size).map(|_| committee_member(&mut rng)).collect();
-        let new_next_ids: HashSet<PeerId> = members.iter().map(|(_, _, id)| *id).collect();
-        let new_next: Vec<(BlsPublicKey, NetworkInfo)> =
-            members.into_iter().map(|(b, i, _)| (b, i)).collect();
+        let prev_size = rng.random_range(0..=4usize);
+        let (previous, prev_ids) = random_committee(&mut rng, prev_size);
+        let curr_size = rng.random_range(0..=4usize);
+        let (current, curr_ids) = random_committee(&mut rng, curr_size);
+        let next_size = rng.random_range(0..=4usize);
+        let (next, next_ids) = random_committee(&mut rng, next_size);
 
         let ts = round + 1;
-        all_peers.rotate_to_next_epoch(new_next, ts);
+        all_peers.update_committees(previous, current, next, ts);
 
-        // expected shift
-        let previous = std::mem::take(&mut current);
-        current = std::mem::take(&mut next);
-        next = new_next_ids;
-
-        assert_eq!(all_peers.previous_committee, previous, "previous slot after round {round}");
-        assert_eq!(all_peers.current_committee, current, "current slot after round {round}");
-        assert_eq!(all_peers.next_committee, next, "next slot after round {round}");
+        // each slot equals exactly its input set (direct set, no positional shift)
+        assert_eq!(all_peers.previous_committee, prev_ids, "previous slot after round {round}");
+        assert_eq!(all_peers.current_committee, curr_ids, "current slot after round {round}");
+        assert_eq!(all_peers.next_committee, next_ids, "next slot after round {round}");
         assert_eq!(all_peers.epoch_end_timestamp, ts, "timestamp after round {round}");
 
-        // each slot is bounded by the committee size that produced it (sets dedup, so `<=`)
-        assert!(all_peers.next_committee.len() <= size);
-        assert!(all_peers.current_committee.len() <= curr_size);
-        assert!(all_peers.previous_committee.len() <= prev_size);
+        // every member of the new window is trusted
+        let union: HashSet<PeerId> =
+            prev_ids.iter().chain(curr_ids.iter()).chain(next_ids.iter()).copied().collect();
+        for id in &union {
+            assert!(
+                all_peers.get_peer(id).unwrap().is_trusted(),
+                "union member {id} should be trusted after round {round}"
+            );
+        }
 
-        prev_size = curr_size;
-        curr_size = size;
+        // every peer tracked last round but absent this round is demoted (all ids are distinct
+        // across rounds, so the entire prior union should now be untrusted)
+        for id in prev_union.difference(&union) {
+            assert!(
+                !all_peers.get_peer(id).unwrap().is_trusted(),
+                "exited peer {id} should be untrusted after round {round}"
+            );
+        }
+
+        prev_union = union;
     }
 }

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -852,7 +852,7 @@ fn test_update_committees_does_not_demote_operator_trusted_peer_never_in_committ
 
 #[test]
 fn test_update_committees_current_is_authoritative() {
-    // Finding #2: `current` is set directly from authoritative state, never carried over from the
+    // `current` is set directly from authoritative state, never carried over from the
     // previously-predicted `next`. When the new `current` differs from the prior `next`, the slot
     // must reflect the authoritative arg rather than the stale prediction.
     let mut rng = StdRng::from_seed([20; 32]);
@@ -875,7 +875,7 @@ fn test_update_committees_current_is_authoritative() {
 
 #[test]
 fn test_update_committees_populates_previous() {
-    // Finding #4: a non-empty `previous` arg lands in the slot. After a restart the previous
+    // a non-empty `previous` arg lands in the slot. After a restart the previous
     // committee is read from authoritative state rather than reset to empty, so just-rotated-out
     // peers keep validator protection for the duration of the window.
     let mut rng = StdRng::from_seed([21; 32]);

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -139,6 +139,30 @@ fn test_peer_exchange() {
 }
 
 #[test]
+fn test_upsert_peer_seeds_multiaddrs_for_new_peer() {
+    let mut all_peers = create_all_peers(None);
+
+    // upsert a previously-unknown peer with a known addr but no connection
+    let network_key: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let peer_id: PeerId = network_key.clone().into();
+    let addr = create_multiaddr(None);
+    let mut rng = StdRng::from_seed([7; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    all_peers.upsert_peer(bls, network_key, vec![addr.clone()]);
+
+    // the fresh record carries the addr through to peer exchange and ip-ban association,
+    // even though the peer has never connected
+    let peer = all_peers.get_peer(&peer_id).expect("peer exists after upsert");
+    assert!(peer.exchange_info().unwrap().1.iter().any(|a| a == &addr));
+    let expected_ip = addr.iter().find_map(|p| match p {
+        libp2p::multiaddr::Protocol::Ip4(ip) => Some(IpAddr::from(ip)),
+        libp2p::multiaddr::Protocol::Ip6(ip) => Some(IpAddr::from(ip)),
+        _ => None,
+    });
+    assert!(peer.known_ip_addresses().any(|ip| Some(ip) == expected_ip));
+}
+
+#[test]
 fn test_connected_peers_by_score() {
     let mut all_peers = create_all_peers(None);
 

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -3,8 +3,9 @@
 use super::*;
 use crate::common::{create_multiaddr, ensure_score_config, random_ip_addr};
 use libp2p::PeerId;
-use rand::{rngs::StdRng, SeedableRng as _};
+use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
 use std::{
+    collections::HashSet,
     net::IpAddr,
     time::{Duration, Instant},
 };
@@ -625,5 +626,219 @@ fn test_ban_action_returns_only_unbanned_ips() {
         assert!(!ips.contains(&ip1), "Should NOT include ip1 as it's already IP-banned");
     } else {
         panic!("Expected Ban action for peer3");
+    }
+}
+
+/// Build a distinct committee member: (bls key, network info, derived peer id).
+fn committee_member(rng: &mut StdRng) -> (BlsPublicKey, NetworkInfo, PeerId) {
+    let bls = *BlsKeypair::generate(rng).public();
+    let net: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let peer_id: PeerId = net.clone().into();
+    let info = NetworkInfo { pubkey: net, multiaddrs: vec![create_multiaddr(None)], timestamp: 0 };
+    (bls, info, peer_id)
+}
+
+#[test]
+fn test_initialize_committees_seeds_current_and_next() {
+    let mut rng = StdRng::from_seed([10; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (c_bls, c_info, c_peer_id) = committee_member(&mut rng);
+    let (n_bls, n_info, n_peer_id) = committee_member(&mut rng);
+
+    all_peers.initialize_committees(vec![(c_bls, c_info)], vec![(n_bls, n_info)]);
+
+    assert!(all_peers.current_committee.contains(&c_peer_id));
+    assert!(all_peers.next_committee.contains(&n_peer_id));
+    assert!(all_peers.previous_committee.is_empty());
+    assert!(all_peers.is_peer_validator(&c_peer_id));
+    assert!(all_peers.is_peer_validator(&n_peer_id));
+    assert!(!all_peers.is_peer_validator(&PeerId::random()));
+}
+
+#[test]
+fn test_rotate_to_next_epoch_shifts_queue() {
+    let mut rng = StdRng::from_seed([11; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (a_bls, a_info, a_id) = committee_member(&mut rng);
+    let (b_bls, b_info, b_id) = committee_member(&mut rng);
+    let (c_bls, c_info, c_id) = committee_member(&mut rng);
+    let (d_bls, d_info, d_id) = committee_member(&mut rng);
+
+    // initialize with current={A}, next={B}
+    all_peers.initialize_committees(vec![(a_bls, a_info)], vec![(b_bls, b_info)]);
+
+    // rotate: previous <- current({A}), current <- next({B}), next <- {C}
+    all_peers.rotate_to_next_epoch(vec![(c_bls, c_info)], 1);
+    assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
+    assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
+    assert_eq!(all_peers.next_committee, HashSet::from([c_id]));
+
+    // rotate again: previous <- current({B}), current <- next({C}), next <- {D}
+    all_peers.rotate_to_next_epoch(vec![(d_bls, d_info)], 2);
+    assert_eq!(all_peers.previous_committee, HashSet::from([b_id]));
+    assert_eq!(all_peers.current_committee, HashSet::from([c_id]));
+    assert_eq!(all_peers.next_committee, HashSet::from([d_id]));
+}
+
+#[test]
+fn test_rotate_records_epoch_end_timestamp() {
+    let mut rng = StdRng::from_seed([12; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (c_bls, c_info, _) = committee_member(&mut rng);
+    let (n_bls, n_info, _) = committee_member(&mut rng);
+    all_peers.initialize_committees(vec![(c_bls, c_info)], vec![(n_bls, n_info)]);
+
+    let (m_bls, m_info, _) = committee_member(&mut rng);
+    all_peers.rotate_to_next_epoch(vec![(m_bls, m_info)], 4242);
+    assert_eq!(all_peers.epoch_end_timestamp, 4242);
+
+    let (m2_bls, m2_info, _) = committee_member(&mut rng);
+    all_peers.rotate_to_next_epoch(vec![(m2_bls, m2_info)], 5000);
+    assert_eq!(all_peers.epoch_end_timestamp, 5000);
+}
+
+#[test]
+fn test_rotate_committees_no_change() {
+    let mut rng = StdRng::from_seed([13; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (x_bls, x_info, x_id) = committee_member(&mut rng);
+
+    // X is in both current and next
+    all_peers.initialize_committees(vec![(x_bls, x_info.clone())], vec![(x_bls, x_info.clone())]);
+
+    // rotate with X again as the incoming next
+    all_peers.rotate_to_next_epoch(vec![(x_bls, x_info.clone())], 1);
+
+    // full overlap keeps X a validator and present in both current and next
+    assert!(all_peers.is_peer_validator(&x_id));
+    assert!(all_peers.current_committee.contains(&x_id));
+    assert!(all_peers.next_committee.contains(&x_id));
+}
+
+#[test]
+fn test_rotate_committees_full_turnover() {
+    let mut rng = StdRng::from_seed([14; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    let (a_bls, a_info, a_id) = committee_member(&mut rng);
+    let (b_bls, b_info, b_id) = committee_member(&mut rng);
+    let (c_bls, c_info, c_id) = committee_member(&mut rng);
+
+    // initialize with current={A}, next={B}
+    all_peers.initialize_committees(vec![(a_bls, a_info)], vec![(b_bls, b_info)]);
+
+    // rotate in disjoint C: three disjoint slots placed correctly
+    all_peers.rotate_to_next_epoch(vec![(c_bls, c_info)], 1);
+    assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
+    assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
+    assert_eq!(all_peers.next_committee, HashSet::from([c_id]));
+}
+
+#[test]
+fn test_is_peer_validator_returns_true_for_all_three_slots() {
+    let mut all_peers = create_all_peers(None);
+
+    let prev_id = PeerId::random();
+    let curr_id = PeerId::random();
+    let next_id = PeerId::random();
+
+    all_peers.previous_committee.insert(prev_id);
+    all_peers.current_committee.insert(curr_id);
+    all_peers.next_committee.insert(next_id);
+
+    assert!(all_peers.is_peer_validator(&prev_id));
+    assert!(all_peers.is_peer_validator(&curr_id));
+    assert!(all_peers.is_peer_validator(&next_id));
+    assert!(!all_peers.is_peer_validator(&PeerId::random()));
+}
+
+#[test]
+fn test_rotate_does_not_re_apply_unban_to_previous() {
+    let mut rng = StdRng::from_seed([15; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    // P is placed directly in the current committee, then driven to banned
+    let (_p_bls, _p_info, p_id) = committee_member(&mut rng);
+    all_peers.current_committee.insert(p_id);
+    all_peers.update_connection_status(&p_id, NewConnectionStatus::Disconnected);
+    all_peers.update_connection_status(&p_id, NewConnectionStatus::Banned);
+    assert!(all_peers.peer_banned(&p_id));
+
+    // Q is the disjoint incoming next committee
+    let (q_bls, q_info, _q_id) = committee_member(&mut rng);
+    let actions = all_peers.rotate_to_next_epoch(vec![(q_bls, q_info)], 1);
+
+    // P moved current -> previous and is NOT in the incoming set, so it stays banned
+    assert!(all_peers.peer_banned(&p_id));
+    // rotate only unbans the incoming `next`, so no action targets P
+    assert!(!actions.iter().any(|(id, _)| *id == p_id));
+}
+
+#[test]
+fn test_rotate_preserves_existing_trust() {
+    let mut rng = StdRng::from_seed([16; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    // M is in the current committee and made trusted by initialize_committees
+    let (m_bls, m_info, m_id) = committee_member(&mut rng);
+    all_peers.initialize_committees(vec![(m_bls, m_info)], vec![]);
+    assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
+
+    // rotate in a disjoint member; M moves current -> previous
+    let (other_bls, other_info, _other_id) = committee_member(&mut rng);
+    all_peers.rotate_to_next_epoch(vec![(other_bls, other_info)], 1);
+
+    // make_trusted is a one-way ratchet, so M remains trusted after demotion
+    assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
+}
+
+#[test]
+fn test_rotation_invariants_under_random_committees() {
+    // Property-style coverage without a proptest dependency: across many epochs with random
+    // committee sizes, the queue must always shift correctly (previous <- current <- next <-
+    // new_next), each slot stays bounded by the committee size that produced it, and
+    // epoch_end_timestamp records the last timestamp passed in (monotonic as timestamps increase).
+    let mut rng = StdRng::from_seed([42; 32]);
+    let mut all_peers = create_all_peers(None);
+
+    // Mirror of the expected `current`/`next` slot contents (which carry across rounds) and the
+    // committee sizes that produced them. The initial AllPeers slots are all empty.
+    let mut current: HashSet<PeerId> = HashSet::new();
+    let mut next: HashSet<PeerId> = HashSet::new();
+    let mut prev_size = 0usize;
+    let mut curr_size = 0usize;
+
+    for round in 0..32u64 {
+        let size = rng.random_range(0..=5usize);
+        let members: Vec<(BlsPublicKey, NetworkInfo, PeerId)> =
+            (0..size).map(|_| committee_member(&mut rng)).collect();
+        let new_next_ids: HashSet<PeerId> = members.iter().map(|(_, _, id)| *id).collect();
+        let new_next: Vec<(BlsPublicKey, NetworkInfo)> =
+            members.into_iter().map(|(b, i, _)| (b, i)).collect();
+
+        let ts = round + 1;
+        all_peers.rotate_to_next_epoch(new_next, ts);
+
+        // expected shift
+        let previous = std::mem::take(&mut current);
+        current = std::mem::take(&mut next);
+        next = new_next_ids;
+
+        assert_eq!(all_peers.previous_committee, previous, "previous slot after round {round}");
+        assert_eq!(all_peers.current_committee, current, "current slot after round {round}");
+        assert_eq!(all_peers.next_committee, next, "next slot after round {round}");
+        assert_eq!(all_peers.epoch_end_timestamp, ts, "timestamp after round {round}");
+
+        // each slot is bounded by the committee size that produced it (sets dedup, so `<=`)
+        assert!(all_peers.next_committee.len() <= size);
+        assert!(all_peers.current_committee.len() <= curr_size);
+        assert!(all_peers.previous_committee.len() <= prev_size);
+
+        prev_size = curr_size;
+        curr_size = size;
     }
 }

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -876,7 +876,8 @@ fn test_undiscovered_committee_member_banned_then_unbanned_on_discovery() {
     assert!(all_peers.peer_banned(&peer_id), "member should be banned during the window");
     assert!(!all_peers.is_peer_validator(&peer_id), "still unidentified, still not a validator");
 
-    // kad resolves the bls: re-key the Unidentified record onto Confirmed, then apply committee trust
+    // kad resolves the bls: re-key the Unidentified record onto Confirmed, then apply committee
+    // trust
     all_peers.upsert_peer(bls, net, vec![create_multiaddr(None)]);
     let actions = all_peers.apply_membership_if_committee(bls);
 

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -663,13 +663,11 @@ fn test_update_committees_sets_all_three_slots() {
         vec![(p_bls, p_info)],
         vec![(c_bls, c_info)],
         vec![(n_bls, n_info)],
-        7,
     );
 
     assert!(all_peers.previous_committee.contains(&p_peer_id));
     assert!(all_peers.current_committee.contains(&c_peer_id));
     assert!(all_peers.next_committee.contains(&n_peer_id));
-    assert_eq!(all_peers.epoch_end_timestamp, 7);
     assert!(all_peers.is_peer_validator(&p_peer_id));
     assert!(all_peers.is_peer_validator(&c_peer_id));
     assert!(all_peers.is_peer_validator(&n_peer_id));
@@ -693,7 +691,6 @@ fn test_update_committees_overwrites_slots_directly() {
         vec![(a_bls, a_info)],
         vec![(b_bls, b_info)],
         vec![(c_bls, c_info)],
-        1,
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
@@ -705,26 +702,10 @@ fn test_update_committees_overwrites_slots_directly() {
         vec![(d_bls, d_info)],
         vec![(e_bls, e_info)],
         vec![(f_bls, f_info)],
-        2,
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
     assert_eq!(all_peers.next_committee, HashSet::from([f_id]));
-}
-
-#[test]
-fn test_update_committees_records_epoch_end_timestamp() {
-    let mut rng = StdRng::from_seed([12; 32]);
-    let mut all_peers = create_all_peers(None);
-
-    let (c_bls, c_info, _) = committee_member(&mut rng);
-    let (n_bls, n_info, _) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![(n_bls, n_info)], 4242);
-    assert_eq!(all_peers.epoch_end_timestamp, 4242);
-
-    let (m_bls, m_info, _) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(m_bls, m_info)], vec![], 5000);
-    assert_eq!(all_peers.epoch_end_timestamp, 5000);
 }
 
 #[test]
@@ -739,7 +720,6 @@ fn test_update_committees_no_change() {
         vec![],
         vec![(x_bls, x_info.clone())],
         vec![(x_bls, x_info.clone())],
-        1,
     );
 
     // repeat the same membership next epoch
@@ -747,7 +727,6 @@ fn test_update_committees_no_change() {
         vec![],
         vec![(x_bls, x_info.clone())],
         vec![(x_bls, x_info.clone())],
-        2,
     );
 
     // full overlap keeps X a validator, present in both current and next, never demoted
@@ -771,7 +750,6 @@ fn test_update_committees_full_turnover() {
         vec![(a_bls, a_info)],
         vec![(b_bls, b_info)],
         vec![(c_bls, c_info)],
-        1,
     );
 
     // a fully disjoint set replaces every slot directly
@@ -782,7 +760,6 @@ fn test_update_committees_full_turnover() {
         vec![(d_bls, d_info)],
         vec![(e_bls, e_info)],
         vec![(f_bls, f_info)],
-        2,
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
@@ -819,12 +796,12 @@ fn test_update_committees_in_window_peer_stays_trusted() {
 
     // M starts in the current committee and is made trusted by update_committees
     let (m_bls, m_info, m_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(m_bls, m_info.clone())], vec![], 1);
+    all_peers.update_committees(vec![], vec![(m_bls, m_info.clone())], vec![]);
     assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
 
     // next epoch: M moves to the previous slot (still in-window) alongside a disjoint current
     let (other_bls, other_info, _other_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![(m_bls, m_info)], vec![(other_bls, other_info)], vec![], 2);
+    all_peers.update_committees(vec![(m_bls, m_info)], vec![(other_bls, other_info)], vec![]);
 
     // M is still inside the three-slot window (now in previous), so it stays trusted -- not via a
     // one-way ratchet, but because it is still a tracked committee member.
@@ -840,13 +817,13 @@ fn test_update_committees_demotes_peer_that_exits_window() {
 
     // E starts trusted as a current-committee member
     let (e_bls, e_info, e_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(e_bls, e_info)], vec![], 1);
+    all_peers.update_committees(vec![], vec![(e_bls, e_info)], vec![]);
     assert!(all_peers.get_peer(&e_id).unwrap().is_trusted());
     assert!(all_peers.is_peer_validator(&e_id));
 
     // next epoch's three slots do not include E at all
     let (f_bls, f_info, _f_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(f_bls, f_info)], vec![], 2);
+    all_peers.update_committees(vec![], vec![(f_bls, f_info)], vec![]);
 
     // E fell out of the window: demoted to untrusted and no longer counts as a validator
     assert!(!all_peers.get_peer(&e_id).unwrap().is_trusted());
@@ -867,7 +844,7 @@ fn test_update_committees_does_not_demote_operator_trusted_peer_never_in_committ
 
     // a committee update that does not involve the operator peer
     let (c_bls, c_info, _c_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![], 1);
+    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![]);
 
     // the operator peer was never tracked in a committee slot, so demotion does not touch it
     assert!(all_peers.get_peer(&op_id).unwrap().is_trusted());
@@ -885,11 +862,11 @@ fn test_update_committees_current_is_authoritative() {
     let (actual_bls, actual_info, actual_id) = committee_member(&mut rng);
 
     // epoch N predicts next = {predicted}
-    all_peers.update_committees(vec![], vec![], vec![(predicted_bls, predicted_info)], 1);
+    all_peers.update_committees(vec![], vec![], vec![(predicted_bls, predicted_info)]);
     assert_eq!(all_peers.next_committee, HashSet::from([predicted_id]));
 
     // epoch N+1's authoritative current is {actual}, which differs from the prediction
-    all_peers.update_committees(vec![], vec![(actual_bls, actual_info)], vec![], 2);
+    all_peers.update_committees(vec![], vec![(actual_bls, actual_info)], vec![]);
 
     // current matches the authoritative arg, not the stale prediction
     assert_eq!(all_peers.current_committee, HashSet::from([actual_id]));
@@ -907,7 +884,7 @@ fn test_update_committees_populates_previous() {
     let (p_bls, p_info, p_id) = committee_member(&mut rng);
     let (c_bls, c_info, _c_id) = committee_member(&mut rng);
 
-    all_peers.update_committees(vec![(p_bls, p_info)], vec![(c_bls, c_info)], vec![], 9);
+    all_peers.update_committees(vec![(p_bls, p_info)], vec![(c_bls, c_info)], vec![]);
 
     assert_eq!(all_peers.previous_committee, HashSet::from([p_id]));
     assert!(all_peers.is_peer_validator(&p_id));
@@ -917,9 +894,9 @@ fn test_update_committees_populates_previous() {
 #[test]
 fn test_update_committees_invariants_under_random_committees() {
     // Property-style coverage without a proptest dependency: across many epochs with random
-    // committees in each slot, every slot must equal exactly the set it was given,
-    // epoch_end_timestamp records the last timestamp passed in, every union member is trusted, and
-    // every peer tracked last round but absent this round is demoted to untrusted.
+    // committees in each slot, every slot must equal exactly the set it was given, every union
+    // member is trusted, and every peer tracked last round but absent this round is demoted to
+    // untrusted.
     let mut rng = StdRng::from_seed([42; 32]);
     let mut all_peers = create_all_peers(None);
 
@@ -933,14 +910,12 @@ fn test_update_committees_invariants_under_random_committees() {
         let next_size = rng.random_range(0..=4usize);
         let (next, next_ids) = random_committee(&mut rng, next_size);
 
-        let ts = round + 1;
-        all_peers.update_committees(previous, current, next, ts);
+        all_peers.update_committees(previous, current, next);
 
         // each slot equals exactly its input set (direct set, no positional shift)
         assert_eq!(all_peers.previous_committee, prev_ids, "previous slot after round {round}");
         assert_eq!(all_peers.current_committee, curr_ids, "current slot after round {round}");
         assert_eq!(all_peers.next_committee, next_ids, "next slot after round {round}");
-        assert_eq!(all_peers.epoch_end_timestamp, ts, "timestamp after round {round}");
 
         // every member of the new window is trusted
         let union: HashSet<PeerId> =

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -739,6 +739,35 @@ fn test_rotate_committees_full_turnover() {
 }
 
 #[test]
+fn test_rotate_on_never_seeded_slots_leaves_current_empty() {
+    // Guards the regression fixed by `EpochManager::network_initialized`. Rotation is positional
+    // (previous <- current <- next <- new_next): rotating before the slots were ever seeded by
+    // `initialize_committees` carries the empty seed forward, leaving `current` empty for a full
+    // epoch. The epoch manager must therefore SEED on the first network setup -- never ROTATE --
+    // even when that setup happens late on a post-restart `NewEpoch` iteration. Seeding (shown
+    // second) populates `current` immediately; rotating (shown first) does not.
+    let mut rng = StdRng::from_seed([99; 32]);
+
+    // rotate-on-never-seeded: the incoming committee lands in `next`, `current` stays empty.
+    let mut rotated = create_all_peers(None);
+    let (n_bls, n_info, n_id) = committee_member(&mut rng);
+    rotated.rotate_to_next_epoch(vec![(n_bls, n_info)], 1);
+    assert_eq!(rotated.next_committee, HashSet::from([n_id]));
+    assert!(
+        rotated.current_committee.is_empty(),
+        "rotating before seeding must leave current empty (the bug the epoch-manager fix avoids)"
+    );
+
+    // seed-on-first-init: `current` is populated immediately and recognized as a validator.
+    let mut seeded = create_all_peers(None);
+    let (c_bls, c_info, c_id) = committee_member(&mut rng);
+    let (x_bls, x_info, _x_id) = committee_member(&mut rng);
+    seeded.initialize_committees(vec![(c_bls, c_info)], vec![(x_bls, x_info)]);
+    assert!(seeded.current_committee.contains(&c_id));
+    assert!(seeded.is_peer_validator(&c_id));
+}
+
+#[test]
 fn test_is_peer_validator_returns_true_for_all_three_slots() {
     let mut all_peers = create_all_peers(None);
 

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -5,7 +5,7 @@ use crate::common::{create_multiaddr, ensure_score_config, random_ip_addr};
 use libp2p::PeerId;
 use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     net::IpAddr,
     time::{Duration, Instant},
 };
@@ -642,11 +642,11 @@ fn committee_member(rng: &mut StdRng) -> (BlsPublicKey, NetworkInfo, PeerId) {
 fn random_committee(
     rng: &mut StdRng,
     size: usize,
-) -> (Vec<(BlsPublicKey, NetworkInfo)>, HashSet<PeerId>) {
+) -> (HashMap<PeerId, (BlsPublicKey, NetworkInfo)>, HashSet<PeerId>) {
     let members: Vec<(BlsPublicKey, NetworkInfo, PeerId)> =
         (0..size).map(|_| committee_member(rng)).collect();
     let ids: HashSet<PeerId> = members.iter().map(|(_, _, id)| *id).collect();
-    let committee = members.into_iter().map(|(b, i, _)| (b, i)).collect();
+    let committee = members.into_iter().map(|(b, i, id)| (id, (b, i))).collect();
     (committee, ids)
 }
 
@@ -660,9 +660,9 @@ fn test_update_committees_sets_all_three_slots() {
     let (n_bls, n_info, n_peer_id) = committee_member(&mut rng);
 
     all_peers.update_committees(
-        vec![(p_bls, p_info)],
-        vec![(c_bls, c_info)],
-        vec![(n_bls, n_info)],
+        HashMap::from([(p_peer_id, (p_bls, p_info))]),
+        HashMap::from([(c_peer_id, (c_bls, c_info))]),
+        HashMap::from([(n_peer_id, (n_bls, n_info))]),
     );
 
     assert!(all_peers.previous_committee.contains(&p_peer_id));
@@ -688,9 +688,9 @@ fn test_update_committees_overwrites_slots_directly() {
 
     // first update: previous={A}, current={B}, next={C}
     all_peers.update_committees(
-        vec![(a_bls, a_info)],
-        vec![(b_bls, b_info)],
-        vec![(c_bls, c_info)],
+        HashMap::from([(a_id, (a_bls, a_info))]),
+        HashMap::from([(b_id, (b_bls, b_info))]),
+        HashMap::from([(c_id, (c_bls, c_info))]),
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([a_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([b_id]));
@@ -699,9 +699,9 @@ fn test_update_committees_overwrites_slots_directly() {
     // second update: each slot is set directly from its arg, NOT positionally shifted from the
     // prior round (otherwise current would be the prior next, {C}).
     all_peers.update_committees(
-        vec![(d_bls, d_info)],
-        vec![(e_bls, e_info)],
-        vec![(f_bls, f_info)],
+        HashMap::from([(d_id, (d_bls, d_info))]),
+        HashMap::from([(e_id, (e_bls, e_info))]),
+        HashMap::from([(f_id, (f_bls, f_info))]),
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
@@ -717,16 +717,16 @@ fn test_update_committees_no_change() {
 
     // X is in both current and next
     all_peers.update_committees(
-        vec![],
-        vec![(x_bls, x_info.clone())],
-        vec![(x_bls, x_info.clone())],
+        HashMap::new(),
+        HashMap::from([(x_id, (x_bls, x_info.clone()))]),
+        HashMap::from([(x_id, (x_bls, x_info.clone()))]),
     );
 
     // repeat the same membership next epoch
     all_peers.update_committees(
-        vec![],
-        vec![(x_bls, x_info.clone())],
-        vec![(x_bls, x_info.clone())],
+        HashMap::new(),
+        HashMap::from([(x_id, (x_bls, x_info.clone()))]),
+        HashMap::from([(x_id, (x_bls, x_info.clone()))]),
     );
 
     // full overlap keeps X a validator, present in both current and next, never demoted
@@ -747,9 +747,9 @@ fn test_update_committees_full_turnover() {
 
     // initialize with previous={A}, current={B}, next={C}
     all_peers.update_committees(
-        vec![(a_bls, a_info)],
-        vec![(b_bls, b_info)],
-        vec![(c_bls, c_info)],
+        HashMap::from([(a_id, (a_bls, a_info))]),
+        HashMap::from([(b_id, (b_bls, b_info))]),
+        HashMap::from([(c_id, (c_bls, c_info))]),
     );
 
     // a fully disjoint set replaces every slot directly
@@ -757,9 +757,9 @@ fn test_update_committees_full_turnover() {
     let (e_bls, e_info, e_id) = committee_member(&mut rng);
     let (f_bls, f_info, f_id) = committee_member(&mut rng);
     all_peers.update_committees(
-        vec![(d_bls, d_info)],
-        vec![(e_bls, e_info)],
-        vec![(f_bls, f_info)],
+        HashMap::from([(d_id, (d_bls, d_info))]),
+        HashMap::from([(e_id, (e_bls, e_info))]),
+        HashMap::from([(f_id, (f_bls, f_info))]),
     );
     assert_eq!(all_peers.previous_committee, HashSet::from([d_id]));
     assert_eq!(all_peers.current_committee, HashSet::from([e_id]));
@@ -796,12 +796,20 @@ fn test_update_committees_in_window_peer_stays_trusted() {
 
     // M starts in the current committee and is made trusted by update_committees
     let (m_bls, m_info, m_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(m_bls, m_info.clone())], vec![]);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::from([(m_id, (m_bls, m_info.clone()))]),
+        HashMap::new(),
+    );
     assert!(all_peers.get_peer(&m_id).unwrap().is_trusted());
 
     // next epoch: M moves to the previous slot (still in-window) alongside a disjoint current
-    let (other_bls, other_info, _other_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![(m_bls, m_info)], vec![(other_bls, other_info)], vec![]);
+    let (other_bls, other_info, other_id) = committee_member(&mut rng);
+    all_peers.update_committees(
+        HashMap::from([(m_id, (m_bls, m_info))]),
+        HashMap::from([(other_id, (other_bls, other_info))]),
+        HashMap::new(),
+    );
 
     // M is still inside the three-slot window (now in previous), so it stays trusted -- not via a
     // one-way ratchet, but because it is still a tracked committee member.
@@ -817,13 +825,21 @@ fn test_update_committees_demotes_peer_that_exits_window() {
 
     // E starts trusted as a current-committee member
     let (e_bls, e_info, e_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(e_bls, e_info)], vec![]);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::from([(e_id, (e_bls, e_info))]),
+        HashMap::new(),
+    );
     assert!(all_peers.get_peer(&e_id).unwrap().is_trusted());
     assert!(all_peers.is_peer_validator(&e_id));
 
     // next epoch's three slots do not include E at all
-    let (f_bls, f_info, _f_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(f_bls, f_info)], vec![]);
+    let (f_bls, f_info, f_id) = committee_member(&mut rng);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::from([(f_id, (f_bls, f_info))]),
+        HashMap::new(),
+    );
 
     // E fell out of the window: demoted to untrusted and no longer counts as a validator
     assert!(!all_peers.get_peer(&e_id).unwrap().is_trusted());
@@ -843,8 +859,12 @@ fn test_update_committees_does_not_demote_operator_trusted_peer_never_in_committ
     assert!(all_peers.get_peer(&op_id).unwrap().is_trusted());
 
     // a committee update that does not involve the operator peer
-    let (c_bls, c_info, _c_id) = committee_member(&mut rng);
-    all_peers.update_committees(vec![], vec![(c_bls, c_info)], vec![]);
+    let (c_bls, c_info, c_id) = committee_member(&mut rng);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::from([(c_id, (c_bls, c_info))]),
+        HashMap::new(),
+    );
 
     // the operator peer was never tracked in a committee slot, so demotion does not touch it
     assert!(all_peers.get_peer(&op_id).unwrap().is_trusted());
@@ -862,11 +882,19 @@ fn test_update_committees_current_is_authoritative() {
     let (actual_bls, actual_info, actual_id) = committee_member(&mut rng);
 
     // epoch N predicts next = {predicted}
-    all_peers.update_committees(vec![], vec![], vec![(predicted_bls, predicted_info)]);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::from([(predicted_id, (predicted_bls, predicted_info))]),
+    );
     assert_eq!(all_peers.next_committee, HashSet::from([predicted_id]));
 
     // epoch N+1's authoritative current is {actual}, which differs from the prediction
-    all_peers.update_committees(vec![], vec![(actual_bls, actual_info)], vec![]);
+    all_peers.update_committees(
+        HashMap::new(),
+        HashMap::from([(actual_id, (actual_bls, actual_info))]),
+        HashMap::new(),
+    );
 
     // current matches the authoritative arg, not the stale prediction
     assert_eq!(all_peers.current_committee, HashSet::from([actual_id]));
@@ -882,9 +910,13 @@ fn test_update_committees_populates_previous() {
     let mut all_peers = create_all_peers(None);
 
     let (p_bls, p_info, p_id) = committee_member(&mut rng);
-    let (c_bls, c_info, _c_id) = committee_member(&mut rng);
+    let (c_bls, c_info, c_id) = committee_member(&mut rng);
 
-    all_peers.update_committees(vec![(p_bls, p_info)], vec![(c_bls, c_info)], vec![]);
+    all_peers.update_committees(
+        HashMap::from([(p_id, (p_bls, p_info))]),
+        HashMap::from([(c_id, (c_bls, c_info))]),
+        HashMap::new(),
+    );
 
     assert_eq!(all_peers.previous_committee, HashSet::from([p_id]));
     assert!(all_peers.is_peer_validator(&p_id));

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -297,8 +297,6 @@ where
         current: HashSet<BlsPublicKey>,
         /// The next epoch committee.
         next: HashSet<BlsPublicKey>,
-        /// Timestamp (sec) at which the just-completed epoch ended.
-        epoch_end_timestamp: TimestampSec,
     },
     /// Pre-dial recovery: forgive bans for a committee so it can be dialed, without mutating the
     /// committee slots.
@@ -568,18 +566,14 @@ where
         res.await.map_err(Into::into)
     }
 
-    /// Set the previous/current/next committees directly from authoritative state, every epoch,
-    /// recording the just-completed epoch's end timestamp.
+    /// Set the previous/current/next committees directly from authoritative state, every epoch.
     pub async fn update_committees(
         &self,
         previous: HashSet<BlsPublicKey>,
         current: HashSet<BlsPublicKey>,
         next: HashSet<BlsPublicKey>,
-        epoch_end_timestamp: TimestampSec,
     ) -> NetworkResult<()> {
-        self.sender
-            .send(NetworkCommand::UpdateCommittees { previous, current, next, epoch_end_timestamp })
-            .await?;
+        self.sender.send(NetworkCommand::UpdateCommittees { previous, current, next }).await?;
         Ok(())
     }
 

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -289,18 +289,14 @@ where
         /// The reply to caller.
         reply: oneshot::Sender<PeerExchangeMap>,
     },
-    /// Seed the previous/current/next committees on the initial epoch.
-    InitializeCommittees {
+    /// Set the previous/current/next committees directly from authoritative state, every epoch.
+    UpdateCommittees {
+        /// The previous epoch committee.
+        previous: HashSet<BlsPublicKey>,
         /// The current epoch committee.
         current: HashSet<BlsPublicKey>,
         /// The next epoch committee.
         next: HashSet<BlsPublicKey>,
-    },
-    /// Rotate committees forward at an epoch boundary (`previous <- current`, `current <- next`,
-    /// `next <- next_committee`).
-    NextCommittee {
-        /// The new next committee.
-        next_committee: HashSet<BlsPublicKey>,
         /// Timestamp (sec) at which the just-completed epoch ended.
         epoch_end_timestamp: TimestampSec,
     },
@@ -572,25 +568,17 @@ where
         res.await.map_err(Into::into)
     }
 
-    /// Seed the previous/current/next committees on the initial epoch.
-    pub async fn initialize_committees(
+    /// Set the previous/current/next committees directly from authoritative state, every epoch,
+    /// recording the just-completed epoch's end timestamp.
+    pub async fn update_committees(
         &self,
+        previous: HashSet<BlsPublicKey>,
         current: HashSet<BlsPublicKey>,
         next: HashSet<BlsPublicKey>,
-    ) -> NetworkResult<()> {
-        self.sender.send(NetworkCommand::InitializeCommittees { current, next }).await?;
-        Ok(())
-    }
-
-    /// Rotate committees forward at an epoch boundary, recording the just-completed epoch's end
-    /// timestamp.
-    pub async fn next_committee(
-        &self,
-        next_committee: HashSet<BlsPublicKey>,
         epoch_end_timestamp: TimestampSec,
     ) -> NetworkResult<()> {
         self.sender
-            .send(NetworkCommand::NextCommittee { next_committee, epoch_end_timestamp })
+            .send(NetworkCommand::UpdateCommittees { previous, current, next, epoch_end_timestamp })
             .await?;
         Ok(())
     }
@@ -598,7 +586,7 @@ where
     /// Forgive bans for a committee so it can be dialed, without mutating the committee slots.
     ///
     /// Used by the deadlock-breaker pre-dial path; the real slot update follows via
-    /// [`Self::initialize_committees`] or [`Self::next_committee`].
+    /// [`Self::update_committees`].
     pub async fn prepare_committee_dial(
         &self,
         committee: HashSet<BlsPublicKey>,

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -289,9 +289,25 @@ where
         /// The reply to caller.
         reply: oneshot::Sender<PeerExchangeMap>,
     },
-    /// Start a new epoch.
-    NewEpoch {
-        /// The epoch committee.
+    /// Seed the previous/current/next committees on the initial epoch.
+    InitializeCommittees {
+        /// The current epoch committee.
+        current: HashSet<BlsPublicKey>,
+        /// The next epoch committee.
+        next: HashSet<BlsPublicKey>,
+    },
+    /// Rotate committees forward at an epoch boundary (`previous <- current`, `current <- next`,
+    /// `next <- next_committee`).
+    NextCommittee {
+        /// The new next committee.
+        next_committee: HashSet<BlsPublicKey>,
+        /// Timestamp (sec) at which the just-completed epoch ended.
+        epoch_end_timestamp: TimestampSec,
+    },
+    /// Pre-dial recovery: forgive bans for a committee so it can be dialed, without mutating the
+    /// committee slots.
+    PrepareCommitteeDial {
+        /// The committee whose peers should be unbanned for dialing.
         committee: HashSet<BlsPublicKey>,
     },
     /// Find authorities for a future committee by bls key and return to sender.
@@ -556,9 +572,38 @@ where
         res.await.map_err(Into::into)
     }
 
-    /// Create a [PeerExchangeMap] for exchanging peers.
-    pub async fn new_epoch(&self, committee: HashSet<BlsPublicKey>) -> NetworkResult<()> {
-        self.sender.send(NetworkCommand::NewEpoch { committee }).await?;
+    /// Seed the previous/current/next committees on the initial epoch.
+    pub async fn initialize_committees(
+        &self,
+        current: HashSet<BlsPublicKey>,
+        next: HashSet<BlsPublicKey>,
+    ) -> NetworkResult<()> {
+        self.sender.send(NetworkCommand::InitializeCommittees { current, next }).await?;
+        Ok(())
+    }
+
+    /// Rotate committees forward at an epoch boundary, recording the just-completed epoch's end
+    /// timestamp.
+    pub async fn next_committee(
+        &self,
+        next_committee: HashSet<BlsPublicKey>,
+        epoch_end_timestamp: TimestampSec,
+    ) -> NetworkResult<()> {
+        self.sender
+            .send(NetworkCommand::NextCommittee { next_committee, epoch_end_timestamp })
+            .await?;
+        Ok(())
+    }
+
+    /// Forgive bans for a committee so it can be dialed, without mutating the committee slots.
+    ///
+    /// Used by the deadlock-breaker pre-dial path; the real slot update follows via
+    /// [`Self::initialize_committees`] or [`Self::next_committee`].
+    pub async fn prepare_committee_dial(
+        &self,
+        committee: HashSet<BlsPublicKey>,
+    ) -> NetworkResult<()> {
+        self.sender.send(NetworkCommand::PrepareCommitteeDial { committee }).await?;
         Ok(())
     }
 

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -62,13 +62,13 @@ pub(crate) struct EpochManager<P, DB> {
     /// (start listening, register bootstrap peers).
     ///
     /// This setup normally runs on the `Initial` epoch, but the `Initial` iteration can return
-    /// early from [`EpochManager::replay_missed_consensus`] — when a restart must replay-and-close
-    /// an epoch boundary — *before* `create_consensus` runs the setup. In that case the setup runs
+    /// early from [`EpochManager::replay_missed_consensus`] - when a restart must replay-and-close
+    /// an epoch boundary - *before* `create_consensus` runs the setup. In that case the setup runs
     /// on the first following `NewEpoch` iteration instead. Gating on this flag, rather than on
     /// [`RunEpochMode::Initial`], guarantees the networks are set up exactly once even on that
     /// restart path (mirrors the `are_workers_initialized` guard used for worker components).
     ///
-    /// Committee slots are NOT gated on this flag — they are set every epoch from authoritative
+    /// Committee slots are NOT gated on this flag. They are set every epoch from authoritative
     /// state via `update_committees`.
     network_initialized: bool,
     /// Reth DB, keep for entire execution.

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -58,13 +58,6 @@ pub(crate) struct EpochManager<P, DB> {
     /// If the timestamp of the leader is >= the epoch_boundary then the
     /// manager closes the epoch after the engine executes all data.
     epoch_boundary: TimestampSec,
-    /// The boundary (end timestamp) of the previous epoch.
-    ///
-    /// Captured at the start of each epoch before [`Self::epoch_boundary`] is overwritten, and
-    /// handed to the network as `epoch_end_timestamp` on rotation so it can later accept late
-    /// gossip from the just-completed committee. The `0` sentinel means no previous epoch boundary
-    /// has been observed yet (initial epoch / fresh process).
-    previous_epoch_boundary: TimestampSec,
     /// Whether the long-running p2p networks have completed their one-time, per-process setup
     /// (start listening, register bootstrap peers).
     ///
@@ -228,7 +221,6 @@ where
             key_config,
             node_shutdown,
             epoch_boundary: Default::default(),
-            previous_epoch_boundary: Default::default(),
             network_initialized: false,
             reth_db,
             consensus_db,

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -66,7 +66,7 @@ pub(crate) struct EpochManager<P, DB> {
     /// has been observed yet (initial epoch / fresh process).
     previous_epoch_boundary: TimestampSec,
     /// Whether the long-running p2p networks have completed their one-time, per-process setup
-    /// (start listening, register bootstrap peers, seed the previous/current/next committee slots).
+    /// (start listening, register bootstrap peers).
     ///
     /// This setup normally runs on the `Initial` epoch, but the `Initial` iteration can return
     /// early from [`EpochManager::replay_missed_consensus`] — when a restart must replay-and-close
@@ -74,6 +74,9 @@ pub(crate) struct EpochManager<P, DB> {
     /// on the first following `NewEpoch` iteration instead. Gating on this flag, rather than on
     /// [`RunEpochMode::Initial`], guarantees the networks are set up exactly once even on that
     /// restart path (mirrors the `are_workers_initialized` guard used for worker components).
+    ///
+    /// Committee slots are NOT gated on this flag — they are set every epoch from authoritative
+    /// state via `update_committees`.
     network_initialized: bool,
     /// Reth DB, keep for entire execution.
     reth_db: RethDb,

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -58,6 +58,13 @@ pub(crate) struct EpochManager<P, DB> {
     /// If the timestamp of the leader is >= the epoch_boundary then the
     /// manager closes the epoch after the engine executes all data.
     epoch_boundary: TimestampSec,
+    /// The boundary (end timestamp) of the previous epoch.
+    ///
+    /// Captured at the start of each epoch before [`Self::epoch_boundary`] is overwritten, and
+    /// handed to the network as `epoch_end_timestamp` on rotation so it can later accept late
+    /// gossip from the just-completed committee. The `0` sentinel means no previous epoch boundary
+    /// has been observed yet (initial epoch / fresh process).
+    previous_epoch_boundary: TimestampSec,
     /// Reth DB, keep for entire execution.
     reth_db: RethDb,
     /// Consensus DB, keep for entire execution.
@@ -208,6 +215,7 @@ where
             key_config,
             node_shutdown,
             epoch_boundary: Default::default(),
+            previous_epoch_boundary: Default::default(),
             reth_db,
             consensus_db,
             consensus_bus,

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -65,6 +65,16 @@ pub(crate) struct EpochManager<P, DB> {
     /// gossip from the just-completed committee. The `0` sentinel means no previous epoch boundary
     /// has been observed yet (initial epoch / fresh process).
     previous_epoch_boundary: TimestampSec,
+    /// Whether the long-running p2p networks have completed their one-time, per-process setup
+    /// (start listening, register bootstrap peers, seed the previous/current/next committee slots).
+    ///
+    /// This setup normally runs on the `Initial` epoch, but the `Initial` iteration can return
+    /// early from [`EpochManager::replay_missed_consensus`] — when a restart must replay-and-close
+    /// an epoch boundary — *before* `create_consensus` runs the setup. In that case the setup runs
+    /// on the first following `NewEpoch` iteration instead. Gating on this flag, rather than on
+    /// [`RunEpochMode::Initial`], guarantees the networks are set up exactly once even on that
+    /// restart path (mirrors the `are_workers_initialized` guard used for worker components).
+    network_initialized: bool,
     /// Reth DB, keep for entire execution.
     reth_db: RethDb,
     /// Consensus DB, keep for entire execution.
@@ -216,6 +226,7 @@ where
             node_shutdown,
             epoch_boundary: Default::default(),
             previous_epoch_boundary: Default::default(),
+            network_initialized: false,
             reth_db,
             consensus_db,
             consensus_bus,

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -168,17 +168,29 @@ where
         let mut consensus_output = self.consensus_bus.subscribe_consensus_output();
         let consensus_config = self.configure_consensus(engine, network_config).await?;
 
+        // The networks need their one-time, per-process setup (start listening, register bootstrap
+        // peers, seed the previous/current/next committee slots) on the first iteration that
+        // actually reaches `create_consensus`. This is usually the `Initial` epoch, but the replay
+        // above can return early (line ~154) before `create_consensus` on a restart that
+        // replays-and-closes an epoch boundary, so the first real setup then happens on a following
+        // `NewEpoch` iteration. Drive the decision off whether the network has actually been set up
+        // yet (not off `RunEpochMode::Initial`) so the setup (and committee seeding) is never
+        // skipped on that restart path.
+        let network_first_init = epoch_mode.initial_epoch() || !self.network_initialized;
+
         // create primary and worker nodes
         let (primary, worker_node) = self
             .create_consensus(
                 engine,
                 &epoch_task_manager,
-                epoch_mode.initial_epoch(),
+                network_first_init,
                 gas_accumulator.clone(),
                 consensus_bus.clone(),
                 consensus_config.clone(),
             )
             .await?;
+        // Networks are now set up; subsequent epochs rotate committees instead of re-seeding.
+        self.network_initialized = true;
         // consensus config for shutdown subscribers
         let consensus_shutdown = primary.shutdown_signal().await;
         let epoch_shutdown_rx = consensus_shutdown.subscribe();

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -166,7 +166,7 @@ where
 
         // The networks need their one-time, per-process setup (start listening, register bootstrap
         // peers) on the first iteration that actually reaches `create_consensus`. This is usually
-        // the `Initial` epoch, but the replay above can return early (line ~154) before
+        // the `Initial` epoch, but the replay above can return early before
         // `create_consensus` on a restart that replays-and-closes an epoch boundary, so the first
         // real setup then happens on a following `NewEpoch` iteration. Drive the decision off
         // whether the network has actually been set up yet (not off `RunEpochMode::Initial`) so the
@@ -1342,7 +1342,7 @@ where
     /// Read the previous epoch's committee from the persisted epoch records.
     ///
     /// Empty for epoch 0 (no previous) or if the prior record isn't available yet (degrades to
-    /// pre-tracking behavior rather than failing network setup). Returns the *active* committee of
+    /// pre-tracking behavior rather than failing network setup). Returns the active committee of
     /// epoch `N-1` (`record.committee`), not its `next_committee` (which equals the current
     /// committee by the invariant enforced when epoch records are built).
     async fn previous_committee_keys(&self, epoch: Epoch) -> HashSet<BlsPublicKey> {
@@ -1360,12 +1360,12 @@ where
     /// Initialize a network handle for a new epoch.
     ///
     /// On the initial epoch this registers bootstrap peers and starts listening (the one-time,
-    /// per-process setup gated on `initial_epoch`). Every epoch — initial or not — it sets the
+    /// per-process setup gated on `initial_epoch`). Every epoch sets the
     /// previous/current/next committee slots directly from authoritative state via
     /// `update_committees`.
     ///
     /// On the initial epoch, bootstrap peers must be added BEFORE `update_committees` so that
-    /// `known_peers` is populated when the peer manager resolves the committees from it.
+    /// `known_peers` is populated when the peer manager resolves the committees.
     async fn init_network_for_epoch<Req: TNMessage, Res: TNMessage>(
         handle: &NetworkHandle<Req, Res>,
         bootstrap_peers: BTreeMap<BlsPublicKey, P2pNode>,

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -761,6 +761,14 @@ where
     ) -> eyre::Result<(PrimaryNode<DB>, WorkerNode<DB>)> {
         // create config for consensus
         let _mode = self.identify_node_mode(&consensus_config, &consensus_bus).await?;
+        let epoch = consensus_config.committee().epoch();
+
+        // previous committee from on-chain state - canonical source of truth
+        let previous_committee_keys: HashSet<BlsPublicKey> = if epoch == 0 {
+            HashSet::new() // no previous committee
+        } else {
+            engine.validators_for_epoch(epoch - 1).await?.into_iter().collect()
+        };
 
         let consensus_bus_app = consensus_bus.app().clone();
         let primary = self
@@ -769,6 +777,7 @@ where
                 epoch_task_manager.get_spawner(),
                 initial_epoch,
                 consensus_bus,
+                previous_committee_keys.clone(),
             )
             .await?;
 
@@ -806,6 +815,7 @@ where
                 initial_epoch,
                 engine_to_primary,
                 gas_accumulator,
+                previous_committee_keys,
             )
             .await?;
 
@@ -906,6 +916,7 @@ where
         epoch_task_spawner: TaskSpawner,
         initial_epoch: bool,
         consensus_bus: ConsensusBus,
+        previous_committee_keys: HashSet<BlsPublicKey>,
     ) -> eyre::Result<PrimaryNode<DB>> {
         let state_sync = StateSynchronizer::new(
             consensus_config.clone(),
@@ -926,6 +937,7 @@ where
             &network_handle,
             initial_epoch,
             consensus_bus.clone(),
+            previous_committee_keys,
         )
         .await?;
 
@@ -937,6 +949,7 @@ where
     }
 
     /// Create a [WorkerNode].
+    #[allow(clippy::too_many_arguments)]
     async fn spawn_worker_node_components(
         &mut self,
         consensus_config: &ConsensusConfig<DB>,
@@ -945,6 +958,7 @@ where
         initial_epoch: bool,
         engine_to_primary: EngineToPrimaryRpc,
         gas_accumulator: GasAccumulator,
+        previous_committee_keys: HashSet<BlsPublicKey>,
     ) -> eyre::Result<WorkerNode<DB>> {
         // only support one worker for now (with id 0) - otherwise, loop here
         let worker_id = 0;
@@ -995,6 +1009,7 @@ where
             epoch_task_spawner,
             &network_handle,
             initial_epoch,
+            previous_committee_keys,
         )
         .await?;
 
@@ -1012,6 +1027,7 @@ where
     /// Create the primary network for the specific epoch.
     ///
     /// This is not the swarm level, but the [PrimaryNetwork] interface.
+    #[allow(clippy::too_many_arguments)]
     async fn spawn_primary_network_for_epoch(
         &mut self,
         consensus_config: &ConsensusConfig<DB>,
@@ -1020,6 +1036,7 @@ where
         network_handle: &PrimaryNetworkHandle,
         initial_epoch: bool,
         consensus_bus: ConsensusBus,
+        previous_committee_keys: HashSet<BlsPublicKey>,
     ) -> eyre::Result<()> {
         // get event streams for the primary network handler
         let rx_event_stream = self.consensus_bus.subscribe_primary_network_events();
@@ -1041,8 +1058,6 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
-        let previous_committee_keys =
-            self.previous_committee_keys(consensus_config.committee().epoch()).await;
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
@@ -1154,6 +1169,7 @@ where
     }
 
     /// Create the worker network.
+    #[allow(clippy::too_many_arguments)]
     async fn spawn_worker_network_for_epoch(
         &mut self,
         consensus_config: &ConsensusConfig<DB>,
@@ -1162,6 +1178,7 @@ where
         epoch_task_spawner: TaskSpawner,
         network_handle: &WorkerNetworkHandle,
         initial_epoch: bool,
+        previous_committee_keys: HashSet<BlsPublicKey>,
     ) -> eyre::Result<()> {
         // get event streams for the worker network handler
         let rx_event_stream = self.worker_event_stream.subscribe();
@@ -1182,8 +1199,6 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
-        let previous_committee_keys =
-            self.previous_committee_keys(consensus_config.committee().epoch()).await;
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
@@ -1337,24 +1352,6 @@ where
                     })
             })
             .unwrap_or(Ok(fallback))
-    }
-
-    /// Read the previous epoch's committee from the persisted epoch records.
-    ///
-    /// Empty for epoch 0 (no previous) or if the prior record isn't available yet (degrades to
-    /// pre-tracking behavior rather than failing network setup). Returns the active committee of
-    /// epoch `N-1` (`record.committee`), not its `next_committee` (which equals the current
-    /// committee by the invariant enforced when epoch records are built).
-    async fn previous_committee_keys(&self, epoch: Epoch) -> HashSet<BlsPublicKey> {
-        if epoch == 0 {
-            return HashSet::new();
-        }
-        self.consensus_chain
-            .epochs()
-            .record_by_epoch(epoch - 1)
-            .await
-            .map(|rec| rec.committee.into_iter().collect())
-            .unwrap_or_default()
     }
 
     /// Initialize a network handle for a new epoch.

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -169,13 +169,13 @@ where
         let consensus_config = self.configure_consensus(engine, network_config).await?;
 
         // The networks need their one-time, per-process setup (start listening, register bootstrap
-        // peers, seed the previous/current/next committee slots) on the first iteration that
-        // actually reaches `create_consensus`. This is usually the `Initial` epoch, but the replay
-        // above can return early (line ~154) before `create_consensus` on a restart that
-        // replays-and-closes an epoch boundary, so the first real setup then happens on a following
-        // `NewEpoch` iteration. Drive the decision off whether the network has actually been set up
-        // yet (not off `RunEpochMode::Initial`) so the setup (and committee seeding) is never
-        // skipped on that restart path.
+        // peers) on the first iteration that actually reaches `create_consensus`. This is usually
+        // the `Initial` epoch, but the replay above can return early (line ~154) before
+        // `create_consensus` on a restart that replays-and-closes an epoch boundary, so the first
+        // real setup then happens on a following `NewEpoch` iteration. Drive the decision off
+        // whether the network has actually been set up yet (not off `RunEpochMode::Initial`) so the
+        // setup is never skipped on that restart path. (Committee slots are set every epoch
+        // regardless via `update_committees`.)
         let network_first_init = epoch_mode.initial_epoch() || !self.network_initialized;
 
         // create primary and worker nodes
@@ -1045,9 +1045,12 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
+        let previous_committee_keys =
+            self.previous_committee_keys(consensus_config.committee().epoch()).await;
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
+            previous_committee_keys,
             committee_keys.clone(),
             next_committee_keys,
             self.previous_epoch_boundary,
@@ -1184,9 +1187,12 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
+        let previous_committee_keys =
+            self.previous_committee_keys(consensus_config.committee().epoch()).await;
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
+            previous_committee_keys,
             committee_keys.clone(),
             next_committee_keys,
             self.previous_epoch_boundary,
@@ -1339,17 +1345,37 @@ where
             .unwrap_or(Ok(fallback))
     }
 
+    /// Read the previous epoch's committee from the persisted epoch records.
+    ///
+    /// Empty for epoch 0 (no previous) or if the prior record isn't available yet (degrades to
+    /// pre-tracking behavior rather than failing network setup). Returns the *active* committee of
+    /// epoch `N-1` (`record.committee`), not its `next_committee` (which equals the current
+    /// committee by the invariant enforced when epoch records are built).
+    async fn previous_committee_keys(&self, epoch: Epoch) -> HashSet<BlsPublicKey> {
+        if epoch == 0 {
+            return HashSet::new();
+        }
+        self.consensus_chain
+            .epochs()
+            .record_by_epoch(epoch - 1)
+            .await
+            .map(|rec| rec.committee.into_iter().collect())
+            .unwrap_or_default()
+    }
+
     /// Initialize a network handle for a new epoch.
     ///
-    /// On the initial epoch this registers bootstrap peers and then seeds the previous/current/next
-    /// committees (`initialize_committees`). On every subsequent epoch it rotates the committees
-    /// forward (`next_committee`), recording the just-completed epoch's end timestamp.
+    /// On the initial epoch this registers bootstrap peers and starts listening (the one-time,
+    /// per-process setup gated on `initial_epoch`). Every epoch — initial or not — it sets the
+    /// previous/current/next committee slots directly from authoritative state via
+    /// `update_committees`, recording the just-completed epoch's end timestamp.
     ///
-    /// Bootstrap peers must be added BEFORE `initialize_committees` so that `known_peers` is
-    /// populated when the peer manager resolves the committees from it.
+    /// On the initial epoch, bootstrap peers must be added BEFORE `update_committees` so that
+    /// `known_peers` is populated when the peer manager resolves the committees from it.
     async fn init_network_for_epoch<Req: TNMessage, Res: TNMessage>(
         handle: &NetworkHandle<Req, Res>,
         bootstrap_peers: BTreeMap<BlsPublicKey, P2pNode>,
+        previous_committee_keys: HashSet<BlsPublicKey>,
         committee_keys: HashSet<BlsPublicKey>,
         next_committee_keys: HashSet<BlsPublicKey>,
         epoch_end_timestamp: TimestampSec,
@@ -1357,10 +1383,15 @@ where
     ) -> eyre::Result<()> {
         if initial_epoch {
             handle.add_bootstrap_peers(bootstrap_peers).await?;
-            handle.initialize_committees(committee_keys, next_committee_keys).await?;
-        } else {
-            handle.next_committee(next_committee_keys, epoch_end_timestamp).await?;
         }
+        handle
+            .update_committees(
+                previous_committee_keys,
+                committee_keys,
+                next_committee_keys,
+                epoch_end_timestamp,
+            )
+            .await?;
         Ok(())
     }
 

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -43,7 +43,7 @@ use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
     BlsSigner, Committee, CommitteeBuilder, ConsensusOutput, Database as TNDatabase, Epoch,
     EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode, TaskJoinError, TaskManager,
-    TaskSpawner, TnReceiver, B256,
+    TaskSpawner, TimestampSec, TnReceiver, B256,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -109,6 +109,10 @@ where
         // ourselves... Note, any consensus output to replay should be in the same epoch...
         let (committee, epoch_info, epoch_start) =
             self.get_committee_with_epoch_start_info(engine).await?;
+        // Capture the just-closed epoch's boundary before overwriting it so the network can record
+        // when the previous epoch ended (a future PR uses this to accept late gossip from the
+        // previous committee). On the initial epoch this is the `0` sentinel.
+        self.previous_epoch_boundary = self.epoch_boundary;
         self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
         // Produce a "dummy" epoch 0 EpochRecord if missing.
         // This will let us use simple code to find any epoch including 0 at startup.
@@ -484,7 +488,10 @@ where
             if primary_network_handle.connected_peers_count().await.unwrap_or_default() == 0 {
                 let committee_keys: HashSet<BlsPublicKey> =
                     committee.bls_keys().into_iter().collect();
-                let _ = primary_network_handle.inner_handle().new_epoch(committee_keys).await;
+                let _ = primary_network_handle
+                    .inner_handle()
+                    .prepare_committee_dial(committee_keys)
+                    .await;
                 for bls_key in committee.bls_keys() {
                     self.dial_peer_bls(
                         primary_network_handle.inner_handle().clone(),
@@ -1024,10 +1031,14 @@ where
             .iter()
             .map(|(k, v)| (*k, v.primary.clone()))
             .collect();
+        let next_committee_keys: HashSet<BlsPublicKey> =
+            consensus_config.next_committee_keys().iter().copied().collect();
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
             committee_keys.clone(),
+            next_committee_keys,
+            self.previous_epoch_boundary,
             initial_epoch,
         )
         .await?;
@@ -1159,10 +1170,14 @@ where
             .iter()
             .map(|(k, v)| (*k, v.worker.clone()))
             .collect();
+        let next_committee_keys: HashSet<BlsPublicKey> =
+            consensus_config.next_committee_keys().iter().copied().collect();
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
             committee_keys.clone(),
+            next_committee_keys,
+            self.previous_epoch_boundary,
             initial_epoch,
         )
         .await?;
@@ -1312,21 +1327,28 @@ where
             .unwrap_or(Ok(fallback))
     }
 
-    /// Initialize a network handle for a new epoch: register bootstrap peers (on first epoch)
-    /// then update the epoch committee.
+    /// Initialize a network handle for a new epoch.
     ///
-    /// Bootstrap peers must be added BEFORE `new_epoch()` so that `known_peers` is populated
-    /// when `new_epoch()` builds `current_committee` from it.
+    /// On the initial epoch this registers bootstrap peers and then seeds the previous/current/next
+    /// committees (`initialize_committees`). On every subsequent epoch it rotates the committees
+    /// forward (`next_committee`), recording the just-completed epoch's end timestamp.
+    ///
+    /// Bootstrap peers must be added BEFORE `initialize_committees` so that `known_peers` is
+    /// populated when the peer manager resolves the committees from it.
     async fn init_network_for_epoch<Req: TNMessage, Res: TNMessage>(
         handle: &NetworkHandle<Req, Res>,
         bootstrap_peers: BTreeMap<BlsPublicKey, P2pNode>,
         committee_keys: HashSet<BlsPublicKey>,
+        next_committee_keys: HashSet<BlsPublicKey>,
+        epoch_end_timestamp: TimestampSec,
         initial_epoch: bool,
     ) -> eyre::Result<()> {
         if initial_epoch {
             handle.add_bootstrap_peers(bootstrap_peers).await?;
+            handle.initialize_committees(committee_keys, next_committee_keys).await?;
+        } else {
+            handle.next_committee(next_committee_keys, epoch_end_timestamp).await?;
         }
-        handle.new_epoch(committee_keys).await?;
         Ok(())
     }
 

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -43,7 +43,7 @@ use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
     BlsSigner, Committee, CommitteeBuilder, ConsensusOutput, Database as TNDatabase, Epoch,
     EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode, TaskJoinError, TaskManager,
-    TaskSpawner, TimestampSec, TnReceiver, B256,
+    TaskSpawner, TnReceiver, B256,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -109,10 +109,6 @@ where
         // ourselves... Note, any consensus output to replay should be in the same epoch...
         let (committee, epoch_info, epoch_start) =
             self.get_committee_with_epoch_start_info(engine).await?;
-        // Capture the just-closed epoch's boundary before overwriting it so the network can record
-        // when the previous epoch ended (a future PR uses this to accept late gossip from the
-        // previous committee). On the initial epoch this is the `0` sentinel.
-        self.previous_epoch_boundary = self.epoch_boundary;
         self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
         // Produce a "dummy" epoch 0 EpochRecord if missing.
         // This will let us use simple code to find any epoch including 0 at startup.
@@ -1053,7 +1049,6 @@ where
             previous_committee_keys,
             committee_keys.clone(),
             next_committee_keys,
-            self.previous_epoch_boundary,
             initial_epoch,
         )
         .await?;
@@ -1195,7 +1190,6 @@ where
             previous_committee_keys,
             committee_keys.clone(),
             next_committee_keys,
-            self.previous_epoch_boundary,
             initial_epoch,
         )
         .await?;
@@ -1368,7 +1362,7 @@ where
     /// On the initial epoch this registers bootstrap peers and starts listening (the one-time,
     /// per-process setup gated on `initial_epoch`). Every epoch — initial or not — it sets the
     /// previous/current/next committee slots directly from authoritative state via
-    /// `update_committees`, recording the just-completed epoch's end timestamp.
+    /// `update_committees`.
     ///
     /// On the initial epoch, bootstrap peers must be added BEFORE `update_committees` so that
     /// `known_peers` is populated when the peer manager resolves the committees from it.
@@ -1378,19 +1372,13 @@ where
         previous_committee_keys: HashSet<BlsPublicKey>,
         committee_keys: HashSet<BlsPublicKey>,
         next_committee_keys: HashSet<BlsPublicKey>,
-        epoch_end_timestamp: TimestampSec,
         initial_epoch: bool,
     ) -> eyre::Result<()> {
         if initial_epoch {
             handle.add_bootstrap_peers(bootstrap_peers).await?;
         }
         handle
-            .update_committees(
-                previous_committee_keys,
-                committee_keys,
-                next_committee_keys,
-                epoch_end_timestamp,
-            )
+            .update_committees(previous_committee_keys, committee_keys, next_committee_keys)
             .await?;
         Ok(())
     }


### PR DESCRIPTION
- The peer layer now tracks three committees (previous/current/next) instead of one. `is_peer_validator` matches any of the three, so the outgoing committee survives one rotation (late gossip still counts) and the next committee is trusted before it votes.
- `NewEpoch` splits into three commands: `InitializeCommittees` (seed current + next on epoch 0), `NextCommittee` (rotate slots forward + record the closed epoch's end timestamp), and `PrepareCommitteeDial` (deadlock-breaker pre-dial — unban without mutating slots).
- The epoch manager seeds on the initial epoch and rotates thereafter, sourcing `next` from `consensus_config.next_committee_keys()` and the boundary from a new `previous_epoch_boundary` field captured before `epoch_boundary` is overwritten.

Foundational change; NVV support and the late-gossip window land in follow-ups.

closes #708 