### PR TITLE
fix(network): handle unresolved peer identity in gossip and response paths (#743)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -832,8 +832,11 @@ where
 
                 // process gossip in application layer
                 if valid {
-                    // We should not be able to recieve a message from an unknown peer so this
-                    // should always work.
+                    // A peer is `Connected` before its `NodeRecord` resolves its BLS
+                    // identity, so a live mesh neighbor can relay a message before
+                    // `peer_to_bls` can resolve it. This is rare on a warm node but
+                    // reachable, so handle the unresolved case explicitly instead of
+                    // dropping an accepted message with no trace.
                     if let Some(bls) =
                         self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source)
                     {
@@ -846,6 +849,19 @@ where
                             // During epoch change the event_stream reciever can be closed.
                             return Ok(());
                         }
+                    } else {
+                        // The message was accepted into the mesh (and re-propagated),
+                        // but this node cannot yet resolve the relaying peer's BLS
+                        // identity, so it is not delivered to the local consensus
+                        // layer. Warn so the drop is observable rather than silent;
+                        // the node recovers the payload via sync once the identity
+                        // resolves.
+                        warn!(
+                            target: "network",
+                            ?propagation_source,
+                            ?message_id,
+                            "accepted gossip not delivered locally: relaying peer's BLS identity is not yet resolved"
+                        );
                     }
                 } else {
                     let GossipMessage { source, topic, .. } = message;
@@ -951,16 +967,13 @@ where
 
                         // try to forward response to original caller
                         let _ = self.outbound_requests.remove(&(peer, request_id)).map(|ack| {
-                            if let Some(key) =
-                                self.swarm.behaviour().peer_manager.peer_to_bls(&peer)
-                            {
-                                let _ = ack.send(Ok(NetworkResponseMessage {
-                                    peer: key,
-                                    result: response,
-                                }));
-                            } else {
-                                let _ = ack.send(Err(NetworkError::PeerMissing));
-                            }
+                            // The response payload is genuine (we still hold the
+                            // matching outbound request). If the responder's BLS
+                            // identity has not resolved yet, report a transient
+                            // `PeerUnresolved` rather than a misleading `PeerMissing`
+                            // so the caller does not retry a request that succeeded.
+                            let resolved = self.swarm.behaviour().peer_manager.peer_to_bls(&peer);
+                            let _ = ack.send(resolve_response(resolved, response));
                         });
                     }
                 }
@@ -1642,4 +1655,20 @@ where
             .field("swarm", &"<swarm>") // Skip detailed debug for swarm
             .finish()
     }
+}
+
+/// Pair a response payload with the responding peer's resolved BLS identity.
+///
+/// The payload is genuine whenever this node still holds the matching outbound
+/// request, so a peer whose identity has not resolved yet (it connected before
+/// its `NodeRecord` populated the confirmed-identity index) is reported as a
+/// transient [`NetworkError::PeerUnresolved`] rather than the misleading
+/// [`NetworkError::PeerMissing`].
+fn resolve_response<Res: TNMessage>(
+    resolved: Option<BlsPublicKey>,
+    response: Res,
+) -> NetworkResult<NetworkResponseMessage<Res>> {
+    resolved
+        .map(|peer| NetworkResponseMessage { peer, result: response })
+        .ok_or(NetworkError::PeerUnresolved)
 }

--- a/crates/network-libp2p/src/error.rs
+++ b/crates/network-libp2p/src/error.rs
@@ -100,6 +100,16 @@ pub enum NetworkError {
     /// The requested peer is not on our local store.
     #[error("Requested peer is not in our local store.")]
     PeerMissing,
+    /// The peer's BLS identity has not been resolved yet.
+    ///
+    /// The peer is connected, but it connected before its `NodeRecord` populated
+    /// the confirmed-identity index, so no `BlsPublicKey` can be attached to its
+    /// message or response. This is a transient resolution gap, distinct from
+    /// [`NetworkError::PeerMissing`] ("not in our local store"): the underlying
+    /// payload is genuine, so a caller should treat it as a retryable race rather
+    /// than a failed exchange.
+    #[error("Peer identity not yet resolved.")]
+    PeerUnresolved,
     /// Kademlia error.
     #[error("Failed to get kad record: {0}")]
     GetKademliaRecord(#[from] GetRecordError),

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -7,12 +7,13 @@ use crate::common::{
 };
 use assert_matches::assert_matches;
 use eyre::eyre;
+use rand::{rngs::StdRng, SeedableRng as _};
 use std::num::NonZeroUsize;
 use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::{Certificate, Header, TaskManager};
+use tn_types::{BlsKeypair, Certificate, Header, TaskManager};
 use tokio::{sync::mpsc, time::timeout};
 
 /// Test topic for gossip.
@@ -2537,5 +2538,27 @@ async fn test_startup_tolerates_legacy_and_corrupt_kad_records() -> eyre::Result
     assert!(store.get(&kad::RecordKey::new(&garbage_bls)).is_none(), "corrupt record purged");
     assert!(store.get(&kad::RecordKey::new(&owner_bls)).is_some(), "legacy record preserved");
 
+    Ok(())
+}
+
+/// Regression for issue #743: a response from a peer whose BLS identity is not
+/// yet resolved must surface as the transient `PeerUnresolved`, never the
+/// misleading `PeerMissing`, because the response payload itself is genuine.
+#[test]
+fn unresolved_response_reports_peer_unresolved_not_peer_missing() -> eyre::Result<()> {
+    let response = TestWorkerResponse::MissingBatches { batches: vec![] };
+    let result = resolve_response(None, response);
+    assert_matches!(result, Err(NetworkError::PeerUnresolved));
+    Ok(())
+}
+
+/// A resolved responder identity is attached to the genuine response payload.
+#[test]
+fn resolved_response_attaches_identity_to_payload() -> eyre::Result<()> {
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([7; 32])).public();
+    let response = TestWorkerResponse::MissingBatches { batches: vec![] };
+    let NetworkResponseMessage { peer, result } = resolve_response(Some(bls), response.clone())?;
+    assert_eq!(peer, bls);
+    assert_eq!(result, response);
     Ok(())
 }


### PR DESCRIPTION
## Summary

Issue #743: when a relaying peer is `Connected` but its BLS identity has not yet
resolved (it connected before its `NodeRecord` populated the confirmed-identity
index `bls_by_peer_id`), `peer_to_bls` returns `None`. Two delivery paths in
`consensus.rs` mishandled that window:

- **Gossip:** a valid, accepted (and already re-propagated) message was dropped
  locally with no log when `peer_to_bls(&propagation_source)` returned `None`, so
  the loss was invisible in production.
- **Response:** a genuine RPC response was converted into
  `NetworkError::PeerMissing` (a spurious failure) when `peer_to_bls(&peer)`
  returned `None`.

The request path in the same file already handles this exact race deliberately
(it sends a `NetworkEvent::Error` back). This PR brings the gossip and response
paths in line.

## Changes

- **Gossip:** add the missing `else` branch and emit a `warn!` so an undelivered
  accepted message is observable instead of silently dropped. Corrected the
  inline comment that asserted the unknown-peer case "should always work"; the
  issue documents why the window is reachable.
- **Response:** introduce `NetworkError::PeerUnresolved` and a small pure helper
  `resolve_response`, so an unresolved responder identity is reported as a
  transient, retryable race distinct from `PeerMissing` ("not in our local
  store"). The success path is unchanged.
- `NetworkError::PeerUnresolved` is additive. No code matches `NetworkError`
  variants exhaustively, so existing callers are unaffected; callers that want to
  can now distinguish the transient race from a genuine miss.

## Scope

This addresses the reliability and observability gap (the "at minimum, emit a
`warn!`" option in the issue). It deliberately does not yet surface the
unresolved-gossip event to the application layer for buffer-or-penalize handling
(the issue's "better" option). That is a larger cross-crate design change that
overlaps the #739 plan to turn peer admission into an explicit decision, so it is
better as a focused follow-up than bundled here.

## Testing

- `cargo +nightly-2026-03-20 fmt --all -- --check`: clean
- `cargo +nightly-2026-03-20 clippy -p tn-network-libp2p --all-features --all-targets -- -D warnings`: clean
- `cargo +1.94 test -p tn-network-libp2p --all-features`: 135 passed, 0 failed

Adds two deterministic regression tests covering the resolved and unresolved
response paths.

## Dependencies

Independent of the other open network PRs. If #749 (owning outbound-failure
types) lands first, the only interaction is a trivial adjacency in `error.rs`
(both add a `NetworkError` variant). #740 (#722 rotation) is complementary and
does not close this window, so the fix is still needed regardless.

Closes #743.