### PR TITLE
Use specific types for specific digests.

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -355,8 +355,8 @@ mod tests {
     };
     use tn_storage::{open_db, tables::NodeBatchesCache};
     use tn_types::{
-        gas_accumulator::GasAccumulator, test_genesis, BlockHash, Bytes, Certificate,
-        CommittedSubDag, ConsensusOutput, Database, GenesisAccount, TaskManager,
+        gas_accumulator::GasAccumulator, test_genesis, Bytes, Certificate, CommittedSubDag,
+        ConsensusHeaderDigest, ConsensusOutput, Database, GenesisAccount, TaskManager,
         MIN_PROTOCOL_BASE_FEE, U160, U256,
     };
     use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
@@ -646,7 +646,7 @@ mod tests {
         let mut headers = Vec::new();
         headers.push(leader_cert.header().clone());
         let subdag = CommittedSubDag::new_with_headers_for_test(headers);
-        let output = ConsensusOutput::new_with_subdag(subdag, BlockHash::default(), 0);
+        let output = ConsensusOutput::new_with_subdag(subdag, ConsensusHeaderDigest::default(), 0);
 
         // receive new blocks and return non-fatal errors
         // non-fatal errors cause the loop to break and wait for txpool updates

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -17,9 +17,9 @@ use tn_reth::{
 use tn_storage::{open_db, tables::NodeBatchesCache};
 use tn_types::{
     gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    test_genesis, Address, Batch, BatchValidation, BlockHash, Bytes, Certificate, CertifiedBatch,
-    CommittedSubDag, ConsensusOutput, Database, Encodable2718, GenesisAccount, ReputationScores,
-    SealedBatch, TaskManager, MIN_PROTOCOL_BASE_FEE, U160, U256,
+    test_genesis, Address, Batch, BatchValidation, Bytes, Certificate, CertifiedBatch,
+    CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database, Encodable2718,
+    GenesisAccount, ReputationScores, SealedBatch, TaskManager, MIN_PROTOCOL_BASE_FEE, U160, U256,
 };
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
 use tokio::time::timeout;
@@ -500,7 +500,7 @@ async fn test_canonical_notification_updates_pool() {
             None,
         )
         .into(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests,

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -19,7 +19,7 @@ use tn_types::{
     encode, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash, BlsSigner as _,
     CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusHeaderDigest,
     ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp,
-    TimestampSec, TnReceiver, TnSender, B256,
+    TimestampSec, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument, warn};
 

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -17,9 +17,9 @@ use tn_primary::{
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     encode, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash, BlsSigner as _,
-    CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusOutput, Database,
-    Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp, TimestampSec, TnReceiver, TnSender,
-    B256,
+    CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusHeaderDigest,
+    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp,
+    TimestampSec, TnReceiver, TnSender, B256,
 };
 use tracing::{debug, error, info, instrument, warn};
 
@@ -254,7 +254,7 @@ impl<DB: Database> Subscriber<DB> {
     ///
     /// This method is called on startup to retrieve the needed information to build the next
     /// `ConsensusHeader` off of this parent.
-    async fn get_last_executed_consensus(&self) -> SubscriberResult<(BlockHash, u64)> {
+    async fn get_last_executed_consensus(&self) -> SubscriberResult<(ConsensusHeaderDigest, u64)> {
         let result = last_consensus_parent(&self.consensus_bus, &self.inner.consensus_chain).await;
 
         info!(
@@ -434,7 +434,7 @@ impl<DB: Database> Subscriber<DB> {
     async fn fetch_batches(
         &self,
         sub_dag: CommittedSubDag,
-        parent_hash: B256,
+        parent_hash: ConsensusHeaderDigest,
         number: u64,
     ) -> SubscriberResult<ConsensusOutput> {
         let num_blocks = sub_dag.num_primary_batches();

--- a/crates/consensus/executor/tests/it/main.rs
+++ b/crates/consensus/executor/tests/it/main.rs
@@ -18,9 +18,9 @@ use tn_primary::{
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils::{create_signed_certificates_for_rounds, CommitteeFixture};
 use tn_types::{
-    now, test_chain_spec_arc, Batch, BlockHash, BlockNumHash, ExecHeader, Hash as _, HeaderBuilder,
-    HeaderDigest, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, WorkerId, B256,
-    DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    now, test_chain_spec_arc, Batch, BlockHash, ConsensusHeaderDigest, ConsensusNumHash,
+    ExecHeader, Hash as _, HeaderBuilder, HeaderDigest, SealedHeader, TaskManager, TnReceiver as _,
+    TnSender as _, WorkerId, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::sync::mpsc;
 
@@ -91,7 +91,11 @@ async fn test_output_to_header() -> eyre::Result<()> {
 
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     Consensus::spawn(
@@ -200,7 +204,11 @@ async fn test_executor_output_ordering() -> eyre::Result<()> {
 
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager2 = TaskManager::default();
     Consensus::spawn(
@@ -300,7 +308,11 @@ async fn test_executor_batch_fetching() -> eyre::Result<()> {
 
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager2 = TaskManager::default();
     Consensus::spawn(
@@ -488,7 +500,11 @@ async fn test_duplicate_batch_digest() -> eyre::Result<()> {
 
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager2 = TaskManager::default();
     Consensus::spawn(

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -16,8 +16,9 @@ use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    AuthorityIdentifier, BlockHash, BlockNumHash, EpochRecord, ExecHeader, Header, Notifier,
-    SealedHeader, TaskManager, TnReceiver, TnSender, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    AuthorityIdentifier, BlockHash, ConsensusHeaderDigest, ConsensusNumHash, EpochRecord,
+    ExecHeader, Header, Notifier, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
+    DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tracing::info;
 
@@ -434,7 +435,11 @@ async fn commit_one() {
     Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain, None).await;
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
 
     // Feed all certificates to the consensus. Only the last certificate should trigger
@@ -494,7 +499,7 @@ async fn dead_node() {
             .unwrap();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(0, ConsensusNumHash::default(), Some(dummy_parent))
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
@@ -629,7 +634,7 @@ async fn not_enough_support() {
             .unwrap();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(0, ConsensusNumHash::default(), Some(dummy_parent))
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
@@ -729,7 +734,7 @@ async fn missing_leader() {
             .unwrap();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(0, ConsensusNumHash::default(), Some(dummy_parent))
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
@@ -801,7 +806,7 @@ async fn committed_round_after_restart() {
         let cb = ConsensusBus::new();
         let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
         cb.app().recent_blocks().send_modify(|blocks| {
-            blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+            blocks.push_latest(0, ConsensusNumHash::default(), Some(dummy_parent))
         });
         let mut rx_primary = cb.subscribe_committed_own_headers();
         let mut rx_output = cb.subscribe_sequence();
@@ -1055,9 +1060,9 @@ async fn restart_with_new_committee() {
             committee: committee.bls_keys().iter().copied().collect(),
             next_committee: committee.bls_keys().iter().copied().collect(),
             parent_hash: prev_epoch_digest,
-            final_consensus: BlockNumHash {
+            final_consensus: ConsensusNumHash {
                 number: last.map(|l| l.number).unwrap_or_default(),
-                hash: BlockHash::default(),
+                hash: ConsensusHeaderDigest::default(),
             },
             ..Default::default()
         };
@@ -1065,7 +1070,7 @@ async fn restart_with_new_committee() {
         consensus_chain.new_epoch(previous_epoch, committee.clone()).await.unwrap();
         let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
         cb.app().recent_blocks().send_modify(|blocks| {
-            blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+            blocks.push_latest(0, ConsensusNumHash::default(), Some(dummy_parent))
         });
         let mut rx_output = cb.subscribe_sequence();
         let mut task_manager = TaskManager::default();

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -16,7 +16,7 @@ use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    AuthorityIdentifier, BlockHash, ConsensusHeaderDigest, ConsensusNumHash, EpochRecord,
+    AuthorityIdentifier, ConsensusHeaderDigest, ConsensusNumHash, EpochDigest, EpochRecord,
     ExecHeader, Header, Notifier, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
@@ -1031,7 +1031,7 @@ async fn restart_with_new_committee() {
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
     let temp_dir = TempDir::new().unwrap();
     let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
-    let mut prev_epoch_digest = BlockHash::default();
+    let mut prev_epoch_digest = EpochDigest::default();
 
     // Run for a few epochs.
     for epoch in 0..5 {

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -12,8 +12,9 @@ use tempfile::TempDir;
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    BlockNumHash, Certificate, ExecHeader, Hash as _, Header, HeaderDigest, ReputationScores,
-    SealedHeader, TaskManager, TnReceiver, TnSender, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    Certificate, ConsensusHeaderDigest, ConsensusNumHash, ExecHeader, Hash as _, Header,
+    HeaderDigest, ReputationScores, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
+    DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::fs::create_dir_all;
 
@@ -66,7 +67,11 @@ async fn test_consensus_recovery_with_bullshark() {
     let cb = ConsensusBus::new();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
@@ -159,7 +164,11 @@ async fn test_consensus_recovery_with_bullshark() {
     let cb = ConsensusBus::new();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
@@ -221,7 +230,11 @@ async fn test_consensus_recovery_with_bullshark() {
     let cb = ConsensusBus::new();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -18,9 +18,9 @@ use tn_config::Parameters;
 use tn_network_libp2p::types::NetworkEvent;
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
-    deconstruct_nonce, BlockHash, BlockNumHash, Certificate, CommittedSubDag, ConsensusHeader,
-    ConsensusOutput, Epoch, EpochRecord, EpochVote, Header, Round, TnReceiver, TnSender, B256,
-    CHANNEL_CAPACITY,
+    deconstruct_nonce, BlockNumHash, Certificate, CommittedSubDag, ConsensusHeader,
+    ConsensusHeaderDigest, ConsensusOutput, Epoch, EpochRecord, EpochVote, Header, Round,
+    TnReceiver, TnSender, CHANNEL_CAPACITY,
 };
 use tokio::{
     sync::{
@@ -215,7 +215,7 @@ pub struct ConsensusBusAppInner {
     /// Watch tracking most recently seen consensus header.
     tx_last_consensus_header: watch::Sender<Option<ConsensusHeader>>,
     /// Watch tracking the last gossipped consensus block number and hash.
-    tx_last_published_consensus_num_hash: watch::Sender<(Epoch, u64, BlockHash)>,
+    tx_last_published_consensus_num_hash: watch::Sender<(Epoch, u64, ConsensusHeaderDigest)>,
 
     /// Consensus header.  Note this can be used to create consensus output to execute for non
     /// validators.
@@ -238,7 +238,7 @@ pub struct ConsensusBusAppInner {
     epoch_request_queue_rx:
         Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<(EpochRecord, EpochRecord)>>>,
     /// Channel to request consensus headers to cache.
-    consensus_request_queue: QueChannel<(Epoch, u64, B256)>,
+    consensus_request_queue: QueChannel<(Epoch, u64, ConsensusHeaderDigest)>,
 }
 
 /// The thread-safe inner type that holds all the channels for inner-consensus
@@ -269,7 +269,7 @@ impl ConsensusBusApp {
         let (tx_primary_round_updates, _) = watch::channel(0u32);
         let (tx_last_consensus_header, _) = watch::channel(None);
         let (tx_last_published_consensus_num_hash, _) =
-            watch::channel((0, 0, BlockHash::default()));
+            watch::channel((0, 0, ConsensusHeaderDigest::default()));
 
         let (tx_recent_blocks, _) = watch::channel(RecentBlocks::new(recent_blocks as usize));
         let (tx_sync_status, _) = watch::channel(NodeMode::default());
@@ -393,7 +393,9 @@ impl ConsensusBusApp {
     /// Track the latest published consensus header block number and hash seen on the gossip
     /// network. This value will have been verified and can be trusted to be the correct hash
     /// for block number.  DO NOT send unverified values to this watch.
-    pub fn last_published_consensus_num_hash(&self) -> &watch::Sender<(Epoch, u64, BlockHash)> {
+    pub fn last_published_consensus_num_hash(
+        &self,
+    ) -> &watch::Sender<(Epoch, u64, ConsensusHeaderDigest)> {
         &self.inner.tx_last_published_consensus_num_hash
     }
 
@@ -418,7 +420,7 @@ impl ConsensusBusApp {
     }
 
     /// Returns the latest verified consensus block number and hash from gossip.
-    pub fn published_consensus_num_hash(&self) -> (Epoch, u64, BlockHash) {
+    pub fn published_consensus_num_hash(&self) -> (Epoch, u64, ConsensusHeaderDigest) {
         *self.inner.tx_last_published_consensus_num_hash.borrow()
     }
 
@@ -550,7 +552,7 @@ impl ConsensusBusApp {
     /// Note if the chain is not advancing this may never return.
     pub async fn wait_for_consensus_execution(
         &self,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     ) -> Result<(), WaitForExecutionElapsed> {
         let mut watch_execution_result = self.recent_blocks().subscribe();
         if self.recent_blocks().borrow().contains_consensus(hash) {
@@ -577,7 +579,7 @@ impl ConsensusBusApp {
         let parent_beacon_block_root = header.parent_beacon_block_root;
         if let Some(consensus_hash) = parent_beacon_block_root {
             consensus_chain
-                .consensus_header_by_digest(epoch, consensus_hash)
+                .consensus_header_by_digest(epoch, consensus_hash.into())
                 .await
                 .unwrap_or_default()
         } else {
@@ -652,12 +654,14 @@ impl ConsensusBusApp {
     }
 
     /// Channel to request consensus headers to be fetched and cached.
-    pub fn consensus_request_queue(&self) -> &impl TnSender<(Epoch, u64, B256)> {
+    pub fn consensus_request_queue(&self) -> &impl TnSender<(Epoch, u64, ConsensusHeaderDigest)> {
         &self.inner.consensus_request_queue
     }
 
     /// Subscribe to consensus header fetch queue.
-    pub fn subscribe_consensus_request_queue(&self) -> impl TnReceiver<(Epoch, u64, B256)> {
+    pub fn subscribe_consensus_request_queue(
+        &self,
+    ) -> impl TnReceiver<(Epoch, u64, ConsensusHeaderDigest)> {
         self.inner.consensus_request_queue.subscribe()
     }
 }

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -405,7 +405,7 @@ impl ConsensusBusApp {
         &self,
         epoch: Epoch,
         number: u64,
-        hash: B256,
+        hash: ConsensusHeaderDigest,
     ) -> bool {
         self.last_published_consensus_num_hash().send_if_modified(|state| {
             if number > state.1 {

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -5,7 +5,7 @@ use tn_network_libp2p::Penalty;
 use tn_storage::StoreError;
 use tn_types::{
     error::{CertificateError, HeaderError},
-    BcsError, BlockHash, BlsPublicKey, Epoch,
+    BcsError, BlockHash, BlsPublicKey, ConsensusHeaderDigest, Epoch,
 };
 
 /// Result alias for results that possibly return [`PrimaryNetworkError`].
@@ -37,10 +37,10 @@ pub(crate) enum PrimaryNetworkError {
     Internal(String),
     /// Unknown consensus header.
     #[error("Unknown consensus header: {0}")]
-    UnknownConsensusHeaderDigest(BlockHash),
+    UnknownConsensusHeaderDigest(ConsensusHeaderDigest),
     /// Unknown consensus header certificate.
     #[error("Unknown consensus header certificate for: {0}")]
-    UnknownConsensusHeaderCert(BlockHash),
+    UnknownConsensusHeaderCert(ConsensusHeaderDigest),
     /// Peer that is not committee published invalid gosip.
     /// Temparily disabled, will be back soon.
     #[error("Peer {0} is not in the committee!")]

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -5,7 +5,7 @@ use tn_network_libp2p::Penalty;
 use tn_storage::StoreError;
 use tn_types::{
     error::{CertificateError, HeaderError},
-    BcsError, BlockHash, BlsPublicKey, ConsensusHeaderDigest, Epoch,
+    BcsError, BlockHash, BlsPublicKey, ConsensusHeaderDigest, Epoch, EpochDigest,
 };
 
 /// Result alias for results that possibly return [`PrimaryNetworkError`].
@@ -50,7 +50,7 @@ pub(crate) enum PrimaryNetworkError {
     UnavailableEpoch(Epoch),
     /// Unavaliable epoch hash (either it is invalid or this node does not have it).
     #[error("Unknown epoch record digest: {0}")]
-    UnavailableEpochDigest(BlockHash),
+    UnavailableEpochDigest(EpochDigest),
     /// Invalid epoch request.
     #[error("Must suply an epoch or hash when requesting an epoch record")]
     InvalidEpochRequest,

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -24,8 +24,9 @@ use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
     now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlsPublicKey, Certificate,
-    ConsensusHeader, Database, Epoch, EpochCertificate, EpochRecord, Hash as _, Header,
-    HeaderDigest, ProtocolSignature, Round, SignatureVerificationState, TnSender as _, Vote, B256,
+    ConsensusHeader, ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochRecord,
+    Hash as _, Header, HeaderDigest, ProtocolSignature, Round, SignatureVerificationState,
+    TnSender as _, Vote, B256,
 };
 use tokio::{io::AsyncReadExt, sync::Mutex as TokioMutex, time::timeout};
 use tracing::{debug, error, info, warn};
@@ -845,7 +846,7 @@ where
     pub(super) async fn retrieve_consensus_header(
         &self,
         number: u64,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     ) -> PrimaryNetworkResult<PrimaryResponse> {
         let mut my_number = self.consensus_chain.latest_consensus_number();
         // If we are behind then wait up to two seconds to catch up.
@@ -885,7 +886,7 @@ where
     async fn get_header_by_hash(
         &self,
         number: u64,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     ) -> PrimaryNetworkResult<ConsensusHeader> {
         let epoch = self.consensus_chain.epochs().number_to_epoch(number);
         match self.consensus_chain.consensus_header_by_digest(epoch, hash).await {

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -24,9 +24,9 @@ use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
     now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlsPublicKey, Certificate,
-    ConsensusHeader, ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochRecord,
-    Hash as _, Header, HeaderDigest, ProtocolSignature, Round, SignatureVerificationState,
-    TnSender as _, Vote, B256,
+    ConsensusHeader, ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochDigest,
+    EpochRecord, Hash as _, Header, HeaderDigest, ProtocolSignature, Round,
+    SignatureVerificationState, TnSender as _, Vote, B256,
 };
 use tokio::{io::AsyncReadExt, sync::Mutex as TokioMutex, time::timeout};
 use tracing::{debug, error, info, warn};
@@ -871,7 +871,7 @@ where
     pub(super) async fn retrieve_epoch_record(
         &self,
         epoch: Option<Epoch>,
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
     ) -> PrimaryNetworkResult<PrimaryResponse> {
         let (record, certificate) = match (epoch, hash) {
             (_, Some(hash)) => self.get_epoch_by_hash(hash).await?,
@@ -921,7 +921,7 @@ where
     /// Retrieve the consensus header by hash
     async fn get_epoch_by_hash(
         &self,
-        hash: BlockHash,
+        hash: EpochDigest,
     ) -> PrimaryNetworkResult<(EpochRecord, EpochCertificate)> {
         match self.consensus_chain.epochs().get_epoch_by_hash(hash).await {
             Some((record, Some(cert))) => Ok((record, cert)),

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -10,8 +10,8 @@ use std::{
 use tn_network_libp2p::{types::IntoRpcError, PeerExchangeMap, TNMessage};
 use tn_types::{
     error::HeaderError, AuthorityIdentifier, BlockHash, BlsPublicKey, BlsSignature, Certificate,
-    ConsensusHeader, Epoch, EpochCertificate, EpochRecord, EpochVote, Header, HeaderDigest, Round,
-    Vote, B256,
+    ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochCertificate, EpochRecord, EpochVote,
+    Header, HeaderDigest, Round, Vote, B256,
 };
 
 /// Info that is published (via gossip) by validators once they reach consensus.
@@ -24,7 +24,7 @@ pub struct ConsensusResult {
     /// the consensus header block number
     pub number: u64,
     /// hash of the consensus header that was reached
-    pub hash: BlockHash,
+    pub hash: ConsensusHeaderDigest,
     /// the validator that produced this result
     pub validator: BlsPublicKey,
     /// the signature of the validator publishing this record
@@ -45,7 +45,12 @@ impl ConsensusResult {
     /// Used for generating the signature of the raw data.
     /// This will be the same for all validadors and is what signature signs
     /// (verifying all the data fields not just the hash).
-    pub fn digest_data(epoch: Epoch, round: Round, number: u64, hash: BlockHash) -> BlockHash {
+    pub fn digest_data(
+        epoch: Epoch,
+        round: Round,
+        number: u64,
+        hash: ConsensusHeaderDigest,
+    ) -> BlockHash {
         let mut hasher = tn_types::DefaultHashFunction::new();
         hasher.update(&epoch.to_be_bytes());
         hasher.update(&round.to_be_bytes());
@@ -110,7 +115,7 @@ pub enum PrimaryRequest {
         /// Block number requesting if not None.
         number: u64,
         /// Block hash requesting if not None.
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     },
     /// Exchange peer information.
     ///

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -10,8 +10,8 @@ use std::{
 use tn_network_libp2p::{types::IntoRpcError, PeerExchangeMap, TNMessage};
 use tn_types::{
     error::HeaderError, AuthorityIdentifier, BlockHash, BlsPublicKey, BlsSignature, Certificate,
-    ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochCertificate, EpochRecord, EpochVote,
-    Header, HeaderDigest, Round, Vote, B256,
+    ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochCertificate, EpochDigest, EpochRecord,
+    EpochVote, Header, HeaderDigest, Round, Vote, B256,
 };
 
 /// Info that is published (via gossip) by validators once they reach consensus.
@@ -132,7 +132,7 @@ pub enum PrimaryRequest {
         /// Block number requesting if not None.
         epoch: Option<Epoch>,
         /// Block hash requesting if not None.
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
     },
     /// Request to stream a pack file of the consensus data for epoch.
     StreamEpoch {

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -34,9 +34,9 @@ use tn_storage::{
     PayloadStore,
 };
 use tn_types::{
-    encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader,
-    ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochRecord, EpochVote, Header,
-    HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, B256,
+    encode, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader, ConsensusHeaderDigest,
+    Database, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote, Header, HeaderDigest,
+    Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, B256,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -309,7 +309,7 @@ impl PrimaryNetworkHandle {
     pub async fn request_epoch_cert(
         &self,
         epoch: Option<Epoch>,
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
     ) -> NetworkResult<(EpochRecord, EpochCertificate)> {
         let request = PrimaryRequest::EpochRecord { epoch, hash };
         // Try up to three times (from three peers) to get consensus.
@@ -742,7 +742,7 @@ where
         &self,
         peer: BlsPublicKey,
         epoch: Option<Epoch>,
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -34,9 +34,9 @@ use tn_storage::{
     PayloadStore,
 };
 use tn_types::{
-    encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader, Database, Epoch,
-    EpochCertificate, EpochRecord, EpochVote, Header, HeaderDigest, Round, TaskError, TaskSpawner,
-    TnReceiver, TnSender, Vote, B256,
+    encode, BlockHash, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader,
+    ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochRecord, EpochVote, Header,
+    HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, B256,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -147,7 +147,7 @@ impl PrimaryNetworkHandle {
         epoch: Epoch,
         round: Round,
         consensus_block_num: u64,
-        consensus_header_hash: BlockHash,
+        consensus_header_hash: ConsensusHeaderDigest,
         key: BlsPublicKey,
         signature: BlsSignature,
     ) -> NetworkResult<()> {
@@ -240,7 +240,7 @@ impl PrimaryNetworkHandle {
         &self,
         peer: BlsPublicKey,
         number: u64,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     ) -> NetworkResult<ConsensusHeader> {
         let request = PrimaryRequest::ConsensusHeader { number, hash };
         let res = self.handle.send_request(request, peer).await?;
@@ -269,7 +269,7 @@ impl PrimaryNetworkHandle {
     pub async fn request_consensus(
         &self,
         number: u64,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
     ) -> NetworkResult<ConsensusHeader> {
         const TIMEOUT: Duration = Duration::from_secs(10);
         let request = PrimaryRequest::ConsensusHeader { number, hash };
@@ -699,7 +699,7 @@ where
         &self,
         peer: BlsPublicKey,
         number: u64,
-        hash: BlockHash,
+        hash: ConsensusHeaderDigest,
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {

--- a/crates/consensus/primary/src/recent_blocks.rs
+++ b/crates/consensus/primary/src/recent_blocks.rs
@@ -1,7 +1,9 @@
 //! Track the most recent execution blocks for the consensus layer.
 
 use std::collections::VecDeque;
-use tn_types::{BlockHash, BlockNumHash, Round, SealedHeader};
+use tn_types::{
+    BlockHash, BlockNumHash, ConsensusHeaderDigest, ConsensusNumHash, Round, SealedHeader,
+};
 
 /// Tracks 'num_blocks' most recently executed block hashes and numbers.
 #[derive(Clone, Debug)]
@@ -12,7 +14,7 @@ pub struct RecentBlocks {
     executed_blocks: VecDeque<SealedHeader>,
     /// Recent consensus output number/hash (both skipped and executed).
     /// Used by `contains_consensus` to resolve wait_for_consensus_execution.
-    recent_consensus_num_hashes: VecDeque<BlockNumHash>,
+    recent_consensus_num_hashes: VecDeque<ConsensusNumHash>,
 }
 
 impl RecentBlocks {
@@ -38,7 +40,7 @@ impl RecentBlocks {
     pub fn push_latest(
         &mut self,
         latest_consensus_round: Round,
-        consensus_num_hash: BlockNumHash,
+        consensus_num_hash: ConsensusNumHash,
         latest_canonical_tip: Option<SealedHeader>,
     ) {
         self.last_consensus_round = latest_consensus_round;
@@ -87,14 +89,14 @@ impl RecentBlocks {
     }
 
     /// Is hash (consensus output) in a recent block we have executed?
-    pub fn contains_consensus(&self, hash: BlockHash) -> bool {
+    pub fn contains_consensus(&self, hash: ConsensusHeaderDigest) -> bool {
         // Check dedicated consensus num/hash tracker (covers both skipped and executed rounds)
         if self.recent_consensus_num_hashes.iter().any(|num_hash| num_hash.hash == hash) {
             return true;
         }
         // Fallback: check block's parent_beacon_block_root
         for block in &self.executed_blocks {
-            if block.parent_beacon_block_root == Some(hash) {
+            if block.parent_beacon_block_root == Some(hash.into()) {
                 return true;
             }
         }
@@ -102,7 +104,7 @@ impl RecentBlocks {
     }
 
     /// Return the number/hash of the latest processed consensus output.
-    pub fn latest_consensus_block_num_hash(&self) -> BlockNumHash {
+    pub fn latest_consensus_block_num_hash(&self) -> ConsensusNumHash {
         self.recent_consensus_num_hashes.back().copied().unwrap_or_else(Default::default)
     }
 
@@ -115,12 +117,12 @@ impl RecentBlocks {
 #[cfg(test)]
 mod tests {
     use super::RecentBlocks;
-    use tn_types::{BlockHash, BlockNumHash, ExecHeader, SealedHeader};
+    use tn_types::{ConsensusHeaderDigest, ConsensusNumHash, ExecHeader, SealedHeader};
 
     #[test]
     fn tracks_latest_consensus_num_hash_for_skipped_rounds() {
         let mut recent = RecentBlocks::new(4);
-        let consensus_num_hash = BlockNumHash::new(10, BlockHash::from([1u8; 32]));
+        let consensus_num_hash = ConsensusNumHash::new(10, ConsensusHeaderDigest::from([1u8; 32]));
 
         recent.push_latest(1, consensus_num_hash, None);
 
@@ -132,7 +134,7 @@ mod tests {
     #[test]
     fn tracks_latest_execution_and_consensus_after_execution() {
         let mut recent = RecentBlocks::new(4);
-        let consensus_num_hash = BlockNumHash::new(11, BlockHash::from([2u8; 32]));
+        let consensus_num_hash = ConsensusNumHash::new(11, ConsensusHeaderDigest::from([2u8; 32]));
         let mut header = ExecHeader::default();
         header.number = 7;
         let executed = SealedHeader::seal_slow(header);

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -24,8 +24,8 @@ use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
-    BlsPublicKey, Certificate, Database, Epoch, EpochVote, ExecHeader, Hash as _, HeaderDigest,
-    SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
+    BlsPublicKey, Certificate, ConsensusHeaderDigest, ConsensusNumHash, Database, Epoch, EpochVote,
+    ExecHeader, Hash as _, HeaderDigest, SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -96,7 +96,11 @@ async fn create_test_types_with_params(path: &Path, params: Option<Parameters>) 
 
     // set the latest execution result to genesis - test headers are proposed for round 1
     let mut recent = RecentBlocks::new(1);
-    recent.push_latest(0, BlockNumHash::new(0, B256::default()), Some(parent.clone()));
+    recent.push_latest(
+        0,
+        ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+        Some(parent.clone()),
+    );
     cb.app().recent_blocks().send_replace(recent);
 
     let consensus_chain =
@@ -135,7 +139,11 @@ async fn create_test_types_at_epoch(path: &Path, epoch: Epoch) -> TestTypes {
 
     // set the latest execution result to genesis - test headers are proposed for round 1
     let mut recent = RecentBlocks::new(1);
-    recent.push_latest(0, BlockNumHash::new(0, B256::default()), Some(parent.clone()));
+    recent.push_latest(
+        0,
+        ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+        Some(parent.clone()),
+    );
     cb.app().recent_blocks().send_replace(recent);
 
     let consensus_chain =
@@ -725,7 +733,7 @@ async fn test_behind_consensus_committed_round_prevents_false_positive() {
     // Without the fix: effective_exec_round = 18, 18 + 40 = 58 < 59 → false positive!
     // With the fix: effective_exec_round = max(0, 18, 59) = 59, 59 + 40 = 99 > 59 → correct.
     let mut recent = RecentBlocks::new(1);
-    recent.push_latest(18, BlockNumHash::new(0, B256::default()), None);
+    recent.push_latest(18, ConsensusNumHash::new(0, ConsensusHeaderDigest::default()), None);
     consensus_bus.recent_blocks().send_replace(recent);
 
     // Set committed round to 59 (as Bullshark would)
@@ -746,7 +754,7 @@ async fn test_behind_consensus_genuinely_behind() {
     // Incoming gossip is at round 60 in the same epoch.
     // effective_exec_round = max(0, 5, 5) = 5, gc_depth = 40, 5 + 40 = 45 < 60 → behind.
     let mut recent = RecentBlocks::new(1);
-    recent.push_latest(5, BlockNumHash::new(0, B256::default()), None);
+    recent.push_latest(5, ConsensusNumHash::new(0, ConsensusHeaderDigest::default()), None);
     consensus_bus.recent_blocks().send_replace(recent);
     consensus_bus.committed_round_updates().send_replace(5);
 

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -19,8 +19,9 @@ use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
-    error::HeaderError, now, AuthorityIdentifier, BlockNumHash, Certificate, Committee, ExecHeader,
-    Hash as _, SealedHeader, SignatureVerificationState, TaskManager, B256,
+    error::HeaderError, now, AuthorityIdentifier, BlockNumHash, Certificate, Committee,
+    ConsensusHeaderDigest, ConsensusNumHash, ExecHeader, Hash as _, SealedHeader,
+    SignatureVerificationState, TaskManager,
 };
 use tokio::time::timeout;
 
@@ -45,7 +46,11 @@ async fn test_request_vote_too_new() {
     // Need a dummy parent so we can request a vote.
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -112,7 +117,11 @@ async fn test_request_vote_has_missing_execution_block() {
     // Need a dummy parent so we can request a vote.
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -189,14 +198,18 @@ async fn test_request_vote_older_execution_block() {
     let dummy_hash = dummy_parent.hash();
     // This will be an "older" execution block, test this still works.
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let mut dummy = ExecHeader { nonce: 110_u64.into(), ..Default::default() };
     dummy.nonce = 110_u64.into();
     cb.app().recent_blocks().send_modify(|blocks| {
         blocks.push_latest(
             0,
-            BlockNumHash::new(0, B256::default()),
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
             Some(SealedHeader::seal_slow(dummy)),
         )
     });
@@ -204,7 +217,7 @@ async fn test_request_vote_older_execution_block() {
     cb.app().recent_blocks().send_modify(|blocks| {
         blocks.push_latest(
             0,
-            BlockNumHash::new(0, B256::default()),
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
             Some(SealedHeader::seal_slow(dummy)),
         )
     });
@@ -283,7 +296,11 @@ async fn test_request_vote_has_missing_parents() {
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     let dummy_hash = dummy_parent.hash();
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -397,7 +414,11 @@ async fn test_request_vote_accept_missing_parents() {
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     let dummy_hash = dummy_parent.hash();
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -501,7 +522,11 @@ async fn test_request_vote_missing_batches() {
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     let dummy_hash = dummy_parent.hash();
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -577,7 +602,11 @@ async fn test_request_vote_already_voted() {
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     let dummy_hash = dummy_parent.hash();
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =
@@ -824,7 +853,11 @@ async fn test_request_vote_created_at_in_future() {
     let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
     let dummy_hash = dummy_parent.hash();
     cb.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     let task_manager = TaskManager::default();
     let synchronizer =

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -28,8 +28,8 @@ use tn_test_utils::default_test_execution_node;
 use tn_types::{
     gas_accumulator::GasAccumulator, max_batch_gas, now, test_chain_spec_arc, test_genesis,
     Address, Batch, BlockHash, Bloom, Bytes, Certificate, CertifiedBatch, CommittedSubDag,
-    ConsensusOutput, Encodable2718, GenesisAccount, Hash as _, Notifier, ReputationScores,
-    SealedBlock, TaskManager, TransactionTrait as _, B256, EMPTY_WITHDRAWALS,
+    ConsensusHeaderDigest, ConsensusOutput, Encodable2718, GenesisAccount, Hash as _, Notifier,
+    ReputationScores, SealedBlock, TaskManager, TransactionTrait as _, B256, EMPTY_WITHDRAWALS,
     MIN_PROTOCOL_BASE_FEE, U256,
 };
 use tokio::{sync::oneshot, time::timeout};
@@ -64,7 +64,7 @@ fn calc_priority_fees(basefee: u64) -> u64 {
 fn assert_eip4788(
     reth_env: &RethEnv,
     block: &SealedBlock,
-    consensus_hash: B256,
+    consensus_hash: ConsensusHeaderDigest,
 ) -> eyre::Result<()> {
     // for EIP-4788, the storage slot is derived from the timestamp:
     //  - timestamp_slot = to_uint256_be(evm.timestamp) % HISTORY_BUFFER_LENGTH
@@ -83,7 +83,8 @@ fn assert_eip4788(
 
     // assert the block hash was correctly written to the contract
     let root_storage_slot = timestamp_storage_slot + U256::from(HISTORY_BUFFER_LENGTH);
-    let expected_blockhash = U256::from_be_bytes(consensus_hash.0);
+    let expected_blockhash: B256 = consensus_hash.into();
+    let expected_blockhash = U256::from_be_bytes(expected_blockhash.0);
     let stored_value =
         state_provider.storage(BEACON_ROOTS_ADDRESS, root_storage_slot.into())?.unwrap_or_default();
     assert_eq!(
@@ -151,7 +152,8 @@ async fn test_empty_output_skips_execution() -> eyre::Result<()> {
         reputation_scores,
         previous_sub_dag,
     );
-    let consensus_output = ConsensusOutput::new_with_subdag(sub_dag, BlockHash::default(), 0);
+    let consensus_output =
+        ConsensusOutput::new_with_subdag(sub_dag, ConsensusHeaderDigest::default(), 0);
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
     let reth_env = execution_node.get_reth_env().await;
@@ -256,8 +258,14 @@ async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()>
         reputation_scores,
         previous_sub_dag,
     );
-    let consensus_output =
-        ConsensusOutput::new(subdag, BlockHash::default(), 0, true, VecDeque::new(), vec![]);
+    let consensus_output = ConsensusOutput::new(
+        subdag,
+        ConsensusHeaderDigest::default(),
+        0,
+        true,
+        VecDeque::new(),
+        vec![],
+    );
     let consensus_output_hash = consensus_output.consensus_header_hash();
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
@@ -353,10 +361,9 @@ async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()>
     // timestamp
     assert_eq!(expected_block.timestamp, consensus_output.committed_at());
     // parent beacon block root is output digest
-    assert_eq!(
-        expected_block.parent_beacon_block_root,
-        Some(consensus_output.consensus_header_hash())
-    );
+    let parent_beacon_block_root: Option<ConsensusHeaderDigest> =
+        expected_block.parent_beacon_block_root.map(|d| d.into());
+    assert_eq!(parent_beacon_block_root, Some(consensus_output.consensus_header_hash()));
     // first block's parent is expected to be genesis
     assert_eq!(expected_block.parent_hash, chain.genesis_hash());
     // expect state roots are different after writing parent hash to BEACON_ROOT_CONTRACT
@@ -431,8 +438,14 @@ async fn test_empty_output_increments_leader_count() -> eyre::Result<()> {
         reputation_scores,
         previous_sub_dag,
     );
-    let consensus_output =
-        ConsensusOutput::new(subdag, BlockHash::default(), 0, false, VecDeque::new(), vec![]);
+    let consensus_output = ConsensusOutput::new(
+        subdag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        VecDeque::new(),
+        vec![],
+    );
 
     // verify leader counts start at zero
     let address_counts = gas_accumulator.rewards_counter().get_address_counts();
@@ -716,7 +729,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     );
     let consensus_output_1 = ConsensusOutput::new(
         subdag_1.clone(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests_1.clone(),
@@ -928,7 +941,9 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
         // timestamp
         assert_eq!(block.timestamp, expected_output.committed_at());
         // parent beacon block root is output digest
-        assert_eq!(block.parent_beacon_block_root, Some(expected_parent_beacon_block_root));
+        let parent_beacon_block_root: Option<ConsensusHeaderDigest> =
+            block.parent_beacon_block_root.map(|d| d.into());
+        assert_eq!(parent_beacon_block_root, Some(expected_parent_beacon_block_root));
 
         if idx == 0 {
             // first block's parent is expected to be genesis
@@ -1227,7 +1242,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     );
     let consensus_output_1 = ConsensusOutput::new(
         subdag_1.clone(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests_1.clone(),
@@ -1470,7 +1485,9 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
         // timestamp
         assert_eq!(block.timestamp, expected_output.committed_at());
         // parent beacon block root is output digest
-        assert_eq!(block.parent_beacon_block_root, Some(expected_parent_beacon_block_root));
+        let parent_beacon_block_root: Option<ConsensusHeaderDigest> =
+            block.parent_beacon_block_root.map(|d| d.into());
+        assert_eq!(parent_beacon_block_root, Some(expected_parent_beacon_block_root));
 
         if idx == 0 {
             // first block's parent is expected to be genesis
@@ -1607,7 +1624,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     );
     let consensus_output_1 = ConsensusOutput::new(
         subdag_1.clone(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests_1,
@@ -1842,7 +1859,7 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
     );
     let consensus_output = ConsensusOutput::new(
         subdag.clone(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests.clone(),
@@ -1987,7 +2004,9 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
         // timestamp
         assert_eq!(block.timestamp, consensus_output.committed_at());
         // parent beacon block root is output digest
-        assert_eq!(block.parent_beacon_block_root, Some(consensus_output_hash));
+        let parent_beacon_block_root: Option<ConsensusHeaderDigest> =
+            block.parent_beacon_block_root.map(|d| d.into());
+        assert_eq!(parent_beacon_block_root, Some(consensus_output_hash));
 
         if idx == 0 {
             // first block's parent is expected to be genesis
@@ -2003,7 +2022,8 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
         }
 
         // mix hash is xor batch's hash and consensus output digest
-        let expected_mix_hash = consensus_output_hash ^ batch_digest;
+        let consensus_output_hash_bytes: B256 = consensus_output_hash.into();
+        let expected_mix_hash = consensus_output_hash_bytes ^ batch_digest;
         assert_eq!(block.mix_hash, expected_mix_hash);
         // bloom expected to be the same bc all proposed transactions should be good
         // ie) no duplicates, etc.
@@ -2147,7 +2167,7 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
     );
     let consensus_output = ConsensusOutput::new(
         subdag.clone(),
-        BlockHash::default(),
+        ConsensusHeaderDigest::default(),
         0,
         false,
         batch_digests.clone(),

--- a/crates/execution/tn-rpc/src/lib.rs
+++ b/crates/execution/tn-rpc/src/lib.rs
@@ -7,8 +7,8 @@ mod rpc_ext;
 pub use rpc_ext::{TelcoinNetworkRpcExt, TelcoinNetworkRpcExtApiServer};
 use serde::Serialize;
 use tn_types::{
-    Address, AuthorityIdentifier, BlockHash, BlsPublicKey, ConsensusHeader, Epoch,
-    EpochCertificate, EpochRecord, Multiaddr, NetworkPublicKey,
+    Address, AuthorityIdentifier, BlsPublicKey, ConsensusHeader, Epoch, EpochCertificate,
+    EpochDigest, EpochRecord, Multiaddr, NetworkPublicKey,
 };
 
 /// Contain the node's identifying info to provide over RPC.
@@ -48,7 +48,7 @@ pub trait EngineToPrimary {
     fn epoch(
         &self,
         epoch: Option<Epoch>,
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
     ) -> impl std::future::Future<Output = Option<(EpochRecord, EpochCertificate)>> + Send;
     /// Return the node's static information.
     fn node_info(&self) -> &RpcNodeInfo;

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -7,7 +7,7 @@ use crate::{
 use async_trait::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use tn_reth::RethEnv;
-use tn_types::{BlockHash, ConsensusHeader, Epoch, EpochCertificate, EpochRecord, Genesis};
+use tn_types::{ConsensusHeader, Epoch, EpochCertificate, EpochDigest, EpochRecord, Genesis};
 
 /// Telcoin Network RPC namespace.
 ///
@@ -40,7 +40,7 @@ pub trait TelcoinNetworkRpcExtApi {
     #[method(name = "epochRecordByHash")]
     async fn epoch_record_by_hash(
         &self,
-        hash: BlockHash,
+        hash: EpochDigest,
     ) -> TelcoinNetworkRpcResult<(EpochRecord, EpochCertificate)>;
 }
 
@@ -84,7 +84,7 @@ where
 
     async fn epoch_record_by_hash(
         &self,
-        hash: BlockHash,
+        hash: EpochDigest,
     ) -> TelcoinNetworkRpcResult<(EpochRecord, EpochCertificate)> {
         self.inner_node_network.epoch(None, Some(hash)).await.ok_or(TNRpcError::NotFound)
     }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -18,8 +18,8 @@ use tn_reth::{
 use tn_rpc::{EngineToPrimary, TelcoinNetworkRpcExt, TelcoinNetworkRpcExtApiServer};
 use tn_types::{
     gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    Address, BatchSender, BatchValidation, BlockHeader, BlsPublicKey, ConsensusOutput,
-    EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId, B256,
+    Address, BatchSender, BatchValidation, BlockHeader, BlsPublicKey, ConsensusHeaderDigest,
+    ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId,
     MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::WorkerNetworkHandle;
@@ -206,7 +206,7 @@ impl ExecutionNodeInner {
     ///
     /// This returns the hash of the last executed ConsensusHeader on the consensus chain.
     /// since the execution layer is confirming the last executing block.
-    pub(super) fn last_executed_output(&self) -> eyre::Result<B256> {
+    pub(super) fn last_executed_output(&self) -> eyre::Result<ConsensusHeaderDigest> {
         // NOTE: The payload_builder only extends canonical tip and sets finalized after
         // entire output is successfully executed. This ensures consistent recovery state.
         //
@@ -223,7 +223,7 @@ impl ExecutionNodeInner {
             .map(|opt| opt.parent_beacon_block_root.unwrap_or_default())
             .unwrap_or_else(Default::default);
 
-        Ok(last_round_of_consensus)
+        Ok(last_round_of_consensus.into())
     }
 
     /// Return a vector of the last 'number' executed block headers.

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -21,8 +21,8 @@ use tn_reth::{
 use tn_rpc::EngineToPrimary;
 use tn_types::{
     gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    BatchSender, BatchValidation, BlsPublicKey, ConsensusOutput, EngineUpdate, Epoch, ExecHeader,
-    Noticer, SealedHeader, TaskSpawner, WorkerId, B256,
+    BatchSender, BatchValidation, BlsPublicKey, ConsensusHeaderDigest, ConsensusOutput,
+    EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::{mpsc, RwLock};
@@ -138,7 +138,7 @@ impl ExecutionNode {
     }
 
     /// Retrieve the last executed block from the database to restore consensus.
-    pub async fn last_executed_output(&self) -> eyre::Result<B256> {
+    pub async fn last_executed_output(&self) -> eyre::Result<ConsensusHeaderDigest> {
         let guard = self.internal.read().await;
         guard.last_executed_output()
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -9,7 +9,7 @@ use tn_config::{KeyConfig, TelcoinDirs};
 use tn_primary::ConsensusBusApp;
 use tn_rpc::{EngineToPrimary, RpcNodeInfo};
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{BlockHash, ConsensusHeader, Epoch, EpochCertificate, EpochRecord};
+use tn_types::{ConsensusHeader, Epoch, EpochCertificate, EpochDigest, EpochRecord};
 use tokio::task::JoinHandle;
 
 pub mod engine;
@@ -84,7 +84,10 @@ impl EngineToPrimaryRpc {
     }
 
     /// Retrieve the consensus header by hash
-    async fn get_epoch_by_hash(&self, hash: BlockHash) -> Option<(EpochRecord, EpochCertificate)> {
+    async fn get_epoch_by_hash(
+        &self,
+        hash: EpochDigest,
+    ) -> Option<(EpochRecord, EpochCertificate)> {
         if let Some((r, Some(c))) = self.consensus_chain.epochs().get_epoch_by_hash(hash).await {
             Some((r, c))
         } else {
@@ -101,7 +104,7 @@ impl EngineToPrimary for EngineToPrimaryRpc {
     async fn epoch(
         &self,
         epoch: Option<Epoch>,
-        hash: Option<BlockHash>,
+        hash: Option<EpochDigest>,
     ) -> Option<(EpochRecord, EpochCertificate)> {
         match (epoch, hash) {
             (_, Some(hash)) => self.get_epoch_by_hash(hash).await,

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -9,8 +9,8 @@ use tn_config::KeyConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, epoch_records::EpochRecordDb};
 use tn_types::{
-    BlsAggregateSignature, BlsPublicKey, BlsSignature, Epoch, EpochCertificate, EpochRecord,
-    EpochVote, Noticer, TaskSpawner, TnReceiver as _, B256,
+    BlsAggregateSignature, BlsPublicKey, BlsSignature, Epoch, EpochCertificate, EpochDigest,
+    EpochRecord, EpochVote, Noticer, TaskSpawner, TnReceiver as _,
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{error, info, warn};
@@ -76,7 +76,7 @@ async fn manage_epoch_votes(
     let mut reached_quorum = false;
     let mut timeout = Duration::from_millis(2500);
     let mut timeouts = 0;
-    let mut alt_recs: HashMap<B256, usize> = HashMap::default();
+    let mut alt_recs: HashMap<EpochDigest, usize> = HashMap::default();
     let mut committee_keys: HashSet<BlsPublicKey> = epoch_rec.committee.iter().copied().collect();
     let committee_size = committee_keys.len() as u64;
     let quorum = epoch_rec.super_quorum();

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -529,7 +529,7 @@ where
             let (epoch, round) = deconstruct_nonce(recent_block.nonce.into());
             let consensus_number = self
                 .consensus_chain
-                .consensus_header_by_digest(epoch, consensus_hash.into())
+                .consensus_header_by_digest(epoch, consensus_hash)
                 .await?
                 .map(|h| h.number)
                 .unwrap_or_default();

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -19,10 +19,10 @@ use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode, QueCh
 use tn_reth::{system_calls::EpochState, RethDb, RethEnv};
 use tn_storage::{consensus::ConsensusChain, open_db, DatabaseType};
 use tn_types::{
-    deconstruct_nonce, gas_accumulator::GasAccumulator, BlockNumHash, BlsPublicKey,
-    BootstrapServer, Committee, ConsensusHeader, ConsensusOutput, Database as TNDatabase,
-    EngineUpdate, Epoch, Notifier, TaskError, TaskManager, TaskSpawner, TimestampSec,
-    MIN_PROTOCOL_BASE_FEE,
+    deconstruct_nonce, gas_accumulator::GasAccumulator, BlsPublicKey, BootstrapServer, Committee,
+    ConsensusHeader, ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput,
+    Database as TNDatabase, EngineUpdate, Epoch, Notifier, TaskError, TaskManager, TaskSpawner,
+    TimestampSec, MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::{WorkerNetworkHandle, WorkerRequest, WorkerResponse};
 use tokio::sync::mpsc;
@@ -524,15 +524,16 @@ where
             // On restore, use the block's consensus hash from parent_beacon_block_root.
             // Round is set to 0 since we don't persist it; consensus number/hash still allows
             // wait_for_consensus_execution to resolve hash lookups.
-            let consensus_hash = recent_block.parent_beacon_block_root.unwrap_or_default();
+            let consensus_hash: ConsensusHeaderDigest =
+                recent_block.parent_beacon_block_root.unwrap_or_default().into();
             let (epoch, round) = deconstruct_nonce(recent_block.nonce.into());
             let consensus_number = self
                 .consensus_chain
-                .consensus_header_by_digest(epoch, consensus_hash)
+                .consensus_header_by_digest(epoch, consensus_hash.into())
                 .await?
                 .map(|h| h.number)
                 .unwrap_or_default();
-            let consensus_num_hash = BlockNumHash::new(consensus_number, consensus_hash);
+            let consensus_num_hash = ConsensusNumHash::new(consensus_number, consensus_hash);
             self.consensus_bus.recent_blocks().send_modify(|blocks| {
                 blocks.push_latest(round, consensus_num_hash, Some(recent_block))
             });

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -42,8 +42,8 @@ use tn_storage::{
 use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlsPublicKey, BlsSigner,
     Committee, CommitteeBuilder, ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput,
-    Database as TNDatabase, Epoch, EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode,
-    TaskJoinError, TaskManager, TaskSpawner, TnReceiver, B256,
+    Database as TNDatabase, Epoch, EpochDigest, EpochRecord, Multiaddr, NetworkPublicKey, Notifier,
+    P2pNode, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -634,7 +634,7 @@ where
         let committee_keys = engine.validators_for_epoch(epoch).await?;
         let next_committee_keys = engine.validators_for_epoch(epoch + 1).await?;
         let parent_hash = if epoch == 0 {
-            B256::default()
+            EpochDigest::default()
         } else if let Some(prev) = self.consensus_chain.epochs().record_by_epoch(epoch - 1).await {
             if committee_keys != prev.next_committee {
                 error!(

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -40,10 +40,10 @@ use tn_storage::{
     },
 };
 use tn_types::{
-    gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
-    BlsSigner, Committee, CommitteeBuilder, ConsensusOutput, Database as TNDatabase, Epoch,
-    EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode, TaskJoinError, TaskManager,
-    TaskSpawner, TnReceiver, B256,
+    gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlsPublicKey, BlsSigner,
+    Committee, CommitteeBuilder, ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput,
+    Database as TNDatabase, Epoch, EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode,
+    TaskJoinError, TaskManager, TaskSpawner, TnReceiver, B256,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -55,9 +55,9 @@ const EPOCH_TASK_MANAGER: &str = "Epoch Task Manager";
 /// Result from replaying missed consensus outputs.
 struct ReplayResult {
     /// If the epoch boundary was crossed during replay, this is the hash to close the epoch with.
-    epoch_close_hash: Option<BlockHash>,
+    epoch_close_hash: Option<ConsensusHeaderDigest>,
     /// The hash of the last consensus output that was actually forwarded to the engine.
-    last_replayed_hash: Option<BlockHash>,
+    last_replayed_hash: Option<ConsensusHeaderDigest>,
 }
 
 /// Modes for an epoch.
@@ -554,7 +554,7 @@ where
         &mut self,
         consensus_output: &mut impl TnReceiver<ConsensusOutput>,
         to_engine: &mpsc::Sender<ConsensusOutput>,
-    ) -> Option<BlockHash> {
+    ) -> Option<ConsensusHeaderDigest> {
         // Phase 1: Drain broadcast channel (existing behavior)
         while let Ok(output) = consensus_output.try_recv() {
             let result = if output.committed_at() >= self.epoch_boundary {
@@ -668,7 +668,7 @@ where
             next_committee: next_committee_keys,
             parent_hash,
             final_state: parent_state,
-            final_consensus: BlockNumHash::new(last_consensus_header.number, target_hash),
+            final_consensus: ConsensusNumHash::new(last_consensus_header.number, target_hash),
         };
 
         self.consensus_chain.epochs().save_record(epoch_rec.clone()).await?;
@@ -684,7 +684,7 @@ where
         &mut self,
         to_engine: &mpsc::Sender<ConsensusOutput>,
         consensus_output: &mut impl TnReceiver<ConsensusOutput>,
-    ) -> eyre::Result<B256> {
+    ) -> eyre::Result<ConsensusHeaderDigest> {
         // receive output from consensus and forward to engine
         while let Some(mut output) = consensus_output.recv().await {
             // observe epoch boundary to initiate epoch transition
@@ -730,7 +730,7 @@ where
         &self,
         shutdown_consensus: Option<Notifier>,
         gas_accumulator: &GasAccumulator,
-        target_hash: B256,
+        target_hash: ConsensusHeaderDigest,
     ) -> eyre::Result<()> {
         // begin consensus shutdown while engine executes
         if let Some(s) = shutdown_consensus {

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -27,8 +27,8 @@ use tn_test_utils::{
     create_signed_certificates_for_rounds, default_test_execution_node, CommitteeFixture,
 };
 use tn_types::{
-    adiri_genesis, gas_accumulator::GasAccumulator, Batch, BlockNumHash, ExecHeader, Notifier,
-    SealedHeader, TaskManager, TnReceiver as _, TnSender as _, B256,
+    adiri_genesis, gas_accumulator::GasAccumulator, Batch, ConsensusHeaderDigest, ConsensusNumHash,
+    ExecHeader, Notifier, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, B256,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::{
@@ -508,7 +508,11 @@ async fn spawn_consensus(
     // spawn consensus to await certificates
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     consensus_bus.app().recent_blocks().send_modify(|blocks| {
-        blocks.push_latest(0, BlockNumHash::new(0, B256::default()), Some(dummy_parent))
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
     });
     Consensus::spawn(config, consensus_bus, bullshark, task_manager, consensus_chain, None).await;
 }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -12,8 +12,8 @@ use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusHeaderCache};
 use tn_types::{
-    Database as TNDatabase, Epoch, EpochRecord, Noticer, TaskSpawner, TnReceiver, TnSender as _,
-    B256,
+    ConsensusHeaderDigest, Database as TNDatabase, Epoch, EpochRecord, Noticer, TaskSpawner,
+    TnReceiver, TnSender as _,
 };
 use tracing::{debug, error, info, warn};
 
@@ -33,7 +33,7 @@ enum ConsensusHeaderResult {
 /// make is that the returned header matches the hash.
 async fn get_consensus_header<DB: TNDatabase>(
     number: u64,
-    hash: B256,
+    hash: ConsensusHeaderDigest,
     db: &DB,
     consensus_bus: &ConsensusBusApp,
     network: &PrimaryNetworkHandle,
@@ -260,7 +260,7 @@ pub async fn spawn_fetch_consensus(
 /// Start at number/hash and work backwards to end number.
 async fn get_consensus_header_range<DB: TNDatabase>(
     number: u64,
-    hash: B256,
+    hash: ConsensusHeaderDigest,
     db: &DB,
     consensus_bus: &ConsensusBusApp,
     network: &PrimaryNetworkHandle,
@@ -314,7 +314,7 @@ async fn manage_new_consensus<DB: TNDatabase>(
     tasks: Arc<AtomicI32>,
     epoch: Epoch,
     number: u64,
-    hash: B256,
+    hash: ConsensusHeaderDigest,
     first_gossipped_epoch: &mut Option<Epoch>,
     last_number: &mut Option<u64>,
     current_fetch_epoch: &mut Epoch,
@@ -371,7 +371,7 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
     consensus_chain: ConsensusChain,
     rx_shutdown: Noticer,
     task_spawner: TaskSpawner,
-    mut rx_consensus_request: impl TnReceiver<(Epoch, u64, B256)>,
+    mut rx_consensus_request: impl TnReceiver<(Epoch, u64, ConsensusHeaderDigest)>,
 ) {
     // Attempt to clear the consensus header cache on startup.
     // This should not really be needed (records are evicted as they are processed) but

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -23,7 +23,7 @@ const PACK_RECORD_TIMEOUT_SECS: u64 = 10;
 
 enum ConsensusHeaderResult {
     Done,
-    Continue(u64, B256),
+    Continue(u64, ConsensusHeaderDigest),
     Retry,
 }
 

--- a/crates/state-sync/src/epoch.rs
+++ b/crates/state-sync/src/epoch.rs
@@ -7,7 +7,9 @@ use std::{collections::BTreeSet, time::Duration};
 
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{BlsPublicKey, Epoch, EpochRecord, Noticer, TaskSpawner, B256};
+use tn_types::{
+    BlsPublicKey, ConsensusHeaderDigest, Epoch, EpochRecord, Noticer, TaskSpawner, B256,
+};
 use tracing::{debug, error, info};
 
 /// How long to wait before retrying a failed epoch record collection.
@@ -53,7 +55,7 @@ async fn collect_epoch_records(
     // Track the highest final_consensus seen across all downloaded epoch records.
     // We emit a single state-sync notification at the end rather than one per epoch,
     // to avoid flooding peers with concurrent request_consensus calls during catch-up.
-    let mut best_final_consensus: Option<(Epoch, u64, B256)> = None;
+    let mut best_final_consensus: Option<(Epoch, u64, ConsensusHeaderDigest)> = None;
     for epoch in last_epoch.. {
         // If we already have epoch record AND it's certificate then continue.
         if let Some((rec, Some(_))) = consensus_chain.epochs().get_epoch_by_number(epoch).await {
@@ -116,7 +118,7 @@ async fn collect_epoch_records(
                         "retrieved cert for epoch {epoch}: {epoch_hash} from a peer",
                     );
                     // Track the highest final_consensus across downloaded epochs.
-                    if final_consensus.hash != B256::default()
+                    if final_consensus.hash != ConsensusHeaderDigest::default()
                         && final_consensus.number
                             > best_final_consensus.map(|(_, n, _)| n).unwrap_or(0)
                     {
@@ -218,7 +220,7 @@ mod tests {
     use super::*;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
-    use tn_types::{BlockNumHash, BlsKeypair};
+    use tn_types::{BlockNumHash, BlsKeypair, ConsensusNumHash};
 
     /// Generate a deterministic test BLS public key from a seed.
     fn test_bls_key(seed: u8) -> BlsPublicKey {
@@ -234,7 +236,7 @@ mod tests {
             next_committee: vec![],
             parent_hash: B256::ZERO,
             final_state: BlockNumHash::default(),
-            final_consensus: BlockNumHash::default(),
+            final_consensus: ConsensusNumHash::default(),
         }
     }
 

--- a/crates/state-sync/src/epoch.rs
+++ b/crates/state-sync/src/epoch.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeSet, time::Duration};
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
-    BlsPublicKey, ConsensusHeaderDigest, Epoch, EpochRecord, Noticer, TaskSpawner, B256,
+    BlsPublicKey, ConsensusHeaderDigest, Epoch, EpochDigest, EpochRecord, Noticer, TaskSpawner,
 };
 use tracing::{debug, error, info};
 
@@ -84,7 +84,7 @@ async fn collect_epoch_records(
                         .get_committee_keys(0)
                         .await
                         .expect("always can retrieve epoch 0 committee");
-                    (B256::default(), committee)
+                    (EpochDigest::default(), committee)
                 } else if let Some(prev) = consensus_chain.epochs().record_by_epoch(epoch - 1).await
                 {
                     (prev.digest(), prev.next_committee.iter().copied().collect())
@@ -220,7 +220,7 @@ mod tests {
     use super::*;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
-    use tn_types::{BlockNumHash, BlsKeypair, ConsensusNumHash};
+    use tn_types::{BlockNumHash, BlsKeypair, ConsensusNumHash, B256};
 
     /// Generate a deterministic test BLS public key from a seed.
     fn test_bls_key(seed: u8) -> BlsPublicKey {
@@ -234,7 +234,7 @@ mod tests {
             epoch: 1,
             committee,
             next_committee: vec![],
-            parent_hash: B256::ZERO,
+            parent_hash: B256::ZERO.into(),
             final_state: BlockNumHash::default(),
             final_consensus: ConsensusNumHash::default(),
         }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -15,7 +15,8 @@ use tn_config::ConsensusConfig;
 use tn_primary::{ConsensusBusApp, NodeMode};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusHeaderCache};
 use tn_types::{
-    BlockHash, ConsensusHeader, ConsensusOutput, Database, Epoch, TaskError, TaskSpawner, TnSender,
+    ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, Database, Epoch, TaskError,
+    TaskSpawner, TnSender,
 };
 use tracing::{debug, error, info, warn};
 
@@ -128,7 +129,7 @@ pub async fn last_executed_consensus_block(
 pub async fn last_consensus_parent(
     consensus_bus: &ConsensusBusApp,
     consensus_chain: &ConsensusChain,
-) -> (BlockHash, u64) {
+) -> (ConsensusHeaderDigest, u64) {
     let last_executed =
         last_executed_consensus_block(consensus_bus, consensus_chain).await.unwrap_or_default();
     let last_db = consensus_chain

--- a/crates/state-sync/tests/it/main.rs
+++ b/crates/state-sync/tests/it/main.rs
@@ -10,7 +10,10 @@ use std::collections::{BTreeSet, VecDeque};
 use tempfile::TempDir;
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils_committee::CommitteeFixture;
-use tn_types::{CommittedSubDag, ConsensusHeader, ConsensusOutput, ReputationScores, B256};
+use tn_types::{
+    CommittedSubDag, ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, ReputationScores,
+    B256,
+};
 
 /// Test that save_consensus correctly persists ConsensusOutput to database.
 #[tokio::test]
@@ -33,7 +36,8 @@ async fn test_sync_save_consensus() {
     let sub_dag = CommittedSubDag::new(certificates.clone(), leader.clone(), 0, reputation, None);
 
     // Create ConsensusOutput using struct initialization
-    let output = ConsensusOutput::new(sub_dag, B256::ZERO, 1, false, VecDeque::new(), vec![]);
+    let output =
+        ConsensusOutput::new(sub_dag, B256::ZERO.into(), 1, false, VecDeque::new(), vec![]);
 
     // Save consensus using state_sync
     state_sync::save_consensus(output, &mut consensus_chain).await.unwrap();
@@ -66,8 +70,8 @@ async fn test_sync_parent_hash_chain() {
     let (_, headers) = fixture.headers_round(0, &genesis);
     let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
 
-    let mut parent_hash = B256::ZERO;
-    let mut saved_digests: Vec<B256> = vec![B256::ZERO]; // Genesis parent
+    let mut parent_hash: ConsensusHeaderDigest = B256::ZERO.into();
+    let mut saved_digests: Vec<ConsensusHeaderDigest> = vec![B256::ZERO.into()]; // Genesis parent
 
     for i in 1..=3u64 {
         let leader = certificates.last().cloned().unwrap();
@@ -122,12 +126,12 @@ async fn test_sync_lookup_by_hash() {
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
 
     let output =
-        ConsensusOutput::new(sub_dag.clone(), B256::ZERO, 1, false, VecDeque::new(), vec![]);
+        ConsensusOutput::new(sub_dag.clone(), B256::ZERO.into(), 1, false, VecDeque::new(), vec![]);
 
     state_sync::save_consensus(output, &mut consensus_chain).await.unwrap();
 
     // Compute the expected digest
-    let expected_digest = ConsensusHeader::digest_from_parts(B256::ZERO, &sub_dag, 1);
+    let expected_digest = ConsensusHeader::digest_from_parts(B256::ZERO.into(), &sub_dag, 1);
 
     // Verify we can look up by hash
     let by_hash = consensus_chain.consensus_header_by_digest(0, expected_digest).await.unwrap();
@@ -149,7 +153,7 @@ async fn test_digest_determinism() {
     let reputation = ReputationScores::new(&committee);
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
 
-    let parent_hash = B256::ZERO;
+    let parent_hash: ConsensusHeaderDigest = B256::ZERO.into();
     let number = 1u64;
 
     // Compute digest multiple times - must be identical
@@ -176,11 +180,11 @@ async fn test_digest_collision_resistance() {
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
 
     // Same subdag but different parent_hash
-    let digest_parent_zero = ConsensusHeader::digest_from_parts(B256::ZERO, &sub_dag, 1);
+    let digest_parent_zero = ConsensusHeader::digest_from_parts(B256::ZERO.into(), &sub_dag, 1);
     let mut different_parent = [0u8; 32];
     different_parent[31] = 1;
     let digest_parent_one =
-        ConsensusHeader::digest_from_parts(B256::from(different_parent), &sub_dag, 1);
+        ConsensusHeader::digest_from_parts(B256::from(different_parent).into(), &sub_dag, 1);
 
     assert_ne!(
         digest_parent_zero, digest_parent_one,
@@ -188,8 +192,8 @@ async fn test_digest_collision_resistance() {
     );
 
     // Same subdag and parent but different number
-    let digest_num_1 = ConsensusHeader::digest_from_parts(B256::ZERO, &sub_dag, 1);
-    let digest_num_2 = ConsensusHeader::digest_from_parts(B256::ZERO, &sub_dag, 2);
+    let digest_num_1 = ConsensusHeader::digest_from_parts(B256::ZERO.into(), &sub_dag, 1);
+    let digest_num_2 = ConsensusHeader::digest_from_parts(B256::ZERO.into(), &sub_dag, 2);
 
     assert_ne!(digest_num_1, digest_num_2, "Different number must produce different digest");
 }
@@ -214,7 +218,8 @@ async fn test_digest_mismatch_detection() {
     let sub_dag = CommittedSubDag::new(certificates, leader, 0, reputation, None);
 
     // Save block 1 with correct parent (ZERO)
-    let output1 = ConsensusOutput::new(sub_dag, B256::ZERO, 1, false, VecDeque::new(), vec![]);
+    let output1 =
+        ConsensusOutput::new(sub_dag, B256::ZERO.into(), 1, false, VecDeque::new(), vec![]);
     state_sync::save_consensus(output1, &mut consensus_chain).await.unwrap();
 
     // Get block 1's digest
@@ -224,7 +229,7 @@ async fn test_digest_mismatch_detection() {
     // Now simulate verification: if we compute digest with wrong parent, it won't match
     let mut wrong_parent_bytes = [0u8; 32];
     wrong_parent_bytes[31] = 99;
-    let wrong_parent = B256::from(wrong_parent_bytes);
+    let wrong_parent: ConsensusHeaderDigest = B256::from(wrong_parent_bytes).into();
     let computed_with_wrong_parent =
         ConsensusHeader::digest_from_parts(wrong_parent, &block1.sub_dag, 1);
 
@@ -236,7 +241,7 @@ async fn test_digest_mismatch_detection() {
 
     // Verify that correct parent produces matching digest
     let computed_with_correct_parent =
-        ConsensusHeader::digest_from_parts(B256::ZERO, &block1.sub_dag, 1);
+        ConsensusHeader::digest_from_parts(B256::ZERO.into(), &block1.sub_dag, 1);
     assert_eq!(
         computed_with_correct_parent, block1_digest,
         "Computed digest with correct parent must match stored digest"

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -366,7 +366,7 @@ impl ConsensusChain {
         timeout: Duration,
     ) -> Result<(), ConsensusChainError> {
         let epoch = epoch_record.epoch;
-        let epoch_final_hash: ConsensusHeaderDigest = epoch_record.final_consensus.hash.into();
+        let epoch_final_hash = epoch_record.final_consensus.hash;
         if let Ok(pack) = self.get_static(epoch).await {
             if let Some(last_header) = pack.latest_consensus_header().await {
                 if epoch_record.final_consensus.number == last_header.number
@@ -459,8 +459,7 @@ impl ConsensusChain {
             if let Some((epoch_record, _)) = self.epochs().get_epoch_by_number(epoch).await {
                 match pack.latest_consensus_header().await {
                     Some(last_header) => {
-                        let epoch_final_hash: ConsensusHeaderDigest =
-                            epoch_record.final_consensus.hash.into();
+                        let epoch_final_hash = epoch_record.final_consensus.hash;
                         if epoch_record.final_consensus.number == last_header.number
                             && epoch_final_hash == last_header.digest()
                         {

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -14,9 +14,9 @@ use std::{
 
 use parking_lot::Mutex;
 use tn_types::{
-    gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, BlockNumHash,
-    CommittedSubDag, Committee, ConsensusChainReader, ConsensusChainWriter, ConsensusHeader,
-    ConsensusOutput, Epoch, EpochRecord, ReadStream, Round, B256,
+    gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, CommittedSubDag,
+    Committee, ConsensusChainReader, ConsensusChainWriter, ConsensusHeader, ConsensusHeaderDigest,
+    ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, ReadStream, Round,
 };
 use tokio::{
     fs::File as AsyncFile,
@@ -310,7 +310,7 @@ impl ConsensusChain {
             epoch: 0,
             committee: committee.bls_keys().iter().copied().collect(),
             next_committee: committee.bls_keys().iter().copied().collect(),
-            final_consensus: BlockNumHash::new(1000, BlockHash::default()),
+            final_consensus: ConsensusNumHash::new(1000, ConsensusHeaderDigest::default()),
             ..Default::default()
         };
         me.new_epoch(rec.clone(), committee).await?;
@@ -366,10 +366,11 @@ impl ConsensusChain {
         timeout: Duration,
     ) -> Result<(), ConsensusChainError> {
         let epoch = epoch_record.epoch;
+        let epoch_final_hash: ConsensusHeaderDigest = epoch_record.final_consensus.hash.into();
         if let Ok(pack) = self.get_static(epoch).await {
             if let Some(last_header) = pack.latest_consensus_header().await {
                 if epoch_record.final_consensus.number == last_header.number
-                    && epoch_record.final_consensus.hash == last_header.digest()
+                    && epoch_final_hash == last_header.digest()
                 {
                     // If we already have a complete pack file then we are done, no need to
                     // stream...
@@ -404,7 +405,7 @@ impl ConsensusChain {
                         // the expected final_consensus then the entire pack
                         // file should be valid.
                         if epoch_record.final_consensus.number != last_header.number
-                            || epoch_record.final_consensus.hash != last_header.digest()
+                            || epoch_final_hash != last_header.digest()
                         {
                             // Invalid final consensus header...
                             return Err(ConsensusChainError::InvalidImport);
@@ -458,8 +459,10 @@ impl ConsensusChain {
             if let Some((epoch_record, _)) = self.epochs().get_epoch_by_number(epoch).await {
                 match pack.latest_consensus_header().await {
                     Some(last_header) => {
+                        let epoch_final_hash: ConsensusHeaderDigest =
+                            epoch_record.final_consensus.hash.into();
                         if epoch_record.final_consensus.number == last_header.number
-                            && epoch_record.final_consensus.hash == last_header.digest()
+                            && epoch_final_hash == last_header.digest()
                         {
                             drop(pack);
                             // Remove the other open file.
@@ -531,7 +534,7 @@ impl ConsensusChain {
     pub async fn consensus_header_by_digest(
         &self,
         epoch: Epoch,
-        digest: B256,
+        digest: ConsensusHeaderDigest,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
         if let Some(pack) = &self.current_pack() {
             if epoch == pack.epoch() {
@@ -659,7 +662,7 @@ impl ConsensusChain {
     pub async fn write_subdag_for_test(&self, number: u64, sub_dag: CommittedSubDag) {
         let output = ConsensusOutput::new(
             sub_dag,
-            BlockHash::default(),
+            ConsensusHeaderDigest::default(),
             number,
             false,
             VecDeque::new(),
@@ -744,7 +747,7 @@ impl ConsensusChainReader for ConsensusChain {
     async fn consensus_header_by_digest(
         &self,
         epoch: Epoch,
-        digest: B256,
+        digest: ConsensusHeaderDigest,
     ) -> eyre::Result<Option<ConsensusHeader>> {
         ConsensusChain::consensus_header_by_digest(self, epoch, digest).await.map_err(Into::into)
     }
@@ -972,7 +975,8 @@ mod test {
     use std::{sync::Arc, time::Duration};
 
     use tn_types::{
-        test_genesis, BlockHash, BlockNumHash, ConsensusHeader, Epoch, EpochRecord, Hash as _, B256,
+        test_genesis, ConsensusHeader, ConsensusHeaderDigest, ConsensusNumHash, Epoch, EpochRecord,
+        Hash as _,
     };
 
     use crate::{
@@ -1034,7 +1038,7 @@ mod test {
         }
         let last = outputs.last().unwrap();
         let mut epoch_record = previous_epoch.clone();
-        epoch_record.final_consensus = BlockNumHash::new(last.number(), last.digest().into());
+        epoch_record.final_consensus = ConsensusNumHash::new(last.number(), last.digest());
         for i in 0..num_outputs {
             let output_db =
                 consensus_chain.get_consensus_output_current(i as u64 + 1).await.unwrap();
@@ -1080,7 +1084,7 @@ mod test {
 
         let num_outputs = 100;
         let mut outputs = Vec::new();
-        let mut parent = BlockHash::default();
+        let mut parent = ConsensusHeaderDigest::default();
         for i in 0..num_outputs {
             let consensus_output =
                 make_test_output(&committee, i % 4, chain.clone(), (i as u64) + 1, parent);
@@ -1099,7 +1103,10 @@ mod test {
             committee: committee.bls_keys().iter().copied().collect(),
             next_committee: committee.bls_keys().iter().copied().collect(),
             parent_hash: previous_epoch.digest(),
-            final_consensus: BlockNumHash { number: 100, hash: BlockHash::default() },
+            final_consensus: ConsensusNumHash {
+                number: 100,
+                hash: ConsensusHeaderDigest::default(),
+            },
             ..Default::default()
         };
         let committee = committee.advance_epoch_for_test(1);
@@ -1129,7 +1136,10 @@ mod test {
             committee: committee.bls_keys().iter().copied().collect(),
             next_committee: committee.bls_keys().iter().copied().collect(),
             parent_hash: previous_epoch.digest(),
-            final_consensus: BlockNumHash { number: 200, hash: BlockHash::default() },
+            final_consensus: ConsensusNumHash {
+                number: 200,
+                hash: ConsensusHeaderDigest::default(),
+            },
             ..Default::default()
         };
         let committee = committee.advance_epoch_for_test(2);
@@ -1183,7 +1193,7 @@ mod test {
         // Now by digest
         for i in 0..(num_outputs * 3) {
             let epoch = (i / num_outputs) as Epoch;
-            let digest: B256 = outputs[i].digest().into();
+            let digest = outputs[i].digest();
             let header_db =
                 consensus_chain.consensus_header_by_digest(epoch, digest).await.unwrap().unwrap();
             assert_eq!(digest, header_db.digest(), "consensus headers mismatch (by digest) {i}");
@@ -1202,7 +1212,7 @@ mod test {
         }
         for i in 0..(num_outputs * 3) {
             let epoch = i / num_outputs;
-            let digest: B256 = outputs[i].digest().into();
+            let digest = outputs[i].digest();
             let header_db = consensus_chain
                 .consensus_header_by_digest(epoch as u32, digest)
                 .await

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -805,7 +805,7 @@ impl Inner {
         let mut parent_digest = if epoch == 0 {
             ConsensusHeader::default().digest()
         } else {
-            previous_epoch.final_consensus.hash.into()
+            previous_epoch.final_consensus.hash
         };
         let mut batches = HashSet::new();
         let mut referenced_batches = HashSet::new();

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -18,8 +18,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tn_types::{
     gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, BlockNumHash,
-    BlsPublicKey, CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusOutput,
-    Epoch, EpochRecord, Round, B256,
+    BlsPublicKey, CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader,
+    ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, Round, B256,
 };
 use tokio::{
     io::AsyncRead,
@@ -55,7 +55,7 @@ pub struct EpochMeta {
     pub genesis_exec_state: BlockNumHash,
     /// The hash of the last ['ConsensusHeader'] of the previous epoch.
     /// This is the "genesis" consensus ofder  this epoch.
-    pub genesis_consensus: BlockNumHash,
+    pub genesis_consensus: ConsensusNumHash,
 }
 
 /// Descriminant type for records in a Consensus Pack file.
@@ -93,8 +93,8 @@ impl PackRecord {
 enum PackMessage {
     ConsensusOutput(ConsensusOutput),
     ContainsConsensusHeaderNumber(u64, oneshot::Sender<bool>),
-    ContainsConsensusHeader(B256, oneshot::Sender<bool>),
-    ConsensusHeader(B256, oneshot::Sender<Option<ConsensusHeader>>),
+    ContainsConsensusHeader(ConsensusHeaderDigest, oneshot::Sender<bool>),
+    ConsensusHeader(ConsensusHeaderDigest, oneshot::Sender<Option<ConsensusHeader>>),
     ConsensusHeaderNumber(u64, oneshot::Sender<Result<ConsensusHeader, PackError>>),
     GetConsensusOutput(u64, oneshot::Sender<Result<ConsensusOutput, PackError>>),
     Persist(oneshot::Sender<Result<(), PackError>>),
@@ -325,7 +325,7 @@ impl ConsensusPack {
     }
 
     /// True if consensus header by digest is found by digest.
-    pub async fn contains_consensus_header(&self, digest: B256) -> bool {
+    pub async fn contains_consensus_header(&self, digest: ConsensusHeaderDigest) -> bool {
         let (tx, rx) = oneshot::channel();
         if self.tx.send(PackMessage::ContainsConsensusHeader(digest, tx)).await.is_ok() {
             rx.await.unwrap_or(false)
@@ -335,7 +335,10 @@ impl ConsensusPack {
     }
 
     /// Retrieve a consensus header by digest.
-    pub async fn consensus_header_by_digest(&self, digest: B256) -> Option<ConsensusHeader> {
+    pub async fn consensus_header_by_digest(
+        &self,
+        digest: ConsensusHeaderDigest,
+    ) -> Option<ConsensusHeader> {
         let (tx, rx) = oneshot::channel();
         if self.tx.send(PackMessage::ConsensusHeader(digest, tx)).await.is_ok() {
             rx.await.unwrap_or(None)
@@ -802,7 +805,7 @@ impl Inner {
         let mut parent_digest = if epoch == 0 {
             ConsensusHeader::default().digest()
         } else {
-            previous_epoch.final_consensus.hash
+            previous_epoch.final_consensus.hash.into()
         };
         let mut batches = HashSet::new();
         let mut referenced_batches = HashSet::new();
@@ -859,7 +862,7 @@ impl Inner {
                         .append(&PackRecord::Consensus(consensus_header))
                         .map_err(|e| PackError::Append(e.to_string()))?;
                     consensus_digests
-                        .save(consensus_digest, position)
+                        .save(consensus_digest.into(), position)
                         .map_err(|e| PackError::IndexAppend(format!("consensus digest {e}")))?;
                     let consensus_idx_pos =
                         consensus_number.saturating_sub(epoch_meta.start_consensus_number);
@@ -923,7 +926,7 @@ impl Inner {
             .append(&PackRecord::Consensus(Box::new(consensus.consensus_header())))
             .map_err(|e| PackError::Append(e.to_string()))?;
         self.consensus_digests
-            .save(consensus_digest, position)
+            .save(consensus_digest.into(), position)
             .map_err(|e| PackError::IndexAppend(format!("consensus {e}")))?;
         self.consensus_idx
             .save(consensus_idx, position)
@@ -1006,11 +1009,11 @@ impl Inner {
     }
 
     /// True if consensus header is found by digest.
-    fn contains_consensus_header(&mut self, digest: B256) -> bool {
+    fn contains_consensus_header(&mut self, digest: ConsensusHeaderDigest) -> bool {
         // This is a bit more complicated (the pos file_len check) because in a very rare
         // case of repairing a damaged pack we might have something in the index not in the
         // pack file (yet).
-        if let Ok(pos) = self.consensus_digests.load(digest) {
+        if let Ok(pos) = self.consensus_digests.load(digest.into()) {
             pos < self.data.file_len()
         } else {
             false
@@ -1018,8 +1021,11 @@ impl Inner {
     }
 
     /// Retrieve a consensus header by digest.
-    fn consensus_header_by_digest(&mut self, digest: B256) -> Option<ConsensusHeader> {
-        let pos = self.consensus_digests.load(digest).ok()?;
+    fn consensus_header_by_digest(
+        &mut self,
+        digest: ConsensusHeaderDigest,
+    ) -> Option<ConsensusHeader> {
+        let pos = self.consensus_digests.load(digest.into()).ok()?;
         // This is not strickly needed, the fetch below will fail if
         // we try to read past the end of the file but this potentially
         // short circuits a lot of checks for a small cost.
@@ -1287,7 +1293,8 @@ pub(crate) mod test {
     use tn_test_utils::CommitteeFixture;
     use tn_types::{
         test_genesis, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
-        ConsensusHeader, ConsensusOutput, EpochRecord, Hash, HeaderBuilder, ReputationScores,
+        ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, EpochRecord, Hash, HeaderBuilder,
+        ReputationScores,
     };
 
     use crate::{
@@ -1300,7 +1307,7 @@ pub(crate) mod test {
         authority_index: usize,
         chain: Arc<RethChainSpec>,
         number: u64,
-        parent: BlockHash,
+        parent: ConsensusHeaderDigest,
     ) -> ConsensusOutput {
         let batches_1 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
         let authority_1 = committee

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use parking_lot::Mutex;
-use tn_types::{BlsPublicKey, Epoch, EpochCertificate, EpochRecord, B256};
+use tn_types::{BlsPublicKey, Epoch, EpochCertificate, EpochDigest, EpochRecord};
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     oneshot, watch,
@@ -42,17 +42,17 @@ enum EpochDbMessage {
     /// If the record is already stored, only the certificate is saved.
     Save(EpochRecord, EpochCertificate),
     /// Save an [`EpochCertificate`] keyed by its record digest.
-    SaveCertificate(B256, EpochCertificate),
+    SaveCertificate(EpochDigest, EpochCertificate),
     /// Retrieve an [`EpochRecord`] by epoch number.
     RecordByEpoch(Epoch, oneshot::Sender<Option<EpochRecord>>),
     /// Retrieve an [`EpochRecord`] by its digest.
-    RecordByDigest(B256, oneshot::Sender<Option<EpochRecord>>),
+    RecordByDigest(EpochDigest, oneshot::Sender<Option<EpochRecord>>),
     /// Retrieve an [`EpochCertificate`] by its epoch_hash digest.
-    CertByDigest(B256, oneshot::Sender<Option<EpochCertificate>>),
+    CertByDigest(EpochDigest, oneshot::Sender<Option<EpochCertificate>>),
     /// True if the database contains a record for the given epoch number.
     ContainsEpoch(Epoch, oneshot::Sender<bool>),
     /// True if the database contains a record with the given digest.
-    ContainsRecordDigest(B256, oneshot::Sender<bool>),
+    ContainsRecordDigest(EpochDigest, oneshot::Sender<bool>),
     /// Return the latest (highest epoch) [`EpochRecord`] stored, if any.
     LatestRecord(oneshot::Sender<Option<EpochRecord>>),
     /// Flush all pending writes to disk.
@@ -242,7 +242,7 @@ impl EpochRecordDb {
     /// Idempotent: returns `Ok(())` if a certificate for this digest is already stored.
     pub async fn save_certificate(
         &self,
-        digest: B256,
+        digest: EpochDigest,
         cert: EpochCertificate,
     ) -> Result<(), EpochDbError> {
         self.get_error()?;
@@ -284,7 +284,7 @@ impl EpochRecordDb {
     }
 
     /// Retrieve an [`EpochRecord`] by its digest.
-    pub async fn record_by_digest(&self, digest: B256) -> Option<EpochRecord> {
+    pub async fn record_by_digest(&self, digest: EpochDigest) -> Option<EpochRecord> {
         let (tx, rx) = oneshot::channel();
         if self.tx.send(EpochDbMessage::RecordByDigest(digest, tx)).await.is_ok() {
             rx.await.unwrap_or(None)
@@ -294,7 +294,7 @@ impl EpochRecordDb {
     }
 
     /// Retrieve an [`EpochCertificate`] by its `epoch_hash` digest.
-    pub async fn cert_by_digest(&self, digest: B256) -> Option<EpochCertificate> {
+    pub async fn cert_by_digest(&self, digest: EpochDigest) -> Option<EpochCertificate> {
         let (tx, rx) = oneshot::channel();
         if self.tx.send(EpochDbMessage::CertByDigest(digest, tx)).await.is_ok() {
             rx.await.unwrap_or(None)
@@ -314,7 +314,7 @@ impl EpochRecordDb {
     }
 
     /// True if the database contains a record with the given digest.
-    pub async fn contains_record_digest(&self, digest: B256) -> bool {
+    pub async fn contains_record_digest(&self, digest: EpochDigest) -> bool {
         let (tx, rx) = oneshot::channel();
         if self.tx.send(EpochDbMessage::ContainsRecordDigest(digest, tx)).await.is_ok() {
             rx.await.unwrap_or(false)
@@ -375,7 +375,7 @@ impl EpochRecordDb {
     /// Retrieve the epoch record and certificate (if available) by record digest.
     pub async fn get_epoch_by_hash(
         &self,
-        hash: B256,
+        hash: EpochDigest,
     ) -> Option<(EpochRecord, Option<EpochCertificate>)> {
         let record = self.record_by_digest(hash).await?;
         let cert = self.cert_by_digest(record.digest()).await;
@@ -578,7 +578,7 @@ impl Inner {
         let record_pos =
             self.records.append(&record).map_err(|e| EpochDbError::Append(e.to_string()))?;
         self.record_digests
-            .save(record_digest, record_pos)
+            .save(record_digest.into(), record_pos)
             .map_err(|e| EpochDbError::IndexAppend(format!("record digest: {e}")))?;
         self.epoch_idx
             .save(idx, record_pos)
@@ -597,13 +597,13 @@ impl Inner {
         self.save_record(record)?;
 
         // Skip if the cert is already stored.
-        if self.cert_digests.load(record_digest).is_ok() {
+        if self.cert_digests.load(record_digest.into()).is_ok() {
             return Ok(());
         }
 
         let cert_pos = self.certs.append(&cert).map_err(|e| EpochDbError::Append(e.to_string()))?;
         self.cert_digests
-            .save(record_digest, cert_pos)
+            .save(record_digest.into(), cert_pos)
             .map_err(|e| EpochDbError::IndexAppend(format!("cert digest: {e}")))?;
         self.cert_digests.set_data_file_length(self.certs.file_len());
         Ok(())
@@ -612,15 +612,15 @@ impl Inner {
     /// Save an [`EpochCertificate`] keyed by `digest`. Idempotent.
     fn save_certificate(
         &mut self,
-        digest: B256,
+        digest: EpochDigest,
         cert: EpochCertificate,
     ) -> Result<(), EpochDbError> {
-        if self.cert_digests.load(digest).is_ok() {
+        if self.cert_digests.load(digest.into()).is_ok() {
             return Ok(());
         }
         let cert_pos = self.certs.append(&cert).map_err(|e| EpochDbError::Append(e.to_string()))?;
         self.cert_digests
-            .save(digest, cert_pos)
+            .save(digest.into(), cert_pos)
             .map_err(|e| EpochDbError::IndexAppend(format!("cert digest: {e}")))?;
         self.cert_digests.set_data_file_length(self.certs.file_len());
         Ok(())
@@ -638,13 +638,13 @@ impl Inner {
         }
     }
 
-    fn record_by_digest(&mut self, digest: B256) -> Option<EpochRecord> {
-        let pos = self.record_digests.load(digest).ok()?;
+    fn record_by_digest(&mut self, digest: EpochDigest) -> Option<EpochRecord> {
+        let pos = self.record_digests.load(digest.into()).ok()?;
         self.records.fetch(pos).ok()
     }
 
-    fn cert_by_digest(&mut self, digest: B256) -> Option<EpochCertificate> {
-        let pos = self.cert_digests.load(digest).ok()?;
+    fn cert_by_digest(&mut self, digest: EpochDigest) -> Option<EpochCertificate> {
+        let pos = self.cert_digests.load(digest.into()).ok()?;
         self.certs.fetch(pos).ok()
     }
 
@@ -659,8 +659,8 @@ impl Inner {
         }
     }
 
-    fn contains_record_digest(&mut self, digest: B256) -> bool {
-        if let Ok(pos) = self.record_digests.load(digest) {
+    fn contains_record_digest(&mut self, digest: EpochDigest) -> bool {
+        if let Ok(pos) = self.record_digests.load(digest.into()) {
             pos < self.records.file_len()
         } else {
             false
@@ -756,8 +756,8 @@ mod test {
     use tempfile::TempDir;
     use tn_types::{
         BlsAggregateSignature, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner,
-        ConsensusHeaderDigest, ConsensusNumHash, Epoch, EpochCertificate, EpochRecord, Signer as _,
-        B256,
+        ConsensusHeaderDigest, ConsensusNumHash, Epoch, EpochCertificate, EpochDigest, EpochRecord,
+        Signer as _,
     };
 
     use crate::epoch_records::{EpochRecordDb, RECORDS_NAME};
@@ -786,7 +786,7 @@ mod test {
     fn make_test_pair(
         epoch: Epoch,
         signers: &[TestSigner],
-        parent_hash: B256,
+        parent_hash: EpochDigest,
     ) -> (EpochRecord, EpochCertificate) {
         let committee: Vec<BlsPublicKey> = signers.iter().map(|s| s.public_key()).collect();
         let record = EpochRecord {
@@ -825,7 +825,7 @@ mod test {
 
         let num_records: u32 = 20;
         let mut pairs = Vec::new();
-        let mut parent = B256::default();
+        let mut parent = EpochDigest::default();
         for epoch in 0..num_records {
             let (record, cert) = make_test_pair(epoch, &signers, parent);
             parent = record.digest();

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -755,8 +755,9 @@ mod test {
     use roaring::RoaringBitmap;
     use tempfile::TempDir;
     use tn_types::{
-        BlockNumHash, BlsAggregateSignature, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner,
-        Epoch, EpochCertificate, EpochRecord, Signer as _, B256,
+        BlsAggregateSignature, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner,
+        ConsensusHeaderDigest, ConsensusNumHash, Epoch, EpochCertificate, EpochRecord, Signer as _,
+        B256,
     };
 
     use crate::epoch_records::{EpochRecordDb, RECORDS_NAME};
@@ -793,7 +794,10 @@ mod test {
             committee: committee.clone(),
             next_committee: committee,
             parent_hash,
-            final_consensus: BlockNumHash::new((epoch as u64 + 1) * 10, B256::default()),
+            final_consensus: ConsensusNumHash::new(
+                (epoch as u64 + 1) * 10,
+                ConsensusHeaderDigest::default(),
+            ),
             ..Default::default()
         };
 

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -118,9 +118,10 @@ use tn_config::{
 use tn_types::{
     deconstruct_nonce,
     gas_accumulator::{RewardsCounter, WorkerFeeConfig},
-    Address, BlockBody, BlockHashOrNumber, BlockNumHash, BlockNumber, EngineUpdate, Epoch,
-    ExecHeader, Genesis, GenesisAccount, RecoveredBlock, Round, SealedBlock, SealedHeader,
-    TaskManager, TaskSpawner, TransactionSigned, B256, ETHEREUM_BLOCK_GAS_LIMIT_30M, U256,
+    Address, BlockBody, BlockHashOrNumber, BlockNumHash, BlockNumber, ConsensusNumHash,
+    EngineUpdate, Epoch, ExecHeader, Genesis, GenesisAccount, RecoveredBlock, Round, SealedBlock,
+    SealedHeader, TaskManager, TaskSpawner, TransactionSigned, B256, ETHEREUM_BLOCK_GAS_LIMIT_30M,
+    U256,
 };
 use tracing::{debug, error, info, warn};
 use traits::{TNPrimitives, TelcoinNode};
@@ -805,7 +806,7 @@ impl RethEnv {
     pub fn finish_executing_output(
         &self,
         blocks: Vec<ExecutedBlock>,
-        engine_update: Option<(Round, BlockNumHash, tokio::sync::mpsc::Sender<EngineUpdate>)>,
+        engine_update: Option<(Round, ConsensusNumHash, tokio::sync::mpsc::Sender<EngineUpdate>)>,
     ) -> TnRethResult<()> {
         // NOTE: this makes all blocks canonical, commits them to the database,
         // and broadcasts new chain on `canon_state_notification_sender`

--- a/crates/types/src/consensus_chain_traits.rs
+++ b/crates/types/src/consensus_chain_traits.rs
@@ -23,7 +23,8 @@ use tokio::io::{AsyncRead, AsyncSeek};
 
 use crate::{
     gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, CommittedSubDag,
-    Committee, ConsensusHeader, ConsensusOutput, Database, Epoch, EpochRecord, Round, B256,
+    Committee, ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, Database, Epoch,
+    EpochRecord, Round,
 };
 
 /// Marker trait for an async readable+seekable stream over an epoch's pack
@@ -48,7 +49,7 @@ pub trait ConsensusChainReader: Send + Sync + Clone + 'static {
     fn consensus_header_by_digest(
         &self,
         epoch: Epoch,
-        digest: B256,
+        digest: ConsensusHeaderDigest,
     ) -> impl Future<Output = eyre::Result<Option<ConsensusHeader>>> + Send;
 
     /// Retrieve a consensus header by global number.

--- a/crates/types/src/crypto/mod.rs
+++ b/crates/types/src/crypto/mod.rs
@@ -141,6 +141,74 @@ impl<const DIGEST_LEN: usize> From<Digest<DIGEST_LEN>> for [u8; DIGEST_LEN] {
     }
 }
 
+/// Define a [`DIGEST_LENGTH`]-byte digest newtype wrapping [`Digest`].
+///
+/// Consensus uses several distinct-but-structurally-identical digest types (one per
+/// semantic domain, e.g. consensus output vs. consensus header) so that the type
+/// system prevents mixing them up. This macro generates the boilerplate shared by all
+/// of them: the wrapped struct, the standard derives, `AsRef<[u8]>`, conversions
+/// to/from [`Digest`], [`B256`] and `[u8; DIGEST_LENGTH]`, and `Debug`/`Display`
+/// (Display truncates to the first 16 chars, matching [`Digest`]'s bs58 rendering).
+///
+/// The struct is constructed via the generated `From` impls (or its tuple form within
+/// the defining module, e.g. `Foo(Digest { digest: hasher.finalize().into() })`).
+macro_rules! digest_newtype {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident;) => {
+        $(#[$meta])*
+        #[derive(
+            Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord,
+            ::serde::Serialize, ::serde::Deserialize,
+        )]
+        $vis struct $name($crate::crypto::Digest<{ $crate::crypto::DIGEST_LENGTH }>);
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                &self.0.digest
+            }
+        }
+
+        impl From<$name> for $crate::crypto::Digest<{ $crate::crypto::DIGEST_LENGTH }> {
+            fn from(d: $name) -> Self {
+                d.0
+            }
+        }
+
+        // Convenience conversion to EL `B256`; note both are `DIGEST_LENGTH` bytes.
+        impl From<$name> for $crate::B256 {
+            fn from(value: $name) -> Self {
+                $crate::B256::from_slice(value.as_ref())
+            }
+        }
+
+        // Convenience conversion from EL `B256`; note both are `DIGEST_LENGTH` bytes.
+        impl From<$crate::B256> for $name {
+            fn from(value: $crate::B256) -> Self {
+                Self($crate::crypto::Digest { digest: value.into() })
+            }
+        }
+
+        impl From<[u8; $crate::crypto::DIGEST_LENGTH]> for $name {
+            fn from(value: [u8; $crate::crypto::DIGEST_LENGTH]) -> Self {
+                Self($crate::crypto::Digest { digest: value })
+            }
+        }
+
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                write!(f, "{}", self.0.to_string().get(0..16).ok_or(::core::fmt::Error)?)
+            }
+        }
+    };
+}
+
+pub(crate) use digest_newtype;
+
 /// Trait implemented by hash functions providing a output of fixed length
 pub trait HashFunction<const DIGEST_LENGTH: usize>: Default {
     /// The length of this hash functions digests in bytes.

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -6,8 +6,6 @@
 //! or observer) or any task that requires realtime or historic consesus data
 //! if not directly participating in consesus.
 
-use std::fmt;
-
 use super::{CommittedSubDag, ConsensusOutput};
 use crate::{crypto, Certificate, Digest, Hash, B256};
 use serde::{Deserialize, Serialize};
@@ -94,56 +92,9 @@ impl From<&ConsensusHeader> for Vec<u8> {
     }
 }
 
-// Digest of ConsensusHeader
-#[derive(
-    Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
-pub struct ConsensusHeaderDigest(Digest<{ crypto::DIGEST_LENGTH }>);
-
-impl AsRef<[u8]> for ConsensusHeaderDigest {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.digest
-    }
-}
-
-impl From<ConsensusHeaderDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
-    fn from(d: ConsensusHeaderDigest) -> Self {
-        d.0
-    }
-}
-
-// Convenience function for casting `ConsensusHeaderDigest` into EL B256.
-// note: these are both 32-bytes
-impl From<ConsensusHeaderDigest> for B256 {
-    fn from(value: ConsensusHeaderDigest) -> Self {
-        B256::from_slice(value.as_ref())
-    }
-}
-
-// Convenience function for casting `ConsensusHeaderDigest` into EL B256.
-// note: these are both 32-bytes
-impl From<B256> for ConsensusHeaderDigest {
-    fn from(value: B256) -> Self {
-        Self(Digest { digest: value.into() })
-    }
-}
-
-impl From<[u8; 32]> for ConsensusHeaderDigest {
-    fn from(value: [u8; 32]) -> Self {
-        Self(Digest { digest: value.into() })
-    }
-}
-
-impl fmt::Debug for ConsensusHeaderDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for ConsensusHeaderDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0.to_string().get(0..16).ok_or(fmt::Error)?)
-    }
+crate::crypto::digest_newtype! {
+    /// Digest of a [`ConsensusHeader`].
+    pub struct ConsensusHeaderDigest;
 }
 
 /// A consensus header number and a hash.

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -6,8 +6,10 @@
 //! or observer) or any task that requires realtime or historic consesus data
 //! if not directly participating in consesus.
 
+use std::fmt;
+
 use super::{CommittedSubDag, ConsensusOutput};
-use crate::{crypto, BlockHash, Certificate, Hash, B256};
+use crate::{crypto, Certificate, Digest, Hash, B256};
 use serde::{Deserialize, Serialize};
 
 /// Header for the consensus chain.
@@ -17,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Serialize, Deserialize, Clone, Debug)]
 pub struct ConsensusHeader {
     /// The hash of the previous ConsesusHeader in the chain.
-    pub parent_hash: B256,
+    pub parent_hash: ConsensusHeaderDigest,
 
     /// This is the committed sub dag used to extend the execution chain.
     pub sub_dag: CommittedSubDag,
@@ -33,25 +35,25 @@ pub struct ConsensusHeader {
 
 impl ConsensusHeader {
     /// Return the digest for this ConsensusHeader.
-    pub fn digest(&self) -> BlockHash {
+    pub fn digest(&self) -> ConsensusHeaderDigest {
         Self::digest_from_parts(self.parent_hash, &self.sub_dag, self.number)
     }
 
     /// Produce the digest that result from a ConsensusHeader with this data.
     /// This allows digesting in some cases with out cloning a CommittedSubDag.
     pub fn digest_from_parts(
-        parent_hash: B256,
+        parent_hash: ConsensusHeaderDigest,
         sub_dag: &CommittedSubDag,
         number: u64,
-    ) -> BlockHash {
+    ) -> ConsensusHeaderDigest {
         let mut hasher = crypto::DefaultHashFunction::new();
-        hasher.update(parent_hash.as_slice());
+        hasher.update(parent_hash.as_ref());
         hasher.update(sub_dag.digest().as_ref());
         hasher.update(number.to_le_bytes().as_ref());
         // Include the extra field.
         // Not using this yet but include the default in the hash in prep when we do.
         hasher.update(B256::default().as_slice());
-        BlockHash::from_slice(hasher.finalize().as_bytes())
+        ConsensusHeaderDigest(Digest { digest: hasher.finalize().into() })
     }
 }
 
@@ -65,7 +67,12 @@ impl Default for ConsensusHeader {
             crate::ReputationScores::default(),
             None,
         );
-        Self { parent_hash: B256::default(), sub_dag, number: 0, extra: B256::default() }
+        Self {
+            parent_hash: ConsensusHeaderDigest::default(),
+            sub_dag,
+            number: 0,
+            extra: B256::default(),
+        }
     }
 }
 
@@ -84,5 +91,111 @@ impl From<&[u8]> for ConsensusHeader {
 impl From<&ConsensusHeader> for Vec<u8> {
     fn from(value: &ConsensusHeader) -> Self {
         crate::encode(value)
+    }
+}
+
+// Digest of ConsensusHeader
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub struct ConsensusHeaderDigest(Digest<{ crypto::DIGEST_LENGTH }>);
+
+impl AsRef<[u8]> for ConsensusHeaderDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0.digest
+    }
+}
+
+impl From<ConsensusHeaderDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
+    fn from(d: ConsensusHeaderDigest) -> Self {
+        d.0
+    }
+}
+
+// Convenience function for casting `ConsensusHeaderDigest` into EL B256.
+// note: these are both 32-bytes
+impl From<ConsensusHeaderDigest> for B256 {
+    fn from(value: ConsensusHeaderDigest) -> Self {
+        B256::from_slice(value.as_ref())
+    }
+}
+
+// Convenience function for casting `ConsensusHeaderDigest` into EL B256.
+// note: these are both 32-bytes
+impl From<B256> for ConsensusHeaderDigest {
+    fn from(value: B256) -> Self {
+        Self(Digest { digest: value.into() })
+    }
+}
+
+impl From<[u8; 32]> for ConsensusHeaderDigest {
+    fn from(value: [u8; 32]) -> Self {
+        Self(Digest { digest: value.into() })
+    }
+}
+
+impl fmt::Debug for ConsensusHeaderDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Display for ConsensusHeaderDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.0.to_string().get(0..16).ok_or(fmt::Error)?)
+    }
+}
+
+/// A consensus header number and a hash.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, std::hash::Hash, Serialize, Deserialize)]
+pub struct ConsensusNumHash {
+    /// The number
+    pub number: u64,
+    /// The hash.
+    pub hash: ConsensusHeaderDigest,
+}
+
+impl ConsensusNumHash {
+    /// Creates a new `NumHash` from a number and hash.
+    pub const fn new(number: u64, hash: ConsensusHeaderDigest) -> Self {
+        Self { number, hash }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::{eips::NumHash, primitives::B256};
+
+    use crate::{crypto, decode, encode, ConsensusHeaderDigest, ConsensusNumHash};
+
+    /// Verify that ConsensusHeaderDigest encodes/decodes to the same bytes as a B256/BlockHash.
+    #[test]
+    fn test_consensus_digest_serde() {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        hasher.update(b"test_consensus_digest_serde");
+        let init_bytes = B256::from_slice(hasher.finalize().as_bytes());
+        let cdigest: ConsensusHeaderDigest = init_bytes.into();
+        let enc = encode(&cdigest);
+        let b256: B256 = decode(&enc);
+        assert_eq!(init_bytes, b256);
+        let enc = encode(&b256);
+        let cdigest2: ConsensusHeaderDigest = decode(&enc);
+        assert_eq!(cdigest, cdigest2);
+    }
+
+    /// Verify that ConsensusNumHash encodes/decodes to the same bytes as a NumHash.
+    #[test]
+    fn test_consensus_numhash_serde() {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        hasher.update(b"test_consensus_digest_serde");
+        let init_bytes = B256::from_slice(hasher.finalize().as_bytes());
+        let num_hash = NumHash { number: 3, hash: init_bytes };
+        let consensus_num_hash = ConsensusNumHash { number: 3, hash: init_bytes.into() };
+        let enc = encode(&consensus_num_hash);
+        let num_hash2: NumHash = decode(&enc);
+        assert_eq!(num_hash, num_hash2);
+        let enc = encode(&num_hash2);
+        let cnum_hash: ConsensusNumHash = decode(&enc);
+        assert_eq!(consensus_num_hash, cnum_hash);
     }
 }

--- a/crates/types/src/primary/epoch.rs
+++ b/crates/types/src/primary/epoch.rs
@@ -7,9 +7,9 @@
 //! execute with known correct consensus outputs.
 
 use crate::{
-    crypto, encode, serde::RoaringBitmapSerde, BlockHash, BlsAggregateSignature, BlsPublicKey,
-    BlsSignature, BlsSigner, ConsensusNumHash, Epoch, Intent, IntentMessage, IntentScope,
-    ValidatorAggregateSignature as _, B256,
+    crypto, encode, serde::RoaringBitmapSerde, BlsAggregateSignature, BlsPublicKey, BlsSignature,
+    BlsSigner, ConsensusNumHash, Epoch, Intent, IntentMessage, IntentScope,
+    ValidatorAggregateSignature as _,
 };
 use alloy::eips::BlockNumHash;
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub struct EpochRecord {
     /// This can be used for trustless syncing.
     pub next_committee: Vec<BlsPublicKey>,
     /// Hash of the previous EpochRecord.
-    pub parent_hash: B256,
+    pub parent_hash: EpochDigest,
     /// The block number and hash of the last execution state of this epoch.
     /// Basically the execution genesis for the next epoch after this one.
     /// Also a signed checkpoint of execution state (with the certificate).
@@ -39,10 +39,10 @@ pub struct EpochRecord {
 
 impl EpochRecord {
     /// Return the digest for this ConsensusHeader.
-    pub fn digest(&self) -> B256 {
+    pub fn digest(&self) -> EpochDigest {
         let mut hasher = crypto::DefaultHashFunction::new();
         hasher.update(&encode(self));
-        BlockHash::from_slice(hasher.finalize().as_bytes())
+        (*hasher.finalize().as_bytes()).into()
     }
 
     /// Use signer to generate an [`EpochVote`] for this EpochRecord.
@@ -107,7 +107,7 @@ pub struct EpochVote {
     /// The hash of the ['EpochRecord'].
     /// Store the hash not the record to keep gossip size down.
     /// Other nodes can request the record once vs recieving it many times.
-    pub epoch_hash: B256,
+    pub epoch_hash: EpochDigest,
     /// Public key of the committee member that signed this.
     /// This needs to be verified to be a committee member.
     pub public_key: BlsPublicKey,
@@ -136,7 +136,7 @@ pub struct EpochCertificate {
     /// The hash of the ['EpochRecord'].
     /// Store the hash not the record to keep gossip size down.
     /// Other nodes can request the record once vs recieving it many times.
-    pub epoch_hash: B256,
+    pub epoch_hash: EpochDigest,
     /// Signatures of a quorum of committee member for the epoch.
     pub signature: BlsSignature,
     /// Bitmap defining which committee members signed this certificate.
@@ -154,6 +154,11 @@ impl EpochCertificate {
     }
 }
 
+crate::crypto::digest_newtype! {
+    /// Digest of a [`EpochRecord`].
+    pub struct EpochDigest;
+}
+
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
@@ -161,7 +166,8 @@ mod test {
     use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng as _};
     use roaring::RoaringBitmap;
 
-    use crate::{BlsKeypair, Signer as _};
+    use crate::{crypto, decode, encode, BlsKeypair, ConsensusNumHash, Signer as _};
+    use alloy::primitives::B256;
 
     use super::*;
 
@@ -194,7 +200,7 @@ mod test {
             epoch: 0,
             committee: vec![com1.public_key(), com2.public_key(), com3.public_key()],
             next_committee: vec![com1.public_key(), com2.public_key(), com3.public_key()],
-            parent_hash: B256::default(),
+            parent_hash: EpochDigest::default(),
             final_state: BlockNumHash::default(),
             final_consensus: ConsensusNumHash::default(),
         };
@@ -230,5 +236,20 @@ mod test {
                 panic!("failed to aggregate epoch record signatures",);
             }
         }
+    }
+
+    /// Verify that EpochDigest encodes/decodes to the same bytes as a B256/BlockHash.
+    #[test]
+    fn test_epoch_digest_serde() {
+        let mut hasher = crypto::DefaultHashFunction::new();
+        hasher.update(b"test_epoch_digest_serde");
+        let init_bytes = B256::from_slice(hasher.finalize().as_bytes());
+        let edigest: EpochDigest = init_bytes.into();
+        let enc = encode(&edigest);
+        let b256: B256 = decode(&enc);
+        assert_eq!(init_bytes, b256);
+        let enc = encode(&b256);
+        let edigest2: EpochDigest = decode(&enc);
+        assert_eq!(edigest, edigest2);
     }
 }

--- a/crates/types/src/primary/epoch.rs
+++ b/crates/types/src/primary/epoch.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     crypto, encode, serde::RoaringBitmapSerde, BlockHash, BlsAggregateSignature, BlsPublicKey,
-    BlsSignature, BlsSigner, Epoch, Intent, IntentMessage, IntentScope,
+    BlsSignature, BlsSigner, ConsensusNumHash, Epoch, Intent, IntentMessage, IntentScope,
     ValidatorAggregateSignature as _, B256,
 };
 use alloy::eips::BlockNumHash;
@@ -34,7 +34,7 @@ pub struct EpochRecord {
     pub final_state: BlockNumHash,
     /// The hash and consensus block number of the last ['ConsensusHeader'] of this epoch.
     /// Can be used as a signed checkpoint for consensus (with the certificate).
-    pub final_consensus: BlockNumHash,
+    pub final_consensus: ConsensusNumHash,
 }
 
 impl EpochRecord {
@@ -196,7 +196,7 @@ mod test {
             next_committee: vec![com1.public_key(), com2.public_key(), com3.public_key()],
             parent_hash: B256::default(),
             final_state: BlockNumHash::default(),
-            final_consensus: BlockNumHash::default(),
+            final_consensus: ConsensusNumHash::default(),
         };
         let vote1 = record.sign_vote(&com1);
         let vote2 = record.sign_vote(&com2);

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -471,45 +471,12 @@ impl Hash<{ crypto::DIGEST_LENGTH }> for CommittedSubDag {
     }
 }
 
-// Convenience function for casting `ConsensusDigest` into EL B256.
-// note: these are both 32-bytes
-impl From<ConsensusDigest> for B256 {
-    fn from(value: ConsensusDigest) -> Self {
-        B256::from_slice(value.as_ref())
-    }
-}
-
 /// Shutdown token dropped when a task is properly shut down.
 pub type ShutdownToken = mpsc::Sender<()>;
 
-// Digest of ConsususOutput and CommittedSubDag
-#[derive(
-    Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
-pub struct ConsensusDigest(Digest<{ crypto::DIGEST_LENGTH }>);
-
-impl AsRef<[u8]> for ConsensusDigest {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.digest
-    }
-}
-
-impl From<ConsensusDigest> for Digest<{ crypto::DIGEST_LENGTH }> {
-    fn from(d: ConsensusDigest) -> Self {
-        d.0
-    }
-}
-
-impl fmt::Debug for ConsensusDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl fmt::Display for ConsensusDigest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0.to_string().get(0..16).ok_or(fmt::Error)?)
-    }
+crate::crypto::digest_newtype! {
+    /// Digest of a [`ConsensusOutput`]/[`CommittedSubDag`].
+    pub struct ConsensusDigest;
 }
 
 // See test_utils output_tests.rs for this modules tests.

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -3,8 +3,9 @@
 
 use super::ConsensusHeader;
 use crate::{
-    crypto, encode, Address, Batch, BlockHash, BlockNumHash, BlsSignature, Certificate, Digest,
-    Epoch, Hash, Header, ReputationScores, Round, SealedHeader, TimestampSec, B256,
+    crypto, encode, Address, Batch, BlockHash, BlsSignature, Certificate, ConsensusHeaderDigest,
+    ConsensusNumHash, Digest, Epoch, Hash, Header, ReputationScores, Round, SealedHeader,
+    TimestampSec, B256,
 };
 use alloy::primitives::keccak256;
 use serde::{Deserialize, Serialize};
@@ -25,7 +26,7 @@ pub type SequenceNumber = u64;
 /// - leader round from consensus
 /// - consensus block number/hash
 /// - latest canonical tip when execution produced a block (`None` when execution was skipped)
-pub type EngineUpdate = (Round, BlockNumHash, Option<SealedHeader>);
+pub type EngineUpdate = (Round, ConsensusNumHash, Option<SealedHeader>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Struct that contains all necessary information for executing a batch post-consensus.
@@ -53,7 +54,7 @@ struct ConsensusOutputInner {
     batch_digests: VecDeque<BlockHash>,
     // These fields are used to construct the ConsensusHeader.
     /// The hash of the previous ConsesusHeader in the chain.
-    parent_hash: B256,
+    parent_hash: ConsensusHeaderDigest,
     /// A scalar value equal to the number of ancestor blocks. The genesis block has a number of
     /// zero.
     number: u64,
@@ -72,7 +73,7 @@ pub struct ConsensusOutput {
     /// The engine should make a system call to consensus registry contract to close the epoch.
     close_epoch: bool,
     /// Cached digest of the consensus header for this output.
-    consensus_header_hash_cache: B256,
+    consensus_header_hash_cache: ConsensusHeaderDigest,
 }
 
 // NOTE: only [Self::inner] is serialized. `close_epoch` is intentionally NOT part of the
@@ -106,7 +107,7 @@ impl ConsensusOutput {
     /// Create a
     pub fn new(
         sub_dag: CommittedSubDag,
-        parent_hash: BlockHash,
+        parent_hash: ConsensusHeaderDigest,
         number: u64,
         close_epoch: bool,
         batch_digests: VecDeque<BlockHash>,
@@ -124,12 +125,16 @@ impl ConsensusOutput {
             ConsensusHeader::digest_from_parts(inner.parent_hash, &inner.sub_dag, inner.number);
         ConsensusOutput { inner, close_epoch, consensus_header_hash_cache }
     }
-    pub fn new_with_subdag(sub_dag: CommittedSubDag, parent_hash: BlockHash, number: u64) -> Self {
+    pub fn new_with_subdag(
+        sub_dag: CommittedSubDag,
+        parent_hash: ConsensusHeaderDigest,
+        number: u64,
+    ) -> Self {
         Self::new(sub_dag, parent_hash, number, false, VecDeque::new(), Vec::new())
     }
     pub fn new_closed_with_subdag(
         sub_dag: CommittedSubDag,
-        parent_hash: BlockHash,
+        parent_hash: ConsensusHeaderDigest,
         number: u64,
     ) -> Self {
         Self::new(sub_dag, parent_hash, number, true, VecDeque::new(), Vec::new())
@@ -218,13 +223,13 @@ impl ConsensusOutput {
     }
 
     /// Return the hash of the consensus header that matches this output.
-    pub fn consensus_header_hash(&self) -> B256 {
+    pub fn consensus_header_hash(&self) -> ConsensusHeaderDigest {
         self.consensus_header_hash_cache
     }
 
     /// Return number/hash tuple for this consensus output.
-    pub fn num_hash(&self) -> BlockNumHash {
-        BlockNumHash::new(self.inner.number, self.consensus_header_hash())
+    pub fn num_hash(&self) -> ConsensusNumHash {
+        ConsensusNumHash::new(self.inner.number, self.consensus_header_hash())
     }
 
     /// Return a `bool` if this is the last batch (by index) of the last output for the epoch.
@@ -260,17 +265,17 @@ impl ConsensusOutput {
     }
 
     /// The parent hash for this output.
-    pub fn parent_hash(&self) -> BlockHash {
+    pub fn parent_hash(&self) -> ConsensusHeaderDigest {
         self.inner.parent_hash
     }
 }
 
 impl Hash<{ crypto::DIGEST_LENGTH }> for ConsensusOutput {
-    type TypedDigest = ConsensusDigest;
+    type TypedDigest = ConsensusHeaderDigest;
 
     /// The digest of the corresponding [ConsensusHeader] that produced this output.
-    fn digest(&self) -> ConsensusDigest {
-        ConsensusDigest(Digest { digest: self.consensus_header_hash().into() })
+    fn digest(&self) -> ConsensusHeaderDigest {
+        self.consensus_header_hash()
     }
 }
 


### PR DESCRIPTION
This has no functional changes.  It introduces a macro to make it easy to add a new specific digest type.  Use it to make specific types for ConsensusHeaders and EpochRecords.  This should make code easier to read and understand and avoid digest based foot guns.