### PR TITLE
network-libp2p: bound codec decode buffers to delivered bytes

### DIFF
--- a/crates/network-libp2p/src/codec.rs
+++ b/crates/network-libp2p/src/codec.rs
@@ -88,8 +88,9 @@ where
     // Decompress, bounding the output to the validated `uncompressed_len` so a malformed snappy
     // stream cannot expand past `max_message_size`, and growing `decode_buffer` only as bytes are
     // produced rather than committing it up front.
+    let decode_limit = u64::try_from(uncompressed_len).map_err(std::io::Error::other)?;
     let reader = std::io::Cursor::new(&*compressed_buffer);
-    let mut decoder = FrameDecoder::new(reader).take(uncompressed_len as u64);
+    let mut decoder = FrameDecoder::new(reader).take(decode_limit);
     decoder.read_to_end(decode_buffer)?;
 
     // the decompressed output must match the reported uncompressed length

--- a/crates/network-libp2p/src/codec.rs
+++ b/crates/network-libp2p/src/codec.rs
@@ -13,11 +13,22 @@ use std::{
 };
 use tn_types::encode_into_buffer;
 
+/// Maximum number of bytes pulled from the wire in a single read while streaming in the compressed
+/// body.
+///
+/// Reading the body in bounded increments keeps committed memory proportional to the bytes that
+/// have actually arrived rather than to the attacker-declared length prefix.
+const BODY_READ_CHUNK_SIZE: usize = 8 * 1024;
+
 /// Decode a single length-prefixed, snappy-compressed BCS message from an async reader.
 ///
 /// Wire format: `[4-byte uncompressed_len][4-byte compressed_len][compressed_data]`
 ///
 /// The caller provides reusable buffers to avoid repeated allocation.
+///
+/// The length prefixes are only used to bound the read; the buffers grow with the bytes that
+/// actually arrive, so a peer that declares a large body and then withholds it cannot force a large
+/// up-front allocation.
 pub async fn decode_message<T, M>(
     io: &mut T,
     decode_buffer: &mut Vec<u8>,
@@ -55,17 +66,38 @@ where
         ));
     }
 
-    // resize buffers to reported sizes
-    decode_buffer.resize(uncompressed_len, 0);
-    compressed_buffer.resize(compressed_len, 0);
+    // Stream the compressed body in bounded chunks so committed memory tracks the bytes that
+    // actually arrive rather than the attacker-declared `compressed_len`. A peer that declares a
+    // large body but withholds it stalls here holding only what it has sent, until the request
+    // timeout reaps the stream, instead of forcing a large zero-filled allocation up front.
+    let mut remaining = compressed_len;
+    let mut chunk = [0u8; BODY_READ_CHUNK_SIZE];
+    while remaining > 0 {
+        let want = remaining.min(chunk.len());
+        let read = io.read(&mut chunk[..want]).await?;
+        if read == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "compressed body shorter than reported compressed size",
+            ));
+        }
+        compressed_buffer.extend_from_slice(&chunk[..read]);
+        remaining -= read;
+    }
 
-    // read compressed data
-    io.read_exact(compressed_buffer).await?;
-
-    // decompress
+    // Decompress, bounding the output to the validated `uncompressed_len` so a malformed snappy
+    // stream cannot expand past `max_message_size`, and growing `decode_buffer` only as bytes are
+    // produced rather than committing it up front.
     let reader = std::io::Cursor::new(&*compressed_buffer);
-    let mut decoder = FrameDecoder::new(reader);
-    decoder.read_exact(decode_buffer)?;
+    let mut decoder = FrameDecoder::new(reader).take(uncompressed_len as u64);
+    decoder.read_to_end(decode_buffer)?;
+
+    // the decompressed output must match the reported uncompressed length
+    if decode_buffer.len() != uncompressed_len {
+        return Err(std::io::Error::other(
+            "decompressed size does not match reported uncompressed size",
+        ));
+    }
 
     // deserialize
     bcs::from_bytes(decode_buffer).map_err(std::io::Error::other)

--- a/crates/network-libp2p/src/tests/codec_tests.rs
+++ b/crates/network-libp2p/src/tests/codec_tests.rs
@@ -225,3 +225,127 @@ async fn test_malicious_prefix_deceives_peer_to_read_message_and_fails() {
     let res = honest_peer.read_response(&protocol, &mut encoded.as_ref()).await;
     assert!(res.is_err());
 }
+
+/// Build the 8-byte length header a malicious peer would send: a 1 MiB uncompressed length (passes
+/// the `<= max_message_size` check) paired with a ~1.2 MB compressed length (passes the
+/// `<= snap::raw::max_compress_len(1 MiB)` check, which is ~1_223_370).
+fn malicious_header(uncompressed_len: u32, compressed_len: u32) -> Vec<u8> {
+    let mut header = Vec::with_capacity(8);
+    header.extend_from_slice(&uncompressed_len.to_le_bytes());
+    header.extend_from_slice(&compressed_len.to_le_bytes());
+    header
+}
+
+/// Regression test for issue #728: a peer that sends only the 8-byte length header and withholds
+/// the body must not cause the decoder to commit memory proportional to the declared prefixes.
+#[tokio::test]
+async fn test_header_only_does_not_commit_declared_buffers() {
+    let max_chunk_size = 1024 * 1024; // 1mb
+    let header = malicious_header(1024 * 1024, 1_200_000);
+    assert_eq!(header.len(), 8, "attacker input is only the 8-byte header");
+
+    let mut decode_buffer = Vec::new();
+    let mut compressed_buffer = Vec::new();
+    // reader yields the 8 header bytes then EOF (no body)
+    let mut reader = header.as_slice();
+    let res = decode_message::<_, TestPrimaryRequest>(
+        &mut reader,
+        &mut decode_buffer,
+        &mut compressed_buffer,
+        max_chunk_size,
+    )
+    .await;
+
+    // the decode fails because the body never arrives
+    assert!(res.is_err(), "decode must fail when the body is withheld");
+
+    // crucially, neither buffer was sized to the attacker-declared prefixes: with no body
+    // delivered, both hold zero bytes rather than the ~2.15 MiB the prefixes declared
+    assert_eq!(compressed_buffer.len(), 0, "no body arrived, so no compressed bytes are committed");
+    assert_eq!(decode_buffer.len(), 0, "decompression never ran, so no bytes are committed");
+}
+
+/// Regression test for issue #728: a peer that declares a large compressed body but delivers only
+/// part of it before closing commits memory proportional to what it actually sent, not the declared
+/// prefix.
+#[tokio::test]
+async fn test_partial_body_commits_only_delivered_bytes() {
+    let max_chunk_size = 1024 * 1024; // 1mb
+    let compressed_len: u32 = 1_000_000;
+    let delivered = 4096; // only a small slice of the declared body is sent
+
+    let mut wire = malicious_header(1024 * 1024, compressed_len);
+    wire.resize(wire.len() + delivered, 0);
+
+    let mut decode_buffer = Vec::new();
+    let mut compressed_buffer = Vec::new();
+    let mut reader = wire.as_slice();
+    let res = decode_message::<_, TestPrimaryRequest>(
+        &mut reader,
+        &mut decode_buffer,
+        &mut compressed_buffer,
+        max_chunk_size,
+    )
+    .await;
+
+    // fails because fewer bytes arrived than the declared compressed length
+    assert!(res.is_err(), "decode must fail on a short body");
+
+    // only the delivered bytes were committed, far below the ~1 MB the prefix declared
+    assert_eq!(
+        compressed_buffer.len(),
+        delivered,
+        "committed memory tracks delivered bytes, not the declared compressed_len"
+    );
+}
+
+/// Reader that yields a fixed header then stalls forever on the body read, modeling a peer that
+/// sends the length prefixes and withholds the body.
+struct HeaderThenStall {
+    header: Vec<u8>,
+    pos: usize,
+}
+
+impl futures::AsyncRead for HeaderThenStall {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        if this.pos < this.header.len() {
+            let n = (buf.len()).min(this.header.len() - this.pos);
+            buf[..n].copy_from_slice(&this.header[this.pos..this.pos + n]);
+            this.pos += n;
+            std::task::Poll::Ready(Ok(n))
+        } else {
+            // body never arrives
+            std::task::Poll::Pending
+        }
+    }
+}
+
+/// Regression test for issue #728: while parked awaiting a withheld body, the decoder holds only
+/// the bytes that have arrived (none), not the declared prefixes.
+#[tokio::test]
+async fn test_withheld_body_holds_no_declared_memory_while_parked() {
+    let mut reader = HeaderThenStall { header: malicious_header(1024 * 1024, 1_200_000), pos: 0 };
+    let mut decode_buffer = Vec::new();
+    let mut compressed_buffer = Vec::new();
+
+    let fut = decode_message::<_, TestPrimaryRequest>(
+        &mut reader,
+        &mut decode_buffer,
+        &mut compressed_buffer,
+        1024 * 1024,
+    );
+
+    // the body never arrives; the read stays parked until our short test timeout fires (on the wire
+    // the libp2p request timeout, 10s by default, governs the hold)
+    let res = tokio::time::timeout(std::time::Duration::from_millis(200), fut).await;
+    assert!(res.is_err(), "future stays parked at the body read while the body is withheld");
+
+    // while parked, nothing proportional to the declared prefixes was committed
+    assert_eq!(compressed_buffer.len(), 0, "no body bytes arrived while parked");
+    assert_eq!(decode_buffer.len(), 0, "decompression never ran while parked");
+}


### PR DESCRIPTION
network-libp2p: bound codec decode buffers to delivered bytes (#728)

## What this fixes

`TNCodec::decode_message` sized and zero-filled its decode buffers from the two attacker-declared 4-byte length prefixes before reading the body. An unauthenticated peer could send an 8-byte header declaring a ~1 MiB uncompressed length and a ~1.17 MiB compressed length, withhold the body, and commit ~2.17 MiB of resident memory per inbound substream until the 10s request timeout reaped the stream. With the default `request_response::Config` (100 concurrent streams per connection) that is roughly 217 MiB of attacker-controlled resident memory from a few hundred bytes of input, repeatable at no cost.

Fixes #728.

## The change

`crates/network-libp2p/src/codec.rs`, `decode_message`:

- Removed the two eager `resize(reported_len, 0)` calls that committed memory from the prefixes before any body byte arrived.
- The compressed body is now streamed in bounded 8 KiB chunks, appending only what actually arrives, so committed memory tracks delivered bytes rather than the declared `compressed_len`. A peer that declares a large body and withholds it holds only what it has sent until the timeout. A body shorter than the declared length is rejected with `UnexpectedEof`.
- Decompression now bounds its output to the validated `uncompressed_len` (`FrameDecoder::take(uncompressed_len)`), grows `decode_buffer` only as bytes are produced, and errors if the decompressed size disagrees with the declared prefix. This preserves the previous decompression-bomb ceiling (`max_message_size`) without the up-front commit.

The prefix validations (`uncompressed_len <= max_message_size`, `compressed_len <= snap::raw::max_compress_len(uncompressed_len)`) and the wire format are unchanged, so this is wire-compatible.

Note on implementation: the body read uses an explicit chunked loop rather than `io.take(compressed_len).read_to_end(...)` on purpose. `futures` `read_to_end` zero-fills the entire spare capacity of the target `Vec` on its first growth, which would re-introduce an eager commit for the worker's reused (pre-sized) buffers. The chunked `extend_from_slice` commits only the bytes that arrive regardless of the buffer's pre-existing capacity.

## Coverage

The same codec serves both the consensus request-response swarms (`consensus.rs`) and the worker batch-sync streams (`crates/consensus/worker/src/network/stream_codec.rs` calls the same `decode_message`/`encode_message`), so both paths are fixed by this change.

## Tests

Three regression tests added to `crates/network-libp2p/src/tests/codec_tests.rs`:

- `test_header_only_does_not_commit_declared_buffers`: a header-only read (body withheld, EOF) fails and leaves both buffers at length 0 rather than the ~2.15 MiB the prefixes declared.
- `test_partial_body_commits_only_delivered_bytes`: a peer that declares a ~1 MB body but delivers only 4096 bytes before closing commits exactly the delivered bytes, not the declared length.
- `test_withheld_body_holds_no_declared_memory_while_parked`: while the decode future is parked awaiting a withheld body, neither buffer holds memory proportional to the declared prefixes.

All existing codec tests and the 12 worker `stream_codec` tests (including the back-to-back multi-batch and multi-chunk roundtrips, which confirm the chunked read leaves the stream correctly positioned for the next message) pass unchanged.

Local gate (pinned toolchains):
- `cargo +nightly-2026-03-20 fmt --all -- --check`: clean
- `cargo +nightly-2026-03-20 clippy -p tn-network-libp2p --all-features --tests -- -D warnings`: clean
- `cargo test -p tn-network-libp2p --lib codec`: 7 passed
- `cargo test -p tn-worker --lib stream_codec`: 12 passed

## Scope and recommended follow-ups (not in this PR)

This PR removes the amplification at its root: a stalled or short body now costs the node only the bytes the peer actually sent, so the attack is bounded by attacker bandwidth rather than by an 8-byte header. The issue also lists outer-layer defenses that involve peer-scoring and connection policy decisions better owned by the maintainers, and which are deliberately left out of this focused fix:

- `request_response::Config::with_max_concurrent_streams(...)` at `consensus.rs` to tighten the per-connection blast radius.
- A libp2p `ConnectionLimits` behaviour and/or per-IP admission cap in `TNBehavior`.
- Revisiting the no-op `InboundFailure::Timeout` arm so sustained inbound timeouts from a peer are not entirely cost-free.

I'd be happy to follow up with any or all of these in a separate PR if you want them.
