### PR TITLE
Key AllPeers by domain identity instead of libp2p PeerId.

### DIFF
--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -94,10 +94,11 @@ impl AllPeers {
     /// A peer is `Confirmed` once its bls key is known (committee/trusted/known peers); otherwise
     /// it is `Unidentified` and keyed by its libp2p id.
     fn identity_for(&self, peer_id: &PeerId) -> PeerIdentity {
-        match self.confirmed.get(peer_id) {
-            Some(bls_public_key) => PeerIdentity::Confirmed(*bls_public_key),
-            None => PeerIdentity::Unidentified(*peer_id),
-        }
+        self.confirmed
+            .get(peer_id)
+            .map_or(PeerIdentity::Unidentified(*peer_id), |bls_public_key| {
+                PeerIdentity::Confirmed(*bls_public_key)
+            })
     }
 
     /// Recover the libp2p [PeerId] for a stored peer.
@@ -732,7 +733,10 @@ impl AllPeers {
     /// Gives the ids of all known connected peers.
     pub(super) fn connected_peer_ids(&self) -> impl Iterator<Item = PeerId> + '_ {
         self.peers.iter().filter_map(|(id, peer)| {
-            peer.connection_status().is_connected().then(|| Self::peer_id_for(id, peer)).flatten()
+            peer.connection_status()
+                .is_connected()
+                .then_some(())
+                .and_then(|()| Self::peer_id_for(id, peer))
         })
     }
 
@@ -743,8 +747,8 @@ impl AllPeers {
             .filter_map(|(id, peer)| {
                 let status = peer.connection_status();
                 (status.is_connected() || status.is_dialing())
-                    .then(|| Self::peer_id_for(id, peer))
-                    .flatten()
+                    .then_some(())
+                    .and_then(|()| Self::peer_id_for(id, peer))
             })
             .collect()
     }

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -48,8 +48,8 @@ pub(super) struct AllPeers {
     ///
     /// libp2p connection events only carry a [PeerId], so this is the single point where a libp2p
     /// id is translated to the telcoin-domain identity that keys `peers`. It is kept in lockstep
-    /// with the `Confirmed` entries in `peers`: an entry exists here iff the peer is stored under a
-    /// [PeerIdentity::Confirmed] key.
+    /// with the `Confirmed` entries in `peers`: an entry exists here iff the peer is stored under
+    /// a [PeerIdentity::Confirmed] key.
     bls_by_peer_id: HashMap<PeerId, BlsPublicKey>,
     /// The collection of staked current_committee at the beginning of each epoch.
     current_committee: HashSet<BlsPublicKey>,

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -4,8 +4,12 @@
 //! manager to take. Some actions are propagated up to the swarm level and affect other behaviors.
 
 use super::{
-    banned::BannedPeers, peer::Peer, score::ReputationUpdate, status::ConnectionStatus,
-    types::ConnectionDirection, PeerExchangeMap, Penalty,
+    banned::BannedPeers,
+    peer::Peer,
+    score::ReputationUpdate,
+    status::ConnectionStatus,
+    types::{ConnectionDirection, PeerIdentity},
+    PeerExchangeMap, Penalty,
 };
 use crate::{
     error::NetworkError,
@@ -33,10 +37,20 @@ mod peers;
 /// This keeps track of [Peer], [BannedPeers], and the number of disconnected peers.
 #[derive(Debug)]
 pub(super) struct AllPeers {
-    /// The collection of known connected peers, their status and reputation
-    peers: HashMap<PeerId, Peer>,
+    /// The collection of known peers, keyed by their domain [PeerIdentity].
+    ///
+    /// Committee/trusted/known peers are keyed by their [BlsPublicKey] (`Confirmed`); anonymous
+    /// inbound or kad-dialed peers that have no known bls key yet are keyed by their libp2p
+    /// [PeerId] (`Unidentified`).
+    peers: HashMap<PeerIdentity, Peer>,
+    /// Resolution index from a libp2p [PeerId] to the [BlsPublicKey] of a `Confirmed` peer.
+    ///
+    /// libp2p connection events only carry a [PeerId], so this index recovers the `Confirmed`
+    /// identity of a known peer. It is kept in lockstep with the `Confirmed` entries in `peers`:
+    /// an entry exists here iff the peer is stored under a [PeerIdentity::Confirmed] key.
+    confirmed: HashMap<PeerId, BlsPublicKey>,
     /// The collection of staked current_committee at the beginning of each epoch.
-    current_committee: HashSet<PeerId>,
+    current_committee: HashSet<BlsPublicKey>,
     /// The collection of staked current_committee pub key to peerid at the beginning of each
     /// epoch.
     current_committee_keys: HashMap<BlsPublicKey, Option<PeerId>>,
@@ -63,6 +77,7 @@ impl AllPeers {
     ) -> Self {
         Self {
             peers: Default::default(),
+            confirmed: Default::default(),
             current_committee: Default::default(),
             current_committee_keys: Default::default(),
             banned_peers: Default::default(),
@@ -72,6 +87,39 @@ impl AllPeers {
             max_banned_peers,
             max_disconnected_peers,
         }
+    }
+
+    /// Resolve a libp2p [PeerId] to the [PeerIdentity] used to key the peer collection.
+    ///
+    /// A peer is `Confirmed` once its bls key is known (committee/trusted/known peers); otherwise
+    /// it is `Unidentified` and keyed by its libp2p id.
+    fn identity_for(&self, peer_id: &PeerId) -> PeerIdentity {
+        match self.confirmed.get(peer_id) {
+            Some(bls_public_key) => PeerIdentity::Confirmed(*bls_public_key),
+            None => PeerIdentity::Unidentified(*peer_id),
+        }
+    }
+
+    /// Recover the libp2p [PeerId] for a stored peer.
+    ///
+    /// `Unidentified` peers carry their id in the key; `Confirmed` peers derive it from their
+    /// network key, which is always set whenever a bls key is recorded.
+    fn peer_id_for(identity: &PeerIdentity, peer: &Peer) -> Option<PeerId> {
+        match identity {
+            PeerIdentity::Unidentified(peer_id) => Some(*peer_id),
+            PeerIdentity::Confirmed(_) => peer.peer_id(),
+        }
+    }
+
+    /// Remove a peer from the collection, keeping the `confirmed` resolution index in sync.
+    fn evict(&mut self, identity: &PeerIdentity) -> Option<Peer> {
+        let removed = self.peers.remove(identity);
+        if let (PeerIdentity::Confirmed(_), Some(peer)) = (identity, removed.as_ref()) {
+            if let Some(peer_id) = peer.peer_id() {
+                self.confirmed.remove(&peer_id);
+            }
+        }
+        removed
     }
 
     /// Create a peer that is "trusted".
@@ -86,7 +134,10 @@ impl AllPeers {
         let peer_id: PeerId = network_key.clone().into();
         let trusted_peer = Peer::new_trusted(bls_public_key, network_key, addr);
         let _ = self.banned_peers.remove_banned_peer(trusted_peer.known_ip_addresses());
-        self.peers.insert(peer_id, trusted_peer);
+        // overwrite any prior record and key the peer by its confirmed (bls) identity
+        self.peers.remove(&PeerIdentity::Unidentified(peer_id));
+        self.confirmed.insert(peer_id, bls_public_key);
+        self.peers.insert(PeerIdentity::Confirmed(bls_public_key), trusted_peer);
     }
 
     /// Create a peer.
@@ -97,19 +148,26 @@ impl AllPeers {
         addrs: Vec<Multiaddr>,
     ) {
         let peer_id: PeerId = network_key.clone().into();
-        if let Some(peer) = self.peers.get_mut(&peer_id) {
-            peer.update_net(bls_public_key, network_key, addrs);
-        } else {
-            let peer = Peer::new(bls_public_key, network_key, addrs);
-            self.peers.insert(peer_id, peer);
-        }
+        // migrate any existing record (anonymous or already-confirmed) onto the confirmed identity,
+        // preserving its accumulated state; otherwise create a fresh peer
+        let current = self.identity_for(&peer_id);
+        let peer = match self.peers.remove(&current) {
+            Some(mut peer) => {
+                peer.update_net(bls_public_key, network_key, addrs);
+                peer
+            }
+            None => Peer::new(bls_public_key, network_key, addrs),
+        };
+        self.confirmed.insert(peer_id, bls_public_key);
+        self.peers.insert(PeerIdentity::Confirmed(bls_public_key), peer);
     }
 
     /// Handle reported action.
     ///
     /// This method is called when the application layer identifies a problem and reports a peer.
     pub(super) fn process_penalty(&mut self, peer_id: &PeerId, penalty: Penalty) -> PeerAction {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             let prior_reputation = peer.reputation();
             let new_reputation = peer.apply_penalty(penalty);
             debug!(target: "peer-manager", ?peer_id, ?prior_reputation, ?new_reputation);
@@ -162,7 +220,8 @@ impl AllPeers {
         peer_id: &PeerId,
         new_status: &NewConnectionStatus,
     ) -> ConnectionStatus {
-        if !self.peers.contains_key(peer_id) {
+        let id = self.identity_for(peer_id);
+        if !self.peers.contains_key(&id) {
             // initialize unknown peer and log warning if status update is invalid for unknown peers
             if !new_status.valid_initial_state() {
                 warn!(target: "peer-manager",
@@ -174,12 +233,12 @@ impl AllPeers {
             }
 
             // add default peer
-            self.peers.insert(*peer_id, Peer::default());
+            self.peers.insert(id, Peer::default());
         }
 
         // ensure peer is banned if the new state is Banned
         if matches!(new_status, &NewConnectionStatus::Banned) {
-            if let Some(peer) = self.peers.get_mut(peer_id) {
+            if let Some(peer) = self.peers.get_mut(&id) {
                 peer.ensure_banned(peer_id);
             } else {
                 // unreachable
@@ -188,7 +247,7 @@ impl AllPeers {
         }
 
         self.peers
-            .get(peer_id)
+            .get(&id)
             .map(|peer| *peer.connection_status())
             .unwrap_or(ConnectionStatus::Unknown)
     }
@@ -202,13 +261,13 @@ impl AllPeers {
     /// `ConnectionStatus::Disconnected`. It's important these peers are disconnected because
     /// dialing peers are counted towards the limit on inbound connections.
     pub(super) fn heartbeat_maintenance(&mut self) -> Vec<(PeerId, PeerAction)> {
-        let peers_to_disconnect: Vec<_> = self
+        let peers_to_disconnect: Vec<PeerId> = self
             .peers
             .iter()
-            .filter_map(|(peer_id, info)| {
+            .filter_map(|(id, info)| {
                 if let ConnectionStatus::Dialing { instant } = info.connection_status() {
                     if (*instant) + self.dial_timeout < Instant::now() {
-                        return Some(*peer_id);
+                        return Self::peer_id_for(id, info);
                     }
                 }
                 None
@@ -237,7 +296,7 @@ impl AllPeers {
             let update = peer.heartbeat();
             match update {
                 ReputationUpdate::Unbanned => {
-                    Some(*id)
+                    Self::peer_id_for(id, peer)
                 },
                 // filter other results and log error
                 ReputationUpdate::Banned | ReputationUpdate::Disconnect => {
@@ -359,7 +418,8 @@ impl AllPeers {
         multiaddr: Multiaddr,
         direction: ConnectionDirection,
     ) -> PeerAction {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             // update counters based on previous state
             match current_status {
                 ConnectionStatus::Disconnected { .. } => {
@@ -393,7 +453,8 @@ impl AllPeers {
         peer_id: &PeerId,
         current_status: ConnectionStatus,
     ) -> PeerAction {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             match current_status {
                 ConnectionStatus::Banned { .. } => {
                     warn!(target: "peer-manager", ?peer_id, "dialing a banned peer");
@@ -441,7 +502,8 @@ impl AllPeers {
             | ConnectionStatus::Connected { .. }
             | ConnectionStatus::Dialing { .. } => {
                 self.disconnected_peers += 1;
-                if let Some(peer) = self.peers.get_mut(peer_id) {
+                let id = self.identity_for(peer_id);
+                if let Some(peer) = self.peers.get_mut(&id) {
                     peer.set_connection_status(ConnectionStatus::Disconnected {
                         instant: Instant::now(),
                     });
@@ -466,7 +528,8 @@ impl AllPeers {
         debug!(target: "peer-manager", ?already_banned_ips, "handle disconnected and banned");
 
         // update peer's status
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             peer.set_connection_status(ConnectionStatus::Banned { instant: Instant::now() });
             self.banned_peers.add_banned_peer(peer);
             let banned_ips = peer
@@ -484,7 +547,8 @@ impl AllPeers {
     /// Handle disconnected state for a peer that was disconnected without being banned.
     fn handle_disconnected_normal(&mut self, peer_id: &PeerId) -> PeerAction {
         self.disconnected_peers += 1;
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             peer.set_connection_status(ConnectionStatus::Disconnected { instant: Instant::now() });
         }
 
@@ -499,7 +563,8 @@ impl AllPeers {
         banned: bool,
     ) -> PeerAction {
         // set the peer to disconnecting state
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             peer.set_connection_status(ConnectionStatus::Disconnecting { banned });
         }
 
@@ -531,7 +596,8 @@ impl AllPeers {
         peer_id: &PeerId,
         current_state: ConnectionStatus,
     ) -> PeerAction {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             match current_state {
                 ConnectionStatus::Disconnected { .. } => {
                     self.banned_peers.add_banned_peer(peer);
@@ -584,7 +650,8 @@ impl AllPeers {
         peer_id: &PeerId,
         current_state: ConnectionStatus,
     ) -> PeerAction {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             if matches!(peer.reputation(), Reputation::Banned) {
                 error!(target: "peer-manager", ?peer_id, "unbanning a banned peer");
             }
@@ -629,7 +696,7 @@ impl AllPeers {
 
     /// Return the [Peer] by [PeerId] if it is known.
     pub(super) fn get_peer(&self, peer_id: &PeerId) -> Option<&Peer> {
-        self.peers.get(peer_id)
+        self.peers.get(&self.identity_for(peer_id))
     }
 
     /// Boolean indicating if this peer is a validator.
@@ -640,7 +707,12 @@ impl AllPeers {
 
     /// Boolean indicating if this peer is in the current committee of voting validators.
     fn is_peer_cvv(&self, peer_id: &PeerId) -> bool {
-        self.current_committee.contains(peer_id)
+        match self.identity_for(peer_id) {
+            PeerIdentity::Confirmed(bls_public_key) => {
+                self.current_committee.contains(&bls_public_key)
+            }
+            PeerIdentity::Unidentified(_) => false,
+        }
     }
 
     /// Boolean indicating if the ip address is associated with a banned peer.
@@ -652,15 +724,15 @@ impl AllPeers {
     /// NOTE: the peer can still be in a connected status but pending a ban, so the connection
     /// status is not used.
     pub(super) fn peer_banned(&self, peer_id: &PeerId) -> bool {
-        self.peers.get(peer_id).is_some_and(|peer| {
+        self.get_peer(peer_id).is_some_and(|peer| {
             peer.reputation().banned() || peer.known_ip_addresses().any(|ip| self.ip_banned(&ip))
         })
     }
 
     /// Gives the ids of all known connected peers.
-    pub(super) fn connected_peer_ids(&self) -> impl Iterator<Item = &PeerId> {
-        self.peers.iter().filter_map(|(peer_id, peer)| {
-            peer.connection_status().is_connected().then_some(peer_id)
+    pub(super) fn connected_peer_ids(&self) -> impl Iterator<Item = PeerId> + '_ {
+        self.peers.iter().filter_map(|(id, peer)| {
+            peer.connection_status().is_connected().then(|| Self::peer_id_for(id, peer)).flatten()
         })
     }
 
@@ -668,11 +740,12 @@ impl AllPeers {
     pub(super) fn connected_or_dialing_peers(&self) -> Vec<PeerId> {
         self.peers
             .iter()
-            .filter(|(_, peer)| {
+            .filter_map(|(id, peer)| {
                 let status = peer.connection_status();
-                status.is_connected() || status.is_dialing()
+                (status.is_connected() || status.is_dialing())
+                    .then(|| Self::peer_id_for(id, peer))
+                    .flatten()
             })
-            .map(|(peer_id, _)| *peer_id)
             .collect()
     }
 
@@ -680,7 +753,7 @@ impl AllPeers {
     ///
     /// Used when handling connection closed events from the swarm.
     pub(super) fn is_peer_connected_or_disconnecting(&self, peer_id: &PeerId) -> bool {
-        self.peers.get(peer_id).is_some_and(|peer| {
+        self.get_peer(peer_id).is_some_and(|peer| {
             matches!(
                 peer.connection_status(),
                 ConnectionStatus::Connected { .. } | ConnectionStatus::Disconnecting { .. }
@@ -707,9 +780,13 @@ impl AllPeers {
     ///
     /// The shuffle ensures peers with equal scores are sorted in a random order. Peers with the
     /// lowest score and are not part of the kademlia table are prioritized.
-    pub(super) fn connected_peers_by_score_and_routability(&self) -> Vec<(&PeerId, &Peer)> {
-        let mut connected_peers: Vec<_> =
-            self.peers.iter().filter(|(_, peer)| peer.connection_status().is_connected()).collect();
+    pub(super) fn connected_peers_by_score_and_routability(&self) -> Vec<(PeerId, &Peer)> {
+        let mut connected_peers: Vec<(PeerId, &Peer)> = self
+            .peers
+            .iter()
+            .filter(|(_, peer)| peer.connection_status().is_connected())
+            .filter_map(|(id, peer)| Self::peer_id_for(id, peer).map(|peer_id| (peer_id, peer)))
+            .collect();
 
         // shuffle here for unbiased tie-breakers
         connected_peers.shuffle(&mut rand::rng());
@@ -742,18 +819,17 @@ impl AllPeers {
         &self,
         excess: usize,
         filter: F,
-    ) -> BinaryHeap<(Reverse<Instant>, PeerId, Vec<IpAddr>)>
+    ) -> BinaryHeap<(Reverse<Instant>, PeerIdentity, Vec<IpAddr>)>
     where
         F: Fn(&ConnectionStatus) -> Option<Instant>,
     {
         // collection of peers to prune
         let mut excess_peers = BinaryHeap::with_capacity(excess);
 
-        for (peer_id, peer) in &self.peers {
+        for (id, peer) in &self.peers {
             if let Some(instant) = filter(peer.connection_status()) {
                 // min-heap sorted by instant (oldest first)
-                let entry =
-                    (Reverse(instant), *peer_id, peer.known_ip_addresses().collect::<Vec<_>>());
+                let entry = (Reverse(instant), *id, peer.known_ip_addresses().collect::<Vec<_>>());
 
                 if excess_peers.len() < excess {
                     // fill the heap until `excess` elements
@@ -786,10 +862,12 @@ impl AllPeers {
                 }
             });
 
-            for (_, peer_id, ip_addrs) in excess_peers {
-                self.peers.remove(&peer_id);
+            for (_, id, ip_addrs) in excess_peers {
+                let peer_id = self.evict(&id).and_then(|peer| Self::peer_id_for(&id, &peer));
                 let ips = self.banned_peers.remove_banned_peer(ip_addrs.clone().into_iter());
-                unbanned.push((peer_id, ips));
+                if let Some(peer_id) = peer_id {
+                    unbanned.push((peer_id, ips));
+                }
             }
         }
 
@@ -810,8 +888,8 @@ impl AllPeers {
             });
 
             // remove peer
-            for (_, peer_id, _) in excess_peers {
-                self.peers.remove(&peer_id);
+            for (_, id, _) in excess_peers {
+                self.evict(&id);
                 self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
             }
         }
@@ -835,11 +913,12 @@ impl AllPeers {
         let mut actions = Vec::with_capacity(committee.len());
         for (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. }) in committee {
             let peer_id: PeerId = pubkey.clone().into();
-            self.current_committee.insert(peer_id);
+            self.current_committee.insert(bls_key);
             self.current_committee_keys.insert(bls_key, Some(peer_id));
             // the NewConnectionStatus doesn't affect this call
             let status = self.ensure_peer_exists(&peer_id, &NewConnectionStatus::Unbanned);
-            // We have all our network settings so go ahead and make sure they are set.
+            // We have all our network settings so go ahead and make sure they are set. This also
+            // re-keys a peer first seen as `Unidentified` onto its `Confirmed` identity.
             self.upsert_peer(bls_key, pubkey, addr.clone());
 
             match status {
@@ -864,8 +943,9 @@ impl AllPeers {
                 | ConnectionStatus::Connected { .. } => { /* nothing to do */ }
             }
 
-            // already ensured peer exists
-            if let Some(peer) = self.peers.get_mut(&peer_id) {
+            // already ensured peer exists (and re-keyed onto its confirmed identity)
+            let id = self.identity_for(&peer_id);
+            if let Some(peer) = self.peers.get_mut(&id) {
                 // update peer regardless of connection status
                 peer.make_trusted();
                 peer.update_listening_addrs(addr);
@@ -883,13 +963,27 @@ impl AllPeers {
     /// of being banned (connected/disconnecting).
     pub(super) fn can_dial(&self, peer_id: &PeerId) -> bool {
         // unknown peers are eligible for dial attempts
-        self.peers.get(peer_id).map(|peer| peer.can_dial()).unwrap_or(true)
+        self.get_peer(peer_id).map(|peer| peer.can_dial()).unwrap_or(true)
     }
 
     /// Update a peer's status in the routing table.
     pub(super) fn update_routing_for_peer(&mut self, peer_id: &PeerId, routable: bool) {
-        if let Some(peer) = self.peers.get_mut(peer_id) {
+        let id = self.identity_for(peer_id);
+        if let Some(peer) = self.peers.get_mut(&id) {
             peer.update_routability(routable)
         }
+    }
+
+    /// Test-only: mutable access to a peer resolved by its libp2p [PeerId].
+    #[cfg(test)]
+    pub(super) fn get_peer_mut(&mut self, peer_id: &PeerId) -> Option<&mut Peer> {
+        let id = self.identity_for(peer_id);
+        self.peers.get_mut(&id)
+    }
+
+    /// Test-only: insert a peer keyed by its libp2p [PeerId] (an `Unidentified` peer).
+    #[cfg(test)]
+    pub(super) fn insert_unidentified(&mut self, peer_id: PeerId, peer: Peer) {
+        self.peers.insert(PeerIdentity::Unidentified(peer_id), peer);
     }
 }

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -43,17 +43,16 @@ pub(super) struct AllPeers {
     /// inbound or kad-dialed peers that have no known bls key yet are keyed by their libp2p
     /// [PeerId] (`Unidentified`).
     peers: HashMap<PeerIdentity, Peer>,
-    /// Resolution index from a libp2p [PeerId] to the [BlsPublicKey] of a `Confirmed` peer.
+    /// Inbound boundary resolver: maps a libp2p [PeerId] to the [BlsPublicKey] of a `Confirmed`
+    /// peer.
     ///
-    /// libp2p connection events only carry a [PeerId], so this index recovers the `Confirmed`
-    /// identity of a known peer. It is kept in lockstep with the `Confirmed` entries in `peers`:
-    /// an entry exists here iff the peer is stored under a [PeerIdentity::Confirmed] key.
-    confirmed: HashMap<PeerId, BlsPublicKey>,
+    /// libp2p connection events only carry a [PeerId], so this is the single point where a libp2p
+    /// id is translated to the telcoin-domain identity that keys `peers`. It is kept in lockstep
+    /// with the `Confirmed` entries in `peers`: an entry exists here iff the peer is stored under a
+    /// [PeerIdentity::Confirmed] key.
+    bls_by_peer_id: HashMap<PeerId, BlsPublicKey>,
     /// The collection of staked current_committee at the beginning of each epoch.
     current_committee: HashSet<BlsPublicKey>,
-    /// The collection of staked current_committee pub key to peerid at the beginning of each
-    /// epoch.
-    current_committee_keys: HashMap<BlsPublicKey, Option<PeerId>>,
     /// Information for peers that scored poorly enough to become banned.
     banned_peers: BannedPeers,
     /// The number of peers that have disconnected from this node.
@@ -77,9 +76,8 @@ impl AllPeers {
     ) -> Self {
         Self {
             peers: Default::default(),
-            confirmed: Default::default(),
+            bls_by_peer_id: Default::default(),
             current_committee: Default::default(),
-            current_committee_keys: Default::default(),
             banned_peers: Default::default(),
             disconnected_peers: 0,
             pending_dials: Default::default(),
@@ -94,7 +92,7 @@ impl AllPeers {
     /// A peer is `Confirmed` once its bls key is known (committee/trusted/known peers); otherwise
     /// it is `Unidentified` and keyed by its libp2p id.
     fn identity_for(&self, peer_id: &PeerId) -> PeerIdentity {
-        self.confirmed
+        self.bls_by_peer_id
             .get(peer_id)
             .map_or(PeerIdentity::Unidentified(*peer_id), |bls_public_key| {
                 PeerIdentity::Confirmed(*bls_public_key)
@@ -112,12 +110,12 @@ impl AllPeers {
         }
     }
 
-    /// Remove a peer from the collection, keeping the `confirmed` resolution index in sync.
+    /// Remove a peer from the collection, keeping the `bls_by_peer_id` resolution index in sync.
     fn evict(&mut self, identity: &PeerIdentity) -> Option<Peer> {
         let removed = self.peers.remove(identity);
         if let (PeerIdentity::Confirmed(_), Some(peer)) = (identity, removed.as_ref()) {
             if let Some(peer_id) = peer.peer_id() {
-                self.confirmed.remove(&peer_id);
+                self.bls_by_peer_id.remove(&peer_id);
             }
         }
         removed
@@ -137,7 +135,7 @@ impl AllPeers {
         let _ = self.banned_peers.remove_banned_peer(trusted_peer.known_ip_addresses());
         // overwrite any prior record and key the peer by its confirmed (bls) identity
         self.peers.remove(&PeerIdentity::Unidentified(peer_id));
-        self.confirmed.insert(peer_id, bls_public_key);
+        self.bls_by_peer_id.insert(peer_id, bls_public_key);
         self.peers.insert(PeerIdentity::Confirmed(bls_public_key), trusted_peer);
     }
 
@@ -159,7 +157,7 @@ impl AllPeers {
             }
             None => Peer::new(bls_public_key, network_key, addrs),
         };
-        self.confirmed.insert(peer_id, bls_public_key);
+        self.bls_by_peer_id.insert(peer_id, bls_public_key);
         self.peers.insert(PeerIdentity::Confirmed(bls_public_key), peer);
     }
 
@@ -912,13 +910,11 @@ impl AllPeers {
     ) -> Vec<(PeerId, PeerAction)> {
         // update current committee
         self.current_committee.clear();
-        self.current_committee_keys.clear();
 
         let mut actions = Vec::with_capacity(committee.len());
         for (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. }) in committee {
             let peer_id: PeerId = pubkey.clone().into();
             self.current_committee.insert(bls_key);
-            self.current_committee_keys.insert(bls_key, Some(peer_id));
             // the NewConnectionStatus doesn't affect this call
             let status = self.ensure_peer_exists(&peer_id, &NewConnectionStatus::Unbanned);
             // We have all our network settings so go ahead and make sure they are set. This also

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -514,7 +514,7 @@ impl PeerManager {
             .iter()
             .filter_map(|(peer_id, peer)| {
                 if !self.is_peer_validator(peer_id) && !peer.is_trusted() {
-                    Some(**peer_id)
+                    Some(*peer_id)
                 } else {
                     None
                 }

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -132,6 +132,15 @@ impl Peer {
         self.bls_public_key
     }
 
+    /// This peer's libp2p [PeerId], derived from its network public key.
+    ///
+    /// Returns `None` if the network key is not yet known. The derivation is a pure,
+    /// total function of the network key, so any peer with a recorded bls key (which is
+    /// always set alongside the network key) also has a recoverable [PeerId].
+    pub(super) fn peer_id(&self) -> Option<PeerId> {
+        self.network_key.as_ref().map(|network_key| network_key.clone().into())
+    }
+
     /// Return a peer's reputation based on the aggregate score.
     pub(super) fn reputation(&self) -> Reputation {
         match self.score.aggregate_score() {

--- a/crates/network-libp2p/src/peers/types.rs
+++ b/crates/network-libp2p/src/peers/types.rs
@@ -10,6 +10,29 @@ use std::{
 use tn_types::{BlsPublicKey, NetworkPublicKey};
 use tokio::sync::oneshot;
 
+/// Domain identity for a tracked peer.
+///
+/// Telcoin associates a [BlsPublicKey] with a peer once its network settings are known
+/// (committee, trusted, or otherwise known peers). Until then a peer discovered through
+/// libp2p - an inbound connection or a kad-dialed candidate - is known only by its libp2p
+/// [PeerId]. This sum type captures that distinction so the domain key (the bls public key)
+/// is used wherever it is known, and the libp2p id only where it isn't.
+///
+/// `Confirmed` and `Unidentified` are distinct keys: a peer first seen as `Unidentified`
+/// is re-keyed onto its `Confirmed` identity once its bls key is learned.
+///
+/// The variants differ in size (a bls key is larger than a libp2p id), but this type is a
+/// `Copy` map key resolved on every libp2p connection event; boxing would forfeit `Copy` and
+/// add indirection to those lookups, so the inline layout is intentional.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(super) enum PeerIdentity {
+    /// A peer whose [BlsPublicKey] is known. This is the telcoin-domain identity.
+    Confirmed(BlsPublicKey),
+    /// A peer known only by its libp2p [PeerId] (no bls key learned yet).
+    Unidentified(PeerId),
+}
+
 /// Events for the `PeerManager`.
 #[derive(Debug)]
 pub(crate) enum PeerEvent {

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -31,8 +31,8 @@ fn test_add_trusted_peer() {
     let peer_id: PeerId = net.clone().into();
     all_peers.add_trusted_peer(bls, net, vec![addr.clone()]);
 
-    assert!(all_peers.peers.contains_key(&peer_id));
-    let peer = all_peers.peers.get_mut(&peer_id).unwrap();
+    assert!(all_peers.get_peer(&peer_id).is_some());
+    let peer = all_peers.get_peer_mut(&peer_id).unwrap();
     assert_eq!(peer.reputation(), Reputation::Trusted);
     assert_eq!(peer.score().aggregate_score(), config.max_score);
 
@@ -53,7 +53,7 @@ fn test_process_penalty() {
     // add connected peer first and set as this node dialed
     let mut peer = Peer::default_for_test();
     peer.set_connection_status(ConnectionStatus::Connected { num_in: 0, num_out: 1 });
-    all_peers.peers.insert(peer_id, peer);
+    all_peers.insert_unidentified(peer_id, peer);
 
     // test penalty that doesn't change reputation
     let action = all_peers.process_penalty(&peer_id, Penalty::Mild);
@@ -92,7 +92,7 @@ fn test_ensure_peer_exists() {
     // Unknown peer, valid initial state
     let status = all_peers.ensure_peer_exists(&peer_id, &NewConnectionStatus::Dialing);
     assert!(matches!(status, ConnectionStatus::Unknown));
-    assert!(all_peers.peers.contains_key(&peer_id));
+    assert!(all_peers.get_peer(&peer_id).is_some());
 
     // now peer exists with default status
     all_peers.peers.clear();
@@ -100,7 +100,7 @@ fn test_ensure_peer_exists() {
     assert!(matches!(status, ConnectionStatus::Unknown));
 
     // Check that peer is banned when new status is Banned
-    let peer = all_peers.peers.get(&peer_id).unwrap();
+    let peer = all_peers.get_peer(&peer_id).unwrap();
     assert_eq!(peer.reputation(), Reputation::Banned);
 }
 
@@ -184,7 +184,7 @@ fn test_heartbeat_maintenance() {
     all_peers.update_connection_status(&peer_id, NewConnectionStatus::Dialing);
 
     // Manually set the dialing time to be older than the timeout
-    if let Some(peer) = all_peers.peers.get_mut(&peer_id) {
+    if let Some(peer) = all_peers.get_peer_mut(&peer_id) {
         if peer.connection_status().is_dialing() {
             peer.set_connection_status(ConnectionStatus::Dialing {
                 instant: Instant::now() - Duration::from_secs(10),
@@ -196,7 +196,7 @@ fn test_heartbeat_maintenance() {
     let _ = all_peers.heartbeat_maintenance();
 
     // The peer should now be disconnected
-    let peer = all_peers.peers.get(&peer_id).unwrap();
+    let peer = all_peers.get_peer(&peer_id).unwrap();
     assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnected { .. }));
     assert_eq!(all_peers.disconnected_peers, 1);
 }
@@ -214,7 +214,7 @@ fn test_pruning_logic() {
         all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
 
         // Manually set disconnection time to be older for first peers
-        if let Some(peer) = all_peers.peers.get_mut(&peer_id) {
+        if let Some(peer) = all_peers.get_peer_mut(&peer_id) {
             let disconnected =
                 matches!(peer.connection_status(), ConnectionStatus::Disconnected { .. });
             if disconnected {
@@ -251,7 +251,7 @@ fn test_pruning_logic() {
         all_peers.update_connection_status(&peer_id, NewConnectionStatus::Banned);
 
         // Manually set banned time to be older for first peers
-        if let Some(peer) = all_peers.peers.get_mut(&peer_id) {
+        if let Some(peer) = all_peers.get_peer_mut(&peer_id) {
             let banned = matches!(peer.connection_status(), ConnectionStatus::Banned { .. });
             if banned {
                 // set a deterministic order - earlier IDs are older
@@ -276,9 +276,16 @@ fn test_pruning_logic() {
 #[test]
 fn test_is_validator() {
     ensure_score_config(None);
-    let validator_id = PeerId::random();
     let mut all_peers = AllPeers::new(Duration::from_secs(5), 10, 10);
-    all_peers.current_committee.insert(validator_id);
+
+    // a committee member is a confirmed peer (bls known) whose libp2p id resolves to its bls
+    let mut rng = StdRng::from_seed([0; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    let net: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let validator_id: PeerId = net.clone().into();
+    all_peers.upsert_peer(bls, net, vec![]);
+    all_peers.current_committee.insert(bls);
+
     assert!(all_peers.is_peer_validator(&validator_id));
     assert!(!all_peers.is_peer_validator(&PeerId::random()));
 }
@@ -361,7 +368,7 @@ fn test_connected_peer_methods() {
     // Test connected_peer_ids
     let connected_ids: Vec<_> = all_peers.connected_peer_ids().collect();
     assert_eq!(connected_ids.len(), 1);
-    assert!(connected_ids.contains(&&connected_peer_id));
+    assert!(connected_ids.contains(&connected_peer_id));
 
     // Test connected_or_dialing_peers
     let connected_or_dialing: Vec<_> = all_peers.connected_or_dialing_peers();


### PR DESCRIPTION
`AllPeers` previously keyed every peer by its libp2p `PeerId`, an implementation-level id, even though committee/trusted/known peers are identified in the telcoin domain by their `BlsPublicKey`.   A blanket `PeerId` -> `BlsPublicKey` swap is unsound: `AllPeers` also tracks anonymous inbound and kad-dialed peers that have no bls key (ensure_peer_exists inserts Peer::default()), and libp2p connection events only ever carry a `PeerId`.

Introduce a `PeerIdentity` sum type that captures the real invariant:

```
      enum PeerIdentity {
          Confirmed(BlsPublicKey),   // bls known (committee/trusted/known)
          Unidentified(PeerId),      // no bls learned yet
      }
```
`AllPeers.peers` is now keyed by `PeerIdentity` and `current_committee` by `BlsPublicKey`.  A private `PeerId -> BlsPublicKey` index (kept in lockstep with the Confirmed entries) resolves incoming libp2p events to the right key; the three bls-ingesting methods (`add_trusted_peer`, `upsert_peer`, `new_epoch`) promote a peer from `Unidentified` onto its `Confirmed` identity, preserving accumulated state.  Methods that return ids for libp2p calls recover the `PeerId` from the peer's network key.

The change is contained to the peers module: the `PeerManager` API, `PeerEvent`, and `PeerExchangeMap` (already bls-keyed) are unchanged, so no `PeerId` leaks across the crate boundary.


This relates to https://github.com/Telcoin-Association/telcoin-network/issues/710