### PR TITLE
Index so we can access all the bytes (batches plus consensus header) for consensus output in a pack file.

### DIFF
--- a/crates/consensus/executor/src/errors.rs
+++ b/crates/consensus/executor/src/errors.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Debug;
 use thiserror::Error;
+use tn_primary::consensus::ConsensusError;
 use tn_storage::StoreError;
 use tn_types::{AuthorityIdentifier, BlockHash, HeaderDigest, WorkerId};
 
@@ -137,4 +138,8 @@ pub enum SubscriberError {
     /// are behaving correctly and may indicate either a worker bug or data corruption.
     #[error("A fetched batch is missing from the collection: {0}")]
     MissingFetchedBatch(BlockHash),
+
+    /// An error from spawning consensus.
+    #[error("Consensus error (from spawn): {0}")]
+    Consensus(#[from] ConsensusError),
 }

--- a/crates/consensus/executor/tests/it/main.rs
+++ b/crates/consensus/executor/tests/it/main.rs
@@ -81,7 +81,8 @@ async fn test_output_to_header() -> eyre::Result<()> {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -103,10 +104,11 @@ async fn test_output_to_header() -> eyre::Result<()> {
         &consensus_bus,
         bullshark,
         &task_manager,
-        consensus_chain,
+        &consensus_chain,
         None,
     )
-    .await;
+    .await
+    .unwrap();
 
     // forward certificates to trigger subdag commit
     for certificate in certificates.iter() {
@@ -194,7 +196,8 @@ async fn test_executor_output_ordering() -> eyre::Result<()> {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -216,10 +219,11 @@ async fn test_executor_output_ordering() -> eyre::Result<()> {
         &consensus_bus,
         bullshark,
         &task_manager2,
-        consensus_chain.clone(),
+        &consensus_chain,
         None,
     )
-    .await;
+    .await
+    .unwrap();
 
     for certificate in certificates.iter() {
         consensus_bus.new_certificates().send(certificate.clone()).await.unwrap();
@@ -298,7 +302,8 @@ async fn test_executor_batch_fetching() -> eyre::Result<()> {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -320,10 +325,11 @@ async fn test_executor_batch_fetching() -> eyre::Result<()> {
         &consensus_bus,
         bullshark,
         &task_manager2,
-        consensus_chain,
+        &consensus_chain,
         None,
     )
-    .await;
+    .await
+    .unwrap();
 
     for certificate in certificates.iter() {
         consensus_bus.new_certificates().send(certificate.clone()).await.unwrap();
@@ -490,7 +496,8 @@ async fn test_duplicate_batch_digest() -> eyre::Result<()> {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -512,10 +519,11 @@ async fn test_duplicate_batch_digest() -> eyre::Result<()> {
         &consensus_bus,
         bullshark,
         &task_manager2,
-        consensus_chain,
+        &consensus_chain,
         None,
     )
-    .await;
+    .await
+    .unwrap();
 
     // feed all certificates to trigger subdag commits
     for certificate in all_certificates.iter() {

--- a/crates/consensus/primary/src/consensus/leader_schedule.rs
+++ b/crates/consensus/primary/src/consensus/leader_schedule.rs
@@ -8,9 +8,9 @@ use std::{
     fmt::{Debug, Formatter},
     sync::Arc,
 };
-use tn_storage::consensus::ConsensusChain;
 use tn_types::{
-    Authority, AuthorityIdentifier, Certificate, Committee, ReputationScores, Round, VotingPower,
+    Authority, AuthorityIdentifier, Certificate, Committee, ConsensusChainReader, ReputationScores,
+    Round, VotingPower,
 };
 use tracing::{debug, trace};
 
@@ -252,12 +252,12 @@ impl LeaderSchedule {
     /// for the LeaderSchedule.
     pub async fn from_store(
         committee: Committee,
-        consensus_chain: &mut ConsensusChain,
+        consensus_chain: &impl ConsensusChainReader,
         bad_nodes_percent_threshold: u64,
-    ) -> Self {
+    ) -> eyre::Result<Self> {
         let table = consensus_chain
             .read_latest_commit_with_final_reputation_scores(committee.epoch())
-            .await;
+            .await?;
         let table = table.map_or(LeaderSwapTable::default(), |subdag| {
             LeaderSwapTable::new(
                 &committee,
@@ -267,7 +267,7 @@ impl LeaderSchedule {
             )
         });
         // create the schedule
-        Self::new(committee, table)
+        Ok(Self::new(committee, table))
     }
 
     /// Atomically updates the leader swap table with the new provided one. Any leader queried from

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -12,12 +12,11 @@ use std::{
 use tn_config::ConsensusConfig;
 use tn_storage::{
     certificate_pack::{CertificatePack, PackError},
-    consensus::ConsensusChain,
     CertificateStore,
 };
 use tn_types::{
-    AuthorityIdentifier, Certificate, CommittedSubDag, Committee, Database, Hash as _,
-    HeaderDigest, Noticer, Round, TaskManager, TnReceiver, TnSender,
+    AuthorityIdentifier, Certificate, CommittedSubDag, Committee, ConsensusChainReader, Database,
+    Hash as _, HeaderDigest, Noticer, Round, TaskManager, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument};
 
@@ -282,13 +281,13 @@ impl<DB: Database> Consensus<DB> {
         consensus_bus: &ConsensusBus,
         protocol: Bullshark,
         task_manager: &TaskManager,
-        consensus_chain: ConsensusChain,
+        consensus_chain: &impl ConsensusChainReader,
         certificate_pack: Option<CertificatePack>,
-    ) {
+    ) -> Result<(), ConsensusError> {
         let rx_shutdown = consensus_config.shutdown().subscribe();
         // The consensus state (everything else is immutable).
         let current_epoch = consensus_config.epoch();
-        let recovered_last_committed = consensus_chain.read_last_committed(current_epoch).await;
+        let recovered_last_committed = consensus_chain.read_last_committed(current_epoch).await?;
 
         debug!(target: "epoch-manager", ?recovered_last_committed, "recovered last committed for epoch {}", current_epoch);
         let last_committed_round = recovered_last_committed
@@ -349,6 +348,7 @@ impl<DB: Database> Consensus<DB> {
                 Ok(s.run(rx_new_certificates).await?)
             });
         }
+        Ok(())
     }
 
     async fn run(

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -432,7 +432,7 @@ async fn commit_one() {
             .unwrap();
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain, None).await;
+    Consensus::spawn(config, &cb, bullshark, &task_manager, &consensus_chain, None).await.unwrap();
     let dummy_parent = SealedHeader::new(ExecHeader::default(), B256::default());
     cb.app().recent_blocks().send_modify(|blocks| {
         blocks.push_latest(
@@ -503,7 +503,7 @@ async fn dead_node() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain, None).await;
+    Consensus::spawn(config, &cb, bullshark, &task_manager, &consensus_chain, None).await.unwrap();
 
     let cb_clone = cb.clone();
     // Feed all certificates to the consensus.
@@ -638,7 +638,7 @@ async fn not_enough_support() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain, None).await;
+    Consensus::spawn(config, &cb, bullshark, &task_manager, &consensus_chain, None).await.unwrap();
 
     // Feed all certificates to the consensus. Only the last certificate should trigger
     // commits, so the task should not block.
@@ -738,7 +738,7 @@ async fn missing_leader() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain, None).await;
+    Consensus::spawn(config, &cb, bullshark, &task_manager, &consensus_chain, None).await.unwrap();
 
     // Feed all certificates to the consensus. We should only commit upon receiving the last
     // certificate, so calls below should not block the task.
@@ -811,15 +811,9 @@ async fn committed_round_after_restart() {
         let mut rx_primary = cb.subscribe_committed_own_headers();
         let mut rx_output = cb.subscribe_sequence();
         let mut task_manager = TaskManager::default();
-        Consensus::spawn(
-            config.clone(),
-            &cb,
-            bullshark,
-            &task_manager,
-            consensus_chain.clone(),
-            None,
-        )
-        .await;
+        Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, &consensus_chain, None)
+            .await
+            .unwrap();
 
         // When `input_round` is 2 * r + 1, r > 1, the previous commit round would be 2 * (r - 1),
         // and the expected commit round after sending in certificates up to `input_round` would
@@ -1074,15 +1068,9 @@ async fn restart_with_new_committee() {
         });
         let mut rx_output = cb.subscribe_sequence();
         let mut task_manager = TaskManager::default();
-        Consensus::spawn(
-            config.clone(),
-            &cb,
-            bullshark,
-            &task_manager,
-            consensus_chain.clone(),
-            None,
-        )
-        .await;
+        Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, &consensus_chain, None)
+            .await
+            .unwrap();
 
         // Make certificates for rounds 1 and 2.
         let genesis =

--- a/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/consensus_tests.rs
@@ -56,7 +56,8 @@ async fn test_consensus_recovery_with_bullshark() {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -75,8 +76,9 @@ async fn test_consensus_recovery_with_bullshark() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, consensus_chain.clone(), None)
-        .await;
+    Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, &consensus_chain, None)
+        .await
+        .unwrap();
 
     // WHEN we feed all certificates to the consensus.
     for certificate in certificates.iter() {
@@ -124,7 +126,7 @@ async fn test_consensus_recovery_with_bullshark() {
     }
 
     // AND the last committed store should be updated correctly
-    let last_committed = consensus_chain.read_last_committed(config.epoch()).await;
+    let last_committed = consensus_chain.read_last_committed(config.epoch()).await.unwrap();
 
     for id in ids.clone() {
         let last_round = *last_committed.get(&id).unwrap();
@@ -153,7 +155,8 @@ async fn test_consensus_recovery_with_bullshark() {
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         num_sub_dags_per_schedule,
@@ -172,8 +175,9 @@ async fn test_consensus_recovery_with_bullshark() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, consensus_chain.clone(), None)
-        .await;
+    Consensus::spawn(config.clone(), &cb, bullshark, &task_manager, &consensus_chain, None)
+        .await
+        .unwrap();
 
     // WHEN we send same certificates but up to round 3 (inclusive)
     // Then we store all the certificates up to round 6 so we can let the recovery algorithm
@@ -238,7 +242,7 @@ async fn test_consensus_recovery_with_bullshark() {
     });
     let mut rx_output = cb.subscribe_sequence();
     let task_manager = TaskManager::default();
-    Consensus::spawn(config, &cb, bullshark, &task_manager, consensus_chain.clone(), None).await;
+    Consensus::spawn(config, &cb, bullshark, &task_manager, &consensus_chain, None).await.unwrap();
 
     // WHEN send the certificates of round >= 5 to trigger a leader election for round 4
     // and start committing.

--- a/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/leader_schedule_tests.rs
@@ -437,7 +437,7 @@ async fn test_leader_schedule_from_store() {
     consensus_chain.write_subdag_for_test(1, sub_dag).await;
 
     // WHEN
-    let schedule = LeaderSchedule::from_store(committee, &mut consensus_chain, 33).await;
+    let schedule = LeaderSchedule::from_store(committee, &mut consensus_chain, 33).await.unwrap();
 
     // THEN the stored schedule should be returned and eventually the low score leader should be
     // swapped with a high score one.

--- a/crates/consensus/primary/tests/it/recovery_tests.rs
+++ b/crates/consensus/primary/tests/it/recovery_tests.rs
@@ -257,7 +257,7 @@ async fn test_last_committed_persists() {
     consensus_chain.persist_current().await.unwrap();
 
     // Read last committed state
-    let last_committed = consensus_chain.read_last_committed(committee.epoch()).await;
+    let last_committed = consensus_chain.read_last_committed(committee.epoch()).await.unwrap();
 
     // Should have entries for authorities that were leaders
     assert!(!last_committed.is_empty(), "Should have last committed entries for authorities");

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -130,8 +130,10 @@ async fn test_consensus_store_read_latest_final_reputation_scores() {
     }
 
     // WHEN we try to read the final schedule. The one of sub dag sequence 12 should be returned
-    let commit =
-        consensus_chain.read_latest_commit_with_final_reputation_scores(committee.epoch()).await;
+    let commit = consensus_chain
+        .read_latest_commit_with_final_reputation_scores(committee.epoch())
+        .await
+        .unwrap();
 
     // THEN no commit is returned
     assert!(commit.is_none());
@@ -155,6 +157,7 @@ async fn test_consensus_store_read_latest_final_reputation_scores() {
     let commit = consensus_chain
         .read_latest_commit_with_final_reputation_scores(committee.epoch())
         .await
+        .unwrap()
         .unwrap();
 
     assert!(commit.reputation_scores().final_of_schedule);

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -37,6 +37,10 @@ pub enum TnEngineError {
     /// The output's leader is unknown.
     #[error("Unknown authority for block rewards {0}")]
     UnknownAuthority(AuthorityIdentifier),
+    /// A ConsensusOutput produced a different number of batches and batch digests.
+    /// This should not happen outside of a bug in ConsensusOutput production...
+    #[error("Uneven number of sealed blocks from batches and batch digests, batches {0}, batch digests {1}")]
+    ConsensusOutputUnevenBatches(usize, usize),
 }
 
 impl From<oneshot::error::RecvError> for TnEngineError {

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -53,6 +53,13 @@ pub fn execute_consensus_output(
         output.batch_digests().len(),
         "uneven number of sealed blocks from batches and batch digests"
     );
+    // This should maybe panic but for prod code at least error out since this an invalid condition.
+    if batches.len() != output.batch_digests().len() {
+        return Err(TnEngineError::ConsensusOutputUnevenBatches(
+            batches.len(),
+            output.batch_digests().len(),
+        ));
+    }
 
     // ensure at least 1 block for empty output when close_epoch is true
     let mut executed_blocks = Vec::with_capacity(batches.len().max(1));

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -74,15 +74,15 @@ impl<CDB: ConsensusDatabase> PrimaryNodeInner<CDB> {
         &self,
         consensus_bus: &ConsensusBus,
         task_manager: &TaskManager,
-        mut consensus_chain: ConsensusChain,
+        consensus_chain: ConsensusChain,
         certificate_pack: Option<CertificatePack>,
     ) -> SubscriberResult<LeaderSchedule> {
         let leader_schedule = LeaderSchedule::from_store(
             self.consensus_config.committee().clone(),
-            &mut consensus_chain,
+            &consensus_chain,
             DEFAULT_BAD_NODES_STAKE_THRESHOLD,
         )
-        .await;
+        .await?;
 
         // Spawn the consensus core who only sequences transactions.
         let ordering_engine = Bullshark::new(
@@ -96,10 +96,10 @@ impl<CDB: ConsensusDatabase> PrimaryNodeInner<CDB> {
             consensus_bus,
             ordering_engine,
             task_manager,
-            consensus_chain.clone(),
+            &consensus_chain,
             certificate_pack,
         )
-        .await;
+        .await?;
 
         Ok(leader_schedule)
     }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -497,7 +497,8 @@ async fn spawn_consensus(
         &mut consensus_chain,
         DEFAULT_BAD_NODES_STAKE_THRESHOLD,
     )
-    .await;
+    .await
+    .unwrap();
     let bullshark = Bullshark::new(
         committee.clone(),
         3,
@@ -514,5 +515,7 @@ async fn spawn_consensus(
             Some(dummy_parent),
         )
     });
-    Consensus::spawn(config, consensus_bus, bullshark, task_manager, consensus_chain, None).await;
+    Consensus::spawn(config, consensus_bus, bullshark, task_manager, &consensus_chain, None)
+        .await
+        .unwrap();
 }

--- a/crates/storage/src/archive/digest_index/index.rs
+++ b/crates/storage/src/archive/digest_index/index.rs
@@ -741,7 +741,7 @@ impl<const KSIZE: usize, S: BuildHasher + Default> Drop for HdxIndex<KSIZE, S> {
     }
 }
 
-impl<const KSIZE: usize, S: BuildHasher + Default> Index<B256> for HdxIndex<KSIZE, S> {
+impl<const KSIZE: usize, S: BuildHasher + Default> Index<B256, u64> for HdxIndex<KSIZE, S> {
     fn save(&mut self, key: B256, record_pos: u64) -> Result<(), AppendError> {
         if self.read_only {
             Err(AppendError::ReadOnly)

--- a/crates/storage/src/archive/index.rs
+++ b/crates/storage/src/archive/index.rs
@@ -3,11 +3,11 @@
 use crate::archive::error::{commit::CommitError, fetch::FetchError, insert::AppendError};
 
 /// Trait that any archive pack file can use for an index.
-pub trait Index<K> {
+pub trait Index<K, V> {
     /// Save the file pos for key into the index.
-    fn save(&mut self, key: K, record_pos: u64) -> Result<(), AppendError>;
+    fn save(&mut self, key: K, record_pos: V) -> Result<(), AppendError>;
     /// Load the file pos for key from the index.
-    fn load(&mut self, key: K) -> Result<u64, FetchError>;
+    fn load(&mut self, key: K) -> Result<V, FetchError>;
     /// Flush and sync all the index data to disk.
     fn sync(&mut self) -> Result<(), CommitError>;
     /// True if the index contains the key.

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -215,7 +215,6 @@ where
 
     /// Read raw bytes from the file.  Will return an error if not able to read all the bytes.
     fn read_bytes(&mut self, start_pos: u64, end_pos: u64) -> Result<Vec<u8>, FetchError> {
-        // +1, end_pos is inclusive
         let mut bytes = vec![0; end_pos.saturating_sub(start_pos) as usize];
         self.data_file.seek(SeekFrom::Start(start_pos))?;
         self.data_file.read_exact(&mut bytes[..])?;

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -58,6 +58,11 @@ where
         self.inner.fetch(pos)
     }
 
+    /// Read raw bytes from the file.  Will return an error if not able to read all the bytes.
+    pub fn read_bytes(&mut self, start_pos: u64, end_pos: u64) -> Result<Vec<u8>, FetchError> {
+        self.inner.read_bytes(start_pos, end_pos)
+    }
+
     /// Read the record size (with crc32) at position.
     /// Will produce an error for IO or or for a failed CRC32 integrity check.
     pub fn record_size(&mut self, pos: u64) -> Result<u32, FetchError> {
@@ -206,6 +211,15 @@ where
     /// Fetch the value stored at key.  Will return an error if not found.
     fn fetch(&mut self, pos: u64) -> Result<V, FetchError> {
         self.read_record(pos)
+    }
+
+    /// Read raw bytes from the file.  Will return an error if not able to read all the bytes.
+    fn read_bytes(&mut self, start_pos: u64, end_pos: u64) -> Result<Vec<u8>, FetchError> {
+        // +1, end_pos is inclusive
+        let mut bytes = vec![0; end_pos.saturating_sub(start_pos) as usize];
+        self.data_file.seek(SeekFrom::Start(start_pos))?;
+        self.data_file.read_exact(&mut bytes[..])?;
+        Ok(bytes)
     }
 
     /// Do the actual insert so the public function can rollback easily on an error.

--- a/crates/storage/src/archive/pack_iter.rs
+++ b/crates/storage/src/archive/pack_iter.rs
@@ -182,6 +182,24 @@ where
         })
     }
 
+    /// Open the iterator using reader as a data source.
+    /// Produces an iterator over all the (key, values).  All and records
+    /// are returned in insert order.
+    /// This version only expects a chunk of records not a complete pack file (no header for
+    /// instance).
+    pub async fn open_partial(
+        reader: R,
+        compression: PackCompression,
+    ) -> Result<Self, LoadHeaderError> {
+        Ok(AsyncPackIter {
+            _val: PhantomData,
+            reader,
+            buffer: Vec::new(),
+            decompress_buffer: Vec::new(),
+            compression,
+        })
+    }
+
     /// Read the next record or return an error if an overflow bucket.
     /// This expects the file cursor to be positioned at the records first byte.
     async fn read_record_file(

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -272,7 +272,7 @@ impl<T: PosIndexValue> PositionIter<T> {
 }
 
 impl<T: PosIndexValue> Iterator for PositionIter<T> {
-    type Item = T;
+    type Item = Result<T, FetchError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.done {
@@ -286,7 +286,7 @@ impl<T: PosIndexValue> Iterator for PositionIter<T> {
                 self.pos = self.pos.saturating_add(buffer_len);
                 self.done = self.pos >= self.data.len();
             }
-            Some(T::decode(&buf[..buffer_len]).ok()?)
+            Some(T::decode(&buf[..buffer_len]))
         } else {
             None
         }
@@ -417,10 +417,10 @@ mod tests {
         let iter = idx.rev_iter(1000).unwrap();
         assert_eq!(iter.count(), 1000, "asked for 1000 items");
         let mut iter = idx.rev_iter(1000).unwrap();
-        assert_eq!(iter.next().unwrap(), 66, "last record wrong");
+        assert_eq!(iter.next().unwrap().unwrap(), 66, "last record wrong");
         let d = 999_999;
         for (i, pos) in iter.enumerate() {
-            assert_eq!(pos, ((d - i) * 100) as u64, "failed rev on iteration {i}");
+            assert_eq!(pos.unwrap(), ((d - i) * 100) as u64, "failed rev on iteration {i}");
         }
 
         // Test iter
@@ -428,7 +428,7 @@ mod tests {
         assert_eq!(iter.count(), 1000, "asked for 1000 items");
         let iter = idx.iter(1000).unwrap();
         for (i, pos) in iter.enumerate() {
-            assert_eq!(pos, (i * 100) as u64, "failed rev on iteration {i}");
+            assert_eq!(pos.unwrap(), (i * 100) as u64, "failed rev on iteration {i}");
         }
 
         assert_eq!(idx.load(1_000_000).expect("load idx"), 66);
@@ -476,11 +476,11 @@ mod tests {
         let iter = idx.rev_iter(1000).unwrap();
         assert_eq!(iter.count(), 1000, "asked for 1000 items");
         let mut iter = idx.rev_iter(1000).unwrap();
-        assert_eq!(iter.next().unwrap(), (66, 66), "last record wrong");
+        assert_eq!(iter.next().unwrap().unwrap(), (66, 66), "last record wrong");
         let d = 999_999;
         for (i, pos) in iter.enumerate() {
             assert_eq!(
-                pos,
+                pos.unwrap(),
                 ((d - i) as u64, ((d - i) * 100) as u64),
                 "failed rev on iteration {i}"
             );
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(iter.count(), 1000, "asked for 1000 items");
         let iter = idx.iter(1000).unwrap();
         for (i, pos) in iter.enumerate() {
-            assert_eq!(pos, (i as u64, (i * 100) as u64), "failed rev on iteration {i}");
+            assert_eq!(pos.unwrap(), (i as u64, (i * 100) as u64), "failed rev on iteration {i}");
         }
 
         assert_eq!(idx.load(1_000_000).expect("load idx"), (66, 66));

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -3,6 +3,7 @@
 use std::{
     fs,
     io::{self, Read as _, Seek as _, SeekFrom, Write as _},
+    marker::PhantomData,
     path::{Path, PathBuf},
 };
 
@@ -106,23 +107,29 @@ impl PdxHeader {
     }
 }
 
-/// Header for an hdx (index) file.  This contains the hash buckets for lookups.
-/// This file is not a log file and the header and buckets will change in place over time.
-/// This data in the file will be followed by a CRC32 checksum value to verify it.
+/// PoristionIndex, an index that is a simple index to position in a DB file.
 #[derive(Debug)]
-pub struct PositionIndex {
+pub struct PositionIndex<T> {
     _header: PdxHeader,
     pdx_file: DataFile,
     _index_dir: PathBuf,
+    _phantom: PhantomData<T>,
 }
 
-impl PositionIndex {
+impl<T: PosIndexValue> PositionIndex<T> {
+    /// True if the pdx file at dir and filename exists.
+    pub fn pdx_file_exists<P: AsRef<Path>>(dir: P, file_name: &str) -> bool {
+        let dir = dir.as_ref();
+        dir.join(file_name).exists()
+    }
+
     /// Open a PDX index file and return the open index.
     pub fn open_pdx_file<P: AsRef<Path>>(
         dir: P,
         data_header: &DataHeader,
+        file_name: &str,
         read_only: bool,
-    ) -> Result<PositionIndex, LoadHeaderError> {
+    ) -> Result<PositionIndex<T>, LoadHeaderError> {
         let dir = dir.as_ref();
         let dir_created = fs::create_dir(dir).is_ok();
         if dir_created {
@@ -131,7 +138,7 @@ impl PositionIndex {
                 let _ = fsync_directory(parent);
             }
         }
-        let mut pdx_file = DataFile::open(dir.join("index.pdx"), read_only)?;
+        let mut pdx_file = DataFile::open(dir.join(file_name), read_only)?;
 
         let was_empty = pdx_file.is_empty();
         let header = if was_empty {
@@ -158,12 +165,13 @@ impl PositionIndex {
             }
             header
         };
-        Ok(Self { _header: header, pdx_file, _index_dir: dir.to_owned() })
+        Ok(Self { _header: header, pdx_file, _index_dir: dir.to_owned(), _phantom: PhantomData })
     }
 
     /// Return the number of values in this index.
     pub fn len(&self) -> usize {
-        (self.pdx_file.len().saturating_sub(PDX_HEADER_SIZE as u64) / 8) as usize
+        let len = self.pdx_file.len() as usize;
+        len.saturating_sub(PDX_HEADER_SIZE) / T::buffer_len()
     }
 
     /// True if there are no keys stored in this index.
@@ -172,26 +180,29 @@ impl PositionIndex {
     }
 
     /// Return an iterator over file positions with up to len items.
-    pub fn iter(&mut self, len: usize) -> Result<PositionIter, std::io::Error> {
+    pub fn iter(&mut self, len: usize) -> Result<PositionIter<T>, std::io::Error> {
         let data_len = if len < self.len() { len } else { self.len() };
-        let mut data = vec![0_u8; data_len * 8];
+        let buffer_len = T::buffer_len();
+        let mut data = vec![0_u8; data_len * buffer_len];
         self.pdx_file.seek(SeekFrom::Start(PDX_HEADER_SIZE as u64))?;
         self.pdx_file.read_exact(data.as_mut_slice())?;
         Ok(PositionIter::new(data))
     }
 
     /// Return a reverse iterator over file positions with up to len items.
-    pub fn rev_iter(&mut self, len: usize) -> Result<PositionIter, std::io::Error> {
+    pub fn rev_iter(&mut self, len: usize) -> Result<PositionIter<T>, std::io::Error> {
         let data_len = if len < self.len() { len } else { self.len() };
-        let mut data = vec![0_u8; data_len * 8];
-        self.pdx_file.seek(SeekFrom::End(-(data_len as i64 * 8)))?;
+        let buffer_len = T::buffer_len();
+        let mut data = vec![0_u8; data_len * buffer_len];
+        self.pdx_file.seek(SeekFrom::End(-(data_len as i64 * buffer_len as i64)))?;
         self.pdx_file.read_exact(data.as_mut_slice())?;
         Ok(PositionIter::new_rev(data))
     }
 
     /// Truncate the index to key (inclusive).
     pub fn truncate_to_index(&mut self, key: u64) -> Result<(), io::Error> {
-        let pos = PDX_HEADER_SIZE as u64 + (key * 8) + 8;
+        let buffer_len = T::buffer_len() as u64;
+        let pos = PDX_HEADER_SIZE as u64 + (key * buffer_len) + buffer_len;
         self.pdx_file.set_len(pos)
     }
 
@@ -202,8 +213,8 @@ impl PositionIndex {
     }
 }
 
-impl Index<u64> for PositionIndex {
-    fn save(&mut self, key: u64, record_pos: u64) -> Result<(), AppendError> {
+impl<T: PosIndexValue> Index<u64, T> for PositionIndex<T> {
+    fn save(&mut self, key: u64, value: T) -> Result<(), AppendError> {
         if self.len() != key as usize {
             Err(AppendError::SerializeValue(format!(
                 "{} must add the next item by position, expected {} got {key}",
@@ -211,17 +222,21 @@ impl Index<u64> for PositionIndex {
                 self.len()
             )))
         } else {
-            self.pdx_file.write_all(&record_pos.to_le_bytes())?;
+            let mut buffer = [0_u8; 32];
+            let buffer_len = T::buffer_len();
+            value.encode(&mut buffer[0..buffer_len]);
+            self.pdx_file.write_all(&buffer[0..buffer_len])?;
             Ok(())
         }
     }
 
-    fn load(&mut self, key: u64) -> Result<u64, FetchError> {
-        let pos = PDX_HEADER_SIZE as u64 + (key * 8);
+    fn load(&mut self, key: u64) -> Result<T, FetchError> {
+        let buffer_len = T::buffer_len();
+        let pos = PDX_HEADER_SIZE as u64 + (key * buffer_len as u64);
         self.pdx_file.seek(SeekFrom::Start(pos))?;
-        let mut buf = [0_u8; 8];
-        self.pdx_file.read_exact(&mut buf[..])?;
-        Ok(u64::from_le_bytes(buf))
+        let mut buf = [0_u8; 32];
+        self.pdx_file.read_exact(&mut buf[..buffer_len])?;
+        T::decode(&buf[..buffer_len])
     }
 
     fn sync(&mut self) -> Result<(), CommitError> {
@@ -233,46 +248,110 @@ impl Index<u64> for PositionIndex {
 
 /// Iterator of u64 record positions from a position index.
 #[derive(Debug)]
-pub struct PositionIter {
+pub struct PositionIter<T> {
     data: Vec<u8>,
     pos: usize,
     done: bool,
     reverse: bool,
+    _phantom: PhantomData<T>,
 }
 
-impl PositionIter {
+impl<T: PosIndexValue> PositionIter<T> {
     /// New position iter over data.
     fn new(data: Vec<u8>) -> Self {
         let done = data.is_empty();
-        Self { data, pos: 0, done, reverse: false }
+        Self { data, pos: 0, done, reverse: false, _phantom: PhantomData }
     }
 
     /// New reverse iter over data.
     fn new_rev(data: Vec<u8>) -> Self {
         let done = data.is_empty();
-        let pos = data.len().saturating_sub(8);
-        Self { data, pos, done, reverse: true }
+        let pos = data.len().saturating_sub(T::buffer_len());
+        Self { data, pos, done, reverse: true, _phantom: PhantomData }
     }
 }
 
-impl Iterator for PositionIter {
-    type Item = u64;
+impl<T: PosIndexValue> Iterator for PositionIter<T> {
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.done {
-            let mut buf = [0_u8; 8];
-            buf.copy_from_slice(&self.data[self.pos..self.pos + 8]);
+            let mut buf = [0_u8; 32];
+            let buffer_len = T::buffer_len();
+            buf[..buffer_len].copy_from_slice(&self.data[self.pos..self.pos + buffer_len]);
             if self.reverse {
                 self.done = self.pos == 0;
-                self.pos = self.pos.saturating_sub(8);
+                self.pos = self.pos.saturating_sub(buffer_len);
             } else {
-                self.pos = self.pos.saturating_add(8);
+                self.pos = self.pos.saturating_add(buffer_len);
                 self.done = self.pos >= self.data.len();
             }
-            Some(u64::from_le_bytes(buf))
+            Some(T::decode(&buf[..buffer_len]).ok()?)
         } else {
             None
         }
+    }
+}
+
+/// Trait that index values must implement in order to encode/decode themselves
+/// into bytes to read/write to disk.
+/// These must ALWAYS encode/decode to the same number of bytes.
+pub trait PosIndexValue {
+    /// Encode an item into a byte array.
+    fn encode(&self, buffer: &mut [u8]);
+    /// Decode a byte array into an item.
+    fn decode(bytes: &[u8]) -> Result<Self, FetchError>
+    where
+        Self: Sized;
+    /// How many bytes needed for a buffer.
+    fn buffer_len() -> usize;
+}
+
+impl PosIndexValue for u64 {
+    fn encode(&self, buffer: &mut [u8]) {
+        if buffer.len() != 8 {
+            panic!("u64 buffer not 8 bytes");
+        }
+        buffer.copy_from_slice(&self.to_le_bytes());
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, FetchError> {
+        if bytes.len() != 8 {
+            panic!("u64 buffer not 8 bytes");
+        }
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(bytes);
+        Ok(u64::from_le_bytes(buf))
+    }
+
+    fn buffer_len() -> usize {
+        8
+    }
+}
+
+impl PosIndexValue for (u64, u64) {
+    fn encode(&self, buffer: &mut [u8]) {
+        if buffer.len() != 16 {
+            panic!("(u64, u64) buffer not 16 bytes");
+        }
+        buffer[..8].copy_from_slice(&self.0.to_le_bytes());
+        buffer[8..].copy_from_slice(&self.1.to_le_bytes());
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, FetchError> {
+        if bytes.len() != 16 {
+            panic!("(u64, u64) buffer not 16 bytes");
+        }
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(&bytes[..8]);
+        let one = u64::from_le_bytes(buf);
+        buf.copy_from_slice(&bytes[8..]);
+        let two = u64::from_le_bytes(buf);
+        Ok((one, two))
+    }
+
+    fn buffer_len() -> usize {
+        16
     }
 }
 
@@ -285,12 +364,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_archive_pdx_index() {
+    fn test_archive_pdx_index_single() {
         let tmp_path = TempDir::with_prefix("test_archive_pdx_index").expect("temp dir");
         let data_header = DataHeader::new(0, PackCompression::ZStd);
-        let mut idx: PositionIndex =
-            PositionIndex::open_pdx_file(tmp_path.path().join("index.pdx"), &data_header, false)
-                .expect("pdx file");
+        let mut idx: PositionIndex<u64> = PositionIndex::open_pdx_file(
+            tmp_path.path().join("index.pdx"),
+            &data_header,
+            "index.pdx",
+            false,
+        )
+        .expect("pdx file");
         for i in 0..1_000_000 {
             idx.save(i, i * 100).expect("add to index");
         }
@@ -298,9 +381,13 @@ mod tests {
             assert_eq!(idx.load(i).expect("load idx"), i * 100, "failed on iteration {i}");
         }
         drop(idx);
-        let mut idx: PositionIndex =
-            PositionIndex::open_pdx_file(tmp_path.path().join("index.pdx"), &data_header, false)
-                .expect("pdx file");
+        let mut idx: PositionIndex<u64> = PositionIndex::open_pdx_file(
+            tmp_path.path().join("index.pdx"),
+            &data_header,
+            "index.pdx",
+            false,
+        )
+        .expect("pdx file");
         for i in (0..1_000_000).rev() {
             assert_eq!(
                 idx.load(i).expect(&format!("load idx {i}")),
@@ -311,9 +398,13 @@ mod tests {
         idx.save(1_000_000, 66).expect("add to index");
         assert_eq!(idx.load(1_000_000).expect("load idx"), 66);
         drop(idx);
-        let mut idx: PositionIndex =
-            PositionIndex::open_pdx_file(tmp_path.path().join("index.pdx"), &data_header, true)
-                .expect("pdx file");
+        let mut idx: PositionIndex<u64> = PositionIndex::open_pdx_file(
+            tmp_path.path().join("index.pdx"),
+            &data_header,
+            "index.pdx",
+            true,
+        )
+        .expect("pdx file");
         for i in (0..1_000_000).rev() {
             assert_eq!(
                 idx.load(i).expect(&format!("load idx {i}")),
@@ -341,5 +432,68 @@ mod tests {
         }
 
         assert_eq!(idx.load(1_000_000).expect("load idx"), 66);
+    }
+
+    #[test]
+    fn test_archive_pdx_index_double() {
+        let tmp_path = TempDir::with_prefix("test_archive_pdx_index_double").expect("temp dir");
+        let data_header = DataHeader::new(0, PackCompression::ZStd);
+        let mut idx: PositionIndex<(u64, u64)> =
+            PositionIndex::open_pdx_file(tmp_path.path(), &data_header, "index2.pdx", false)
+                .expect("pdx file");
+        for i in 0..1_000_000 {
+            idx.save(i, (i, i * 100)).expect("add to index");
+        }
+        for i in 0..1_000_000 {
+            assert_eq!(idx.load(i).expect("load idx"), (i, i * 100), "failed on iteration {i}");
+        }
+        drop(idx);
+        let mut idx: PositionIndex<(u64, u64)> =
+            PositionIndex::open_pdx_file(tmp_path.path(), &data_header, "index2.pdx", false)
+                .expect("pdx file");
+        for i in (0..1_000_000).rev() {
+            assert_eq!(
+                idx.load(i).expect(&format!("load idx {i}")),
+                (i, i * 100),
+                "failed on iteration {i}"
+            );
+        }
+        idx.save(1_000_000, (66, 66)).expect("add to index");
+        assert_eq!(idx.load(1_000_000).expect("load idx"), (66, 66));
+        drop(idx);
+        let mut idx: PositionIndex<(u64, u64)> =
+            PositionIndex::open_pdx_file(tmp_path.path(), &data_header, "index2.pdx", true)
+                .expect("pdx file");
+        for i in (0..1_000_000).rev() {
+            assert_eq!(
+                idx.load(i).expect(&format!("load idx {i}")),
+                (i, i * 100),
+                "failed on iteration {i}"
+            );
+        }
+
+        // Test reverse iter.
+        let iter = idx.rev_iter(1000).unwrap();
+        assert_eq!(iter.count(), 1000, "asked for 1000 items");
+        let mut iter = idx.rev_iter(1000).unwrap();
+        assert_eq!(iter.next().unwrap(), (66, 66), "last record wrong");
+        let d = 999_999;
+        for (i, pos) in iter.enumerate() {
+            assert_eq!(
+                pos,
+                ((d - i) as u64, ((d - i) * 100) as u64),
+                "failed rev on iteration {i}"
+            );
+        }
+
+        // Test iter
+        let iter = idx.iter(1000).unwrap();
+        assert_eq!(iter.count(), 1000, "asked for 1000 items");
+        let iter = idx.iter(1000).unwrap();
+        for (i, pos) in iter.enumerate() {
+            assert_eq!(pos, (i as u64, (i * 100) as u64), "failed rev on iteration {i}");
+        }
+
+        assert_eq!(idx.load(1_000_000).expect("load idx"), (66, 66));
     }
 }

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -222,7 +222,7 @@ impl<T: PosIndexValue> Index<u64, T> for PositionIndex<T> {
                 self.len()
             )))
         } else {
-            let mut buffer = [0_u8; 32];
+            let mut buffer = [0_u8; VALUE_MAX_BYTES];
             let buffer_len = T::buffer_len();
             value.encode(&mut buffer[0..buffer_len]);
             self.pdx_file.write_all(&buffer[0..buffer_len])?;
@@ -234,7 +234,7 @@ impl<T: PosIndexValue> Index<u64, T> for PositionIndex<T> {
         let buffer_len = T::buffer_len();
         let pos = PDX_HEADER_SIZE as u64 + (key * buffer_len as u64);
         self.pdx_file.seek(SeekFrom::Start(pos))?;
-        let mut buf = [0_u8; 32];
+        let mut buf = [0_u8; VALUE_MAX_BYTES];
         self.pdx_file.read_exact(&mut buf[..buffer_len])?;
         T::decode(&buf[..buffer_len])
     }
@@ -276,7 +276,7 @@ impl<T: PosIndexValue> Iterator for PositionIter<T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.done {
-            let mut buf = [0_u8; 32];
+            let mut buf = [0_u8; VALUE_MAX_BYTES];
             let buffer_len = T::buffer_len();
             buf[..buffer_len].copy_from_slice(&self.data[self.pos..self.pos + buffer_len]);
             if self.reverse {
@@ -292,6 +292,10 @@ impl<T: PosIndexValue> Iterator for PositionIter<T> {
         }
     }
 }
+
+/// The max number of bytes an implementor of PosIndexValue can encode into, decode from.
+/// PosIndexValue::buffer_len() can not exceed this value- other code will panic if so.
+const VALUE_MAX_BYTES: usize = 32;
 
 /// Trait that index values must implement in order to encode/decode themselves
 /// into bytes to read/write to disk.

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -624,16 +624,19 @@ impl ConsensusChain {
     }
 
     /// Read the last committed rounds for authorities from an epoch.
-    pub async fn read_last_committed(&self, epoch: Epoch) -> HashMap<AuthorityIdentifier, Round> {
+    pub async fn read_last_committed(
+        &self,
+        epoch: Epoch,
+    ) -> Result<HashMap<AuthorityIdentifier, Round>, ConsensusChainError> {
         if let Some(pack) = &self.current_pack() {
             if pack.epoch() == epoch {
-                return pack.read_last_committed().await;
+                return Ok(pack.read_last_committed().await?);
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
-            pack.read_last_committed().await
+            Ok(pack.read_last_committed().await?)
         } else {
-            HashMap::new()
+            Ok(HashMap::new())
         }
     }
 
@@ -641,16 +644,16 @@ impl ConsensusChain {
     pub async fn read_latest_commit_with_final_reputation_scores(
         &self,
         epoch: Epoch,
-    ) -> Option<CommittedSubDag> {
+    ) -> Result<Option<CommittedSubDag>, ConsensusChainError> {
         if let Some(pack) = &self.current_pack() {
             if pack.epoch() == epoch {
-                return pack.read_latest_commit_with_final_reputation_scores().await;
+                return Ok(pack.read_latest_commit_with_final_reputation_scores().await?);
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
-            pack.read_latest_commit_with_final_reputation_scores().await
+            Ok(pack.read_latest_commit_with_final_reputation_scores().await?)
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -776,15 +779,18 @@ impl ConsensusChainReader for ConsensusChain {
         ConsensusChain::latest_consensus_epoch(self)
     }
 
-    async fn read_last_committed(&self, epoch: Epoch) -> HashMap<AuthorityIdentifier, Round> {
-        ConsensusChain::read_last_committed(self, epoch).await
+    async fn read_last_committed(
+        &self,
+        epoch: Epoch,
+    ) -> eyre::Result<HashMap<AuthorityIdentifier, Round>> {
+        Ok(ConsensusChain::read_last_committed(self, epoch).await?)
     }
 
     async fn read_latest_commit_with_final_reputation_scores(
         &self,
         epoch: Epoch,
-    ) -> Option<CommittedSubDag> {
-        ConsensusChain::read_latest_commit_with_final_reputation_scores(self, epoch).await
+    ) -> eyre::Result<Option<CommittedSubDag>> {
+        Ok(ConsensusChain::read_latest_commit_with_final_reputation_scores(self, epoch).await?)
     }
 
     async fn get_consensus_output_current(&self, number: u64) -> eyre::Result<ConsensusOutput> {

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -735,8 +735,7 @@ impl ConsensusChain {
                 let _ = recents.pop_front();
             }
         }
-        let pack = ConsensusPack::open_static(&self.base_path, epoch);
-        pack.persist().await?; // Surface any open errors.
+        let pack = ConsensusPack::open_static(&self.base_path, epoch)?;
         self.recent_packs.lock().push_back(pack.clone());
         Ok(pack)
     }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1545,6 +1545,75 @@ pub(crate) mod test {
         )
     }
 
+    /// Make a test output with two certificates from different authorities that share one
+    /// batch digest.  The shared batch is only stored once in the pack file but must be
+    /// assigned to both certificates when the output is rebuilt.
+    fn make_test_output_shared_batch(
+        committee: &Committee,
+        chain: Arc<RethChainSpec>,
+        number: u64,
+        parent: ConsensusHeaderDigest,
+    ) -> ConsensusOutput {
+        let mut batches = tn_reth::test_utils::batches(chain, 3);
+        let batch_2 = batches.pop().expect("three batches");
+        let batch_1 = batches.pop().expect("three batches");
+        let batch_0 = batches.pop().expect("three batches");
+
+        let authorities = committee.authorities();
+        let authority_a = authorities.first().expect("first in 4 auth committee");
+        let authority_b = authorities.get(1).expect("second in 4 auth committee");
+
+        let mut cert_a = Certificate::default();
+        cert_a.update_header_author_for_test(authority_a.id());
+        for batch in [&batch_0, &batch_1] {
+            let builder =
+                HeaderBuilder::from_header(cert_a.header()).with_payload_batch(batch, 0_u16);
+            cert_a.update_header_for_test(builder.build());
+        }
+        cert_a.update_header_round_for_test(1);
+        cert_a.update_header_epoch_for_test(committee.epoch());
+
+        let mut cert_b = Certificate::default();
+        cert_b.update_header_author_for_test(authority_b.id());
+        // batch_1 is shared with cert_a's payload.
+        for batch in [&batch_1, &batch_2] {
+            let builder =
+                HeaderBuilder::from_header(cert_b.header()).with_payload_batch(batch, 0_u16);
+            cert_b.update_header_for_test(builder.build());
+        }
+        cert_b.update_header_round_for_test(1);
+        cert_b.update_header_epoch_for_test(committee.epoch());
+
+        let sub_dag = CommittedSubDag::new(
+            vec![cert_a.clone(), cert_b.clone()],
+            cert_b,
+            1,
+            ReputationScores::default(),
+            None,
+        );
+        let batch_digests: VecDeque<BlockHash> =
+            [batch_0.digest(), batch_1.digest(), batch_1.digest(), batch_2.digest()]
+                .into_iter()
+                .collect();
+        ConsensusOutput::new(
+            sub_dag,
+            parent,
+            number,
+            false,
+            batch_digests,
+            vec![
+                CertifiedBatch {
+                    address: authority_a.execution_address(),
+                    batches: vec![batch_0, batch_1.clone()],
+                },
+                CertifiedBatch {
+                    address: authority_b.execution_address(),
+                    batches: vec![batch_1, batch_2],
+                },
+            ],
+        )
+    }
+
     pub(crate) fn compare_outputs(output1: &ConsensusOutput, output2: &ConsensusOutput) {
         assert_eq!(output1.digest(), output2.digest(), "Consensus Output have different hashes");
         assert_eq!(
@@ -1760,5 +1829,68 @@ pub(crate) mod test {
         let stream2_len = stream.seek(SeekFrom::End(0)).expect("stream length");
         drop(stream);
         assert_eq!(stream_len, stream2_len);
+    }
+
+    /// Regression test: one batch digest referenced by two certificates within a single
+    /// consensus output.  The batch is stored once in the pack file and must be assigned
+    /// to both certificates when the output is rebuilt (previously failed with
+    /// PackError::MissingBatch).
+    #[tokio::test]
+    async fn test_consensus_pack_dup_batch_across_certs() {
+        let temp_dir = TempDir::with_prefix("test_consensus_pack_dup").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let pack =
+            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
+                .expect("open pack");
+
+        // Output 1 contains the shared batch, output 2 is a normal output to confirm
+        // the pack continues cleanly after a duplicate.
+        let output_1 = make_test_output_shared_batch(
+            &committee,
+            chain.clone(),
+            1,
+            ConsensusHeader::default().digest(),
+        );
+        let output_2 = make_test_output(&committee, 2, chain.clone(), 2, output_1.digest().into());
+        pack.save_consensus_output(output_1.clone()).await.unwrap();
+        pack.save_consensus_output(output_2.clone()).await.unwrap();
+
+        compare_outputs(&pack.get_consensus_output(1).await.expect("dup batch output"), &output_1);
+        compare_outputs(&pack.get_consensus_output(2).await.expect("output after dup"), &output_2);
+        pack.persist().await.expect("persist");
+        drop(pack);
+
+        // Read back through the read only static path.
+        let pack = ConsensusPack::open_static(temp_dir.path(), 0).expect("open static");
+        compare_outputs(&pack.get_consensus_output(1).await.expect("dup batch output"), &output_1);
+        compare_outputs(&pack.get_consensus_output(2).await.expect("output after dup"), &output_2);
+        drop(pack);
+
+        // Stream into a new pack (peer epoch sync path) and read back.
+        let temp_dir2 = TempDir::with_prefix("test_consensus_pack_dup2").expect("temp dir");
+        let stream = tokio::fs::File::open(temp_dir.path().join("epoch-0").join(Inner::DATA_NAME))
+            .await
+            .expect("log file");
+        let pack = ConsensusPack::stream_import(
+            temp_dir2.path(),
+            stream,
+            0,
+            &previous_epoch,
+            2,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("stream import");
+        compare_outputs(&pack.get_consensus_output(1).await.expect("dup batch output"), &output_1);
+        compare_outputs(&pack.get_consensus_output(2).await.expect("output after dup"), &output_2);
+        drop(pack);
     }
 }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1477,6 +1477,7 @@ pub(crate) mod test {
         collections::VecDeque,
         fs::{File, OpenOptions},
         io::{Seek as _, SeekFrom},
+        path::Path,
         sync::Arc,
         time::Duration,
     };
@@ -1491,7 +1492,12 @@ pub(crate) mod test {
     };
 
     use crate::{
-        consensus_pack::{ConsensusPack, Inner},
+        archive::{
+            index::Index as _,
+            pack::{DataHeader, PackCompression},
+            position_index::index::PositionIndex,
+        },
+        consensus_pack::{ConsensusPack, IndexPositions, Inner},
         mem_db::MemDatabase,
     };
 
@@ -1891,6 +1897,141 @@ pub(crate) mod test {
         .expect("stream import");
         compare_outputs(&pack.get_consensus_output(1).await.expect("dup batch output"), &output_1);
         compare_outputs(&pack.get_consensus_output(2).await.expect("output after dup"), &output_2);
+        drop(pack);
+    }
+
+    /// Convert a pack directory's position index into the legacy format written by older
+    /// nodes: an "index.pdx" of u64 consensus header positions and no "index_pos.pdx".
+    /// The pack data file is identical between the two formats so this faithfully
+    /// recreates an old pack directory for migration testing.
+    fn make_legacy_index(epoch_dir: &Path) {
+        let idx_dir = epoch_dir.join("idx");
+        let header = DataHeader::new(0, PackCompression::ZStd);
+        let mut new_idx: PositionIndex<IndexPositions> =
+            PositionIndex::open_pdx_file(&idx_dir, &header, "index_pos.pdx", true)
+                .expect("open new index");
+        let mut old_idx: PositionIndex<u64> =
+            PositionIndex::open_pdx_file(&idx_dir, &header, "index.pdx", false)
+                .expect("open legacy index");
+        assert!(old_idx.is_empty(), "legacy index must start empty");
+        for i in 0..new_idx.len() as u64 {
+            let positions = new_idx.load(i).expect("new index entry");
+            old_idx.save(i, positions.consensus_header).expect("save legacy entry");
+        }
+        old_idx.sync().expect("sync legacy index");
+        drop(old_idx);
+        drop(new_idx);
+        std::fs::remove_file(idx_dir.join("index_pos.pdx")).expect("remove new index");
+    }
+
+    /// Test the one time migration of a legacy position index (consensus header positions
+    /// only) to the new index containing consensus output byte ranges.  Covers the append
+    /// path, the read only static path and recovery from a stale tmp file left by a crash
+    /// between the tmp write and the rename.
+    #[tokio::test]
+    async fn test_consensus_pack_index_migration() {
+        let temp_dir = TempDir::with_prefix("test_consensus_pack_migration").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let epoch_dir = temp_dir.path().join("epoch-0");
+        let idx_dir = epoch_dir.join("idx");
+
+        // Build a pack with the current format.
+        let pack =
+            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
+                .expect("open pack");
+        let num_outputs = 10;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output = make_test_output(&committee, i % 4, chain.clone(), i as u64 + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            pack.save_consensus_output(output).await.unwrap();
+        }
+        pack.persist().await.expect("persist");
+        drop(pack);
+
+        // Migrate on the append path.  Reading the first output verifies the migrated
+        // byte range starts after the EpochMeta record.
+        make_legacy_index(&epoch_dir);
+        assert!(PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index.pdx"));
+        assert!(!PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx"));
+        let pack =
+            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
+                .expect("open legacy pack for append");
+        assert!(
+            PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx"),
+            "migration creates the new index"
+        );
+        assert!(
+            !PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index.pdx"),
+            "migration removes the old index"
+        );
+        for (i, output) in outputs.iter().enumerate() {
+            let output_db = pack
+                .get_consensus_output(i as u64 + 1)
+                .await
+                .expect(&format!("output {} after append migration", i + 1));
+            compare_outputs(&output_db, output);
+        }
+        // The pack keeps working for new appends after migration.
+        let output = make_test_output(&committee, 0, chain.clone(), num_outputs as u64 + 1, parent);
+        outputs.push(output.clone());
+        pack.save_consensus_output(output).await.unwrap();
+        let output_db = pack
+            .get_consensus_output(num_outputs as u64 + 1)
+            .await
+            .expect("appended output after migration");
+        compare_outputs(&output_db, outputs.last().unwrap());
+        pack.persist().await.expect("persist");
+        drop(pack);
+
+        // Migrate on the read only static path.
+        make_legacy_index(&epoch_dir);
+        let pack = ConsensusPack::open_static(temp_dir.path(), 0).expect("open legacy pack static");
+        for (i, output) in outputs.iter().enumerate() {
+            let output_db = pack
+                .get_consensus_output(i as u64 + 1)
+                .await
+                .expect(&format!("output {} after static migration", i + 1));
+            compare_outputs(&output_db, output);
+        }
+        drop(pack);
+
+        // Migrate with a stale partial tmp file left by a "crash" between the tmp write
+        // and the rename.  The migration must discard it and rebuild.
+        make_legacy_index(&epoch_dir);
+        {
+            let header = DataHeader::new(0, PackCompression::ZStd);
+            let mut stale: PositionIndex<IndexPositions> =
+                PositionIndex::open_pdx_file(&idx_dir, &header, "index_pos.pdx.tmp", false)
+                    .expect("open stale tmp");
+            stale.save(0, IndexPositions::new(1, 1, 1)).expect("save stale entry");
+            stale.sync().expect("sync stale tmp");
+        }
+        assert!(PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx.tmp"));
+        let pack =
+            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
+                .expect("open legacy pack with stale tmp");
+        assert!(
+            !PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx.tmp"),
+            "stale tmp removed by migration"
+        );
+        for (i, output) in outputs.iter().enumerate() {
+            let output_db = pack
+                .get_consensus_output(i as u64 + 1)
+                .await
+                .expect(&format!("output {} after stale tmp migration", i + 1));
+            compare_outputs(&output_db, output);
+        }
         drop(pack);
     }
 }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -99,8 +99,8 @@ enum PackMessage {
     ConsensusHeaderNumber(u64, oneshot::Sender<Result<ConsensusHeader, PackError>>),
     Persist(oneshot::Sender<Result<(), PackError>>),
     BytesForConsensus(u64, oneshot::Sender<Result<Vec<u8>, PackError>>),
-    ReadLastCommitted(oneshot::Sender<HashMap<AuthorityIdentifier, Round>>),
-    ReadLatestFinalRep(oneshot::Sender<Option<CommittedSubDag>>),
+    ReadLastCommitted(oneshot::Sender<Result<HashMap<AuthorityIdentifier, Round>, PackError>>),
+    ReadLatestFinalRep(oneshot::Sender<Result<Option<CommittedSubDag>, PackError>>),
     ContainsBatch(B256, oneshot::Sender<bool>),
     Batch(B256, oneshot::Sender<Option<Batch>>),
     CountLeaders(Round, RewardsCounter, oneshot::Sender<Result<(), PackError>>),
@@ -303,13 +303,13 @@ impl ConsensusPack {
 
     /// Load and return the consensus output form this epoch.
     pub async fn get_consensus_output(&self, number: u64) -> Result<ConsensusOutput, PackError> {
+        self.get_error()?;
         let (tx, rx) = oneshot::channel();
         let bytes = if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
             rx.await.map_err(|_| PackError::ReceiveFailed)??
         } else {
             return Err(PackError::SendFailed);
         };
-        self.get_error()?;
         let cursor = Cursor::new(bytes);
         let reader = BufReader::new(cursor);
         bytes_to_output(reader, PackCompression::ZStd, Duration::from_secs(5), &self.committee)
@@ -374,19 +374,31 @@ impl ConsensusPack {
     }
 
     /// Read the last committed rounds for authorities from the epoch.
-    pub async fn read_last_committed(&self) -> HashMap<AuthorityIdentifier, Round> {
+    pub async fn read_last_committed(
+        &self,
+    ) -> Result<HashMap<AuthorityIdentifier, Round>, PackError> {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::ReadLastCommitted(tx)).await;
-        rx.await.unwrap_or_default()
+        if let Ok(r) = rx.await {
+            r
+        } else {
+            Err(PackError::SendFailed)
+        }
     }
 
     /// Reads from storage the latest commit sub dag from the epoch where its
     /// ReputationScores are marked as "final". If none exists then this
     /// method returns `None`.
-    pub async fn read_latest_commit_with_final_reputation_scores(&self) -> Option<CommittedSubDag> {
+    pub async fn read_latest_commit_with_final_reputation_scores(
+        &self,
+    ) -> Result<Option<CommittedSubDag>, PackError> {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::ReadLatestFinalRep(tx)).await;
-        rx.await.unwrap_or_default()
+        if let Ok(r) = rx.await {
+            r
+        } else {
+            Err(PackError::SendFailed)
+        }
     }
 
     /// Return the latest consensus header by reading directly from the pack index.
@@ -438,8 +450,9 @@ pub const DATA_NAME: &str = Inner::DATA_NAME;
 struct Inner {
     data: Pack<PackRecord>,
     /// Positional index pointing to the first byte of ConsensusHeader, the first byte of the first
-    /// Batch and the last byte of the ConsensusHeader at a position. In short the first and
-    /// last byte of the encoded data for a ConsensusOutput as well as just the ConsensusHeader.
+    /// Batch and the byte past the end of the ConsensusHeader at a position. In short the first
+    /// and last (exclusive) bytes of the encoded data for a ConsensusOutput as well as just
+    /// the ConsensusHeader.
     consensus_pos_idx: PositionIndex<IndexPositions>,
     consensus_digests: HdxIndex,
     batch_digests: HdxIndex,
@@ -546,11 +559,24 @@ impl Inner {
     }
 
     /// Open a PDX index file and return the open index.
-    /// This will handle an update of the index on older testnet epochs.
     fn open_pdx_file<P: AsRef<Path>, T: PosIndexValue>(
         dir: P,
         data_header: &DataHeader,
         read_only: bool,
+    ) -> Result<PositionIndex<T>, PackError> {
+        let base_dir = dir.as_ref().join(Self::CONSENSUS_POS_NAME);
+        let consensus_pos_idx =
+            PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
+                .map_err(OpenError::IndexFileOpen)?;
+        Ok(consensus_pos_idx)
+    }
+
+    /// Open a PDX index file and return the open index.
+    /// This will handle an update of the index on older testnet epochs.
+    fn open_pdx_file_with_update<P: AsRef<Path>, T: PosIndexValue>(
+        dir: P,
+        read_only: bool,
+        data: &mut Pack<PackRecord>,
     ) -> Result<PositionIndex<T>, PackError> {
         let base_dir = dir.as_ref().join(Self::CONSENSUS_POS_NAME);
         if PositionIndex::<T>::pdx_file_exists(&base_dir, "index.pdx")
@@ -561,28 +587,37 @@ impl Inner {
             // This code should only effect OG testnet nodes and should not need
             // to be maintained forever.
             let mut old_idx: PositionIndex<u64> =
-                PositionIndex::open_pdx_file(&base_dir, data_header, "index.pdx", false)
+                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", false)
                     .map_err(OpenError::IndexFileOpen)?;
+            let _ = std::fs::remove_dir_all(base_dir.join("index_pos.pdx.tmp"));
             let mut new_idx: PositionIndex<IndexPositions> =
-                PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
+                PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx.tmp", true)
                     .map_err(OpenError::IndexFileOpen)?;
             for i in 0..old_idx.len() {
                 let idx = i as u64;
                 let pos = old_idx.load(idx)?;
-                // We save the consensus header position and 0 out the consensus output fields.
-                // We can get away with this (vs doing an expesive regen of the actual values)
-                // because we use this to get ConsensusOutput and this is only ever done on the
-                // current pack file.  Only older testnet nodes will be effected by this and they
-                // should never go to previous pack files.  We will let at least one epoch pass and
-                // new packs will have new indexes.  Syncing nodes will generate the proper indexes
-                // from the beginning (even for older epochs).
+                let start = if idx > 0 {
+                    if let Ok(prev_pos) = old_idx.load(idx - 1) {
+                        let record_size = data.record_size(prev_pos)?;
+                        prev_pos + record_size as u64
+                    } else {
+                        DATA_HEADER_BYTES as u64
+                    }
+                } else {
+                    DATA_HEADER_BYTES as u64
+                };
+                let record_size = data.record_size(pos)?;
+                let end = pos + record_size as u64;
                 new_idx
-                    .save(idx, IndexPositions::new(pos, 0, 0))
+                    .save(idx, IndexPositions::new(pos, start, end))
                     .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
             }
+            drop(new_idx);
+            std::fs::rename(base_dir.join("index_pos.pdx.tmp"), base_dir.join("index_pos.pdx"))?;
+            let _ = std::fs::remove_dir_all(base_dir.join("index.pdx"));
         }
         let consensus_pos_idx =
-            PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
+            PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx", read_only)
                 .map_err(OpenError::IndexFileOpen)?;
         Ok(consensus_pos_idx)
     }
@@ -623,7 +658,7 @@ impl Inner {
             data.append(&PackRecord::EpochMeta(epoch_meta.clone()))
                 .map_err(|e| PackError::Append(e.to_string()))?;
         }
-        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
+        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, false, &mut data)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -670,7 +705,7 @@ impl Inner {
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
+        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, false, &mut data)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -712,7 +747,7 @@ impl Inner {
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), true)?;
+        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, true, &mut data)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -1036,13 +1071,12 @@ impl Inner {
         self.consensus_header_by_number(latest_number).ok()
     }
 
-    fn read_last_committed(&mut self) -> HashMap<AuthorityIdentifier, Round> {
+    fn read_last_committed(&mut self) -> Result<HashMap<AuthorityIdentifier, Round>, PackError> {
         let mut res = HashMap::new();
         if let Ok(iter) = self.consensus_pos_idx.rev_iter(50) {
-            for block in iter.filter_map(|pos| {
-                let block = self.data.fetch(pos.consensus_header);
-                block.ok().map(|b| b.into_consensus().ok()).unwrap_or_default()
-            }) {
+            for pos in iter {
+                let pos = pos?;
+                let block = self.data.fetch(pos.consensus_header)?.into_consensus()?;
                 let id = block.sub_dag.leader().author().clone();
                 let round = block.sub_dag.leader_round();
                 let headers = block.sub_dag.headers();
@@ -1054,31 +1088,28 @@ impl Inner {
                 }
             }
         }
-        res
+        Ok(res)
     }
 
-    fn read_latest_commit_with_final_reputation_scores(&mut self) -> Option<CommittedSubDag> {
+    fn read_latest_commit_with_final_reputation_scores(
+        &mut self,
+    ) -> Result<Option<CommittedSubDag>, PackError> {
         if let Ok(iter) = self.consensus_pos_idx.rev_iter(1000) {
-            for commit in iter.filter_map(|pos| {
-                let block = self.data.fetch(pos.consensus_header);
-                if let Some(block) = block.ok().map(|b| b.into_consensus().ok()) {
-                    block.map(|b| b.sub_dag)
-                } else {
-                    None
-                }
-            }) {
+            for pos in iter {
+                let pos = pos?;
+                let commit = self.data.fetch(pos.consensus_header)?.into_consensus()?.sub_dag;
                 // found a final of schedule score, so we'll return that
                 if commit.reputation_scores().final_of_schedule {
                     debug!(
                         "Found latest final reputation scores: {:?} from commit",
                         commit.reputation_scores(),
                     );
-                    return Some(commit);
+                    return Ok(Some(commit));
                 }
             }
         }
         debug!("No final reputation scores have been found");
-        None
+        Ok(None)
     }
 
     /// True if the pack contains the batch for digest.
@@ -1122,6 +1153,7 @@ impl Inner {
         let headers = self.consensus_pos_idx.len();
         let iter = self.consensus_pos_idx.rev_iter(headers)?;
         for pos in iter {
+            let pos = pos?;
             let header = self
                 .data
                 .fetch(pos.consensus_header)
@@ -1243,7 +1275,12 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                     // Handle the case with dup batches.  This should be rare to non-existant so not
                     // worried about the poor efficiency here.  This allows us
                     // to remove in the common case to avoid a batch clone.
-                    if let Some(batch) = cert_batches.iter().find(|b| b.digest() == *digest) {
+                    if let Some(batch) = batches
+                        .iter()
+                        .flat_map(|cb: &CertifiedBatch| cb.batches.iter())
+                        .chain(cert_batches.iter())
+                        .find(|b| b.digest() == *digest)
+                    {
                         cert_batches.push(batch.clone());
                     } else {
                         return Err(PackError::MissingBatch);

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -7,7 +7,7 @@ use std::{
     error::Error,
     fmt::Display,
     hash::BuildHasherDefault,
-    io::{self},
+    io::{self, Cursor},
     path::{Path, PathBuf},
     sync::Arc,
     thread::JoinHandle,
@@ -19,25 +19,26 @@ use serde::{Deserialize, Serialize};
 use tn_types::{
     gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, BlockNumHash,
     BlsPublicKey, CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader,
-    ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, Round, B256,
+    ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, Hash as _, Round,
+    B256,
 };
 use tokio::{
-    io::AsyncRead,
+    io::{AsyncRead, BufReader},
     sync::{
         mpsc::{self, Receiver, Sender},
         oneshot, watch,
     },
 };
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::archive::{
     digest_index::index::HdxIndex,
     error::{fetch::FetchError, open::OpenError},
     fxhasher::FxHasher,
     index::Index as _,
-    pack::{Pack, PackCompression, DATA_HEADER_BYTES},
+    pack::{DataHeader, Pack, PackCompression, DATA_HEADER_BYTES},
     pack_iter::AsyncPackIter,
-    position_index::index::PositionIndex,
+    position_index::index::{PosIndexValue, PositionIndex},
 };
 
 /// Metadata for an Epoch.  Should always be the first record in a consensus pack.
@@ -96,8 +97,8 @@ enum PackMessage {
     ContainsConsensusHeader(ConsensusHeaderDigest, oneshot::Sender<bool>),
     ConsensusHeader(ConsensusHeaderDigest, oneshot::Sender<Option<ConsensusHeader>>),
     ConsensusHeaderNumber(u64, oneshot::Sender<Result<ConsensusHeader, PackError>>),
-    GetConsensusOutput(u64, oneshot::Sender<Result<ConsensusOutput, PackError>>),
     Persist(oneshot::Sender<Result<(), PackError>>),
+    BytesForConsensus(u64, oneshot::Sender<Result<Vec<u8>, PackError>>),
     ReadLastCommitted(oneshot::Sender<HashMap<AuthorityIdentifier, Round>>),
     ReadLatestFinalRep(oneshot::Sender<Option<CommittedSubDag>>),
     ContainsBatch(B256, oneshot::Sender<bool>),
@@ -114,6 +115,7 @@ pub struct ConsensusPack {
     handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     error: watch::Receiver<Option<PackError>>,
     epoch: Epoch,
+    committee: Committee,
 }
 
 /// In case of an error consume the command loop so any waiting calls will error out.
@@ -149,11 +151,11 @@ fn run_pack_loop(
             PackMessage::ConsensusHeaderNumber(number, tx) => {
                 let _ = tx.send(inner.consensus_header_by_number(number));
             }
-            PackMessage::GetConsensusOutput(number, tx) => {
-                let _ = tx.send(inner.get_consensus_output(number));
-            }
             PackMessage::Persist(tx) => {
                 let _ = tx.send(inner.persist());
+            }
+            PackMessage::BytesForConsensus(number, tx) => {
+                let _ = tx.send(inner.bytes_for_consensus(number));
             }
             PackMessage::ReadLastCommitted(tx) => {
                 let _ = tx.send(inner.read_last_committed());
@@ -209,8 +211,9 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let epoch = committee.epoch();
+        let committee_clone = committee.clone();
         let handle = std::thread::spawn(move || {
-            match Inner::open_append(path, &previous_epoch, committee) {
+            match Inner::open_append(path, &previous_epoch, committee_clone) {
                 Ok(inner) => run_pack_loop(inner, rx, tx_error),
                 Err(e) => {
                     tx_error.send_replace(Some(e));
@@ -218,7 +221,7 @@ impl ConsensusPack {
                 }
             }
         });
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch })
+        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
     }
 
     /// Open up the files for previous epoch in append mode.  Will fail if files do not exist.
@@ -227,27 +230,22 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let inner = Inner::open_append_exists(path.clone(), epoch)?;
+        let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch })
+        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
     }
 
     /// Open up the static files for previous epoch.  These will be read only.
     /// Note, you should call persist() on the returned pack to make sure it
     /// opened cleanly.
-    pub fn open_static<P: Into<PathBuf>>(path: P, epoch: Epoch) -> ConsensusPack {
+    pub fn open_static<P: Into<PathBuf>>(path: P, epoch: Epoch) -> Result<Self, PackError> {
         let (tx, rx) = mpsc::channel(1000);
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
-        let handle = std::thread::spawn(move || match Inner::open_static(path.clone(), epoch) {
-            Ok(inner) => {
-                run_pack_loop(inner, rx, tx_error);
-            }
-            Err(e) => {
-                tx_error.send_replace(Some(e));
-                clear_pack_loop(rx);
-            }
-        });
-        Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch }
+        let inner = Inner::open_static(path.clone(), epoch)?;
+        let committee = inner.epoch_meta.committee.clone();
+        let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
+        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
     }
 
     /// Create a new set of epoch static files to write consensus output into.
@@ -271,10 +269,11 @@ impl ConsensusPack {
             timeout,
         )
         .await?;
+        let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || {
             run_pack_loop(inner, rx, tx_error);
         });
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch })
+        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
     }
 
     /// Return the epoch for this pack file.
@@ -304,13 +303,17 @@ impl ConsensusPack {
 
     /// Load and return the consensus output form this epoch.
     pub async fn get_consensus_output(&self, number: u64) -> Result<ConsensusOutput, PackError> {
-        self.get_error()?;
         let (tx, rx) = oneshot::channel();
-        if self.tx.send(PackMessage::GetConsensusOutput(number, tx)).await.is_ok() {
-            rx.await.map_err(|_| PackError::ReceiveFailed)?
+        let bytes = if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
+            rx.await.map_err(|_| PackError::ReceiveFailed)??
         } else {
-            Err(PackError::SendFailed)
-        }
+            return Err(PackError::SendFailed);
+        };
+        self.get_error()?;
+        let cursor = Cursor::new(bytes);
+        let reader = BufReader::new(cursor);
+        bytes_to_output(reader, PackCompression::ZStd, Duration::from_secs(5), &self.committee)
+            .await
     }
 
     /// True if consensus header by digest is found by digest.
@@ -434,7 +437,10 @@ pub const DATA_NAME: &str = Inner::DATA_NAME;
 #[derive(Debug)]
 struct Inner {
     data: Pack<PackRecord>,
-    consensus_idx: PositionIndex,
+    /// Positional index pointing to the first byte of ConsensusHeader, the first byte of the first
+    /// Batch and the last byte of the ConsensusHeader at a position. In short the first and
+    /// last byte of the encoded data for a ConsensusOutput as well as just the ConsensusHeader.
+    consensus_pos_idx: PositionIndex<IndexPositions>,
     consensus_digests: HdxIndex,
     batch_digests: HdxIndex,
     epoch_meta: EpochMeta,
@@ -449,7 +455,7 @@ impl Inner {
     /// Determine if the pack and indexes appear to have been closed cleanly.
     fn files_consistent(
         data: &Pack<PackRecord>,
-        consensus_idx: &mut PositionIndex,
+        consensus_pos_idx: &mut PositionIndex<IndexPositions>,
         consensus_digests: &HdxIndex,
         batch_digests: &HdxIndex,
     ) -> bool {
@@ -459,9 +465,9 @@ impl Inner {
         if pack_len != consensus_final || pack_len != batch_final {
             return false;
         }
-        if !consensus_idx.is_empty() {
-            let last_record = match consensus_idx.load(consensus_idx.len() as u64 - 1) {
-                Ok(p) => p,
+        if !consensus_pos_idx.is_empty() {
+            let last_record = match consensus_pos_idx.load(consensus_pos_idx.len() as u64 - 1) {
+                Ok(p) => p.consensus_header,
                 Err(_) => return false,
             };
             let mut iter = match data.raw_iter() {
@@ -483,7 +489,7 @@ impl Inner {
     /// Truncate the pack file in order to get back to a clean state.
     fn trunc_and_heal(
         data: &mut Pack<PackRecord>,
-        consensus_idx: &mut PositionIndex,
+        consensus_pos_idx: &mut PositionIndex<IndexPositions>,
         consensus_digests: &HdxIndex,
         batch_digests: &HdxIndex,
     ) -> Result<(), PackError> {
@@ -503,27 +509,30 @@ impl Inner {
             // remove digests, both would be expensive operations.
         }
         let pack_len = data.file_len();
-        if !consensus_idx.is_empty() {
+        if !consensus_pos_idx.is_empty() {
             let mut new_pack_len = pack_len;
             // Make sure we are not indexing any records that no longer exist.
             // Also make sure we don not have a partial record left on a short file.
-            let start_idx = consensus_idx.len() as u64 - 1;
+            let start_idx = consensus_pos_idx.len() as u64 - 1;
             let mut idx = start_idx;
             loop {
-                if let Ok(last_record) = consensus_idx.load(idx) {
-                    let record_size_res = data.record_size(last_record);
+                if let Ok(last_record) = consensus_pos_idx.load(idx) {
+                    let record_size_res = data.record_size(last_record.consensus_header);
                     let record_valid = record_size_res.is_ok();
                     if record_valid {
                         if idx != start_idx {
-                            consensus_idx.truncate_to_index(idx)?;
+                            // Keep the bytes index in sync with the consensus index so the two
+                            // never diverge in length after healing a damaged pack.
+                            consensus_pos_idx.truncate_to_index(idx)?;
                         }
-                        new_pack_len = last_record + record_size_res.unwrap_or_default() as u64;
+                        new_pack_len = last_record.consensus_header
+                            + record_size_res.unwrap_or_default() as u64;
                         break;
                     }
                 }
                 if idx == 0 {
                     if idx != start_idx {
-                        consensus_idx.truncate_all()?;
+                        consensus_pos_idx.truncate_all()?;
                     }
                     break;
                 }
@@ -534,6 +543,48 @@ impl Inner {
             }
         }
         Ok(())
+    }
+
+    /// Open a PDX index file and return the open index.
+    /// This will handle an update of the index on older testnet epochs.
+    fn open_pdx_file<P: AsRef<Path>, T: PosIndexValue>(
+        dir: P,
+        data_header: &DataHeader,
+        read_only: bool,
+    ) -> Result<PositionIndex<T>, PackError> {
+        let base_dir = dir.as_ref().join(Self::CONSENSUS_POS_NAME);
+        if PositionIndex::<T>::pdx_file_exists(&base_dir, "index.pdx")
+            && !PositionIndex::<T>::pdx_file_exists(&base_dir, "index_pos.pdx")
+        {
+            warn!(target: "consensus_pack", "Found old but not new position index, updating");
+            // We have an old index but , need to create a new one and build it.
+            // This code should only effect OG testnet nodes and should not need
+            // to be maintained forever.
+            let mut old_idx: PositionIndex<u64> =
+                PositionIndex::open_pdx_file(&base_dir, data_header, "index.pdx", false)
+                    .map_err(OpenError::IndexFileOpen)?;
+            let mut new_idx: PositionIndex<IndexPositions> =
+                PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
+                    .map_err(OpenError::IndexFileOpen)?;
+            for i in 0..old_idx.len() {
+                let idx = i as u64;
+                let pos = old_idx.load(idx)?;
+                // We save the consensus header position and 0 out the consensus output fields.
+                // We can get away with this (vs doing an expesive regen of the actual values)
+                // because we use this to get ConsensusOutput and this is only ever done on the
+                // current pack file.  Only older testnet nodes will be effected by this and they
+                // should never go to previous pack files.  We will let at least one epoch pass and
+                // new packs will have new indexes.  Syncing nodes will generate the proper indexes
+                // from the beginning (even for older epochs).
+                new_idx
+                    .save(idx, IndexPositions::new(pos, 0, 0))
+                    .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
+            }
+        }
+        let consensus_pos_idx =
+            PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
+                .map_err(OpenError::IndexFileOpen)?;
+        Ok(consensus_pos_idx)
     }
 
     /// Opens a new epoch pack for append.  Will create a new set of epoch static
@@ -572,12 +623,7 @@ impl Inner {
             data.append(&PackRecord::EpochMeta(epoch_meta.clone()))
                 .map_err(|e| PackError::Append(e.to_string()))?;
         }
-        let mut consensus_idx = PositionIndex::open_pdx_file(
-            base_dir.join(Self::CONSENSUS_POS_NAME),
-            data.header(),
-            false,
-        )
-        .map_err(OpenError::IndexFileOpen)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -601,8 +647,13 @@ impl Inner {
             batch_digests.set_data_file_length(len);
         }
         // Repair damage.
-        Self::trunc_and_heal(&mut data, &mut consensus_idx, &consensus_digests, &batch_digests)?;
-        Ok(Self { data, consensus_idx, consensus_digests, batch_digests, epoch_meta })
+        Self::trunc_and_heal(
+            &mut data,
+            &mut consensus_pos_idx,
+            &consensus_digests,
+            &batch_digests,
+        )?;
+        Ok(Self { data, consensus_digests, consensus_pos_idx, batch_digests, epoch_meta })
     }
 
     /// Open up the files for previous epoch in append mode.  Will fail if files do not exist.
@@ -619,12 +670,7 @@ impl Inner {
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_idx = PositionIndex::open_pdx_file(
-            base_dir.join(Self::CONSENSUS_POS_NAME),
-            data.header(),
-            false,
-        )
-        .map_err(OpenError::IndexFileOpen)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -643,8 +689,13 @@ impl Inner {
         .map_err(OpenError::IndexFileOpen)?;
 
         // Repair damage.
-        Self::trunc_and_heal(&mut data, &mut consensus_idx, &consensus_digests, &batch_digests)?;
-        Ok(Self { data, consensus_idx, consensus_digests, batch_digests, epoch_meta })
+        Self::trunc_and_heal(
+            &mut data,
+            &mut consensus_pos_idx,
+            &consensus_digests,
+            &batch_digests,
+        )?;
+        Ok(Self { data, consensus_digests, consensus_pos_idx, batch_digests, epoch_meta })
     }
 
     /// Open up the static files for previous epoch.  These will be read only.
@@ -661,12 +712,7 @@ impl Inner {
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_idx = PositionIndex::open_pdx_file(
-            base_dir.join(Self::CONSENSUS_POS_NAME),
-            data.header(),
-            true,
-        )
-        .map_err(OpenError::IndexFileOpen)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), true)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -684,11 +730,16 @@ impl Inner {
         )
         .map_err(OpenError::IndexFileOpen)?;
 
-        if !Self::files_consistent(&data, &mut consensus_idx, &consensus_digests, &batch_digests) {
+        if !Self::files_consistent(
+            &data,
+            &mut consensus_pos_idx,
+            &consensus_digests,
+            &batch_digests,
+        ) {
             // Corrupt static file is bad (damaged at rest?), produce an error.
             return Err(PackError::CorruptPack);
         }
-        Ok(Self { data, consensus_idx, consensus_digests, batch_digests, epoch_meta })
+        Ok(Self { data, consensus_digests, consensus_pos_idx, batch_digests, epoch_meta })
     }
 
     /// Verify a streamed EpochMeta record is valid.
@@ -780,14 +831,9 @@ impl Inner {
         Self::verify_epoch_meta(epoch, previous_epoch, &epoch_meta)?;
         data.append(&PackRecord::EpochMeta(epoch_meta.clone()))
             .map_err(|e| PackError::Append(e.to_string()))?;
-        let mut consensus_idx = PositionIndex::open_pdx_file(
-            base_dir.join(Self::CONSENSUS_POS_NAME),
-            data.header(),
-            false,
-        )
-        .map_err(OpenError::IndexFileOpen)?;
+        let consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
-        let mut consensus_digests = HdxIndex::open_hdx_file(
+        let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
             data.header(),
             builder,
@@ -795,7 +841,7 @@ impl Inner {
         )
         .map_err(OpenError::IndexFileOpen)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
-        let mut batch_digests = HdxIndex::open_hdx_file(
+        let batch_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::BATCH_HASH_NAME),
             data.header(),
             builder,
@@ -807,75 +853,29 @@ impl Inner {
         } else {
             previous_epoch.final_consensus.hash
         };
-        let mut batches = HashSet::new();
-        let mut referenced_batches = HashSet::new();
-        while let Some(record) = next(&mut stream_iter, timeout).await? {
-            match record {
-                PackRecord::EpochMeta(_epoch_meta) => {
-                    return Err(PackError::EpochLoad("epoch meta data found twice".to_string()))
-                }
-                PackRecord::Batch(batch) => {
-                    let batch_digest = batch.digest();
-                    batches.insert(batch_digest);
-                    let position = data
-                        .append(&PackRecord::Batch(batch))
-                        .map_err(|e| PackError::Append(e.to_string()))?;
-                    batch_digests
-                        .save(batch_digest, position)
-                        .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
-                    let len = data.file_len();
-                    consensus_digests.set_data_file_length(len);
-                    batch_digests.set_data_file_length(len);
-                }
-                PackRecord::Consensus(consensus_header) => {
-                    if consensus_header.parent_hash != parent_digest {
-                        return Err(PackError::InvalidConsensusChain);
-                    }
-                    for header in consensus_header.sub_dag.headers() {
-                        for (digest, _) in header.payload().iter() {
-                            if !batches.contains(digest) {
-                                return Err(PackError::MissingBatches);
-                            }
-                            referenced_batches.insert(*digest);
-                        }
-                    }
-                    // batches.len() will generally equal referenced_batches.len() but if it is
-                    // greater than we had batches that were not accounted for.
-                    // It is possible (at time of writing) for a batch to
-                    // be in more than one subdag.  This is also why we don't just
-                    // remove batches as we check above.
-                    if batches.len() > referenced_batches.len() {
-                        return Err(PackError::ExtraBatches);
-                    }
-                    batches.clear();
-                    referenced_batches.clear();
-                    let consensus_digest = consensus_header.digest();
-                    parent_digest = consensus_digest;
-                    let consensus_number = consensus_header.number;
-                    if consensus_number > final_consensus_number {
-                        return Err(PackError::InvalidConsensusNumber(
-                            consensus_number,
-                            final_consensus_number,
-                        ));
-                    }
-                    let position = data
-                        .append(&PackRecord::Consensus(consensus_header))
-                        .map_err(|e| PackError::Append(e.to_string()))?;
-                    consensus_digests
-                        .save(consensus_digest.into(), position)
-                        .map_err(|e| PackError::IndexAppend(format!("consensus digest {e}")))?;
-                    let consensus_idx_pos =
-                        consensus_number.saturating_sub(epoch_meta.start_consensus_number);
-                    consensus_idx
-                        .save(consensus_idx_pos, position)
-                        .map_err(|e| PackError::IndexAppend(format!("consensus number {e}")))?;
-                    let len = data.file_len();
-                    consensus_digests.set_data_file_length(len);
-                    batch_digests.set_data_file_length(len);
-                }
+        let mut pack =
+            Self { data, consensus_pos_idx, consensus_digests, batch_digests, epoch_meta };
+        loop {
+            let output =
+                match iter_to_output(&mut stream_iter, timeout, &pack.epoch_meta.committee).await {
+                    Ok(output) => output,
+                    Err(PackError::NotConsensus) => break,
+                    Err(e) => return Err(e),
+                };
+            if output.parent_hash() != parent_digest {
+                return Err(PackError::InvalidConsensusChain);
             }
+            let consensus_number = output.number();
+            if consensus_number > final_consensus_number {
+                return Err(PackError::InvalidConsensusNumber(
+                    consensus_number,
+                    final_consensus_number,
+                ));
+            }
+            parent_digest = output.digest();
+            pack.save_consensus_output(&output)?;
         }
-        Ok(Self { data, consensus_idx, consensus_digests, batch_digests, epoch_meta })
+        Ok(pack)
     }
 
     /// Save all the batches and consensus header from the ConsensusOutput the pack file.
@@ -884,13 +884,13 @@ impl Inner {
         // Adjusted consensus index for this pack file.
         let consensus_idx = consensus_number.saturating_sub(self.epoch_meta.start_consensus_number);
         // Make sure this number is valid before we write anything...
-        if (consensus_idx as usize) < self.consensus_idx.len() {
+        if (consensus_idx as usize) < self.consensus_pos_idx.len() {
             // If we have saved this output already then ignore it.
             // Note this can be important when we replay consensus from downloaded pack files.
             return Ok(());
-        } else if consensus_idx as usize != self.consensus_idx.len() {
+        } else if consensus_idx as usize != self.consensus_pos_idx.len() {
             return Err(PackError::InvalidConsensusNumber(
-                self.consensus_idx.len() as u64 + self.epoch_meta.start_consensus_number,
+                self.consensus_pos_idx.len() as u64 + self.epoch_meta.start_consensus_number,
                 consensus_number,
             ));
         }
@@ -906,12 +906,16 @@ impl Inner {
                 batches.insert(digest, batch.clone());
             }
         }
+        let mut first_batch_pos = None;
         // Save all the required batcdhes into the pack file.
         for (batch_digest, batch) in batches.into_iter() {
             let position = self
                 .data
                 .append(&PackRecord::Batch(batch))
                 .map_err(|e| PackError::Append(e.to_string()))?;
+            if first_batch_pos.is_none() {
+                first_batch_pos = Some(position);
+            }
             self.batch_digests
                 .save(batch_digest, position)
                 .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
@@ -925,87 +929,24 @@ impl Inner {
             .data
             .append(&PackRecord::Consensus(Box::new(consensus.consensus_header())))
             .map_err(|e| PackError::Append(e.to_string()))?;
+        let batch_pos = if let Some(batch_pos) = first_batch_pos { batch_pos } else { position };
         self.consensus_digests
             .save(consensus_digest.into(), position)
             .map_err(|e| PackError::IndexAppend(format!("consensus {e}")))?;
-        self.consensus_idx
-            .save(consensus_idx, position)
-            .map_err(|e| PackError::IndexAppend(format!("consensus number {e}")))?;
         let len = self.data.file_len();
+        self.consensus_pos_idx
+            .save(consensus_idx, IndexPositions::new(position, batch_pos, len))
+            .map_err(|e| PackError::IndexAppend(format!("consensus number {e}")))?;
         self.consensus_digests.set_data_file_length(len);
         self.batch_digests.set_data_file_length(len);
 
         Ok(())
     }
 
-    /// Load and return the consensus output form this epoch.
-    fn get_consensus_output(&mut self, number: u64) -> Result<ConsensusOutput, PackError> {
-        let rec_pos_idx = number.saturating_sub(self.epoch_meta.start_consensus_number);
-        let position = self
-            .consensus_idx
-            .load(rec_pos_idx)
-            .map_err(|e| PackError::ReadError(e.to_string()))?;
-        let header = self
-            .data
-            .fetch(position)
-            .map_err(|e| PackError::ReadError(e.to_string()))?
-            .into_consensus()?;
-        let parent_hash = header.parent_hash;
-        let deliver = header.sub_dag;
-        let num_blocks = deliver.num_primary_batches();
-        let num_certs = deliver.len();
-
-        let sub_dag = deliver;
-        if num_blocks == 0 {
-            return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, number));
-        }
-
-        let mut batch_set: HashSet<BlockHash> = HashSet::new();
-
-        let mut batch_digests = VecDeque::with_capacity(num_certs);
-        for header in sub_dag.headers() {
-            for (digest, _) in header.payload().iter() {
-                batch_set.insert(*digest);
-                batch_digests.push_back(*digest);
-            }
-        }
-
-        // map all fetched batches to their respective certificates for applying block rewards
-        let mut batches = Vec::with_capacity(num_certs);
-        for header in sub_dag.headers() {
-            // create collection of batches to execute for this certificate
-            let mut cert_batches = Vec::with_capacity(header.payload().len());
-
-            // retrieve fetched batch by digest
-            for digest in header.payload().keys() {
-                let position = self
-                    .batch_digests
-                    .load(*digest)
-                    .map_err(|e| PackError::ReadError(e.to_string()))?;
-                let batch = self
-                    .data
-                    .fetch(position)
-                    .map_err(|e| PackError::ReadError(e.to_string()))?
-                    .into_batch()?;
-                cert_batches.push(batch);
-            }
-
-            let address =
-                self.epoch_meta.committee.authority(header.author()).map(|a| a.execution_address());
-            if let Some(address) = address {
-                // main collection for execution
-                batches.push(CertifiedBatch { address, batches: cert_batches });
-            } else {
-                return Err(PackError::MissingAuthority);
-            }
-        }
-        Ok(ConsensusOutput::new(sub_dag, parent_hash, number, false, batch_digests, batches))
-    }
-
     /// True if consensus header by digest is found by digest.
     fn contains_consensus_header_number(&self, number: u64) -> bool {
         number >= self.epoch_meta.start_consensus_number
-            && number < self.consensus_idx.len() as u64 + self.epoch_meta.start_consensus_number
+            && number < self.consensus_pos_idx.len() as u64 + self.epoch_meta.start_consensus_number
     }
 
     /// True if consensus header is found by digest.
@@ -1048,42 +989,58 @@ impl Inner {
         if number < self.epoch_meta.start_consensus_number {
             return Err(PackError::ConsensusNumberTooLow);
         }
-        if number >= (self.epoch_meta.start_consensus_number + self.consensus_idx.len() as u64) {
+        if number >= (self.epoch_meta.start_consensus_number + self.consensus_pos_idx.len() as u64)
+        {
             return Err(PackError::ConsensusNumberTooHigh);
         }
         let pos = self
-            .consensus_idx
-            .load(number.saturating_sub(self.epoch_meta.start_consensus_number))?;
+            .consensus_pos_idx
+            .load(number.saturating_sub(self.epoch_meta.start_consensus_number))?
+            .consensus_header;
         self.data.fetch(pos)?.into_consensus()
     }
 
     fn persist(&mut self) -> Result<(), PackError> {
         if !self.data.read_only() {
             self.data.commit().map_err(|e| PackError::PersistError(e.to_string()))?;
-            self.consensus_idx.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
+            self.consensus_pos_idx.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
             self.consensus_digests.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
             self.batch_digests.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
         }
         Ok(())
     }
 
+    /// Read and return all the bytes for consensus number (all batches and the consensus header).
+    fn bytes_for_consensus(&mut self, number: u64) -> Result<Vec<u8>, PackError> {
+        let rec_pos_idx = number.saturating_sub(self.epoch_meta.start_consensus_number);
+        let IndexPositions { consensus_header: _, output_start, output_end } = self
+            .consensus_pos_idx
+            .load(rec_pos_idx)
+            .map_err(|e| PackError::ReadError(e.to_string()))?;
+        let bytes = self
+            .data
+            .read_bytes(output_start, output_end)
+            .map_err(|e| PackError::ReadError(e.to_string()))?;
+        Ok(bytes)
+    }
+
     /// Return the latest consensus header by reading directly from the pack index,
     /// bypassing the slot file (LatestConsensus). Used during startup recovery to
     /// get a ground-truth latest header consistent with read_last_committed.
     fn latest_consensus_header(&mut self) -> Option<ConsensusHeader> {
-        if self.consensus_idx.is_empty() {
+        if self.consensus_pos_idx.is_empty() {
             return None;
         }
         let latest_number =
-            self.epoch_meta.start_consensus_number + self.consensus_idx.len() as u64 - 1;
+            self.epoch_meta.start_consensus_number + self.consensus_pos_idx.len() as u64 - 1;
         self.consensus_header_by_number(latest_number).ok()
     }
 
     fn read_last_committed(&mut self) -> HashMap<AuthorityIdentifier, Round> {
         let mut res = HashMap::new();
-        if let Ok(iter) = self.consensus_idx.rev_iter(50) {
+        if let Ok(iter) = self.consensus_pos_idx.rev_iter(50) {
             for block in iter.filter_map(|pos| {
-                let block = self.data.fetch(pos);
+                let block = self.data.fetch(pos.consensus_header);
                 block.ok().map(|b| b.into_consensus().ok()).unwrap_or_default()
             }) {
                 let id = block.sub_dag.leader().author().clone();
@@ -1101,9 +1058,9 @@ impl Inner {
     }
 
     fn read_latest_commit_with_final_reputation_scores(&mut self) -> Option<CommittedSubDag> {
-        if let Ok(iter) = self.consensus_idx.rev_iter(1000) {
+        if let Ok(iter) = self.consensus_pos_idx.rev_iter(1000) {
             for commit in iter.filter_map(|pos| {
-                let block = self.data.fetch(pos);
+                let block = self.data.fetch(pos.consensus_header);
                 if let Some(block) = block.ok().map(|b| b.into_consensus().ok()) {
                     block.map(|b| b.sub_dag)
                 } else {
@@ -1162,12 +1119,12 @@ impl Inner {
         last_executed_round: Round,
         rewards_counter: &RewardsCounter,
     ) -> Result<(), PackError> {
-        let headers = self.consensus_idx.len();
-        let iter = self.consensus_idx.rev_iter(headers)?;
+        let headers = self.consensus_pos_idx.len();
+        let iter = self.consensus_pos_idx.rev_iter(headers)?;
         for pos in iter {
             let header = self
                 .data
-                .fetch(pos)
+                .fetch(pos.consensus_header)
                 .map_err(|e| PackError::Fetch(e.to_string()))?
                 .into_consensus()?;
             let leader_round = header.sub_dag.leader_round();
@@ -1182,6 +1139,194 @@ impl Inner {
             rewards_counter.inc_leader_count(header.sub_dag.leader().author());
         }
         Ok(())
+    }
+}
+
+/// Create a new set of epoch static files to write consensus output into.
+pub async fn bytes_to_output<R: AsyncRead + Unpin>(
+    stream: R,
+    compression: PackCompression,
+    timeout: Duration,
+    committee: &Committee,
+) -> Result<ConsensusOutput, PackError> {
+    let mut stream_iter = AsyncPackIter::<PackRecord, R>::open_partial(stream, compression)
+        .await
+        .map_err(|e| PackError::ReadError(e.to_string()))?;
+    iter_to_output(&mut stream_iter, timeout, committee).await
+}
+
+/// Create a new set of epoch static files to write consensus output into.
+async fn iter_to_output<R: AsyncRead + Unpin>(
+    stream_iter: &mut AsyncPackIter<PackRecord, R>,
+    timeout: Duration,
+    committee: &Committee,
+) -> Result<ConsensusOutput, PackError> {
+    /// Private helper to read the next record from a pack iterator or timeout if it takes
+    /// longer than timeout.
+    async fn next<R: AsyncRead + Unpin>(
+        iter: &mut AsyncPackIter<PackRecord, R>,
+        timeout: Duration,
+    ) -> Result<Option<PackRecord>, PackError> {
+        match tokio::time::timeout(timeout, iter.next()).await {
+            Ok(Some(Ok(rec))) => Ok(Some(rec)),
+            Ok(Some(Err(e))) => Err(PackError::ReadError(e.to_string())),
+            Ok(None) => Ok(None),
+            Err(_) => Err(PackError::ReadError("timeout".to_string())),
+        }
+    }
+    let mut header = None;
+    let mut available_batches = HashMap::new();
+    let mut referenced_batches = HashSet::new();
+    while let Some(record) = next(stream_iter, timeout).await? {
+        match record {
+            PackRecord::EpochMeta(_epoch_meta) => {
+                return Err(PackError::EpochLoad("unexpected epoch meta data found".to_string()))
+            }
+            PackRecord::Batch(batch) => {
+                let batch_digest = batch.digest();
+                available_batches.insert(batch_digest, batch);
+            }
+            PackRecord::Consensus(consensus_header) => {
+                for header in consensus_header.sub_dag.headers() {
+                    for (digest, _) in header.payload().iter() {
+                        if !available_batches.contains_key(digest) {
+                            return Err(PackError::MissingBatches);
+                        }
+                        referenced_batches.insert(*digest);
+                    }
+                }
+                // batches.len() will generally equal referenced_batches.len() but if it is
+                // greater than we had batches that were not accounted for.
+                // It is possible (at time of writing) for a batch to
+                // be in more than one subdag.  This is also why we don't just
+                // remove batches as we check above.
+                if available_batches.len() > referenced_batches.len() {
+                    return Err(PackError::ExtraBatches);
+                }
+                header = Some(consensus_header);
+                break;
+            }
+        }
+    }
+    if let Some(header) = header {
+        let parent_hash = header.parent_hash;
+        let deliver = header.sub_dag;
+        let num_blocks = deliver.num_primary_batches();
+        let num_certs = deliver.len();
+
+        let sub_dag = deliver;
+        if num_blocks == 0 {
+            return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, header.number));
+        }
+
+        let mut batch_set: HashSet<BlockHash> = HashSet::new();
+
+        let mut batch_digests = VecDeque::with_capacity(num_certs);
+        for header in sub_dag.headers() {
+            for (digest, _) in header.payload().iter() {
+                batch_set.insert(*digest);
+                batch_digests.push_back(*digest);
+            }
+        }
+
+        // map all fetched batches to their respective certificates for applying block rewards
+        let mut batches = Vec::with_capacity(num_certs);
+        for header in sub_dag.headers() {
+            // create collection of batches to execute for this certificate
+            let mut cert_batches = Vec::with_capacity(header.payload().len());
+
+            // retrieve fetched batch by digest
+            for digest in header.payload().keys() {
+                if let Some(batch) = available_batches.remove(digest) {
+                    cert_batches.push(batch);
+                } else if referenced_batches.contains(digest) {
+                    // Handle the case with dup batches.  This should be rare to non-existant so not
+                    // worried about the poor efficiency here.  This allows us
+                    // to remove in the common case to avoid a batch clone.
+                    if let Some(batch) = cert_batches.iter().find(|b| b.digest() == *digest) {
+                        cert_batches.push(batch.clone());
+                    } else {
+                        return Err(PackError::MissingBatch);
+                    }
+                } else {
+                    return Err(PackError::MissingBatch);
+                }
+            }
+
+            let address = committee.authority(header.author()).map(|a| a.execution_address());
+            if let Some(address) = address {
+                // main collection for execution
+                batches.push(CertifiedBatch { address, batches: cert_batches });
+            } else {
+                return Err(PackError::MissingAuthority);
+            }
+        }
+        Ok(ConsensusOutput::new(sub_dag, parent_hash, header.number, false, batch_digests, batches))
+    } else {
+        Err(PackError::NotConsensus)
+    }
+}
+
+/// Values stored in the position index.
+#[derive(Debug, Copy, Clone)]
+struct IndexPositions {
+    /// The first byte of the ConsensusHeader record for position.
+    consensus_header: u64,
+    /// The first byte of the first Batch for the output at position.
+    /// Reading bytes from output_start..output_end will provide all the
+    /// bytes to build the consensus output at position.
+    output_start: u64,
+    /// The byte after the ConsensusHeader for the output at position.
+    output_end: u64,
+}
+
+impl IndexPositions {
+    fn new(consensus_header: u64, output_start: u64, output_end: u64) -> Self {
+        Self { consensus_header, output_start, output_end }
+    }
+}
+impl PosIndexValue for IndexPositions {
+    fn encode(&self, buffer: &mut [u8]) {
+        if buffer.len() != Self::buffer_len() {
+            // Not passing in the exact sized buffer is a coding error so panic vs return error.
+            panic!("buffer not 28 bytes");
+        }
+        let mut crc32_hasher = crc32fast::Hasher::new();
+        buffer[..8].copy_from_slice(&self.consensus_header.to_le_bytes());
+        buffer[8..16].copy_from_slice(&self.output_start.to_le_bytes());
+        buffer[16..24].copy_from_slice(&self.output_end.to_le_bytes());
+        crc32_hasher.update(&buffer[0..24]);
+        let crc32 = crc32_hasher.finalize();
+        buffer[24..28].copy_from_slice(&crc32.to_le_bytes());
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, FetchError> {
+        if bytes.len() != Self::buffer_len() {
+            // Not passing in the exact sized bytes is a coding error so panic vs return error.
+            panic!("input not 28 bytes");
+        }
+        let mut crc32_hasher = crc32fast::Hasher::new();
+        crc32_hasher.update(&bytes[0..24]);
+        let crc32 = crc32_hasher.finalize();
+        let mut buf32 = [0_u8; 4];
+        buf32.copy_from_slice(&bytes[24..28]);
+        let crc32_from_buffer = u32::from_le_bytes(buf32);
+        if crc32 != crc32_from_buffer {
+            return Err(FetchError::CrcFailed);
+        }
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(&bytes[..8]);
+        let consensus_header = u64::from_le_bytes(buf);
+        buf.copy_from_slice(&bytes[8..16]);
+        let output_start = u64::from_le_bytes(buf);
+        buf.copy_from_slice(&bytes[16..24]);
+        let output_end = u64::from_le_bytes(buf);
+        Ok(Self { consensus_header, output_start, output_end })
+    }
+
+    /// 28, three u64s and u32 crc.
+    fn buffer_len() -> usize {
+        28
     }
 }
 
@@ -1447,7 +1592,7 @@ pub(crate) mod test {
         drop(pack);
 
         // Open read only and verify.
-        let pack = ConsensusPack::open_static(temp_dir.path(), 0);
+        let pack = ConsensusPack::open_static(temp_dir.path(), 0).unwrap();
         for i in 0..(num_outputs * 2) {
             let output_db = pack.get_consensus_output(i as u64 + 1).await.unwrap();
             let output = outputs.get(i as usize).unwrap();

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -32,6 +32,7 @@ use tokio::{
 use tracing::{debug, error, warn};
 
 use crate::archive::{
+    data_file::fsync_directory,
     digest_index::index::HdxIndex,
     error::{fetch::FetchError, open::OpenError},
     fxhasher::FxHasher,
@@ -617,15 +618,21 @@ impl Inner {
                 } else {
                     DATA_HEADER_BYTES as u64 + data.record_size(DATA_HEADER_BYTES as u64)? as u64
                 };
-                let pos = old_idx.load(idx)?;
-                let record_size = data.record_size(pos)?;
+                let Ok(pos) = old_idx.load(idx) else {
+                    break;
+                };
+                let Ok(record_size) = data.record_size(pos) else {
+                    break;
+                };
                 end = pos + record_size as u64;
                 new_idx
                     .save(idx, IndexPositions::new(pos, start, end))
                     .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
             }
             drop(new_idx);
+            drop(old_idx);
             std::fs::rename(base_dir.join("index_pos.pdx.tmp"), base_dir.join("index_pos.pdx"))?;
+            fsync_directory(&base_dir)?;
             let _ = std::fs::remove_file(base_dir.join("index.pdx"));
         }
         let consensus_pos_idx =
@@ -1262,12 +1269,9 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
             return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, header.number));
         }
 
-        let mut batch_set: HashSet<BlockHash> = HashSet::new();
-
         let mut batch_digests = VecDeque::with_capacity(num_certs);
         for header in sub_dag.headers() {
             for (digest, _) in header.payload().iter() {
-                batch_set.insert(*digest);
                 batch_digests.push_back(*digest);
             }
         }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -116,14 +116,7 @@ pub struct ConsensusPack {
     error: watch::Receiver<Option<PackError>>,
     epoch: Epoch,
     committee: Committee,
-}
-
-/// In case of an error consume the command loop so any waiting calls will error out.
-fn clear_pack_loop(mut rx: Receiver<PackMessage>) {
-    rx.close();
-    while let Ok(msg) = rx.try_recv() {
-        drop(msg);
-    }
+    compression: PackCompression,
 }
 
 fn run_pack_loop(
@@ -211,17 +204,17 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let epoch = committee.epoch();
-        let committee_clone = committee.clone();
-        let handle = std::thread::spawn(move || {
-            match Inner::open_append(path, &previous_epoch, committee_clone) {
-                Ok(inner) => run_pack_loop(inner, rx, tx_error),
-                Err(e) => {
-                    tx_error.send_replace(Some(e));
-                    clear_pack_loop(rx);
-                }
-            }
-        });
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
+        let inner = Inner::open_append(path.clone(), &previous_epoch, committee.clone())?;
+        let compression = inner.data.header().compression();
+        let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
+        Ok(Self {
+            tx,
+            handle: Arc::new(Mutex::new(Some(handle))),
+            error,
+            epoch,
+            committee,
+            compression,
+        })
     }
 
     /// Open up the files for previous epoch in append mode.  Will fail if files do not exist.
@@ -230,9 +223,17 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let inner = Inner::open_append_exists(path.clone(), epoch)?;
+        let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
+        Ok(Self {
+            tx,
+            handle: Arc::new(Mutex::new(Some(handle))),
+            error,
+            epoch,
+            committee,
+            compression,
+        })
     }
 
     /// Open up the static files for previous epoch.  These will be read only.
@@ -243,9 +244,17 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let inner = Inner::open_static(path.clone(), epoch)?;
+        let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
+        Ok(Self {
+            tx,
+            handle: Arc::new(Mutex::new(Some(handle))),
+            error,
+            epoch,
+            committee,
+            compression,
+        })
     }
 
     /// Create a new set of epoch static files to write consensus output into.
@@ -269,11 +278,19 @@ impl ConsensusPack {
             timeout,
         )
         .await?;
+        let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || {
             run_pack_loop(inner, rx, tx_error);
         });
-        Ok(Self { tx, handle: Arc::new(Mutex::new(Some(handle))), error, epoch, committee })
+        Ok(Self {
+            tx,
+            handle: Arc::new(Mutex::new(Some(handle))),
+            error,
+            epoch,
+            committee,
+            compression,
+        })
     }
 
     /// Return the epoch for this pack file.
@@ -312,8 +329,7 @@ impl ConsensusPack {
         };
         let cursor = Cursor::new(bytes);
         let reader = BufReader::new(cursor);
-        bytes_to_output(reader, PackCompression::ZStd, Duration::from_secs(5), &self.committee)
-            .await
+        bytes_to_output(reader, self.compression, Duration::from_secs(5), &self.committee).await
     }
 
     /// True if consensus header by digest is found by digest.
@@ -587,24 +603,21 @@ impl Inner {
             // This code should only effect OG testnet nodes and should not need
             // to be maintained forever.
             let mut old_idx: PositionIndex<u64> =
-                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", false)
+                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", true)
                     .map_err(OpenError::IndexFileOpen)?;
-            let _ = std::fs::remove_dir_all(base_dir.join("index_pos.pdx.tmp"));
+            let _ = std::fs::remove_file(base_dir.join("index_pos.pdx.tmp"));
             let mut new_idx: PositionIndex<IndexPositions> =
-                PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx.tmp", true)
+                PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx.tmp", false)
                     .map_err(OpenError::IndexFileOpen)?;
             for i in 0..old_idx.len() {
                 let idx = i as u64;
                 let pos = old_idx.load(idx)?;
                 let start = if idx > 0 {
-                    if let Ok(prev_pos) = old_idx.load(idx - 1) {
-                        let record_size = data.record_size(prev_pos)?;
-                        prev_pos + record_size as u64
-                    } else {
-                        DATA_HEADER_BYTES as u64
-                    }
+                    let prev_pos = old_idx.load(idx - 1)?;
+                    let record_size = data.record_size(prev_pos)?;
+                    prev_pos + record_size as u64
                 } else {
-                    DATA_HEADER_BYTES as u64
+                    DATA_HEADER_BYTES as u64 + data.record_size(DATA_HEADER_BYTES as u64)? as u64
                 };
                 let record_size = data.record_size(pos)?;
                 let end = pos + record_size as u64;
@@ -614,7 +627,7 @@ impl Inner {
             }
             drop(new_idx);
             std::fs::rename(base_dir.join("index_pos.pdx.tmp"), base_dir.join("index_pos.pdx"))?;
-            let _ = std::fs::remove_dir_all(base_dir.join("index.pdx"));
+            let _ = std::fs::remove_file(base_dir.join("index.pdx"));
         }
         let consensus_pos_idx =
             PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx", read_only)
@@ -1073,19 +1086,18 @@ impl Inner {
 
     fn read_last_committed(&mut self) -> Result<HashMap<AuthorityIdentifier, Round>, PackError> {
         let mut res = HashMap::new();
-        if let Ok(iter) = self.consensus_pos_idx.rev_iter(50) {
-            for pos in iter {
-                let pos = pos?;
-                let block = self.data.fetch(pos.consensus_header)?.into_consensus()?;
-                let id = block.sub_dag.leader().author().clone();
-                let round = block.sub_dag.leader_round();
-                let headers = block.sub_dag.headers();
-                res.entry(id).and_modify(|r| *r = max(*r, round)).or_insert_with(|| round);
-                for h in headers {
-                    res.entry(h.author().clone())
-                        .and_modify(|r| *r = max(*r, h.round()))
-                        .or_insert_with(|| h.round());
-                }
+        let iter = self.consensus_pos_idx.rev_iter(50)?;
+        for pos in iter {
+            let pos = pos?;
+            let block = self.data.fetch(pos.consensus_header)?.into_consensus()?;
+            let id = block.sub_dag.leader().author().clone();
+            let round = block.sub_dag.leader_round();
+            let headers = block.sub_dag.headers();
+            res.entry(id).and_modify(|r| *r = max(*r, round)).or_insert_with(|| round);
+            for h in headers {
+                res.entry(h.author().clone())
+                    .and_modify(|r| *r = max(*r, h.round()))
+                    .or_insert_with(|| h.round());
             }
         }
         Ok(res)
@@ -1094,18 +1106,17 @@ impl Inner {
     fn read_latest_commit_with_final_reputation_scores(
         &mut self,
     ) -> Result<Option<CommittedSubDag>, PackError> {
-        if let Ok(iter) = self.consensus_pos_idx.rev_iter(1000) {
-            for pos in iter {
-                let pos = pos?;
-                let commit = self.data.fetch(pos.consensus_header)?.into_consensus()?.sub_dag;
-                // found a final of schedule score, so we'll return that
-                if commit.reputation_scores().final_of_schedule {
-                    debug!(
-                        "Found latest final reputation scores: {:?} from commit",
-                        commit.reputation_scores(),
-                    );
-                    return Ok(Some(commit));
-                }
+        let iter = self.consensus_pos_idx.rev_iter(1000)?;
+        for pos in iter {
+            let pos = pos?;
+            let commit = self.data.fetch(pos.consensus_header)?.into_consensus()?.sub_dag;
+            // found a final of schedule score, so we'll return that
+            if commit.reputation_scores().final_of_schedule {
+                debug!(
+                    "Found latest final reputation scores: {:?} from commit",
+                    commit.reputation_scores(),
+                );
+                return Ok(Some(commit));
             }
         }
         debug!("No final reputation scores have been found");
@@ -1174,7 +1185,8 @@ impl Inner {
     }
 }
 
-/// Create a new set of epoch static files to write consensus output into.
+/// Take an async stream of bytes that in pack file representation of ConsensusOutput and return the
+/// ConsensusOutput.
 pub async fn bytes_to_output<R: AsyncRead + Unpin>(
     stream: R,
     compression: PackCompression,
@@ -1187,7 +1199,7 @@ pub async fn bytes_to_output<R: AsyncRead + Unpin>(
     iter_to_output(&mut stream_iter, timeout, committee).await
 }
 
-/// Create a new set of epoch static files to write consensus output into.
+/// Take an iter over PackRecords that represent a ConsensusOutput and return the ConsensusOutput.
 async fn iter_to_output<R: AsyncRead + Unpin>(
     stream_iter: &mut AsyncPackIter<PackRecord, R>,
     timeout: Duration,

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -599,28 +599,27 @@ impl Inner {
             && !PositionIndex::<T>::pdx_file_exists(&base_dir, "index_pos.pdx")
         {
             warn!(target: "consensus_pack", "Found old but not new position index, updating");
-            // We have an old index but , need to create a new one and build it.
+            // We have an old index but, need to create a new one and build it.
             // This code should only effect OG testnet nodes and should not need
             // to be maintained forever.
             let mut old_idx: PositionIndex<u64> =
-                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", true)
+                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", false)
                     .map_err(OpenError::IndexFileOpen)?;
             let _ = std::fs::remove_file(base_dir.join("index_pos.pdx.tmp"));
             let mut new_idx: PositionIndex<IndexPositions> =
                 PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx.tmp", false)
                     .map_err(OpenError::IndexFileOpen)?;
+            let mut end = 0;
             for i in 0..old_idx.len() {
                 let idx = i as u64;
-                let pos = old_idx.load(idx)?;
                 let start = if idx > 0 {
-                    let prev_pos = old_idx.load(idx - 1)?;
-                    let record_size = data.record_size(prev_pos)?;
-                    prev_pos + record_size as u64
+                    end
                 } else {
                     DATA_HEADER_BYTES as u64 + data.record_size(DATA_HEADER_BYTES as u64)? as u64
                 };
+                let pos = old_idx.load(idx)?;
                 let record_size = data.record_size(pos)?;
-                let end = pos + record_size as u64;
+                end = pos + record_size as u64;
                 new_idx
                     .save(idx, IndexPositions::new(pos, start, end))
                     .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -404,7 +404,7 @@ struct Inner {
     /// Log file for [`EpochCertificate`] entries.
     certs: Pack<EpochCertificate>,
     /// Position index: (epoch - start_epoch) → byte offset in `records`.
-    epoch_idx: PositionIndex,
+    epoch_idx: PositionIndex<u64>,
     /// Hash index: EpochRecord digest → byte offset in `records`.
     record_digests: HdxIndex,
     /// Hash index: EpochCertificate epoch_hash → byte offset in `certs`.
@@ -429,7 +429,7 @@ impl Inner {
     /// Truncate records and its indexes back to a consistent state.
     fn heal_records(
         records: &mut Pack<EpochRecord>,
-        epoch_idx: &mut PositionIndex,
+        epoch_idx: &mut PositionIndex<u64>,
         record_digests: &HdxIndex,
     ) -> Result<(), EpochDbError> {
         let records_len = records.file_len();
@@ -495,9 +495,10 @@ impl Inner {
             PackCompression::ZStd,
         )?;
 
-        let mut epoch_idx = PositionIndex::open_pdx_file(
+        let mut epoch_idx: PositionIndex<u64> = PositionIndex::open_pdx_file(
             base_dir.join(Self::EPOCH_POS_NAME),
             records.header(),
+            "index.pdx",
             false,
         )
         .map_err(OpenError::IndexFileOpen)?;

--- a/crates/types/src/consensus_chain_traits.rs
+++ b/crates/types/src/consensus_chain_traits.rs
@@ -81,14 +81,14 @@ pub trait ConsensusChainReader: Send + Sync + Clone + 'static {
     fn read_last_committed(
         &self,
         epoch: Epoch,
-    ) -> impl Future<Output = HashMap<AuthorityIdentifier, Round>> + Send;
+    ) -> impl Future<Output = eyre::Result<HashMap<AuthorityIdentifier, Round>>> + Send;
 
     /// Read the final committed sub dag of `epoch` together with its
     /// finalised reputation scores.
     fn read_latest_commit_with_final_reputation_scores(
         &self,
         epoch: Epoch,
-    ) -> impl Future<Output = Option<CommittedSubDag>> + Send;
+    ) -> impl Future<Output = eyre::Result<Option<CommittedSubDag>>> + Send;
 
     /// Load a consensus output from the current epoch by number.
     fn get_consensus_output_current(


### PR DESCRIPTION
This is a foundational refactor to allow coherent access to relevant bytes from pack files of improving sync.

It also greatly reduces the IO ops need to load a ConsensusOutput.  The core refactor is replacing the position index with a more complete version that in addition to the consensus header it also stores the bytes that make up the complete consensus output.