### PR TITLE
chore(ci): raise e2e slow-timeout period from 120s to 720s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,9 +22,9 @@ max-threads = 2
 [[profile.default.overrides]]
 filter = "package(e2e-tests)"
 test-group = "e2e"
-slow-timeout = { period = "120s", terminate-after = 3 }
+slow-timeout = { period = "720s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
 filter = "package(e2e-tests)"
 test-group = "e2e"
-slow-timeout = { period = "120s", terminate-after = 3 }
+slow-timeout = { period = "720s", terminate-after = 3 }


### PR DESCRIPTION
  E2E tests spawn 4-6 node processes and need longer to reach
  attestation/consensus under load.  Bump the slow-timeout period
  for both the default and ci profile e2e overrides so legitimate
  runs aren't terminated early (terminate-after = 3 unchanged).