### PR TITLE
Use `RethEnv` for TN RPC

### DIFF
--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use jsonrpsee::proc_macros::rpc;
-use tn_reth::ChainSpec;
+use tn_reth::RethEnv;
 use tn_types::{BlockHash, ConsensusHeader, Epoch, EpochCertificate, EpochRecord, Genesis};
 
 /// Telcoin Network RPC namespace.
@@ -47,8 +47,8 @@ pub trait TelcoinNetworkRpcExtApi {
 /// The type that implements `tn` namespace trait.
 #[derive(Debug)]
 pub struct TelcoinNetworkRpcExt<N: EngineToPrimary> {
-    /// The chain id for this node.
-    chain: ChainSpec,
+    /// Type to interact with EVM state.
+    evm_state: RethEnv,
     /// The inner-node network.
     ///
     /// The interface that handles primary <-> engine network communication.
@@ -72,7 +72,7 @@ where
     }
 
     async fn genesis(&self) -> TelcoinNetworkRpcResult<Genesis> {
-        Ok(self.chain.genesis().clone())
+        Ok(self.evm_state.chainspec().genesis().clone())
     }
 
     async fn epoch_record(
@@ -92,7 +92,7 @@ where
 
 impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
     /// Create new instance of the Telcoin Network RPC extension.
-    pub fn new(chain: ChainSpec, inner_node_network: N) -> Self {
-        Self { chain, inner_node_network }
+    pub fn new(evm_state: RethEnv, inner_node_network: N) -> Self {
+        Self { evm_state, inner_node_network }
     }
 }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -153,7 +153,7 @@ impl ExecutionNodeInner {
         transaction_pool.set_block_info(tx_pool_latest);
 
         // extend TN namespace
-        let tn_ext = TelcoinNetworkRpcExt::new(self.reth_env.chainspec(), engine_to_primary);
+        let tn_ext = TelcoinNetworkRpcExt::new(self.reth_env.clone(), engine_to_primary);
         let server = self.reth_env.get_rpc_server(
             transaction_pool.clone(),
             network.clone(),


### PR DESCRIPTION
- pass `RethEnv` to TN RPC for state queries
- replace `chain` field (available on `RethEnv`)