### PR TITLE
Route genesis PoP through the BLS precompile and adopt the integration ConsensusRegistry ABI

### DIFF
--- a/crates/config/src/genesis.rs
+++ b/crates/config/src/genesis.rs
@@ -27,8 +27,6 @@ pub const ISSUANCE_JSON: &str = include_str!("../../../tn-contracts/artifacts/Is
 /// The path to erc1967proxy json (tn-contracts submodule).
 pub const ERC1967PROXY_JSON: &str =
     include_str!("../../../tn-contracts/artifacts/ERC1967Proxy.json");
-/// The path to blsg1 json (tn-contracts submodule).
-pub const BLSG1_JSON: &str = include_str!("../../../tn-contracts/artifacts/BlsG1.json");
 /// The path to the configuration yaml for genesis accounts (tn-contracts submodule).
 pub const GENESIS_ACCOUNT_STATE_YAML: &str =
     include_str!("../../../tn-contracts/deployments/genesis/precompile-config.yaml");

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -209,6 +209,56 @@ async fn assert_tn_registry_endpoints<P: Provider>(provider: &P) -> eyre::Result
         provider.raw_request("tn_getValidators".into(), ("Any",)).await?;
     assert!(!validators.is_empty(), "tn_getValidators(\"Any\") returned no validators");
 
+    // `"Any"` must equal the union of the five concrete status sets, read at one pinned tip.
+    // The five internal reads can no longer straddle a block commit, so a validator that changes
+    // status mid-read is never double-counted or dropped. The dedup check below is the direct
+    // regression guard; the length check confirms union completeness. The per-status sets are
+    // fetched as separate requests, so an epoch boundary between them could move a validator
+    // between sets; retry until all reads land in one epoch (mirrors the convergence loop above).
+    let statuses = ["Staked", "PendingActivation", "Active", "PendingExit", "Exited"];
+    let mut set_attempts = 0;
+    let (any_set, per_status_total) = loop {
+        let epoch_before: u32 = provider.raw_request("tn_getCurrentEpoch".into(), ()).await?;
+        let any_set: Vec<ConsensusRegistry::ValidatorInfo> =
+            provider.raw_request("tn_getValidators".into(), ("Any",)).await?;
+        let mut per_status_total = 0usize;
+        for status in statuses {
+            let set: Vec<ConsensusRegistry::ValidatorInfo> =
+                provider.raw_request("tn_getValidators".into(), (status,)).await?;
+            per_status_total += set.len();
+        }
+        let epoch_after: u32 = provider.raw_request("tn_getCurrentEpoch".into(), ()).await?;
+        if epoch_before == epoch_after {
+            break (any_set, per_status_total);
+        }
+        set_attempts += 1;
+        assert!(set_attempts < 3, "validator-set reads never landed in a single epoch");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    };
+
+    // union completeness (best-effort): "Any" holds exactly as many entries as the five status
+    // sets combined. The `epoch_before == epoch_after` guard rules out epoch-boundary transitions,
+    // but this still assumes no mid-epoch status change (e.g. a `stake`/`activate` tx) lands
+    // between the separate per-status RPC requests — true in this quiescent test. The no-duplicate
+    // `HashSet` check below is the load-bearing regression guard: it operates on the single atomic
+    // "Any" response and needs no such assumption.
+    assert_eq!(
+        any_set.len(),
+        per_status_total,
+        "tn_getValidators(\"Any\") length must equal the sum of the five per-status sets"
+    );
+
+    // no double-count: each validator lives in exactly one status set, so the pinned "Any" union
+    // must contain each validator address at most once
+    let mut seen = std::collections::HashSet::new();
+    for info in &any_set {
+        assert!(
+            seen.insert(info.validatorAddress),
+            "tn_getValidators(\"Any\") double-counted validator {}",
+            info.validatorAddress
+        );
+    }
+
     // `Undefined` (0) reverts on-chain: expect an eth_call-style error (code 3 with revert
     // bytes in `data`) rather than a leaked internal error string
     let revert_err = provider

--- a/crates/e2e-tests/tests/it/genesis_tests.rs
+++ b/crates/e2e-tests/tests/it/genesis_tests.rs
@@ -15,13 +15,13 @@ use jsonrpsee::{
 use std::{collections::HashMap, time::Duration};
 use telcoin_network_cli::args::clap_u256_parser_to_18_decimals;
 use tn_config::{
-    NetworkGenesis, BLSG1_JSON, CONSENSUS_REGISTRY_JSON, DEPLOYMENTS_JSON,
-    GENESIS_ACCOUNT_STATE_YAML, ISSUANCE_ADDRESS, ISSUANCE_JSON,
+    NetworkGenesis, CONSENSUS_REGISTRY_JSON, GENESIS_ACCOUNT_STATE_YAML, ISSUANCE_ADDRESS,
+    ISSUANCE_JSON,
 };
 use tn_reth::{
     system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS},
     test_utils::TransactionFactory,
-    RethEnv,
+    RethEnv, BLS_G1_PRECOMPILE_ADDRESS,
 };
 use tn_types::{Address, Bytes, FromHex, GenesisAccount};
 use tracing::debug;
@@ -97,17 +97,15 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
     )?;
     let unlinked_runtimecode =
         registry_runtimecode_binding.as_str().ok_or_eyre("Couldn't fetch bytecode")?;
-    let tao_address_binding = RethEnv::fetch_value_from_json_str(DEPLOYMENTS_JSON, Some("Safe"))?;
-    let tao_address =
-        Address::from_hex(tao_address_binding.as_str().ok_or_eyre("Safe owner address")?)?;
-    let blsg1_address = tao_address.create(0).to_string();
+    // BlsG1 is a native precompile at `BLS_G1_PRECOMPILE_ADDRESS`: the registry runtime bytecode is
+    // linked against that address, and the address itself carries a single `0xfe` (INVALID)
+    // placeholder byte rather than deployed library code. See
+    // `create_consensus_registry_genesis_accounts`.
+    let blsg1_address = BLS_G1_PRECOMPILE_ADDRESS.to_string();
     let registry_deployed_bytecode =
         RethEnv::link_solidity_library(unlinked_runtimecode, &blsg1_address)?;
 
-    let blsg1_runtimecode_binding =
-        RethEnv::fetch_value_from_json_str(BLSG1_JSON, Some("deployedBytecode.object"))?;
-    let blsg1_deployed_bytecode =
-        blsg1_runtimecode_binding.as_str().ok_or_eyre("invalid blsg1 json")?;
+    let blsg1_deployed_bytecode = "0xfe";
 
     let issuance_json_val =
         RethEnv::fetch_value_from_json_str(ISSUANCE_JSON, Some("deployedBytecode.object"))?;
@@ -218,15 +216,16 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
     assert_eq!(epochIssuance, expected_epoch_issuance);
     assert_eq!(stakeVersion, 0);
 
-    let validators = consensus_registry
+    // `getValidators` returns validator addresses directly (the full structs are available via
+    // `getValidatorsInfo`).
+    let validator_addresses = consensus_registry
         .getValidators(ConsensusRegistry::ValidatorStatus::Active.into())
         .call()
         .await
         .expect("failed active validators read");
 
-    let validator_addresses: Vec<_> = validators.iter().map(|v| v.validatorAddress).collect();
     assert_eq!(committee, validator_addresses);
-    debug!(target: "genesis-test", "active validators??\n{:?}", validators);
+    debug!(target: "genesis-test", "active validators??\n{:?}", validator_addresses);
 
     Ok(())
 }

--- a/crates/e2e-tests/tests/it/genesis_tests.rs
+++ b/crates/e2e-tests/tests/it/genesis_tests.rs
@@ -19,7 +19,7 @@ use tn_config::{
     ISSUANCE_JSON,
 };
 use tn_reth::{
-    system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS},
+    system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS, PRECOMPILE_GENESIS_BYTECODE},
     test_utils::TransactionFactory,
     RethEnv, BLS_G1_PRECOMPILE_ADDRESS,
 };
@@ -105,8 +105,6 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
     let registry_deployed_bytecode =
         RethEnv::link_solidity_library(unlinked_runtimecode, &blsg1_address)?;
 
-    let blsg1_deployed_bytecode = "0xfe";
-
     let issuance_json_val =
         RethEnv::fetch_value_from_json_str(ISSUANCE_JSON, Some("deployedBytecode.object"))?;
     let issuance_deployed_bytecode =
@@ -144,7 +142,7 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
     );
     assert_eq!(
         Bytes::from_hex(&returned_blsg1_bytecode)?,
-        Bytes::from_hex(blsg1_deployed_bytecode)?
+        Bytes::from(PRECOMPILE_GENESIS_BYTECODE)
     );
 
     // verify all precompile-config.yaml accounts are present in genesis on-chain

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -19,8 +19,8 @@ use tn_reth::{
     system_calls::EpochState,
     test_utils::{
         calculate_withdrawals_root, create_committee_from_state,
-        seeded_genesis_from_random_batches, TransactionFactory, BEACON_ROOTS_ADDRESS,
-        EMPTY_REQUESTS_HASH, HISTORY_STORAGE_ADDRESS,
+        seeded_genesis_from_random_batches, test_genesis_with_consensus_registry,
+        TransactionFactory, BEACON_ROOTS_ADDRESS, EMPTY_REQUESTS_HASH, HISTORY_STORAGE_ADDRESS,
     },
     FixedBytes, RethChainSpec, RethEnv,
 };
@@ -220,7 +220,7 @@ async fn test_empty_output_skips_execution() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()> {
     let _guard = IT_TEST_GUARD.lock();
-    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis_with_consensus_registry(4).into());
     let tmp_dir = TempDir::new().expect("temp dir");
     // execution node components
     let gas_accumulator = GasAccumulator::new(1); // 1 worker
@@ -539,7 +539,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     let mut batches_2 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
 
     // add eip1559 transactions to set max priority fee per gas so batch producer earns fees
-    let genesis = test_genesis();
+    let genesis = test_genesis_with_consensus_registry(4);
     let mut tx_factory = TransactionFactory::new_random();
     let encoded_tx_priority_fee_1 = tx_factory
         .create_explicit_eip1559(
@@ -1017,7 +1017,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     let mut batches_2 = tn_reth::test_utils::batches(chain, 4); // create 4 batches
 
     // add eip1559 transactions to set max priority fee per gas so batch producer earns fees
-    let genesis = test_genesis();
+    let genesis = test_genesis_with_consensus_registry(4);
     let mut tx_factory = TransactionFactory::new_random();
     let encoded_tx_priority_fee_1 = tx_factory
         .create_explicit_eip1559(

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -242,9 +242,39 @@ where
         &self,
         status: ConsensusRegistry::ValidatorStatus,
     ) -> TelcoinNetworkRpcResult<Vec<ConsensusRegistry::ValidatorInfo>> {
-        let calldata =
-            ConsensusRegistry::getValidatorsCall { status: status as u8 }.abi_encode().into();
-        self.registry_read(calldata).await
+        use ConsensusRegistry::ValidatorStatus;
+
+        // `getValidatorsInfo` returns exactly one status set and reverts on the `Undefined`/`Any`
+        // sentinels (the registry no longer folds statuses on-chain). Emulate the documented
+        // `"Any"` => "all validators" behavior by unioning every concrete status set off-chain.
+        // Each validator lives in exactly one set, so the union is a plain concatenation (no
+        // dedup); retired validators intentionally appear in no set, matching the old scan. Any
+        // other status (including `Undefined`) is passed straight through, so `Undefined` still
+        // surfaces the on-chain revert that callers rely on.
+        if status == ValidatorStatus::Any {
+            let mut all = Vec::new();
+            for set_status in [
+                ValidatorStatus::Staked,
+                ValidatorStatus::PendingActivation,
+                ValidatorStatus::Active,
+                ValidatorStatus::PendingExit,
+                ValidatorStatus::Exited,
+            ] {
+                let calldata =
+                    ConsensusRegistry::getValidatorsInfoCall { status: set_status as u8 }
+                        .abi_encode()
+                        .into();
+                let mut infos: Vec<ConsensusRegistry::ValidatorInfo> =
+                    self.registry_read(calldata).await?;
+                all.append(&mut infos);
+            }
+            Ok(all)
+        } else {
+            let calldata = ConsensusRegistry::getValidatorsInfoCall { status: status as u8 }
+                .abi_encode()
+                .into();
+            self.registry_read(calldata).await
+        }
     }
 
     async fn get_committee_validators(

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -8,7 +8,11 @@ use async_trait::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tn_reth::{error::RegistryReadError, system_calls::ConsensusRegistry, RethEnv};
+use tn_reth::{
+    error::{RegistryReadError, RegistryReadResult},
+    system_calls::ConsensusRegistry,
+    RethEnv,
+};
 use tn_types::{
     Address, Bytes, ConsensusHeader, Epoch, EpochCertificate, EpochDigest, EpochRecord, Genesis,
     SolCall, SolType, SolValue, B256, U256,
@@ -246,29 +250,32 @@ where
 
         // `getValidatorsInfo` returns exactly one status set and reverts on the `Undefined`/`Any`
         // sentinels (the registry no longer folds statuses on-chain). Emulate the documented
-        // `"Any"` => "all validators" behavior by unioning every concrete status set off-chain.
+        // `"Any"` => "all validators" behavior by unioning every concrete status set. The five
+        // reads run against ONE pinned canonical tip (`read_consensus_registry_batch`), so a
+        // validator that changes status between block commits cannot be double-counted or dropped.
         // Each validator lives in exactly one set, so the union is a plain concatenation (no
         // dedup); retired validators intentionally appear in no set, matching the old scan. Any
         // other status (including `Undefined`) is passed straight through, so `Undefined` still
         // surfaces the on-chain revert that callers rely on.
         if status == ValidatorStatus::Any {
-            let mut all = Vec::new();
-            for set_status in [
+            let calldatas = [
                 ValidatorStatus::Staked,
                 ValidatorStatus::PendingActivation,
                 ValidatorStatus::Active,
                 ValidatorStatus::PendingExit,
                 ValidatorStatus::Exited,
-            ] {
-                let calldata =
-                    ConsensusRegistry::getValidatorsInfoCall { status: set_status as u8 }
-                        .abi_encode()
-                        .into();
-                let mut infos: Vec<ConsensusRegistry::ValidatorInfo> =
-                    self.registry_read(calldata).await?;
-                all.append(&mut infos);
-            }
-            Ok(all)
+            ]
+            .into_iter()
+            .map(|s| {
+                ConsensusRegistry::getValidatorsInfoCall { status: s as u8 }.abi_encode().into()
+            })
+            .collect::<Vec<Bytes>>();
+
+            // one permit, one blocking task, one pinned EVM for all five status reads
+            let sets: Vec<Vec<ConsensusRegistry::ValidatorInfo>> = self
+                .spawn_registry_read(move |evm| evm.read_consensus_registry_batch(calldatas))
+                .await?;
+            Ok(sets.into_iter().flatten().collect())
         } else {
             let calldata = ConsensusRegistry::getValidatorsInfoCall { status: status as u8 }
                 .abi_encode()
@@ -405,20 +412,37 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
 
     /// Execute a read-only [`ConsensusRegistry`] call at the canonical tip and decode the result.
     ///
+    /// Thin wrapper over [`Self::spawn_registry_read`] for the common single-read endpoints.
+    async fn registry_read<T>(&self, calldata: Bytes) -> TelcoinNetworkRpcResult<T>
+    where
+        T: SolValue + Send + 'static,
+        T: From<<<T as SolValue>::SolType as SolType>::RustType>,
+    {
+        self.spawn_registry_read(move |evm| evm.read_consensus_registry::<T>(calldata)).await
+    }
+
+    /// Run a read-only [`ConsensusRegistry`] closure on the blocking pool and map its result to
+    /// an RPC response.
+    ///
     /// EVM reads are synchronous database/CPU work, so they run on the protocol [`TaskSpawner`]'s
     /// blocking pool to avoid stalling the async runtime on a public endpoint. A
     /// [`MAX_CONCURRENT_REGISTRY_READS`] permit is acquired before spawning and moved into the
     /// blocking task, so it is released only when the work finishes — bounding blocking-pool
     /// occupancy even if a client disconnects mid-read.
     ///
+    /// The closure receives an owned [`RethEnv`] and may issue one read
+    /// ([`RethEnv::read_consensus_registry`]) or several pinned reads
+    /// ([`RethEnv::read_consensus_registry_batch`]); both single- and multi-read endpoints share
+    /// this permit/spawn/revert-mapping path.
+    ///
     /// On-chain reverts surface to the client eth_call-style (code 3 with revert bytes in
     /// `data`); internal failures are logged server-side and return a generic error.
     ///
     /// [`TaskSpawner`]: tn_types::TaskSpawner
-    async fn registry_read<T>(&self, calldata: Bytes) -> TelcoinNetworkRpcResult<T>
+    async fn spawn_registry_read<R, F>(&self, read: F) -> TelcoinNetworkRpcResult<R>
     where
-        T: SolValue + Send + 'static,
-        T: From<<<T as SolValue>::SolType as SolType>::RustType>,
+        R: Send + 'static,
+        F: FnOnce(RethEnv) -> RegistryReadResult<R> + Send + 'static,
     {
         // bound concurrent blocking reads; queues (does not reject) at capacity, mirroring
         // reth's eth_call guard. acquire only fails if the semaphore is closed, which never
@@ -433,7 +457,7 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
         self.evm_state.get_task_spawner().spawn_blocking_task("tn-rpc-registry-read", move || {
             // hold the permit until the blocking read completes
             let _permit = permit;
-            if tx.send(evm.read_consensus_registry::<T>(calldata)).is_err() {
+            if tx.send(read(evm)).is_err() {
                 tracing::debug!(target: "tn::rpc", "registry read receiver dropped before result");
             }
             Ok(())
@@ -444,14 +468,14 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
                 tracing::warn!(target: "tn::rpc", error = %e, "registry read result channel closed");
                 TNRpcError::Internal
             })?
-            .map_err(|report| match report.downcast_ref::<RegistryReadError>() {
-                Some(RegistryReadError::Revert { output, .. }) => {
-                    TNRpcError::Revert { message: report.to_string(), output: output.clone() }
+            .map_err(|err| match &err {
+                RegistryReadError::Revert { output, .. } => {
+                    TNRpcError::Revert { message: err.to_string(), output: output.clone() }
                 }
-                _ => {
+                RegistryReadError::Internal(_) => {
                     tracing::debug!(
                         target: "tn::rpc",
-                        error = ?report,
+                        error = ?err,
                         "consensus registry read failed"
                     );
                     TNRpcError::Internal

--- a/crates/tn-reth/src/error.rs
+++ b/crates/tn-reth/src/error.rs
@@ -77,3 +77,10 @@ pub enum RegistryReadError {
     #[error("{0}")]
     Internal(String),
 }
+
+/// Result of an on-chain `ConsensusRegistry` read.
+///
+/// The error is always a [`RegistryReadError`], so consumers (e.g. the RPC layer) can match
+/// revert-vs-internal directly instead of recovering it via a runtime downcast. Every non-revert
+/// failure — state provider/EVM setup, `Halt`, ABI decode — is a [`RegistryReadError::Internal`].
+pub type RegistryReadResult<T> = Result<T, RegistryReadError>;

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -271,18 +271,29 @@ where
     fn shuffle_new_committee(&mut self, randomness: B256) -> TnRethResult<Vec<Address>> {
         let new_committee_size = self.next_committee_size()?;
 
-        // read all active validators from consensus registry
-        let calldata =
-            ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
+        // Read the committee-eligible validator pool from the consensus registry. The registry's
+        // per-status `getValidators`/`getValidatorsInfo` return ONLY the exact status set; the
+        // committee-eligible pool is the union of `{ Active, PendingActivation, PendingExit }` (the
+        // statuses for which `_eligibleForCommitteeNextEpoch` is true). The registry computes the
+        // O(1) eligible *count* on-chain and expects the protocol to assemble the eligible *pool*
+        // by unioning these queries off-chain. We use `getValidatorsInfo` (full structs)
+        // because the pending-exit validators are separated out below by `currentStatus`.
+        let mut all_active_validators: Vec<ConsensusRegistry::ValidatorInfo> = Vec::new();
+        for status in [
+            ValidatorStatus::Active,
+            ValidatorStatus::PendingActivation,
+            ValidatorStatus::PendingExit,
+        ] {
+            let calldata = ConsensusRegistry::getValidatorsInfoCall { status: status.into() }
                 .abi_encode()
                 .into();
-        let state =
-            self.read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
-
-        trace!(target: "engine", "get validators call:\n{:?}", state);
-
-        let all_active_validators: Vec<ConsensusRegistry::ValidatorInfo> =
-            alloy::sol_types::SolValue::abi_decode(&state)?;
+            let state =
+                self.read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
+            trace!(target: "engine", ?status, "get validators call:\n{:?}", state);
+            let validators: Vec<ConsensusRegistry::ValidatorInfo> =
+                alloy::sol_types::SolValue::abi_decode(&state)?;
+            all_active_validators.extend(validators);
+        }
 
         debug!(target: "engine",  "validators pre-shuffle {:?}", all_active_validators);
 

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -98,14 +98,11 @@ fn bls_precompile(input: PrecompileInput<'_>) -> PrecompileResult {
 /// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`]
 /// (which would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
 fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
-    if data.len() < 4 {
+    let Some((selector, calldata)) = data.split_first_chunk::<4>() else {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
-    }
+    };
 
-    let selector: [u8; 4] = data[0..4].try_into().unwrap();
-    let calldata = &data[4..];
-
-    match selector {
+    match *selector {
         verifyProofOfPossessionCall::SELECTOR => handle_verify_pop(calldata, gas),
         proofOfPossessionMessageCall::SELECTOR => handle_pop_message(calldata, gas),
         _ => Err(PrecompileError::Other("Unknown function selector".into())),

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -42,8 +42,7 @@ use tn_types::{
 ///
 /// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is
 /// linked against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
-pub(crate) const BLS_G1_PRECOMPILE_ADDRESS: Address =
-    address!("000000000000000000000000000000000000b151");
+pub const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
 sol! {
     /// Verifies a validator's BLS12-381 proof of possession from raw uncompressed inputs.
@@ -79,7 +78,7 @@ const POP_MESSAGE_GAS_COST: u64 = 5_000;
 ///
 /// Called from the EVM factory alongside `add_telcoin_precompile`, so the precompile is present for
 /// all execution including pre-genesis registry construction.
-pub(crate) fn add_bls_precompile(map: &mut PrecompilesMap) {
+pub fn add_bls_precompile(map: &mut PrecompilesMap) {
     map.apply_precompile(&BLS_G1_PRECOMPILE_ADDRESS, move |_| {
         Some(DynPrecompile::new_stateful(PrecompileId::Custom("bls_g1".into()), move |input| {
             bls_precompile(input)

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -29,6 +29,7 @@ mod tel_precompile;
 mod utils;
 use crate::evm::handler::TNEvmHandler;
 pub(crate) use block::*;
+pub use bls_precompile::{add_bls_precompile, BLS_G1_PRECOMPILE_ADDRESS};
 pub(crate) use config::*;
 pub(crate) use context::*;
 pub(crate) use factory::*;

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -26,6 +26,7 @@ mod clippy {
 
 use crate::{
     evm::TNEvm,
+    system_calls::PRECOMPILE_GENESIS_BYTECODE,
     traits::{DefaultEthPayloadTypes, TNExecution},
 };
 use alloy::{
@@ -1268,7 +1269,10 @@ impl RethEnv {
             // (`BLS_G1_PRECOMPILE_ADDRESS`). Mirror the TEL precompile and give it a single `0xfe`
             // (INVALID) byte of code so the account is non-empty (never state-pruned) and any call
             // that bypasses precompile dispatch reverts instead of succeeding against an EOA.
-            (blsg1_address, GenesisAccount::default().with_code(Some(vec![0xfe_u8].into()))),
+            (
+                blsg1_address,
+                GenesisAccount::default().with_code(Some(PRECOMPILE_GENESIS_BYTECODE.into())),
+            ),
             (
                 CONSENSUS_REGISTRY_ADDRESS,
                 GenesisAccount::default()
@@ -2203,7 +2207,7 @@ mod tests {
             epochDuration: epoch_duration,
         };
 
-        let mut governance_multisig =
+        let governance_multisig =
             TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
         let governance = governance_multisig.address();
         let tmp_genesis = tn_types::test_genesis().extend_accounts([

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -111,8 +111,8 @@ use system_calls::{
 };
 use tempfile::TempDir;
 use tn_config::{
-    NodeInfo, BLSG1_JSON, CONSENSUS_REGISTRY_JSON, GOVERNANCE_SAFE_ADDRESS, ISSUANCE_ADDRESS,
-    ISSUANCE_JSON, WORKER_CONFIGS_ADDRESS, WORKER_CONFIGS_JSON,
+    NodeInfo, CONSENSUS_REGISTRY_JSON, GOVERNANCE_SAFE_ADDRESS, ISSUANCE_ADDRESS, ISSUANCE_JSON,
+    WORKER_CONFIGS_ADDRESS, WORKER_CONFIGS_JSON,
 };
 use tn_types::{
     deconstruct_nonce,
@@ -173,8 +173,9 @@ pub mod worker;
 #[cfg(not(feature = "faucet"))]
 pub use evm::TIMELOCK_DURATION;
 pub use evm::{
-    add_telcoin_precompile, burnCall, calculate_gas_penalty, claimCall, grantMintRoleCall,
-    hasMintRoleCall, mintCall, revokeMintRoleCall, totalSupplyCall, TELCOIN_PRECOMPILE_ADDRESS,
+    add_bls_precompile, add_telcoin_precompile, burnCall, calculate_gas_penalty, claimCall,
+    grantMintRoleCall, hasMintRoleCall, mintCall, revokeMintRoleCall, totalSupplyCall,
+    BLS_G1_PRECOMPILE_ADDRESS, TELCOIN_PRECOMPILE_ADDRESS,
 };
 
 #[cfg(any(feature = "test-utils", test))]
@@ -1115,30 +1116,14 @@ impl RethEnv {
             .with_bundle_update()
             .build();
 
-        // deploy blsg1 library separately first, scoped to release borrow on db before registry
-        let blsg1_address = {
-            let mut tn_evm = reth_env.inner.evm_config.evm_factory().create_evm(
-                &mut db,
-                reth_env.inner.evm_config.evm_env(&tmp_chain.sealed_genesis_header())?,
-            );
-
-            let blsg1_initcode_binding =
-                Self::fetch_value_from_json_str(BLSG1_JSON, Some("bytecode.object"))?;
-            let blsg1_initcode =
-                hex::decode(blsg1_initcode_binding.as_str().ok_or_eyre("invalid blsg1 json")?)?;
-            let ResultAndState { result, state } =
-                tn_evm.transact_pre_genesis_create(owner_address, blsg1_initcode.into())?;
-            debug!(target: "engine", "create blsg1 library result:\n{:#?}", result);
-
-            // commit state to db so it persists
-            tn_evm.db_mut().commit(state);
-
-            // tmp BlsG1 library address is owner's first create tx on tmp chain
-            owner_address.create(0)
-        };
-
-        // merge transitions but keep the library state in db
-        db.merge_transitions(BundleRetention::PlainState);
+        // The BlsG1 proof-of-possession library is a native precompile registered by the EVM
+        // factory at `BLS_G1_PRECOMPILE_ADDRESS`, so there is nothing to deploy at genesis:
+        // the registry is linked directly against the precompile address. The registry
+        // constructor's PoP verification `delegatecall`s this address and is served
+        // natively by the precompile, which shares the exact `blst` verification the
+        // consensus layer uses to produce the proofs (so the on-chain check cannot drift
+        // from the off-chain encoding).
+        let blsg1_address = BLS_G1_PRECOMPILE_ADDRESS;
 
         // prepare registry deployment
         let (validators, (bls_pubkeys, proofs)): (Vec<_>, (Vec<_>, Vec<_>)) = validators
@@ -1206,8 +1191,9 @@ impl RethEnv {
 
             tn_evm.db_mut().commit(state);
 
-            // tmp BlsG1 library address is owner's second create tx on tmp chain
-            owner_address.create(1)
+            // With BlsG1 now a precompile (no genesis deploy), the registry is the owner's first
+            // create tx on the tmp chain.
+            owner_address.create(0)
         };
 
         // deploy WorkerConfigs contract
@@ -1236,8 +1222,8 @@ impl RethEnv {
 
             tn_evm.db_mut().commit(state);
 
-            // Third create tx on tmp chain (after blsg1 at nonce 0 and registry at nonce 1)
-            owner_address.create(2)
+            // Second create tx on tmp chain (registry at nonce 0, worker configs at nonce 1).
+            owner_address.create(1)
         };
 
         // execute the transactions to get final bundle state
@@ -1273,17 +1259,16 @@ impl RethEnv {
                 .ok_or_eyre("invalid worker configs json")?,
         )?;
 
-        let blsg1_runtimecode_binding =
-            Self::fetch_value_from_json_str(BLSG1_JSON, Some("deployedBytecode.object"))?;
-        let blsg1_runtimecode =
-            hex::decode(blsg1_runtimecode_binding.as_str().ok_or_eyre("invalid blsg1 json")?)?;
-
         let issuance_json_binding =
             Self::fetch_value_from_json_str(ISSUANCE_JSON, Some("deployedBytecode.object"))?;
         let issuance_runtimecode =
             hex::decode(issuance_json_binding.as_str().ok_or_eyre("invalid issuance json")?)?;
         let genesis = genesis.extend_accounts([
-            (blsg1_address, GenesisAccount::default().with_code(Some(blsg1_runtimecode.into()))),
+            // The BLS proof-of-possession library is a precompile at `blsg1_address`
+            // (`BLS_G1_PRECOMPILE_ADDRESS`). Mirror the TEL precompile and give it a single `0xfe`
+            // (INVALID) byte of code so the account is non-empty (never state-pruned) and any call
+            // that bypasses precompile dispatch reverts instead of succeeding against an EOA.
+            (blsg1_address, GenesisAccount::default().with_code(Some(vec![0xfe_u8].into()))),
             (
                 CONSENSUS_REGISTRY_ADDRESS,
                 GenesisAccount::default()
@@ -2072,26 +2057,29 @@ mod tests {
         debug!(target: "engine", ?validator_2_info, "getting validator 2 info");
         assert_eq!(validator_2_info.currentStatus, ValidatorStatus::PendingExit);
 
-        // read all active validators from consensus registry
-        let calldata =
-            ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
-                .abi_encode()
-                .into();
-        let eligible_validators = reth_env
+        // With the per-status sets, `getValidatorsInfo(Active)` returns strictly-active validators;
+        // the committee-eligible pool is the union of Active/PendingActivation/PendingExit, so the
+        // pending-exit validator is queried separately rather than partitioned out of `Active`.
+        let active_validators = reth_env
             .call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
                 &mut tn_evm,
-                calldata,
+                ConsensusRegistry::getValidatorsInfoCall { status: ValidatorStatus::Active.into() }
+                    .abi_encode()
+                    .into(),
             )?;
-
-        assert_eq!(eligible_validators.len(), 6);
-
-        // check for pending exit status
-        let (pending_exit, active_validators): (Vec<_>, Vec<_>) = eligible_validators
-            .into_iter()
-            .partition(|v| v.currentStatus == ValidatorStatus::PendingExit.into());
-
-        assert_eq!(pending_exit.len(), 1);
         assert_eq!(active_validators.len(), 5);
+
+        // validator 2 should be the single pending-exit validator
+        let pending_exit = reth_env
+            .call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
+                &mut tn_evm,
+                ConsensusRegistry::getValidatorsInfoCall {
+                    status: ValidatorStatus::PendingExit.into(),
+                }
+                .abi_encode()
+                .into(),
+            )?;
+        assert_eq!(pending_exit.len(), 1);
         assert_eq!(
             pending_exit.first().expect("one pending validator").validatorAddress,
             validator_2_address
@@ -2138,7 +2126,7 @@ mod tests {
 
         // read all active validators from consensus registry
         let calldata =
-            ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
+            ConsensusRegistry::getValidatorsInfoCall { status: ValidatorStatus::Active.into() }
                 .abi_encode()
                 .into();
         let eligible_validators = reth_env
@@ -2158,6 +2146,157 @@ mod tests {
         assert_eq!(active_validators.len(), 5);
         for v in active_validators {
             assert!(v.validatorAddress != validator_2_address);
+        }
+
+        Ok(())
+    }
+
+    /// Guards the committee backfill path in `block.rs::shuffle_new_committee`: when there are
+    /// fewer strictly-active validators than the committee size, the shuffle must backfill from
+    /// the `PendingExit` pool so the next committee still reaches the required size. Five
+    /// genesis validators form a committee of 5; two begin exiting, leaving 3 active + 2
+    /// pending-exit. Since `committeeSize (5) > active (3)`, every subsequent committee must
+    /// include the two exiting validators - otherwise `concludeEpoch` would revert on its
+    /// committee-size check.
+    #[tokio::test]
+    async fn test_committee_backfill_from_pending_exit() -> eyre::Result<()> {
+        // the two validators that begin exiting need EOAs to sign their `beginExit` txns
+        let mut exit_a_eoa =
+            TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(101));
+        let exit_a = exit_a_eoa.address();
+        let mut exit_b_eoa =
+            TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(102));
+        let exit_b = exit_b_eoa.address();
+
+        let all_validators = [
+            Address::from_slice(&[0x11; 20]),
+            Address::from_slice(&[0x33; 20]),
+            Address::from_slice(&[0x44; 20]),
+            exit_a,
+            exit_b,
+        ];
+        let validators: Vec<_> = all_validators
+            .iter()
+            .enumerate()
+            .map(|(i, addr)| {
+                let mut rng = StdRng::seed_from_u64(i as u64);
+                let bls = BlsKeypair::generate(&mut rng);
+                let pop = generate_proof_of_possession_bls_for_test(&bls, addr)
+                    .expect("pop generation failed");
+                NodeInfo {
+                    name: format!("validator-{i}"),
+                    bls_public_key: *bls.public(),
+                    p2p_info: NodeP2pInfo::default(),
+                    execution_address: *addr,
+                    proof_of_possession: pop,
+                }
+            })
+            .collect();
+
+        let epoch_duration = 60 * 60 * 24;
+        let initial_stake_config = ConsensusRegistry::StakeConfig {
+            stakeAmount: U256::from(parse_ether("1_000_000").unwrap()),
+            minWithdrawAmount: U256::from(parse_ether("1_000").unwrap()),
+            epochIssuance: U256::from(parse_ether("20_000_000").unwrap())
+                .checked_div(U256::from(28))
+                .expect("u256 div checked"),
+            epochDuration: epoch_duration,
+        };
+
+        let mut governance_multisig =
+            TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+        let governance = governance_multisig.address();
+        let tmp_genesis = tn_types::test_genesis().extend_accounts([
+            (
+                governance,
+                GenesisAccount::default().with_balance(U256::from(parse_ether("50_000_000")?)),
+            ),
+            (exit_a, GenesisAccount::default().with_balance(U256::from(parse_ether("1_000")?))),
+            (exit_b, GenesisAccount::default().with_balance(U256::from(parse_ether("1_000")?))),
+        ]);
+
+        let genesis = RethEnv::create_consensus_registry_genesis_accounts(
+            validators.clone(),
+            tmp_genesis,
+            initial_stake_config.clone(),
+            governance,
+            vec![(0u8, 30_000_000u64)],
+        )?;
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Backfill Test Task Manager");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+                .unwrap();
+
+        // sanity: genesis committee is the full set of 5 validators
+        let EpochState { epoch, validators: committee, .. } =
+            reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 0);
+        assert_eq!(committee.len(), 5);
+
+        // two validators begin exiting (Active -> PendingExit)
+        let begin_exit_a = exit_a_eoa.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(CONSENSUS_REGISTRY_ADDRESS),
+            U256::ZERO,
+            ConsensusRegistry::beginExitCall {}.abi_encode().into(),
+        );
+        let begin_exit_b = exit_b_eoa.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(CONSENSUS_REGISTRY_ADDRESS),
+            U256::ZERO,
+            ConsensusRegistry::beginExitCall {}.abi_encode().into(),
+        );
+
+        // execute the exits in the first block (no epoch close yet)
+        let mut expected_epoch = 0u32;
+        let consensus_output = consensus_output_for_tests(2, expected_epoch, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(
+            &reth_env,
+            payload,
+            vec![begin_exit_a, begin_exit_b],
+        )?;
+        let mut canonical_header = block1.recovered_block.clone_sealed_header();
+
+        // close several epochs so the post-exit committees (computed 2 epochs ahead by the shuffle)
+        // become current. If the backfill is broken, `concludeEpoch` reverts on the size check.
+        for round in 2..=6u64 {
+            expected_epoch += 1;
+            let consensus_output = consensus_output_for_tests(2, expected_epoch, round, true);
+            let payload = TNPayload::new_for_test(canonical_header, &consensus_output);
+            let block = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+            canonical_header = block.recovered_block.clone_sealed_header();
+
+            // the committee must stay full at every close: active(3) < committeeSize(5) forces the
+            // shuffle to backfill from the pending-exit pool each epoch
+            let EpochState { validators: committee, .. } =
+                reth_env.epoch_state_from_canonical_tip()?;
+            assert_eq!(committee.len(), 5, "committee stays full via pending-exit backfill");
+        }
+
+        // with active(3) < committeeSize(5), the backfill must keep every committee full and
+        // include the two pending-exit validators
+        let EpochState { validators: committee, .. } = reth_env.epoch_state_from_canonical_tip()?;
+        let committee_addrs: Vec<Address> = committee.iter().map(|v| v.validatorAddress).collect();
+        assert_eq!(committee_addrs.len(), 5, "committee stays full via pending-exit backfill");
+        assert!(committee_addrs.contains(&exit_a), "pending-exit validator A backfilled");
+        assert!(committee_addrs.contains(&exit_b), "pending-exit validator B backfilled");
+
+        // the backfilled validators remain PendingExit (still serving, not yet exited)
+        for exiting in [exit_a, exit_b] {
+            let info = reth_env.get_validator_info(canonical_header.hash(), exiting)?;
+            assert_eq!(
+                info.currentStatus,
+                ConsensusRegistry::ValidatorStatus::PendingExit,
+                "backfilled validator stays PendingExit"
+            );
         }
 
         Ok(())

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -37,7 +37,7 @@ use alloy::{
 use alloy_evm::Evm;
 use clap::Parser;
 use dirs::path_to_datadir;
-use error::{RegistryReadError, TnRethError, TnRethResult};
+use error::{RegistryReadError, RegistryReadResult, TnRethError, TnRethResult};
 use evm::TnEvmConfig;
 use eyre::OptionExt;
 use jsonrpsee::Methods;
@@ -1416,19 +1416,48 @@ impl RethEnv {
     ) -> eyre::Result<Vec<ConsensusRegistry::ValidatorInfo>> {
         debug!(target: "engine", "retrieving validators for epoch {epoch}");
         let calldata = ConsensusRegistry::getCommitteeValidatorsCall { epoch }.abi_encode().into();
-        self.read_consensus_registry(calldata)
+        self.read_consensus_registry(calldata).map_err(Into::into)
     }
 
     /// Read the BLS pubkeys for the committee of the provided epoch from the [ConsensusRegistry]
     /// on-chain.
     pub fn bls_pubkeys_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
         let calldata = ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into();
-        self.read_consensus_registry(calldata)
+        self.read_consensus_registry(calldata).map_err(Into::into)
     }
 
     /// Build an EVM at the canonical tip, execute a read-only [ConsensusRegistry] call, and
     /// decode the returned data to `T`.
-    pub fn read_consensus_registry<T>(&self, calldata: Bytes) -> eyre::Result<T>
+    ///
+    /// Convenience wrapper over [`Self::read_consensus_registry_batch`] for the common
+    /// single-read case (one pinned EVM, one call).
+    pub fn read_consensus_registry<T>(&self, calldata: Bytes) -> RegistryReadResult<T>
+    where
+        T: alloy::sol_types::SolValue,
+        T: From<
+            <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
+        >,
+    {
+        self.read_consensus_registry_batch(vec![calldata])?.pop().ok_or_else(|| {
+            RegistryReadError::Internal("consensus registry batch read returned no result".into())
+        })
+    }
+
+    /// Build a single EVM at the canonical tip and execute several read-only [ConsensusRegistry]
+    /// calls against it, decoding each result to `T`.
+    ///
+    /// Every calldata in a batch must decode to the same Solidity type `T` (current caller: five
+    /// `getValidatorsInfo(status)` reads → `Vec<ValidatorInfo>`).
+    ///
+    /// All calls observe ONE pinned state snapshot, so a multi-call query (e.g. unioning
+    /// per-status validator sets) cannot straddle a block commit and double-count or drop a
+    /// validator that changes status between reads. Each call still runs under its own fresh 30M
+    /// gas budget (`transact_system_call`), so splitting a large query across calls keeps gas
+    /// bounded per call.
+    pub fn read_consensus_registry_batch<T>(
+        &self,
+        calldatas: Vec<Bytes>,
+    ) -> RegistryReadResult<Vec<T>>
     where
         T: alloy::sol_types::SolValue,
         T: From<
@@ -1437,18 +1466,27 @@ impl RethEnv {
     {
         // create EVM with latest state
         let canonical_tip = self.canonical_tip();
-        debug!(target: "engine", ?canonical_tip, "reading consensus registry at canonical tip");
-        let state_provider =
-            self.inner.blockchain_provider.state_by_block_hash(canonical_tip.hash())?;
+        debug!(target: "engine", ?canonical_tip, "reading consensus registry batch at canonical tip");
+        let state_provider = self
+            .inner
+            .blockchain_provider
+            .state_by_block_hash(canonical_tip.hash())
+            .map_err(|e| RegistryReadError::Internal(e.to_string()))?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder().with_database(state).with_bundle_update().build();
-        let mut tn_evm = self
+        let evm_env = self
             .inner
             .evm_config
-            .evm_factory()
-            .create_evm(&mut db, self.inner.evm_config.evm_env(&canonical_tip)?);
+            .evm_env(&canonical_tip)
+            .map_err(|e| RegistryReadError::Internal(e.to_string()))?;
+        let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
-        self.call_consensus_registry(&mut tn_evm, calldata)
+        // reuse the one pinned EVM for every read; `call_consensus_registry` is non-committing,
+        // so each read sees the same base state.
+        calldatas
+            .into_iter()
+            .map(|calldata| self.call_consensus_registry(&mut tn_evm, calldata))
+            .collect()
     }
 
     /// Extract the epoch number from a header's nonce.
@@ -1458,7 +1496,7 @@ impl RethEnv {
     }
 
     /// Read the curret epoch number from the [ConsensusRegistry] on-chain.
-    fn get_current_epoch_number<DB>(&self, evm: &mut TNEvm<DB>) -> eyre::Result<u32>
+    fn get_current_epoch_number<DB>(&self, evm: &mut TNEvm<DB>) -> RegistryReadResult<u32>
     where
         DB: alloy_evm::Database,
     {
@@ -1470,7 +1508,7 @@ impl RethEnv {
     fn get_current_epoch_info<DB>(
         &self,
         evm: &mut TNEvm<DB>,
-    ) -> eyre::Result<ConsensusRegistry::EpochInfo>
+    ) -> RegistryReadResult<ConsensusRegistry::EpochInfo>
     where
         DB: alloy_evm::Database,
     {
@@ -1483,7 +1521,7 @@ impl RethEnv {
         &self,
         epoch: Epoch,
         evm: &mut TNEvm<DB>,
-    ) -> eyre::Result<Vec<ConsensusRegistry::ValidatorInfo>>
+    ) -> RegistryReadResult<Vec<ConsensusRegistry::ValidatorInfo>>
     where
         DB: alloy_evm::Database,
     {
@@ -1496,7 +1534,7 @@ impl RethEnv {
         &self,
         epoch: Epoch,
         evm: &mut TNEvm<DB>,
-    ) -> eyre::Result<Vec<alloy::primitives::Bytes>>
+    ) -> RegistryReadResult<Vec<alloy::primitives::Bytes>>
     where
         DB: alloy_evm::Database,
     {
@@ -1615,7 +1653,7 @@ impl RethEnv {
         &self,
         evm: &mut TNEvm<DB>,
         calldata: Bytes,
-    ) -> eyre::Result<T>
+    ) -> RegistryReadResult<T>
     where
         DB: alloy_evm::Database,
         T: alloy::sol_types::SolValue,
@@ -1634,18 +1672,15 @@ impl RethEnv {
                 // use SolValue to decode the result
                 alloy::sol_types::SolValue::abi_decode(&data).map_err(|e| {
                     RegistryReadError::Internal(format!("registry return decode failed: {e}"))
-                        .into()
                 })
             }
             ExecutionResult::Revert { output, .. } => Err(RegistryReadError::Revert {
                 reason: alloy::sol_types::decode_revert_reason(&output),
                 output,
-            }
-            .into()),
+            }),
             ExecutionResult::Halt { reason, gas_used } => Err(RegistryReadError::Internal(
                 format!("registry call halted: {reason:?} (gas {gas_used})"),
-            )
-            .into()),
+            )),
         }
     }
 

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -11,10 +11,11 @@ pub(super) const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffff
 
 /// Precompile genesis bytecode.
 ///
-/// This is intercepted by revm at runtime and prevents a reth issue where it skips calls with no bytecode.
+/// This is intercepted by revm at runtime and prevents a reth issue where it skips calls with no
+/// bytecode.
 ///
-/// A single `0xfe` (INVALID) byte of code is used so the account is non-empty (never state-pruned) and any call
-/// that bypasses precompile dispatch reverts instead of succeeding against an EOA.
+/// A single `0xfe` (INVALID) byte of code is used so the account is non-empty (never state-pruned)
+/// and any call that bypasses precompile dispatch reverts instead of succeeding against an EOA.
 pub const PRECOMPILE_GENESIS_BYTECODE: &[u8] = &[0xfe];
 
 /// The address for consensus registry.

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -158,9 +158,12 @@ sol!(
         function getCurrentEpochInfo() external view returns (EpochInfo memory currentEpochInfo);
         /// Return committee epoch info for a specific epoch.
         function getEpochInfo(uint32 epoch) public view returns (EpochInfo memory epochInfo);
-        /// Return the validators by status. Pass `Any` (6) for status to return all
-        /// validators. `Undefined` (0) reverts on-chain.
-        function getValidators(uint8 status) public view returns (ValidatorInfo[] memory);
+        /// Return the validator addresses for exactly the given status's set. Reverts on `Undefined`
+        /// (0) and `Any` (6); neither folds statuses. The committee-eligible pool is the off-chain
+        /// union of `Active`, `PendingActivation`, and `PendingExit`.
+        function getValidators(uint8 status) public view returns (address[] memory);
+        /// Like `getValidators`, but returns the full `ValidatorInfo` structs for the status's set.
+        function getValidatorsInfo(uint8 status) public view returns (ValidatorInfo[] memory);
         /// Fetch the committee for a given epoch.
         function getCommitteeValidators(uint32 epoch) external view returns (ValidatorInfo[] memory);
         /// Fetch the BLS pubkey for a given validator address.

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -9,6 +9,14 @@ use tn_types::{Address, Epoch};
 /// The system address.
 pub(super) const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
 
+/// Precompile genesis bytecode.
+///
+/// This is intercepted by revm at runtime and prevents a reth issue where it skips calls with no bytecode.
+///
+/// A single `0xfe` (INVALID) byte of code is used so the account is non-empty (never state-pruned) and any call
+/// that bypasses precompile dispatch reverts instead of succeeding against an EOA.
+pub const PRECOMPILE_GENESIS_BYTECODE: &[u8] = &[0xfe];
+
 /// The address for consensus registry.
 pub const CONSENSUS_REGISTRY_ADDRESS: Address =
     address!("07E17e17E17e17E17e17E17E17E17e17e17E17e1");

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -11,7 +11,7 @@ use alloy::{
     consensus::{SignableTransaction as _, TxEip4844, TxEip4844Variant, TxLegacy},
     eips::eip7594::BlobTransactionSidecarVariant,
     hex,
-    primitives::ChainId,
+    primitives::{utils::parse_ether, ChainId},
     signers::{
         k256::sha2::{Digest as _, Sha256},
         local::PrivateKeySigner,
@@ -32,14 +32,16 @@ use secp256k1::{
     Secp256k1,
 };
 use std::{collections::HashMap, path::Path, str::FromStr, sync::Arc};
+use tn_config::NodeInfo;
 use tn_types::{
-    address, calculate_transaction_root, gas_accumulator::RewardsCounter, keccak256, now,
-    test_chain_spec_arc, test_genesis, AccessList, Address, Batch, BlobTransactionSidecar, Block,
-    BlockBody, BlockHash, BlsPublicKey, Bytes, Committee, CommitteeBuilder, Encodable2718,
-    EthSignature, ExecHeader, ExecutionKeypair, Genesis, GenesisAccount, RecoveredBlock,
-    SealedHeader, TaskManager, Transaction, TransactionSigned, TxEip1559, TxHash, TxKind, WorkerId,
-    B256, EMPTY_OMMER_ROOT_HASH, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS,
-    ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE, U256,
+    address, calculate_transaction_root, gas_accumulator::RewardsCounter,
+    generate_proof_of_possession_bls_for_test, keccak256, now, test_chain_spec_arc, test_genesis,
+    AccessList, Address, Batch, BlobTransactionSidecar, Block, BlockBody, BlockHash, BlsKeypair,
+    BlsPublicKey, Bytes, Committee, CommitteeBuilder, Encodable2718, EthSignature, ExecHeader,
+    ExecutionKeypair, Genesis, GenesisAccount, NodeP2pInfo, RecoveredBlock, SealedHeader,
+    TaskManager, Transaction, TransactionSigned, TxEip1559, TxHash, TxKind, WorkerId, B256,
+    EMPTY_OMMER_ROOT_HASH, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS, ETHEREUM_BLOCK_GAS_LIMIT_30M,
+    MIN_PROTOCOL_BASE_FEE, U256,
 };
 // re-exports for tests
 pub use crate::evm::precompile_test_utils;
@@ -698,4 +700,75 @@ pub async fn create_committee_from_state(epoch_state: EpochState) -> eyre::Resul
     }
     let committee = committee_builder.build();
     Ok(committee)
+}
+
+/// Build a test genesis whose `ConsensusRegistry` is freshly deployed from the current artifact
+/// (so the new ABI surface like `getValidatorsInfo` exists) and seeded with `num_validators`
+/// active validators forming the genesis committee.
+///
+/// Unlike [`test_genesis`], which embeds the committed testnet `genesis.yaml` verbatim and can
+/// therefore drift from the compiled contract, this deploys the registry at test runtime so the
+/// genesis state always matches the current bytecode. Use it for close-epoch tests that run
+/// system calls reading the registry (e.g. committee shuffling), which revert against the stale
+/// embedded registry.
+///
+/// NOTE: this is sync but must be called from within a tokio runtime (e.g. a `#[tokio::test]`),
+/// because deploying the registry spins up a temporary `RethEnv`.
+pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
+    // deterministic committee-eligible validator addresses (0x11.., 0x22.., ...)
+    let all_validators: Vec<Address> = (1..=num_validators)
+        .map(|i| Address::from_slice(&[(i as u8).wrapping_mul(0x11); 20]))
+        .collect();
+
+    // build active validator info with deterministic BLS keys + proofs of possession
+    let validators: Vec<NodeInfo> = all_validators
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let bls = BlsKeypair::generate(&mut rng);
+            let bls_pubkey = bls.public();
+            let pop = generate_proof_of_possession_bls_for_test(&bls, addr)
+                .expect("pop generation failed");
+            NodeInfo {
+                name: format!("validator-{i}"),
+                bls_public_key: *bls_pubkey,
+                p2p_info: NodeP2pInfo::default(),
+                execution_address: *addr,
+                proof_of_possession: pop,
+            }
+        })
+        .collect();
+
+    // Mirror the canonical testnet `StakeConfig` (the CLI genesis defaults that built the embedded
+    // testnet genesis) so this drop-in registry matches what `test_genesis` provided before its
+    // bytecode went stale. NOTE: `epochIssuance` (25_806 TEL) is even, so a closed epoch's rewards
+    // split exactly between leaders (close-epoch reward assertions compare against `div_ceil(2)`).
+    let initial_stake_config = ConsensusRegistry::StakeConfig {
+        stakeAmount: U256::from(parse_ether("1_000_000").expect("parse stake amount")),
+        minWithdrawAmount: U256::from(parse_ether("1_000").expect("parse min withdraw amount")),
+        epochIssuance: U256::from(parse_ether("25_806").expect("parse epoch issuance")),
+        epochDuration: 60 * 60 * 8, // 8hrs (testnet default)
+    };
+
+    // deterministic, funded governance owner
+    let governance_multisig =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+    let governance = governance_multisig.address();
+    let base_genesis = test_genesis().extend_accounts([(
+        governance,
+        GenesisAccount::default()
+            .with_balance(U256::from(parse_ether("50_000_000").expect("parse governance balance"))),
+    )]);
+
+    // overwrite the embedded registry account at `CONSENSUS_REGISTRY_ADDRESS` with a freshly
+    // deployed registry seeded with the active validators above
+    RethEnv::create_consensus_registry_genesis_accounts(
+        validators,
+        base_genesis,
+        initial_stake_config,
+        governance,
+        vec![(0u8, 30_000_000u64)],
+    )
+    .expect("create consensus registry genesis accounts")
 }

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -24,7 +24,7 @@ pub struct BlsAggregateSignature(CoreBlsAggregateSignature);
 impl BlsSignature {
     pub fn from_bytes(bytes: &[u8]) -> eyre::Result<Self> {
         let sig = CoreBlsSignature::from_bytes(bytes)
-            .map_err(|_| eyre::eyre!("Invalid signature bytes!"))?;
+            .map_err(|e| eyre::eyre!("Invalid signature bytes! {e:?}"))?;
         Ok(Self(sig))
     }
 
@@ -35,10 +35,8 @@ impl BlsSignature {
     /// uncompressed bytes the protocol passes to the on-chain `BlsG1` library as a proof of
     /// possession. Used by the native BLS precompile so it can verify the exact bytes the
     /// consensus layer produced, without re-implementing point (de)compression.
-    pub fn from_uncompressed_bytes(bytes: &[u8]) -> eyre::Result<Self> {
-        let sig = CoreBlsSignature::deserialize(bytes)
-            .map_err(|_| eyre::eyre!("Invalid uncompressed signature bytes!"))?;
-        Ok(Self(sig))
+    pub fn from_uncompressed_bytes(bytes: &[u8]) -> Result<Self, blst::BLST_ERROR> {
+        CoreBlsSignature::deserialize(bytes).map(Self)
     }
 
     /// Verify a signature over a message (raw bytes) with public key.

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -35,8 +35,10 @@ impl BlsSignature {
     /// uncompressed bytes the protocol passes to the on-chain `BlsG1` library as a proof of
     /// possession. Used by the native BLS precompile so it can verify the exact bytes the
     /// consensus layer produced, without re-implementing point (de)compression.
-    pub fn from_uncompressed_bytes(bytes: &[u8]) -> Result<Self, blst::BLST_ERROR> {
-        CoreBlsSignature::deserialize(bytes).map(Self)
+    pub fn from_uncompressed_bytes(bytes: &[u8]) -> eyre::Result<Self> {
+        CoreBlsSignature::deserialize(bytes)
+            .map_err(|e| eyre::eyre!("Invalid uncompressed signature bytes! {e:?}"))
+            .map(Self)
     }
 
     /// Verify a signature over a message (raw bytes) with public key.


### PR DESCRIPTION
## Blocked: do not merge until tn-contracts lands

This PR bumps the tn-contracts submodule to `933703c` on `integration/e2e-0835-sets-transient`, which combines tn-contracts #114 (per-status EnumerableSet validator indexing), #118 (transient committee-membership set), and the solc 0.8.35 bump. Before this can merge into main we need to:

1. Merge those changes into tn-contracts master.
2. Re-point the submodule here to the resulting master commit.

It is stacked on #731 (the native BLS precompile), so the base is `feat/bls-precompile`; GitHub will retarget to main automatically once #731 merges.

## Summary

- `crates/tn-reth/src/lib.rs`: routes genesis proof-of-possession validation through the new BLS precompile at `0x...b151` instead of validating natively, so genesis and runtime validation share one code path, and adopts the updated `ConsensusRegistry` ABI from the integration branch.
- `crates/tn-reth/src/evm/block.rs` and `system_calls.rs`: updated for the new ABI and PoP flow.
- `crates/e2e-tests/tests/it/genesis_tests.rs`: updated for the new genesis flow.
- `tn-contracts`: submodule bumped to the integration branch (see blocker above).

## Testing

- e2e genesis tests updated and passing against the integration ConsensusRegistry.