### PR TITLE
Native BLS proof-of-possession precompile at 0x...b151

### DIFF
--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -69,6 +69,7 @@ secp256k1 = { workspace = true, optional = true }
 tn-types = { workspace = true, features = ["test-utils"] }
 secp256k1 = { workspace = true }
 proptest = { workspace = true }
+rand = { workspace = true }
 tn-reth = { workspace = true, features = ["test-utils"] }
 
 [features]

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -1,0 +1,390 @@
+//! Native BLS12-381 proof-of-possession precompile.
+//!
+//! Replaces the Solidity `BlsG1` library (linked at [`BLS_G1_PRECOMPILE_ADDRESS`], `0x…b151`) with
+//! a native implementation that delegates to the **same** `blst` (`min_sig`) verification the
+//! consensus layer uses to *produce* proofs of possession
+//! ([`tn_types::verify_proof_of_possession_bls`]). Having one implementation behind both signing
+//! and verification removes the byte-for-byte drift risk between the Rust signer and an independent
+//! on-chain reimplementation.
+//!
+//! # Structure
+//!
+//! Mirrors [`tel_precompile`](super::tel_precompile): a [`DynPrecompile`] registered via
+//! [`add_bls_precompile`] and dispatched by 4-byte selector. The ABI matches `BlsG1.sol`, so
+//! `ConsensusRegistry`'s existing library `delegatecall`s resolve to this precompile unchanged.
+//!
+//! | Selector | Behavior |
+//! |----------|----------|
+//! | `verifyProofOfPossession(bytes,bytes,address)` | Verify a PoP from uncompressed G1 sig + G2 pubkey. The one crypto entrypoint. |
+//! | `proofOfPossessionMessage(bytes,address)` | Return the exact bytes the PoP is signed/verified over (used for revert reasons). |
+//!
+//! # Encoding
+//!
+//! The signature/pubkey arguments are the protocol's own `blst::min_sig` `serialize()` output
+//! (96-byte uncompressed G1 signature, 192-byte uncompressed G2 pubkey) - the identical bytes the
+//! genesis assembly and `stake`/`delegateStake` callers already pass to `BlsG1`. The precompile
+//! feeds them straight back into `blst` via [`BlsSignature::from_uncompressed_bytes`] /
+//! [`BlsPublicKey::from_uncompressed_bytes`]; no EIP-2537 re-encoding or point (de)compression is
+//! performed here.
+use alloy::{
+    primitives::address,
+    sol,
+    sol_types::{SolCall, SolValue},
+};
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
+use reth_revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use tn_types::{
+    proof_of_possession_message_bytes, verify_proof_of_possession_bls, Address, BlsPublicKey,
+    BlsSignature, Bytes,
+};
+
+/// Canonical address of the BLS proof-of-possession precompile: `0x…b151`.
+///
+/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is
+/// linked against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
+pub(crate) const BLS_G1_PRECOMPILE_ADDRESS: Address =
+    address!("000000000000000000000000000000000000b151");
+
+sol! {
+    /// Verifies a validator's BLS12-381 proof of possession from raw uncompressed inputs.
+    ///
+    /// `uncompressedSignature`: 96-byte uncompressed G1 point. `uncompressedPubkey`: 192-byte
+    /// uncompressed G2 point. Both as produced by `blst::min_sig` `serialize`.
+    function verifyProofOfPossession(
+        bytes uncompressedSignature,
+        bytes uncompressedPubkey,
+        address validatorAddress
+    ) external view returns (bool);
+
+    /// Returns the proof-of-possession message bytes a validator signs / is verified against.
+    function proofOfPossessionMessage(
+        bytes uncompressedPubkey,
+        address validatorAddress
+    ) external pure returns (bytes);
+}
+
+/// Gas charged for a proof-of-possession verification.
+///
+/// Priced to reflect the equivalent EIP-2537 work the verification represents: a 2-pairing check
+/// (`37_700 + 2 * 32_600 = 102_900`) plus hash-to-curve and point decoding, rounded up. This keeps
+/// the on-chain cost proportional to the cryptography while remaining well within a normal
+/// transaction's gas budget (`stake` / `delegateStake` run with a 1M default limit). The native
+/// implementation completes in microseconds; the charge exists for metering, not compute time.
+const VERIFY_POP_GAS_COST: u64 = 150_000;
+
+/// Gas charged for building the proof-of-possession message (pure serialization, no pairing).
+const POP_MESSAGE_GAS_COST: u64 = 5_000;
+
+/// Registers the BLS precompile at [`BLS_G1_PRECOMPILE_ADDRESS`] in the given map.
+///
+/// Called from the EVM factory alongside `add_telcoin_precompile`, so the precompile is present for
+/// all execution including pre-genesis registry construction.
+pub(crate) fn add_bls_precompile(map: &mut PrecompilesMap) {
+    map.apply_precompile(&BLS_G1_PRECOMPILE_ADDRESS, move |_| {
+        Some(DynPrecompile::new_stateful(PrecompileId::Custom("bls_g1".into()), move |input| {
+            bls_precompile(input)
+        }))
+    });
+}
+
+/// Precompile entrypoint. Delegates to [`dispatch`]; the precompile is stateless, so it never
+/// touches the EVM internals carried by [`PrecompileInput`].
+fn bls_precompile(input: PrecompileInput<'_>) -> PrecompileResult {
+    dispatch(input.data, input.gas)
+}
+
+/// Selector dispatch: extracts the 4-byte selector from calldata and routes to the handler.
+///
+/// Split out from [`bls_precompile`] so the selector routing, gas metering, and ABI round-trips can
+/// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`]
+/// (which would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
+fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
+    if data.len() < 4 {
+        return Err(PrecompileError::Other("Invalid input: too short".into()));
+    }
+
+    let selector: [u8; 4] = data[0..4].try_into().unwrap();
+    let calldata = &data[4..];
+
+    match selector {
+        verifyProofOfPossessionCall::SELECTOR => handle_verify_pop(calldata, gas),
+        proofOfPossessionMessageCall::SELECTOR => handle_pop_message(calldata, gas),
+        _ => Err(PrecompileError::Other("Unknown function selector".into())),
+    }
+}
+
+/// `verifyProofOfPossession(bytes,bytes,address) -> bool`.
+fn handle_verify_pop(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
+    if gas_limit < VERIFY_POP_GAS_COST {
+        return Err(PrecompileError::OutOfGas);
+    }
+
+    let decoded = verifyProofOfPossessionCall::abi_decode_raw(calldata)
+        .map_err(|e| PrecompileError::Other(format!("verifyProofOfPossession: {e}").into()))?;
+
+    // Reuse the exact crypto the consensus layer uses to *produce* PoPs, so signer and verifier can
+    // never disagree. A malformed point or failed pairing yields `false` (not a revert), matching
+    // `BlsG1.verifyProofOfPossession`'s boolean contract; the caller (`ConsensusRegistry`) is what
+    // turns `false` into its own `InvalidProofOfPossession` revert.
+    let verified = verify_pop(
+        &decoded.uncompressedSignature,
+        &decoded.uncompressedPubkey,
+        decoded.validatorAddress,
+    );
+
+    Ok(PrecompileOutput::new(VERIFY_POP_GAS_COST, Bytes::from(verified.abi_encode())))
+}
+
+/// Decode the uncompressed inputs and run the `blst` proof-of-possession check. Any decode or
+/// verification failure maps to `false` so a bad proof can never panic or revert the precompile.
+fn verify_pop(uncompressed_sig: &[u8], uncompressed_pubkey: &[u8], address: Address) -> bool {
+    let Ok(pubkey) = BlsPublicKey::from_uncompressed_bytes(uncompressed_pubkey) else {
+        return false;
+    };
+    let Ok(sig) = BlsSignature::from_uncompressed_bytes(uncompressed_sig) else {
+        return false;
+    };
+
+    verify_proof_of_possession_bls(&sig, &pubkey, &address).is_ok()
+}
+
+/// `proofOfPossessionMessage(bytes,address) -> bytes`.
+///
+/// Returns the canonical message bytes (`encode(IntentMessage)`) the PoP is verified against, so
+/// the message reported here and the message verified by [`handle_verify_pop`] are produced by the
+/// same code. A malformed pubkey reverts (it cannot be the basis of any valid message).
+fn handle_pop_message(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
+    if gas_limit < POP_MESSAGE_GAS_COST {
+        return Err(PrecompileError::OutOfGas);
+    }
+
+    let decoded = proofOfPossessionMessageCall::abi_decode_raw(calldata)
+        .map_err(|e| PrecompileError::Other(format!("proofOfPossessionMessage: {e}").into()))?;
+
+    let pubkey =
+        BlsPublicKey::from_uncompressed_bytes(&decoded.uncompressedPubkey).map_err(|e| {
+            PrecompileError::Other(format!("invalid uncompressed pubkey: {e:?}").into())
+        })?;
+    let message = proof_of_possession_message_bytes(&pubkey, &decoded.validatorAddress)
+        .map_err(|e| PrecompileError::Other(format!("message build failed: {e}").into()))?;
+
+    Ok(PrecompileOutput::new(POP_MESSAGE_GAS_COST, Bytes::from(Bytes::from(message).abi_encode())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+    use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair};
+
+    /// A deterministic keypair + the uncompressed sig/pubkey bytes of a valid PoP for `address`.
+    ///
+    /// `sig`/`pubkey` are `blst::min_sig` `serialize()` output (96-byte G1 sig, 192-byte G2
+    /// pubkey), the exact bytes the protocol passes to `BlsG1` / this precompile.
+    struct Vector {
+        keypair: BlsKeypair,
+        address: Address,
+        sig: Vec<u8>,
+        pubkey: Vec<u8>,
+    }
+
+    /// Builds a valid proof-of-possession vector from a fixed RNG seed and address byte.
+    fn vector(seed: u8, address_byte: u8) -> Vector {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([seed; 32]));
+        let address = Address::repeat_byte(address_byte);
+        let proof = generate_proof_of_possession_bls_for_test(&keypair, &address)
+            .expect("generate test PoP");
+        let sig = proof.serialize().to_vec();
+        let pubkey = keypair.public().serialize().to_vec();
+        Vector { keypair, address, sig, pubkey }
+    }
+
+    /// ABI-encodes a `verifyProofOfPossession` call (selector + args), as a caller would.
+    fn encode_verify(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
+        verifyProofOfPossessionCall {
+            uncompressedSignature: Bytes::copy_from_slice(sig),
+            uncompressedPubkey: Bytes::copy_from_slice(pubkey),
+            validatorAddress: address,
+        }
+        .abi_encode()
+    }
+
+    /// Decodes the ABI-encoded `bool` returned by a `verifyProofOfPossession` call.
+    fn decode_bool(bytes: &[u8]) -> bool {
+        <bool as SolValue>::abi_decode(bytes).expect("decode bool return")
+    }
+
+    // --- `verify_pop` crypto semantics -----------------------------------------------------------
+
+    /// A well-formed proof of possession verifies through the same `blst` path the signer used.
+    /// Looped over several keypairs/addresses to stand in for the Solidity fuzz coverage.
+    #[test]
+    fn verify_pop_accepts_valid_proof() {
+        for (seed, addr) in [(7u8, 0x42u8), (11, 0x01), (99, 0xab), (1, 0xff)] {
+            let v = vector(seed, addr);
+            assert!(verify_pop(&v.sig, &v.pubkey, v.address), "seed {seed} addr {addr:#x}");
+        }
+    }
+
+    /// A proof bound to a different address must fail (the address is part of the signed message).
+    #[test]
+    fn verify_pop_rejects_wrong_address() {
+        let v = vector(7, 0x42);
+        assert!(!verify_pop(&v.sig, &v.pubkey, Address::repeat_byte(0x43)));
+    }
+
+    /// A signature produced by a different key must fail against the original pubkey
+    /// (port of the Solidity "mutated signature" negative case).
+    #[test]
+    fn verify_pop_rejects_wrong_signature() {
+        let v = vector(7, 0x42);
+        let other = vector(8, 0x42);
+        assert!(!verify_pop(&other.sig, &v.pubkey, v.address));
+    }
+
+    /// A valid signature must not verify against a substituted pubkey
+    /// (port of the Solidity "pubkey substitution" attack case).
+    #[test]
+    fn verify_pop_rejects_pubkey_substitution() {
+        let v = vector(7, 0x42);
+        let other = vector(8, 0x42);
+        assert!(!verify_pop(&v.sig, &other.pubkey, v.address));
+    }
+
+    /// Identity/infinity points and all-zero inputs return `false`, never panic
+    /// (port of the Solidity zero-point / infinity-point rejection cases).
+    #[test]
+    fn verify_pop_rejects_zero_and_infinity_points() {
+        let v = vector(7, 0x42);
+        // all-zero sig + pubkey (the uncompressed infinity-point encoding)
+        assert!(!verify_pop(&[0u8; 96], &[0u8; 192], Address::ZERO));
+        // zero signature against an otherwise valid pubkey/address
+        assert!(!verify_pop(&[0u8; 96], &v.pubkey, v.address));
+        // zero pubkey against an otherwise valid signature/address
+        assert!(!verify_pop(&v.sig, &[0u8; 192], v.address));
+    }
+
+    /// Wrong-length sig/pubkey inputs are rejected without panicking (port of the Solidity
+    /// `invalidPubkeyLength` length-validation cases: empty, short, and over-long).
+    #[test]
+    fn verify_pop_rejects_wrong_length_inputs() {
+        let v = vector(7, 0x42);
+
+        // pubkey lengths that are not the 192-byte uncompressed G2 form
+        for len in [0usize, 32, 48, 64, 95, 96, 128, 191, 193, 256] {
+            assert!(!verify_pop(&v.sig, &vec![0u8; len], v.address), "pubkey len {len}");
+        }
+        // signature lengths that are not the 96-byte uncompressed G1 form
+        for len in [0usize, 32, 48, 95, 97, 128, 192] {
+            assert!(!verify_pop(&vec![0u8; len], &v.pubkey, v.address), "sig len {len}");
+        }
+    }
+
+    // --- selector dispatch / ABI surface ---------------------------------------------------------
+
+    /// A valid PoP through the full ABI path returns ABI-encoded `true` and charges the fixed cost.
+    #[test]
+    fn dispatch_verify_valid_returns_true() {
+        let v = vector(7, 0x42);
+        let out = dispatch(&encode_verify(&v.sig, &v.pubkey, v.address), VERIFY_POP_GAS_COST)
+            .expect("dispatch ok");
+        assert!(decode_bool(&out.bytes));
+        assert_eq!(out.gas_used, VERIFY_POP_GAS_COST);
+    }
+
+    /// An invalid PoP returns ABI-encoded `false` rather than reverting: the precompile mirrors
+    /// `BlsG1.verifyProofOfPossession`'s boolean contract, leaving the revert to
+    /// `ConsensusRegistry`.
+    #[test]
+    fn dispatch_verify_invalid_returns_false_not_revert() {
+        let v = vector(7, 0x42);
+        let out = dispatch(
+            &encode_verify(&v.sig, &v.pubkey, Address::repeat_byte(0x43)),
+            VERIFY_POP_GAS_COST,
+        )
+        .expect("dispatch ok (false, not error)");
+        assert!(!decode_bool(&out.bytes));
+        // gas is still charged for the work performed
+        assert_eq!(out.gas_used, VERIFY_POP_GAS_COST);
+    }
+
+    /// Verification with less gas than the fixed cost is metered as out-of-gas.
+    #[test]
+    fn dispatch_verify_out_of_gas() {
+        let v = vector(7, 0x42);
+        let res = dispatch(&encode_verify(&v.sig, &v.pubkey, v.address), VERIFY_POP_GAS_COST - 1);
+        assert!(matches!(res, Err(PrecompileError::OutOfGas)));
+    }
+
+    /// `proofOfPossessionMessage` returns exactly the bytes verification signs over, so the message
+    /// reported on-chain and the message checked by `verify` come from one code path. Signing the
+    /// returned message yields a proof that verifies.
+    #[test]
+    fn dispatch_message_matches_signed_bytes_and_round_trips() {
+        let v = vector(7, 0x42);
+        let calldata = proofOfPossessionMessageCall {
+            uncompressedPubkey: Bytes::copy_from_slice(&v.pubkey),
+            validatorAddress: v.address,
+        }
+        .abi_encode();
+
+        let out = dispatch(&calldata, POP_MESSAGE_GAS_COST).expect("dispatch ok");
+        assert_eq!(out.gas_used, POP_MESSAGE_GAS_COST);
+
+        let returned = <Bytes as SolValue>::abi_decode(&out.bytes).expect("decode bytes return");
+        let expected = proof_of_possession_message_bytes(v.keypair.public(), &v.address)
+            .expect("build expected message");
+        assert_eq!(returned.as_ref(), expected.as_slice());
+
+        // the verifier accepts the proof signed over exactly this message
+        assert!(verify_pop(&v.sig, &v.pubkey, v.address));
+    }
+
+    /// The message is bound to the validator address: a different address yields different bytes.
+    #[test]
+    fn dispatch_message_is_address_bound() {
+        let v = vector(7, 0x42);
+        let msg_a = proof_of_possession_message_bytes(v.keypair.public(), &v.address).unwrap();
+        let msg_b =
+            proof_of_possession_message_bytes(v.keypair.public(), &Address::repeat_byte(0x43))
+                .unwrap();
+        assert_ne!(msg_a, msg_b);
+    }
+
+    /// A malformed pubkey to `proofOfPossessionMessage` reverts (it cannot form any valid message).
+    #[test]
+    fn dispatch_message_rejects_malformed_pubkey() {
+        let calldata = proofOfPossessionMessageCall {
+            uncompressedPubkey: Bytes::from_static(&[0xAB; 10]),
+            validatorAddress: Address::ZERO,
+        }
+        .abi_encode();
+        assert!(dispatch(&calldata, POP_MESSAGE_GAS_COST).is_err());
+    }
+
+    /// Building the message with less gas than the fixed cost is metered as out-of-gas.
+    #[test]
+    fn dispatch_message_out_of_gas() {
+        let v = vector(7, 0x42);
+        let calldata = proofOfPossessionMessageCall {
+            uncompressedPubkey: Bytes::copy_from_slice(&v.pubkey),
+            validatorAddress: v.address,
+        }
+        .abi_encode();
+        let res = dispatch(&calldata, POP_MESSAGE_GAS_COST - 1);
+        assert!(matches!(res, Err(PrecompileError::OutOfGas)));
+    }
+
+    /// Unknown selectors and truncated calldata are rejected.
+    #[test]
+    fn dispatch_rejects_unknown_selector_and_short_input() {
+        // unknown 4-byte selector + padding
+        let mut unknown = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        unknown.extend_from_slice(&[0u8; 32]);
+        assert!(dispatch(&unknown, VERIFY_POP_GAS_COST).is_err());
+
+        // fewer than 4 bytes cannot carry a selector
+        assert!(dispatch(&[0x01, 0x02], VERIFY_POP_GAS_COST).is_err());
+        assert!(dispatch(&[], VERIFY_POP_GAS_COST).is_err());
+    }
+}

--- a/crates/tn-reth/src/evm/factory.rs
+++ b/crates/tn-reth/src/evm/factory.rs
@@ -1,8 +1,9 @@
 //! The factory to create EVM environments.
 
 use super::{
-    tel_precompile::add_telcoin_precompile, TNBlockExecutionCtx, TNBlockExecutor, TNContext as _,
-    TNContextBuilder as _, TNEvm, TNEvmContext,
+    bls_precompile::add_bls_precompile, tel_precompile::add_telcoin_precompile,
+    TNBlockExecutionCtx, TNBlockExecutor, TNContext as _, TNContextBuilder as _, TNEvm,
+    TNEvmContext,
 };
 use alloy_evm::Database;
 use reth_evm::{
@@ -55,6 +56,7 @@ impl EvmFactory for TNEvmFactory {
                         PrecompileSpecId::from_spec_id(spec_id),
                     ));
                     add_telcoin_precompile(&mut map);
+                    add_bls_precompile(&mut map);
                     map
                 }),
             inspect: false,
@@ -79,6 +81,7 @@ impl EvmFactory for TNEvmFactory {
                         PrecompileSpecId::from_spec_id(spec_id),
                     ));
                     add_telcoin_precompile(&mut map);
+                    add_bls_precompile(&mut map);
                     map
                 }),
             inspect: true,

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -18,10 +18,13 @@ use reth_revm::{
 use std::ops::{Deref, DerefMut};
 use tn_types::{Address, Bytes, TxKind, U256};
 mod block;
+mod bls_precompile;
 mod config;
 mod context;
 mod factory;
 mod handler;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod precompile_test_utils;
 mod tel_precompile;
 mod utils;
 use crate::evm::handler::TNEvmHandler;
@@ -29,8 +32,6 @@ pub(crate) use block::*;
 pub(crate) use config::*;
 pub(crate) use context::*;
 pub(crate) use factory::*;
-#[cfg(any(test, feature = "test-utils"))]
-pub use tel_precompile::test_utils as precompile_test_utils;
 #[cfg(not(feature = "faucet"))]
 pub use tel_precompile::TIMELOCK_DURATION;
 pub use tel_precompile::{

--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -1,0 +1,334 @@
+//! Shared in-memory EVM test harness for the native precompiles.
+//!
+//! This is the single source of truth for lightweight EVM test infrastructure used to exercise the
+//! precompiles registered by the production factory (TEL at `0x7e1`, BLS at `0x…b151`). It builds a
+//! [`TestEnv`] backed by an [`InMemoryDB`] with both precompiles registered, and provides
+//! execution, balance/storage inspection, and output-decoding helpers.
+//!
+//! Precompile-specific helpers live alongside their precompile: the TEL token helpers
+//! (`mint`, `get_total_supply`, `set_total_supply`, [`GENESIS_SUPPLY`]) are defined in
+//! [`tel_precompile::test_utils`](crate::evm::tel_precompile::test_utils) as an extension of
+//! [`TestEnv`]. The stateless BLS precompile needs no extra harness.
+
+use crate::evm::{
+    bls_precompile::add_bls_precompile,
+    context::{TNEvmContext, TelcoinEvm},
+    tel_precompile::{add_telcoin_precompile, TELCOIN_PRECOMPILE_ADDRESS},
+};
+use alloy_evm::precompiles::PrecompilesMap;
+use reth_revm::{
+    bytecode::Bytecode,
+    context::{
+        result::{EVMError, ExecutionResult, InvalidTransaction},
+        BlockEnv, Context, ContextSetters, Evm, FrameStack, TxEnv,
+    },
+    db::InMemoryDB,
+    handler::{instructions::EthInstructions, EthPrecompiles, Handler, MainnetHandler},
+    inspector::NoOpInspector,
+    primitives::{address, Address, KECCAK_EMPTY},
+    state::AccountInfo,
+    Database, MainContext,
+};
+use std::collections::HashMap;
+use tn_config::GOVERNANCE_SAFE_ADDRESS;
+use tn_types::{Bytes, TxKind, U256};
+
+/// TEL genesis supply, re-exported here so consumers keep importing it from
+/// `precompile_test_utils` even though it (and the TEL token helpers) live with the TEL
+/// precompile.
+pub use crate::evm::tel_precompile::test_utils::GENESIS_SUPPLY;
+
+// --- Type aliases ---
+
+/// EVM context type used by the test harness, backed by an [`InMemoryDB`].
+///
+/// Resolves to the same `Context<BlockEnv, TxEnv, CfgEnv, InMemoryDB>` that mainnet
+/// code uses, but with an in-memory database for isolation.
+pub type TestCtx = TNEvmContext<InMemoryDB>;
+
+/// Fully-assembled EVM instance for tests, with the native precompiles registered.
+///
+/// Uses [`PrecompilesMap`] containing both standard Ethereum precompiles and the
+/// Telcoin precompiles (TEL at [`TELCOIN_PRECOMPILE_ADDRESS`], BLS at `0x…b151`).
+pub type TestEvmInner = TelcoinEvm<TestCtx, NoOpInspector>;
+
+/// Result type returned by [`TestEnv::exec`] and [`TestEnv::exec_default`].
+///
+/// `Ok(ExecutionResult)` contains the EVM execution outcome (success, revert, or halt).
+/// `Err(EVMError)` indicates a validation failure before execution (e.g., invalid nonce).
+pub type TestResult =
+    Result<ExecutionResult, EVMError<core::convert::Infallible, InvalidTransaction>>;
+
+// --- Constants ---
+
+/// Test address used as a generic unprivileged caller in unit and integration tests.
+pub const USER: Address = address!("1111100000000000000000000000000000000001");
+
+/// Test address used as a transfer/mint recipient in unit and integration tests.
+pub const RECIPIENT: Address = address!("2222222000000000000000000000000000000002");
+
+// --- Test environment ---
+
+/// Lightweight in-memory EVM environment for testing the native precompiles.
+///
+/// Wraps a fully-configured [`TestEvmInner`] with pre-funded accounts and both Telcoin precompiles
+/// registered. Tracks per-address nonces to allow sequential calls without manual nonce
+/// management.
+///
+/// # Default accounts
+///
+/// [`TestEnv::new`] creates accounts with 1 ETH (10^18 wei) each:
+/// - [`GOVERNANCE_SAFE_ADDRESS`] — governance caller
+/// - [`USER`] — unprivileged caller
+///
+/// The TEL precompile account at [`TELCOIN_PRECOMPILE_ADDRESS`] is funded with 1000 wei and
+/// seeded with [`GENESIS_SUPPLY`] in `totalSupply`.
+#[derive(Debug)]
+pub struct TestEnv {
+    /// The EVM instance with in-memory state and the precompiles registered.
+    pub evm: TestEvmInner,
+    /// Per-address nonce tracker, auto-incremented by [`exec`](Self::exec).
+    pub nonces: HashMap<Address, u64>,
+}
+
+impl TestEnv {
+    /// Create a test environment with default balances.
+    pub fn new() -> Self {
+        Self::new_with_balances(
+            U256::from(10).pow(U256::from(18)),
+            U256::from(10).pow(U256::from(18)),
+            U256::from(1000),
+        )
+    }
+
+    /// Create a test environment with explicit initial balances for governance, user, and
+    /// precompile accounts.
+    pub fn new_with_balances(governance_bal: U256, user_bal: U256, precompile_bal: U256) -> Self {
+        let mut db = InMemoryDB::default();
+
+        db.insert_account_info(
+            GOVERNANCE_SAFE_ADDRESS,
+            AccountInfo {
+                balance: governance_bal,
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                ..Default::default()
+            },
+        );
+
+        db.insert_account_info(
+            USER,
+            AccountInfo {
+                balance: user_bal,
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                ..Default::default()
+            },
+        );
+
+        db.insert_account_info(
+            TELCOIN_PRECOMPILE_ADDRESS,
+            AccountInfo {
+                balance: precompile_bal,
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                ..Default::default()
+            },
+        );
+
+        // Seed the TEL precompile's genesis supply. This is TEL-specific state, but lives in the
+        // shared constructor so the many existing TEL tests get a realistic genesis from
+        // `TestEnv::new()`; the stateless BLS precompile is unaffected by it.
+        db.insert_account_storage(
+            TELCOIN_PRECOMPILE_ADDRESS,
+            U256::from(100),
+            U256::from(GENESIS_SUPPLY) * U256::from(10).pow(U256::from(18)),
+        )
+        .unwrap();
+
+        let block = BlockEnv { timestamp: U256::from(1000), ..Default::default() };
+        let context = Context::mainnet().with_db(db).with_block(block);
+
+        // Register both native precompiles, mirroring the production factory.
+        let mut precompiles = PrecompilesMap::from(EthPrecompiles::default());
+        add_telcoin_precompile(&mut precompiles);
+        add_bls_precompile(&mut precompiles);
+
+        let evm = Evm {
+            ctx: context,
+            inspector: NoOpInspector,
+            instruction: EthInstructions::default(),
+            precompiles,
+            frame_stack: FrameStack::new(),
+        };
+
+        Self { evm, nonces: HashMap::new() }
+    }
+
+    /// Add an account with the given balance after construction.
+    pub fn add_account(&mut self, addr: Address, balance: U256) {
+        self.evm.ctx.journaled_state.database.insert_account_info(
+            addr,
+            AccountInfo {
+                balance,
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                ..Default::default()
+            },
+        );
+    }
+
+    /// Deploy raw EVM bytecode at `addr`.
+    ///
+    /// The account is created with zero balance, nonce 1 (so it looks deployed), and a
+    /// recomputed `code_hash`. Subsequent `CALL`s targeting `addr` execute `code` instead
+    /// of being treated as a non-existent account.
+    pub fn deploy_code(&mut self, addr: Address, code: Bytes) {
+        let bytecode = Bytecode::new_raw(code);
+        let code_hash = bytecode.hash_slow();
+        self.evm.ctx.journaled_state.database.insert_account_info(
+            addr,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash,
+                code: Some(bytecode),
+                ..Default::default()
+            },
+        );
+    }
+
+    /// Execute a precompile call with the given gas limit.
+    ///
+    /// Automatically increments the caller's nonce. The call targets
+    /// [`TELCOIN_PRECOMPILE_ADDRESS`].
+    pub fn exec(&mut self, caller: Address, calldata: Vec<u8>, gas_limit: u64) -> TestResult {
+        self.exec_to(caller, TELCOIN_PRECOMPILE_ADDRESS, calldata, gas_limit)
+    }
+
+    /// Execute a transaction targeting `target` with the given gas limit.
+    ///
+    /// Automatically increments the caller's nonce. Useful for routing through a
+    /// deployed contract (e.g. a `DELEGATECALL` relay) before reaching the precompile.
+    pub fn exec_to(
+        &mut self,
+        caller: Address,
+        target: Address,
+        calldata: Vec<u8>,
+        gas_limit: u64,
+    ) -> TestResult {
+        let nonce = self.nonces.entry(caller).or_insert(0);
+        self.evm.ctx.set_tx(
+            TxEnv::builder()
+                .caller(caller)
+                .kind(TxKind::Call(target))
+                .data(calldata.into())
+                .gas_limit(gas_limit)
+                .nonce(*nonce)
+                .build()
+                .unwrap(),
+        );
+        *nonce += 1;
+        // use mainnet handler with default gas to 0 for simpler test logic
+        // pipeline tests use TN tools and account for gas usage
+        MainnetHandler::default().run(&mut self.evm)
+    }
+
+    /// Execute a precompile call with the default gas limit (100,000).
+    pub fn exec_default(&mut self, caller: Address, calldata: Vec<u8>) -> TestResult {
+        self.exec(caller, calldata, 100_000)
+    }
+
+    /// Read the native account balance of `account`.
+    ///
+    /// Prefers the in-memory journal state (which holds uncommitted modifications from
+    /// previously executed test transactions); falls back to the database.
+    pub fn get_balance(&mut self, account: Address) -> U256 {
+        if let Some(acc) = self.evm.ctx.journaled_state.state.get(&account) {
+            return acc.info.balance;
+        }
+        self.evm
+            .ctx
+            .journaled_state
+            .database
+            .basic(account)
+            .unwrap()
+            .map(|info| info.balance)
+            .unwrap_or(U256::ZERO)
+    }
+
+    /// Read a storage slot from `addr`.
+    ///
+    /// Prefers the in-memory journal state (which holds uncommitted modifications from
+    /// previously executed test transactions); falls back to the database. Returns
+    /// `U256::ZERO` if the slot was never written and the database has no entry.
+    pub fn get_storage(&mut self, addr: Address, slot: U256) -> U256 {
+        if let Some(acc) = self.evm.ctx.journaled_state.state.get(&addr) {
+            if let Some(cell) = acc.storage.get(&slot) {
+                return cell.present_value;
+            }
+        }
+        self.evm.ctx.journaled_state.database.storage(addr, slot).unwrap_or(U256::ZERO)
+    }
+
+    /// Override the block timestamp for subsequent calls. Useful for testing timelocks.
+    pub fn set_timestamp(&mut self, ts: u64) {
+        let block = BlockEnv { timestamp: U256::from(ts), ..Default::default() };
+        self.evm.ctx.set_block(block);
+    }
+}
+
+impl Default for TestEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// --- Assertion helpers ---
+
+/// Assert that the result is `Ok(ExecutionResult::Success { .. })` and return the inner result.
+///
+/// Panics if the result is an error or a non-success execution outcome (revert/halt).
+pub fn assert_success(result: &TestResult) -> &ExecutionResult {
+    let r = result.as_ref().expect("expected Ok, got Err");
+    assert!(matches!(r, ExecutionResult::Success { .. }), "expected Success, got {r:?}");
+    r
+}
+
+/// Assert that the result is **not** a successful execution.
+///
+/// Accepts `Err(...)`, `Ok(Revert { .. })`, or `Ok(Halt { .. })`. Panics only on
+/// `Ok(Success { .. })`.
+pub fn assert_not_success(result: &TestResult) {
+    if let Ok(ExecutionResult::Success { .. }) = result {
+        panic!("expected non-success, got Success")
+    }
+}
+
+/// Extract the raw output bytes from a successful execution result.
+///
+/// Panics if the result is not a success.
+pub fn extract_output_bytes(result: &TestResult) -> Bytes {
+    let r = assert_success(result);
+    if let ExecutionResult::Success { output, .. } = r {
+        output.data().clone()
+    } else {
+        unreachable!()
+    }
+}
+
+/// Decode the first 32 bytes of a successful execution's output as a big-endian `U256`.
+pub fn decode_u256(result: &TestResult) -> U256 {
+    let bytes = extract_output_bytes(result);
+    assert!(bytes.len() >= 32, "output too short for U256");
+    U256::from_be_slice(&bytes[..32])
+}
+
+/// Decode a successful execution's output as a `bool` (`U256 != 0`).
+pub fn decode_bool(result: &TestResult) -> bool {
+    !decode_u256(result).is_zero()
+}

--- a/crates/tn-reth/src/evm/tel_precompile/burnable.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/burnable.rs
@@ -379,7 +379,7 @@ pub(super) fn handle_burn(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::tel_precompile::test_utils::*;
+    use crate::evm::precompile_test_utils::*;
     use alloy::sol_types::SolCall;
     use tn_config::GOVERNANCE_SAFE_ADDRESS;
     use tn_types::U256;

--- a/crates/tn-reth/src/evm/tel_precompile/faucet.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/faucet.rs
@@ -201,9 +201,11 @@ pub(super) fn handle_has_mint_role(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::evm::tel_precompile::{
-        burnable::{burnCall, claimCall, grantMintRoleCall, hasMintRoleCall, revokeMintRoleCall},
-        test_utils::*,
+    use crate::evm::{
+        precompile_test_utils::*,
+        tel_precompile::burnable::{
+            burnCall, claimCall, grantMintRoleCall, hasMintRoleCall, revokeMintRoleCall,
+        },
     };
     use alloy::sol_types::SolCall;
     use reth_revm::{

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -57,7 +57,7 @@ mod faucet;
 mod helpers;
 /// In-memory EVM test harness (available in tests and with `test-utils` feature).
 #[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils;
+pub(crate) mod test_utils;
 
 // --- Re-exports for external consumers ---
 
@@ -151,7 +151,7 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
 
 #[cfg(test)]
 mod tests {
-    use super::test_utils::*;
+    use crate::evm::precompile_test_utils::*;
     use tn_config::GOVERNANCE_SAFE_ADDRESS;
 
     #[test]

--- a/crates/tn-reth/src/evm/tel_precompile/test_utils.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/test_utils.rs
@@ -1,190 +1,41 @@
-//! Test-utilities for unit and integration tests.
+//! TEL-specific extensions to the shared precompile test harness.
 //!
-//! This module is the single source of truth for lightweight in-memory EVM test
-//! infrastructure for the Telcoin precompile.
+//! The generic in-memory EVM harness ([`TestEnv`]) lives in
+//! [`precompile_test_utils`](crate::evm::precompile_test_utils). This module adds the TEL token
+//! helpers (`mint`, `get_total_supply`, `set_total_supply`) as an inherent extension of `TestEnv`,
+//! plus the [`GENESIS_SUPPLY`] constant the shared constructor seeds.
 
-use super::*;
-use crate::evm::context::{TNEvmContext, TelcoinEvm};
-use alloy_evm::precompiles::PrecompilesMap;
-use reth_revm::{
-    bytecode::Bytecode,
-    context::{
-        result::{EVMError, ExecutionResult, InvalidTransaction},
-        BlockEnv, Context, ContextSetters, Evm, FrameStack, TxEnv,
-    },
-    db::InMemoryDB,
-    handler::{instructions::EthInstructions, EthPrecompiles, Handler, MainnetHandler},
-    inspector::NoOpInspector,
-    primitives::{address, Address, KECCAK_EMPTY},
-    state::AccountInfo,
-    Database, MainContext,
-};
-use std::collections::HashMap;
-use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_types::{Bytes, TxKind, U256};
-
-// --- Type aliases ---
-
-/// EVM context type used by the test harness, backed by an [`InMemoryDB`].
-///
-/// Resolves to the same `Context<BlockEnv, TxEnv, CfgEnv, InMemoryDB>` that mainnet
-/// code uses, but with an in-memory database for isolation.
-pub type TestCtx = TNEvmContext<InMemoryDB>;
-
-/// Fully-assembled EVM instance for tests, with the Telcoin precompile registered.
-///
-/// Uses [`PrecompilesMap`] containing both standard Ethereum precompiles and the
-/// TEL precompile at [`TELCOIN_PRECOMPILE_ADDRESS`].
-pub type TestEvmInner = TelcoinEvm<TestCtx, NoOpInspector>;
-
-/// Result type returned by [`TestEnv::exec`] and [`TestEnv::exec_default`].
-///
-/// `Ok(ExecutionResult)` contains the EVM execution outcome (success, revert, or halt).
-/// `Err(EVMError)` indicates a validation failure before execution (e.g., invalid nonce).
-pub type TestResult =
-    Result<ExecutionResult, EVMError<core::convert::Infallible, InvalidTransaction>>;
-
-// --- Constants ---
-
-/// Test address used as a generic unprivileged caller in unit and integration tests.
-pub const USER: Address = address!("1111100000000000000000000000000000000001");
-
-/// Test address used as a transfer/mint recipient in unit and integration tests.
-pub const RECIPIENT: Address = address!("2222222000000000000000000000000000000002");
+use super::TELCOIN_PRECOMPILE_ADDRESS;
+use crate::evm::precompile_test_utils::{TestEnv, TestResult};
+use alloy::sol_types::SolCall;
+use tn_types::{Address, U256};
 
 /// Genesis total supply in whole TEL units (100 billion).
 ///
-/// The test harness seeds `TOTAL_SUPPLY_SLOT` with `GENESIS_SUPPLY * 10^18` wei.
+/// The shared [`TestEnv`] constructor seeds the `totalSupply` slot with `GENESIS_SUPPLY * 10^18`
+/// wei.
 pub const GENESIS_SUPPLY: u128 = 100_000_000_000; // 100B
 
-// --- Test environment ---
-
-/// Lightweight in-memory EVM environment for testing the Telcoin precompile.
-///
-/// Wraps a fully-configured [`TestEvmInner`] with pre-funded accounts and the TEL precompile
-/// registered. Tracks per-address nonces to allow sequential calls without manual nonce
-/// management.
-///
-/// # Default accounts
-///
-/// [`TestEnv::new`] creates accounts with 1 ETH (10^18 wei) each:
-/// - [`GOVERNANCE_SAFE_ADDRESS`] — governance caller
-/// - [`USER`] — unprivileged caller
-///
-/// The precompile account at [`TELCOIN_PRECOMPILE_ADDRESS`] is funded with 1000 wei and
-/// seeded with [`GENESIS_SUPPLY`] in `totalSupply`.
-#[derive(Debug)]
-pub struct TestEnv {
-    /// The EVM instance with in-memory state and the Telcoin precompile.
-    pub evm: TestEvmInner,
-    /// Per-address nonce tracker, auto-incremented by [`exec`](Self::exec).
-    pub nonces: HashMap<Address, u64>,
-}
-
+/// TEL-token helpers layered onto the shared [`TestEnv`].
 impl TestEnv {
-    /// Create a test environment with default balances.
-    pub fn new() -> Self {
-        Self::new_with_balances(
-            U256::from(10).pow(U256::from(18)),
-            U256::from(10).pow(U256::from(18)),
-            U256::from(1000),
-        )
-    }
-
-    /// Create a test environment with explicit initial balances for governance, user, and
-    /// precompile accounts.
-    pub fn new_with_balances(governance_bal: U256, user_bal: U256, precompile_bal: U256) -> Self {
-        let mut db = InMemoryDB::default();
-
-        db.insert_account_info(
-            GOVERNANCE_SAFE_ADDRESS,
-            AccountInfo {
-                balance: governance_bal,
-                nonce: 0,
-                code_hash: KECCAK_EMPTY,
-                code: None,
-                ..Default::default()
-            },
-        );
-
-        db.insert_account_info(
-            USER,
-            AccountInfo {
-                balance: user_bal,
-                nonce: 0,
-                code_hash: KECCAK_EMPTY,
-                code: None,
-                ..Default::default()
-            },
-        );
-
-        db.insert_account_info(
-            TELCOIN_PRECOMPILE_ADDRESS,
-            AccountInfo {
-                balance: precompile_bal,
-                nonce: 0,
-                code_hash: KECCAK_EMPTY,
-                code: None,
-                ..Default::default()
-            },
-        );
-
-        db.insert_account_storage(
-            TELCOIN_PRECOMPILE_ADDRESS,
-            U256::from(100),
-            U256::from(GENESIS_SUPPLY) * U256::from(10).pow(U256::from(18)),
-        )
-        .unwrap();
-
-        let block = BlockEnv { timestamp: U256::from(1000), ..Default::default() };
-        let context = Context::mainnet().with_db(db).with_block(block);
-
-        let mut precompiles = PrecompilesMap::from(EthPrecompiles::default());
-        add_telcoin_precompile(&mut precompiles);
-
-        let evm = Evm {
-            ctx: context,
-            inspector: NoOpInspector,
-            instruction: EthInstructions::default(),
-            precompiles,
-            frame_stack: FrameStack::new(),
-        };
-
-        Self { evm, nonces: HashMap::new() }
-    }
-
-    /// Add an account with the given balance after construction.
-    pub fn add_account(&mut self, addr: Address, balance: U256) {
-        self.evm.ctx.journaled_state.database.insert_account_info(
-            addr,
-            AccountInfo {
-                balance,
-                nonce: 0,
-                code_hash: KECCAK_EMPTY,
-                code: None,
-                ..Default::default()
-            },
-        );
-    }
-
-    /// Deploy raw EVM bytecode at `addr`.
+    /// Mint tokens via the precompile.
     ///
-    /// The account is created with zero balance, nonce 1 (so it looks deployed), and a
-    /// recomputed `code_hash`. Subsequent `CALL`s targeting `addr` execute `code` instead
-    /// of being treated as a non-existent account.
-    pub fn deploy_code(&mut self, addr: Address, code: Bytes) {
-        let bytecode = Bytecode::new_raw(code);
-        let code_hash = bytecode.hash_slow();
-        self.evm.ctx.journaled_state.database.insert_account_info(
-            addr,
-            AccountInfo {
-                balance: U256::ZERO,
-                nonce: 1,
-                code_hash,
-                code: Some(bytecode),
-                ..Default::default()
-            },
-        );
+    /// In mainnet mode, creates a timelocked pending mint to governance (ignores `recipient`).
+    /// In faucet mode, directly credits `recipient`.
+    pub fn mint(&mut self, caller: Address, recipient: Address, amount: U256) -> TestResult {
+        let _ = recipient; // unused in mainnet mode; suppress warning in faucet mode via cfg
+        #[cfg(not(feature = "faucet"))]
+        let data = super::burnable::mintCall { amount }.abi_encode();
+        #[cfg(feature = "faucet")]
+        let data = super::faucet::mintCall { recipient, amount }.abi_encode();
+        self.exec_default(caller, data)
+    }
+
+    /// Read the precompile's `totalSupply` slot.
+    ///
+    /// Prefers the in-memory journal state; falls back to the database.
+    pub fn get_total_supply(&mut self) -> U256 {
+        self.get_storage(TELCOIN_PRECOMPILE_ADDRESS, U256::from(100))
     }
 
     /// Override the precompile's `totalSupply` storage slot.
@@ -198,160 +49,4 @@ impl TestEnv {
             .insert_account_storage(TELCOIN_PRECOMPILE_ADDRESS, U256::from(100), amount)
             .unwrap();
     }
-
-    /// Execute a precompile call with the given gas limit.
-    ///
-    /// Automatically increments the caller's nonce. The call targets
-    /// [`TELCOIN_PRECOMPILE_ADDRESS`].
-    pub fn exec(&mut self, caller: Address, calldata: Vec<u8>, gas_limit: u64) -> TestResult {
-        self.exec_to(caller, TELCOIN_PRECOMPILE_ADDRESS, calldata, gas_limit)
-    }
-
-    /// Execute a transaction targeting `target` with the given gas limit.
-    ///
-    /// Automatically increments the caller's nonce. Useful for routing through a
-    /// deployed contract (e.g. a `DELEGATECALL` relay) before reaching the precompile.
-    pub fn exec_to(
-        &mut self,
-        caller: Address,
-        target: Address,
-        calldata: Vec<u8>,
-        gas_limit: u64,
-    ) -> TestResult {
-        let nonce = self.nonces.entry(caller).or_insert(0);
-        self.evm.ctx.set_tx(
-            TxEnv::builder()
-                .caller(caller)
-                .kind(TxKind::Call(target))
-                .data(calldata.into())
-                .gas_limit(gas_limit)
-                .nonce(*nonce)
-                .build()
-                .unwrap(),
-        );
-        *nonce += 1;
-        // use mainnet handler with default gas to 0 for simpler test logic
-        // pipeline tests use TN tools and account for gas usage
-        MainnetHandler::default().run(&mut self.evm)
-    }
-
-    /// Execute a precompile call with the default gas limit (100,000).
-    pub fn exec_default(&mut self, caller: Address, calldata: Vec<u8>) -> TestResult {
-        self.exec(caller, calldata, 100_000)
-    }
-
-    /// Mint tokens via the precompile.
-    ///
-    /// In mainnet mode, creates a timelocked pending mint to governance (ignores `recipient`).
-    /// In faucet mode, directly credits `recipient`.
-    pub fn mint(&mut self, caller: Address, recipient: Address, amount: U256) -> TestResult {
-        let _ = recipient; // unused in mainnet mode; suppress warning in faucet mode via cfg
-        #[cfg(not(feature = "faucet"))]
-        let data = {
-            use alloy::sol_types::SolCall;
-            super::burnable::mintCall { amount }.abi_encode()
-        };
-        #[cfg(feature = "faucet")]
-        let data = {
-            use alloy::sol_types::SolCall;
-            super::faucet::mintCall { recipient, amount }.abi_encode()
-        };
-        self.exec_default(caller, data)
-    }
-
-    /// Read the native account balance of `account`.
-    ///
-    /// Prefers the in-memory journal state (which holds uncommitted modifications from
-    /// previously executed test transactions); falls back to the database.
-    pub fn get_balance(&mut self, account: Address) -> U256 {
-        if let Some(acc) = self.evm.ctx.journaled_state.state.get(&account) {
-            return acc.info.balance;
-        }
-        self.evm
-            .ctx
-            .journaled_state
-            .database
-            .basic(account)
-            .unwrap()
-            .map(|info| info.balance)
-            .unwrap_or(U256::ZERO)
-    }
-
-    /// Read the precompile's `totalSupply` slot.
-    ///
-    /// Prefers the in-memory journal state; falls back to the database.
-    pub fn get_total_supply(&mut self) -> U256 {
-        self.get_storage(TELCOIN_PRECOMPILE_ADDRESS, U256::from(100))
-    }
-
-    /// Read a storage slot from `addr`.
-    ///
-    /// Prefers the in-memory journal state (which holds uncommitted modifications from
-    /// previously executed test transactions); falls back to the database. Returns
-    /// `U256::ZERO` if the slot was never written and the database has no entry.
-    pub fn get_storage(&mut self, addr: Address, slot: U256) -> U256 {
-        if let Some(acc) = self.evm.ctx.journaled_state.state.get(&addr) {
-            if let Some(cell) = acc.storage.get(&slot) {
-                return cell.present_value;
-            }
-        }
-        self.evm.ctx.journaled_state.database.storage(addr, slot).unwrap_or(U256::ZERO)
-    }
-
-    /// Override the block timestamp for subsequent calls. Useful for testing timelocks.
-    pub fn set_timestamp(&mut self, ts: u64) {
-        let block = BlockEnv { timestamp: U256::from(ts), ..Default::default() };
-        self.evm.ctx.set_block(block);
-    }
-}
-
-impl Default for TestEnv {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// --- Assertion helpers ---
-
-/// Assert that the result is `Ok(ExecutionResult::Success { .. })` and return the inner result.
-///
-/// Panics if the result is an error or a non-success execution outcome (revert/halt).
-pub fn assert_success(result: &TestResult) -> &ExecutionResult {
-    let r = result.as_ref().expect("expected Ok, got Err");
-    assert!(matches!(r, ExecutionResult::Success { .. }), "expected Success, got {r:?}");
-    r
-}
-
-/// Assert that the result is **not** a successful execution.
-///
-/// Accepts `Err(...)`, `Ok(Revert { .. })`, or `Ok(Halt { .. })`. Panics only on
-/// `Ok(Success { .. })`.
-pub fn assert_not_success(result: &TestResult) {
-    if let Ok(ExecutionResult::Success { .. }) = result {
-        panic!("expected non-success, got Success")
-    }
-}
-
-/// Extract the raw output bytes from a successful execution result.
-///
-/// Panics if the result is not a success.
-pub fn extract_output_bytes(result: &TestResult) -> Bytes {
-    let r = assert_success(result);
-    if let ExecutionResult::Success { output, .. } = r {
-        output.data().clone()
-    } else {
-        unreachable!()
-    }
-}
-
-/// Decode the first 32 bytes of a successful execution's output as a big-endian `U256`.
-pub fn decode_u256(result: &TestResult) -> U256 {
-    let bytes = extract_output_bytes(result);
-    assert!(bytes.len() >= 32, "output too short for U256");
-    U256::from_be_slice(&bytes[..32])
-}
-
-/// Decode a successful execution's output as a `bool` (`U256 != 0`).
-pub fn decode_bool(result: &TestResult) -> bool {
-    !decode_u256(result).is_zero()
 }

--- a/crates/tn-reth/tests/it/bls_precompile_props.rs
+++ b/crates/tn-reth/tests/it/bls_precompile_props.rs
@@ -1,0 +1,331 @@
+//! Property-based tests for the native BLS proof-of-possession precompile (`0x…b151`).
+//!
+//! These exercise the precompile through the real EVM call path (the same one
+//! `ConsensusRegistry`'s linked `BlsG1` library reaches via `delegatecall`), verifying its
+//! observable contract across randomized inputs:
+//! - A correctly-generated proof of possession verifies; wrong address / wrong key / wrong
+//!   signature do not.
+//! - Malformed or wrong-length point bytes return `false` rather than reverting (matching
+//!   `BlsG1.verifyProofOfPossession`'s boolean contract), and never panic.
+//! - `proofOfPossessionMessage` returns exactly the bytes verification signs over and is bound to
+//!   the validator address.
+//! - Calldata validation: short calldata and unknown selectors revert.
+
+use alloy::{
+    primitives::address,
+    sol,
+    sol_types::{SolCall, SolValue},
+};
+use proptest::prelude::*;
+use rand::{rngs::StdRng, SeedableRng};
+use reth_revm::primitives::Address;
+use tn_reth::test_utils::precompile_test_utils::{
+    assert_not_success, decode_bool, extract_output_bytes, TestEnv, USER,
+};
+use tn_types::{
+    generate_proof_of_possession_bls_for_test, proof_of_possession_message_bytes, BlsKeypair,
+    BlsPublicKey, Bytes,
+};
+
+sol! {
+    function verifyProofOfPossession(
+        bytes uncompressedSignature,
+        bytes uncompressedPubkey,
+        address validatorAddress
+    ) external view returns (bool);
+
+    function proofOfPossessionMessage(
+        bytes uncompressedPubkey,
+        address validatorAddress
+    ) external pure returns (bytes);
+}
+
+/// Canonical address the BLS precompile is registered at (matches `BlsG1`'s link address). The
+/// integration crate cannot see the crate-internal constant, so it is pinned here independently -
+/// which also guards against the address silently drifting.
+const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
+
+/// Gas limit for verify calls. The precompile charges 150k for a verification, so the default
+/// 100k harness limit is insufficient; mirror the 1M budget `stake`/`delegateStake` run with.
+const VERIFY_GAS: u64 = 1_000_000;
+
+/// A valid proof-of-possession vector: the keypair plus its uncompressed `blst::min_sig`
+/// `serialize()` bytes (96-byte G1 signature, 192-byte G2 pubkey) - the exact bytes the protocol
+/// passes to `BlsG1` / this precompile.
+struct Vector {
+    keypair: BlsKeypair,
+    sig: Vec<u8>,
+    pubkey: Vec<u8>,
+}
+
+/// Builds a valid proof of possession for `address` from a deterministic RNG seed.
+fn vector(seed: [u8; 32], address: Address) -> Vector {
+    let keypair = BlsKeypair::generate(&mut StdRng::from_seed(seed));
+    let proof =
+        generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
+    let sig = proof.serialize().to_vec();
+    let pubkey = keypair.public().serialize().to_vec();
+    Vector { keypair, sig, pubkey }
+}
+
+/// ABI-encodes a `verifyProofOfPossession` call.
+fn verify_calldata(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
+    verifyProofOfPossessionCall {
+        uncompressedSignature: Bytes::copy_from_slice(sig),
+        uncompressedPubkey: Bytes::copy_from_slice(pubkey),
+        validatorAddress: address,
+    }
+    .abi_encode()
+}
+
+/// Executes `verifyProofOfPossession` against the precompile and returns the decoded `bool`.
+///
+/// Asserts the call itself succeeded - an invalid proof returns `Ok(false)`, not a revert, so a
+/// revert here would be a contract violation and fails the test inside `decode_bool`.
+fn verify(env: &mut TestEnv, sig: &[u8], pubkey: &[u8], address: Address) -> bool {
+    let result = env.exec_to(
+        USER,
+        BLS_G1_PRECOMPILE_ADDRESS,
+        verify_calldata(sig, pubkey, address),
+        VERIFY_GAS,
+    );
+    decode_bool(&result)
+}
+
+// ==============================
+// Verification invariants
+// ==============================
+
+proptest! {
+    /// A correctly-generated proof of possession always verifies.
+    #[test]
+    fn prop_valid_pop_verifies(seed in any::<[u8; 32]>(), addr in any::<[u8; 20]>()) {
+        let address = Address::from(addr);
+        let v = vector(seed, address);
+        let mut env = TestEnv::new();
+        prop_assert!(verify(&mut env, &v.sig, &v.pubkey, address));
+    }
+
+    /// A proof bound to one address never verifies for a different address.
+    #[test]
+    fn prop_wrong_address_rejected(
+        seed in any::<[u8; 32]>(),
+        addr_a in any::<[u8; 20]>(),
+        addr_b in any::<[u8; 20]>(),
+    ) {
+        prop_assume!(addr_a != addr_b);
+        let bound = Address::from(addr_a);
+        let other = Address::from(addr_b);
+        let v = vector(seed, bound);
+        let mut env = TestEnv::new();
+        prop_assert!(!verify(&mut env, &v.sig, &v.pubkey, other));
+    }
+
+    /// A valid signature never verifies against a substituted public key.
+    #[test]
+    fn prop_pubkey_substitution_rejected(
+        seed_a in any::<[u8; 32]>(),
+        seed_b in any::<[u8; 32]>(),
+        addr in any::<[u8; 20]>(),
+    ) {
+        prop_assume!(seed_a != seed_b);
+        let address = Address::from(addr);
+        let a = vector(seed_a, address);
+        let b = vector(seed_b, address);
+        let mut env = TestEnv::new();
+        // a's signature, b's pubkey -> must fail
+        prop_assert!(!verify(&mut env, &a.sig, &b.pubkey, address));
+    }
+
+    /// A signature from a different key never verifies against the original pubkey.
+    #[test]
+    fn prop_wrong_signature_rejected(
+        seed_a in any::<[u8; 32]>(),
+        seed_b in any::<[u8; 32]>(),
+        addr in any::<[u8; 20]>(),
+    ) {
+        prop_assume!(seed_a != seed_b);
+        let address = Address::from(addr);
+        let a = vector(seed_a, address);
+        let b = vector(seed_b, address);
+        let mut env = TestEnv::new();
+        // b's signature, a's pubkey -> must fail
+        prop_assert!(!verify(&mut env, &b.sig, &a.pubkey, address));
+    }
+
+    /// Random, correctly-sized point bytes return `false` (not a revert) and never panic. The ABI
+    /// encoding is well-formed, so the precompile decodes it and reports a failed verification.
+    #[test]
+    fn prop_garbage_points_return_false(
+        sig in prop::collection::vec(any::<u8>(), 96),
+        pubkey in prop::collection::vec(any::<u8>(), 192),
+        addr in any::<[u8; 20]>(),
+    ) {
+        let address = Address::from(addr);
+        let mut env = TestEnv::new();
+        // Astronomically unlikely to be a valid PoP; the invariant is "false, never panic/revert".
+        prop_assert!(!verify(&mut env, &sig, &pubkey, address));
+    }
+
+    /// Wrong-length pubkey bytes (anything but the 192-byte uncompressed G2 form) return `false`
+    /// against an otherwise valid signature. Mirrors the Solidity `invalidPubkeyLength` cases.
+    #[test]
+    fn prop_wrong_length_pubkey_returns_false(
+        seed in any::<[u8; 32]>(),
+        addr in any::<[u8; 20]>(),
+        bad_len in 0usize..256,
+    ) {
+        prop_assume!(bad_len != 192);
+        let address = Address::from(addr);
+        let v = vector(seed, address);
+        let mut env = TestEnv::new();
+        prop_assert!(!verify(&mut env, &v.sig, &vec![0xABu8; bad_len], address));
+    }
+
+    /// Wrong-length signature bytes (anything but the 96-byte uncompressed G1 form) return `false`
+    /// against an otherwise valid pubkey.
+    #[test]
+    fn prop_wrong_length_signature_returns_false(
+        seed in any::<[u8; 32]>(),
+        addr in any::<[u8; 20]>(),
+        bad_len in 0usize..200,
+    ) {
+        prop_assume!(bad_len != 96);
+        let address = Address::from(addr);
+        let v = vector(seed, address);
+        let mut env = TestEnv::new();
+        prop_assert!(!verify(&mut env, &vec![0xABu8; bad_len], &v.pubkey, address));
+    }
+}
+
+// ==============================
+// `proofOfPossessionMessage`
+// ==============================
+
+/// Decodes the ABI-encoded `bytes` returned by a successful `proofOfPossessionMessage` call.
+fn message_for(env: &mut TestEnv, pubkey: &[u8], address: Address) -> Vec<u8> {
+    let calldata = proofOfPossessionMessageCall {
+        uncompressedPubkey: Bytes::copy_from_slice(pubkey),
+        validatorAddress: address,
+    }
+    .abi_encode();
+    let result = env.exec_to(USER, BLS_G1_PRECOMPILE_ADDRESS, calldata, VERIFY_GAS);
+    <Bytes as SolValue>::abi_decode(&extract_output_bytes(&result)).expect("decode bytes").to_vec()
+}
+
+proptest! {
+    /// `proofOfPossessionMessage` returns exactly the bytes verification signs over (the tn-types
+    /// `IntentMessage` encoding), and is bound to the validator address.
+    #[test]
+    fn prop_message_matches_types_and_is_address_bound(
+        seed in any::<[u8; 32]>(),
+        addr_a in any::<[u8; 20]>(),
+        addr_b in any::<[u8; 20]>(),
+    ) {
+        let a = Address::from(addr_a);
+        let b = Address::from(addr_b);
+        let v = vector(seed, a);
+        let public: &BlsPublicKey = v.keypair.public();
+        let mut env = TestEnv::new();
+
+        let from_precompile = message_for(&mut env, &v.pubkey, a);
+        let from_types = proof_of_possession_message_bytes(public, &a).expect("build message");
+        prop_assert_eq!(&from_precompile, &from_types, "precompile message must match tn-types");
+
+        if a != b {
+            let other = message_for(&mut env, &v.pubkey, b);
+            prop_assert_ne!(from_precompile, other, "message must be address-bound");
+        }
+    }
+}
+
+// ==============================
+// Calldata validation
+// ==============================
+
+/// The two selectors the precompile implements.
+fn known_selectors() -> [[u8; 4]; 2] {
+    [verifyProofOfPossessionCall::SELECTOR, proofOfPossessionMessageCall::SELECTOR]
+}
+
+proptest! {
+    /// Unknown function selectors revert.
+    #[test]
+    fn prop_unknown_selector_fails(selector_val in any::<u32>()) {
+        let selector = selector_val.to_be_bytes();
+        prop_assume!(!known_selectors().contains(&selector));
+
+        let mut data = Vec::with_capacity(36);
+        data.extend_from_slice(&selector);
+        data.extend_from_slice(&[0u8; 32]);
+
+        let mut env = TestEnv::new();
+        let result = env.exec_to(USER, BLS_G1_PRECOMPILE_ADDRESS, data, VERIFY_GAS);
+        assert_not_success(&result);
+    }
+
+    /// Calldata too short to ABI-decode the arguments reverts (the selector is valid but the
+    /// dynamic `bytes`/`address` arguments cannot be parsed).
+    #[test]
+    fn prop_short_calldata_fails(selector_idx in 0usize..2, len in 0usize..32) {
+        let selector = known_selectors()[selector_idx];
+        let mut data = Vec::with_capacity(4 + len);
+        data.extend_from_slice(&selector);
+        data.extend(std::iter::repeat_n(0u8, len));
+
+        let mut env = TestEnv::new();
+        let result = env.exec_to(USER, BLS_G1_PRECOMPILE_ADDRESS, data, VERIFY_GAS);
+        assert_not_success(&result);
+    }
+}
+
+// ==============================
+// `DELEGATECALL` relay (the `ConsensusRegistry` path)
+// ==============================
+
+/// Address hosting the `DELEGATECALL` relay contract.
+const RELAY_ADDR: Address = address!("dddd0000000000000000000000000000000000b1");
+
+/// Minimal runtime bytecode that forwards calldata to `0x…b151` via `DELEGATECALL` and returns the
+/// precompile's output verbatim. This is exactly how `ConsensusRegistry`'s linked `BlsG1` library
+/// reaches the precompile, so it proves that integration path resolves to our native code.
+///
+/// Disassembly:
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY      // mem[0..csize] = calldata
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;          // retSize, retOffset, argsSize, argsOffset
+///   PUSH2 0xb151; GAS; DELEGATECALL; POP              // delegatecall to BLS precompile
+///   RETURNDATASIZE; PUSH1 0; PUSH1 0; RETURNDATACOPY  // mem[0..rsize] = returndata
+///   RETURNDATASIZE; PUSH1 0; RETURN                   // return mem[0..rsize]
+/// ```
+const RELAY_BYTECODE: &[u8] = &[
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x61, 0xb1, 0x51, 0x5a, 0xf4,
+    0x50, // PUSH2 0xb151; GAS; DELEGATECALL; POP
+    0x3d, 0x60, 0x00, 0x60, 0x00, 0x3e, // RETURNDATACOPY(0, 0, RETURNDATASIZE)
+    0x3d, 0x60, 0x00, 0xf3, // RETURN(0, RETURNDATASIZE)
+];
+
+/// A valid proof verifies, and a tampered one is rejected, when reached via `DELEGATECALL` - the
+/// same way `ConsensusRegistry`'s `BlsG1.verifyProofOfPossession` library call lands here.
+#[test]
+fn test_delegatecall_verify_pop() {
+    let address = Address::repeat_byte(0x42);
+    let v = vector([7; 32], address);
+
+    let mut env = TestEnv::new();
+    env.deploy_code(RELAY_ADDR, Bytes::from_static(RELAY_BYTECODE));
+
+    // Valid PoP through the relay -> true.
+    let ok = env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, address), VERIFY_GAS);
+    assert!(decode_bool(&ok), "valid PoP must verify via DELEGATECALL");
+
+    // Wrong address through the relay -> false (still a successful call returning `false`).
+    let bad = env.exec_to(
+        USER,
+        RELAY_ADDR,
+        verify_calldata(&v.sig, &v.pubkey, Address::repeat_byte(0x43)),
+        VERIFY_GAS,
+    );
+    assert!(!decode_bool(&bad), "wrong-address PoP must be rejected via DELEGATECALL");
+}

--- a/crates/tn-reth/tests/it/main.rs
+++ b/crates/tn-reth/tests/it/main.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused_crate_dependencies)]
 
+mod bls_precompile_props;
 mod economics_props;
 mod pipeline_helpers;
 

--- a/crates/types/src/crypto/bls_public_key.rs
+++ b/crates/types/src/crypto/bls_public_key.rs
@@ -100,6 +100,16 @@ impl BlsPublicKey {
         CorePublicKey::from_bytes(bytes).map(|key| key.into())
     }
 
+    /// Decode a public key from its 192-byte uncompressed (serialized) G2 form, as produced by
+    /// [`blst::min_sig::PublicKey::serialize`].
+    ///
+    /// Unlike [`Self::from_literal_bytes`] (which expects the 96-byte compressed form), this
+    /// accepts the uncompressed bytes the protocol passes to the on-chain `BlsG1` library. Used
+    /// by the native BLS precompile.
+    pub fn from_uncompressed_bytes(bytes: &[u8]) -> Result<Self, BLST_ERROR> {
+        CorePublicKey::deserialize(bytes).map(|key| key.into())
+    }
+
     /// Take the first 8 bytes and convert to a base58 rep String.
     pub fn to_short_string(&self) -> String {
         self.bytes.to_short_string()

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -28,6 +28,19 @@ impl BlsSignature {
         Ok(Self(sig))
     }
 
+    /// Decode a signature from its 96-byte uncompressed (serialized) G1 form, as produced by
+    /// [`blst::min_sig::Signature::serialize`].
+    ///
+    /// Unlike [`Self::from_bytes`] (which expects the 48-byte compressed form), this accepts the
+    /// uncompressed bytes the protocol passes to the on-chain `BlsG1` library as a proof of
+    /// possession. Used by the native BLS precompile so it can verify the exact bytes the
+    /// consensus layer produced, without re-implementing point (de)compression.
+    pub fn from_uncompressed_bytes(bytes: &[u8]) -> eyre::Result<Self> {
+        let sig = CoreBlsSignature::deserialize(bytes)
+            .map_err(|_| eyre::eyre!("Invalid uncompressed signature bytes!"))?;
+        Ok(Self(sig))
+    }
+
     /// Verify a signature over a message (raw bytes) with public key.
     pub fn verify_raw(&self, message: &[u8], public_key: &BlsPublicKey) -> bool {
         self.verify(true, message, DST_G1, &[], public_key, true) == blst::BLST_ERROR::BLST_SUCCESS
@@ -195,6 +208,20 @@ pub fn construct_proof_of_possession_message(
     let msg = IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg_unprefixed);
 
     Ok(msg)
+}
+
+/// Returns the exact serialized bytes that a proof of possession is signed over and verified
+/// against, i.e. `encode(construct_proof_of_possession_message(pubkey, address))`.
+///
+/// This is the canonical equivalent of `BlsG1.proofOfPossessionMessage` on-chain. The native BLS
+/// precompile returns these bytes so the message it verifies and the message it reports are one and
+/// the same, with no second (drift-prone) implementation of the intent encoding.
+pub fn proof_of_possession_message_bytes(
+    bls_pubkey: &BlsPublicKey,
+    address: &Address,
+) -> eyre::Result<Vec<u8>> {
+    let msg = construct_proof_of_possession_message(bls_pubkey, address)?;
+    Ok(encode(&msg))
 }
 
 /// A trait for sign and verify over an intent message, instead of the message itself. See more at


### PR DESCRIPTION
## Summary

Adds a native precompile at the canonical `BLS_G1_LIBRARY` address (`0x000000000000000000000000000000000000b151`) that verifies BLS proofs of possession by delegating to tn-types blst verification, replacing the Solidity `BlsG1` library and its on-chain EIP-2537 reimplementation.

- `crates/tn-reth/src/evm/bls_precompile/`: new `DynPrecompile` implementing the two selectors `ConsensusRegistry` calls, `verifyProofOfPossession` and `proofOfPossessionMessage`. Gas is priced at 150k, matching the equivalent EIP-2537 pairing work. Structured the same way as the existing TEL precompile.
- `crates/tn-reth/src/evm/factory.rs`: registers the precompile at `0x...b151` alongside the TEL precompile, so it is live at that address on all chains and shadows any genesis-deployed `BlsG1` library code.
- `crates/types`: adds uncompressed-bytes constructors for `BlsPublicKey` and `BlsSignature`, used by the precompile to decode calldata without round-tripping through compressed encodings.

The tn-contracts submodule is unchanged in this PR. The follow-up that routes genesis PoP validation through this precompile and adopts the updated `ConsensusRegistry` ABI is stacked on top in a separate PR, since it depends on tn-contracts changes that have not merged yet.

## Testing

- Unit tests in `bls_precompile/mod.rs` cover a valid proof of possession, rejection when the call targets the wrong address, and malformed input.