### PR TITLE
  fix(network-libp2p): make operator-set peer-scoring thresholds take effect

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -288,10 +288,6 @@ pub struct PeerConfig {
     pub target_num_peers: usize,
     /// The timeout for dialing a peer.
     pub dial_timeout: Duration,
-    /// The threshold before a peer is disconnected
-    pub min_score_for_disconnect: f64,
-    /// The threshold before a peer is banned.
-    pub min_score_for_ban: f64,
     /// A fraction of `Self::target_num_peers` that is allowed to connect to this node in excess of
     /// `PeerManager::target_num_peers`.
     ///
@@ -335,8 +331,6 @@ impl Default for PeerConfig {
             heartbeat_interval: 30,
             target_num_peers,
             dial_timeout: Duration::from_secs(15),
-            min_score_for_disconnect: -20.0,
-            min_score_for_ban: -50.0,
             peer_excess_factor: 0.3,
             priority_peer_excess: 0.2,
             target_outbound_only_factor: 0.3,
@@ -395,9 +389,6 @@ impl PeerConfig {
 pub struct ScoreConfig {
     /// The default score for new peers.
     pub default_score: f64,
-    /// The threshold for a peer's score before they are banned, regardless of any other scoring
-    /// parameters.
-    pub min_application_score_before_ban: f64,
     /// The maximum score a peer can obtain.
     pub max_score: f64,
     /// The minimum score a peer can obtain.
@@ -406,9 +397,15 @@ pub struct ScoreConfig {
     pub score_halflife: f64,
     /// The minimum amount of time (seconds) a peer is banned before their score begins to decay.
     pub banned_before_decay_secs: u64,
-    /// Minimum score before a peer is disconnected.
+    /// Aggregate score at or below which a peer is disconnected.
+    ///
+    /// This is the live disconnect threshold read by the reputation decision; lowering it makes
+    /// the node more tolerant of misbehaving peers before disconnecting them.
     pub min_score_before_disconnect: f64,
-    /// Minimum score before a peer is banned.
+    /// Aggregate score at or below which a peer is banned.
+    ///
+    /// This is the live ban threshold: it drives both the reputation decision and the ban/decay
+    /// lockout, so the two always agree.
     pub min_score_before_ban: f64,
 }
 
@@ -416,7 +413,6 @@ impl Default for ScoreConfig {
     fn default() -> Self {
         ScoreConfig {
             default_score: 0.0,
-            min_application_score_before_ban: -60.0,
             max_score: 100.0,
             min_score: -100.0,
             // 5-minute halflife: transient WAN penalties (peer flap, slow request) decay

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -11,7 +11,6 @@ use libp2p::{
     PeerId,
 };
 use std::{collections::HashSet, net::IpAddr, time::Instant};
-use tn_config::PeerConfig;
 use tn_types::{BlsPublicKey, NetworkPublicKey};
 use tracing::{error, warn};
 
@@ -26,8 +25,6 @@ pub(super) struct Peer {
     bls_public_key: Option<BlsPublicKey>,
     /// The peers network public key (libp2p public key).
     network_key: Option<NetworkPublicKey>,
-    /// The config
-    config: PeerConfig,
     /// The peer's score - used to derive [Reputation].
     score: Score,
     /// The multiaddrs this node has witnessed the peer using.
@@ -62,7 +59,6 @@ impl Peer {
             network_key: Some(network_key),
             score: Score::new_max(),
             operator_allowlisted: true,
-            config: Default::default(),
             multiaddrs: Default::default(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -81,7 +77,6 @@ impl Peer {
             network_key: Some(network_key),
             score: Score::default(),
             operator_allowlisted: false,
-            config: Default::default(),
             multiaddrs: addrs.into_iter().collect(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -101,7 +96,6 @@ impl Peer {
             network_key: Some(network_key),
             score: Score::new_max(),
             operator_allowlisted: false,
-            config: Default::default(),
             multiaddrs: Default::default(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -137,11 +131,7 @@ impl Peer {
 
     /// Return a peer's reputation based on the aggregate score.
     pub(super) fn reputation(&self) -> Reputation {
-        match self.score.aggregate_score() {
-            score if score <= self.config.min_score_for_ban => Reputation::Banned,
-            score if score <= self.config.min_score_for_disconnect => Reputation::Disconnected,
-            _ => Reputation::Trusted,
-        }
+        self.score.reputation()
     }
 
     /// Return an iterator of known ip addresses for a peer.

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -18,16 +18,16 @@ Score deltas are applied in `crates/network-libp2p/src/peers/score.rs:84-100`.
 
 ## 2. Score Model Invariants
 
-- Score range: `[min_score, max_score]` = `[-100.0, 100.0]`. `crates/config/src/network.rs:438-439`.
-- Default starting score: `0.0`. `crates/config/src/network.rs:436`.
-- Ban threshold (`min_score_before_ban`): `-50.0`. `crates/config/src/network.rs:443`.
-- Disconnect threshold (`min_score_before_disconnect`): `-20.0`. `crates/config/src/network.rs:442`.
-- Score halflife: `300.0` seconds; decay factor is `e^(-ln(2)/halflife * dt)`. `crates/config/src/network.rs:440`, `crates/network-libp2p/src/peers/score.rs:130-132`.
-- `banned_before_decay_secs`: `30 * 60` (30 min). When a peer crosses the ban threshold, `last_updated` is pushed forward by this duration so the score does not decay during the lockout. `crates/config/src/network.rs:441`, `crates/network-libp2p/src/peers/score.rs:149-154`.
+- Score range: `[min_score, max_score]` = `[-100.0, 100.0]`. `crates/config/src/network.rs:416-417`.
+- Default starting score: `0.0`. `crates/config/src/network.rs:415`.
+- Ban threshold (`min_score_before_ban`): `-50.0`. `crates/config/src/network.rs:428`.
+- Disconnect threshold (`min_score_before_disconnect`): `-20.0`. `crates/config/src/network.rs:427`.
+- Score halflife: `300.0` seconds; decay factor is `e^(-ln(2)/halflife * dt)`. `crates/config/src/network.rs:421`, `crates/network-libp2p/src/peers/score.rs:130-132`.
+- `banned_before_decay_secs`: `30 * 60` (30 min). When a peer crosses the ban threshold, `last_updated` is pushed forward by this duration so the score does not decay during the lockout. `crates/config/src/network.rs:426`, `crates/network-libp2p/src/peers/score.rs:149-154`.
 - Exempt peers skip penalty application entirely — `Peer::apply_penalty` short-circuits when the caller passes a `TrustBasis` (operator allowlist or committee validator); validator status is derived from the three tracked committee slots (previous/current/next) in `AllPeers::trust_basis`, not stored on the peer. `crates/network-libp2p/src/peers/peer.rs`, `crates/network-libp2p/src/peers/all_peers.rs`.
 - Penalty application has no debouncing: every `process_penalty` call evaluates reputation immediately and may produce a ban on the same call. `crates/network-libp2p/src/peers/all_peers.rs:111-147`.
 - Bans surface to the rest of the swarm as `PeerEvent::Banned`, pushed by `process_ban`. `crates/network-libp2p/src/peers/manager.rs:389-401`.
-- `Penalty::Fatal` always crosses the ban threshold on the first call because `min_score` (`-100`) is less than `min_score_before_ban` (`-50`). `crates/network-libp2p/src/peers/score.rs:93`, `crates/config/src/network.rs:439,443`.
+- `Penalty::Fatal` always crosses the ban threshold on the first call because `min_score` (`-100`) is less than `min_score_before_ban` (`-50`). `crates/network-libp2p/src/peers/score.rs:93`, `crates/config/src/network.rs:417,428`.
 - Only the `Banned`/`Disconnected`/`Trusted` reputation transitions trigger a `PeerAction`. If the new reputation equals the prior reputation, `process_penalty` returns `PeerAction::NoAction`. `crates/network-libp2p/src/peers/all_peers.rs:117-119`.
 
 ## 3. Penalty Application Sites — Network Layer

--- a/crates/network-libp2p/src/peers/score.rs
+++ b/crates/network-libp2p/src/peers/score.rs
@@ -159,6 +159,31 @@ impl Score {
         let config = global_score_config();
         self.aggregate_score <= config.min_score_before_ban
     }
+
+    /// Derive the peer's [Reputation] from its aggregate score.
+    ///
+    /// The ban and disconnect thresholds are read from the global [ScoreConfig], which is the
+    /// single source of truth for scoring and is initialized from the operator's config via
+    /// [`init_peer_score_config`]. Reading them here (rather than from a per-peer config copy)
+    /// is what makes operator-set thresholds actually take effect (issue #746). The ban
+    /// threshold is the same `min_score_before_ban` used by [`Score::is_banned`], so the
+    /// reputation decision and the decay lockout stay consistent.
+    pub(super) fn reputation(&self) -> Reputation {
+        let config = global_score_config();
+        reputation_for(self.aggregate_score, &config)
+    }
+}
+
+/// Map an aggregate score onto a [Reputation] using the ban/disconnect thresholds in `config`.
+///
+/// Split out from [`Score::reputation`] so the threshold logic can be exercised against an
+/// arbitrary [ScoreConfig] without touching the process-global config.
+fn reputation_for(aggregate_score: f64, config: &ScoreConfig) -> Reputation {
+    match aggregate_score {
+        score if score <= config.min_score_before_ban => Reputation::Banned,
+        score if score <= config.min_score_before_disconnect => Reputation::Disconnected,
+        _ => Reputation::Trusted,
+    }
 }
 
 impl Eq for Score {}
@@ -216,4 +241,40 @@ pub(super) enum ReputationUpdate {
     Disconnect,
     /// The updated score resulted no effective change for the peer's reputation.
     None,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a [ScoreConfig] with the given ban/disconnect thresholds, defaulting the rest.
+    fn config_with(min_score_before_disconnect: f64, min_score_before_ban: f64) -> ScoreConfig {
+        ScoreConfig { min_score_before_disconnect, min_score_before_ban, ..ScoreConfig::default() }
+    }
+
+    #[test]
+    fn reputation_honors_operator_thresholds() {
+        // Default-equivalent thresholds: ban at -50, disconnect at -20.
+        let strict = config_with(-20.0, -50.0);
+        // Operator relaxes both thresholds to tolerate honest peers that fall behind during WAN
+        // sync lag (the scenario in #689). Before #746 these overrides were silently ignored.
+        let relaxed = config_with(-90.0, -95.0);
+
+        // A score of -60 is well past the strict ban threshold...
+        assert_eq!(reputation_for(-60.0, &strict), Reputation::Banned);
+        // ...but the operator's relaxed config keeps the same peer trusted.
+        assert_eq!(reputation_for(-60.0, &relaxed), Reputation::Trusted);
+    }
+
+    #[test]
+    fn reputation_threshold_boundaries() {
+        let config = config_with(-20.0, -50.0);
+
+        // At or below a threshold counts as crossing it; ban takes precedence over disconnect.
+        assert_eq!(reputation_for(-50.0, &config), Reputation::Banned);
+        assert_eq!(reputation_for(-49.9, &config), Reputation::Disconnected);
+        assert_eq!(reputation_for(-20.0, &config), Reputation::Disconnected);
+        assert_eq!(reputation_for(-19.9, &config), Reputation::Trusted);
+        assert_eq!(reputation_for(0.0, &config), Reputation::Trusted);
+    }
 }


### PR DESCRIPTION
Fixes #746.

## Problem

The peer-scoring config exposed ban/disconnect thresholds an operator could set, but the
values that actually drove ban/disconnect decisions came from a defaulted config the
operator's settings never reached.

`Peer::reputation()` decided ban/disconnect from `self.config` (a per-`Peer` `PeerConfig`),
and every `Peer` was constructed with `PeerConfig::default()`. The operator's `PeerConfig`
was deserialized and stored on the `PeerManager`, but never threaded into the individual
`Peer` structs. So `min_score_for_ban` / `min_score_for_disconnect` set by an operator were
silent no-ops: the live thresholds were always the compiled-in defaults.

Separately, two documented `ScoreConfig` fields were effectively dead:
`min_application_score_before_ban` (never read in production) and `min_score_before_disconnect`
(referenced only in tests).

## Fix

Consolidate the ban/disconnect thresholds onto the single source of truth that already
governs scoring: the global `ScoreConfig`. `Score` is already fully driven by
`GLOBAL_SCORE_CONFIG` (initialized from the operator config via `init_peer_score_config`),
and `penalty.md` already documented `ScoreConfig::min_score_before_ban` /
`min_score_before_disconnect` as *the* thresholds. This change makes the code match that.

- `Score::reputation()` (new) reads the ban/disconnect thresholds from the global
  `ScoreConfig`. `Peer::reputation()` now delegates to it. Because the ban threshold is the
  same `min_score_before_ban` used by `Score::is_banned()`, the reputation decision and the
  ban/decay lockout stay consistent.
- Removed the now-redundant, never-threaded `PeerConfig::min_score_for_ban` /
  `min_score_for_disconnect`. Their values duplicated the `ScoreConfig` fields (same defaults,
  -50 / -20).
- Removed the never-read `ScoreConfig::min_application_score_before_ban`. With this change
  `min_score_before_disconnect` is now wired into the live decision, so the config surface
  matches behavior.
- Pure threshold logic is split into a `reputation_for(score, &ScoreConfig)` helper so it can
  be unit-tested against arbitrary operator configs without touching the process-global
  `OnceLock`.
- Updated `penalty.md` line references that shifted in `network.rs`.

## Behavior change for operators

An operator who relaxes the ban/disconnect thresholds (e.g. to stop banning honest peers
during WAN sync lag, the situation in #689) now gets the expected behavior. The knobs live in
the `score_config` section: `min_score_before_ban` and `min_score_before_disconnect`.

Config migration note: the removed keys (`min_score_for_ban`, `min_score_for_disconnect`,
`min_application_score_before_ban`) were already inert. `PeerConfig` and `ScoreConfig` use
`#[serde(default)]` (no `deny_unknown_fields`), so existing TOML that still sets the old keys
continues to deserialize; the keys are simply ignored. Operators should move ban/disconnect
tuning to `score_config.min_score_before_ban` / `score_config.min_score_before_disconnect`.

## Tests

- New `reputation_honors_operator_thresholds`: a peer at score -60 is `Banned` under strict
  (-50 ban) thresholds but `Trusted` under an operator-relaxed config (-95 ban). This is the
  property that was broken before #746.
- New `reputation_threshold_boundaries`: covers the at-or-below boundary and ban-over-disconnect
  precedence.
- Existing `tn-network-libp2p` lib tests already assert reputation transitions at
  `ScoreConfig::min_score_before_disconnect`; they now exercise the genuinely wired path.

`cargo test -p tn-network-libp2p --lib`: 152 passed (150 + 2 new). `cargo fmt --check` and
`cargo clippy --all-targets -- -D warnings` clean for both crates.

## Scope

Confirmed on `main` at `1bbec7c9`. Config-plumbing defect spanning `crates/config` and
`crates/network-libp2p`. Related but distinct from #689 (penalty harshness on WAN), which
assumed these thresholds were tunable. Not covered by the `network-libp2p` security review
(PR #620, NL-001..NL-010).
