### PR TITLE
Make sure we can not save consensus to the wrong epoch pack file.

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -485,6 +485,7 @@ impl PrimaryNetworkHandle {
             ConsensusChainError::StreamUnavailable
             | ConsensusChainError::NoCurrentEpoch
             | ConsensusChainError::EpochDbError(_)
+            | ConsensusChainError::InvalidPackEpoch(_, _)
             | ConsensusChainError::IO(_) => None,
         }
     }

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -494,8 +494,19 @@ impl ConsensusChain {
         if number > self.latest_consensus.number() {
             let epoch = consensus.sub_dag().leader_epoch();
             if let Some(pack) = &self.current_pack() {
-                pack.save_consensus_output(consensus).await?;
-                self.latest_consensus.update(epoch, number).await;
+                if epoch != pack.epoch() {
+                    // The output's epoch does not match the current pack. Saving it would either
+                    // corrupt this pack or poison its async error channel. The pack
+                    // layer also rejects this (defense in depth), but the reject is asynchronous so
+                    // we must guard here to avoid advancing latest_consensus to a wrong-epoch
+                    // pointer for data that was never persisted.
+                    // This is an error and should not happen on a properly working node.
+                    error!(target: "consensus-chain", epoch, pack_epoch = pack.epoch(), number, "Refused to save consensus output: epoch does not match the current pack.");
+                    return Err(ConsensusChainError::InvalidPackEpoch(pack.epoch(), epoch));
+                } else {
+                    pack.save_consensus_output(consensus).await?;
+                    self.latest_consensus.update(epoch, number).await;
+                }
             } else if let Ok(pack) = self.get_static(epoch).await {
                 // We may be replaying consensus from old epochs and not have a current pack to save
                 // too.
@@ -874,6 +885,7 @@ pub enum ConsensusChainError {
     EmptyImport,
     InvalidImport,
     StreamUnavailable,
+    InvalidPackEpoch(Epoch, Epoch),
 }
 
 impl Error for ConsensusChainError {}
@@ -897,6 +909,9 @@ impl Display for ConsensusChainError {
             }
             ConsensusChainError::StreamUnavailable => {
                 write!(f, "Incomplete data to stream a pack file")
+            }
+            ConsensusChainError::InvalidPackEpoch(pack_epoch, epoch) => {
+                write!(f, "Tried to save an output from epoch {epoch} into the current pack epoch {pack_epoch}")
             }
         }
     }
@@ -984,7 +999,7 @@ mod test {
     };
 
     use crate::{
-        consensus::ConsensusChain,
+        consensus::{ConsensusChain, ConsensusChainError},
         consensus_pack::test::{compare_outputs, make_test_output},
         mem_db::MemDatabase,
     };
@@ -1012,6 +1027,59 @@ mod test {
         assert_eq!(latest.epoch(), 2);
         assert_eq!(latest.number(), 20);
         assert_eq!(latest.current_slot(), ConsensusSlot::Slot2);
+    }
+
+    #[tokio::test]
+    async fn test_save_consensus_output_wrong_epoch_rejected() {
+        let temp_dir = TempDir::with_prefix("test_wrong_epoch").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        // Save a few legitimate epoch-0 outputs.
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..3u64 {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            consensus_chain.save_consensus_output(output).await.unwrap();
+        }
+        assert_eq!(consensus_chain.latest_consensus.number(), 3);
+        assert_eq!(consensus_chain.latest_consensus.epoch(), 0);
+
+        // Feed an output whose leader epoch is 1 while the current pack is still epoch 0.
+        // It must be rejected with InvalidPackEpoch before latest_consensus advances or the data
+        // is saved.
+        let next_committee = committee.advance_epoch_for_test(1);
+        let wrong = make_test_output(&next_committee, 0, chain.clone(), 4, parent);
+        assert_eq!(wrong.sub_dag().leader_epoch(), 1, "test output must be from epoch 1");
+        let err = consensus_chain
+            .save_consensus_output(wrong)
+            .await
+            .expect_err("wrong-epoch output must be rejected");
+        assert!(
+            matches!(err, ConsensusChainError::InvalidPackEpoch(0, 1)),
+            "expected InvalidPackEpoch(0, 1), got {err:?}"
+        );
+
+        assert_eq!(
+            consensus_chain.latest_consensus.number(),
+            3,
+            "latest_consensus must not advance on a wrong-epoch output"
+        );
+        assert_eq!(consensus_chain.latest_consensus.epoch(), 0);
+        assert!(
+            consensus_chain.get_consensus_output_current(4).await.is_err(),
+            "wrong-epoch output must not be persisted to the epoch-0 pack"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -937,6 +937,17 @@ impl Inner {
         let consensus_number = consensus.number();
         // Adjusted consensus index for this pack file.
         let consensus_idx = consensus_number.saturating_sub(self.epoch_meta.start_consensus_number);
+        let epoch = consensus.sub_dag().leader_epoch();
+        if epoch != self.epoch_meta.epoch {
+            // Trying to save to the wrong epoch...
+            return Err(PackError::InvalidEpoch(
+                epoch,
+                format!(
+                    "Tried to save output from epoch {epoch} to the pack file for epoch {}",
+                    self.epoch_meta.epoch
+                ),
+            ));
+        }
         // Make sure this number is valid before we write anything...
         if (consensus_idx as usize) < self.consensus_pos_idx.len() {
             // If we have saved this output already then ignore it.

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1665,6 +1665,44 @@ pub(crate) mod test {
     }
 
     #[tokio::test]
+    async fn test_pack_save_wrong_epoch_rejected() {
+        let temp_dir = TempDir::with_prefix("test_pack_wrong_epoch").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let pack = ConsensusPack::open_append(temp_dir.path(), previous_epoch, committee.clone())
+            .expect("open pack");
+
+        // An output whose leader epoch differs from the pack's epoch must be rejected by
+        // Inner::save_consensus_output rather than appended at a saturated index.
+        let next_committee = committee.advance_epoch_for_test(1);
+        let parent = ConsensusHeader::default().digest();
+        let wrong = make_test_output(&next_committee, 0, chain.clone(), 1, parent);
+        assert_ne!(wrong.sub_dag().leader_epoch(), committee.epoch());
+        pack.save_consensus_output(wrong).await.expect("queued to pack thread");
+
+        // The rejection is delivered asynchronously via the watch channel; poll for it.
+        let mut err = None;
+        for _ in 0..100 {
+            if let Err(e) = pack.get_error() {
+                err = Some(e);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            matches!(err, Some(super::PackError::InvalidEpoch(..))),
+            "expected InvalidEpoch, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_consensus_pack() {
         let temp_dir = TempDir::with_prefix("test_consensus_pack").expect("temp dir");
         let fixture = CommitteeFixture::builder(MemDatabase::default).build();


### PR DESCRIPTION
This was added to address this finding.  Note this should not happen and has not on testnet or else packs would be corrupt but this is a reasonable defense.

### 4. Epoch-mismatched ConsensusOutput can be appended into the wrong pack file
- **Severity (initial)**: High
- **Category**: State corruption
- **Location**: `crates/storage/src/consensus.rs:494-498`, `crates/storage/src/consensus_pack.rs:882-896`
- **Claim**: `ConsensusChain::save_consensus_output` branch 1 writes to `current_pack` without checking `consensus.sub_dag().leader_epoch() == pack.epoch()`. In `Inner::save_consensus_output`, `consensus_idx = consensus_number.saturating_sub(self.epoch_meta.start_consensus_number)` maps any output with `number < start_consensus_number` to index 0; on a freshly-created empty epoch pack, the guards `0 < 0` and `0 != 0` both pass, so a prior-epoch header and its batches are appended at index 0 of the new epoch's pack, and the legitimate first output of the epoch is then silently dropped as "already saved". Symmetrically, the first output of epoch E+1 arriving while `current_pack` is still the sealed epoch-E pack hits `consensus_idx == len` and is appended into the sealed pack. The corrupted pack persists across restarts and `trunc_and_heal` cannot repair it (the record is CRC-valid and indexed). Reachability: after a restart with stale `LatestConsensus` slot files (fsynced only on epoch change), and `handle_consensus_header` (subscriber.rs:139-145) only rejects headers with epoch *greater* than the committee epoch, not lesser.
- **Key Question**: Can `save_consensus_output` be invoked with an output whose leader_epoch differs from `current_pack.epoch()` while `consensus.number() > latest_consensus.number()` — specifically after a restart with stale slot files and a freshly-opened empty epoch pack, or at the sealed/next-pack boundary before `new_epoch` runs?
- **Relevant Files**: crates/storage/src/consensus.rs, crates/storage/src/consensus_pack.rs, crates/consensus/executor/src/subscriber.rs, crates/node/src/manager/node/epoch.rs
- **Source**: tn-review