### PR TITLE
Use saturating sub when collecting epoch records and going back one.

### DIFF
--- a/crates/state-sync/src/epoch.rs
+++ b/crates/state-sync/src/epoch.rs
@@ -93,7 +93,7 @@ async fn collect_epoch_records(
                     // Should not be here but if so just skipping won't really help...
                     // Reduce last_epoch by one and once this loop finishes skipping we can
                     // try to get the missing epoch again.
-                    return epoch - 1;
+                    return epoch.saturating_sub(1);
                 };
                 // Verify the epoch has the expected parent and committee and is signed by
                 // that committee.
@@ -110,7 +110,7 @@ async fn collect_epoch_records(
                             ?e,
                             "failed to save epoch record/cert for epoch {epoch}",
                         );
-                        return epoch - 1;
+                        return epoch.saturating_sub(1);
                     }
                     result_epoch = epoch;
                     info!(
@@ -133,7 +133,7 @@ async fn collect_epoch_records(
                         ?epoch_valid,
                         "got an invalid epoch record, epoch {epoch}",
                     );
-                    return epoch - 1;
+                    return epoch.saturating_sub(1);
                 }
             }
             Err(err) => {


### PR DESCRIPTION
This uses some saturating subs in a few places that had potential roll overs in prod code.  Addressed this finding:

### 5. `collect_epoch_records` u32 underflow at epoch 0 disables epoch-record collector (pre-existing)
- **Severity (initial)**: High
- **Category**: Liveness
- **Location**: `crates/state-sync/src/epoch.rs:96`, `crates/state-sync/src/epoch.rs:113`, `crates/state-sync/src/epoch.rs:136`
- **Claim**: When a fresh node requests epoch 0's record/cert from peers and validation of a peer response fails, the function executes `return epoch - 1` with `epoch == 0`. With release-profile arithmetic (no `overflow-checks`), this wraps to `u32::MAX`, which becomes `last_epoch` in `spawn_epoch_record_collector` (epoch.rs:190-201); `requested_epoch >= last_epoch` is then effectively never true again, silently disabling epoch-record collection for the process lifetime. A node that cannot collect epoch records cannot sync past epoch boundaries. In debug builds this panics. The code is byte-identical on `origin/main` (pre-existing, file modified by this branch).
- **Key Question**: Does `request_epoch_cert(Some(0), None)` accept the first peer response such that an invalid record reaches the `return epoch - 1` statements at lines 113/136 with `epoch == 0`, with no saturating arithmetic or earlier guard?
- **Relevant Files**: crates/state-sync/src/epoch.rs, crates/consensus/primary/src/network/mod.rs, crates/node/src/manager/node/epoch.rs, Cargo.toml
- **Source**: tn-review