### PR TITLE
Re-key bls_by_peer_id on network-key rotation

### DIFF
--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -134,6 +134,57 @@ impl AllPeers {
         removed
     }
 
+    /// Release the status-counter bookkeeping held by a record dropped outside the normal
+    /// status-transition path (displaced by [`Self::add_trusted_peer`] or [`Self::upsert_peer`]).
+    ///
+    /// `disconnected_peers` counts records in `Disconnected` status and `banned_peers` tracks
+    /// records in `Banned` status; a record removed without passing through
+    /// [`Self::update_connection_status`] must release them here so pruning math stays accurate.
+    fn release_displaced_record(&mut self, displaced: &Peer) {
+        match displaced.connection_status() {
+            ConnectionStatus::Disconnected { .. } => {
+                self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+            }
+            ConnectionStatus::Banned { .. } => {
+                let _ = self.banned_peers.remove_banned_peer(displaced.known_ip_addresses());
+            }
+            ConnectionStatus::Connected { .. }
+            | ConnectionStatus::Dialing { .. }
+            | ConnectionStatus::Disconnecting { .. }
+            | ConnectionStatus::Unknown => {}
+        }
+    }
+
+    /// Normalize the transport-liveness status of a record carried across a network-key
+    /// rotation.
+    ///
+    /// Reputation (score, trust, ban) is a property of the domain identity and survives the
+    /// rotation, but `Connected`/`Dialing`/`Disconnecting` describe the rotated-away key's
+    /// connection, which no longer belongs to this record. Left in place they wedge the new
+    /// identity: `can_dial` reports false and dial attempts short-circuit with
+    /// `AlreadyConnected` even though no connection exists for the new peer id, and no
+    /// libp2p event for the new id ever corrects the record. Live transport states map onto
+    /// `Disconnected` (or `Banned` when a ban was pending) with matching counter bookkeeping.
+    fn normalize_carried_status(&mut self, peer: &mut Peer) {
+        match *peer.connection_status() {
+            ConnectionStatus::Connected { .. }
+            | ConnectionStatus::Dialing { .. }
+            | ConnectionStatus::Disconnecting { banned: false } => {
+                peer.set_connection_status(ConnectionStatus::Disconnected {
+                    instant: Instant::now(),
+                });
+                self.disconnected_peers = self.disconnected_peers.saturating_add(1);
+            }
+            ConnectionStatus::Disconnecting { banned: true } => {
+                peer.set_connection_status(ConnectionStatus::Banned { instant: Instant::now() });
+                self.banned_peers.add_banned_peer(peer);
+            }
+            ConnectionStatus::Disconnected { .. }
+            | ConnectionStatus::Banned { .. }
+            | ConnectionStatus::Unknown => {}
+        }
+    }
+
     /// Create a peer that is "trusted".
     ///
     /// This overwrites peer records and unbans ips.
@@ -143,12 +194,20 @@ impl AllPeers {
         network_key: NetworkPublicKey,
     ) {
         let peer_id: PeerId = network_key.clone().into();
-        let trusted_peer = Peer::new_trusted(bls_public_key, network_key);
-        let _ = self.banned_peers.remove_banned_peer(trusted_peer.known_ip_addresses());
-        // overwrite any prior record and key the peer by its confirmed (bls) identity
-        self.peers.remove(&PeerIdentity::Unidentified(peer_id));
+        let confirmed = PeerIdentity::Confirmed(bls_public_key);
+        let current = self.identity_for(&peer_id);
+        // overwrite any prior record: anonymous under this peer id, confirmed under a different
+        // bls key that previously presented this network key, or confirmed under a previous
+        // network key; each displaced record is removed through `evict` / released so no
+        // `bls_by_peer_id` entry or status counter goes stale
+        if let Some(displaced) = (current != confirmed).then(|| self.evict(&current)).flatten() {
+            self.release_displaced_record(&displaced);
+        }
+        if let Some(displaced) = self.evict(&confirmed) {
+            self.release_displaced_record(&displaced);
+        }
         self.bls_by_peer_id.insert(peer_id, bls_public_key);
-        self.peers.insert(PeerIdentity::Confirmed(bls_public_key), trusted_peer);
+        self.peers.insert(confirmed, Peer::new_trusted(bls_public_key, network_key));
     }
 
     /// Create a peer.
@@ -159,18 +218,35 @@ impl AllPeers {
         addrs: Vec<Multiaddr>,
     ) {
         let peer_id: PeerId = network_key.clone().into();
-        // migrate any existing record (anonymous or already-confirmed) onto the confirmed identity,
-        // preserving its accumulated state; otherwise create a fresh peer
+        let confirmed = PeerIdentity::Confirmed(bls_public_key);
         let current = self.identity_for(&peer_id);
-        let peer = match self.peers.remove(&current) {
-            Some(mut peer) => {
-                peer.update_net(bls_public_key, network_key, addrs);
-                peer
-            }
-            None => Peer::new(bls_public_key, network_key, addrs),
-        };
+        // network-key rotation: a record already stored under the confirmed identity is not
+        // reachable from the new peer id, so displace it through `evict` to clear the
+        // `bls_by_peer_id` entry derived from its previous network key
+        let rotated = (current != confirmed).then(|| self.evict(&confirmed)).flatten();
+        // migrate any record reachable from the new peer id (anonymous-inbound promotion or a
+        // repeat upsert); a rotated record it displaces releases its counter bookkeeping
+        // NOTE: when the anonymous record wins this merge it keeps its fresh score, so a banned
+        // peer that reconnects anonymously before its kad record arrives sheds its ban here
+        // (pre-existing semantics); carrying reputation across the merge is a possible follow-up
+        let migrated = self.peers.remove(&current);
+        if let (Some(_), Some(displaced)) = (migrated.as_ref(), rotated.as_ref()) {
+            self.release_displaced_record(displaced);
+        }
+        // otherwise the rotated record carries forward (same domain peer, new transport key),
+        // preserving its accumulated reputation; its transport status describes the old key's
+        // connection, so it is normalized onto the new identity; a peer never seen before
+        // starts fresh
+        let carried = migrated.is_none();
+        let mut peer = migrated
+            .or(rotated)
+            .unwrap_or_else(|| Peer::new(bls_public_key, network_key.clone(), Vec::new()));
+        if carried {
+            self.normalize_carried_status(&mut peer);
+        }
+        peer.update_net(bls_public_key, network_key, addrs);
         self.bls_by_peer_id.insert(peer_id, bls_public_key);
-        self.peers.insert(PeerIdentity::Confirmed(bls_public_key), peer);
+        self.peers.insert(confirmed, peer);
     }
 
     /// Handle reported action.
@@ -231,7 +307,20 @@ impl AllPeers {
         peer_id: &PeerId,
         new_status: &NewConnectionStatus,
     ) -> ConnectionStatus {
-        let id = self.identity_for(peer_id);
+        let resolved = self.identity_for(peer_id);
+        // self-heal a stale resolution-index entry: a confirmed identity with no backing record
+        // violates the `bls_by_peer_id` iff-invariant; repair the index and treat the peer as
+        // unidentified so a keyless default record is never stored under a confirmed key (such
+        // a record has no recoverable peer id, so `evict` could never clear its index entry)
+        let id = if matches!(resolved, PeerIdentity::Confirmed(_))
+            && !self.peers.contains_key(&resolved)
+        {
+            error!(target: "peer-manager", ?peer_id, "bls_by_peer_id entry found without a confirmed record - repairing index");
+            self.bls_by_peer_id.remove(peer_id);
+            PeerIdentity::Unidentified(*peer_id)
+        } else {
+            resolved
+        };
         if !self.peers.contains_key(&id) {
             // initialize unknown peer and log warning if status update is invalid for unknown peers
             if !new_status.valid_initial_state() {

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -241,10 +241,15 @@ impl AllPeers {
         let mut peer = migrated
             .or(rotated)
             .unwrap_or_else(|| Peer::new(bls_public_key, network_key.clone(), Vec::new()));
+        // apply the rotated-to keys and addresses before normalizing: when a carried record is
+        // mid-ban (`Disconnecting { banned: true }`), `normalize_carried_status` completes the ban
+        // through `add_banned_peer`, which reads the record's `known_ip_addresses`. `update_net`
+        // extends (does not replace) the address set, so updating first records the address the
+        // peer presents on the rotated-to key against the ban, not just the rotated-away one
+        peer.update_net(bls_public_key, network_key, addrs);
         if carried {
             self.normalize_carried_status(&mut peer);
         }
-        peer.update_net(bls_public_key, network_key, addrs);
         self.bls_by_peer_id.insert(peer_id, bls_public_key);
         self.peers.insert(confirmed, peer);
     }

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -379,6 +379,71 @@ fn test_upsert_peer_rotation_normalizes_carried_connected_status() {
 }
 
 #[test]
+fn test_upsert_peer_rotation_normalizes_carried_pending_ban_status() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(35);
+    let addr = create_multiaddr(None);
+
+    // the peer is mid-ban under its first network key (disconnecting with the ban pending, not
+    // yet completed to Banned) when the rotated kad record arrives
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers
+        .update_connection_status(&peer_id_1, NewConnectionStatus::Disconnecting { banned: true });
+    assert_eq!(all_peers.banned_peers.total(), 0);
+
+    all_peers.upsert_peer(bls, net2, vec![addr]);
+
+    // the carried Disconnecting { banned: true } status normalizes onto the new identity as
+    // Banned with the banned counter incremented, so the pending ban survives the rotation
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated peer resolves");
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Banned { .. }));
+    assert_eq!(all_peers.banned_peers.total(), 1);
+    assert_eq!(all_peers.disconnected_peers, 0);
+
+    // iff-invariant: the old peer id no longer resolves, the new one does, one confirmed record
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.peers.len(), 1);
+}
+
+#[test]
+fn test_upsert_peer_rotation_pending_ban_records_rotated_address() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, _peer_id_2) = rotation_keys(36);
+
+    // a separate peer is already banned on the address the rotating peer will present, leaving
+    // that ip one ban short of the per-ip block threshold
+    let rotated_ip = IpAddr::V4("192.168.77.1".parse().unwrap());
+    let rotated_addr = create_multiaddr(Some(rotated_ip));
+    let other = PeerId::random();
+    all_peers.update_connection_status(
+        &other,
+        NewConnectionStatus::Connected {
+            multiaddr: rotated_addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.update_connection_status(&other, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(&other, NewConnectionStatus::Disconnected);
+    assert!(!all_peers.ip_banned(&rotated_ip), "a single ban is below the per-ip threshold");
+
+    // the rotating peer is mid-ban under its first network key, presenting a different address
+    let old_addr = create_multiaddr(Some(IpAddr::V4("10.0.0.1".parse().unwrap())));
+    all_peers.upsert_peer(bls, net1, vec![old_addr]);
+    all_peers
+        .update_connection_status(&peer_id_1, NewConnectionStatus::Disconnecting { banned: true });
+
+    // it rotates and presents the shared address: normalizing the carried pending ban must record
+    // the rotated-to address (not just the rotated-away one), pushing the shared ip over the
+    // threshold; with the ban recorded before the address update the ip would stay below it
+    all_peers.upsert_peer(bls, net2, vec![rotated_addr]);
+    assert!(
+        all_peers.ip_banned(&rotated_ip),
+        "the rotated-to address must be banned when the carried pending ban is normalized"
+    );
+}
+
+#[test]
 fn test_upsert_peer_merge_releases_displaced_banned_record() {
     let mut all_peers = create_all_peers(None);
     let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(28);

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -162,6 +162,348 @@ fn test_upsert_peer_seeds_multiaddrs_for_new_peer() {
     assert!(peer.known_ip_addresses().any(|ip| Some(ip) == expected_ip));
 }
 
+/// Build a peer with a bls key and two network keys for rotation scenarios:
+/// (bls, first network key, its peer id, rotated network key, its peer id).
+fn rotation_keys(seed: u8) -> (BlsPublicKey, NetworkPublicKey, PeerId, NetworkPublicKey, PeerId) {
+    let mut rng = StdRng::from_seed([seed; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    let net1: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let peer_id_1: PeerId = net1.clone().into();
+    let net2: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let peer_id_2: PeerId = net2.clone().into();
+    (bls, net1, peer_id_1, net2, peer_id_2)
+}
+
+#[test]
+fn test_upsert_peer_network_key_rotation() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(21);
+    let addr = create_multiaddr(None);
+
+    // known peer via its first network key, driven to a non-default status so the counter
+    // bookkeeping is observable
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.disconnected_peers, 1);
+
+    // rotate the network key, same bls key
+    all_peers.upsert_peer(bls, net2, vec![addr.clone()]);
+
+    // iff-invariant: the old peer id no longer resolves, the new one does, and exactly one
+    // confirmed record exists
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.bls_by_peer_id.len(), 1);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls)));
+    assert!(all_peers.get_peer(&peer_id_1).is_none());
+
+    // accumulated state survives the rotation: the record's recoverable peer id follows the
+    // new key, its status is untouched, and the status counters are unchanged
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated peer resolves");
+    assert_eq!(peer.peer_id(), Some(peer_id_2));
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnected { .. }));
+    assert_eq!(all_peers.disconnected_peers, 1);
+    assert_eq!(all_peers.banned_peers.total(), 0);
+
+    // after the record is evicted (as pruning would), no orphaned index entry remains;
+    // evict alone does not manage counters (the pruning paths decrement separately)
+    all_peers.evict(&PeerIdentity::Confirmed(bls));
+    assert!(all_peers.bls_by_peer_id.is_empty());
+    assert_eq!(all_peers.disconnected_peers, 1);
+
+    // a late event carrying the rotated-away peer id creates a normal unidentified record
+    // instead of resurrecting a keyless record under the confirmed key
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Dialing);
+    assert!(all_peers.peers.contains_key(&PeerIdentity::Unidentified(peer_id_1)));
+    assert!(!all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls)));
+    assert!(all_peers.bls_by_peer_id.is_empty());
+}
+
+#[test]
+fn test_upsert_peer_network_key_rotation_banned_peer() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(22);
+    let addr = create_multiaddr(None);
+
+    // ban the peer under its first network key
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers
+        .update_connection_status(&peer_id_1, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.banned_peers.total(), 1);
+
+    // rotation does not reset the ban: the record carries forward under the new key with its
+    // banned status and bookkeeping intact
+    all_peers.upsert_peer(bls, net2, vec![addr]);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.peers.len(), 1);
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated peer resolves");
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Banned { .. }));
+    assert_eq!(all_peers.banned_peers.total(), 1);
+    assert_eq!(all_peers.disconnected_peers, 0);
+}
+
+#[test]
+fn test_upsert_peer_rotation_releases_displaced_record_counters() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(23);
+    let addr = create_multiaddr(None);
+
+    // disconnected record under the confirmed identity from the first network key
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.disconnected_peers, 1);
+
+    // the peer reconnects anonymously with its rotated key before publishing a kad record
+    let addr2 = create_multiaddr(None);
+    all_peers.update_connection_status(
+        &peer_id_2,
+        NewConnectionStatus::Connected {
+            multiaddr: addr2.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    assert_eq!(all_peers.peers.len(), 2);
+
+    // the kad record arrives: the anonymous record is promoted onto the confirmed identity and
+    // the displaced (disconnected) record releases its counter as it is dropped
+    all_peers.upsert_peer(bls, net2, vec![addr2]);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.bls_by_peer_id.len(), 1);
+    let peer = all_peers.get_peer(&peer_id_2).expect("promoted peer resolves");
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Connected { .. }));
+    assert_eq!(all_peers.disconnected_peers, 0);
+}
+
+#[test]
+fn test_add_trusted_peer_network_key_rotation() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(24);
+
+    all_peers.add_trusted_peer(bls, net1);
+    assert_eq!(all_peers.bls_for_peer(&peer_id_1), Some(bls));
+
+    // rotate the network key, same bls key
+    all_peers.add_trusted_peer(bls, net2);
+
+    // iff-invariant: the old peer id no longer resolves, the new one does, and exactly one
+    // confirmed record exists with a recoverable peer id for the new key
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.bls_by_peer_id.len(), 1);
+    assert_eq!(all_peers.peers.len(), 1);
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated trusted peer resolves");
+    assert_eq!(peer.peer_id(), Some(peer_id_2));
+    assert_eq!(peer.reputation(), Reputation::Trusted);
+}
+
+#[test]
+fn test_add_trusted_peer_preserves_banned_total() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, _, _, _) = rotation_keys(25);
+
+    // ban an unrelated peer
+    let banned_peer = PeerId::random();
+    all_peers.update_connection_status(
+        &banned_peer,
+        NewConnectionStatus::Disconnecting { banned: true },
+    );
+    all_peers.update_connection_status(&banned_peer, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.banned_peers.total(), 1);
+
+    // adding a trusted peer displaces no record, so the banned total is untouched
+    all_peers.add_trusted_peer(bls, net1);
+    assert_eq!(all_peers.banned_peers.total(), 1);
+}
+
+#[test]
+fn test_ensure_peer_exists_repairs_stale_index_entry() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, _, peer_id_1, _, _) = rotation_keys(26);
+
+    // manufacture an iff-invariant violation: an index entry with no confirmed record
+    all_peers.bls_by_peer_id.insert(peer_id_1, bls);
+
+    // an event for the stale peer id repairs the index instead of storing a keyless default
+    // record under the confirmed key
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Dialing);
+    assert!(all_peers.bls_by_peer_id.is_empty());
+    assert!(all_peers.peers.contains_key(&PeerIdentity::Unidentified(peer_id_1)));
+    assert!(!all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls)));
+}
+
+#[test]
+fn test_upsert_peer_rotation_normalizes_carried_connected_status() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(27);
+    let addr = create_multiaddr(None);
+
+    // the peer is connected under its first network key when the rotated kad record arrives
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+
+    all_peers.upsert_peer(bls, net2, vec![addr]);
+
+    // the carried record's Connected status described the old key's transport; it is
+    // normalized to Disconnected (with the counter incremented) so the new identity is
+    // immediately dialable instead of wedged behind a phantom connection
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated peer resolves");
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnected { .. }));
+    assert!(peer.can_dial());
+    assert_eq!(all_peers.disconnected_peers, 1);
+    assert_eq!(all_peers.banned_peers.total(), 0);
+}
+
+#[test]
+fn test_upsert_peer_merge_releases_displaced_banned_record() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(28);
+    let addr = create_multiaddr(None);
+
+    // ban the peer under its first network key
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers
+        .update_connection_status(&peer_id_1, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.banned_peers.total(), 1);
+
+    // the peer reconnects anonymously with its rotated key, then its kad record arrives;
+    // the anonymous record wins the merge and the displaced banned record releases its
+    // bookkeeping as it is dropped (the ban itself is shed: pre-existing merge semantics)
+    let addr2 = create_multiaddr(None);
+    all_peers.update_connection_status(
+        &peer_id_2,
+        NewConnectionStatus::Connected {
+            multiaddr: addr2.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.upsert_peer(bls, net2, vec![addr2]);
+    assert_eq!(all_peers.banned_peers.total(), 0);
+    assert_eq!(all_peers.disconnected_peers, 0);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    let peer = all_peers.get_peer(&peer_id_2).expect("promoted peer resolves");
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Connected { .. }));
+}
+
+#[test]
+fn test_add_trusted_peer_releases_displaced_anonymous_record_counters() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, _, _) = rotation_keys(29);
+    let addr = create_multiaddr(None);
+
+    // anonymous peer connects then disconnects under the peer id the operator later trusts
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr,
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.disconnected_peers, 1);
+
+    // the displaced anonymous record releases its counter as it is overwritten
+    all_peers.add_trusted_peer(bls, net1);
+    assert_eq!(all_peers.disconnected_peers, 0);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert_eq!(all_peers.bls_for_peer(&peer_id_1), Some(bls));
+}
+
+#[test]
+fn test_add_trusted_peer_rotation_releases_displaced_record_counters() {
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(30);
+    let addr = create_multiaddr(None);
+
+    // disconnected confirmed record under the first network key
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr,
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.disconnected_peers, 1);
+
+    // trusting the peer under a rotated network key displaces the old record through the
+    // proper path: counter released, index re-keyed
+    all_peers.add_trusted_peer(bls, net2);
+    assert_eq!(all_peers.disconnected_peers, 0);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    assert_eq!(all_peers.peers.len(), 1);
+}
+
+#[test]
+fn test_add_trusted_peer_rekeys_network_key_bound_to_other_bls() {
+    let mut all_peers = create_all_peers(None);
+    let (bls_x, net1, peer_id_1, _, _) = rotation_keys(31);
+    let mut rng = StdRng::from_seed([32; 32]);
+    let bls_y = *BlsKeypair::generate(&mut rng).public();
+    let addr = create_multiaddr(None);
+
+    // the network key is first bound to a different bls identity
+    all_peers.upsert_peer(bls_x, net1.clone(), vec![addr]);
+    assert_eq!(all_peers.bls_for_peer(&peer_id_1), Some(bls_x));
+
+    // trusting bls_y with the same network key must displace the bls_x record, not orphan it
+    // (an orphaned record's later eviction would delete the legitimate index entry)
+    all_peers.add_trusted_peer(bls_y, net1);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(!all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls_x)));
+    assert!(all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls_y)));
+    assert_eq!(all_peers.bls_by_peer_id.len(), 1);
+    assert_eq!(all_peers.bls_for_peer(&peer_id_1), Some(bls_y));
+}
+
+#[test]
+fn test_upsert_peer_rekeys_network_key_bound_to_other_bls() {
+    let mut all_peers = create_all_peers(None);
+    let (bls_x, net1, peer_id_1, _, _) = rotation_keys(33);
+    let mut rng = StdRng::from_seed([34; 32]);
+    let bls_y = *BlsKeypair::generate(&mut rng).public();
+    let addr = create_multiaddr(None);
+
+    // the network key is first bound to a different bls identity, then re-presented with a
+    // new bls key; the record migrates onto the new confirmed identity and the index follows
+    all_peers.upsert_peer(bls_x, net1.clone(), vec![addr.clone()]);
+    all_peers.upsert_peer(bls_y, net1, vec![addr]);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(!all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls_x)));
+    assert!(all_peers.peers.contains_key(&PeerIdentity::Confirmed(bls_y)));
+    assert_eq!(all_peers.bls_by_peer_id.len(), 1);
+    assert_eq!(all_peers.bls_for_peer(&peer_id_1), Some(bls_y));
+}
+
 #[test]
 fn test_connected_peers_by_score() {
     let mut all_peers = create_all_peers(None);


### PR DESCRIPTION
Fixes #722.

`bls_by_peer_id` is documented to stay in lockstep with the `Confirmed` entries in `peers`: an entry exists iff the peer is stored under a `Confirmed` key whose record derives that `PeerId`.  Network-key rotation (`upsert_peer` with the same bls key and a new network key, a supported `add_known_peer` flow) broke the invariant three ways: the index entry derived from the previous network key was never removed (the only removal site, `evict`, keys on the record's current peer id); the existing `Confirmed` record was raw-overwritten, skipping `disconnected_peers`/`banned_peers` bookkeeping; and once the live record was later pruned, the stale entry resurrected a keyless `Peer::default()` under the `Confirmed` key, which `evict` can never clear because the record has no recoverable peer id.

`upsert_peer` now treats rotation explicitly.  A record already stored under the confirmed identity but unreachable from the new peer id is displaced through `evict`, clearing the stale index entry.  In the common rotation case the displaced record carries forward via `update_net` (same domain peer, new transport key), so accumulated score, trust, and Banned/Disconnected status survive; in particular a banned peer cannot launder its reputation by rotating its network key.  Transport-liveness statuses (`Connected`/`Dialing`/`Disconnecting`) describe the rotated-away key's connection, so the carry normalizes them to `Disconnected` (or `Banned` when a ban was pending) with matching counter bookkeeping; otherwise the new identity would be wedged behind a phantom connection (`can_dial` false, dial attempts short-circuiting with `AlreadyConnected`) that no libp2p event for the new id ever corrects.  When an anonymous record for the new peer id also exists (the peer reconnected before publishing its kad record), that record is promoted onto the confirmed identity as before, and the displaced record releases its counter bookkeeping through the new `release_displaced_record` helper.

`add_trusted_peer` gets the same eviction treatment, including one case `upsert_peer` already handled by construction: a network key re-presented under a different bls key.  Resolving the current identity through the index and evicting it prevents an orphaned `Confirmed` record whose later pruning would delete the legitimate index entry and silently make the trusted peer unresolvable.  Its old `remove_banned_peer(trusted_peer.known_ip_addresses())` call is dropped: ever since `Peer::new_trusted` lost its addr parameter that iterator is always empty, so the call could never unban an IP and only decremented the banned total spuriously (`BannedPeers::remove_banned_peer` decrements `total` unconditionally).  Displacement-release now does that job with the displaced record's actual addresses.

`ensure_peer_exists` self-heals as a backstop for the third bug: a confirmed identity with no backing record means a stale index entry, so it repairs the index and stores the default record under `Unidentified` instead of creating a keyless record under a `Confirmed` key.

Twelve new tests cover the acceptance criteria and the edge cases above: pure rotation (iff-invariant, status counters before and after eviction, no orphaned index entry, no zombie resurrection from the rotated-away peer id), rotation of a banned peer, rotation while connected (transport-status normalization), rotation displacing a disconnected record behind an anonymous reconnect, the same merge displacing a banned record, trusted-peer rotation with and without counters to release, anonymous-record displacement by `add_trusted_peer`, a network key re-bound to a different bls key through both `upsert_peer` and `add_trusted_peer`, banned-total preservation in `add_trusted_peer`, and the `ensure_peer_exists` index repair.

Two known limitations are left as possible follow-ups (both pre-existing semantics, now documented in code comments): a displaced banned record releases its `banned_peers` bookkeeping without emitting an `Unbanned` event (these methods have no `PeerAction` channel), and in the anonymous-reconnect merge the surviving record keeps its fresh score, so a banned peer that reconnects anonymously before its kad record arrives sheds its AllPeers-level ban there, exactly as it did before this change.