### PR TITLE
Fix two critical/high issues found with a scan.

### DIFF
--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -32,3 +32,7 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = []
+adiri = []

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -491,12 +491,14 @@ impl<DB: Database> Subscriber<DB> {
                         .find(|b| b.digest() == *digest)
                     {
                         warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - duplicate");
-                        if sub_dag.leader_epoch() != 74
+                        if number != 832748
                             || self.config.config().genesis().config.chain_id != 2017
                         {
-                            // Epoch 74 of adiri testnet had a bug with duplicate batches.
-                            // We have to recreate it in order to sync testnet so we skip this push
-                            // on adiri in epoch 74.
+                            // ADIRI BUG
+                            // Epoch 74 consensus number 832748 of adiri testnet had a bug with
+                            // duplicate batches. We have to recreate it
+                            // in order to sync testnet so we skip this push
+                            // on adiri for 832748.
                             cert_batches.push(batch.clone());
                         }
                     } else {

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -495,12 +495,12 @@ impl<DB: Database> Subscriber<DB> {
                         cert_batches.push(batch.clone());
 
                         #[cfg(feature = "adiri")]
-                        if sub_dag.leader_epoch() > 150 {
+                        if sub_dag.leader_epoch() > tn_types::forks::ADIRI_DUP_BATCH_EPOCH {
                             // ADIRI BUG
-                            // Epoch 74 consensus number 832748 of adiri testnet had a bug with
-                            // duplicate batches. We have to recreate it
-                            // in order to sync testnet so we skip this push
-                            // on adiri for 832748.
+                            // Epoch 74 and possibly other early epochs of adiri testnet had a bug
+                            // with duplicate batches. We have to
+                            // recreate it in order to sync testnet so we skip this push
+                            // on adiri with early epochs.
                             cert_batches.push(batch.clone());
                         }
                     } else {

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -491,9 +491,11 @@ impl<DB: Database> Subscriber<DB> {
                         .find(|b| b.digest() == *digest)
                     {
                         warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - duplicate");
-                        if number != 832748
-                            || self.config.config().genesis().config.chain_id != 2017
-                        {
+                        #[cfg(not(feature = "adiri"))]
+                        cert_batches.push(batch.clone());
+
+                        #[cfg(feature = "adiri")]
+                        if sub_dag.leader_epoch() > 150 {
                             // ADIRI BUG
                             // Epoch 74 consensus number 832748 of adiri testnet had a bug with
                             // duplicate batches. We have to recreate it

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -491,7 +491,14 @@ impl<DB: Database> Subscriber<DB> {
                         .find(|b| b.digest() == *digest)
                     {
                         warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - duplicate");
-                        cert_batches.push(batch.clone());
+                        if sub_dag.leader_epoch() != 74
+                            || self.config.config().genesis().config.chain_id != 2017
+                        {
+                            // Epoch 74 of adiri testnet had a bug with duplicate batches.
+                            // We have to recreate it in order to sync testnet so we skip this push
+                            // on adiri in epoch 74.
+                            cert_batches.push(batch.clone());
+                        }
                     } else {
                         error!(target: "subscriber", ?digest, "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
                         return Err(SubscriberError::MissingFetchedBatch(*digest));

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -4,7 +4,7 @@ use crate::{errors::SubscriberResult, SubscriberError};
 use futures::{stream::FuturesOrdered, StreamExt};
 use state_sync::{last_consensus_parent, save_consensus, spawn_state_sync};
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{BTreeSet, HashMap, VecDeque},
     sync::Arc,
     time::Duration,
 };
@@ -458,7 +458,6 @@ impl<DB: Database> Subscriber<DB> {
         // SAFETY: 10-node committees * 6-round commit max * 5 batch max = 300 max batch digests
         // possible 32bytes * 300 = 9.6 kb => well within 1MB max message size
         let mut fetched_batches = self.fetch_batches_from_peers(batch_set).await?;
-        let fetched_digests: HashSet<BlockHash> = fetched_batches.keys().copied().collect();
 
         let mut batches = Vec::with_capacity(num_certs);
         // map all fetched batches to their respective certificates for applying block rewards
@@ -485,8 +484,15 @@ impl<DB: Database> Subscriber<DB> {
                     cert_batches.push(batch);
                 } else {
                     // if the batch is a duplicate, the engine will ignore
-                    warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - possible duplicate");
-                    if !fetched_digests.contains(digest) {
+                    if let Some(batch) = batches
+                        .iter()
+                        .flat_map(|cb: &CertifiedBatch| cb.batches.iter())
+                        .chain(cert_batches.iter())
+                        .find(|b| b.digest() == *digest)
+                    {
+                        warn!(target: "subscriber", ?digest, ?batch_digests, "failed to remove fetched batch - duplicate");
+                        cert_batches.push(batch.clone());
+                    } else {
                         error!(target: "subscriber", ?digest, "[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
                         return Err(SubscriberError::MissingFetchedBatch(*digest));
                     }

--- a/crates/consensus/executor/tests/it/main.rs
+++ b/crates/consensus/executor/tests/it/main.rs
@@ -18,9 +18,10 @@ use tn_primary::{
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils::{create_signed_certificates_for_rounds, CommitteeFixture};
 use tn_types::{
-    now, test_chain_spec_arc, Batch, BlockHash, ConsensusHeaderDigest, ConsensusNumHash,
-    ExecHeader, Hash as _, HeaderBuilder, HeaderDigest, SealedHeader, TaskManager, TnReceiver as _,
-    TnSender as _, WorkerId, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    now, test_chain_spec_arc, Batch, BlockHash, CommittedSubDag, ConsensusHeaderDigest,
+    ConsensusNumHash, ExecHeader, Hash as _, HeaderBuilder, HeaderDigest, ReputationScores,
+    SealedHeader, TaskManager, TnReceiver as _, TnSender as _, WorkerId, B256,
+    DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::sync::mpsc;
 
@@ -554,6 +555,156 @@ async fn test_duplicate_batch_digest() -> eyre::Result<()> {
         "Expected at least {expected_outputs} outputs, got {outputs_received}"
     );
     assert!(found_shared_digest, "The shared batch digest should appear in at least one output");
+
+    Ok(())
+}
+
+/// Test a single output containing one batch digest referenced by two certificates.
+///
+/// The subscriber must clone the duplicate so `batch_digests` and the flattened batches
+/// stay aligned: every flattened index maps to its own digest (block digest/mix hash
+/// binding) and the final index satisfies `close_epoch_for_last_batch` (epoch closing
+/// system calls).  Feeds a crafted subdag directly to the subscriber, bypassing Bullshark,
+/// so the duplicate is deterministically within one output.
+#[tokio::test]
+async fn test_subscriber_dup_batch_across_certs() -> eyre::Result<()> {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let config = primary.consensus_config().clone();
+    let task_manager = TaskManager::new("dup batch alignment tests");
+    let rx_shutdown = config.shutdown().subscribe();
+    let consensus_bus = ConsensusBus::new();
+    let temp_dir = TempDir::with_prefix("test_subscriber_dup_batch").unwrap();
+    let consensus_chain =
+        ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone()).await.unwrap();
+
+    let mut consensus_output = consensus_bus.app().subscribe_consensus_output();
+
+    // network mock to handle publish commands
+    let (tx, mut rx) = mpsc::channel(5);
+    tokio::spawn(async move {
+        while let Some(com) = rx.recv().await {
+            if let NetworkCommand::Publish { topic: _, msg: _, reply } = com {
+                reply.send(Ok(MessageId::new(&[0]))).unwrap();
+            }
+        }
+    });
+    let network = PrimaryNetworkHandle::new_for_test(tx);
+
+    spawn_subscriber(
+        config.clone(),
+        rx_shutdown,
+        consensus_bus.clone(),
+        &task_manager,
+        network,
+        consensus_chain.clone(),
+        u64::max_value(),
+    );
+    tokio::task::yield_now().await;
+
+    // three batches; batch_1 is shared between the two certificates
+    let chain = test_chain_spec_arc();
+    let batch_0 = tn_reth::test_utils::batch(chain.clone());
+    let batch_1 = tn_reth::test_utils::batch(chain.clone());
+    let batch_2 = tn_reth::test_utils::batch(chain);
+    let mock_batches: HashMap<BlockHash, Batch> = [
+        (batch_0.digest(), batch_0.clone()),
+        (batch_1.digest(), batch_1.clone()),
+        (batch_2.digest(), batch_2.clone()),
+    ]
+    .into_iter()
+    .collect();
+    let mock_client = Arc::new(MockPrimaryToWorkerClient { batches: mock_batches });
+    config.local_network().set_primary_to_worker_local_handler(mock_client);
+
+    // two round 1 certificates from different authorities sharing batch_1
+    let authorities: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
+    let parents: BTreeSet<HeaderDigest> = fixture.genesis().collect();
+    let header_a = HeaderBuilder::default()
+        .author(authorities[0].clone())
+        .round(1)
+        .epoch(0)
+        .parents(parents.clone())
+        .created_at(now())
+        .with_payload_batch(&batch_0, 0)
+        .with_payload_batch(&batch_1, 0)
+        .build();
+    let cert_a = fixture.certificate(&header_a);
+    let header_b = HeaderBuilder::default()
+        .author(authorities[1].clone())
+        .round(1)
+        .epoch(0)
+        .parents(parents)
+        .created_at(now())
+        .with_payload_batch(&batch_1, 0)
+        .with_payload_batch(&batch_2, 0)
+        .build();
+    let cert_b = fixture.certificate(&header_b);
+
+    let sub_dag = CommittedSubDag::new(
+        vec![cert_a, cert_b.clone()],
+        cert_b,
+        1,
+        ReputationScores::default(),
+        None,
+    );
+    // expected digests in subdag iteration order (contains the duplicate)
+    let expected_digests: Vec<BlockHash> =
+        sub_dag.headers().iter().flat_map(|header| header.payload().keys().copied()).collect();
+    assert_eq!(expected_digests.len(), 4, "two payloads of two with one shared digest");
+
+    // feed the subdag straight to the subscriber
+    consensus_bus.sequence().send(sub_dag).await?;
+
+    let mut output = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        consensus_output.recv().await
+    })
+    .await
+    .expect("timed out waiting for consensus output — subscriber may have crashed")
+    .expect("consensus output");
+
+    // digests and flattened batches must stay aligned, including the duplicate
+    assert_eq!(output.batch_digests().len(), expected_digests.len());
+    let flattened = output.flatten_batches();
+    assert_eq!(
+        flattened.len(),
+        output.batch_digests().len(),
+        "uneven number of batches and batch digests"
+    );
+    for (index, (cert_idx, batch_idx)) in flattened.iter().enumerate() {
+        let batch = &output.batches()[*cert_idx].batches[*batch_idx];
+        let digest = output.get_batch_digest(index).expect("digest for index");
+        assert_eq!(digest, expected_digests[index], "wrong digest order at index {index}");
+        assert_eq!(
+            batch.digest(),
+            digest,
+            "batch executed at index {index} bound to the wrong digest"
+        );
+    }
+
+    // both certificates carry their full batch lists (duplicate cloned into the second)
+    let batches = output.batches();
+    assert_eq!(batches.len(), 2);
+    assert_eq!(batches[0].batches.len(), 2);
+    assert_eq!(batches[1].batches.len(), 2);
+    assert_eq!(batches[1].batches[0].digest(), batch_1.digest(), "duplicate batch not cloned");
+
+    // the last flattened index closes the epoch (engine applies closing system calls)
+    output.set_epoch_close();
+    let last = output.batch_digests().len() - 1;
+    for index in 0..last {
+        assert_eq!(
+            output.close_epoch_for_last_batch(index),
+            Some(false),
+            "index {index} must not close the epoch"
+        );
+    }
+    assert_eq!(
+        output.close_epoch_for_last_batch(last),
+        Some(true),
+        "last batch must close the epoch"
+    );
 
     Ok(())
 }

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -557,7 +557,7 @@ pub(crate) fn send_tel(
     to_addr.copy_from_slice(to_account.as_slice());
     let (from_account, _, _) = decode_key(key)?;
     let new_transaction = LegacyTransaction {
-        chain: 0x7e1,
+        chain: 0xde7e1,
         nonce,
         to: Some(to_addr),
         value: amount,

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -38,25 +38,25 @@ fn run_restart_tests1(
         info.get("execution_address").unwrap(),
         "0x1111111111111111111111111111111111111111"
     );
-    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(2017.into()));
+    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(911329.into()));
     let info = get_node_info(&client_urls[1]).unwrap();
     assert_eq!(
         info.get("execution_address").unwrap(),
         "0x2222222222222222222222222222222222222222"
     );
-    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(2017.into()));
+    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(911329.into()));
     let info = get_node_info(&client_urls[2]).unwrap();
     assert_eq!(
         info.get("execution_address").unwrap(),
         "0x3333333333333333333333333333333333333333"
     );
-    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(2017.into()));
+    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(911329.into()));
     let info = get_node_info(&client_urls[3]).unwrap();
     assert_eq!(
         info.get("execution_address").unwrap(),
         "0x4444444444444444444444444444444444444444"
     );
-    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(2017.into()));
+    assert_eq!(info.get("chain_id").unwrap(), &serde_json::Value::Number(911329.into()));
     let key = get_key("test-source");
     let to_account = address_from_word("testing");
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -36,6 +36,7 @@ assert_matches = { workspace = true }
 [features]
 default = []
 test-utils = ["dep:eyre"]
+adiri = []
 
 [lints]
 workspace = true

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -62,11 +62,12 @@ pub fn execute_consensus_output(
         ));
 
         #[cfg(feature = "adiri")]
-        if epoch > 150 {
+        if epoch > tn_types::forks::ADIRI_DUP_BATCH_EPOCH {
             // ADIRI BUG
-            // Epoch 74 consensus number 832748 of adiri testnet had a bug with duplicate batches.
-            // We have to recreate it in order to sync testnet so we skip this push
-            // on adiri for 832748.
+            // Epoch 74 and possibly other early epochs of adiri testnet had a bug with duplicate
+            // batches. We have to recreate it in order to sync testnet so we skip this
+            // error (it will happen and needs to be ignored) on adiri with early
+            // epochs.
             return Err(TnEngineError::ConsensusOutputUnevenBatches(
                 batches.len(),
                 output.batch_digests().len(),

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -55,7 +55,14 @@ pub fn execute_consensus_output(
     );
     // This should maybe panic but for prod code at least error out since this an invalid condition.
     if batches.len() != output.batch_digests().len() {
-        if output.number() != 832748 || reth_env.chainspec().chain_id() != 2017 {
+        #[cfg(not(feature = "adiri"))]
+        return Err(TnEngineError::ConsensusOutputUnevenBatches(
+            batches.len(),
+            output.batch_digests().len(),
+        ));
+
+        #[cfg(feature = "adiri")]
+        if epoch > 150 {
             // ADIRI BUG
             // Epoch 74 consensus number 832748 of adiri testnet had a bug with duplicate batches.
             // We have to recreate it in order to sync testnet so we skip this push

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -55,10 +55,16 @@ pub fn execute_consensus_output(
     );
     // This should maybe panic but for prod code at least error out since this an invalid condition.
     if batches.len() != output.batch_digests().len() {
-        return Err(TnEngineError::ConsensusOutputUnevenBatches(
-            batches.len(),
-            output.batch_digests().len(),
-        ));
+        if output.number() != 832748 || reth_env.chainspec().chain_id() != 2017 {
+            // ADIRI BUG
+            // Epoch 74 consensus number 832748 of adiri testnet had a bug with duplicate batches.
+            // We have to recreate it in order to sync testnet so we skip this push
+            // on adiri for 832748.
+            return Err(TnEngineError::ConsensusOutputUnevenBatches(
+                batches.len(),
+                output.batch_digests().len(),
+            ));
+        }
     }
 
     // ensure at least 1 block for empty output when close_epoch is true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -47,6 +47,7 @@ redb = []
 reth-libmdbx = ["dep:reth-libmdbx", "dep:page_size"]
 default = ["reth-libmdbx"]
 test-utils = []
+adiri = []
 
 [lints]
 workspace = true

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1258,15 +1258,19 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
             }
         }
     }
-    if let Some(header) = header {
-        let parent_hash = header.parent_hash;
-        let deliver = header.sub_dag;
+    if let Some(consensus_header) = header {
+        let parent_hash = consensus_header.parent_hash;
+        let deliver = consensus_header.sub_dag;
         let num_blocks = deliver.num_primary_batches();
         let num_certs = deliver.len();
 
         let sub_dag = deliver;
         if num_blocks == 0 {
-            return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, header.number));
+            return Ok(ConsensusOutput::new_with_subdag(
+                sub_dag,
+                parent_hash,
+                consensus_header.number,
+            ));
         }
 
         let mut batch_digests = VecDeque::with_capacity(num_certs);
@@ -1296,7 +1300,17 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                         .chain(cert_batches.iter())
                         .find(|b| b.digest() == *digest)
                     {
+                        // We don't have easy access to the chain id...
+                        //if consensus_header.number != 832748
+                        //    || self.config.config().genesis().config.chain_id != 2017
+                        //{
+                        // ADIRI BUG
+                        // Epoch 74 consensus number 832748 of adiri testnet had a bug with
+                        // duplicate batches. We have to recreate it in
+                        // order to sync testnet so we skip this push
+                        // on adiri for 832748.
                         cert_batches.push(batch.clone());
+                        //}
                     } else {
                         return Err(PackError::MissingBatch);
                     }
@@ -1313,7 +1327,14 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                 return Err(PackError::MissingAuthority);
             }
         }
-        Ok(ConsensusOutput::new(sub_dag, parent_hash, header.number, false, batch_digests, batches))
+        Ok(ConsensusOutput::new(
+            sub_dag,
+            parent_hash,
+            consensus_header.number,
+            false,
+            batch_digests,
+            batches,
+        ))
     } else {
         Err(PackError::NotConsensus)
     }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1300,17 +1300,18 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                         .chain(cert_batches.iter())
                         .find(|b| b.digest() == *digest)
                     {
-                        // We don't have easy access to the chain id...
-                        //if consensus_header.number != 832748
-                        //    || self.config.config().genesis().config.chain_id != 2017
-                        //{
-                        // ADIRI BUG
-                        // Epoch 74 consensus number 832748 of adiri testnet had a bug with
-                        // duplicate batches. We have to recreate it in
-                        // order to sync testnet so we skip this push
-                        // on adiri for 832748.
+                        #[cfg(not(feature = "adiri"))]
                         cert_batches.push(batch.clone());
-                        //}
+
+                        #[cfg(feature = "adiri")]
+                        if sub_dag.leader_epoch() > 150 {
+                            // ADIRI BUG
+                            // Epoch 74 consensus number 832748 of adiri testnet had a bug with
+                            // duplicate batches. We have to recreate it in
+                            // order to sync testnet so we skip this push
+                            // on adiri for 832748.
+                            cert_batches.push(batch.clone());
+                        }
                     } else {
                         return Err(PackError::MissingBatch);
                     }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1304,12 +1304,12 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                         cert_batches.push(batch.clone());
 
                         #[cfg(feature = "adiri")]
-                        if sub_dag.leader_epoch() > 150 {
+                        if sub_dag.leader_epoch() > tn_types::forks::ADIRI_DUP_BATCH_EPOCH {
                             // ADIRI BUG
-                            // Epoch 74 consensus number 832748 of adiri testnet had a bug with
-                            // duplicate batches. We have to recreate it in
-                            // order to sync testnet so we skip this push
-                            // on adiri for 832748.
+                            // Epoch 74 and possibly other early epochs of adiri testnet had a bug
+                            // with duplicate batches. We have to
+                            // recreate it in order to sync testnet so we skip this push
+                            // on adiri with early epochs.
                             cert_batches.push(batch.clone());
                         }
                     } else {

--- a/crates/telcoin-network-cli/Cargo.toml
+++ b/crates/telcoin-network-cli/Cargo.toml
@@ -65,3 +65,6 @@ vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }
 
 [lints]
 workspace = true
+
+[features]
+adiri = []

--- a/crates/telcoin-network-cli/src/genesis/mod.rs
+++ b/crates/telcoin-network-cli/src/genesis/mod.rs
@@ -107,8 +107,8 @@ pub struct GenesisArgs {
     #[arg(long)]
     pub min_header_delay_ms: Option<u64>,
     /// Numeric chain id that will go in the genesis.
-    /// Default is 0x7e1 (2017).
-    #[arg(long, default_value_t = 2017, value_parser=maybe_hex)]
+    /// Default is 0xde7e1 (911329).  Used mostly for testing.
+    #[arg(long, default_value_t = 911329, value_parser=maybe_hex)]
     pub chain_id: u64,
     /// Per-worker fee config overrides at genesis.
     ///

--- a/crates/telcoin-network-cli/src/node.rs
+++ b/crates/telcoin-network-cli/src/node.rs
@@ -141,6 +141,22 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
         } else {
             Config::load(&tn_datadir, self.observer, SHORT_VERSION)?
         };
+        #[cfg(not(feature = "adiri"))]
+        if tn_config.genesis().config.chain_id == 2017 {
+            // If we are trying to start an Adiri node without the adiri feature flag then error
+            // out.
+            return Err(eyre::eyre!(
+                "Must compile with adiri feature flag in order to connect to adiri (testnet)!"
+            ));
+        }
+        #[cfg(feature = "adiri")]
+        if tn_config.genesis().config.chain_id != 2017 {
+            // If we are trying to start an Adiri node without the adiri feature flag then error
+            // out.
+            return Err(eyre::eyre!(
+                "Must NOT compile with adiri feature flag when connecting to non-adiri (testnet) networks!"
+            ));
+        }
         debug!(target: "cli", validator = ?tn_config.node_info.name, "tn datadir for node command: {tn_datadir:?}");
         info!(target: "cli", validator = ?tn_config.node_info.name, "config loaded");
 

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -75,6 +75,7 @@ tn-reth = { workspace = true, features = ["test-utils"] }
 default = []
 faucet = []
 test-utils = ["dep:secp256k1"]
+adiri = ["faucet"]
 
 [lints]
 workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -52,6 +52,7 @@ tn-storage = { workspace = true, features = ["test-utils"] }
 [features]
 default = []
 test-utils = ["tracing-subscriber", "clap"]
+adiri = []
 
 [lints]
 workspace = true

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -1,0 +1,8 @@
+//! Code to support various chain forks.
+
+#[cfg(feature = "adiri")]
+use crate::Epoch;
+
+#[cfg(feature = "adiri")]
+/// The epoch below which Adiri testnet may have had duplicate batches.
+pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 153;

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -5,4 +5,4 @@ use crate::Epoch;
 
 #[cfg(feature = "adiri")]
 /// The epoch below which Adiri testnet may have had duplicate batches.
-pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 153;
+pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 158;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -26,6 +26,7 @@ mod task_manager;
 mod worker;
 #[macro_use]
 pub mod error;
+pub mod forks;
 
 pub use codec::*;
 pub use committee::*;


### PR DESCRIPTION
We need to sync testnet past epoch 74 as a sanity check.  Should work based on how packs provide ConsesusOutput.

Issues this addresses:

### 1. Epoch-closing system call silently skipped when final output contains a duplicate batch digest
- **Severity (initial)**: Critical
- **Category**: Consensus Safety
- **Location**: `crates/types/src/primary/output.rs:240-244` (interacting with `crates/consensus/executor/src/subscriber.rs:450-456`)
- **Claim**: `close_epoch_for_last_batch(index)` returns `Some(true)` only when `(index + 1) >= batch_digests.len()`. The subscriber keeps duplicate occurrences in `batch_digests` (pushed at subscriber.rs:450-456) but drops them from `batches` (subscriber.rs:477-493), so the maximum flattened `batch_index` reached by the engine loop is `batch_digests.len() - dup_count - 1` and the condition is never satisfied. If the epoch-closing `ConsensusOutput` contains a duplicated batch digest, no `TNPayload` receives `close_epoch: Some(randomness)`, so `apply_consensus_block_rewards` and `apply_closing_epoch_contract_call` are never invoked. All validators skip identically; the on-chain epoch is never concluded. A single Byzantine validator can trigger this by including an already-referenced batch digest in its header during the epoch-boundary commit window.
- **Key Question**: With `close_epoch == true` and `batch_digests` of length N containing one duplicate while flattened `batches` has N-1 entries, does any iteration of the payload loop satisfy `(index + 1) >= N`, and is there any other code path that applies the closing system calls for a non-empty final output?
- **Relevant Files**: crates/types/src/primary/output.rs, crates/consensus/executor/src/subscriber.rs, crates/engine/src/payload_builder.rs, crates/tn-reth/src/payload.rs, crates/tn-reth/src/evm/block.rs, crates/node/src/manager/node/epoch.rs
- **Source**: tn-review

### 2. Duplicate batch digests desynchronize `batch_digests` from `batches`, misaligning digest→block mapping
- **Severity (initial)**: High
- **Category**: Consensus Safety
- **Location**: `crates/consensus/executor/src/subscriber.rs:477-493` (root cause), manifesting at `crates/engine/src/payload_builder.rs:117-120`
- **Claim**: In `Subscriber::fetch_batches`, `batch_digests` is built by pushing every payload digest of every header including duplicates, but duplicate occurrences are dropped from `cert_batches`/`batches`. The resulting `ConsensusOutput` has `batch_digests.len() > flatten_batches().len()`. The engine's `execute_consensus_output` loop indexes `output.get_batch_digest(batch_index)` by the flattened-batches enumeration index, so every batch positioned after a duplicate's second occurrence executes with the wrong `batch_digest` (used as the block's ommers-hash field) and wrong `mix_hash`/prev_randao. The guard at payload_builder.rs:51-55 is only a `debug_assert_eq!`. Behavior is identical on all honest validators (no divergence), but canonical blocks permanently record incorrect batch-digest bindings and duplicated randomness.
- **Key Question**: In a sub-dag where one batch digest appears in two headers, does `output.batch_digests().len()` exceed `output.flatten_batches().len()`, and does the block built for the post-duplicate batch receive the duplicate's digest as its `batch_digest`/`mix_hash` instead of its own?
- **Relevant Files**: crates/consensus/executor/src/subscriber.rs, crates/engine/src/payload_builder.rs, crates/types/src/primary/output.rs, crates/tn-reth/src/payload.rs
- **Source**: tn-review