### PR TITLE
tn-reth: generic BLS verify precompile (reusable beyond proof-of-possession)

### DIFF
--- a/crates/config/src/keys.rs
+++ b/crates/config/src/keys.rs
@@ -234,8 +234,8 @@ impl KeyConfig {
     ///
     /// The proof of possession is a [BlsSignature] over [`construct_proof_of_possession_message`]:
     /// `intentPrefix || compressedBlsPubkey || address`. Using the compressed key keeps the message
-    /// cheaply reconstructable by the on-chain `ConsensusRegistry`, which verifies it via the native
-    /// BLS precompile.
+    /// cheaply reconstructable by the on-chain `ConsensusRegistry`, which verifies it via the
+    /// native BLS precompile.
     pub fn generate_proof_of_possession_bls(
         &self,
         address: &Address,

--- a/crates/config/src/keys.rs
+++ b/crates/config/src/keys.rs
@@ -11,8 +11,7 @@ use sha2::Sha256;
 use std::sync::Arc;
 use tn_types::{
     construct_proof_of_possession_message, Address, BlsKeypair, BlsPublicKey, BlsSignature,
-    BlsSigner, DefaultHashFunction, NetworkKeypair, NetworkPublicKey, ProtocolSignature as _,
-    Signer,
+    BlsSigner, DefaultHashFunction, NetworkKeypair, NetworkPublicKey, Signer,
 };
 
 /// The work factor for PBKDF2 is implemented through an iteration count, which is based on the
@@ -233,18 +232,16 @@ impl KeyConfig {
     /// holder of authority protocol key, and also ensures that the authority
     /// protocol public key exists.
     ///
-    /// The proof of possession is a [BlsSignature] committed over the intent message
-    /// `intent || message` (See more at [IntentMessage] and [Intent]).
-    /// The message is constructed as: EIP2537([BlsPublicKey]) || [Address].
-    /// Where the public key is uncompressed with G2 point coordinates padded to 64-byte EVM words
+    /// The proof of possession is a [BlsSignature] over [`construct_proof_of_possession_message`]:
+    /// `intentPrefix || compressedBlsPubkey || address`. Using the compressed key keeps the message
+    /// cheaply reconstructable by the on-chain `ConsensusRegistry`, which verifies it via the native
+    /// BLS precompile.
     pub fn generate_proof_of_possession_bls(
         &self,
         address: &Address,
     ) -> eyre::Result<BlsSignature> {
-        let msg = construct_proof_of_possession_message(&self.primary_public_key(), address)?;
-        let sig = BlsSignature::new_secure(&msg.clone(), &self.inner.primary_keypair);
-
-        Ok(sig)
+        let msg = construct_proof_of_possession_message(&self.primary_public_key(), address);
+        Ok(self.inner.primary_keypair.sign(&msg))
     }
 
     /// Derive a NetworkKeypair from a BLS signature, seed string and [DefaultHashFunction].

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -756,8 +756,7 @@ fn generate_new_validator_txs(
 
     // stake tx
     let proof = ConsensusRegistry::ProofOfPossession {
-        uncompressedPubkey: new_validator_info.bls_public_key.serialize().into(),
-        uncompressedSignature: new_validator_info.proof_of_possession.serialize().into(),
+        signature: new_validator_info.proof_of_possession.to_bytes().into(),
     };
     let calldata = ConsensusRegistry::stakeCall {
         blsPubkey: new_validator_info.bls_public_key.compress().into(),

--- a/crates/e2e-tests/tests/it/genesis_tests.rs
+++ b/crates/e2e-tests/tests/it/genesis_tests.rs
@@ -95,15 +95,14 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
         CONSENSUS_REGISTRY_JSON,
         Some("deployedBytecode.object"),
     )?;
-    let unlinked_runtimecode =
+    let registry_runtimecode =
         registry_runtimecode_binding.as_str().ok_or_eyre("Couldn't fetch bytecode")?;
-    // BlsG1 is a native precompile at `BLS_G1_PRECOMPILE_ADDRESS`: the registry runtime bytecode is
-    // linked against that address, and the address itself carries a single `0xfe` (INVALID)
-    // placeholder byte rather than deployed library code. See
+    // The registry calls the BLS precompile directly at `BLS_G1_PRECOMPILE_ADDRESS` (no linked
+    // library), so its deployed bytecode is used as-is. The precompile address itself carries a
+    // single `0xfe` (INVALID) byte of code rather than deployed library code. See
     // `create_consensus_registry_genesis_accounts`.
     let blsg1_address = BLS_G1_PRECOMPILE_ADDRESS.to_string();
-    let registry_deployed_bytecode =
-        RethEnv::link_solidity_library(unlinked_runtimecode, &blsg1_address)?;
+    let registry_deployed_bytecode = Bytes::from_hex(registry_runtimecode)?;
 
     let issuance_json_val =
         RethEnv::fetch_value_from_json_str(ISSUANCE_JSON, Some("deployedBytecode.object"))?;
@@ -132,10 +131,7 @@ async fn test_genesis_with_consensus_registry_accounts() -> eyre::Result<()> {
         .request("eth_getCode", rpc_params!(blsg1_address))
         .await
         .expect("Failed to fetch BLS G1 bytecode");
-    assert_eq!(
-        Bytes::from_hex(&returned_registry_bytecode)?,
-        Bytes::from(registry_deployed_bytecode)
-    );
+    assert_eq!(Bytes::from_hex(&returned_registry_bytecode)?, registry_deployed_bytecode);
     assert_eq!(
         Bytes::from_hex(&returned_issuance_bytecode)?,
         Bytes::from_hex(issuance_deployed_bytecode)?

--- a/crates/e2e-tests/tests/it/staking.rs
+++ b/crates/e2e-tests/tests/it/staking.rs
@@ -116,10 +116,9 @@ async fn test_cli_keygen_to_stake() -> eyre::Result<()> {
         ConfigFmt::YAML,
     )?;
 
-    // Sanity: verify key byte lengths match expected BLS sizes
+    // Sanity: verify key byte lengths match the compressed encodings the stake flow uses
     assert_eq!(node_info.bls_public_key.to_bytes().len(), 96, "compressed BLS pubkey");
-    assert_eq!(node_info.bls_public_key.serialize().len(), 192, "uncompressed BLS pubkey");
-    assert_eq!(node_info.proof_of_possession.serialize().len(), 96, "uncompressed PoP sig");
+    assert_eq!(node_info.proof_of_possession.to_bytes().len(), 48, "compressed PoP signature");
 
     // ── 4. Build genesis with ConsensusRegistry ──
     let stake_amount = U256::from(parse_ether("1_000_000").unwrap());

--- a/crates/execution/tn-rpc/src/error.rs
+++ b/crates/execution/tn-rpc/src/error.rs
@@ -14,6 +14,8 @@ const EXECUTION_REVERTED: i32 = 3;
 const RESOURCE_NOT_FOUND: i32 = -32001;
 /// JSON-RPC 2.0 internal error.
 const INTERNAL_ERROR: i32 = -32603;
+/// JSON-RPC 2.0 invalid params.
+const INVALID_PARAMS: i32 = -32602;
 
 /// Error type for public RPC endpoints in the `tn` namespace.
 #[derive(Debug, Error)]
@@ -32,6 +34,9 @@ pub enum TNRpcError {
     /// Internal failure reading the registry. Detail logged server-side only.
     #[error("consensus registry read failed")]
     Internal,
+    /// Caller supplied an invalid parameter (e.g. a malformed BLS public key).
+    #[error("{0}")]
+    InvalidParams(String),
 }
 
 impl From<TNRpcError> for jsonrpsee_types::ErrorObject<'static> {
@@ -42,6 +47,7 @@ impl From<TNRpcError> for jsonrpsee_types::ErrorObject<'static> {
                 rpc_error(EXECUTION_REVERTED, message, Some(&output))
             }
             TNRpcError::Internal => rpc_error(INTERNAL_ERROR, error.to_string(), None),
+            TNRpcError::InvalidParams(msg) => rpc_error(INVALID_PARAMS, msg, None),
         }
     }
 }
@@ -96,6 +102,14 @@ mod tests {
         let err: ErrorObject<'static> = TNRpcError::Internal.into();
         assert_eq!(err.code(), -32603);
         assert_eq!(err.message(), "consensus registry read failed");
+        assert!(err.data().is_none());
+    }
+
+    #[test]
+    fn invalid_params_maps_to_invalid_params_code() {
+        let err: ErrorObject<'static> = TNRpcError::InvalidParams("bad pubkey".to_string()).into();
+        assert_eq!(err.code(), -32602);
+        assert_eq!(err.message(), "bad pubkey");
         assert!(err.data().is_none());
     }
 }

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -14,8 +14,8 @@ use tn_reth::{
     RethEnv,
 };
 use tn_types::{
-    Address, Bytes, ConsensusHeader, Epoch, EpochCertificate, EpochDigest, EpochRecord, Genesis,
-    SolCall, SolType, SolValue, B256, U256,
+    construct_proof_of_possession_message, Address, BlsPublicKey, Bytes, ConsensusHeader, Epoch,
+    EpochCertificate, EpochDigest, EpochRecord, Genesis, SolCall, SolType, SolValue, B256, U256,
 };
 use tokio::sync::{oneshot, Semaphore};
 
@@ -139,13 +139,14 @@ pub trait TelcoinNetworkRpcExtApi {
         validator_address: Address,
         delegator: Address,
     ) -> TelcoinNetworkRpcResult<B256>;
-    /// Return the BLS12-381 proof of possession message: `blsPubkey || validatorAddress`.
+    /// Return the BLS12-381 proof-of-possession message a validator signs:
+    /// `intentPrefix(3) || compressedBlsPubkey(96) || validatorAddress(20)`.
     ///
-    /// Expects the 192-byte uncompressed BLS public key.
+    /// Expects the 96-byte compressed BLS public key.
     #[method(name = "proofOfPossessionMessage")]
     async fn proof_of_possession_message(
         &self,
-        bls_pubkey_uncompressed: Bytes,
+        bls_pubkey: Bytes,
         validator_address: Address,
     ) -> TelcoinNetworkRpcResult<Bytes>;
     /// Return the committee size for the next epoch.
@@ -372,16 +373,17 @@ where
 
     async fn proof_of_possession_message(
         &self,
-        bls_pubkey_uncompressed: Bytes,
+        bls_pubkey: Bytes,
         validator_address: Address,
     ) -> TelcoinNetworkRpcResult<Bytes> {
-        let calldata = ConsensusRegistry::proofOfPossessionMessageCall {
-            blsPubkey: bls_pubkey_uncompressed,
-            validatorAddress: validator_address,
-        }
-        .abi_encode()
-        .into();
-        self.registry_read(calldata).await
+        // As of the compressed-bytes pivot the registry's `proofOfPossessionMessage` is an internal
+        // helper (not externally callable), so build the message natively from the same `tn_types`
+        // routine the validator signs and the registry reproduces on-chain byte-for-byte:
+        // `intent || compressed pubkey || address`.
+        let pubkey = BlsPublicKey::from_literal_bytes(&bls_pubkey).map_err(|e| {
+            TNRpcError::InvalidParams(format!("invalid 96-byte compressed BLS pubkey: {e:?}"))
+        })?;
+        Ok(construct_proof_of_possession_message(&pubkey, &validator_address).into())
     }
 
     async fn get_next_committee_size(&self) -> TelcoinNetworkRpcResult<u16> {

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -620,8 +620,7 @@ JSON (`--json`):
 ```json
 {
 	"blsPubkey": "0x...",
-	"uncompressedPubkey": "0x...",
-	"uncompressedSignature": "0x..."
+	"signature": "0x..."
 }
 ```
 
@@ -638,12 +637,11 @@ function stake(
 ) public
 
 struct ProofOfPossession {
-    bytes uncompressedPubkey;    // 192 bytes
-    bytes uncompressedSignature; // 96 bytes
+    bytes signature; // 48 bytes (compressed G1)
 }
 ```
 
-The compressed BLS public key is 96 bytes. The proof of possession binds the BLS key to the validator's execution address.
+The compressed BLS public key is 96 bytes and the proof-of-possession signature is 48 bytes. The proof of possession binds the BLS key to the validator's execution address; the native precompile verifies the signature directly against the compressed `blsPubkey`.
 
 ## Observer mode
 

--- a/crates/telcoin-network-cli/src/keytool/export_staking_args.rs
+++ b/crates/telcoin-network-cli/src/keytool/export_staking_args.rs
@@ -35,16 +35,13 @@ impl ExportStakingArgs {
     /// and proof of possession, matching what `--calldata` prints.
     pub fn stake_calldata(&self) -> eyre::Result<Vec<u8>> {
         let node_info = self.load_node_info()?;
-        let compressed = node_info.bls_public_key.to_bytes();
-        let uncompressed_pk = node_info.bls_public_key.serialize();
-        let uncompressed_sig = node_info.proof_of_possession.serialize();
+        let compressed_pubkey = node_info.bls_public_key.to_bytes();
+        let compressed_sig = node_info.proof_of_possession.to_bytes();
 
-        let proof = ConsensusRegistry::ProofOfPossession {
-            uncompressedPubkey: uncompressed_pk.to_vec().into(),
-            uncompressedSignature: uncompressed_sig.to_vec().into(),
-        };
+        let proof =
+            ConsensusRegistry::ProofOfPossession { signature: compressed_sig.to_vec().into() };
         let call = ConsensusRegistry::stakeCall {
-            blsPubkey: compressed.to_vec().into(),
+            blsPubkey: compressed_pubkey.to_vec().into(),
             proofOfPossession: proof,
         };
 
@@ -61,33 +58,26 @@ impl ExportStakingArgs {
 
         let node_info = self.load_node_info()?;
 
-        // compressed BLS pubkey (96 bytes) - used as blsPubkey param
-        let compressed = node_info.bls_public_key.to_bytes();
+        // compressed BLS pubkey (96 bytes) - the blsPubkey param
+        let compressed_pubkey = node_info.bls_public_key.to_bytes();
 
-        // uncompressed BLS pubkey (192 bytes) - used as ProofOfPossession.uncompressedPubkey
-        let uncompressed_pk = node_info.bls_public_key.serialize();
-
-        // uncompressed PoP signature (96 bytes) - used as ProofOfPossession.uncompressedSignature
-        let uncompressed_sig = node_info.proof_of_possession.serialize();
-        let compressed_hex = format!("0x{}", hex::encode(compressed));
-        let uncompressed_pk_hex = format!("0x{}", hex::encode(uncompressed_pk));
-        let uncompressed_sig_hex = format!("0x{}", hex::encode(uncompressed_sig));
+        // compressed PoP signature (48 bytes) - the ProofOfPossession.signature
+        let compressed_sig = node_info.proof_of_possession.to_bytes();
+        let compressed_pubkey_hex = format!("0x{}", hex::encode(compressed_pubkey));
+        let compressed_sig_hex = format!("0x{}", hex::encode(compressed_sig));
 
         if self.json {
             let output = serde_json::json!({
-                "blsPubkey": compressed_hex,
-                "uncompressedPubkey": uncompressed_pk_hex,
-                "uncompressedSignature": uncompressed_sig_hex,
+                "blsPubkey": compressed_pubkey_hex,
+                "signature": compressed_sig_hex,
             });
             println!("{}", serde_json::to_string_pretty(&output)?);
         } else {
             println!("Staking arguments for ConsensusRegistry.stake():\n");
-            println!("blsPubkey (compressed, {} bytes):", compressed.len());
-            println!("{compressed_hex}\n");
-            println!("proofOfPossession.uncompressedPubkey ({} bytes):", uncompressed_pk.len());
-            println!("{uncompressed_pk_hex}\n");
-            println!("proofOfPossession.uncompressedSignature ({} bytes):", uncompressed_sig.len());
-            println!("{uncompressed_sig_hex}");
+            println!("blsPubkey (compressed, {} bytes):", compressed_pubkey.len());
+            println!("{compressed_pubkey_hex}\n");
+            println!("proofOfPossession.signature (compressed, {} bytes):", compressed_sig.len());
+            println!("{compressed_sig_hex}");
         }
 
         Ok(())

--- a/crates/telcoin-network-cli/src/keytool/mod.rs
+++ b/crates/telcoin-network-cli/src/keytool/mod.rs
@@ -163,23 +163,19 @@ mod tests {
         )
         .expect("node info loaded");
 
-        let compressed = node_info.bls_public_key.to_bytes();
-        let uncompressed_pk = node_info.bls_public_key.serialize();
-        let uncompressed_sig = node_info.proof_of_possession.serialize();
+        let compressed_pubkey = node_info.bls_public_key.to_bytes();
+        let compressed_sig = node_info.proof_of_possession.to_bytes();
 
-        assert_eq!(compressed.len(), 96, "compressed BLS pubkey should be 96 bytes");
-        assert_eq!(uncompressed_pk.len(), 192, "uncompressed BLS pubkey should be 192 bytes");
-        assert_eq!(uncompressed_sig.len(), 96, "uncompressed PoP signature should be 96 bytes");
+        assert_eq!(compressed_pubkey.len(), 96, "compressed BLS pubkey should be 96 bytes");
+        assert_eq!(compressed_sig.len(), 48, "compressed PoP signature should be 48 bytes");
 
         // verify hex encoding produces valid 0x-prefixed strings
-        let compressed_hex = format!("0x{}", hex::encode(compressed));
-        let uncompressed_pk_hex = format!("0x{}", hex::encode(uncompressed_pk));
-        let uncompressed_sig_hex = format!("0x{}", hex::encode(uncompressed_sig));
+        let compressed_pubkey_hex = format!("0x{}", hex::encode(compressed_pubkey));
+        let compressed_sig_hex = format!("0x{}", hex::encode(compressed_sig));
 
-        assert!(compressed_hex.starts_with("0x"));
-        assert_eq!(compressed_hex.len(), 2 + 96 * 2); // 0x + 96 bytes hex
-        assert_eq!(uncompressed_pk_hex.len(), 2 + 192 * 2); // 0x + 192 bytes hex
-        assert_eq!(uncompressed_sig_hex.len(), 2 + 96 * 2); // 0x + 96 bytes hex
+        assert!(compressed_pubkey_hex.starts_with("0x"));
+        assert_eq!(compressed_pubkey_hex.len(), 2 + 96 * 2); // 0x + 96 bytes hex
+        assert_eq!(compressed_sig_hex.len(), 2 + 48 * 2); // 0x + 48 bytes hex
 
         // also test that ExportStakingArgs::execute works with directory path
         let args =

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -15,8 +15,8 @@
 //! # Structure
 //!
 //! Mirrors [`tel_precompile`](super::tel_precompile): a [`DynPrecompile`] registered via
-//! [`add_bls_precompile`] and dispatched by 4-byte selector. The ABI matches `BlsG1.sol`, so
-//! `ConsensusRegistry`'s `BlsG1.blsVerify` `delegatecall` resolves to this precompile.
+//! [`add_bls_precompile`] and dispatched by 4-byte selector. The ABI matches `IBlsG1`, so
+//! `ConsensusRegistry`'s `blsVerify` staticcall resolves to this precompile.
 //!
 //! | Selector | Behavior |
 //! |----------|----------|
@@ -43,8 +43,8 @@ use tn_types::{bls_verify_secure, Address, BlsPublicKey, BlsSignature, Bytes};
 
 /// Canonical address of the BLS verification precompile: `0x…b151`.
 ///
-/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is
-/// linked against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
+/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/interfaces/IBlsG1.sol`. `ConsensusRegistry`
+/// staticcalls this address, so its BLS verification lands here.
 pub const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
 sol! {

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -11,21 +11,22 @@
 //!
 //! Mirrors [`tel_precompile`](super::tel_precompile): a [`DynPrecompile`] registered via
 //! [`add_bls_precompile`] and dispatched by 4-byte selector. The ABI matches `BlsG1.sol`, so
-//! `ConsensusRegistry`'s existing library `delegatecall`s resolve to this precompile unchanged.
+//! `ConsensusRegistry`'s `BlsG1.verifyProofOfPossession` `delegatecall` resolves to this
+//! precompile.
 //!
 //! | Selector | Behavior |
 //! |----------|----------|
-//! | `verifyProofOfPossession(bytes,bytes,address)` | Verify a PoP from uncompressed G1 sig + G2 pubkey. The one crypto entrypoint. |
-//! | `proofOfPossessionMessage(bytes,address)` | Return the exact bytes the PoP is signed/verified over (used for revert reasons). |
+//! | `verifyProofOfPossession(bytes,bytes,address)` | Verify a PoP from a compressed G1 sig + G2 pubkey. The one crypto entrypoint. |
 //!
 //! # Encoding
 //!
-//! The signature/pubkey arguments are the protocol's own `blst::min_sig` `serialize()` output
-//! (96-byte uncompressed G1 signature, 192-byte uncompressed G2 pubkey) - the identical bytes the
-//! genesis assembly and `stake`/`delegateStake` callers already pass to `BlsG1`. The precompile
-//! feeds them straight back into `blst` via [`BlsSignature::from_uncompressed_bytes`] /
-//! [`BlsPublicKey::from_uncompressed_bytes`]; no EIP-2537 re-encoding or point (de)compression is
-//! performed here.
+//! The signature/pubkey arguments are the protocol's own `blst::min_sig` compressed encodings
+//! (48-byte compressed G1 signature, 96-byte compressed G2 pubkey) - the identical bytes the
+//! genesis assembly and `stake`/`delegateStake` callers pass as the `ProofOfPossession` signature
+//! and the stored `blsPubkey`. A strict length gate (exactly 48 / 96 bytes) is applied before
+//! decoding, so only the compressed form is accepted: the bytes are fed into `blst` via
+//! [`BlsSignature::from_bytes`] / [`BlsPublicKey::from_literal_bytes`], which decompress the points
+//! internally; no uncompressed input is accepted.
 use alloy::{
     primitives::address,
     sol,
@@ -33,10 +34,7 @@ use alloy::{
 };
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
 use reth_revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
-use tn_types::{
-    proof_of_possession_message_bytes, verify_proof_of_possession_bls, Address, BlsPublicKey,
-    BlsSignature, Bytes,
-};
+use tn_types::{verify_proof_of_possession_bls, Address, BlsPublicKey, BlsSignature, Bytes};
 
 /// Canonical address of the BLS proof-of-possession precompile: `0x…b151`.
 ///
@@ -45,34 +43,25 @@ use tn_types::{
 pub const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
 sol! {
-    /// Verifies a validator's BLS12-381 proof of possession from raw uncompressed inputs.
+    /// Verifies a validator's BLS12-381 proof of possession from compressed inputs.
     ///
-    /// `uncompressedSignature`: 96-byte uncompressed G1 point. `uncompressedPubkey`: 192-byte
-    /// uncompressed G2 point. Both as produced by `blst::min_sig` `serialize`.
+    /// `signature`: 48-byte compressed G1 point. `pubkey`: 96-byte compressed G2 point. Both as
+    /// produced by `blst::min_sig` `to_bytes` / `compress`.
     function verifyProofOfPossession(
-        bytes uncompressedSignature,
-        bytes uncompressedPubkey,
+        bytes signature,
+        bytes pubkey,
         address validatorAddress
     ) external view returns (bool);
-
-    /// Returns the proof-of-possession message bytes a validator signs / is verified against.
-    function proofOfPossessionMessage(
-        bytes uncompressedPubkey,
-        address validatorAddress
-    ) external pure returns (bytes);
 }
 
 /// Gas charged for a proof-of-possession verification.
 ///
 /// Priced to reflect the equivalent EIP-2537 work the verification represents: a 2-pairing check
-/// (`37_700 + 2 * 32_600 = 102_900`) plus hash-to-curve and point decoding, rounded up. This keeps
-/// the on-chain cost proportional to the cryptography while remaining well within a normal
+/// (`37_700 + 2 * 32_600 = 102_900`) plus hash-to-curve and point decompression, rounded up. This
+/// keeps the on-chain cost proportional to the cryptography while remaining well within a normal
 /// transaction's gas budget (`stake` / `delegateStake` run with a 1M default limit). The native
 /// implementation completes in microseconds; the charge exists for metering, not compute time.
 const VERIFY_POP_GAS_COST: u64 = 150_000;
-
-/// Gas charged for building the proof-of-possession message (pure serialization, no pairing).
-const POP_MESSAGE_GAS_COST: u64 = 5_000;
 
 /// Registers the BLS precompile at [`BLS_G1_PRECOMPILE_ADDRESS`] in the given map.
 ///
@@ -104,7 +93,6 @@ fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
 
     match *selector {
         verifyProofOfPossessionCall::SELECTOR => handle_verify_pop(calldata, gas),
-        proofOfPossessionMessageCall::SELECTOR => handle_pop_message(calldata, gas),
         _ => Err(PrecompileError::Other("Unknown function selector".into())),
     }
 }
@@ -122,49 +110,32 @@ fn handle_verify_pop(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
     // never disagree. A malformed point or failed pairing yields `false` (not a revert), matching
     // `BlsG1.verifyProofOfPossession`'s boolean contract; the caller (`ConsensusRegistry`) is what
     // turns `false` into its own `InvalidProofOfPossession` revert.
-    let verified = verify_pop(
-        &decoded.uncompressedSignature,
-        &decoded.uncompressedPubkey,
-        decoded.validatorAddress,
-    );
+    let verified = verify_pop(&decoded.signature, &decoded.pubkey, decoded.validatorAddress);
 
     Ok(PrecompileOutput::new(VERIFY_POP_GAS_COST, Bytes::from(verified.abi_encode())))
 }
 
-/// Decode the uncompressed inputs and run the `blst` proof-of-possession check. Any decode or
+/// Decode the compressed inputs and run the `blst` proof-of-possession check. Any decode or
 /// verification failure maps to `false` so a bad proof can never panic or revert the precompile.
-fn verify_pop(uncompressed_sig: &[u8], uncompressed_pubkey: &[u8], address: Address) -> bool {
-    let Ok(pubkey) = BlsPublicKey::from_uncompressed_bytes(uncompressed_pubkey) else {
+///
+/// The explicit length gate is the functional enforcement of the compressed-only encoding: blst's
+/// `deserialize` accepts *either* encoding by length, so without this gate a 96-byte uncompressed
+/// signature or 192-byte uncompressed pubkey would still decode. Requiring exactly 48 / 96 bytes
+/// rejects the uncompressed forms up front; [`BlsSignature::from_bytes`] /
+/// [`BlsPublicKey::from_literal_bytes`] then require the compression flag, so a 96-byte flag-clear
+/// pubkey is rejected too. Subgroup and infinity checks remain at verify time (unchanged).
+fn verify_pop(compressed_sig: &[u8], compressed_pubkey: &[u8], address: Address) -> bool {
+    if compressed_sig.len() != 48 || compressed_pubkey.len() != 96 {
+        return false;
+    }
+    let Ok(pubkey) = BlsPublicKey::from_literal_bytes(compressed_pubkey) else {
         return false;
     };
-    let Ok(sig) = BlsSignature::from_uncompressed_bytes(uncompressed_sig) else {
+    let Ok(sig) = BlsSignature::from_bytes(compressed_sig) else {
         return false;
     };
 
     verify_proof_of_possession_bls(&sig, &pubkey, &address).is_ok()
-}
-
-/// `proofOfPossessionMessage(bytes,address) -> bytes`.
-///
-/// Returns the canonical message bytes (`encode(IntentMessage)`) the PoP is verified against, so
-/// the message reported here and the message verified by [`handle_verify_pop`] are produced by the
-/// same code. A malformed pubkey reverts (it cannot be the basis of any valid message).
-fn handle_pop_message(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
-    if gas_limit < POP_MESSAGE_GAS_COST {
-        return Err(PrecompileError::OutOfGas);
-    }
-
-    let decoded = proofOfPossessionMessageCall::abi_decode_raw(calldata)
-        .map_err(|e| PrecompileError::Other(format!("proofOfPossessionMessage: {e}").into()))?;
-
-    let pubkey =
-        BlsPublicKey::from_uncompressed_bytes(&decoded.uncompressedPubkey).map_err(|e| {
-            PrecompileError::Other(format!("invalid uncompressed pubkey: {e:?}").into())
-        })?;
-    let message = proof_of_possession_message_bytes(&pubkey, &decoded.validatorAddress)
-        .map_err(|e| PrecompileError::Other(format!("message build failed: {e}").into()))?;
-
-    Ok(PrecompileOutput::new(POP_MESSAGE_GAS_COST, Bytes::from(Bytes::from(message).abi_encode())))
 }
 
 #[cfg(test)]
@@ -173,12 +144,12 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
     use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair};
 
-    /// A deterministic keypair + the uncompressed sig/pubkey bytes of a valid PoP for `address`.
+    /// A valid PoP's compressed sig/pubkey bytes for `address`.
     ///
-    /// `sig`/`pubkey` are `blst::min_sig` `serialize()` output (96-byte G1 sig, 192-byte G2
-    /// pubkey), the exact bytes the protocol passes to `BlsG1` / this precompile.
+    /// `sig`/`pubkey` are `blst::min_sig` compressed `to_bytes()` output (48-byte G1 sig, 96-byte
+    /// G2 pubkey), the exact bytes the protocol passes as the `ProofOfPossession` signature and the
+    /// stored `blsPubkey`.
     struct Vector {
-        keypair: BlsKeypair,
         address: Address,
         sig: Vec<u8>,
         pubkey: Vec<u8>,
@@ -190,16 +161,16 @@ mod tests {
         let address = Address::repeat_byte(address_byte);
         let proof = generate_proof_of_possession_bls_for_test(&keypair, &address)
             .expect("generate test PoP");
-        let sig = proof.serialize().to_vec();
-        let pubkey = keypair.public().serialize().to_vec();
-        Vector { keypair, address, sig, pubkey }
+        let sig = proof.to_bytes().to_vec();
+        let pubkey = keypair.public().to_bytes().to_vec();
+        Vector { address, sig, pubkey }
     }
 
     /// ABI-encodes a `verifyProofOfPossession` call (selector + args), as a caller would.
     fn encode_verify(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
         verifyProofOfPossessionCall {
-            uncompressedSignature: Bytes::copy_from_slice(sig),
-            uncompressedPubkey: Bytes::copy_from_slice(pubkey),
+            signature: Bytes::copy_from_slice(sig),
+            pubkey: Bytes::copy_from_slice(pubkey),
             validatorAddress: address,
         }
         .abi_encode()
@@ -220,6 +191,34 @@ mod tests {
             let v = vector(seed, addr);
             assert!(verify_pop(&v.sig, &v.pubkey, v.address), "seed {seed} addr {addr:#x}");
         }
+    }
+
+    /// S1 (load-bearing): the precompile is compressed-only. A *valid* 96-byte uncompressed
+    /// signature and 192-byte uncompressed pubkey - the pre-change encoding - must be rejected by
+    /// the length gate. blst's `deserialize` would otherwise accept these valid points, so this
+    /// (not random wrong-length bytes) is the proof that the gate is the enforcement.
+    #[test]
+    fn verify_pop_rejects_valid_uncompressed_inputs() {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7u8; 32]));
+        let address = Address::repeat_byte(0x42);
+        let proof = generate_proof_of_possession_bls_for_test(&keypair, &address)
+            .expect("generate test PoP");
+
+        let uncompressed_sig = proof.serialize().to_vec();
+        let uncompressed_pubkey = keypair.public().serialize().to_vec();
+        assert_eq!(uncompressed_sig.len(), 96, "uncompressed G1 signature");
+        assert_eq!(uncompressed_pubkey.len(), 192, "uncompressed G2 pubkey");
+
+        // the same key in compressed form verifies, proving the inputs are otherwise valid
+        let compressed_sig = proof.to_bytes().to_vec();
+        let compressed_pubkey = keypair.public().to_bytes().to_vec();
+        assert!(verify_pop(&compressed_sig, &compressed_pubkey, address), "compressed control");
+
+        // ...but the valid uncompressed encodings are rejected by the length gate
+        assert!(
+            !verify_pop(&uncompressed_sig, &uncompressed_pubkey, address),
+            "uncompressed gated"
+        );
     }
 
     /// A proof bound to a different address must fail (the address is part of the signed message).
@@ -247,31 +246,32 @@ mod tests {
         assert!(!verify_pop(&v.sig, &other.pubkey, v.address));
     }
 
-    /// Identity/infinity points and all-zero inputs return `false`, never panic
-    /// (port of the Solidity zero-point / infinity-point rejection cases).
+    /// Identity/infinity points and all-zero inputs return `false`, never panic. All-zero is not a
+    /// valid compressed point (a valid compressed infinity carries the `0xc0` flag).
     #[test]
     fn verify_pop_rejects_zero_and_infinity_points() {
         let v = vector(7, 0x42);
-        // all-zero sig + pubkey (the uncompressed infinity-point encoding)
-        assert!(!verify_pop(&[0u8; 96], &[0u8; 192], Address::ZERO));
+        // all-zero sig + pubkey at the compressed lengths
+        assert!(!verify_pop(&[0u8; 48], &[0u8; 96], Address::ZERO));
         // zero signature against an otherwise valid pubkey/address
-        assert!(!verify_pop(&[0u8; 96], &v.pubkey, v.address));
+        assert!(!verify_pop(&[0u8; 48], &v.pubkey, v.address));
         // zero pubkey against an otherwise valid signature/address
-        assert!(!verify_pop(&v.sig, &[0u8; 192], v.address));
+        assert!(!verify_pop(&v.sig, &[0u8; 96], v.address));
     }
 
-    /// Wrong-length sig/pubkey inputs are rejected without panicking (port of the Solidity
-    /// `invalidPubkeyLength` length-validation cases: empty, short, and over-long).
+    /// Wrong-length sig/pubkey inputs are rejected by the length gate without panicking.
     #[test]
     fn verify_pop_rejects_wrong_length_inputs() {
         let v = vector(7, 0x42);
 
-        // pubkey lengths that are not the 192-byte uncompressed G2 form
-        for len in [0usize, 32, 48, 64, 95, 96, 128, 191, 193, 256] {
+        // pubkey lengths that are not the 96-byte compressed G2 form (incl. the 192-byte
+        // uncompressed)
+        for len in [0usize, 32, 47, 48, 95, 97, 128, 192, 256] {
             assert!(!verify_pop(&v.sig, &vec![0u8; len], v.address), "pubkey len {len}");
         }
-        // signature lengths that are not the 96-byte uncompressed G1 form
-        for len in [0usize, 32, 48, 95, 97, 128, 192] {
+        // signature lengths that are not the 48-byte compressed G1 form (incl. the 96-byte
+        // uncompressed)
+        for len in [0usize, 32, 47, 49, 96, 128, 192] {
             assert!(!verify_pop(&vec![0u8; len], &v.pubkey, v.address), "sig len {len}");
         }
     }
@@ -309,65 +309,6 @@ mod tests {
     fn dispatch_verify_out_of_gas() {
         let v = vector(7, 0x42);
         let res = dispatch(&encode_verify(&v.sig, &v.pubkey, v.address), VERIFY_POP_GAS_COST - 1);
-        assert!(matches!(res, Err(PrecompileError::OutOfGas)));
-    }
-
-    /// `proofOfPossessionMessage` returns exactly the bytes verification signs over, so the message
-    /// reported on-chain and the message checked by `verify` come from one code path. Signing the
-    /// returned message yields a proof that verifies.
-    #[test]
-    fn dispatch_message_matches_signed_bytes_and_round_trips() {
-        let v = vector(7, 0x42);
-        let calldata = proofOfPossessionMessageCall {
-            uncompressedPubkey: Bytes::copy_from_slice(&v.pubkey),
-            validatorAddress: v.address,
-        }
-        .abi_encode();
-
-        let out = dispatch(&calldata, POP_MESSAGE_GAS_COST).expect("dispatch ok");
-        assert_eq!(out.gas_used, POP_MESSAGE_GAS_COST);
-
-        let returned = <Bytes as SolValue>::abi_decode(&out.bytes).expect("decode bytes return");
-        let expected = proof_of_possession_message_bytes(v.keypair.public(), &v.address)
-            .expect("build expected message");
-        assert_eq!(returned.as_ref(), expected.as_slice());
-
-        // the verifier accepts the proof signed over exactly this message
-        assert!(verify_pop(&v.sig, &v.pubkey, v.address));
-    }
-
-    /// The message is bound to the validator address: a different address yields different bytes.
-    #[test]
-    fn dispatch_message_is_address_bound() {
-        let v = vector(7, 0x42);
-        let msg_a = proof_of_possession_message_bytes(v.keypair.public(), &v.address).unwrap();
-        let msg_b =
-            proof_of_possession_message_bytes(v.keypair.public(), &Address::repeat_byte(0x43))
-                .unwrap();
-        assert_ne!(msg_a, msg_b);
-    }
-
-    /// A malformed pubkey to `proofOfPossessionMessage` reverts (it cannot form any valid message).
-    #[test]
-    fn dispatch_message_rejects_malformed_pubkey() {
-        let calldata = proofOfPossessionMessageCall {
-            uncompressedPubkey: Bytes::from_static(&[0xAB; 10]),
-            validatorAddress: Address::ZERO,
-        }
-        .abi_encode();
-        assert!(dispatch(&calldata, POP_MESSAGE_GAS_COST).is_err());
-    }
-
-    /// Building the message with less gas than the fixed cost is metered as out-of-gas.
-    #[test]
-    fn dispatch_message_out_of_gas() {
-        let v = vector(7, 0x42);
-        let calldata = proofOfPossessionMessageCall {
-            uncompressedPubkey: Bytes::copy_from_slice(&v.pubkey),
-            validatorAddress: v.address,
-        }
-        .abi_encode();
-        let res = dispatch(&calldata, POP_MESSAGE_GAS_COST - 1);
         assert!(matches!(res, Err(PrecompileError::OutOfGas)));
     }
 

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -1,16 +1,16 @@
 //! Native BLS12-381 signature-verification precompile.
 //!
 //! A native `blst` (`min_sig`) signature verifier registered at [`BLS_G1_PRECOMPILE_ADDRESS`]
-//! (`0x…b151`). It verifies that a compressed signature is valid, under a compressed public key, over
-//! a caller-supplied message - the **same** `blst` path the consensus layer uses to *produce*
+//! (`0x…b151`). It verifies that a compressed signature is valid, under a compressed public key,
+//! over a caller-supplied message - the **same** `blst` path the consensus layer uses to *produce*
 //! signatures ([`tn_types::bls_verify_secure`]). Having one implementation behind both signing and
 //! verification removes the byte-for-byte drift risk between the Rust signer and an independent
 //! on-chain reimplementation.
 //!
-//! It is a **generic** primitive: the message is opaque to the precompile, so any contract can verify
-//! any BLS-signed message. `ConsensusRegistry` is one caller - it builds its proof-of-possession
-//! message (`intentPrefix || compressedPubkey || address`) and verifies it here - but the precompile
-//! hard-codes nothing about proof-of-possession.
+//! It is a **generic** primitive: the message is opaque to the precompile, so any contract can
+//! verify any BLS-signed message. `ConsensusRegistry` is one caller - it builds its
+//! proof-of-possession message (`intentPrefix || compressedPubkey || address`) and verifies it here
+//! - but the precompile hard-codes nothing about proof-of-possession.
 //!
 //! # Structure
 //!
@@ -25,10 +25,10 @@
 //! # Encoding
 //!
 //! The signature/pubkey arguments are the protocol's own `blst::min_sig` compressed encodings
-//! (48-byte compressed G1 signature, 96-byte compressed G2 pubkey) - the identical bytes the genesis
-//! assembly and `stake`/`delegateStake` callers pass as the `ProofOfPossession` signature and the
-//! stored `blsPubkey`. A strict length gate (exactly 48 / 96 bytes) is applied before decoding, so
-//! only the compressed form is accepted: the bytes are fed into `blst` via
+//! (48-byte compressed G1 signature, 96-byte compressed G2 pubkey) - the identical bytes the
+//! genesis assembly and `stake`/`delegateStake` callers pass as the `ProofOfPossession` signature
+//! and the stored `blsPubkey`. A strict length gate (exactly 48 / 96 bytes) is applied before
+//! decoding, so only the compressed form is accepted: the bytes are fed into `blst` via
 //! [`BlsSignature::from_bytes`] / [`BlsPublicKey::from_literal_bytes`], which decompress the points
 //! internally; no uncompressed input is accepted. The `message` is verified as raw bytes
 //! (hash-to-curve with the protocol DST happens inside the verify).
@@ -43,8 +43,8 @@ use tn_types::{bls_verify_secure, Address, BlsPublicKey, BlsSignature, Bytes};
 
 /// Canonical address of the BLS verification precompile: `0x…b151`.
 ///
-/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is linked
-/// against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
+/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is
+/// linked against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
 pub const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
 sol! {
@@ -72,8 +72,8 @@ sol! {
 /// bytes). As a generic primitive, `blsVerify` accepts an arbitrary `message` whose hash-to-curve
 /// cost scales with its length; in practice that length is bounded by the calldata gas the caller
 /// already pays to supply it. Before any non-proof-of-possession caller relies on `blsVerify` with
-/// large messages, add a per-word component to this charge (mirroring EIP-2537 hash-to-curve pricing)
-/// or cap `message.len()`.
+/// large messages, add a per-word component to this charge (mirroring EIP-2537 hash-to-curve
+/// pricing) or cap `message.len()`.
 const BLS_VERIFY_GAS_COST: u64 = 150_000;
 
 /// Registers the BLS precompile at [`BLS_G1_PRECOMPILE_ADDRESS`] in the given map.
@@ -97,8 +97,8 @@ fn bls_precompile(input: PrecompileInput<'_>) -> PrecompileResult {
 /// Selector dispatch: extracts the 4-byte selector from calldata and routes to the handler.
 ///
 /// Split out from [`bls_precompile`] so the selector routing, gas metering, and ABI round-trips can
-/// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`] (which
-/// would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
+/// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`]
+/// (which would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
 fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
     let Some((selector, calldata)) = data.split_first_chunk::<4>() else {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
@@ -119,10 +119,11 @@ fn handle_bls_verify(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
     let decoded = blsVerifyCall::abi_decode_raw(calldata)
         .map_err(|e| PrecompileError::Other(format!("blsVerify: {e}").into()))?;
 
-    // Reuse the exact crypto the consensus layer uses to *produce* signatures, so signer and verifier
-    // can never disagree. A malformed point or failed verification yields `false` (not a revert),
-    // matching `BlsG1.blsVerify`'s boolean contract; the caller (`ConsensusRegistry`) is what turns
-    // `false` into its own `InvalidProofOfPossession` revert.
+    // Reuse the exact crypto the consensus layer uses to *produce* signatures, so signer and
+    // verifier can never disagree. A malformed point or failed verification yields `false` (not
+    // a revert), matching `BlsG1.blsVerify`'s boolean contract; the caller
+    // (`ConsensusRegistry`) is what turns `false` into its own `InvalidProofOfPossession`
+    // revert.
     let verified = bls_verify(&decoded.signature, &decoded.pubkey, &decoded.message);
 
     Ok(PrecompileOutput::new(BLS_VERIFY_GAS_COST, Bytes::from(verified.abi_encode())))
@@ -161,17 +162,17 @@ mod tests {
     };
 
     /// A valid signature over a representative message (the consensus proof-of-possession message),
-    /// plus the compressed `blst::min_sig` sig/pubkey bytes the protocol passes on-chain (48-byte G1
-    /// sig, 96-byte G2 pubkey).
+    /// plus the compressed `blst::min_sig` sig/pubkey bytes the protocol passes on-chain (48-byte
+    /// G1 sig, 96-byte G2 pubkey).
     struct Vector {
         sig: Vec<u8>,
         pubkey: Vec<u8>,
         message: Vec<u8>,
     }
 
-    /// Builds a valid (signature, pubkey, message) vector from a fixed RNG seed and address byte. The
-    /// message is the proof-of-possession message; the signature is produced over it by the same
-    /// signer path the protocol uses, so signer and precompile agree by construction.
+    /// Builds a valid (signature, pubkey, message) vector from a fixed RNG seed and address byte.
+    /// The message is the proof-of-possession message; the signature is produced over it by the
+    /// same signer path the protocol uses, so signer and precompile agree by construction.
     fn vector(seed: u8, address_byte: u8) -> Vector {
         let keypair = BlsKeypair::generate(&mut StdRng::from_seed([seed; 32]));
         let address = Address::repeat_byte(address_byte);
@@ -212,10 +213,10 @@ mod tests {
         }
     }
 
-    /// S1 (load-bearing): the precompile is compressed-only. A *valid* 96-byte uncompressed signature
-    /// and 192-byte uncompressed pubkey - the pre-change encoding - must be rejected by the length
-    /// gate. blst's `deserialize` would otherwise accept these valid points, so this (not random
-    /// wrong-length bytes) is the proof that the gate is the enforcement.
+    /// S1 (load-bearing): the precompile is compressed-only. A *valid* 96-byte uncompressed
+    /// signature and 192-byte uncompressed pubkey - the pre-change encoding - must be rejected
+    /// by the length gate. blst's `deserialize` would otherwise accept these valid points, so
+    /// this (not random wrong-length bytes) is the proof that the gate is the enforcement.
     #[test]
     fn bls_verify_rejects_valid_uncompressed_inputs() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7u8; 32]));
@@ -283,11 +284,13 @@ mod tests {
     fn bls_verify_rejects_wrong_length_inputs() {
         let v = vector(7, 0x42);
 
-        // pubkey lengths that are not the 96-byte compressed G2 form (incl. the 192-byte uncompressed)
+        // pubkey lengths that are not the 96-byte compressed G2 form (incl. the 192-byte
+        // uncompressed)
         for len in [0usize, 32, 47, 48, 95, 97, 128, 192, 256] {
             assert!(!bls_verify(&v.sig, &vec![0u8; len], &v.message), "pubkey len {len}");
         }
-        // signature lengths that are not the 48-byte compressed G1 form (incl. the 96-byte uncompressed)
+        // signature lengths that are not the 48-byte compressed G1 form (incl. the 96-byte
+        // uncompressed)
         for len in [0usize, 32, 47, 49, 96, 128, 192] {
             assert!(!bls_verify(&vec![0u8; len], &v.pubkey, &v.message), "sig len {len}");
         }
@@ -306,8 +309,8 @@ mod tests {
         assert_eq!(out.gas_used, BLS_VERIFY_GAS_COST);
     }
 
-    /// An invalid signature returns ABI-encoded `false` rather than reverting: the precompile mirrors
-    /// `BlsG1.blsVerify`'s boolean contract, leaving the revert to `ConsensusRegistry`.
+    /// An invalid signature returns ABI-encoded `false` rather than reverting: the precompile
+    /// mirrors `BlsG1.blsVerify`'s boolean contract, leaving the revert to `ConsensusRegistry`.
     #[test]
     fn dispatch_verify_invalid_returns_false_not_revert() {
         let v = vector(7, 0x42);

--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -1,32 +1,37 @@
-//! Native BLS12-381 proof-of-possession precompile.
+//! Native BLS12-381 signature-verification precompile.
 //!
-//! Replaces the Solidity `BlsG1` library (linked at [`BLS_G1_PRECOMPILE_ADDRESS`], `0x…b151`) with
-//! a native implementation that delegates to the **same** `blst` (`min_sig`) verification the
-//! consensus layer uses to *produce* proofs of possession
-//! ([`tn_types::verify_proof_of_possession_bls`]). Having one implementation behind both signing
-//! and verification removes the byte-for-byte drift risk between the Rust signer and an independent
+//! A native `blst` (`min_sig`) signature verifier registered at [`BLS_G1_PRECOMPILE_ADDRESS`]
+//! (`0x…b151`). It verifies that a compressed signature is valid, under a compressed public key, over
+//! a caller-supplied message - the **same** `blst` path the consensus layer uses to *produce*
+//! signatures ([`tn_types::bls_verify_secure`]). Having one implementation behind both signing and
+//! verification removes the byte-for-byte drift risk between the Rust signer and an independent
 //! on-chain reimplementation.
+//!
+//! It is a **generic** primitive: the message is opaque to the precompile, so any contract can verify
+//! any BLS-signed message. `ConsensusRegistry` is one caller - it builds its proof-of-possession
+//! message (`intentPrefix || compressedPubkey || address`) and verifies it here - but the precompile
+//! hard-codes nothing about proof-of-possession.
 //!
 //! # Structure
 //!
 //! Mirrors [`tel_precompile`](super::tel_precompile): a [`DynPrecompile`] registered via
 //! [`add_bls_precompile`] and dispatched by 4-byte selector. The ABI matches `BlsG1.sol`, so
-//! `ConsensusRegistry`'s `BlsG1.verifyProofOfPossession` `delegatecall` resolves to this
-//! precompile.
+//! `ConsensusRegistry`'s `BlsG1.blsVerify` `delegatecall` resolves to this precompile.
 //!
 //! | Selector | Behavior |
 //! |----------|----------|
-//! | `verifyProofOfPossession(bytes,bytes,address)` | Verify a PoP from a compressed G1 sig + G2 pubkey. The one crypto entrypoint. |
+//! | `blsVerify(bytes,bytes,bytes)` | Verify a signature over a message from a compressed G1 sig + G2 pubkey. The one crypto entrypoint. |
 //!
 //! # Encoding
 //!
 //! The signature/pubkey arguments are the protocol's own `blst::min_sig` compressed encodings
-//! (48-byte compressed G1 signature, 96-byte compressed G2 pubkey) - the identical bytes the
-//! genesis assembly and `stake`/`delegateStake` callers pass as the `ProofOfPossession` signature
-//! and the stored `blsPubkey`. A strict length gate (exactly 48 / 96 bytes) is applied before
-//! decoding, so only the compressed form is accepted: the bytes are fed into `blst` via
+//! (48-byte compressed G1 signature, 96-byte compressed G2 pubkey) - the identical bytes the genesis
+//! assembly and `stake`/`delegateStake` callers pass as the `ProofOfPossession` signature and the
+//! stored `blsPubkey`. A strict length gate (exactly 48 / 96 bytes) is applied before decoding, so
+//! only the compressed form is accepted: the bytes are fed into `blst` via
 //! [`BlsSignature::from_bytes`] / [`BlsPublicKey::from_literal_bytes`], which decompress the points
-//! internally; no uncompressed input is accepted.
+//! internally; no uncompressed input is accepted. The `message` is verified as raw bytes
+//! (hash-to-curve with the protocol DST happens inside the verify).
 use alloy::{
     primitives::address,
     sol,
@@ -34,34 +39,42 @@ use alloy::{
 };
 use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
 use reth_revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
-use tn_types::{verify_proof_of_possession_bls, Address, BlsPublicKey, BlsSignature, Bytes};
+use tn_types::{bls_verify_secure, Address, BlsPublicKey, BlsSignature, Bytes};
 
-/// Canonical address of the BLS proof-of-possession precompile: `0x…b151`.
+/// Canonical address of the BLS verification precompile: `0x…b151`.
 ///
-/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is
-/// linked against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
+/// Matches `BLS_G1_ADDRESS` in `tn-contracts/src/consensus/BlsG1.sol`. `ConsensusRegistry` is linked
+/// against this address at genesis, so its `BlsG1.*` library `delegatecall`s land here.
 pub const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
 sol! {
-    /// Verifies a validator's BLS12-381 proof of possession from compressed inputs.
+    /// Verifies a BLS12-381 signature over `message` from compressed inputs.
     ///
-    /// `signature`: 48-byte compressed G1 point. `pubkey`: 96-byte compressed G2 point. Both as
-    /// produced by `blst::min_sig` `to_bytes` / `compress`.
-    function verifyProofOfPossession(
+    /// `signature`: 48-byte compressed G1 point. `pubkey`: 96-byte compressed G2 point (both as
+    /// produced by `blst::min_sig` `to_bytes`). `message`: the raw signed bytes. Returns whether the
+    /// signature is valid over the message under the pubkey.
+    function blsVerify(
         bytes signature,
         bytes pubkey,
-        address validatorAddress
+        bytes message
     ) external view returns (bool);
 }
 
-/// Gas charged for a proof-of-possession verification.
+/// Gas charged for a BLS signature verification.
 ///
 /// Priced to reflect the equivalent EIP-2537 work the verification represents: a 2-pairing check
 /// (`37_700 + 2 * 32_600 = 102_900`) plus hash-to-curve and point decompression, rounded up. This
 /// keeps the on-chain cost proportional to the cryptography while remaining well within a normal
 /// transaction's gas budget (`stake` / `delegateStake` run with a 1M default limit). The native
 /// implementation completes in microseconds; the charge exists for metering, not compute time.
-const VERIFY_POP_GAS_COST: u64 = 150_000;
+///
+/// This is a flat charge calibrated for the registry's fixed-size proof-of-possession message (119
+/// bytes). As a generic primitive, `blsVerify` accepts an arbitrary `message` whose hash-to-curve
+/// cost scales with its length; in practice that length is bounded by the calldata gas the caller
+/// already pays to supply it. Before any non-proof-of-possession caller relies on `blsVerify` with
+/// large messages, add a per-word component to this charge (mirroring EIP-2537 hash-to-curve pricing)
+/// or cap `message.len()`.
+const BLS_VERIFY_GAS_COST: u64 = 150_000;
 
 /// Registers the BLS precompile at [`BLS_G1_PRECOMPILE_ADDRESS`] in the given map.
 ///
@@ -84,39 +97,39 @@ fn bls_precompile(input: PrecompileInput<'_>) -> PrecompileResult {
 /// Selector dispatch: extracts the 4-byte selector from calldata and routes to the handler.
 ///
 /// Split out from [`bls_precompile`] so the selector routing, gas metering, and ABI round-trips can
-/// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`]
-/// (which would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
+/// be unit-tested directly with raw calldata, without constructing a full [`PrecompileInput`] (which
+/// would require a live EVM for its [`EvmInternals`](alloy_evm::EvmInternals) field).
 fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
     let Some((selector, calldata)) = data.split_first_chunk::<4>() else {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
     };
 
     match *selector {
-        verifyProofOfPossessionCall::SELECTOR => handle_verify_pop(calldata, gas),
+        blsVerifyCall::SELECTOR => handle_bls_verify(calldata, gas),
         _ => Err(PrecompileError::Other("Unknown function selector".into())),
     }
 }
 
-/// `verifyProofOfPossession(bytes,bytes,address) -> bool`.
-fn handle_verify_pop(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
-    if gas_limit < VERIFY_POP_GAS_COST {
+/// `blsVerify(bytes,bytes,bytes) -> bool`.
+fn handle_bls_verify(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
+    if gas_limit < BLS_VERIFY_GAS_COST {
         return Err(PrecompileError::OutOfGas);
     }
 
-    let decoded = verifyProofOfPossessionCall::abi_decode_raw(calldata)
-        .map_err(|e| PrecompileError::Other(format!("verifyProofOfPossession: {e}").into()))?;
+    let decoded = blsVerifyCall::abi_decode_raw(calldata)
+        .map_err(|e| PrecompileError::Other(format!("blsVerify: {e}").into()))?;
 
-    // Reuse the exact crypto the consensus layer uses to *produce* PoPs, so signer and verifier can
-    // never disagree. A malformed point or failed pairing yields `false` (not a revert), matching
-    // `BlsG1.verifyProofOfPossession`'s boolean contract; the caller (`ConsensusRegistry`) is what
-    // turns `false` into its own `InvalidProofOfPossession` revert.
-    let verified = verify_pop(&decoded.signature, &decoded.pubkey, decoded.validatorAddress);
+    // Reuse the exact crypto the consensus layer uses to *produce* signatures, so signer and verifier
+    // can never disagree. A malformed point or failed verification yields `false` (not a revert),
+    // matching `BlsG1.blsVerify`'s boolean contract; the caller (`ConsensusRegistry`) is what turns
+    // `false` into its own `InvalidProofOfPossession` revert.
+    let verified = bls_verify(&decoded.signature, &decoded.pubkey, &decoded.message);
 
-    Ok(PrecompileOutput::new(VERIFY_POP_GAS_COST, Bytes::from(verified.abi_encode())))
+    Ok(PrecompileOutput::new(BLS_VERIFY_GAS_COST, Bytes::from(verified.abi_encode())))
 }
 
-/// Decode the compressed inputs and run the `blst` proof-of-possession check. Any decode or
-/// verification failure maps to `false` so a bad proof can never panic or revert the precompile.
+/// Decode the compressed sig/pubkey and verify the signature over `message` via `blst`. Any decode
+/// or verification failure maps to `false` so bad input can never panic or revert the precompile.
 ///
 /// The explicit length gate is the functional enforcement of the compressed-only encoding: blst's
 /// `deserialize` accepts *either* encoding by length, so without this gate a 96-byte uncompressed
@@ -124,7 +137,7 @@ fn handle_verify_pop(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
 /// rejects the uncompressed forms up front; [`BlsSignature::from_bytes`] /
 /// [`BlsPublicKey::from_literal_bytes`] then require the compression flag, so a 96-byte flag-clear
 /// pubkey is rejected too. Subgroup and infinity checks remain at verify time (unchanged).
-fn verify_pop(compressed_sig: &[u8], compressed_pubkey: &[u8], address: Address) -> bool {
+fn bls_verify(compressed_sig: &[u8], compressed_pubkey: &[u8], message: &[u8]) -> bool {
     if compressed_sig.len() != 48 || compressed_pubkey.len() != 96 {
         return false;
     }
@@ -135,72 +148,79 @@ fn verify_pop(compressed_sig: &[u8], compressed_pubkey: &[u8], address: Address)
         return false;
     };
 
-    verify_proof_of_possession_bls(&sig, &pubkey, &address).is_ok()
+    bls_verify_secure(&sig, &pubkey, message)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use rand::{rngs::StdRng, SeedableRng};
-    use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair};
+    use tn_types::{
+        construct_proof_of_possession_message, generate_proof_of_possession_bls_for_test,
+        BlsKeypair,
+    };
 
-    /// A valid PoP's compressed sig/pubkey bytes for `address`.
-    ///
-    /// `sig`/`pubkey` are `blst::min_sig` compressed `to_bytes()` output (48-byte G1 sig, 96-byte
-    /// G2 pubkey), the exact bytes the protocol passes as the `ProofOfPossession` signature and the
-    /// stored `blsPubkey`.
+    /// A valid signature over a representative message (the consensus proof-of-possession message),
+    /// plus the compressed `blst::min_sig` sig/pubkey bytes the protocol passes on-chain (48-byte G1
+    /// sig, 96-byte G2 pubkey).
     struct Vector {
-        address: Address,
         sig: Vec<u8>,
         pubkey: Vec<u8>,
+        message: Vec<u8>,
     }
 
-    /// Builds a valid proof-of-possession vector from a fixed RNG seed and address byte.
+    /// Builds a valid (signature, pubkey, message) vector from a fixed RNG seed and address byte. The
+    /// message is the proof-of-possession message; the signature is produced over it by the same
+    /// signer path the protocol uses, so signer and precompile agree by construction.
     fn vector(seed: u8, address_byte: u8) -> Vector {
         let keypair = BlsKeypair::generate(&mut StdRng::from_seed([seed; 32]));
         let address = Address::repeat_byte(address_byte);
+        let message = construct_proof_of_possession_message(keypair.public(), &address);
         let proof = generate_proof_of_possession_bls_for_test(&keypair, &address)
             .expect("generate test PoP");
-        let sig = proof.to_bytes().to_vec();
-        let pubkey = keypair.public().to_bytes().to_vec();
-        Vector { address, sig, pubkey }
+        Vector {
+            sig: proof.to_bytes().to_vec(),
+            pubkey: keypair.public().to_bytes().to_vec(),
+            message,
+        }
     }
 
-    /// ABI-encodes a `verifyProofOfPossession` call (selector + args), as a caller would.
-    fn encode_verify(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
-        verifyProofOfPossessionCall {
+    /// ABI-encodes a `blsVerify` call (selector + args), as a caller would.
+    fn encode_verify(sig: &[u8], pubkey: &[u8], message: &[u8]) -> Vec<u8> {
+        blsVerifyCall {
             signature: Bytes::copy_from_slice(sig),
             pubkey: Bytes::copy_from_slice(pubkey),
-            validatorAddress: address,
+            message: Bytes::copy_from_slice(message),
         }
         .abi_encode()
     }
 
-    /// Decodes the ABI-encoded `bool` returned by a `verifyProofOfPossession` call.
+    /// Decodes the ABI-encoded `bool` returned by a `blsVerify` call.
     fn decode_bool(bytes: &[u8]) -> bool {
         <bool as SolValue>::abi_decode(bytes).expect("decode bool return")
     }
 
-    // --- `verify_pop` crypto semantics -----------------------------------------------------------
+    // --- `bls_verify` crypto semantics -----------------------------------------------------------
 
-    /// A well-formed proof of possession verifies through the same `blst` path the signer used.
-    /// Looped over several keypairs/addresses to stand in for the Solidity fuzz coverage.
+    /// A well-formed signature verifies through the same `blst` path the signer used. Looped over
+    /// several keypairs/messages to stand in for the Solidity fuzz coverage.
     #[test]
-    fn verify_pop_accepts_valid_proof() {
+    fn bls_verify_accepts_valid_signature() {
         for (seed, addr) in [(7u8, 0x42u8), (11, 0x01), (99, 0xab), (1, 0xff)] {
             let v = vector(seed, addr);
-            assert!(verify_pop(&v.sig, &v.pubkey, v.address), "seed {seed} addr {addr:#x}");
+            assert!(bls_verify(&v.sig, &v.pubkey, &v.message), "seed {seed} addr {addr:#x}");
         }
     }
 
-    /// S1 (load-bearing): the precompile is compressed-only. A *valid* 96-byte uncompressed
-    /// signature and 192-byte uncompressed pubkey - the pre-change encoding - must be rejected by
-    /// the length gate. blst's `deserialize` would otherwise accept these valid points, so this
-    /// (not random wrong-length bytes) is the proof that the gate is the enforcement.
+    /// S1 (load-bearing): the precompile is compressed-only. A *valid* 96-byte uncompressed signature
+    /// and 192-byte uncompressed pubkey - the pre-change encoding - must be rejected by the length
+    /// gate. blst's `deserialize` would otherwise accept these valid points, so this (not random
+    /// wrong-length bytes) is the proof that the gate is the enforcement.
     #[test]
-    fn verify_pop_rejects_valid_uncompressed_inputs() {
+    fn bls_verify_rejects_valid_uncompressed_inputs() {
         let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7u8; 32]));
         let address = Address::repeat_byte(0x42);
+        let message = construct_proof_of_possession_message(keypair.public(), &address);
         let proof = generate_proof_of_possession_bls_for_test(&keypair, &address)
             .expect("generate test PoP");
 
@@ -212,103 +232,98 @@ mod tests {
         // the same key in compressed form verifies, proving the inputs are otherwise valid
         let compressed_sig = proof.to_bytes().to_vec();
         let compressed_pubkey = keypair.public().to_bytes().to_vec();
-        assert!(verify_pop(&compressed_sig, &compressed_pubkey, address), "compressed control");
+        assert!(bls_verify(&compressed_sig, &compressed_pubkey, &message), "compressed control");
 
         // ...but the valid uncompressed encodings are rejected by the length gate
         assert!(
-            !verify_pop(&uncompressed_sig, &uncompressed_pubkey, address),
+            !bls_verify(&uncompressed_sig, &uncompressed_pubkey, &message),
             "uncompressed gated"
         );
     }
 
-    /// A proof bound to a different address must fail (the address is part of the signed message).
+    /// A signature over one message must not verify against a different message (here, the same key
+    /// bound to a different address yields a different message).
     #[test]
-    fn verify_pop_rejects_wrong_address() {
+    fn bls_verify_rejects_wrong_message() {
         let v = vector(7, 0x42);
-        assert!(!verify_pop(&v.sig, &v.pubkey, Address::repeat_byte(0x43)));
+        let other = vector(7, 0x43);
+        assert!(!bls_verify(&v.sig, &v.pubkey, &other.message));
     }
 
-    /// A signature produced by a different key must fail against the original pubkey
-    /// (port of the Solidity "mutated signature" negative case).
+    /// A signature produced by a different key must fail against the original pubkey (port of the
+    /// Solidity "mutated signature" negative case).
     #[test]
-    fn verify_pop_rejects_wrong_signature() {
+    fn bls_verify_rejects_wrong_signature() {
         let v = vector(7, 0x42);
         let other = vector(8, 0x42);
-        assert!(!verify_pop(&other.sig, &v.pubkey, v.address));
+        assert!(!bls_verify(&other.sig, &v.pubkey, &v.message));
     }
 
-    /// A valid signature must not verify against a substituted pubkey
-    /// (port of the Solidity "pubkey substitution" attack case).
+    /// A valid signature must not verify against a substituted pubkey (port of the Solidity "pubkey
+    /// substitution" attack case).
     #[test]
-    fn verify_pop_rejects_pubkey_substitution() {
+    fn bls_verify_rejects_pubkey_substitution() {
         let v = vector(7, 0x42);
         let other = vector(8, 0x42);
-        assert!(!verify_pop(&v.sig, &other.pubkey, v.address));
+        assert!(!bls_verify(&v.sig, &other.pubkey, &v.message));
     }
 
     /// Identity/infinity points and all-zero inputs return `false`, never panic. All-zero is not a
     /// valid compressed point (a valid compressed infinity carries the `0xc0` flag).
     #[test]
-    fn verify_pop_rejects_zero_and_infinity_points() {
+    fn bls_verify_rejects_zero_and_infinity_points() {
         let v = vector(7, 0x42);
-        // all-zero sig + pubkey at the compressed lengths
-        assert!(!verify_pop(&[0u8; 48], &[0u8; 96], Address::ZERO));
-        // zero signature against an otherwise valid pubkey/address
-        assert!(!verify_pop(&[0u8; 48], &v.pubkey, v.address));
-        // zero pubkey against an otherwise valid signature/address
-        assert!(!verify_pop(&v.sig, &[0u8; 96], v.address));
+        assert!(!bls_verify(&[0u8; 48], &[0u8; 96], &v.message));
+        assert!(!bls_verify(&[0u8; 48], &v.pubkey, &v.message));
+        assert!(!bls_verify(&v.sig, &[0u8; 96], &v.message));
     }
 
     /// Wrong-length sig/pubkey inputs are rejected by the length gate without panicking.
     #[test]
-    fn verify_pop_rejects_wrong_length_inputs() {
+    fn bls_verify_rejects_wrong_length_inputs() {
         let v = vector(7, 0x42);
 
-        // pubkey lengths that are not the 96-byte compressed G2 form (incl. the 192-byte
-        // uncompressed)
+        // pubkey lengths that are not the 96-byte compressed G2 form (incl. the 192-byte uncompressed)
         for len in [0usize, 32, 47, 48, 95, 97, 128, 192, 256] {
-            assert!(!verify_pop(&v.sig, &vec![0u8; len], v.address), "pubkey len {len}");
+            assert!(!bls_verify(&v.sig, &vec![0u8; len], &v.message), "pubkey len {len}");
         }
-        // signature lengths that are not the 48-byte compressed G1 form (incl. the 96-byte
-        // uncompressed)
+        // signature lengths that are not the 48-byte compressed G1 form (incl. the 96-byte uncompressed)
         for len in [0usize, 32, 47, 49, 96, 128, 192] {
-            assert!(!verify_pop(&vec![0u8; len], &v.pubkey, v.address), "sig len {len}");
+            assert!(!bls_verify(&vec![0u8; len], &v.pubkey, &v.message), "sig len {len}");
         }
     }
 
     // --- selector dispatch / ABI surface ---------------------------------------------------------
 
-    /// A valid PoP through the full ABI path returns ABI-encoded `true` and charges the fixed cost.
+    /// A valid signature through the full ABI path returns ABI-encoded `true` and charges the fixed
+    /// cost.
     #[test]
     fn dispatch_verify_valid_returns_true() {
         let v = vector(7, 0x42);
-        let out = dispatch(&encode_verify(&v.sig, &v.pubkey, v.address), VERIFY_POP_GAS_COST)
+        let out = dispatch(&encode_verify(&v.sig, &v.pubkey, &v.message), BLS_VERIFY_GAS_COST)
             .expect("dispatch ok");
         assert!(decode_bool(&out.bytes));
-        assert_eq!(out.gas_used, VERIFY_POP_GAS_COST);
+        assert_eq!(out.gas_used, BLS_VERIFY_GAS_COST);
     }
 
-    /// An invalid PoP returns ABI-encoded `false` rather than reverting: the precompile mirrors
-    /// `BlsG1.verifyProofOfPossession`'s boolean contract, leaving the revert to
-    /// `ConsensusRegistry`.
+    /// An invalid signature returns ABI-encoded `false` rather than reverting: the precompile mirrors
+    /// `BlsG1.blsVerify`'s boolean contract, leaving the revert to `ConsensusRegistry`.
     #[test]
     fn dispatch_verify_invalid_returns_false_not_revert() {
         let v = vector(7, 0x42);
-        let out = dispatch(
-            &encode_verify(&v.sig, &v.pubkey, Address::repeat_byte(0x43)),
-            VERIFY_POP_GAS_COST,
-        )
-        .expect("dispatch ok (false, not error)");
+        let other = vector(7, 0x43);
+        let out = dispatch(&encode_verify(&v.sig, &v.pubkey, &other.message), BLS_VERIFY_GAS_COST)
+            .expect("dispatch ok (false, not error)");
         assert!(!decode_bool(&out.bytes));
         // gas is still charged for the work performed
-        assert_eq!(out.gas_used, VERIFY_POP_GAS_COST);
+        assert_eq!(out.gas_used, BLS_VERIFY_GAS_COST);
     }
 
     /// Verification with less gas than the fixed cost is metered as out-of-gas.
     #[test]
     fn dispatch_verify_out_of_gas() {
         let v = vector(7, 0x42);
-        let res = dispatch(&encode_verify(&v.sig, &v.pubkey, v.address), VERIFY_POP_GAS_COST - 1);
+        let res = dispatch(&encode_verify(&v.sig, &v.pubkey, &v.message), BLS_VERIFY_GAS_COST - 1);
         assert!(matches!(res, Err(PrecompileError::OutOfGas)));
     }
 
@@ -318,10 +333,10 @@ mod tests {
         // unknown 4-byte selector + padding
         let mut unknown = vec![0xDE, 0xAD, 0xBE, 0xEF];
         unknown.extend_from_slice(&[0u8; 32]);
-        assert!(dispatch(&unknown, VERIFY_POP_GAS_COST).is_err());
+        assert!(dispatch(&unknown, BLS_VERIFY_GAS_COST).is_err());
 
         // fewer than 4 bytes cannot carry a selector
-        assert!(dispatch(&[0x01, 0x02], VERIFY_POP_GAS_COST).is_err());
-        assert!(dispatch(&[], VERIFY_POP_GAS_COST).is_err());
+        assert!(dispatch(&[0x01, 0x02], BLS_VERIFY_GAS_COST).is_err());
+        assert!(dispatch(&[], BLS_VERIFY_GAS_COST).is_err());
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1191,8 +1191,7 @@ impl RethEnv {
                 };
                 let bls_pubkey: tn_types::Bytes = v.bls_public_key.to_bytes().into();
                 let proof = ConsensusRegistry::ProofOfPossession {
-                    uncompressedPubkey: v.bls_public_key.serialize().into(),
-                    uncompressedSignature: v.proof_of_possession.serialize().into(),
+                    signature: v.proof_of_possession.to_bytes().into(),
                 };
 
                 (validator, (bls_pubkey, proof))
@@ -1938,8 +1937,7 @@ mod tests {
             calldata,
         );
         let proof = ConsensusRegistry::ProofOfPossession {
-            uncompressedPubkey: new_validator.bls_public_key.serialize().into(),
-            uncompressedSignature: new_validator.proof_of_possession.serialize().into(),
+            signature: new_validator.proof_of_possession.to_bytes().into(),
         };
         let calldata = ConsensusRegistry::stakeCall {
             blsPubkey: new_validator.bls_public_key.to_bytes().into(),

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -30,7 +30,7 @@ use crate::{
     traits::{DefaultEthPayloadTypes, TNExecution},
 };
 use alloy::{
-    hex::{self, ToHexExt},
+    hex,
     primitives::{Bytes, ChainId},
     sol_types::{SolCall, SolConstructor},
 };
@@ -1167,13 +1167,12 @@ impl RethEnv {
             .with_bundle_update()
             .build();
 
-        // The BlsG1 proof-of-possession library is a native precompile registered by the EVM
-        // factory at `BLS_G1_PRECOMPILE_ADDRESS`, so there is nothing to deploy at genesis:
-        // the registry is linked directly against the precompile address. The registry
-        // constructor's PoP verification `delegatecall`s this address and is served
-        // natively by the precompile, which shares the exact `blst` verification the
-        // consensus layer uses to produce the proofs (so the on-chain check cannot drift
-        // from the off-chain encoding).
+        // The BLS proof-of-possession precompile is registered by the EVM factory at
+        // `BLS_G1_PRECOMPILE_ADDRESS`, so there is nothing to deploy at genesis. The registry
+        // constructor's PoP verification staticcalls this address and is served natively by the
+        // precompile, which shares the exact `blst` verification the consensus layer uses to
+        // produce the proofs (so the on-chain check cannot drift from the off-chain
+        // encoding).
         let blsg1_address = BLS_G1_PRECOMPILE_ADDRESS;
 
         // prepare registry deployment
@@ -1218,11 +1217,15 @@ impl RethEnv {
             Self::fetch_value_from_json_str(CONSENSUS_REGISTRY_JSON, Some("bytecode.object"))?;
         let registry_initcode_str =
             registry_initcode_binding.as_str().ok_or_eyre("invalid registry json")?;
-        // link the BlsG1 library address into the registry bytecode
-        let linked_registry_initcode =
-            Self::link_solidity_library(registry_initcode_str, &blsg1_address.encode_hex())?;
-
-        let mut create_registry = linked_registry_initcode;
+        // The registry calls the BLS precompile directly at `BLS_G1_ADDRESS` (no linked library),
+        // so its bytecode carries no link placeholder; deploy it as-is. Guard against a
+        // stale artifact that still contains an unresolved `__$..$__` placeholder.
+        if registry_initcode_str.contains("__$") {
+            eyre::bail!(
+                "ConsensusRegistry initcode has an unresolved library link placeholder; regenerate tn-contracts artifacts"
+            );
+        }
+        let mut create_registry = hex::decode(registry_initcode_str)?;
         create_registry.extend(constructor_args);
 
         // after adding bls proof of possession, registry precompile exceeds size limit so disable
@@ -1295,8 +1298,7 @@ impl RethEnv {
         )?;
         let registry_runtimecode_str =
             registry_runtimecode_binding.as_str().ok_or_eyre("invalid registry json")?;
-        let registry_runtimecode =
-            Self::link_solidity_library(registry_runtimecode_str, &blsg1_address.encode_hex())?;
+        let registry_runtimecode = hex::decode(registry_runtimecode_str)?;
 
         let tmp_worker_configs_storage = state.get(&tmp_worker_configs_address).map(|account| {
             account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
@@ -1314,7 +1316,7 @@ impl RethEnv {
         let issuance_runtimecode =
             hex::decode(issuance_json_binding.as_str().ok_or_eyre("invalid issuance json")?)?;
         let genesis = genesis.extend_accounts([
-            // The BLS proof-of-possession library is a precompile at `blsg1_address`
+            // The BLS proof-of-possession precompile lives at `blsg1_address`
             // (`BLS_G1_PRECOMPILE_ADDRESS`). Mirror the TEL precompile and give it a single `0xfe`
             // (INVALID) byte of code so the account is non-empty (never state-pruned) and any call
             // that bypasses precompile dispatch reverts instead of succeeding against an EOA.
@@ -1342,54 +1344,6 @@ impl RethEnv {
         ]);
 
         Ok(genesis)
-    }
-
-    /// Links a library address into contract bytecode
-    ///
-    /// Replaces Solidity's `__$<34 chars of library hash>$__` placeholder
-    pub fn link_solidity_library(
-        bytecode_hex: &str,
-        library_address: &str,
-    ) -> eyre::Result<Vec<u8>> {
-        const PLACEHOLDER_PREFIX: &str = "__$";
-        const PLACEHOLDER_SUFFIX: &str = "$__";
-        const PLACEHOLDER_LEN: usize = 40; // __$ + 34 chars + $__
-        let library_address_unprefixed =
-            library_address.strip_prefix("0x").unwrap_or(library_address);
-        let mut result = String::with_capacity(bytecode_hex.len());
-        let mut chars = bytecode_hex.chars().peekable();
-
-        while let Some(ch) = chars.next() {
-            // check if we're at the start of a placeholder
-            if ch == '_' && chars.peek() == Some(&'_') {
-                let mut potential_placeholder = String::from("_");
-
-                // collect the next 39 characters (we already have the first _)
-                for _ in 1..PLACEHOLDER_LEN {
-                    if let Some(next_ch) = chars.next() {
-                        potential_placeholder.push(next_ch);
-                    } else {
-                        break;
-                    }
-                }
-
-                // check it matches the placeholder pattern
-                if potential_placeholder.starts_with(PLACEHOLDER_PREFIX)
-                    && potential_placeholder.ends_with(PLACEHOLDER_SUFFIX)
-                    && potential_placeholder.len() == PLACEHOLDER_LEN
-                {
-                    // it's a valid placeholder, replace with address
-                    result.push_str(library_address_unprefixed);
-                } else {
-                    // not a placeholder, add the characters back
-                    result.push_str(&potential_placeholder);
-                }
-            } else {
-                result.push(ch);
-            }
-        }
-
-        hex::decode(result).map_err(Into::into)
     }
 
     /// Fetches json info from the given string

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -181,11 +181,6 @@ sol!(
         function getCommitteeBlsPubkeys(uint32 epoch) external view returns (bytes[] memory);
         /// Fetch the `ValidatorInfo` for a give address.
         function getValidator(address validatorAddress) external view returns (ValidatorInfo memory);
-        /// Returns the BLS12-381 proof of possession message: `blsPubkey || validatorAddress`
-        function proofOfPossessionMessage(
-            bytes memory blsPubkey,
-            address validatorAddress
-        ) external view returns (bytes memory);
         /// Mint an NFT for validator to stake.
         function mint(address validatorAddress) external override onlyOwner;
         /// Stake to the consensus registry.

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -132,12 +132,12 @@ sol!(
             uint32 epochDuration;
         }
 
-        /// Represents a proof of possession for a validator's BLS public key
-        /// Uses a 192-byte uncompressed public key and 96-byte uncompressed PoP
+        /// Represents a validator's BLS12-381 proof of possession: a 48-byte compressed G1
+        /// signature, verified by the native precompile against the separately-supplied 96-byte
+        /// compressed `blsPubkey`.
         #[derive(Debug)]
         struct ProofOfPossession {
-            bytes uncompressedPubkey;
-            bytes uncompressedSignature;
+            bytes signature;
         }
 
         /// Initialize the contract.
@@ -149,7 +149,7 @@ sol!(
             ValidatorInfo[] memory initialValidators_,
             /// The initial validators' BLS12-381 public keys.
             bytes[] memory blsPubkeys_,
-            /// The initial validators' uncompressed proofs of possession
+            /// The initial validators' proofs of possession
             ProofOfPossession[] memory proofsOfPossession,
             /// The address of the owner.
             address owner_

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -681,6 +681,64 @@ pub fn seeded_genesis_from_random_batches<'a>(
     (genesis, txs, senders)
 }
 
+/// Build a complete test [`Genesis`] with the `ConsensusRegistry` deployed and seeded with
+/// `num_validators` deterministic, active validators (the current registry ABI, with the
+/// per-status `EnumerableSet`s populated by the constructor).
+///
+/// [`tn_types::test_genesis`] embeds the *static* testnet registry artifact, which predates the
+/// `getValidatorsInfo` integration ABI. Tests that close an epoch (and therefore make that system
+/// call) must build their chain from this helper so the genesis carries the current registry and a
+/// live committee, rather than the stale static one.
+pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
+    use alloy::primitives::utils::parse_ether;
+    use rand::{rngs::StdRng, SeedableRng as _};
+    use tn_config::NodeInfo;
+    use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair, NodeP2pInfo};
+
+    // deterministic validators so the genesis is reproducible across runs
+    let validators: Vec<NodeInfo> = (0..num_validators)
+        .map(|i| {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let bls = BlsKeypair::generate(&mut rng);
+            // distinct, non-zero execution address per validator
+            let execution_address = Address::from_slice(&[i as u8 + 1; 20]);
+            let proof_of_possession =
+                generate_proof_of_possession_bls_for_test(&bls, &execution_address)
+                    .expect("failed to generate proof of possession for test validator");
+            NodeInfo {
+                name: format!("validator-{i}"),
+                bls_public_key: *bls.public(),
+                p2p_info: NodeP2pInfo::default(),
+                execution_address,
+                proof_of_possession,
+            }
+        })
+        .collect();
+
+    let initial_stake_config = ConsensusRegistry::StakeConfig {
+        stakeAmount: U256::from(parse_ether("1_000_000").expect("parse stake amount")),
+        minWithdrawAmount: U256::from(parse_ether("1_000").expect("parse min withdraw amount")),
+        // Keep issuance even: reward tests assert `epochIssuance.div_ceil(2)` against the contract's
+        // floor split between two leaders, which only agree when the issuance divides exactly.
+        epochIssuance: U256::from(parse_ether("2_000_000").expect("parse epoch issuance")),
+        epochDuration: 60 * 60 * 24, // 24h
+    };
+
+    // Deploy the registry from the default test factory account: `test_genesis` funds it with a
+    // max balance and it is code-less, so it can sign the pre-genesis create. A Safe such as
+    // `GOVERNANCE_SAFE_ADDRESS` carries deployed code, which EIP-3607 rejects as a tx sender.
+    let owner = address!("0xb14d3c4f5fbfbcfb98af2d330000d49c95b93aa7");
+
+    RethEnv::create_consensus_registry_genesis_accounts(
+        validators,
+        test_genesis(),
+        initial_stake_config,
+        owner,
+        vec![(0u8, 30_000_000u64)],
+    )
+    .expect("failed to build test genesis with consensus registry")
+}
+
 /// Helper function to create a committee for tests from on-chain data.
 pub async fn create_committee_from_state(epoch_state: EpochState) -> eyre::Result<Committee> {
     // deconstruct epoch information

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -718,8 +718,9 @@ pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
     let initial_stake_config = ConsensusRegistry::StakeConfig {
         stakeAmount: U256::from(parse_ether("1_000_000").expect("parse stake amount")),
         minWithdrawAmount: U256::from(parse_ether("1_000").expect("parse min withdraw amount")),
-        // Keep issuance even: reward tests assert `epochIssuance.div_ceil(2)` against the contract's
-        // floor split between two leaders, which only agree when the issuance divides exactly.
+        // Keep issuance even: reward tests assert `epochIssuance.div_ceil(2)` against the
+        // contract's floor split between two leaders, which only agree when the issuance
+        // divides exactly.
         epochIssuance: U256::from(parse_ether("2_000_000").expect("parse epoch issuance")),
         epochDuration: 60 * 60 * 24, // 24h
     };

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -681,65 +681,6 @@ pub fn seeded_genesis_from_random_batches<'a>(
     (genesis, txs, senders)
 }
 
-/// Build a complete test [`Genesis`] with the `ConsensusRegistry` deployed and seeded with
-/// `num_validators` deterministic, active validators (the current registry ABI, with the
-/// per-status `EnumerableSet`s populated by the constructor).
-///
-/// [`tn_types::test_genesis`] embeds the *static* testnet registry artifact, which predates the
-/// `getValidatorsInfo` integration ABI. Tests that close an epoch (and therefore make that system
-/// call) must build their chain from this helper so the genesis carries the current registry and a
-/// live committee, rather than the stale static one.
-pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
-    use alloy::primitives::utils::parse_ether;
-    use rand::{rngs::StdRng, SeedableRng as _};
-    use tn_config::NodeInfo;
-    use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair, NodeP2pInfo};
-
-    // deterministic validators so the genesis is reproducible across runs
-    let validators: Vec<NodeInfo> = (0..num_validators)
-        .map(|i| {
-            let mut rng = StdRng::seed_from_u64(i as u64);
-            let bls = BlsKeypair::generate(&mut rng);
-            // distinct, non-zero execution address per validator
-            let execution_address = Address::from_slice(&[i as u8 + 1; 20]);
-            let proof_of_possession =
-                generate_proof_of_possession_bls_for_test(&bls, &execution_address)
-                    .expect("failed to generate proof of possession for test validator");
-            NodeInfo {
-                name: format!("validator-{i}"),
-                bls_public_key: *bls.public(),
-                p2p_info: NodeP2pInfo::default(),
-                execution_address,
-                proof_of_possession,
-            }
-        })
-        .collect();
-
-    let initial_stake_config = ConsensusRegistry::StakeConfig {
-        stakeAmount: U256::from(parse_ether("1_000_000").expect("parse stake amount")),
-        minWithdrawAmount: U256::from(parse_ether("1_000").expect("parse min withdraw amount")),
-        // Keep issuance even: reward tests assert `epochIssuance.div_ceil(2)` against the
-        // contract's floor split between two leaders, which only agree when the issuance
-        // divides exactly.
-        epochIssuance: U256::from(parse_ether("2_000_000").expect("parse epoch issuance")),
-        epochDuration: 60 * 60 * 24, // 24h
-    };
-
-    // Deploy the registry from the default test factory account: `test_genesis` funds it with a
-    // max balance and it is code-less, so it can sign the pre-genesis create. A Safe such as
-    // `GOVERNANCE_SAFE_ADDRESS` carries deployed code, which EIP-3607 rejects as a tx sender.
-    let owner = address!("0xb14d3c4f5fbfbcfb98af2d330000d49c95b93aa7");
-
-    RethEnv::create_consensus_registry_genesis_accounts(
-        validators,
-        test_genesis(),
-        initial_stake_config,
-        owner,
-        vec![(0u8, 30_000_000u64)],
-    )
-    .expect("failed to build test genesis with consensus registry")
-}
-
 /// Helper function to create a committee for tests from on-chain data.
 pub async fn create_committee_from_state(epoch_state: EpochState) -> eyre::Result<Committee> {
     // deconstruct epoch information

--- a/crates/tn-reth/tests/it/bls_precompile_props.rs
+++ b/crates/tn-reth/tests/it/bls_precompile_props.rs
@@ -5,39 +5,24 @@
 //! observable contract across randomized inputs:
 //! - A correctly-generated proof of possession verifies; wrong address / wrong key / wrong
 //!   signature do not.
-//! - Malformed or wrong-length point bytes return `false` rather than reverting (matching
-//!   `BlsG1.verifyProofOfPossession`'s boolean contract), and never panic.
-//! - `proofOfPossessionMessage` returns exactly the bytes verification signs over and is bound to
-//!   the validator address.
+//! - Malformed or wrong-length point bytes (including the valid uncompressed encodings) return
+//!   `false` rather than reverting (matching `BlsG1.verifyProofOfPossession`'s boolean contract),
+//!   and never panic.
 //! - Calldata validation: short calldata and unknown selectors revert.
 
-use alloy::{
-    primitives::address,
-    sol,
-    sol_types::{SolCall, SolValue},
-};
+use alloy::{primitives::address, sol, sol_types::SolCall};
 use proptest::prelude::*;
 use rand::{rngs::StdRng, SeedableRng};
 use reth_revm::primitives::Address;
-use tn_reth::test_utils::precompile_test_utils::{
-    assert_not_success, decode_bool, extract_output_bytes, TestEnv, USER,
-};
-use tn_types::{
-    generate_proof_of_possession_bls_for_test, proof_of_possession_message_bytes, BlsKeypair,
-    BlsPublicKey, Bytes,
-};
+use tn_reth::test_utils::precompile_test_utils::{assert_not_success, decode_bool, TestEnv, USER};
+use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair, Bytes};
 
 sol! {
     function verifyProofOfPossession(
-        bytes uncompressedSignature,
-        bytes uncompressedPubkey,
+        bytes signature,
+        bytes pubkey,
         address validatorAddress
     ) external view returns (bool);
-
-    function proofOfPossessionMessage(
-        bytes uncompressedPubkey,
-        address validatorAddress
-    ) external pure returns (bytes);
 }
 
 /// Canonical address the BLS precompile is registered at (matches `BlsG1`'s link address). The
@@ -49,11 +34,10 @@ const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000
 /// 100k harness limit is insufficient; mirror the 1M budget `stake`/`delegateStake` run with.
 const VERIFY_GAS: u64 = 1_000_000;
 
-/// A valid proof-of-possession vector: the keypair plus its uncompressed `blst::min_sig`
-/// `serialize()` bytes (96-byte G1 signature, 192-byte G2 pubkey) - the exact bytes the protocol
-/// passes to `BlsG1` / this precompile.
+/// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte
+/// G1 signature, 96-byte G2 pubkey) - the exact bytes the protocol passes to `BlsG1` / this
+/// precompile.
 struct Vector {
-    keypair: BlsKeypair,
     sig: Vec<u8>,
     pubkey: Vec<u8>,
 }
@@ -63,16 +47,16 @@ fn vector(seed: [u8; 32], address: Address) -> Vector {
     let keypair = BlsKeypair::generate(&mut StdRng::from_seed(seed));
     let proof =
         generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
-    let sig = proof.serialize().to_vec();
-    let pubkey = keypair.public().serialize().to_vec();
-    Vector { keypair, sig, pubkey }
+    let sig = proof.to_bytes().to_vec();
+    let pubkey = keypair.public().to_bytes().to_vec();
+    Vector { sig, pubkey }
 }
 
 /// ABI-encodes a `verifyProofOfPossession` call.
 fn verify_calldata(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
     verifyProofOfPossessionCall {
-        uncompressedSignature: Bytes::copy_from_slice(sig),
-        uncompressedPubkey: Bytes::copy_from_slice(pubkey),
+        signature: Bytes::copy_from_slice(sig),
+        pubkey: Bytes::copy_from_slice(pubkey),
         validatorAddress: address,
     }
     .abi_encode()
@@ -157,8 +141,8 @@ proptest! {
     /// encoding is well-formed, so the precompile decodes it and reports a failed verification.
     #[test]
     fn prop_garbage_points_return_false(
-        sig in prop::collection::vec(any::<u8>(), 96),
-        pubkey in prop::collection::vec(any::<u8>(), 192),
+        sig in prop::collection::vec(any::<u8>(), 48),
+        pubkey in prop::collection::vec(any::<u8>(), 96),
         addr in any::<[u8; 20]>(),
     ) {
         let address = Address::from(addr);
@@ -167,30 +151,30 @@ proptest! {
         prop_assert!(!verify(&mut env, &sig, &pubkey, address));
     }
 
-    /// Wrong-length pubkey bytes (anything but the 192-byte uncompressed G2 form) return `false`
-    /// against an otherwise valid signature. Mirrors the Solidity `invalidPubkeyLength` cases.
+    /// Wrong-length pubkey bytes (anything but the 96-byte compressed G2 form, including the
+    /// 192-byte uncompressed form) return `false` against an otherwise valid signature.
     #[test]
     fn prop_wrong_length_pubkey_returns_false(
         seed in any::<[u8; 32]>(),
         addr in any::<[u8; 20]>(),
         bad_len in 0usize..256,
     ) {
-        prop_assume!(bad_len != 192);
+        prop_assume!(bad_len != 96);
         let address = Address::from(addr);
         let v = vector(seed, address);
         let mut env = TestEnv::new();
         prop_assert!(!verify(&mut env, &v.sig, &vec![0xABu8; bad_len], address));
     }
 
-    /// Wrong-length signature bytes (anything but the 96-byte uncompressed G1 form) return `false`
-    /// against an otherwise valid pubkey.
+    /// Wrong-length signature bytes (anything but the 48-byte compressed G1 form, including the
+    /// 96-byte uncompressed form) return `false` against an otherwise valid pubkey.
     #[test]
     fn prop_wrong_length_signature_returns_false(
         seed in any::<[u8; 32]>(),
         addr in any::<[u8; 20]>(),
         bad_len in 0usize..200,
     ) {
-        prop_assume!(bad_len != 96);
+        prop_assume!(bad_len != 48);
         let address = Address::from(addr);
         let v = vector(seed, address);
         let mut env = TestEnv::new();
@@ -199,53 +183,50 @@ proptest! {
 }
 
 // ==============================
-// `proofOfPossessionMessage`
+// Compressed-only enforcement (S1)
 // ==============================
 
-/// Decodes the ABI-encoded `bytes` returned by a successful `proofOfPossessionMessage` call.
-fn message_for(env: &mut TestEnv, pubkey: &[u8], address: Address) -> Vec<u8> {
-    let calldata = proofOfPossessionMessageCall {
-        uncompressedPubkey: Bytes::copy_from_slice(pubkey),
-        validatorAddress: address,
-    }
-    .abi_encode();
-    let result = env.exec_to(USER, BLS_G1_PRECOMPILE_ADDRESS, calldata, VERIFY_GAS);
-    <Bytes as SolValue>::abi_decode(&extract_output_bytes(&result)).expect("decode bytes").to_vec()
-}
+/// The precompile is compressed-only: a *valid* 96-byte uncompressed signature and 192-byte
+/// uncompressed pubkey - the pre-change encoding - are rejected by the length gate. blst's
+/// `deserialize` would otherwise accept these valid points, so this (not random wrong-length bytes)
+/// is the proof that the gate is the enforcement.
+#[test]
+fn test_valid_uncompressed_inputs_rejected() {
+    let address = Address::repeat_byte(0x42);
+    let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7; 32]));
+    let proof =
+        generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
 
-proptest! {
-    /// `proofOfPossessionMessage` returns exactly the bytes verification signs over (the tn-types
-    /// `IntentMessage` encoding), and is bound to the validator address.
-    #[test]
-    fn prop_message_matches_types_and_is_address_bound(
-        seed in any::<[u8; 32]>(),
-        addr_a in any::<[u8; 20]>(),
-        addr_b in any::<[u8; 20]>(),
-    ) {
-        let a = Address::from(addr_a);
-        let b = Address::from(addr_b);
-        let v = vector(seed, a);
-        let public: &BlsPublicKey = v.keypair.public();
-        let mut env = TestEnv::new();
+    let uncompressed_sig = proof.serialize().to_vec();
+    let uncompressed_pubkey = keypair.public().serialize().to_vec();
+    assert_eq!(uncompressed_sig.len(), 96, "uncompressed G1 signature");
+    assert_eq!(uncompressed_pubkey.len(), 192, "uncompressed G2 pubkey");
 
-        let from_precompile = message_for(&mut env, &v.pubkey, a);
-        let from_types = proof_of_possession_message_bytes(public, &a).expect("build message");
-        prop_assert_eq!(&from_precompile, &from_types, "precompile message must match tn-types");
-
-        if a != b {
-            let other = message_for(&mut env, &v.pubkey, b);
-            prop_assert_ne!(from_precompile, other, "message must be address-bound");
-        }
-    }
+    let mut env = TestEnv::new();
+    // the compressed control verifies (the key/proof are otherwise valid)
+    assert!(
+        verify(
+            &mut env,
+            &proof.to_bytes().to_vec(),
+            &keypair.public().to_bytes().to_vec(),
+            address
+        ),
+        "compressed control",
+    );
+    // ...but the valid uncompressed encodings are gated out
+    assert!(
+        !verify(&mut env, &uncompressed_sig, &uncompressed_pubkey, address),
+        "uncompressed gated"
+    );
 }
 
 // ==============================
 // Calldata validation
 // ==============================
 
-/// The two selectors the precompile implements.
-fn known_selectors() -> [[u8; 4]; 2] {
-    [verifyProofOfPossessionCall::SELECTOR, proofOfPossessionMessageCall::SELECTOR]
+/// The selectors the precompile implements.
+fn known_selectors() -> [[u8; 4]; 1] {
+    [verifyProofOfPossessionCall::SELECTOR]
 }
 
 proptest! {
@@ -267,10 +248,9 @@ proptest! {
     /// Calldata too short to ABI-decode the arguments reverts (the selector is valid but the
     /// dynamic `bytes`/`address` arguments cannot be parsed).
     #[test]
-    fn prop_short_calldata_fails(selector_idx in 0usize..2, len in 0usize..32) {
-        let selector = known_selectors()[selector_idx];
+    fn prop_short_calldata_fails(len in 0usize..32) {
         let mut data = Vec::with_capacity(4 + len);
-        data.extend_from_slice(&selector);
+        data.extend_from_slice(&verifyProofOfPossessionCall::SELECTOR);
         data.extend(std::iter::repeat_n(0u8, len));
 
         let mut env = TestEnv::new();

--- a/crates/tn-reth/tests/it/bls_precompile_props.rs
+++ b/crates/tn-reth/tests/it/bls_precompile_props.rs
@@ -1,27 +1,32 @@
-//! Property-based tests for the native BLS proof-of-possession precompile (`0x…b151`).
+//! Property-based tests for the native BLS signature-verification precompile (`0x…b151`).
 //!
-//! These exercise the precompile through the real EVM call path (the same one
-//! `ConsensusRegistry`'s linked `BlsG1` library reaches via `delegatecall`), verifying its
-//! observable contract across randomized inputs:
-//! - A correctly-generated proof of possession verifies; wrong address / wrong key / wrong
-//!   signature do not.
+//! These exercise the precompile through the real EVM call path (the same one `ConsensusRegistry`'s
+//! linked `BlsG1` library reaches via `delegatecall`), verifying its observable contract across
+//! randomized inputs:
+//! - A correctly-generated proof of possession verifies; a different message (wrong address) / wrong
+//!   key / wrong signature do not.
 //! - Malformed or wrong-length point bytes (including the valid uncompressed encodings) return
-//!   `false` rather than reverting (matching `BlsG1.verifyProofOfPossession`'s boolean contract),
-//!   and never panic.
+//!   `false` rather than reverting (matching `BlsG1.blsVerify`'s boolean contract), and never panic.
 //! - Calldata validation: short calldata and unknown selectors revert.
+//!
+//! The precompile is a generic BLS verifier; `ConsensusRegistry`'s proof-of-possession message
+//! (`intentPrefix || compressedPubkey || address`) is the representative message used here.
 
 use alloy::{primitives::address, sol, sol_types::SolCall};
 use proptest::prelude::*;
 use rand::{rngs::StdRng, SeedableRng};
 use reth_revm::primitives::Address;
 use tn_reth::test_utils::precompile_test_utils::{assert_not_success, decode_bool, TestEnv, USER};
-use tn_types::{generate_proof_of_possession_bls_for_test, BlsKeypair, Bytes};
+use tn_types::{
+    construct_proof_of_possession_message, generate_proof_of_possession_bls_for_test, BlsKeypair,
+    Bytes,
+};
 
 sol! {
-    function verifyProofOfPossession(
+    function blsVerify(
         bytes signature,
         bytes pubkey,
-        address validatorAddress
+        bytes message
     ) external view returns (bool);
 }
 
@@ -30,47 +35,51 @@ sol! {
 /// which also guards against the address silently drifting.
 const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
 
-/// Gas limit for verify calls. The precompile charges 150k for a verification, so the default
-/// 100k harness limit is insufficient; mirror the 1M budget `stake`/`delegateStake` run with.
+/// Gas limit for verify calls. The precompile charges 150k for a verification, so the default 100k
+/// harness limit is insufficient; mirror the 1M budget `stake`/`delegateStake` run with.
 const VERIFY_GAS: u64 = 1_000_000;
 
-/// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte
-/// G1 signature, 96-byte G2 pubkey) - the exact bytes the protocol passes to `BlsG1` / this
-/// precompile.
+/// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte G1
+/// signature, 96-byte G2 pubkey) and the proof-of-possession message they were produced over - the
+/// exact bytes the protocol passes to `BlsG1` / this precompile.
 struct Vector {
     sig: Vec<u8>,
     pubkey: Vec<u8>,
+    message: Vec<u8>,
 }
 
 /// Builds a valid proof of possession for `address` from a deterministic RNG seed.
 fn vector(seed: [u8; 32], address: Address) -> Vector {
     let keypair = BlsKeypair::generate(&mut StdRng::from_seed(seed));
+    let message = construct_proof_of_possession_message(keypair.public(), &address);
     let proof =
         generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
-    let sig = proof.to_bytes().to_vec();
-    let pubkey = keypair.public().to_bytes().to_vec();
-    Vector { sig, pubkey }
+    Vector {
+        sig: proof.to_bytes().to_vec(),
+        pubkey: keypair.public().to_bytes().to_vec(),
+        message,
+    }
 }
 
-/// ABI-encodes a `verifyProofOfPossession` call.
-fn verify_calldata(sig: &[u8], pubkey: &[u8], address: Address) -> Vec<u8> {
-    verifyProofOfPossessionCall {
+/// ABI-encodes a `blsVerify` call.
+fn verify_calldata(sig: &[u8], pubkey: &[u8], message: &[u8]) -> Vec<u8> {
+    blsVerifyCall {
         signature: Bytes::copy_from_slice(sig),
         pubkey: Bytes::copy_from_slice(pubkey),
-        validatorAddress: address,
+        message: Bytes::copy_from_slice(message),
     }
     .abi_encode()
 }
 
-/// Executes `verifyProofOfPossession` against the precompile and returns the decoded `bool`.
+/// Executes `blsVerify` against the precompile and returns the decoded `bool`.
 ///
 /// Asserts the call itself succeeded - an invalid proof returns `Ok(false)`, not a revert, so a
 /// revert here would be a contract violation and fails the test inside `decode_bool`.
-fn verify(env: &mut TestEnv, sig: &[u8], pubkey: &[u8], address: Address) -> bool {
+fn verify(env: &mut TestEnv, sig: &[u8], pubkey: &[u8], message: &[u8]) -> bool {
     let result = env.exec_to(
         USER,
         BLS_G1_PRECOMPILE_ADDRESS,
-        verify_calldata(sig, pubkey, address),
+        verify_calldata(sig, pubkey, message),
         VERIFY_GAS,
     );
     decode_bool(&result)
@@ -87,10 +96,12 @@ proptest! {
         let address = Address::from(addr);
         let v = vector(seed, address);
         let mut env = TestEnv::new();
-        prop_assert!(verify(&mut env, &v.sig, &v.pubkey, address));
+        prop_assert!(verify(&mut env, &v.sig, &v.pubkey, &v.message));
     }
 
-    /// A proof bound to one address never verifies for a different address.
+    /// A proof bound to one address never verifies against a different address's message (the
+    /// address is bound through the signed message). Same seed -> same key, so only the message
+    /// differs.
     #[test]
     fn prop_wrong_address_rejected(
         seed in any::<[u8; 32]>(),
@@ -98,11 +109,11 @@ proptest! {
         addr_b in any::<[u8; 20]>(),
     ) {
         prop_assume!(addr_a != addr_b);
-        let bound = Address::from(addr_a);
-        let other = Address::from(addr_b);
-        let v = vector(seed, bound);
+        let bound = vector(seed, Address::from(addr_a));
+        let other = vector(seed, Address::from(addr_b));
         let mut env = TestEnv::new();
-        prop_assert!(!verify(&mut env, &v.sig, &v.pubkey, other));
+        // bound's signature/key, but other's (different-address) message -> must fail
+        prop_assert!(!verify(&mut env, &bound.sig, &bound.pubkey, &other.message));
     }
 
     /// A valid signature never verifies against a substituted public key.
@@ -117,8 +128,8 @@ proptest! {
         let a = vector(seed_a, address);
         let b = vector(seed_b, address);
         let mut env = TestEnv::new();
-        // a's signature, b's pubkey -> must fail
-        prop_assert!(!verify(&mut env, &a.sig, &b.pubkey, address));
+        // a's signature, b's pubkey, a's message -> must fail
+        prop_assert!(!verify(&mut env, &a.sig, &b.pubkey, &a.message));
     }
 
     /// A signature from a different key never verifies against the original pubkey.
@@ -133,8 +144,8 @@ proptest! {
         let a = vector(seed_a, address);
         let b = vector(seed_b, address);
         let mut env = TestEnv::new();
-        // b's signature, a's pubkey -> must fail
-        prop_assert!(!verify(&mut env, &b.sig, &a.pubkey, address));
+        // b's signature, a's pubkey, a's message -> must fail
+        prop_assert!(!verify(&mut env, &b.sig, &a.pubkey, &a.message));
     }
 
     /// Random, correctly-sized point bytes return `false` (not a revert) and never panic. The ABI
@@ -145,10 +156,10 @@ proptest! {
         pubkey in prop::collection::vec(any::<u8>(), 96),
         addr in any::<[u8; 20]>(),
     ) {
-        let address = Address::from(addr);
+        let v = vector([1u8; 32], Address::from(addr));
         let mut env = TestEnv::new();
-        // Astronomically unlikely to be a valid PoP; the invariant is "false, never panic/revert".
-        prop_assert!(!verify(&mut env, &sig, &pubkey, address));
+        // Astronomically unlikely to be a valid signature; the invariant is "false, never panic/revert".
+        prop_assert!(!verify(&mut env, &sig, &pubkey, &v.message));
     }
 
     /// Wrong-length pubkey bytes (anything but the 96-byte compressed G2 form, including the
@@ -160,10 +171,9 @@ proptest! {
         bad_len in 0usize..256,
     ) {
         prop_assume!(bad_len != 96);
-        let address = Address::from(addr);
-        let v = vector(seed, address);
+        let v = vector(seed, Address::from(addr));
         let mut env = TestEnv::new();
-        prop_assert!(!verify(&mut env, &v.sig, &vec![0xABu8; bad_len], address));
+        prop_assert!(!verify(&mut env, &v.sig, &vec![0xABu8; bad_len], &v.message));
     }
 
     /// Wrong-length signature bytes (anything but the 48-byte compressed G1 form, including the
@@ -175,10 +185,9 @@ proptest! {
         bad_len in 0usize..200,
     ) {
         prop_assume!(bad_len != 48);
-        let address = Address::from(addr);
-        let v = vector(seed, address);
+        let v = vector(seed, Address::from(addr));
         let mut env = TestEnv::new();
-        prop_assert!(!verify(&mut env, &vec![0xABu8; bad_len], &v.pubkey, address));
+        prop_assert!(!verify(&mut env, &vec![0xABu8; bad_len], &v.pubkey, &v.message));
     }
 }
 
@@ -194,6 +203,7 @@ proptest! {
 fn test_valid_uncompressed_inputs_rejected() {
     let address = Address::repeat_byte(0x42);
     let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7; 32]));
+    let message = construct_proof_of_possession_message(keypair.public(), &address);
     let proof =
         generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
 
@@ -209,13 +219,13 @@ fn test_valid_uncompressed_inputs_rejected() {
             &mut env,
             &proof.to_bytes().to_vec(),
             &keypair.public().to_bytes().to_vec(),
-            address
+            &message
         ),
         "compressed control",
     );
     // ...but the valid uncompressed encodings are gated out
     assert!(
-        !verify(&mut env, &uncompressed_sig, &uncompressed_pubkey, address),
+        !verify(&mut env, &uncompressed_sig, &uncompressed_pubkey, &message),
         "uncompressed gated"
     );
 }
@@ -226,7 +236,7 @@ fn test_valid_uncompressed_inputs_rejected() {
 
 /// The selectors the precompile implements.
 fn known_selectors() -> [[u8; 4]; 1] {
-    [verifyProofOfPossessionCall::SELECTOR]
+    [blsVerifyCall::SELECTOR]
 }
 
 proptest! {
@@ -246,11 +256,11 @@ proptest! {
     }
 
     /// Calldata too short to ABI-decode the arguments reverts (the selector is valid but the
-    /// dynamic `bytes`/`address` arguments cannot be parsed).
+    /// dynamic `bytes` arguments cannot be parsed).
     #[test]
     fn prop_short_calldata_fails(len in 0usize..32) {
         let mut data = Vec::with_capacity(4 + len);
-        data.extend_from_slice(&verifyProofOfPossessionCall::SELECTOR);
+        data.extend_from_slice(&blsVerifyCall::SELECTOR);
         data.extend(std::iter::repeat_n(0u8, len));
 
         let mut env = TestEnv::new();
@@ -287,24 +297,25 @@ const RELAY_BYTECODE: &[u8] = &[
 ];
 
 /// A valid proof verifies, and a tampered one is rejected, when reached via `DELEGATECALL` - the
-/// same way `ConsensusRegistry`'s `BlsG1.verifyProofOfPossession` library call lands here.
+/// same way `ConsensusRegistry`'s `BlsG1.blsVerify` library call lands here.
 #[test]
 fn test_delegatecall_verify_pop() {
     let address = Address::repeat_byte(0x42);
     let v = vector([7; 32], address);
+    let other = vector([7; 32], Address::repeat_byte(0x43));
 
     let mut env = TestEnv::new();
     env.deploy_code(RELAY_ADDR, Bytes::from_static(RELAY_BYTECODE));
 
     // Valid PoP through the relay -> true.
-    let ok = env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, address), VERIFY_GAS);
+    let ok = env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, &v.message), VERIFY_GAS);
     assert!(decode_bool(&ok), "valid PoP must verify via DELEGATECALL");
 
-    // Wrong address through the relay -> false (still a successful call returning `false`).
+    // Different-address message through the relay -> false (still a successful call returning `false`).
     let bad = env.exec_to(
         USER,
         RELAY_ADDR,
-        verify_calldata(&v.sig, &v.pubkey, Address::repeat_byte(0x43)),
+        verify_calldata(&v.sig, &v.pubkey, &other.message),
         VERIFY_GAS,
     );
     assert!(!decode_bool(&bad), "wrong-address PoP must be rejected via DELEGATECALL");

--- a/crates/tn-reth/tests/it/bls_precompile_props.rs
+++ b/crates/tn-reth/tests/it/bls_precompile_props.rs
@@ -1,12 +1,12 @@
 //! Property-based tests for the native BLS signature-verification precompile (`0x…b151`).
 //!
-//! These exercise the precompile through the real EVM call path (the same one `ConsensusRegistry`'s
-//! linked `BlsG1` library reaches via `delegatecall`), verifying its observable contract across
-//! randomized inputs:
+//! These exercise the precompile through the real EVM call path (the same one `ConsensusRegistry`
+//! reaches via a low-level `staticcall`), verifying its observable contract across randomized
+//! inputs:
 //! - A correctly-generated proof of possession verifies; a different message (wrong address) /
 //!   wrong key / wrong signature do not.
 //! - Malformed or wrong-length point bytes (including the valid uncompressed encodings) return
-//!   `false` rather than reverting (matching `BlsG1.blsVerify`'s boolean contract), and never
+//!   `false` rather than reverting (matching `IBlsG1.blsVerify`'s boolean contract), and never
 //!   panic.
 //! - Calldata validation: short calldata and unknown selectors revert.
 //!
@@ -31,7 +31,7 @@ sol! {
     ) external view returns (bool);
 }
 
-/// Canonical address the BLS precompile is registered at (matches `BlsG1`'s link address). The
+/// Canonical address the BLS precompile is registered at (matches `BLS_G1_ADDRESS`). The
 /// integration crate cannot see the crate-internal constant, so it is pinned here independently -
 /// which also guards against the address silently drifting.
 const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000000000000b151");
@@ -42,7 +42,7 @@ const VERIFY_GAS: u64 = 1_000_000;
 
 /// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte
 /// G1 signature, 96-byte G2 pubkey) and the proof-of-possession message they were produced over -
-/// the exact bytes the protocol passes to `BlsG1` / this precompile.
+/// the exact bytes the protocol passes to this precompile.
 struct Vector {
     sig: Vec<u8>,
     pubkey: Vec<u8>,
@@ -267,36 +267,36 @@ proptest! {
 }
 
 // ==============================
-// `DELEGATECALL` relay (the `ConsensusRegistry` path)
+// `STATICCALL` relay (the `ConsensusRegistry` path)
 // ==============================
 
-/// Address hosting the `DELEGATECALL` relay contract.
+/// Address hosting the `STATICCALL` relay contract.
 const RELAY_ADDR: Address = address!("dddd0000000000000000000000000000000000b1");
 
-/// Minimal runtime bytecode that forwards calldata to `0x…b151` via `DELEGATECALL` and returns the
-/// precompile's output verbatim. This is exactly how `ConsensusRegistry`'s linked `BlsG1` library
-/// reaches the precompile, so it proves that integration path resolves to our native code.
+/// Minimal runtime bytecode that forwards calldata to `0x…b151` via `STATICCALL` and returns the
+/// precompile's output verbatim. This is exactly how `ConsensusRegistry` reaches the precompile (a
+/// low-level staticcall), so it proves that integration path resolves to our native code.
 ///
 /// Disassembly:
 /// ```text
 ///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY      // mem[0..csize] = calldata
 ///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;          // retSize, retOffset, argsSize, argsOffset
-///   PUSH2 0xb151; GAS; DELEGATECALL; POP              // delegatecall to BLS precompile
+///   PUSH2 0xb151; GAS; STATICCALL; POP                // staticcall to BLS precompile
 ///   RETURNDATASIZE; PUSH1 0; PUSH1 0; RETURNDATACOPY  // mem[0..rsize] = returndata
 ///   RETURNDATASIZE; PUSH1 0; RETURN                   // return mem[0..rsize]
 /// ```
 const RELAY_BYTECODE: &[u8] = &[
     0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
-    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x61, 0xb1, 0x51, 0x5a, 0xf4,
-    0x50, // PUSH2 0xb151; GAS; DELEGATECALL; POP
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x61, 0xb1, 0x51, 0x5a, 0xfa,
+    0x50, // PUSH2 0xb151; GAS; STATICCALL; POP
     0x3d, 0x60, 0x00, 0x60, 0x00, 0x3e, // RETURNDATACOPY(0, 0, RETURNDATASIZE)
     0x3d, 0x60, 0x00, 0xf3, // RETURN(0, RETURNDATASIZE)
 ];
 
-/// A valid proof verifies, and a tampered one is rejected, when reached via `DELEGATECALL` - the
-/// same way `ConsensusRegistry`'s `BlsG1.blsVerify` library call lands here.
+/// A valid proof verifies, and a tampered one is rejected, when reached via `STATICCALL` - the
+/// same way `ConsensusRegistry`'s `blsVerify` staticcall lands here.
 #[test]
-fn test_delegatecall_verify_pop() {
+fn test_staticcall_verify_pop() {
     let address = Address::repeat_byte(0x42);
     let v = vector([7; 32], address);
     let other = vector([7; 32], Address::repeat_byte(0x43));
@@ -307,7 +307,7 @@ fn test_delegatecall_verify_pop() {
     // Valid PoP through the relay -> true.
     let ok =
         env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, &v.message), VERIFY_GAS);
-    assert!(decode_bool(&ok), "valid PoP must verify via DELEGATECALL");
+    assert!(decode_bool(&ok), "valid PoP must verify via STATICCALL");
 
     // Different-address message through the relay -> false (still a successful call returning
     // `false`).
@@ -317,5 +317,5 @@ fn test_delegatecall_verify_pop() {
         verify_calldata(&v.sig, &v.pubkey, &other.message),
         VERIFY_GAS,
     );
-    assert!(!decode_bool(&bad), "wrong-address PoP must be rejected via DELEGATECALL");
+    assert!(!decode_bool(&bad), "wrong-address PoP must be rejected via STATICCALL");
 }

--- a/crates/tn-reth/tests/it/bls_precompile_props.rs
+++ b/crates/tn-reth/tests/it/bls_precompile_props.rs
@@ -3,10 +3,11 @@
 //! These exercise the precompile through the real EVM call path (the same one `ConsensusRegistry`'s
 //! linked `BlsG1` library reaches via `delegatecall`), verifying its observable contract across
 //! randomized inputs:
-//! - A correctly-generated proof of possession verifies; a different message (wrong address) / wrong
-//!   key / wrong signature do not.
+//! - A correctly-generated proof of possession verifies; a different message (wrong address) /
+//!   wrong key / wrong signature do not.
 //! - Malformed or wrong-length point bytes (including the valid uncompressed encodings) return
-//!   `false` rather than reverting (matching `BlsG1.blsVerify`'s boolean contract), and never panic.
+//!   `false` rather than reverting (matching `BlsG1.blsVerify`'s boolean contract), and never
+//!   panic.
 //! - Calldata validation: short calldata and unknown selectors revert.
 //!
 //! The precompile is a generic BLS verifier; `ConsensusRegistry`'s proof-of-possession message
@@ -39,9 +40,9 @@ const BLS_G1_PRECOMPILE_ADDRESS: Address = address!("000000000000000000000000000
 /// harness limit is insufficient; mirror the 1M budget `stake`/`delegateStake` run with.
 const VERIFY_GAS: u64 = 1_000_000;
 
-/// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte G1
-/// signature, 96-byte G2 pubkey) and the proof-of-possession message they were produced over - the
-/// exact bytes the protocol passes to `BlsG1` / this precompile.
+/// A valid proof-of-possession vector: the compressed `blst::min_sig` `to_bytes()` bytes (48-byte
+/// G1 signature, 96-byte G2 pubkey) and the proof-of-possession message they were produced over -
+/// the exact bytes the protocol passes to `BlsG1` / this precompile.
 struct Vector {
     sig: Vec<u8>,
     pubkey: Vec<u8>,
@@ -54,11 +55,7 @@ fn vector(seed: [u8; 32], address: Address) -> Vector {
     let message = construct_proof_of_possession_message(keypair.public(), &address);
     let proof =
         generate_proof_of_possession_bls_for_test(&keypair, &address).expect("generate test PoP");
-    Vector {
-        sig: proof.to_bytes().to_vec(),
-        pubkey: keypair.public().to_bytes().to_vec(),
-        message,
-    }
+    Vector { sig: proof.to_bytes().to_vec(), pubkey: keypair.public().to_bytes().to_vec(), message }
 }
 
 /// ABI-encodes a `blsVerify` call.
@@ -308,10 +305,12 @@ fn test_delegatecall_verify_pop() {
     env.deploy_code(RELAY_ADDR, Bytes::from_static(RELAY_BYTECODE));
 
     // Valid PoP through the relay -> true.
-    let ok = env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, &v.message), VERIFY_GAS);
+    let ok =
+        env.exec_to(USER, RELAY_ADDR, verify_calldata(&v.sig, &v.pubkey, &v.message), VERIFY_GAS);
     assert!(decode_bool(&ok), "valid PoP must verify via DELEGATECALL");
 
-    // Different-address message through the relay -> false (still a successful call returning `false`).
+    // Different-address message through the relay -> false (still a successful call returning
+    // `false`).
     let bad = env.exec_to(
         USER,
         RELAY_ADDR,

--- a/crates/types/src/crypto/bls_public_key.rs
+++ b/crates/types/src/crypto/bls_public_key.rs
@@ -100,16 +100,6 @@ impl BlsPublicKey {
         CorePublicKey::from_bytes(bytes).map(|key| key.into())
     }
 
-    /// Decode a public key from its 192-byte uncompressed (serialized) G2 form, as produced by
-    /// [`blst::min_sig::PublicKey::serialize`].
-    ///
-    /// Unlike [`Self::from_literal_bytes`] (which expects the 96-byte compressed form), this
-    /// accepts the uncompressed bytes the protocol passes to the on-chain `BlsG1` library. Used
-    /// by the native BLS precompile.
-    pub fn from_uncompressed_bytes(bytes: &[u8]) -> Result<Self, BLST_ERROR> {
-        CorePublicKey::deserialize(bytes).map(|key| key.into())
-    }
-
     /// Take the first 8 bytes and convert to a base58 rep String.
     pub fn to_short_string(&self) -> String {
         self.bytes.to_short_string()

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -4,7 +4,7 @@ use super::{BlsKeypair, BlsPublicKey, Intent, IntentMessage, IntentScope, Signer
 use crate::encode;
 use alloy::primitives::Address;
 use blst::min_sig::{
-    AggregateSignature as CoreBlsAggregateSignature, PublicKey, Signature as CoreBlsSignature,
+    AggregateSignature as CoreBlsAggregateSignature, Signature as CoreBlsSignature,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -160,41 +160,55 @@ pub fn generate_proof_of_possession_bls_for_test(
     keypair: &BlsKeypair,
     address: &Address,
 ) -> eyre::Result<BlsSignature> {
-    let msg = construct_proof_of_possession_message(keypair.public(), address)?;
-    let sig = BlsSignature::new_secure(&msg, keypair);
-
-    Ok(sig)
+    let msg = construct_proof_of_possession_message(keypair.public(), address);
+    Ok(keypair.sign(&msg))
 }
 
-/// Verify proof of possession against the expected intent message,
-///
-/// The intent message is expected to contain the validator's public key
-/// and the [Genesis] for the network.
+/// Verify a validator's BLS proof of possession: that `proof` is a valid signature, under
+/// `public_key`, over [`construct_proof_of_possession_message`] for `address`. Reconstructs the
+/// expected message (binding the key and the address) and verifies it through the generic
+/// [`bls_verify_secure`] primitive.
 pub fn verify_proof_of_possession_bls(
     proof: &BlsSignature,
     public_key: &BlsPublicKey,
     address: &Address,
 ) -> eyre::Result<()> {
     public_key.validate().map_err(|_| eyre::eyre!("Bls Public Key not valid!"))?;
-    let msg = construct_proof_of_possession_message(public_key, address)?;
-    if proof.verify_secure(&msg, public_key) {
+    let msg = construct_proof_of_possession_message(public_key, address);
+    if bls_verify_secure(proof, public_key, &msg) {
         Ok(())
     } else {
         Err(eyre::eyre!("Failed to verify proof of possession!"))
     }
 }
 
+/// Verify a BLS signature over a raw `message` under `public_key`, with full security (signature and
+/// public-key subgroup checks) and the protocol [`DST_G1`]. This is the generic primitive the native
+/// BLS precompile exposes: proof-of-possession is just one message it can verify, so any caller can
+/// verify an arbitrary BLS-signed message without the verifier hard-coding the message's meaning.
+pub fn bls_verify_secure(
+    signature: &BlsSignature,
+    public_key: &BlsPublicKey,
+    message: &[u8],
+) -> bool {
+    signature.verify(true, message, DST_G1, &[], public_key, true) == blst::BLST_ERROR::BLST_SUCCESS
+}
+
+/// The proof-of-possession message a validator signs to prove control of its BLS key and bind it to
+/// its execution `address`. Layout: `intentPrefix(3) || compressedBlsPubkey(96) || address(20)` =
+/// 119 raw bytes, where `intentPrefix` is the serialized telcoin proof-of-possession [`Intent`]
+/// (`0x000000`). Using the compressed pubkey and the raw address makes this cheaply reconstructable
+/// on-chain, so the `ConsensusRegistry` builds the identical bytes and verifies them through the
+/// native BLS precompile ([`bls_verify_secure`]). Returned as raw bytes (not wrapped in an
+/// [`IntentMessage`]) since both the signer and the on-chain verifier operate on the bytes directly.
 pub fn construct_proof_of_possession_message(
     bls_pubkey: &BlsPublicKey,
     address: &Address,
-) -> eyre::Result<IntentMessage<Vec<u8>>> {
-    let mut msg_unprefixed = PublicKey::serialize(bls_pubkey).to_vec();
-    let address_bytes = encode(address);
-    msg_unprefixed.extend_from_slice(address_bytes.as_slice());
-
-    let msg = IntentMessage::new(Intent::telcoin(IntentScope::ProofOfPossession), msg_unprefixed);
-
-    Ok(msg)
+) -> Vec<u8> {
+    let mut message = encode(&Intent::telcoin(IntentScope::ProofOfPossession));
+    message.extend_from_slice(bls_pubkey.to_bytes().as_slice());
+    message.extend_from_slice(address.as_slice());
+    message
 }
 
 /// A trait for sign and verify over an intent message, instead of the message itself. See more at
@@ -359,10 +373,32 @@ mod tests {
         let from_compressed =
             BlsPublicKey::from_literal_bytes(&original.to_bytes()).expect("compressed roundtrip");
 
-        let msg_a = encode(&construct_proof_of_possession_message(original, &address).unwrap());
-        let msg_b =
-            encode(&construct_proof_of_possession_message(&from_compressed, &address).unwrap());
+        let msg_a = construct_proof_of_possession_message(original, &address);
+        let msg_b = construct_proof_of_possession_message(&from_compressed, &address);
         assert_eq!(msg_a, msg_b, "compressed-decoded key rebuilds a byte-identical PoP message");
+    }
+
+    /// Guards the on-chain message layout: `ConsensusRegistry` reconstructs this exact byte string
+    /// (`intentPrefix(3 = 0x000000) || compressedPubkey(96) || address(20)`), so any drift in the
+    /// layout or the intent prefix must be mirrored on-chain.
+    #[test]
+    fn pop_message_layout_is_onchain_constructible() {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([7u8; 32]));
+        let address = Address::repeat_byte(0x22);
+        let msg = construct_proof_of_possession_message(keypair.public(), &address);
+
+        assert_eq!(msg.len(), 3 + 96 + 20, "PoP message is intent(3) + pubkey(96) + address(20)");
+        assert_eq!(
+            &msg[0..3],
+            &[0u8, 0, 0],
+            "telcoin proof-of-possession intent prefix is 0x000000"
+        );
+        assert_eq!(
+            &msg[3..99],
+            keypair.public().to_bytes().as_slice(),
+            "compressed pubkey segment"
+        );
+        assert_eq!(&msg[99..119], address.as_slice(), "address segment");
     }
 
     // --- BlsSignature::from_bytes ---

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -28,19 +28,6 @@ impl BlsSignature {
         Ok(Self(sig))
     }
 
-    /// Decode a signature from its 96-byte uncompressed (serialized) G1 form, as produced by
-    /// [`blst::min_sig::Signature::serialize`].
-    ///
-    /// Unlike [`Self::from_bytes`] (which expects the 48-byte compressed form), this accepts the
-    /// uncompressed bytes the protocol passes to the on-chain `BlsG1` library as a proof of
-    /// possession. Used by the native BLS precompile so it can verify the exact bytes the
-    /// consensus layer produced, without re-implementing point (de)compression.
-    pub fn from_uncompressed_bytes(bytes: &[u8]) -> eyre::Result<Self> {
-        CoreBlsSignature::deserialize(bytes)
-            .map_err(|e| eyre::eyre!("Invalid uncompressed signature bytes! {e:?}"))
-            .map(Self)
-    }
-
     /// Verify a signature over a message (raw bytes) with public key.
     pub fn verify_raw(&self, message: &[u8], public_key: &BlsPublicKey) -> bool {
         self.verify(true, message, DST_G1, &[], public_key, true) == blst::BLST_ERROR::BLST_SUCCESS
@@ -210,20 +197,6 @@ pub fn construct_proof_of_possession_message(
     Ok(msg)
 }
 
-/// Returns the exact serialized bytes that a proof of possession is signed over and verified
-/// against, i.e. `encode(construct_proof_of_possession_message(pubkey, address))`.
-///
-/// This is the canonical equivalent of `BlsG1.proofOfPossessionMessage` on-chain. The native BLS
-/// precompile returns these bytes so the message it verifies and the message it reports are one and
-/// the same, with no second (drift-prone) implementation of the intent encoding.
-pub fn proof_of_possession_message_bytes(
-    bls_pubkey: &BlsPublicKey,
-    address: &Address,
-) -> eyre::Result<Vec<u8>> {
-    let msg = construct_proof_of_possession_message(bls_pubkey, address)?;
-    Ok(encode(&msg))
-}
-
 /// A trait for sign and verify over an intent message, instead of the message itself. See more at
 /// [struct IntentMessage].
 pub trait ProtocolSignature {
@@ -370,6 +343,26 @@ mod tests {
 
     fn make_intent_msg() -> IntentMessage<Vec<u8>> {
         to_intent_message(b"test payload".to_vec())
+    }
+
+    /// The PoP message is byte-stable regardless of how the `BlsPublicKey` was decoded: a key
+    /// decoded from its 96-byte compressed form rebuilds a byte-identical message. This is the
+    /// basis of the no-regeneration guarantee - switching the transport encoding to compressed
+    /// does not change the signed message, so every previously issued proof of possession still
+    /// verifies.
+    #[test]
+    fn construct_pop_message_stable_across_compressed_roundtrip() {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([3u8; 32]));
+        let address = Address::repeat_byte(0x11);
+        let original = keypair.public();
+        // decode the same key from its compressed bytes (the path the precompile uses)
+        let from_compressed =
+            BlsPublicKey::from_literal_bytes(&original.to_bytes()).expect("compressed roundtrip");
+
+        let msg_a = encode(&construct_proof_of_possession_message(original, &address).unwrap());
+        let msg_b =
+            encode(&construct_proof_of_possession_message(&from_compressed, &address).unwrap());
+        assert_eq!(msg_a, msg_b, "compressed-decoded key rebuilds a byte-identical PoP message");
     }
 
     // --- BlsSignature::from_bytes ---

--- a/crates/types/src/crypto/bls_signature.rs
+++ b/crates/types/src/crypto/bls_signature.rs
@@ -182,10 +182,11 @@ pub fn verify_proof_of_possession_bls(
     }
 }
 
-/// Verify a BLS signature over a raw `message` under `public_key`, with full security (signature and
-/// public-key subgroup checks) and the protocol [`DST_G1`]. This is the generic primitive the native
-/// BLS precompile exposes: proof-of-possession is just one message it can verify, so any caller can
-/// verify an arbitrary BLS-signed message without the verifier hard-coding the message's meaning.
+/// Verify a BLS signature over a raw `message` under `public_key`, with full security (signature
+/// and public-key subgroup checks) and the protocol [`DST_G1`]. This is the generic primitive the
+/// native BLS precompile exposes: proof-of-possession is just one message it can verify, so any
+/// caller can verify an arbitrary BLS-signed message without the verifier hard-coding the message's
+/// meaning.
 pub fn bls_verify_secure(
     signature: &BlsSignature,
     public_key: &BlsPublicKey,
@@ -200,7 +201,8 @@ pub fn bls_verify_secure(
 /// (`0x000000`). Using the compressed pubkey and the raw address makes this cheaply reconstructable
 /// on-chain, so the `ConsensusRegistry` builds the identical bytes and verifies them through the
 /// native BLS precompile ([`bls_verify_secure`]). Returned as raw bytes (not wrapped in an
-/// [`IntentMessage`]) since both the signer and the on-chain verifier operate on the bytes directly.
+/// [`IntentMessage`]) since both the signer and the on-chain verifier operate on the bytes
+/// directly.
 pub fn construct_proof_of_possession_message(
     bls_pubkey: &BlsPublicKey,
     address: &Address,


### PR DESCRIPTION
﻿## Summary

Node-side half of the consensus-registry upgrade. Two layered changes:

1. **Compressed + generic BLS verification.** The native precompile is now a generic `blsVerify(signature, pubkey, message)` over compressed inputs (48-byte G1 signature, 96-byte G2 pubkey), reusable beyond proof-of-possession. The `ConsensusRegistry` proof-of-possession is one caller: it builds the message (`intentPrefix || compressedPubkey || address`) on-chain and verifies it here. (An earlier iteration of this branch was a PoP-specific compressed precompile; this generalizes it per review.)
2. **Validator-set migration support.** The tn-contracts submodule adds `migrateValidatorSets`, a one-time system-gated back-fill of the per-status sets for an in-place upgrade.

Stacked on #732. Pairs with Telcoin-Association/tn-contracts#126 (`feat/compressed-pop` @ `f398a3f`), which this branch's submodule points at.

## Changes

- `bls_precompile`: generic `blsVerify(signature, pubkey, message)` - length-gate (48/96) then `bls_verify_secure` over the raw message. Unit + property tests cover the generic semantics, the compressed-only length gate (S1), and the DELEGATECALL relay path.
- tn-types: `construct_proof_of_possession_message` returns the raw, on-chain-constructible message; `generate`/`verify` use the raw sign/verify path; add the generic `bls_verify_secure` primitive and a layout-guard test pinning the intent prefix to `0x000000`. `verify_proof_of_possession_bls` is retained for off-chain use (genesis validation, tests).
- `KeyConfig::generate_proof_of_possession_bls` signs the new message.
- Engine close-epoch tests build from a fresh-registry genesis helper (`test_genesis_with_consensus_registry`) so they exercise `getValidatorsInfo`; the static `TESTNET_GENESIS` fixture is untouched.
- Bump the tn-contracts submodule to `f398a3f`.

## Validation

All green in WSL: tn-types / tn-config / tn-reth lib, tn-reth `it` (45, including the BLS precompile property tests and the DELEGATECALL relay), tn-engine `it` (8), e2e genesis + stake + epoch + sync (6), `fmt`, and `clippy` (lib/bins). tn-contracts consensus + fuzz suite 122/122.

## Audit (self-review)

Differential audit of the Rust and Solidity diffs, 0 Critical / 0 High:

- **Medium (Solidity):** `migrateValidatorSets` is an `O(totalSupply)` loop; paginate before any large validator set (not triggerable at testnet's 5).
- **Low (both, hardened):** the on-chain message builder now asserts `pubkey.length == 96`; the precompile's flat gas is documented as calibrated for the fixed PoP message (add per-word pricing before non-PoP callers).
- The verify primitive is sound: full signature + pubkey subgroup checks, deterministic, no panics; the message binds the compressed pubkey (rogue-key defense). The on-chain/off-chain message byte-match is proven by the e2e suite (real precompile + real crypto), which the contract-level mock cannot show.

## Deployment analysis (observer sync)

This bears on how the testnet adopts the change. TN observers **re-execute** consensus packs from genesis (confirmed in `state-sync` / `consensus_pack`); there is no checkpoint or state-snapshot fast-sync. Therefore:

- A true in-place hardfork (keeping block 0) would require the node binary to carry **both** the pre-fork and post-fork registry/precompile behavior so new nodes can replay across the fork - a large, consensus-critical dual-ABI surface, where any divergence is a chain split.
- A **state-preserving relaunch** (a new genesis baking the live validators/balances + the migrate-computed sets) avoids all of that: new nodes sync the new chain with the new binary only. It preserves validator state (no re-staking); only the block history resets.

Recommendation for the testnet: the state-preserving relaunch. `migrateValidatorSets` is the set-reconstruction primitive it (and any future mainnet in-place upgrade) uses.

## Storage compatibility with the deployed registry (#107)

`forge inspect storageLayout` of #107 (`8d4cb030`) versus this branch is a clean append: slots 0-41 are byte-for-byte identical; only `validatorSets` (slot 42) and `eligibleValidatorCount` (slot 43) are appended. So the deployed validator state maps onto the new code unchanged, which is what makes the migration (and a relaunch snapshot) faithful.

## Status

Draft for team review. Stacked on #732. The testnet deployment approach (a state-preserving relaunch, per the analysis above) is the open decision for the team.


## Update - BlsG1 is now an `IBlsG1` interface (supersedes the DELEGATECALL / library notes above)

Follow-up refactor (node `a7ed03af`, contracts `a44d726`): on the tn-contracts side `BlsG1` became a thin `interface IBlsG1`, and `ConsensusRegistry` now reaches the precompile with a direct low-level `staticcall` instead of a linked-library `delegatecall`. Node-side consequences:

- The registry bytecode no longer carries a link placeholder, so both `link_solidity_library` calls and the helper are removed. The registry initcode/runtimecode deploy as-is, with a fail-fast guard against a stale `__$..$__` placeholder. The unused `BLSG1_JSON` constant is deleted.
- The precompile property test's relay is retargeted to `STATICCALL` to match the registry's new call path; the precompile itself is unchanged.
- The tn-contracts submodule now points at `a44d726` (not `f398a3f`).

Re-validated in WSL after the refactor: tn-reth and tn-engine (94 tests, including the now-`STATICCALL` relay and the 8 genesis / close-epoch tests that verify PoPs through the precompile on the temp chain), plus the e2e genesis tests (2). Nightly `fmt` and `clippy` (default and `--all-features`) are clean; tn-contracts consensus suite 122/122.
