### PR TITLE
separate protocols for primary and worker (by id)

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -1,7 +1,7 @@
 //! Configuration for network variables.
 
 use crate::{ConfigFmt, ConfigTrait, TelcoinDirs};
-use libp2p::{kad::K_VALUE, request_response::ProtocolSupport, StreamProtocol};
+use libp2p::kad::K_VALUE;
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, time::Duration};
 use tn_types::Round;
@@ -81,10 +81,6 @@ impl NetworkConfig {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct LibP2pConfig {
-    /// The supported inbound/outbound protocols for request/response behavior.
-    /// - ex) "/telcoin-network/mainnet/0.0.1"
-    #[serde(with = "protocol_vec")]
-    pub supported_req_res_protocols: Vec<(StreamProtocol, ProtocolSupport)>,
     /// Maximum message size between request/response network messages in bytes.
     pub max_rpc_message_size: usize,
     /// Maximum message size for gossipped network messages in bytes.
@@ -151,27 +147,13 @@ impl LibP2pConfig {
     pub fn worker_txn_topic() -> String {
         String::from("tn-txn")
     }
-
-    /// Protocol for identify behavior.
-    pub fn identify_protocol(&self) -> &'static str {
-        Self::protocol()
-    }
-
-    /// Return the protocol string.
-    pub fn protocol() -> &'static str {
-        "/telcoin-network/0.0.0"
-    }
 }
 
 impl Default for LibP2pConfig {
     fn default() -> Self {
         Self {
-            supported_req_res_protocols: vec![(
-                StreamProtocol::new(Self::protocol()),
-                ProtocolSupport::Full,
-            )],
-            max_rpc_message_size: 1024 * 1024, // 1 MiB
-            max_gossip_message_size: 12_000,   // 12kb
+            max_rpc_message_size: 1024 * 1024,                    // 1 MiB
+            max_gossip_message_size: 12_000,                      // 12kb
             max_idle_connection_timeout: Duration::from_secs(65), // same as quic handshake
             max_px_disconnects: 10,
             px_disconnect_timeout: Duration::from_secs(3),
@@ -465,68 +447,6 @@ impl ScoreConfig {
     }
 }
 
-// Serialize and deserialize for tuples of protocols
-mod protocol_vec {
-    use super::*;
-    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(crate) fn serialize<S>(
-        protocols: &[(StreamProtocol, ProtocolSupport)],
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Simply convert to a Vec of string tuples
-        let string_tuples: Vec<(String, String)> = protocols
-            .iter()
-            .map(|(protocol, support)| {
-                let support_str = match support {
-                    ProtocolSupport::Inbound => "inbound".to_string(),
-                    ProtocolSupport::Outbound => "outbound".to_string(),
-                    ProtocolSupport::Full => "full".to_string(),
-                };
-                (protocol.as_ref().to_string(), support_str)
-            })
-            .collect();
-
-        string_tuples.serialize(serializer)
-    }
-
-    pub(crate) fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<Vec<(StreamProtocol, ProtocolSupport)>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let string_tuples: Vec<(String, String)> = Vec::deserialize(deserializer)?;
-
-        string_tuples
-            .into_iter()
-            .map(|(protocol_str, support_str)| {
-                // Convert the protocol string to StreamProtocol
-                let protocol = StreamProtocol::try_from_owned(protocol_str).map_err(|_| {
-                    D::Error::custom("Invalid protocol: must start with a forward slash")
-                })?;
-
-                // Convert the support string to ProtocolSupport
-                let support = match support_str.as_str() {
-                    "inbound" => ProtocolSupport::Inbound,
-                    "outbound" => ProtocolSupport::Outbound,
-                    "full" => ProtocolSupport::Full,
-                    _ => {
-                        return Err(D::Error::custom(format!(
-                            "Invalid protocol support: {support_str}, expected inbound, outbound, or full"
-                        )))
-                    }
-                };
-
-                Ok((protocol, support))
-            })
-            .collect()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -556,9 +476,6 @@ mod tests {
         // fields (and others) are absent and must fall back to defaults.
         let yaml = r#"
 libp2p_config:
-  supported_req_res_protocols:
-    - - /telcoin-network/0.0.0
-      - full
   max_rpc_message_size: 2097152
   max_gossip_message_size: 12000
   max_idle_connection_timeout:

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -5,13 +5,13 @@
 use crate::{
     codec::{TNCodec, TNMessage},
     error::NetworkError,
-    kad::{KadStore, NetworkType},
+    kad::KadStore,
     peers::{self, PeerEvent, PeerManager, Penalty},
     send_or_log_error,
     stream::{StreamBehavior, StreamEvent},
     types::{
         KadQuery, NetworkCommand, NetworkEvent, NetworkHandle, NetworkInfo, NetworkResponseMessage,
-        NetworkResponseSender, NetworkResult, NodeRecord,
+        NetworkResponseSender, NetworkResult, NetworkType, NodeRecord,
     },
     PeerExchangeMap,
 };

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -5,7 +5,7 @@
 use crate::{
     codec::{TNCodec, TNMessage},
     error::NetworkError,
-    kad::{KadStore, KadStoreType, DEFAULT_KAD_PROTO_NAME},
+    kad::{KadStore, NetworkType},
     peers::{self, PeerEvent, PeerManager, Penalty},
     send_or_log_error,
     stream::{StreamBehavior, StreamEvent},
@@ -25,6 +25,7 @@ use libp2p::{
     request_response::{
         self, Codec, Event as ReqResEvent, InboundFailure as ReqResInboundFailure,
         InboundRequestId, OutboundFailure as ReqResOutboundFailure, OutboundRequestId,
+        ProtocolSupport,
     },
     swarm::{NetworkBehaviour, SwarmEvent},
     Multiaddr, PeerId, Swarm, SwarmBuilder,
@@ -37,7 +38,7 @@ use std::{
 use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
 use tn_types::{
     decode, encode, now, try_decode, BlsPublicKey, BlsSigner, Database, NetworkKeypair,
-    NetworkPublicKey, TaskSpawner, TnSender,
+    NetworkPublicKey, TaskSpawner, TnSender, WorkerId,
 };
 use tokio::sync::{
     mpsc::{Receiver, Sender},
@@ -201,13 +202,14 @@ where
             network_key,
             db,
             task_manager,
-            KadStoreType::Primary,
+            NetworkType::Primary,
             external_addr,
         )
     }
 
     /// Convenience method for spawning a worker network instance.
     pub fn new_for_worker(
+        worker_id: WorkerId,
         network_config: &NetworkConfig,
         event_stream: Events,
         key_config: KeyConfig,
@@ -223,7 +225,7 @@ where
             network_key,
             db,
             task_manager,
-            KadStoreType::Worker,
+            NetworkType::Worker(worker_id),
             external_addr,
         )
     }
@@ -237,7 +239,7 @@ where
         keypair: NetworkKeypair,
         db: DB,
         task_spawner: TaskSpawner,
-        kad_type: KadStoreType,
+        network_type: NetworkType,
         external_addr: Multiaddr,
     ) -> NetworkResult<Self> {
         let gossipsub_config = gossipsub::ConfigBuilder::default()
@@ -259,11 +261,11 @@ where
 
         let req_res = request_response::Behaviour::with_codec(
             tn_codec,
-            network_config.libp2p_config().supported_req_res_protocols.clone(),
+            vec![(network_type.req_res_protocol(), ProtocolSupport::Full)],
             request_response::Config::default(),
         );
         let peer_id: PeerId = keypair.public().into();
-        let mut kad_config = libp2p::kad::Config::new(DEFAULT_KAD_PROTO_NAME);
+        let mut kad_config = libp2p::kad::Config::new(network_type.kad_protocol());
         // manually add peers
         kad_config.set_kbucket_inserts(kad::BucketInserts::Manual);
         let libp2p = network_config.libp2p_config();
@@ -274,7 +276,7 @@ where
             .set_publication_interval(Some(libp2p.kad_publication_interval))
             .set_query_timeout(Duration::from_secs(60))
             .set_provider_record_ttl(Some(libp2p.kad_record_ttl));
-        let kad_store = KadStore::new(db.clone(), &key_config, kad_type);
+        let kad_store = KadStore::new(db.clone(), &key_config, network_type);
         let kademlia = kad::Behaviour::with_config(peer_id, kad_store.clone(), kad_config);
 
         // create custom behavior

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -19,10 +19,7 @@ use tn_config::KeyConfig;
 use tn_storage::tables::{
     KadProviderRecords, KadRecords, KadWorkerProviderRecords, KadWorkerRecords,
 };
-use tn_types::{decode, encode, BlockHash, Database, DefaultHashFunction};
-
-/// The TN-specific kad protocol.
-pub(crate) const DEFAULT_KAD_PROTO_NAME: StreamProtocol = StreamProtocol::new("/tn-kad/1.0.0");
+use tn_types::{decode, encode, BlockHash, Database, DefaultHashFunction, WorkerId};
 
 /// A record stored in the DHT.
 /// This is a "shadow" struct for a kad Record so we can serialize/deserialize
@@ -162,13 +159,40 @@ fn instant_to_system(expires: &Option<Instant>) -> Option<SystemTime> {
     }
 }
 
-/// The type of the Kad store, primary or worker.
+/// The role of a consensus network instance — primary or worker.
+///
+/// A node runs both as fully isolated libp2p swarms in one process. This is the
+/// one source of truth for everything that must differ: the kad store's backing
+/// tables and the wire protocol names that keep the two from ever negotiating a
+/// connection with one another.
 #[derive(Copy, Clone, Debug)]
-pub enum KadStoreType {
-    /// Primary network KadStore.
+pub enum NetworkType {
+    /// Primary network.
     Primary,
-    /// Worker network KadStore.
-    Worker,
+    /// Worker network.
+    Worker(WorkerId),
+}
+
+impl NetworkType {
+    /// Request-response wire protocol, isolated per role (and per worker).
+    pub(crate) fn req_res_protocol(&self) -> StreamProtocol {
+        match self {
+            Self::Primary => StreamProtocol::new("/tn-primary/0.0.1"),
+            Self::Worker(id) => StreamProtocol::try_from_owned(format!("/tn-worker-{id}/0.0.1"))
+                .expect("worker req-res protocol name starts with '/'"),
+        }
+    }
+
+    /// Kademlia wire protocol, isolated per role (and per worker).
+    pub(crate) fn kad_protocol(&self) -> StreamProtocol {
+        match self {
+            Self::Primary => StreamProtocol::new("/tn-primary-kad/1.0.0"),
+            Self::Worker(id) => {
+                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-kad/1.0.0"))
+                    .expect("worker kad protocol name starts with '/'")
+            }
+        }
+    }
 }
 
 /// Provide a persistant store for kademlia data.
@@ -187,20 +211,20 @@ pub struct KadStore<DB> {
     /// Tracks to number of provider records in DB.
     num_providers: usize,
     /// Index used for database retrieval with multiple KAD tables.
-    kad_type: KadStoreType,
+    kad_type: NetworkType,
 }
 
 impl<DB: Database> KadStore<DB> {
     /// Create a new KadStore backed by db.
-    pub fn new(db: DB, key_config: &KeyConfig, kad_type: KadStoreType) -> Self {
+    pub fn new(db: DB, key_config: &KeyConfig, kad_type: NetworkType) -> Self {
         let node_key = RecordKey::new(&encode(&key_config.primary_public_key()));
         // Defaults for sanity.
         let config = MemoryStoreConfig::default();
         let (num_records, num_providers) = match kad_type {
-            KadStoreType::Primary => {
+            NetworkType::Primary => {
                 (db.iter::<KadRecords>().count(), db.iter::<KadProviderRecords>().count())
             }
-            KadStoreType::Worker => (
+            NetworkType::Worker(_) => (
                 db.iter::<KadWorkerRecords>().count(),
                 db.iter::<KadWorkerProviderRecords>().count(),
             ),
@@ -219,7 +243,7 @@ impl<DB: Database> KadStore<DB> {
     fn evict_expired_records(&mut self) -> usize {
         let now = SystemTime::now();
         let expired_keys: Vec<BlockHash> = match self.kad_type {
-            KadStoreType::Primary => self
+            NetworkType::Primary => self
                 .db
                 .iter::<KadRecords>()
                 .filter_map(|(k, v)| {
@@ -227,7 +251,7 @@ impl<DB: Database> KadStore<DB> {
                     r.is_expired(now).then_some(k)
                 })
                 .collect(),
-            KadStoreType::Worker => self
+            NetworkType::Worker(_) => self
                 .db
                 .iter::<KadWorkerRecords>()
                 .filter_map(|(k, v)| {
@@ -239,8 +263,8 @@ impl<DB: Database> KadStore<DB> {
         let mut evicted = 0;
         for k in &expired_keys {
             let ok = match self.kad_type {
-                KadStoreType::Primary => self.db.remove::<KadRecords>(k).is_ok(),
-                KadStoreType::Worker => self.db.remove::<KadWorkerRecords>(k).is_ok(),
+                NetworkType::Primary => self.db.remove::<KadRecords>(k).is_ok(),
+                NetworkType::Worker(_) => self.db.remove::<KadWorkerRecords>(k).is_ok(),
             };
             if ok {
                 evicted += 1;
@@ -255,7 +279,7 @@ impl<DB: Database> KadStore<DB> {
     fn evict_expired_providers(&mut self) -> usize {
         let now = SystemTime::now();
         let drop_keys: Vec<BlockHash> = match self.kad_type {
-            KadStoreType::Primary => self
+            NetworkType::Primary => self
                 .db
                 .iter::<KadProviderRecords>()
                 .filter_map(|(k, v)| {
@@ -263,7 +287,7 @@ impl<DB: Database> KadStore<DB> {
                     (!recs.is_empty() && recs.iter().all(|r| r.is_expired(now))).then_some(k)
                 })
                 .collect(),
-            KadStoreType::Worker => self
+            NetworkType::Worker(_) => self
                 .db
                 .iter::<KadWorkerProviderRecords>()
                 .filter_map(|(k, v)| {
@@ -275,8 +299,8 @@ impl<DB: Database> KadStore<DB> {
         let mut evicted = 0;
         for k in &drop_keys {
             let ok = match self.kad_type {
-                KadStoreType::Primary => self.db.remove::<KadProviderRecords>(k).is_ok(),
-                KadStoreType::Worker => self.db.remove::<KadWorkerProviderRecords>(k).is_ok(),
+                NetworkType::Primary => self.db.remove::<KadProviderRecords>(k).is_ok(),
+                NetworkType::Worker(_) => self.db.remove::<KadWorkerProviderRecords>(k).is_ok(),
             };
             if ok {
                 evicted += 1;
@@ -325,8 +349,8 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     fn get(&self, k: &RecordKey) -> Option<Cow<'_, Record>> {
         let key = self.key_to_hash(k);
         let record = match self.kad_type {
-            KadStoreType::Primary => self.db.get::<KadRecords>(&key).ok()?,
-            KadStoreType::Worker => self.db.get::<KadWorkerRecords>(&key).ok()?,
+            NetworkType::Primary => self.db.get::<KadRecords>(&key).ok()?,
+            NetworkType::Worker(_) => self.db.get::<KadWorkerRecords>(&key).ok()?,
         };
         let raw = record?;
         let r: KadRecord = decode(raw.as_ref());
@@ -345,10 +369,10 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         let kr: KadRecord = r.into();
         // Are we adding a new record or replacing an existing?
         let new_record = match self.kad_type {
-            KadStoreType::Primary => {
+            NetworkType::Primary => {
                 self.db.get::<KadRecords>(&key).map_err(|_| Error::ValueTooLarge)?.is_none()
             }
-            KadStoreType::Worker => {
+            NetworkType::Worker(_) => {
                 self.db.get::<KadWorkerRecords>(&key).map_err(|_| Error::ValueTooLarge)?.is_none()
             }
         };
@@ -365,11 +389,11 @@ impl<DB: Database> RecordStore for KadStore<DB> {
             self.num_records += 1;
         }
         match self.kad_type {
-            KadStoreType::Primary => self
+            NetworkType::Primary => self
                 .db
                 .insert::<KadRecords>(&key, &encode(&kr))
                 .map_err(|_| Error::ValueTooLarge)?,
-            KadStoreType::Worker => self
+            NetworkType::Worker(_) => self
                 .db
                 .insert::<KadWorkerRecords>(&key, &encode(&kr))
                 .map_err(|_| Error::ValueTooLarge)?,
@@ -380,8 +404,8 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     fn remove(&mut self, k: &RecordKey) {
         let key = self.key_to_hash(k);
         if match self.kad_type {
-            KadStoreType::Primary => self.db.remove::<KadRecords>(&key),
-            KadStoreType::Worker => self.db.remove::<KadWorkerRecords>(&key),
+            NetworkType::Primary => self.db.remove::<KadRecords>(&key),
+            NetworkType::Worker(_) => self.db.remove::<KadWorkerRecords>(&key),
         }
         .is_ok()
         {
@@ -392,8 +416,8 @@ impl<DB: Database> RecordStore for KadStore<DB> {
 
     fn records(&self) -> Self::RecordsIter<'_> {
         let iter = match self.kad_type {
-            KadStoreType::Primary => self.db.iter::<KadRecords>(),
-            KadStoreType::Worker => self.db.iter::<KadWorkerRecords>(),
+            NetworkType::Primary => self.db.iter::<KadRecords>(),
+            NetworkType::Worker(_) => self.db.iter::<KadWorkerRecords>(),
         };
         RecordIter { iter }
     }
@@ -410,8 +434,8 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         let kr: KadProviderRecord = record.into();
         let mut inc_providers = false;
         let records: Vec<KadProviderRecord> = if let Ok(Some(recs)) = match self.kad_type {
-            KadStoreType::Primary => self.db.get::<KadProviderRecords>(&key),
-            KadStoreType::Worker => self.db.get::<KadWorkerProviderRecords>(&key),
+            NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
+            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
         } {
             let mut recs: Vec<KadProviderRecord> = decode(&recs);
             let mut found = false;
@@ -436,11 +460,11 @@ impl<DB: Database> RecordStore for KadStore<DB> {
             vec![kr]
         };
         match self.kad_type {
-            KadStoreType::Primary => self
+            NetworkType::Primary => self
                 .db
                 .insert::<KadProviderRecords>(&key, &encode(&records))
                 .map_err(|_| libp2p::kad::store::Error::ValueTooLarge)?,
-            KadStoreType::Worker => self
+            NetworkType::Worker(_) => self
                 .db
                 .insert::<KadWorkerProviderRecords>(&key, &encode(&records))
                 .map_err(|_| libp2p::kad::store::Error::ValueTooLarge)?,
@@ -456,8 +480,8 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     fn providers(&self, key: &RecordKey) -> Vec<ProviderRecord> {
         let key = self.key_to_hash(key);
         if let Ok(Some(recs)) = match self.kad_type {
-            KadStoreType::Primary => self.db.get::<KadProviderRecords>(&key),
-            KadStoreType::Worker => self.db.get::<KadWorkerProviderRecords>(&key),
+            NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
+            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
         } {
             let now = SystemTime::now();
             let records: Vec<KadProviderRecord> = decode(&recs);
@@ -476,16 +500,16 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     fn remove_provider(&mut self, key: &RecordKey, p: &PeerId) {
         let key = self.key_to_hash(key);
         if let Ok(Some(recs)) = match self.kad_type {
-            KadStoreType::Primary => self.db.get::<KadProviderRecords>(&key),
-            KadStoreType::Worker => self.db.get::<KadWorkerProviderRecords>(&key),
+            NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
+            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
         } {
             let records: Vec<KadProviderRecord> = decode(&recs);
             let records: Vec<KadProviderRecord> =
                 records.into_iter().filter(|r| r.provider != *p).collect();
             if records.is_empty() {
                 if match self.kad_type {
-                    KadStoreType::Primary => self.db.remove::<KadProviderRecords>(&key),
-                    KadStoreType::Worker => self.db.remove::<KadWorkerProviderRecords>(&key),
+                    NetworkType::Primary => self.db.remove::<KadProviderRecords>(&key),
+                    NetworkType::Worker(_) => self.db.remove::<KadWorkerProviderRecords>(&key),
                 }
                 .is_ok()
                 {
@@ -494,10 +518,10 @@ impl<DB: Database> RecordStore for KadStore<DB> {
                 }
             } else {
                 let _ = match self.kad_type {
-                    KadStoreType::Primary => {
+                    NetworkType::Primary => {
                         self.db.insert::<KadProviderRecords>(&key, &encode(&records))
                     }
-                    KadStoreType::Worker => {
+                    NetworkType::Worker(_) => {
                         self.db.insert::<KadWorkerProviderRecords>(&key, &encode(&records))
                     }
                 };
@@ -663,8 +687,8 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db.clone(), &key_config, KadStoreType::Primary);
-        let mut kad_store_worker = KadStore::new(db, &key_config, KadStoreType::Worker);
+        let mut kad_store = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
+        let mut kad_store_worker = KadStore::new(db, &key_config, NetworkType::Worker(0));
 
         let rec = test_record(false);
         let rec2 = test_record(false);
@@ -846,7 +870,7 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db, &key_config, KadStoreType::Primary);
+        let mut kad_store = KadStore::new(db, &key_config, NetworkType::Primary);
 
         let expired = test_record(true);
         kad_store.put(expired.clone()).expect("put expired record");
@@ -863,7 +887,7 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db, &key_config, KadStoreType::Primary);
+        let mut kad_store = KadStore::new(db, &key_config, NetworkType::Primary);
 
         let config = MemoryStoreConfig::default();
 
@@ -888,8 +912,8 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db.clone(), &key_config, KadStoreType::Primary);
-        let mut kad_store_worker = KadStore::new(db, &key_config, KadStoreType::Worker);
+        let mut kad_store = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
+        let mut kad_store_worker = KadStore::new(db, &key_config, NetworkType::Worker(0));
 
         let config = MemoryStoreConfig::default();
 
@@ -909,5 +933,18 @@ mod test {
         // Should be full now so get max errors.
         assert!(matches!(kad_store.put(rec.clone()), Err(Error::MaxRecords)));
         assert!(matches!(kad_store_worker.put(rec.clone()), Err(Error::MaxRecords)));
+    }
+
+    /// Lock the per-role wire-protocol names. These strings are a peer-compatibility
+    /// contract: a silent change would prevent peers from negotiating sessions.
+    #[test]
+    fn test_network_type_protocol_names() {
+        assert_eq!(NetworkType::Primary.req_res_protocol().as_ref(), "/tn-primary/0.0.1");
+        assert_eq!(NetworkType::Primary.kad_protocol().as_ref(), "/tn-primary-kad/1.0.0");
+        assert_eq!(NetworkType::Worker(0).req_res_protocol().as_ref(), "/tn-worker-0/0.0.1");
+        assert_eq!(NetworkType::Worker(0).kad_protocol().as_ref(), "/tn-worker-0-kad/1.0.0");
+        // worker id is interpolated, not literal
+        assert_eq!(NetworkType::Worker(3).req_res_protocol().as_ref(), "/tn-worker-3/0.0.1");
+        assert_eq!(NetworkType::Worker(3).kad_protocol().as_ref(), "/tn-worker-3-kad/1.0.0");
     }
 }

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -904,11 +904,11 @@ mod test {
     #[test]
     fn test_network_type_protocol_names() {
         assert_eq!(NetworkType::Primary.req_res_protocol().as_ref(), "/tn-primary/0.0.1");
-        assert_eq!(NetworkType::Primary.kad_protocol().as_ref(), "/tn-primary-kad/1.0.0");
+        assert_eq!(NetworkType::Primary.kad_protocol().as_ref(), "/tn-primary-kad/0.0.1");
         assert_eq!(NetworkType::Worker(0).req_res_protocol().as_ref(), "/tn-worker-0/0.0.1");
-        assert_eq!(NetworkType::Worker(0).kad_protocol().as_ref(), "/tn-worker-0-kad/1.0.0");
+        assert_eq!(NetworkType::Worker(0).kad_protocol().as_ref(), "/tn-worker-0-kad/0.0.1");
         // worker id is interpolated, not literal
         assert_eq!(NetworkType::Worker(3).req_res_protocol().as_ref(), "/tn-worker-3/0.0.1");
-        assert_eq!(NetworkType::Worker(3).kad_protocol().as_ref(), "/tn-worker-3-kad/1.0.0");
+        assert_eq!(NetworkType::Worker(3).kad_protocol().as_ref(), "/tn-worker-3-kad/0.0.1");
     }
 }

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -1,25 +1,25 @@
 //! Module with kademlia specific extensions, like a persistant store.
 
-use std::{
-    borrow::Cow,
-    fmt, iter,
-    time::{Instant, SystemTime},
-};
-
+use crate::types::NetworkType;
 use libp2p::{
     kad::{
         store::{Error, MemoryStoreConfig, RecordStore},
         ProviderRecord, Record, RecordKey,
     },
-    Multiaddr, PeerId, StreamProtocol,
+    Multiaddr, PeerId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{serde_as, DeserializeAs, SerializeAs};
+use std::{
+    borrow::Cow,
+    fmt, iter,
+    time::{Instant, SystemTime},
+};
 use tn_config::KeyConfig;
 use tn_storage::tables::{
     KadProviderRecords, KadRecords, KadWorkerProviderRecords, KadWorkerRecords,
 };
-use tn_types::{decode, encode, BlockHash, Database, DefaultHashFunction, WorkerId};
+use tn_types::{decode, encode, BlockHash, Database, DefaultHashFunction};
 
 /// A record stored in the DHT.
 /// This is a "shadow" struct for a kad Record so we can serialize/deserialize
@@ -156,42 +156,6 @@ fn instant_to_system(expires: &Option<Instant>) -> Option<SystemTime> {
         }
     } else {
         None
-    }
-}
-
-/// The role of a consensus network instance — primary or worker.
-///
-/// A node runs both as fully isolated libp2p swarms in one process. This is the
-/// one source of truth for everything that must differ: the kad store's backing
-/// tables and the wire protocol names that keep the two from ever negotiating a
-/// connection with one another.
-#[derive(Copy, Clone, Debug)]
-pub enum NetworkType {
-    /// Primary network.
-    Primary,
-    /// Worker network.
-    Worker(WorkerId),
-}
-
-impl NetworkType {
-    /// Request-response wire protocol, isolated per role (and per worker).
-    pub(crate) fn req_res_protocol(&self) -> StreamProtocol {
-        match self {
-            Self::Primary => StreamProtocol::new("/tn-primary/0.0.1"),
-            Self::Worker(id) => StreamProtocol::try_from_owned(format!("/tn-worker-{id}/0.0.1"))
-                .expect("worker req-res protocol name starts with '/'"),
-        }
-    }
-
-    /// Kademlia wire protocol, isolated per role (and per worker).
-    pub(crate) fn kad_protocol(&self) -> StreamProtocol {
-        match self {
-            Self::Primary => StreamProtocol::new("/tn-primary-kad/1.0.0"),
-            Self::Worker(id) => {
-                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-kad/1.0.0"))
-                    .expect("worker kad protocol name starts with '/'")
-            }
-        }
     }
 }
 

--- a/crates/network-libp2p/src/stream/behavior.rs
+++ b/crates/network-libp2p/src/stream/behavior.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// The protocol identifier for streaming data.
-pub(crate) const TN_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/tn-stream/1.0.0");
+pub(crate) const TN_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/tn-stream/0.0.1");
 
 /// Events emitted by the stream behavior to the swarm/application layer.
 #[derive(Debug)]

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -49,7 +49,7 @@ fn create_test_peers<Req: TNMessage, Res: TNMessage>(
                 network_key,
                 db,
                 task_manager.get_spawner(),
-                KadStoreType::Primary,
+                NetworkType::Primary,
                 config.primary_address(),
             )
             .expect("peer1 network created");
@@ -164,7 +164,7 @@ where
             network_key_1,
             MemDatabase::default(),
             task_manager.get_spawner(),
-            KadStoreType::Primary,
+            NetworkType::Primary,
             config_1.primary_address(),
         )
         .expect("peer1 network created");
@@ -186,7 +186,7 @@ where
             network_key_2,
             MemDatabase::default(),
             task_manager.get_spawner(),
-            KadStoreType::Primary,
+            NetworkType::Primary,
             config_2.primary_address(),
         )
         .expect("peer2 network created");
@@ -612,6 +612,138 @@ async fn test_outbound_failure_malicious_response() -> eyre::Result<()> {
     // OutboundFailure::Io(Custom { kind: Other, error: Custom("Invalid value was given to the
     // function") })
     assert_matches!(res, Err(NetworkError::Outbound(_)));
+
+    Ok(())
+}
+
+/// Regression test for cross-role network isolation.
+///
+/// A single node runs a primary and a worker `ConsensusNetwork` in the same
+/// process; they must never negotiate a working session with one another. Before
+/// role-derived protocol names, both spoke `/telcoin-network/0.0.0` (req/res) and
+/// `/tn-kad/1.0.0` (kad). Because kad records are keyed on the validator's BLS
+/// pubkey — identical for that validator's worker and primary — a primary could
+/// ingest a *worker's* `NodeRecord` and then dial/RPC it with primary protocols,
+/// penalizing and banning otherwise-healthy peers.
+///
+/// With `NetworkType::Primary` → `/tn-primary/*` and `NetworkType::Worker(0)` →
+/// `/tn-worker-0/*`, the cross-role substreams never negotiate: kad never exchanges
+/// records (so the worker's pushed record never resolves on the primary) and a
+/// req/res request surfaces an `OutboundFailure`. Both networks use IDENTICAL
+/// req/res message types here, so the only thing that can differ is the
+/// role-derived protocol name.
+#[tokio::test]
+async fn test_primary_worker_protocol_isolation() -> eyre::Result<()> {
+    // build two networks from the same committee
+    let mut network_config = NetworkConfig::default();
+    network_config.peer_config_mut().heartbeat_interval = TEST_HEARTBEAT_INTERVAL;
+
+    let all_nodes =
+        CommitteeFixture::builder(MemDatabase::default).with_network_config(network_config).build();
+    let mut authorities = all_nodes.authorities();
+    let config_1 = authorities.next().expect("first authority").consensus_config();
+    let config_2 = authorities.next().expect("second authority").consensus_config();
+    let (tx1, _events_1) = mpsc::channel(10);
+    let (tx2, _events_2) = mpsc::channel(10);
+    let task_manager = TaskManager::default();
+
+    // peer1: PRIMARY role
+    let primary_network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_1.network_config(),
+        tx1,
+        config_1.key_config().clone(),
+        config_1.key_config().primary_network_keypair().clone(),
+        MemDatabase::default(),
+        task_manager.get_spawner(),
+        NetworkType::Primary,
+        config_1.primary_address(),
+    )
+    .expect("primary network created");
+    let primary = primary_network.network_handle();
+    tokio::spawn(async move {
+        primary_network.run().await.expect("primary network run failed!");
+    });
+
+    // peer2: WORKER role
+    let worker_network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_2.network_config(),
+        tx2,
+        config_2.key_config().clone(),
+        config_2.key_config().worker_network_keypair().clone(),
+        MemDatabase::default(),
+        task_manager.get_spawner(),
+        NetworkType::Worker(0),
+        config_2.worker_address(),
+    )
+    .expect("worker network created");
+    let worker = worker_network.network_handle();
+    tokio::spawn(async move {
+        worker_network.run().await.expect("worker network run failed!");
+    });
+
+    // start listening
+    primary.start_listening(config_1.primary_address()).await?;
+    worker.start_listening(config_2.worker_address()).await?;
+    let worker_addr = worker.listeners().await?.first().expect("worker listen addr").clone();
+    let primary_peer_id = primary.local_peer_id().await?;
+
+    // the BLS key is identical for both of the validator's networks — exactly the
+    // shared key that previously let a worker's record contaminate a primary store.
+    let primary_bls = config_1.key_config().primary_public_key();
+    let worker_bls = config_2.key_config().primary_public_key();
+
+    // primary dials the worker across roles
+    primary
+        .add_explicit_peer(
+            worker_bls,
+            config_2.key_config().worker_network_public_key(),
+            worker_addr,
+        )
+        .await?;
+    primary.dial_by_bls(worker_bls).await?;
+
+    // allow the QUIC transport to connect and the kad/req-res substreams to (fail
+    // to) negotiate
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // positive control: the transport connection IS established across roles — the
+    // worker sees the primary's peer id — so the isolation below is protocol-level,
+    // not a failed dial.
+    assert!(
+        worker.connected_peer_ids().await?.contains(&primary_peer_id),
+        "transport connection across roles should establish"
+    );
+
+    // kad isolation: the primary pushes its record to the worker on connect, but
+    // the worker speaks a different kad protocol and never ingests it, so the
+    // worker never resolves the primary's BLS key. (The worker did NOT add the
+    // primary as an explicit peer, so a resolved BLS key could only come from kad.)
+    assert!(
+        !worker.connected_peers().await?.contains(&primary_bls),
+        "worker resolved primary's BLS key — kad records crossed roles"
+    );
+
+    // req/res isolation: a request to the worker cannot negotiate a protocol —
+    // the worker speaks `/tn-worker-0/*`, not the primary's `/tn-primary/*`. With
+    // identical message types, this can ONLY be a protocol-name mismatch.
+    let req = TestWorkerRequest::MissingBatches(vec![]);
+    let reply = primary.send_request(req, worker_bls).await?;
+    let res = timeout(Duration::from_secs(5), reply).await?.expect("reply channel");
+    assert_matches!(
+        res,
+        Err(NetworkError::Outbound(_)),
+        "cross-role req/res must fail to negotiate a protocol"
+    );
 
     Ok(())
 }

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -8,11 +8,13 @@ use libp2p::{
     core::transport::ListenerId,
     gossipsub::{PublishError, SubscriptionError, TopicHash},
     request_response::ResponseChannel,
-    Multiaddr, PeerId, Stream, TransportError,
+    Multiaddr, PeerId, Stream, StreamProtocol, TransportError,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use tn_types::{encode, now, BlsPublicKey, BlsSignature, NetworkPublicKey, P2pNode, TimestampSec};
+use tn_types::{
+    encode, now, BlsPublicKey, BlsSignature, NetworkPublicKey, P2pNode, TimestampSec, WorkerId,
+};
 use tokio::sync::{mpsc, oneshot};
 
 #[cfg(test)]
@@ -52,6 +54,42 @@ pub const WORKER_BATCH_TOPIC: &str = "tn_batches";
 pub const PRIMARY_CERT_TOPIC: &str = "tn_certificates";
 /// The topic for NVVs to subscribe to for published consensus chain.
 pub const CONSENSUS_HEADER_TOPIC: &str = "tn_consensus_headers";
+
+/// The role of a consensus network instance: primary or worker.
+///
+/// A node runs both as fully isolated libp2p swarms in one process. This is the
+/// one source of truth for everything that must differ: the kad store's backing
+/// tables and the wire protocol names that keep the two from ever negotiating a
+/// connection with one another.
+#[derive(Copy, Clone, Debug)]
+pub enum NetworkType {
+    /// Primary network.
+    Primary,
+    /// Worker network.
+    Worker(WorkerId),
+}
+
+impl NetworkType {
+    /// Request-response wire protocol, isolated per role (and per worker).
+    pub(crate) fn req_res_protocol(&self) -> StreamProtocol {
+        match self {
+            Self::Primary => StreamProtocol::new("/tn-primary/0.0.1"),
+            Self::Worker(id) => StreamProtocol::try_from_owned(format!("/tn-worker-{id}/0.0.1"))
+                .expect("worker req-res protocol name starts with '/'"),
+        }
+    }
+
+    /// Kademlia wire protocol, isolated per role (and per worker).
+    pub(crate) fn kad_protocol(&self) -> StreamProtocol {
+        match self {
+            Self::Primary => StreamProtocol::new("/tn-primary-kad/0.0.1"),
+            Self::Worker(id) => {
+                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-kad/0.0.1"))
+                    .expect("worker kad protocol name starts with '/'")
+            }
+        }
+    }
+}
 
 /// Events created from network activity.
 #[derive(Debug)]

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -22,7 +22,7 @@ use tn_types::{
     deconstruct_nonce, gas_accumulator::GasAccumulator, BlockNumHash, BlsPublicKey,
     BootstrapServer, Committee, ConsensusHeader, ConsensusOutput, Database as TNDatabase,
     EngineUpdate, Epoch, Notifier, TaskError, TaskManager, TaskSpawner, TimestampSec,
-    MIN_PROTOCOL_BASE_FEE,
+    DEFAULT_WORKER_ID, MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::{WorkerNetworkHandle, WorkerRequest, WorkerResponse};
 use tokio::sync::mpsc;
@@ -421,6 +421,7 @@ where
 
         // create long-running network task for worker
         let worker_network = ConsensusNetwork::new_for_worker(
+            DEFAULT_WORKER_ID,
             network_config,
             self.worker_event_stream.clone(),
             self.key_config.clone(),

--- a/crates/node/src/manager/node/epoch.rs
+++ b/crates/node/src/manager/node/epoch.rs
@@ -43,7 +43,7 @@ use tn_types::{
     gas_accumulator::GasAccumulator, Batch, BatchValidation, BlockHash, BlockNumHash, BlsPublicKey,
     BlsSigner, Committee, CommitteeBuilder, ConsensusOutput, Database as TNDatabase, Epoch,
     EpochRecord, Multiaddr, NetworkPublicKey, Notifier, P2pNode, TaskJoinError, TaskManager,
-    TaskSpawner, TnReceiver, B256,
+    TaskSpawner, TnReceiver, B256, DEFAULT_WORKER_ID,
 };
 use tn_worker::{quorum_waiter::QuorumWaiterTrait, Worker, WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -942,7 +942,7 @@ where
         gas_accumulator: GasAccumulator,
     ) -> eyre::Result<WorkerNode<DB>> {
         // only support one worker for now (with id 0) - otherwise, loop here
-        let worker_id = 0;
+        let worker_id = DEFAULT_WORKER_ID;
         let base_fee = gas_accumulator.base_fee(worker_id);
 
         // update the network handle's task spawner for reporting batches in the epoch

--- a/crates/types/src/worker/mod.rs
+++ b/crates/types/src/worker/mod.rs
@@ -26,3 +26,6 @@ pub const DEFAULT_WORKER_PORT: u16 = 44895;
 ///
 /// Workers communicate with peers of the same `WorkerId`.
 pub type WorkerId = u16;
+
+/// The default worker id. Today a primary runs exactly one worker, id `0`.
+pub const DEFAULT_WORKER_ID: WorkerId = 0;


### PR DESCRIPTION
- Replace `KadStoreType` with `NetworkType` (`Primary` / `Worker(WorkerId)`); each role derives its own req/res and kad protocol names (`/tn-primary/*`, `/tn-worker-{id}/*`), so cross-role substreams can't negotiate and a worker's BLS-keyed kad record can no longer contaminate a primary's peer store.
- Drop the `supported_req_res_protocols` config field, `protocol_vec` serde, and the shared `protocol()`/`identify_protocol()` helpers — protocols come from role now, not config.
- `new_for_worker` takes a `worker_id`; add `DEFAULT_WORKER_ID = 0` and thread it through the node/epoch wiring.
- Add a cross-role isolation regression test and a test locking the per-role protocol name strings.

closes #725 