### PR TITLE
feat(network): typed sync-frame layer registered alongside /tn-stream (739, step 4)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -94,9 +94,10 @@ where
         kademlia: kad::Behaviour<KadStore<DB>>,
         peer_config: &PeerConfig,
         metrics: PeerManagerMetrics,
+        network_type: NetworkType,
     ) -> Self {
         let peer_manager = PeerManager::new(peer_config, metrics);
-        let stream = StreamBehavior::new();
+        let stream = StreamBehavior::new(network_type);
         Self { peer_manager, gossipsub, req_res, kademlia, stream }
     }
 }
@@ -322,6 +323,7 @@ where
             kademlia,
             network_config.peer_config(),
             PeerManagerMetrics::new_for(&network_type),
+            network_type,
         );
 
         // Promote the surviving records into the local peer cache.

--- a/crates/network-libp2p/src/lib.rs
+++ b/crates/network-libp2p/src/lib.rs
@@ -23,6 +23,7 @@ pub mod kad;
 mod metrics;
 mod peers;
 pub mod stream;
+mod sync;
 pub mod types;
 
 // export types
@@ -30,6 +31,10 @@ pub use codec::{decode_message, encode_message, TNCodec, TNMessage};
 pub use consensus::ConsensusNetwork;
 pub use peers::{PeerExchangeMap, Penalty};
 pub use stream::StreamError;
+pub use sync::{
+    read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame, SyncFrameError,
+    WorkerSyncRequest,
+};
 pub use types::ResponseChannel;
 
 // re-export specific libp2p types

--- a/crates/network-libp2p/src/stream/behavior.rs
+++ b/crates/network-libp2p/src/stream/behavior.rs
@@ -21,7 +21,7 @@ use crate::{
         handler::{HandlerCommand, StreamHandler, StreamHandlerEvent},
         upgrade::{StreamError, StreamFailure},
     },
-    types::NetworkResult,
+    types::{NetworkResult, NetworkType},
 };
 
 /// The protocol identifier for streaming data.
@@ -113,6 +113,9 @@ struct InboundWindow {
 /// error if the peer cannot be reached or the open times out. Inbound streams
 /// are rate limited per peer, and failures are classified for peer scoring.
 pub(crate) struct StreamBehavior {
+    /// Protocols every connection handler advertises (legacy `/tn-stream` first,
+    /// then the per-role sync protocol), cloned into each new handler.
+    protocols: Vec<StreamProtocol>,
     /// Events to emit to the swarm/application.
     events: VecDeque<StreamEvent>,
     /// Outbound opens being driven to completion.
@@ -136,9 +139,15 @@ impl std::fmt::Debug for StreamBehavior {
 }
 
 impl StreamBehavior {
-    /// Create a new instance of the stream behavior.
-    pub(crate) fn new() -> Self {
+    /// Create a new instance of the stream behavior for `network_type`.
+    ///
+    /// Handlers advertise the legacy `/tn-stream/0.0.1` upgrade first, so
+    /// existing opens keep negotiating it, followed by the role's sync protocol,
+    /// so a responder also accepts inbound sync streams.
+    pub(crate) fn new(network_type: NetworkType) -> Self {
+        let protocols = vec![TN_STREAM_PROTOCOL, network_type.sync_protocol()];
         Self {
+            protocols,
             events: VecDeque::new(),
             pending: Vec::new(),
             connected: HashSet::new(),
@@ -269,12 +278,6 @@ impl StreamBehavior {
     }
 }
 
-impl Default for StreamBehavior {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl NetworkBehaviour for StreamBehavior {
     type ConnectionHandler = StreamHandler;
     type ToSwarm = StreamEvent;
@@ -286,7 +289,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: &Multiaddr,
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new())
+        Ok(StreamHandler::new(self.protocols.clone()))
     }
 
     fn handle_established_outbound_connection(
@@ -297,7 +300,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new())
+        Ok(StreamHandler::new(self.protocols.clone()))
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
@@ -403,8 +406,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registers_sync_protocol_after_legacy() {
+        // a worker advertises its per-worker sync protocol, legacy first
+        let worker = StreamBehavior::new(NetworkType::Worker(3));
+        assert_eq!(
+            worker.protocols,
+            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-worker-3-sync/1.0.0")]
+        );
+        // a primary advertises its own sync protocol, legacy first
+        let primary = StreamBehavior::new(NetworkType::Primary);
+        assert_eq!(
+            primary.protocols,
+            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-primary-sync/1.0.0")]
+        );
+    }
+
+    #[tokio::test]
     async fn open_to_unreachable_peer_fails_fast_with_not_connected() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
 
@@ -418,7 +437,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_when_connected_is_queued_for_dispatch() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
@@ -431,7 +450,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_when_disconnected_with_addrs_needs_dial() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
 
@@ -443,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_over_capacity_is_rejected() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         for _ in 0..MAX_PENDING_OPENS {
@@ -461,7 +480,7 @@ mod tests {
 
     #[tokio::test]
     async fn connection_promotes_awaiting_open() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -478,7 +497,7 @@ mod tests {
         // The peer may connect (via another behaviour's dial) while our open is
         // still NeedsDial; it must dispatch rather than dial an already-connected
         // peer (which would fail the PeerCondition::Disconnected dial).
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -491,7 +510,7 @@ mod tests {
 
     #[tokio::test]
     async fn dial_failure_fails_awaiting_open() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -506,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_open_times_out_and_reports_failure() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -526,7 +545,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_rate_limit_trips_after_threshold() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         for _ in 0..MAX_INBOUND_PER_WINDOW {
             assert!(!behavior.inbound_rate_limited(peer));
@@ -536,7 +555,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_window_resets_after_interval() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         for _ in 0..=MAX_INBOUND_PER_WINDOW {
             behavior.inbound_rate_limited(peer);
@@ -550,7 +569,7 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_requeues_connected_open_for_dial() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
@@ -565,7 +584,7 @@ mod tests {
 
     #[tokio::test]
     async fn push_event_sheds_when_full() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         for _ in 0..MAX_EVENTS {
             behavior

--- a/crates/network-libp2p/src/stream/behavior.rs
+++ b/crates/network-libp2p/src/stream/behavior.rs
@@ -411,13 +411,13 @@ mod tests {
         let worker = StreamBehavior::new(NetworkType::Worker(3));
         assert_eq!(
             worker.protocols,
-            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-worker-3-sync/1.0.0")]
+            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-worker-3-sync/0.0.1")]
         );
         // a primary advertises its own sync protocol, legacy first
         let primary = StreamBehavior::new(NetworkType::Primary);
         assert_eq!(
             primary.protocols,
-            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-primary-sync/1.0.0")]
+            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-primary-sync/0.0.1")]
         );
     }
 

--- a/crates/network-libp2p/src/stream/handler.rs
+++ b/crates/network-libp2p/src/stream/handler.rs
@@ -5,7 +5,7 @@ use libp2p::{
         },
         ConnectionHandler, ConnectionHandlerEvent, StreamUpgradeError, SubstreamProtocol,
     },
-    Stream,
+    Stream, StreamProtocol,
 };
 use std::{
     collections::VecDeque,
@@ -68,8 +68,10 @@ pub(crate) enum StreamHandlerEvent {
 /// `OutboundOpenInfo`, bypassing the behavior layer entirely. Open negotiation
 /// is bounded by [`STREAM_OPEN_TIMEOUT`]; failures are classified and reported
 /// to the behaviour for scoring.
-#[derive(Default)]
 pub(crate) struct StreamHandler {
+    /// Protocols advertised for inbound listen and outbound opens (legacy
+    /// `/tn-stream` first, then the per-role sync protocol).
+    protocols: Vec<StreamProtocol>,
     /// Pending outbound stream reply channels.
     pending_outbound: VecDeque<oneshot::Sender<NetworkResult<Stream>>>,
     /// Events to send to the behavior.
@@ -86,9 +88,9 @@ impl std::fmt::Debug for StreamHandler {
 }
 
 impl StreamHandler {
-    /// Create a new stream handler.
-    pub(crate) fn new() -> Self {
-        Self { pending_outbound: VecDeque::new(), events: VecDeque::new() }
+    /// Create a new stream handler advertising `protocols` on this connection.
+    pub(crate) fn new(protocols: Vec<StreamProtocol>) -> Self {
+        Self { protocols, pending_outbound: VecDeque::new(), events: VecDeque::new() }
     }
 
     /// Queue an event to the behaviour, dropping it if the buffer is saturated.
@@ -122,7 +124,7 @@ impl ConnectionHandler for StreamHandler {
     type OutboundOpenInfo = oneshot::Sender<NetworkResult<Stream>>;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(TNStreamProtocol, ())
+        SubstreamProtocol::new(TNStreamProtocol::new(self.protocols.clone()), ())
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
@@ -191,8 +193,11 @@ impl ConnectionHandler for StreamHandler {
         // Request outbound streams, bounding negotiation with a timeout.
         if let Some(reply) = self.pending_outbound.pop_front() {
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(TNStreamProtocol, reply)
-                    .with_timeout(STREAM_OPEN_TIMEOUT),
+                protocol: SubstreamProtocol::new(
+                    TNStreamProtocol::new(self.protocols.clone()),
+                    reply,
+                )
+                .with_timeout(STREAM_OPEN_TIMEOUT),
             });
         }
 

--- a/crates/network-libp2p/src/stream/upgrade.rs
+++ b/crates/network-libp2p/src/stream/upgrade.rs
@@ -155,7 +155,7 @@ mod tests {
     #[test]
     fn protocol_info_preserves_order() {
         let legacy = StreamProtocol::new("/tn-stream/0.0.1");
-        let sync = StreamProtocol::new("/tn-primary-sync/1.0.0");
+        let sync = StreamProtocol::new("/tn-primary-sync/0.0.1");
         let upgrade = TNStreamProtocol::new(vec![legacy.clone(), sync.clone()]);
         let advertised: Vec<_> = upgrade.protocol_info().collect();
         assert_eq!(advertised, vec![legacy, sync]);

--- a/crates/network-libp2p/src/stream/upgrade.rs
+++ b/crates/network-libp2p/src/stream/upgrade.rs
@@ -4,22 +4,37 @@ use std::{
     future::{ready, Ready},
 };
 
-use crate::{stream::behavior::TN_STREAM_PROTOCOL, Penalty};
+use crate::Penalty;
 
 /// Protocol upgrade for streaming data.
 ///
-/// Both inbound and outbound upgrades simply return the raw stream.
-/// Application-layer correlation (e.g. writing a request digest) is
-/// handled by the caller after the stream is established.
+/// Advertises one or more protocols for negotiation, in dialer-preference
+/// order. Both inbound and outbound upgrades simply return the raw stream
+/// regardless of which protocol negotiated; application-layer correlation (e.g.
+/// writing a request digest, or the typed [`SyncFrame`](crate::sync::SyncFrame)
+/// layer) is handled by the caller after the stream is established.
 #[derive(Debug, Clone)]
-pub(crate) struct TNStreamProtocol;
+pub(crate) struct TNStreamProtocol {
+    /// Protocols advertised for negotiation, in dialer-preference order. The
+    /// legacy `/tn-stream/0.0.1` is first so existing opens keep negotiating it;
+    /// the per-role sync protocol follows so a responder also accepts it.
+    protocols: Vec<StreamProtocol>,
+}
+
+impl TNStreamProtocol {
+    /// Create an upgrade advertising `protocols`, in order (legacy first), for
+    /// both inbound listen and outbound open negotiation.
+    pub(crate) fn new(protocols: Vec<StreamProtocol>) -> Self {
+        Self { protocols }
+    }
+}
 
 impl UpgradeInfo for TNStreamProtocol {
     type Info = StreamProtocol;
-    type InfoIter = std::iter::Once<Self::Info>;
+    type InfoIter = std::vec::IntoIter<StreamProtocol>;
 
     fn protocol_info(&self) -> Self::InfoIter {
-        std::iter::once(TN_STREAM_PROTOCOL)
+        self.protocols.clone().into_iter()
     }
 }
 
@@ -28,8 +43,13 @@ impl InboundUpgrade<Stream> for TNStreamProtocol {
     type Error = Infallible;
     type Future = Ready<Result<Self::Output, Self::Error>>;
 
-    // logic in application layer
-    fn upgrade_inbound(self, stream: Stream, _: Self::Info) -> Self::Future {
+    // The negotiated protocol (`_protocol`) is intentionally discarded for now:
+    // every accepted inbound stream is handed to the application as a raw stream
+    // and read on the legacy digest-correlation path. Once a sync stream can
+    // actually arrive (the step-5 cutover adds the first opener), this is the
+    // seam that must branch on `_protocol` to route a sync-framed stream to the
+    // `SyncFrame` layer instead of the digest reader.
+    fn upgrade_inbound(self, stream: Stream, _protocol: Self::Info) -> Self::Future {
         ready(Ok(stream))
     }
 }
@@ -124,9 +144,22 @@ impl StreamFailure {
 
 #[cfg(test)]
 mod tests {
-    use super::StreamFailure;
+    use super::{StreamFailure, TNStreamProtocol};
     use crate::Penalty;
+    use libp2p::{core::UpgradeInfo, StreamProtocol};
     use std::io::ErrorKind;
+
+    /// The upgrade advertises its protocols in the order given (legacy first),
+    /// which is what keeps existing opens negotiating `/tn-stream` while a
+    /// responder still accepts the registered sync protocol.
+    #[test]
+    fn protocol_info_preserves_order() {
+        let legacy = StreamProtocol::new("/tn-stream/0.0.1");
+        let sync = StreamProtocol::new("/tn-primary-sync/1.0.0");
+        let upgrade = TNStreamProtocol::new(vec![legacy.clone(), sync.clone()]);
+        let advertised: Vec<_> = upgrade.protocol_info().collect();
+        assert_eq!(advertised, vec![legacy, sync]);
+    }
 
     /// The stream penalty taxonomy must mirror the request-response one: transport
     /// faults are not penalized, stalls are mild, unsupported protocols are severe.

--- a/crates/network-libp2p/src/sync/frame.rs
+++ b/crates/network-libp2p/src/sync/frame.rs
@@ -1,0 +1,176 @@
+//! Frame-tagged transport for bulk-sync exchanges.
+
+use crate::codec::{decode_message, encode_message};
+use futures::{AsyncRead, AsyncWrite};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// A single frame in a bulk-sync exchange.
+///
+/// Each frame is one [`encode_message`]/[`decode_message`] unit on the wire, so
+/// the BCS enum discriminant doubles as the frame tag. An exchange opens with a
+/// [`SyncFrame::Req`] carrying the typed request; the responder answers
+/// [`SyncFrame::Ack`] or [`SyncFrame::Deny`]; an accepted exchange then streams
+/// zero or more [`SyncFrame::Data`] frames terminated by [`SyncFrame::End`], or
+/// aborts with [`SyncFrame::Err`].
+///
+/// `R` is the typed request the [`SyncFrame::Req`] frame carries
+/// ([`WorkerSyncRequest`](crate::sync::WorkerSyncRequest) or
+/// [`PrimarySyncRequest`](crate::sync::PrimarySyncRequest)).
+///
+/// The variant order is the wire format: BCS encodes each variant by its index,
+/// so variants must never be reordered or removed without a protocol-version
+/// bump. `frame_tags_are_stable` pins the mapping.
+///
+/// [`encode_message`]: crate::encode_message
+/// [`decode_message`]: crate::decode_message
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SyncFrame<R> {
+    /// REQ: opening frame carrying the typed request that initiates the
+    /// exchange.
+    Req(R),
+    /// ACK: the responder accepted the request and will stream [`SyncFrame::Data`]
+    /// frames.
+    Ack,
+    /// DENY: the responder declined the request (e.g. it is over capacity) so the
+    /// requester can give up immediately instead of waiting out its timeout.
+    Deny(DenyReason),
+    /// DATA: a chunk of opaque response payload. The payload encoding is defined
+    /// by each exchange's cutover, not by this frame layer.
+    Data(Vec<u8>),
+    /// END: orderly end of the response stream.
+    End,
+    /// ERR: the responder aborted the exchange after an error.
+    Err(SyncFrameError),
+}
+
+/// Why a responder declined a sync request in a [`SyncFrame::Deny`] frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DenyReason {
+    /// The responder is at its concurrency cap (global or per-peer) and is
+    /// shedding load; the requester should retry elsewhere or back off.
+    AtCapacity,
+    /// The responder does not hold the requested data.
+    Unavailable,
+}
+
+/// Why a responder aborted an exchange in a [`SyncFrame::Err`] frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SyncFrameError {
+    /// The responder hit an internal error while producing the response.
+    Internal,
+    /// The opening request frame was malformed or violated the protocol.
+    Malformed,
+}
+
+/// Write a single [`SyncFrame`] to `io`, length-prefixed and snappy-compressed
+/// via [`encode_message`].
+///
+/// `max_frame_size` bounds the encoded frame; the caller supplies reusable
+/// buffers to avoid repeated allocation across frames.
+///
+/// [`encode_message`]: crate::encode_message
+pub async fn write_frame<T, R>(
+    io: &mut T,
+    frame: &SyncFrame<R>,
+    encode_buffer: &mut Vec<u8>,
+    compressed_buffer: &mut Vec<u8>,
+    max_frame_size: usize,
+) -> std::io::Result<()>
+where
+    T: AsyncWrite + Unpin + Send,
+    R: Serialize + Sync,
+{
+    encode_message(io, frame, encode_buffer, compressed_buffer, max_frame_size).await
+}
+
+/// Read a single [`SyncFrame`] from `io` via [`decode_message`].
+///
+/// `max_frame_size` bounds the decoded frame so a peer cannot force an oversized
+/// allocation; the caller supplies reusable buffers. An [`SyncFrame::Err`] frame
+/// is a successful read (`Ok`), distinct from a transport error (`Err`).
+///
+/// [`decode_message`]: crate::decode_message
+pub async fn read_frame<T, R>(
+    io: &mut T,
+    decode_buffer: &mut Vec<u8>,
+    compressed_buffer: &mut Vec<u8>,
+    max_frame_size: usize,
+) -> std::io::Result<SyncFrame<R>>
+where
+    T: AsyncRead + Unpin + Send,
+    R: DeserializeOwned,
+{
+    decode_message(io, decode_buffer, compressed_buffer, max_frame_size).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 1 MiB cap, generous enough that no test frame is rejected for size
+    /// except the one that deliberately overflows it.
+    const MAX_FRAME: usize = 1024 * 1024;
+
+    /// Round-trip a frame through `write_frame`/`read_frame` over an in-memory
+    /// buffer, returning the decoded frame.
+    async fn roundtrip<R>(frame: &SyncFrame<R>) -> SyncFrame<R>
+    where
+        R: Serialize + DeserializeOwned + Sync,
+    {
+        let (mut enc, mut comp) = (Vec::new(), Vec::new());
+        let mut wire = Vec::new();
+        write_frame(&mut wire, frame, &mut enc, &mut comp, MAX_FRAME).await.expect("write frame");
+
+        let (mut dec, mut comp2) = (Vec::new(), Vec::new());
+        read_frame(&mut wire.as_ref(), &mut dec, &mut comp2, MAX_FRAME).await.expect("read frame")
+    }
+
+    #[tokio::test]
+    async fn every_control_frame_round_trips() {
+        // unit request payload: the control frames are request-type agnostic
+        for frame in [
+            SyncFrame::<()>::Ack,
+            SyncFrame::Deny(DenyReason::AtCapacity),
+            SyncFrame::Deny(DenyReason::Unavailable),
+            SyncFrame::Data(Vec::new()),
+            SyncFrame::Data(vec![0, 1, 2, 3, 4, 5, 6, 7]),
+            SyncFrame::End,
+            SyncFrame::Err(SyncFrameError::Internal),
+            SyncFrame::Err(SyncFrameError::Malformed),
+        ] {
+            assert_eq!(roundtrip(&frame).await, frame);
+        }
+    }
+
+    #[tokio::test]
+    async fn req_frame_round_trips() {
+        let frame = SyncFrame::Req(0xC0FFEE_u32);
+        assert_eq!(roundtrip(&frame).await, frame);
+    }
+
+    /// The BCS discriminant is the wire tag. Pin the exact bytes so a reorder or
+    /// insertion of a `SyncFrame` variant cannot silently change the framing of
+    /// an already-deployed protocol.
+    #[test]
+    fn frame_tags_are_stable() {
+        let tag = |frame: &SyncFrame<()>| bcs::to_bytes(frame).expect("encode frame");
+        assert_eq!(tag(&SyncFrame::Req(())), vec![0]);
+        assert_eq!(tag(&SyncFrame::Ack), vec![1]);
+        assert_eq!(tag(&SyncFrame::Deny(DenyReason::AtCapacity)), vec![2, 0]);
+        assert_eq!(tag(&SyncFrame::Deny(DenyReason::Unavailable)), vec![2, 1]);
+        assert_eq!(tag(&SyncFrame::Data(Vec::new())), vec![3, 0]);
+        assert_eq!(tag(&SyncFrame::End), vec![4]);
+        assert_eq!(tag(&SyncFrame::Err(SyncFrameError::Internal)), vec![5, 0]);
+        assert_eq!(tag(&SyncFrame::Err(SyncFrameError::Malformed)), vec![5, 1]);
+    }
+
+    #[tokio::test]
+    async fn frame_larger_than_max_is_rejected() {
+        let frame = SyncFrame::<()>::Data(vec![0u8; 256]);
+        let (mut enc, mut comp) = (Vec::new(), Vec::new());
+        let mut wire = Vec::new();
+        // a 64-byte cap is smaller than the 256-byte payload
+        let result = write_frame(&mut wire, &frame, &mut enc, &mut comp, 64).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/network-libp2p/src/sync/mod.rs
+++ b/crates/network-libp2p/src/sync/mod.rs
@@ -23,7 +23,7 @@
 //! ## Protocols
 //!
 //! The frames ride on streams negotiated with the per-role sync protocols
-//! (`/tn-primary-sync/1.0.0`, `/tn-worker-{id}-sync/1.0.0`), which the stream
+//! (`/tn-primary-sync/0.0.1`, `/tn-worker-{id}-sync/0.0.1`), which the stream
 //! behaviour registers alongside the legacy `/tn-stream/0.0.1` upgrade. This
 //! layer is inert for now: no call site opens a sync stream until the
 //! per-exchange cutovers migrate the worker batch, epoch pack, and missing

--- a/crates/network-libp2p/src/sync/mod.rs
+++ b/crates/network-libp2p/src/sync/mod.rs
@@ -1,0 +1,39 @@
+//! Typed sync-frame layer for bulk request/response exchanges.
+//!
+//! The legacy bulk path opens a raw `/tn-stream` substream and correlates it
+//! back to a prior request-response handshake by writing a 32-byte digest. This
+//! module is the additive groundwork for folding that handshake into the stream
+//! itself: an exchange carries its request as the first frame, and the responder
+//! answers in the same stream.
+//!
+//! ## Framing
+//!
+//! Every exchange is a sequence of [`SyncFrame`]s, each written as a single
+//! [`encode_message`]/[`decode_message`] unit (length-prefixed, snappy
+//! compressed, BCS encoded). The BCS enum discriminant is the frame tag:
+//!
+//! 1. The requester opens with a [`SyncFrame::Req`] carrying the typed request
+//!    ([`WorkerSyncRequest`] or [`PrimarySyncRequest`]).
+//! 2. The responder answers [`SyncFrame::Ack`] to accept or [`SyncFrame::Deny`] to shed load, so an
+//!    over-capacity responder declines immediately instead of making the requester wait out its
+//!    timeout.
+//! 3. An accepted exchange streams zero or more [`SyncFrame::Data`] frames and finishes with
+//!    [`SyncFrame::End`], or aborts with [`SyncFrame::Err`].
+//!
+//! ## Protocols
+//!
+//! The frames ride on streams negotiated with the per-role sync protocols
+//! (`/tn-primary-sync/1.0.0`, `/tn-worker-{id}-sync/1.0.0`), which the stream
+//! behaviour registers alongside the legacy `/tn-stream/0.0.1` upgrade. This
+//! layer is inert for now: no call site opens a sync stream until the
+//! per-exchange cutovers migrate the worker batch, epoch pack, and missing
+//! certificate paths.
+//!
+//! [`encode_message`]: crate::encode_message
+//! [`decode_message`]: crate::decode_message
+
+mod frame;
+mod request;
+
+pub use frame::{read_frame, write_frame, DenyReason, SyncFrame, SyncFrameError};
+pub use request::{PrimarySyncRequest, WorkerSyncRequest};

--- a/crates/network-libp2p/src/sync/request.rs
+++ b/crates/network-libp2p/src/sync/request.rs
@@ -6,7 +6,7 @@ use tn_types::{AuthorityIdentifier, BlockHash, Epoch, Round};
 
 /// A bulk-sync request from a worker, carried in the opening
 /// [`SyncFrame::Req`](crate::sync::SyncFrame::Req) of a
-/// `/tn-worker-{id}-sync/1.0.0` exchange.
+/// `/tn-worker-{id}-sync/0.0.1` exchange.
 ///
 /// The variant order is the wire format: this enum's BCS discriminant rides on
 /// the wire inside the `Req` frame, so variants must not be reordered or removed
@@ -28,7 +28,7 @@ pub enum WorkerSyncRequest {
 }
 
 /// A bulk-sync request from a primary, carried in the opening
-/// [`SyncFrame::Req`](crate::sync::SyncFrame::Req) of a `/tn-primary-sync/1.0.0`
+/// [`SyncFrame::Req`](crate::sync::SyncFrame::Req) of a `/tn-primary-sync/0.0.1`
 /// exchange.
 ///
 /// The variant order is the wire format: this enum's BCS discriminant rides on
@@ -110,7 +110,7 @@ mod tests {
     /// The request enums' BCS discriminants ride on the wire (inside the `Req`
     /// frame), so pin them exactly as `frame_tags_are_stable` pins the frame
     /// tags. A reorder would keep the round-trip tests green while changing the
-    /// 1.0.0 framing seen by a deployed peer; this catches it.
+    /// 0.0.1 framing seen by a deployed peer; this catches it.
     #[test]
     fn request_tags_are_stable() {
         let worker =

--- a/crates/network-libp2p/src/sync/request.rs
+++ b/crates/network-libp2p/src/sync/request.rs
@@ -1,0 +1,132 @@
+//! Typed requests carried in the opening frame of a bulk-sync exchange.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use tn_types::{AuthorityIdentifier, BlockHash, Epoch, Round};
+
+/// A bulk-sync request from a worker, carried in the opening
+/// [`SyncFrame::Req`](crate::sync::SyncFrame::Req) of a
+/// `/tn-worker-{id}-sync/1.0.0` exchange.
+///
+/// The variant order is the wire format: this enum's BCS discriminant rides on
+/// the wire inside the `Req` frame, so variants must not be reordered or removed
+/// before a protocol-version bump (`request_tags_are_stable` pins it).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkerSyncRequest {
+    /// Request the sealed batches identified by `batch_digests`, produced in
+    /// `epoch`.
+    ///
+    /// Folds the legacy `RequestBatchesStream` ack-plus-digest handshake into a
+    /// single open: the digests travel in the request frame, so the responder
+    /// needs no `(peer, digest)` pending map to correlate a follow-up stream.
+    Batches {
+        /// The batch digests being requested.
+        batch_digests: BTreeSet<BlockHash>,
+        /// The epoch that produced these batches.
+        epoch: Epoch,
+    },
+}
+
+/// A bulk-sync request from a primary, carried in the opening
+/// [`SyncFrame::Req`](crate::sync::SyncFrame::Req) of a `/tn-primary-sync/1.0.0`
+/// exchange.
+///
+/// The variant order is the wire format: this enum's BCS discriminant rides on
+/// the wire inside the `Req` frame, so variants must not be reordered or removed
+/// before a protocol-version bump (`request_tags_are_stable` pins it).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrimarySyncRequest {
+    /// Request the consensus pack file for `epoch`.
+    ///
+    /// Folds the legacy `StreamEpoch` ack-plus-digest handshake into a single
+    /// open.
+    EpochPack {
+        /// The epoch whose consensus data is requested.
+        epoch: Epoch,
+    },
+    /// Request certificates the requester is missing.
+    ///
+    /// Replaces the legacy `MissingCertificates` request. Because the response
+    /// is streamed and ended by the responder, this carries no
+    /// `max_response_size`: the request-response codec's fixed cap no longer
+    /// bounds the reply, so the requester need not pre-declare a budget.
+    MissingCertificates {
+        /// Certificates after this round (exclusive) are requested.
+        exclusive_lower_bound: Round,
+        /// Per-authority rounds to skip, each serialized as a RoaringBitmap.
+        skip_rounds: Vec<(AuthorityIdentifier, Vec<u8>)>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::{read_frame, write_frame, SyncFrame};
+
+    const MAX_FRAME: usize = 1024 * 1024;
+
+    /// Round-trip a typed request through the opening `Req` frame, returning the
+    /// decoded frame so the caller can assert it survived unchanged.
+    async fn roundtrip_req<R>(request: R) -> SyncFrame<R>
+    where
+        R: Serialize + serde::de::DeserializeOwned + Sync,
+    {
+        let frame = SyncFrame::Req(request);
+        let (mut enc, mut comp) = (Vec::new(), Vec::new());
+        let mut wire = Vec::new();
+        write_frame(&mut wire, &frame, &mut enc, &mut comp, MAX_FRAME).await.expect("write req");
+
+        let (mut dec, mut comp2) = (Vec::new(), Vec::new());
+        read_frame(&mut wire.as_ref(), &mut dec, &mut comp2, MAX_FRAME).await.expect("read req")
+    }
+
+    #[tokio::test]
+    async fn worker_batches_request_round_trips() {
+        let request = WorkerSyncRequest::Batches {
+            batch_digests: BTreeSet::from([BlockHash::from([3u8; 32]), BlockHash::from([9u8; 32])]),
+            epoch: 42,
+        };
+        assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
+    }
+
+    #[tokio::test]
+    async fn primary_epoch_pack_request_round_trips() {
+        let request = PrimarySyncRequest::EpochPack { epoch: 7 };
+        assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
+    }
+
+    #[tokio::test]
+    async fn primary_missing_certificates_request_round_trips() {
+        let request = PrimarySyncRequest::MissingCertificates {
+            exclusive_lower_bound: 12,
+            skip_rounds: vec![
+                (AuthorityIdentifier::from_bytes([1u8; 32]), vec![0xDE, 0xAD]),
+                (AuthorityIdentifier::from_bytes([2u8; 32]), vec![0xBE, 0xEF]),
+            ],
+        };
+        assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
+    }
+
+    /// The request enums' BCS discriminants ride on the wire (inside the `Req`
+    /// frame), so pin them exactly as `frame_tags_are_stable` pins the frame
+    /// tags. A reorder would keep the round-trip tests green while changing the
+    /// 1.0.0 framing seen by a deployed peer; this catches it.
+    #[test]
+    fn request_tags_are_stable() {
+        let worker =
+            bcs::to_bytes(&WorkerSyncRequest::Batches { batch_digests: BTreeSet::new(), epoch: 0 })
+                .expect("encode worker request");
+        assert_eq!(worker.first(), Some(&0));
+
+        let epoch_pack =
+            bcs::to_bytes(&PrimarySyncRequest::EpochPack { epoch: 0 }).expect("encode epoch pack");
+        assert_eq!(epoch_pack.first(), Some(&0));
+
+        let missing = bcs::to_bytes(&PrimarySyncRequest::MissingCertificates {
+            exclusive_lower_bound: 0,
+            skip_rounds: Vec::new(),
+        })
+        .expect("encode missing certificates");
+        assert_eq!(missing.first(), Some(&1));
+    }
+}

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -93,6 +93,23 @@ impl NetworkType {
             }
         }
     }
+
+    /// Bulk-sync streaming wire protocol, isolated per role (and per worker).
+    ///
+    /// The stream behaviour registers this alongside the legacy
+    /// `/tn-stream/0.0.1` upgrade so a responder accepts it; the typed
+    /// [`SyncFrame`](crate::sync::SyncFrame) layer rides on streams negotiated
+    /// with this protocol. Additive for now: no call site opens it until the
+    /// per-exchange cutovers migrate the bulk paths.
+    pub(crate) fn sync_protocol(&self) -> StreamProtocol {
+        match self {
+            Self::Primary => StreamProtocol::new("/tn-primary-sync/1.0.0"),
+            Self::Worker(id) => {
+                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-sync/1.0.0"))
+                    .expect("worker sync protocol name starts with '/'")
+            }
+        }
+    }
 }
 
 /// A channel for sending the response to an inbound RPC, bound to the peer that

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -103,9 +103,9 @@ impl NetworkType {
     /// per-exchange cutovers migrate the bulk paths.
     pub(crate) fn sync_protocol(&self) -> StreamProtocol {
         match self {
-            Self::Primary => StreamProtocol::new("/tn-primary-sync/1.0.0"),
+            Self::Primary => StreamProtocol::new("/tn-primary-sync/0.0.1"),
             Self::Worker(id) => {
-                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-sync/1.0.0"))
+                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-sync/0.0.1"))
                     .expect("worker sync protocol name starts with '/'")
             }
         }


### PR DESCRIPTION
Step 4 of the #739 plan: the **typed sync-frame layer**, additive. It introduces
the framing and typed requests that the worker-batch, epoch-pack, and
missing-certificate cutovers (steps 5 to 7) will ride on, and registers the new
protocols, while leaving every current call site on the legacy `/tn-stream`
path. No bulk traffic moves yet.

### What changed

- **New `sync` module (`crates/network-libp2p/src/sync/`).**
  - `SyncFrame<R>` is one frame per `encode_message`/`decode_message` unit
    (length-prefixed, snappy-compressed, BCS), so the BCS enum discriminant is
    the frame tag: `Req(R)` (REQ, the typed request), `Ack` (ACK), `Deny(DenyReason)`
    (DENY), `Data(Vec<u8>)` (DATA, opaque payload), `End` (END), `Err(SyncFrameError)`
    (ERR). An exchange opens with `Req`, the responder answers `Ack` or `Deny`,
    and an accepted exchange streams `Data` frames terminated by `End` (or aborts
    with `Err`).
  - `DenyReason` (`AtCapacity`, `Unavailable`) gives an over-capacity responder a
    way to decline immediately, so the requester does not burn its open timeout.
  - `read_frame` / `write_frame` are thin, named, documented wrappers over
    `decode_message` / `encode_message` that pin the message type to `SyncFrame`.
- **Typed request enums (shared, `pub` and re-exported from the crate root).**
  - `WorkerSyncRequest::Batches { batch_digests, epoch }` folds the legacy
    `RequestBatchesStream` ack-plus-digest handshake into a single open: the
    digests travel in the request frame, so the responder needs no
    `(peer, digest)` pending map.
  - `PrimarySyncRequest::EpochPack { epoch }` and
    `PrimarySyncRequest::MissingCertificates { exclusive_lower_bound, skip_rounds }`.
    The missing-certs variant drops `max_response_size`: a streamed, responder-ended
    reply is no longer bounded by the request-response codec's fixed cap, so the
    caller need not pre-declare a budget.
  - Defined with `tn-types` primitives only (the crate cannot depend on the
    consumer crates), which is why the missing-certs fields are modeled inline
    rather than reusing `primary`'s `MissingCertificatesRequest`.
- **Protocol registration.** `NetworkType::sync_protocol()` returns
  `/tn-primary-sync/1.0.0` or `/tn-worker-{id}-sync/1.0.0`, mirroring the existing
  `req_res_protocol` / `kad_protocol`. `TNStreamProtocol` now advertises a list,
  `[/tn-stream/0.0.1, <sync>]`, threaded `StreamBehavior::new(network_type)` to
  each `StreamHandler` and into both the inbound listen protocol and outbound
  open. The legacy protocol is first in dialer-preference order, so every existing
  open still negotiates `/tn-stream`; a responder now also accepts the sync
  protocol.

### Why it stays additive

The legacy `/tn-stream/0.0.1` path is byte-for-byte unchanged: the inbound and
outbound upgrades still return the raw stream regardless of which protocol
negotiated, and no call site opens a sync stream. Because `/tn-stream` is
advertised first, existing opens negotiate it against both item-4 and pre-item-4
peers, and a pre-item-4 dialer (which only proposes `/tn-stream`) negotiates it
against an item-4 listener. The sync protocols are registered but inert: nothing
opens one, so none is ever negotiated in an item-4 fleet. Routing an inbound
stream by negotiated protocol arrives with the first cutover (step 5), which is
also where the first opener lands.

### Cross-cutting rule honored

BCS encodes enum variant indices, so `frame_tags_are_stable` pins each
`SyncFrame` tag's exact bytes (`Req`=0, `Ack`=1, `Deny`=2, `Data`=3, `End`=4,
`Err`=5, plus the nested reason indices). No variant may be reordered or removed
before the coordinated `/0.0.2` bump; the test makes a regression loud.

### Verification

All green on stable 1.94 (build/test) and nightly-2026-03-20 (fmt/clippy):

- `cargo build -p tn-network-libp2p`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy -p tn-network-libp2p --all-features --all-targets` (also
  compiles the consumer crates `tn-primary`, `tn-worker`, `tn-executor`,
  `tn-node` as dev-deps: they build zero-edit against the new public surface,
  which only grows)
- `cargo test -p tn-network-libp2p --lib`: **181 pass**, including 10 new (frame
  round-trips for every tag, `frame_tags_are_stable`, oversized-frame rejection,
  the three request round-trips, `request_tags_are_stable`, protocol-info
  ordering, and sync-protocol registration)
- `RUSTDOCFLAGS=-D warnings cargo doc -p tn-network-libp2p --no-deps`

A 4-lens adversarial review (wire-format, libp2p negotiation, conventions,
completeness) drove two additions: `request_tags_are_stable` pins the typed
request enums' BCS discriminants (they ride on the wire inside `Req`, so they get
the same encoding-compat pin as the frame tags), and a note at `upgrade_inbound`
marks the negotiated-protocol seam that the step-5 cutover branches on. A live
multistream-select negotiation test (asserting an outbound open still picks
`/tn-stream` against a dual-protocol peer) is intentionally deferred to step 5,
which the issue assigns the cross-version integration harness; step 4 covers the
advertised order with `protocol_info_preserves_order` and relies on libp2p's
dialer-preference negotiation.

### Non-goals

No call site switches to the sync protocols (steps 5 to 7). No request-response,
gossipsub, kad, or scoring-weight changes. The `Data` payload encoding and the
buffer-ownership model for a live exchange are deliberately left to the cutovers
that define them.
```
