### PR TITLE
network: incorporate the chain id into every libp2p protocol string and gossip topic

### DIFF
--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -238,6 +238,15 @@ where
         &self.inner.network_config
     }
 
+    /// The chain id used to namespace this node's wire protocols and gossip topics.
+    ///
+    /// Reads the value stamped onto the network config from genesis at node startup,
+    /// so the gossip-validation side (here) and the publish/subscribe side share one
+    /// source. See [`NetworkConfig::set_chain_id`].
+    pub fn chain_id(&self) -> u64 {
+        self.inner.network_config.chain_id()
+    }
+
     /// The current epoch for [Committee].
     pub fn epoch(&self) -> Epoch {
         self.inner.committee.epoch()

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -37,6 +37,24 @@ impl NetworkConfig {
         &self.libp2p_config
     }
 
+    /// The chain id used to namespace this node's wire protocols and gossip topics.
+    ///
+    /// Sourced from genesis and stamped via [`Self::set_chain_id`] at node startup.
+    /// Defaults to `0` until set; every protocol and topic reads this one value, so
+    /// an unset id yields a self-consistent `0` namespace rather than a mismatch.
+    pub fn chain_id(&self) -> u64 {
+        self.libp2p_config.chain_id
+    }
+
+    /// Stamp the genesis chain id onto this config.
+    ///
+    /// Called once during node startup so wire protocols and gossip topics read a
+    /// single, genesis-derived source. Genesis is authoritative: this overwrites
+    /// whatever the (non-persisted) field held.
+    pub fn set_chain_id(&mut self, chain_id: u64) {
+        self.libp2p_config.chain_id = chain_id;
+    }
+
     /// Return a mutable reference to the [LibP2pConfig].
     #[cfg(feature = "test-utils")]
     pub fn libp2p_config_mut(&mut self) -> &mut LibP2pConfig {
@@ -120,32 +138,42 @@ pub struct LibP2pConfig {
     /// Must be < `kad_record_ttl`, otherwise records expire before they are
     /// refreshed.
     pub kad_publication_interval: Duration,
+    /// The chain id, used to namespace every libp2p wire protocol and gossip
+    /// topic so nodes on different chains never negotiate a connection or share
+    /// a gossip mesh.
+    ///
+    /// Sourced from `genesis.config.chain_id` and stamped onto this config at
+    /// node startup (see `NetworkConfig::set_chain_id`). It is not an operator
+    /// tunable, so it is intentionally skipped during (de)serialization and
+    /// never written to the config file; genesis is the single source of truth.
+    #[serde(skip)]
+    pub chain_id: u64,
 }
 
 impl LibP2pConfig {
-    /// Return topics for primary.
-    pub fn primary_topic() -> String {
-        String::from("tn-primary")
+    /// Return the primary gossip topic for `chain_id`.
+    pub fn primary_topic(chain_id: u64) -> String {
+        format!("tn-primary-{chain_id}")
     }
 
-    /// Return topics for primary.
-    pub fn consensus_output_topic() -> String {
-        String::from("tn-consensus-output")
+    /// Return the consensus-output gossip topic for `chain_id`.
+    pub fn consensus_output_topic(chain_id: u64) -> String {
+        format!("tn-consensus-output-{chain_id}")
     }
 
-    /// Return topics for epoch votes.
-    pub fn epoch_vote_topic() -> String {
-        String::from("tn-epoch-vote")
+    /// Return the epoch-vote gossip topic for `chain_id`.
+    pub fn epoch_vote_topic(chain_id: u64) -> String {
+        format!("tn-epoch-vote-{chain_id}")
     }
 
-    /// Return topics for worker.
-    pub fn worker_batch_topic() -> String {
-        String::from("tn-worker")
+    /// Return the worker-batch gossip topic for `chain_id`.
+    pub fn worker_batch_topic(chain_id: u64) -> String {
+        format!("tn-worker-{chain_id}")
     }
 
-    /// Return topics for worker.
-    pub fn worker_txn_topic() -> String {
-        String::from("tn-txn")
+    /// Return the worker-transaction gossip topic for `chain_id`.
+    pub fn worker_txn_topic(chain_id: u64) -> String {
+        format!("tn-txn-{chain_id}")
     }
 }
 
@@ -160,6 +188,8 @@ impl Default for LibP2pConfig {
             k_bucket_size: K_VALUE,
             kad_record_ttl: Duration::from_secs(48 * 60 * 60),
             kad_publication_interval: Duration::from_secs(12 * 60 * 60),
+            // Overwritten from genesis at node startup via `NetworkConfig::set_chain_id`.
+            chain_id: 0,
         }
     }
 }
@@ -528,5 +558,45 @@ hostname: "my-validator"
         assert_eq!(parsed.kad_publication_interval, default.kad_publication_interval);
         assert_eq!(parsed.max_rpc_message_size, default.max_rpc_message_size);
         assert_eq!(parsed.k_bucket_size, default.k_bucket_size);
+    }
+
+    #[test]
+    fn gossip_topics_are_chain_namespaced() {
+        // Every gossip topic embeds the chain id so two chains never share a mesh
+        // (issue #765).
+        assert_eq!(LibP2pConfig::primary_topic(2017), "tn-primary-2017");
+        assert_eq!(LibP2pConfig::consensus_output_topic(2017), "tn-consensus-output-2017");
+        assert_eq!(LibP2pConfig::epoch_vote_topic(2017), "tn-epoch-vote-2017");
+        assert_eq!(LibP2pConfig::worker_batch_topic(2017), "tn-worker-2017");
+        assert_eq!(LibP2pConfig::worker_txn_topic(2017), "tn-txn-2017");
+        // a different chain id yields a different topic
+        assert_ne!(LibP2pConfig::primary_topic(1), LibP2pConfig::primary_topic(2));
+    }
+
+    #[test]
+    fn set_chain_id_is_read_back() {
+        let mut config = NetworkConfig::default();
+        assert_eq!(config.chain_id(), 0, "defaults to 0 until stamped from genesis");
+        config.set_chain_id(2017);
+        assert_eq!(config.chain_id(), 2017);
+        assert_eq!(config.libp2p_config().chain_id, 2017);
+    }
+
+    #[test]
+    fn chain_id_is_never_persisted() {
+        // chain_id is genesis-derived, not operator-configurable: it must never be
+        // written to (or read from) the config file, so genesis stays authoritative.
+        let libp2p = LibP2pConfig { chain_id: 2017, ..Default::default() };
+        let yaml = serde_yaml::to_string(&libp2p).expect("serialize libp2p config");
+        assert!(!yaml.contains("chain_id"), "chain_id must not be serialized: {yaml}");
+
+        // The load-bearing guard: a config file that *does* contain an explicit
+        // chain_id (hand-edited by an operator) must ignore it on read, so genesis
+        // stays the only source and cannot be overridden from disk.
+        let from_disk: LibP2pConfig =
+            serde_yaml::from_str("max_rpc_message_size: 1\nchain_id: 999\n")
+                .expect("deserialize libp2p config with an explicit chain_id");
+        assert_eq!(from_disk.chain_id, 0, "an on-disk chain_id must be ignored on read");
+        assert_eq!(from_disk.max_rpc_message_size, 1, "other fields still load");
     }
 }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -202,7 +202,9 @@ where
         match gossip {
             PrimaryGossip::Certificate(mut cert) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::primary_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::primary_topic(
+                        self.consensus_config.chain_id()
+                    )),
                     PrimaryNetworkError::InvalidTopic
                 );
                 // process certificate
@@ -242,7 +244,9 @@ where
             }
             PrimaryGossip::Consensus(result) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::consensus_output_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::consensus_output_topic(
+                        self.consensus_config.chain_id()
+                    )),
                     PrimaryNetworkError::InvalidTopic
                 );
                 // We want to confirm all the data (including but not limited to the consensus
@@ -305,7 +309,9 @@ where
             }
             PrimaryGossip::EpochVote(vote) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::epoch_vote_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::epoch_vote_topic(
+                        self.consensus_config.chain_id()
+                    )),
                     PrimaryNetworkError::InvalidTopic
                 );
                 // Verify the BLS signature

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -110,23 +110,30 @@ impl PendingEpochStream {
 #[derive(Clone, Debug)]
 pub struct PrimaryNetworkHandle {
     handle: NetworkHandle<Req, Res>,
+    /// The genesis chain id, used to namespace gossip topics this handle publishes.
+    chain_id: u64,
 }
 
+// Test-only conversion that defaults the chain id to 0. Gated to tests so the only
+// way to build a production handle is `new`, with the genesis chain id supplied
+// explicitly: a 0 here would publish on the `-0` topic suffix while validators read
+// the real id, a silent gossip mismatch.
+#[cfg(test)]
 impl From<NetworkHandle<Req, Res>> for PrimaryNetworkHandle {
     fn from(handle: NetworkHandle<Req, Res>) -> Self {
-        Self { handle }
+        Self { handle, chain_id: 0 }
     }
 }
 
 impl PrimaryNetworkHandle {
     /// Create a new instance of Self.
-    pub fn new(handle: NetworkHandle<Req, Res>) -> Self {
-        Self { handle }
+    pub fn new(handle: NetworkHandle<Req, Res>, chain_id: u64) -> Self {
+        Self { handle, chain_id }
     }
 
     //// Convenience method for creating a new Self for tests.
     pub fn new_for_test(sender: mpsc::Sender<NetworkCommand<Req, Res>>) -> Self {
-        Self { handle: NetworkHandle::new(sender) }
+        Self { handle: NetworkHandle::new(sender), chain_id: 0 }
     }
 
     /// Return a reference to the inner handle.
@@ -137,7 +144,7 @@ impl PrimaryNetworkHandle {
     /// Publish a certificate to the consensus network.
     pub async fn publish_certificate(&self, certificate: Certificate) -> NetworkResult<()> {
         let data = encode(&PrimaryGossip::Certificate(Box::new(certificate)));
-        self.handle.publish(tn_config::LibP2pConfig::primary_topic(), data).await?;
+        self.handle.publish(tn_config::LibP2pConfig::primary_topic(self.chain_id), data).await?;
         Ok(())
     }
 
@@ -159,14 +166,16 @@ impl PrimaryNetworkHandle {
             validator: key,
             signature,
         })));
-        self.handle.publish(tn_config::LibP2pConfig::consensus_output_topic(), data).await?;
+        self.handle
+            .publish(tn_config::LibP2pConfig::consensus_output_topic(self.chain_id), data)
+            .await?;
         Ok(())
     }
 
     /// Publish a certificate to the consensus network.
     pub async fn publish_epoch_vote(&self, vote: EpochVote) -> NetworkResult<()> {
         let data = encode(&PrimaryGossip::EpochVote(Box::new(vote)));
-        self.handle.publish(tn_config::LibP2pConfig::epoch_vote_topic(), data).await?;
+        self.handle.publish(tn_config::LibP2pConfig::epoch_vote_topic(self.chain_id), data).await?;
         Ok(())
     }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -408,7 +408,7 @@ async fn test_primary_batch_gossip_topics() {
 
     let gossip = PrimaryGossip::Certificate(Box::new(Certificate::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::primary_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::primary_topic(0));
     let goodish_msg =
         GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     let res = handler.process_gossip(&goodish_msg).await;
@@ -417,7 +417,7 @@ async fn test_primary_batch_gossip_topics() {
 
     let gossip = PrimaryGossip::Consensus(Box::new(ConsensusResult::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::consensus_output_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::consensus_output_topic(0));
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.process_gossip(&good_msg).await.is_ok());
 
@@ -425,7 +425,7 @@ async fn test_primary_batch_gossip_topics() {
     // and returns InvalidHeader(PeerNotAuthor).
     let gossip = PrimaryGossip::EpochVote(Box::new(EpochVote::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic(0));
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     let res = handler.process_gossip(&good_msg).await;
     // Not rejected for InvalidTopic — rejected for invalid signature instead.
@@ -433,7 +433,7 @@ async fn test_primary_batch_gossip_topics() {
 
     let gossip = PrimaryGossip::Certificate(Box::new(Certificate::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic(0));
     let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     let res = handler.process_gossip(&bad_msg).await;
     // This will be rejected for other reasons, but make sure it is for an invalid topic.
@@ -441,13 +441,13 @@ async fn test_primary_batch_gossip_topics() {
 
     let gossip = PrimaryGossip::Consensus(Box::new(ConsensusResult::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::primary_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::primary_topic(0));
     let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.process_gossip(&bad_msg).await.is_err());
 
     let gossip = PrimaryGossip::EpochVote(Box::new(EpochVote::default()));
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::consensus_output_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::consensus_output_topic(0));
     let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.process_gossip(&bad_msg).await.is_err());
 }

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -43,12 +43,19 @@ pub struct WorkerNetworkHandle {
     task_spawner: TaskSpawner,
     /// The current epoch for this node.
     epoch: Epoch,
+    /// The genesis chain id, used to namespace gossip topics this handle publishes.
+    chain_id: u64,
 }
 
 impl WorkerNetworkHandle {
     /// Create a new instance of [Self].
-    pub fn new(handle: NetworkHandle<Req, Res>, task_spawner: TaskSpawner, epoch: Epoch) -> Self {
-        Self { handle, task_spawner, epoch }
+    pub fn new(
+        handle: NetworkHandle<Req, Res>,
+        task_spawner: TaskSpawner,
+        epoch: Epoch,
+        chain_id: u64,
+    ) -> Self {
+        Self { handle, task_spawner, epoch, chain_id }
     }
 
     /// Return a reference to the task spawner.
@@ -64,7 +71,9 @@ impl WorkerNetworkHandle {
     /// Publish a batch digest to the worker network.
     pub(crate) async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Batch(self.epoch, batch_digest));
-        self.handle.publish(tn_config::LibP2pConfig::worker_batch_topic(), data).await?;
+        self.handle
+            .publish(tn_config::LibP2pConfig::worker_batch_topic(self.chain_id), data)
+            .await?;
         Ok(())
     }
 
@@ -72,7 +81,7 @@ impl WorkerNetworkHandle {
     /// Do this when not a committee member so a CVV can include the txn.
     pub(crate) async fn publish_txn(&self, txn: Vec<u8>) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Txn(txn));
-        self.handle.publish("tn-txn".into(), data).await?;
+        self.handle.publish(tn_config::LibP2pConfig::worker_txn_topic(self.chain_id), data).await?;
         Ok(())
     }
 
@@ -417,7 +426,7 @@ impl WorkerNetworkHandle {
     /// nothing.
     pub fn new_for_test(task_spawner: TaskSpawner) -> Self {
         let (tx, _rx) = tokio::sync::mpsc::channel(5);
-        Self { handle: NetworkHandle::new(tx), task_spawner, epoch: 0 }
+        Self { handle: NetworkHandle::new(tx), task_spawner, epoch: 0, chain_id: 0 }
     }
 
     /// Publicly available for tests.

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -71,7 +71,9 @@ where
         match gossip {
             WorkerGossip::Batch(epoch, batch_hash) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic(
+                        self.consensus_config.chain_id()
+                    )),
                     WorkerNetworkError::InvalidTopic
                 );
                 let my_epoch = self.consensus_config.epoch();
@@ -127,7 +129,9 @@ where
             }
             WorkerGossip::Txn(tx_bytes) => {
                 ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_txn_topic()),
+                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_txn_topic(
+                        self.consensus_config.chain_id()
+                    )),
                     WorkerNetworkError::InvalidTopic
                 );
                 if let Some(authority) = self.consensus_config.authority() {

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -33,7 +33,18 @@ struct TestTypes<DB = MemDatabase> {
 /// Helper function to create an instance of [RequestHandler] for the first authority in the
 /// committee.
 fn create_test_types() -> TestTypes {
-    let committee = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    create_test_types_with_chain_id(0)
+}
+
+/// Like [`create_test_types`], but stamps `chain_id` onto the network config so the
+/// handler validates (and the handle publishes) gossip topics namespaced by that id.
+fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
+    let mut network_config = tn_config::NetworkConfig::default();
+    network_config.set_chain_id(chain_id);
+    let committee = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .with_network_config(network_config)
+        .build();
     let authority = committee.first_authority();
     let config = authority.consensus_config();
     let task_manager = TaskManager::default();
@@ -41,7 +52,7 @@ fn create_test_types() -> TestTypes {
     let batch_validator = Arc::new(NoopBatchValidator);
     let (tx, network_commands_rx) = mpsc::channel(10);
     let network_handle =
-        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, chain_id);
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
 }
@@ -84,24 +95,56 @@ async fn test_batch_gossip_topics() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
 
     // Test swapped topics, must fail.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
     let bad_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let gossip = WorkerGossip::Txn(vec![]);
     let data = tn_types::encode(&gossip);
     let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
 
     // Use the correct topic for a txn and make sure it works.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
     let good_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
+}
+
+/// The handler validates gossip topics against the chain id from its config, not a
+/// hardcoded value: with a non-zero chain id, a message on the chain-0 namespace (what
+/// an un-stamped node would publish) is rejected as an invalid topic. This is the
+/// property that makes the namespacing actually isolate chains.
+#[tokio::test]
+async fn test_batch_gossip_topic_is_chain_namespaced() {
+    let TestTypes { handler, .. } = create_test_types_with_chain_id(2017);
+    let batch_digest = B256::random();
+    let data = tn_types::encode(&WorkerGossip::Batch(0, batch_digest));
+
+    // the config's chain id (2017) is accepted: the topic check passes
+    let good = GossipMessage {
+        source: None,
+        data: data.clone(),
+        sequence_number: None,
+        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(2017)),
+    };
+    assert!(handler.pub_process_gossip_for_test(&good).await.is_ok());
+
+    // the chain-0 namespace is a different topic and is rejected
+    let bad = GossipMessage {
+        source: None,
+        data,
+        sequence_number: None,
+        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0)),
+    };
+    assert_matches!(
+        handler.pub_process_gossip_for_test(&bad).await,
+        Err(WorkerNetworkError::InvalidTopic)
+    );
 }
 
 /// Test that gossip triggers batch fetch via stream-based approach.
@@ -117,7 +160,7 @@ async fn test_batch_gossip_triggers_stream_request() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
 
     task_manager.spawn_task("process-gossip-test", async move {
@@ -168,7 +211,7 @@ async fn test_batch_gossip_stream_accepted_opens_stream() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic());
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
     let msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
 
     task_manager.spawn_task("process-gossip-test", async move {
@@ -250,7 +293,7 @@ async fn test_unknown_stream_request_error_type() {
 async fn test_request_batches_no_peers() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
 
     // reply with empty peer list
     tokio::spawn(async move {
@@ -273,7 +316,7 @@ async fn test_request_batches_no_peers() {
 async fn test_request_batches_peer_rejects_tries_next() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
 
     let fixture = tn_test_utils::CommitteeFixture::builder(MemDatabase::default)
         .randomize_ports(true)
@@ -400,7 +443,7 @@ async fn test_stream_error_penalties() {
 async fn test_request_batches_truncates_oversized_digests() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
 
     let fixture = tn_test_utils::CommitteeFixture::builder(MemDatabase::default)
         .randomize_ports(true)
@@ -639,7 +682,7 @@ async fn test_concurrent_capacity_exactly_max() {
 async fn test_retry_succeeds_after_initial_rejection() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
 
     let fixture = tn_test_utils::CommitteeFixture::builder(MemDatabase::default)
         .randomize_ports(true)
@@ -717,7 +760,7 @@ async fn test_retry_succeeds_after_initial_rejection() {
 async fn test_request_batches_peer_fallback_preserves_digests() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
+    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
 
     let fixture = tn_test_utils::CommitteeFixture::builder(MemDatabase::default)
         .randomize_ports(true)

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -23,7 +23,7 @@ async fn test_wait_for_quorum_happy_path() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -74,7 +74,7 @@ async fn test_batch_rejected_timeout() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -128,7 +128,7 @@ async fn test_batch_some_rejected_stake_still_passes() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -201,7 +201,7 @@ async fn test_batch_rejected_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -263,7 +263,7 @@ async fn test_batch_rejected_antiquorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -313,7 +313,7 @@ async fn test_batch_early_anti_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -393,7 +393,7 @@ async fn test_network_error_retry_then_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -449,7 +449,7 @@ async fn test_network_error_partial_retry_success() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -526,7 +526,7 @@ async fn test_network_error_all_retries_exhausted() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -578,7 +578,7 @@ async fn test_recoverable_error_retry_then_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -638,7 +638,7 @@ async fn test_recoverable_error_exhausts_retries_as_network() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -252,6 +252,12 @@ where
         external_addr: Multiaddr,
         rpc: Option<RpcInfo>,
     ) -> NetworkResult<Self> {
+        // Namespace every wire protocol by the genesis chain id so nodes on
+        // different chains never negotiate a connection. The id is stamped onto
+        // the network config from genesis at node startup; see
+        // `NetworkConfig::set_chain_id`.
+        let chain_id = network_config.libp2p_config().chain_id;
+
         let gossipsub_config = gossipsub::ConfigBuilder::default()
             // explicitly set default
             .heartbeat_interval(Duration::from_secs(1))
@@ -259,6 +265,14 @@ where
             .validation_mode(gossipsub::ValidationMode::Strict)
             // TN specific: filter against authorized_publishers for certain topics
             .validate_messages()
+            // Gossipsub negotiates its own `/meshsub` protocol, independent of the
+            // req-res/kad/stream names below, so without this it is the one wire
+            // protocol two chains still share: namespacing the topics keeps their
+            // messages apart but still lets cross-chain peers negotiate a gossip
+            // substream. Folding the chain id into the protocol id closes that gap.
+            // The builder appends `/1.1.0` and `/1.0.0`, yielding
+            // `/tn-meshsub-{chain_id}/1.1.0` and `/tn-meshsub-{chain_id}/1.0.0`.
+            .protocol_id_prefix(crate::types::gossip_protocol_id_prefix(chain_id))
             .build()?;
         let gossipsub = gossipsub::Behaviour::new(
             gossipsub::MessageAuthenticity::Signed(keypair.clone()),
@@ -268,12 +282,6 @@ where
 
         let tn_codec =
             TNCodec::<Req, Res>::new(network_config.libp2p_config().max_rpc_message_size);
-
-        // Namespace every wire protocol by the genesis chain id so nodes on
-        // different chains never negotiate a connection. The id is stamped onto
-        // the network config from genesis at node startup; see
-        // `NetworkConfig::set_chain_id`.
-        let chain_id = network_config.libp2p_config().chain_id;
 
         let req_res = request_response::Behaviour::with_codec(
             tn_codec,

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -29,7 +29,7 @@ use libp2p::{
         ProtocolSupport,
     },
     swarm::{NetworkBehaviour, SwarmEvent},
-    Multiaddr, PeerId, Swarm, SwarmBuilder,
+    Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -94,9 +94,10 @@ where
         kademlia: kad::Behaviour<KadStore<DB>>,
         peer_config: &PeerConfig,
         metrics: PeerManagerMetrics,
+        stream_protocol: StreamProtocol,
     ) -> Self {
         let peer_manager = PeerManager::new(peer_config, metrics);
-        let stream = StreamBehavior::new();
+        let stream = StreamBehavior::new(stream_protocol);
         Self { peer_manager, gossipsub, req_res, kademlia, stream }
     }
 }
@@ -268,13 +269,19 @@ where
         let tn_codec =
             TNCodec::<Req, Res>::new(network_config.libp2p_config().max_rpc_message_size);
 
+        // Namespace every wire protocol by the genesis chain id so nodes on
+        // different chains never negotiate a connection. The id is stamped onto
+        // the network config from genesis at node startup; see
+        // `NetworkConfig::set_chain_id`.
+        let chain_id = network_config.libp2p_config().chain_id;
+
         let req_res = request_response::Behaviour::with_codec(
             tn_codec,
-            vec![(network_type.req_res_protocol(), ProtocolSupport::Full)],
+            vec![(network_type.req_res_protocol(chain_id)?, ProtocolSupport::Full)],
             request_response::Config::default(),
         );
         let peer_id: PeerId = keypair.public().into();
-        let mut kad_config = libp2p::kad::Config::new(network_type.kad_protocol());
+        let mut kad_config = libp2p::kad::Config::new(network_type.kad_protocol(chain_id)?);
         // manually add peers
         kad_config.set_kbucket_inserts(kad::BucketInserts::Manual);
         let libp2p = network_config.libp2p_config();
@@ -316,12 +323,14 @@ where
         let kademlia = kad::Behaviour::with_config(peer_id, kad_store.clone(), kad_config);
 
         // create custom behavior
+        let stream_protocol = crate::types::stream_protocol(chain_id)?;
         let mut behavior = TNBehavior::new(
             gossipsub,
             req_res,
             kademlia,
             network_config.peer_config(),
             PeerManagerMetrics::new_for(&network_type),
+            stream_protocol,
         );
 
         // Promote the surviving records into the local peer cache.

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -948,4 +948,30 @@ mod test {
         assert_eq!(names, vec!["/tn-stream-2017/0.0.1", "/tn-worker-3-sync-2017/0.0.1"]);
         Ok(())
     }
+
+    /// Lock the chain-namespaced gossipsub protocol-id prefix. Gossip negotiates
+    /// its own `/meshsub` protocol (not the req-res/kad/stream names), so this
+    /// prefix is what keeps two chains from ever sharing a gossip substream. A
+    /// silent change is a peer-compatibility break, and dropping the leading `/`
+    /// would make `gossipsub::ConfigBuilder::build` reject it (issue #765).
+    #[test]
+    fn test_gossip_protocol_id_prefix_is_chain_namespaced() -> crate::types::NetworkResult<()> {
+        use crate::types::gossip_protocol_id_prefix;
+
+        // the chain id is interpolated, not a literal
+        assert_eq!(gossip_protocol_id_prefix(2017), "/tn-meshsub-2017");
+        assert_eq!(gossip_protocol_id_prefix(0), "/tn-meshsub-0");
+        // different chains get different gossip protocol ids
+        assert_ne!(gossip_protocol_id_prefix(1), gossip_protocol_id_prefix(2));
+
+        // the prefix is a valid `/meshsub`-style protocol id: feeding it to a real
+        // gossipsub ConfigBuilder must build. `protocol_id_prefix` appends `/1.1.0`
+        // and `/1.0.0` and does not prepend a `/`, so a prefix without the leading
+        // slash would be a malformed StreamProtocol and `build` would error here.
+        libp2p::gossipsub::ConfigBuilder::default()
+            .protocol_id_prefix(gossip_protocol_id_prefix(2017))
+            .build()
+            .map(|_| ())
+            .map_err(Into::into)
+    }
 }

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -913,16 +913,27 @@ mod test {
         assert!(matches!(kad_store_worker.put(rec.clone()), Err(Error::MaxRecords)));
     }
 
-    /// Lock the per-role wire-protocol names. These strings are a peer-compatibility
-    /// contract: a silent change would prevent peers from negotiating sessions.
+    /// Lock the per-role, chain-namespaced wire-protocol names. These strings are a
+    /// peer-compatibility contract: a silent change would prevent peers from
+    /// negotiating sessions, and the chain id keeps different chains from ever
+    /// negotiating with each other (issue #765).
     #[test]
-    fn test_network_type_protocol_names() {
-        assert_eq!(NetworkType::Primary.req_res_protocol().as_ref(), "/tn-primary/0.0.1");
-        assert_eq!(NetworkType::Primary.kad_protocol().as_ref(), "/tn-primary-kad/0.0.1");
-        assert_eq!(NetworkType::Worker(0).req_res_protocol().as_ref(), "/tn-worker-0/0.0.1");
-        assert_eq!(NetworkType::Worker(0).kad_protocol().as_ref(), "/tn-worker-0-kad/0.0.1");
-        // worker id is interpolated, not literal
-        assert_eq!(NetworkType::Worker(3).req_res_protocol().as_ref(), "/tn-worker-3/0.0.1");
-        assert_eq!(NetworkType::Worker(3).kad_protocol().as_ref(), "/tn-worker-3-kad/0.0.1");
+    fn test_network_type_protocol_names() -> crate::types::NetworkResult<()> {
+        assert_eq!(NetworkType::Primary.req_res_protocol(2017)?.as_ref(), "/tn-primary-2017/0.0.1");
+        assert_eq!(NetworkType::Primary.kad_protocol(2017)?.as_ref(), "/tn-primary-kad-2017/0.0.1");
+        assert_eq!(
+            NetworkType::Worker(0).req_res_protocol(2017)?.as_ref(),
+            "/tn-worker-0-2017/0.0.1"
+        );
+        assert_eq!(
+            NetworkType::Worker(0).kad_protocol(2017)?.as_ref(),
+            "/tn-worker-0-kad-2017/0.0.1"
+        );
+        // worker id and chain id are both interpolated, not literal
+        assert_eq!(NetworkType::Worker(3).req_res_protocol(7)?.as_ref(), "/tn-worker-3-7/0.0.1");
+        assert_eq!(NetworkType::Worker(3).kad_protocol(7)?.as_ref(), "/tn-worker-3-kad-7/0.0.1");
+        // the bulk-transfer stream protocol is chain-namespaced too (role-agnostic)
+        assert_eq!(crate::types::stream_protocol(2017)?.as_ref(), "/tn-stream-2017/0.0.1");
+        Ok(())
     }
 }

--- a/crates/network-libp2p/src/stream/behavior.rs
+++ b/crates/network-libp2p/src/stream/behavior.rs
@@ -24,9 +24,6 @@ use crate::{
     types::NetworkResult,
 };
 
-/// The protocol identifier for streaming data.
-pub(crate) const TN_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/tn-stream/0.0.1");
-
 /// Maximum outbound stream opens buffered before new opens are rejected.
 const MAX_PENDING_OPENS: usize = 1024;
 
@@ -113,6 +110,8 @@ struct InboundWindow {
 /// error if the peer cannot be reached or the open times out. Inbound streams
 /// are rate limited per peer, and failures are classified for peer scoring.
 pub(crate) struct StreamBehavior {
+    /// The chain-namespaced stream protocol handed to every connection handler.
+    protocol: StreamProtocol,
     /// Events to emit to the swarm/application.
     events: VecDeque<StreamEvent>,
     /// Outbound opens being driven to completion.
@@ -136,9 +135,10 @@ impl std::fmt::Debug for StreamBehavior {
 }
 
 impl StreamBehavior {
-    /// Create a new instance of the stream behavior.
-    pub(crate) fn new() -> Self {
+    /// Create a new stream behavior whose handlers negotiate `protocol`.
+    pub(crate) fn new(protocol: StreamProtocol) -> Self {
         Self {
+            protocol,
             events: VecDeque::new(),
             pending: Vec::new(),
             connected: HashSet::new(),
@@ -269,12 +269,6 @@ impl StreamBehavior {
     }
 }
 
-impl Default for StreamBehavior {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl NetworkBehaviour for StreamBehavior {
     type ConnectionHandler = StreamHandler;
     type ToSwarm = StreamEvent;
@@ -286,7 +280,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: &Multiaddr,
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new())
+        Ok(StreamHandler::new(self.protocol.clone()))
     }
 
     fn handle_established_outbound_connection(
@@ -297,7 +291,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new())
+        Ok(StreamHandler::new(self.protocol.clone()))
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
@@ -402,9 +396,13 @@ mod tests {
         "/ip4/127.0.0.1/tcp/1".parse().expect("valid multiaddr")
     }
 
+    fn test_protocol() -> StreamProtocol {
+        StreamProtocol::new("/tn-stream-test/0.0.1")
+    }
+
     #[tokio::test]
     async fn open_to_unreachable_peer_fails_fast_with_not_connected() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
 
@@ -418,7 +416,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_when_connected_is_queued_for_dispatch() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
@@ -431,7 +429,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_when_disconnected_with_addrs_needs_dial() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
 
@@ -443,7 +441,7 @@ mod tests {
 
     #[tokio::test]
     async fn open_over_capacity_is_rejected() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         for _ in 0..MAX_PENDING_OPENS {
@@ -461,7 +459,7 @@ mod tests {
 
     #[tokio::test]
     async fn connection_promotes_awaiting_open() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -478,7 +476,7 @@ mod tests {
         // The peer may connect (via another behaviour's dial) while our open is
         // still NeedsDial; it must dispatch rather than dial an already-connected
         // peer (which would fail the PeerCondition::Disconnected dial).
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -491,7 +489,7 @@ mod tests {
 
     #[tokio::test]
     async fn dial_failure_fails_awaiting_open() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -506,7 +504,7 @@ mod tests {
 
     #[tokio::test]
     async fn expired_open_times_out_and_reports_failure() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
         behavior.open_stream(peer, vec![addr()], tx);
@@ -526,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_rate_limit_trips_after_threshold() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         for _ in 0..MAX_INBOUND_PER_WINDOW {
             assert!(!behavior.inbound_rate_limited(peer));
@@ -536,7 +534,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_window_resets_after_interval() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         for _ in 0..=MAX_INBOUND_PER_WINDOW {
             behavior.inbound_rate_limited(peer);
@@ -550,7 +548,7 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_requeues_connected_open_for_dial() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
@@ -565,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn push_event_sheds_when_full() {
-        let mut behavior = StreamBehavior::new();
+        let mut behavior = StreamBehavior::new(test_protocol());
         let peer = PeerId::random();
         for _ in 0..MAX_EVENTS {
             behavior

--- a/crates/network-libp2p/src/stream/handler.rs
+++ b/crates/network-libp2p/src/stream/handler.rs
@@ -5,7 +5,7 @@ use libp2p::{
         },
         ConnectionHandler, ConnectionHandlerEvent, StreamUpgradeError, SubstreamProtocol,
     },
-    Stream,
+    Stream, StreamProtocol,
 };
 use std::{
     collections::VecDeque,
@@ -68,8 +68,9 @@ pub(crate) enum StreamHandlerEvent {
 /// `OutboundOpenInfo`, bypassing the behavior layer entirely. Open negotiation
 /// is bounded by [`STREAM_OPEN_TIMEOUT`]; failures are classified and reported
 /// to the behaviour for scoring.
-#[derive(Default)]
 pub(crate) struct StreamHandler {
+    /// The chain-namespaced stream protocol negotiated on this connection.
+    protocol: StreamProtocol,
     /// Pending outbound stream reply channels.
     pending_outbound: VecDeque<oneshot::Sender<NetworkResult<Stream>>>,
     /// Events to send to the behavior.
@@ -86,9 +87,9 @@ impl std::fmt::Debug for StreamHandler {
 }
 
 impl StreamHandler {
-    /// Create a new stream handler.
-    pub(crate) fn new() -> Self {
-        Self { pending_outbound: VecDeque::new(), events: VecDeque::new() }
+    /// Create a new stream handler negotiating the chain-namespaced `protocol`.
+    pub(crate) fn new(protocol: StreamProtocol) -> Self {
+        Self { protocol, pending_outbound: VecDeque::new(), events: VecDeque::new() }
     }
 
     /// Queue an event to the behaviour, dropping it if the buffer is saturated.
@@ -122,7 +123,7 @@ impl ConnectionHandler for StreamHandler {
     type OutboundOpenInfo = oneshot::Sender<NetworkResult<Stream>>;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(TNStreamProtocol, ())
+        SubstreamProtocol::new(TNStreamProtocol::new(self.protocol.clone()), ())
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
@@ -191,8 +192,11 @@ impl ConnectionHandler for StreamHandler {
         // Request outbound streams, bounding negotiation with a timeout.
         if let Some(reply) = self.pending_outbound.pop_front() {
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(TNStreamProtocol, reply)
-                    .with_timeout(STREAM_OPEN_TIMEOUT),
+                protocol: SubstreamProtocol::new(
+                    TNStreamProtocol::new(self.protocol.clone()),
+                    reply,
+                )
+                .with_timeout(STREAM_OPEN_TIMEOUT),
             });
         }
 

--- a/crates/network-libp2p/src/stream/mod.rs
+++ b/crates/network-libp2p/src/stream/mod.rs
@@ -7,7 +7,8 @@
 //! ## Protocol Flow
 //!
 //! 1. **Requestor** negotiates via request-response
-//! 2. **Requestor** opens a stream to the responder using `/tn-stream/0.0.1`
+//! 2. **Requestor** opens a stream to the responder using the chain-namespaced
+//!    `/tn-stream-<chain>/0.0.1` protocol
 //! 3. Both sides use the raw stream for application-specific data transfer
 //! 4. Transfer completes and the stream closes
 

--- a/crates/network-libp2p/src/stream/upgrade.rs
+++ b/crates/network-libp2p/src/stream/upgrade.rs
@@ -4,22 +4,35 @@ use std::{
     future::{ready, Ready},
 };
 
-use crate::{stream::behavior::TN_STREAM_PROTOCOL, Penalty};
+use crate::Penalty;
 
 /// Protocol upgrade for streaming data.
 ///
 /// Both inbound and outbound upgrades simply return the raw stream.
 /// Application-layer correlation (e.g. writing a request digest) is
 /// handled by the caller after the stream is established.
+///
+/// Carries the chain-namespaced [`StreamProtocol`] negotiated on the wire, so a
+/// node only ever establishes streams with peers on the same chain.
 #[derive(Debug, Clone)]
-pub(crate) struct TNStreamProtocol;
+pub(crate) struct TNStreamProtocol {
+    /// The chain-namespaced stream protocol to negotiate.
+    protocol: StreamProtocol,
+}
+
+impl TNStreamProtocol {
+    /// Create a stream-protocol upgrade that negotiates `protocol`.
+    pub(crate) fn new(protocol: StreamProtocol) -> Self {
+        Self { protocol }
+    }
+}
 
 impl UpgradeInfo for TNStreamProtocol {
     type Info = StreamProtocol;
     type InfoIter = std::iter::Once<Self::Info>;
 
     fn protocol_info(&self) -> Self::InfoIter {
-        std::iter::once(TN_STREAM_PROTOCOL)
+        std::iter::once(self.protocol.clone())
     }
 }
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -630,8 +630,8 @@ async fn test_outbound_failure_malicious_response() -> eyre::Result<()> {
 /// ingest a *worker's* `NodeRecord` and then dial/RPC it with primary protocols,
 /// penalizing and banning otherwise-healthy peers.
 ///
-/// With `NetworkType::Primary` → `/tn-primary/*` and `NetworkType::Worker(0)` →
-/// `/tn-worker-0/*`, the cross-role substreams never negotiate: kad never exchanges
+/// With `NetworkType::Primary` → `/tn-primary-<chain>/*` and `NetworkType::Worker(0)`
+/// → `/tn-worker-0-<chain>/*`, the cross-role substreams never negotiate: kad never exchanges
 /// records (so the worker's pushed record never resolves on the primary) and a
 /// req/res request surfaces an `OutboundFailure`. Both networks use IDENTICAL
 /// req/res message types here, so the only thing that can differ is the
@@ -739,9 +739,10 @@ async fn test_primary_worker_protocol_isolation() -> eyre::Result<()> {
         "worker resolved primary's BLS key — kad records crossed roles"
     );
 
-    // req/res isolation: a request to the worker cannot negotiate a protocol —
-    // the worker speaks `/tn-worker-0/*`, not the primary's `/tn-primary/*`. With
-    // identical message types, this can ONLY be a protocol-name mismatch.
+    // req/res isolation: a request to the worker cannot negotiate a protocol,
+    // the worker speaks `/tn-worker-0-<chain>/*`, not the primary's
+    // `/tn-primary-<chain>/*`. With identical message types, this can ONLY be a
+    // protocol-name mismatch.
     let req = TestWorkerRequest::MissingBatches(vec![]);
     let reply = primary.send_request(req, worker_bls).await?;
     let res = timeout(Duration::from_secs(5), reply).await?.expect("reply channel");

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -74,25 +74,41 @@ pub enum NetworkType {
 }
 
 impl NetworkType {
-    /// Request-response wire protocol, isolated per role (and per worker).
-    pub(crate) fn req_res_protocol(&self) -> StreamProtocol {
+    /// Request-response wire protocol, isolated per role (and per worker) and
+    /// namespaced by `chain_id` so nodes on different chains never negotiate a
+    /// connection.
+    pub(crate) fn req_res_protocol(&self, chain_id: u64) -> NetworkResult<StreamProtocol> {
         match self {
-            Self::Primary => StreamProtocol::new("/tn-primary/0.0.1"),
-            Self::Worker(id) => StreamProtocol::try_from_owned(format!("/tn-worker-{id}/0.0.1"))
-                .expect("worker req-res protocol name starts with '/'"),
+            Self::Primary => owned_protocol(format!("/tn-primary-{chain_id}/0.0.1")),
+            Self::Worker(id) => owned_protocol(format!("/tn-worker-{id}-{chain_id}/0.0.1")),
         }
     }
 
-    /// Kademlia wire protocol, isolated per role (and per worker).
-    pub(crate) fn kad_protocol(&self) -> StreamProtocol {
+    /// Kademlia wire protocol, isolated per role (and per worker) and namespaced
+    /// by `chain_id`.
+    pub(crate) fn kad_protocol(&self, chain_id: u64) -> NetworkResult<StreamProtocol> {
         match self {
-            Self::Primary => StreamProtocol::new("/tn-primary-kad/0.0.1"),
-            Self::Worker(id) => {
-                StreamProtocol::try_from_owned(format!("/tn-worker-{id}-kad/0.0.1"))
-                    .expect("worker kad protocol name starts with '/'")
-            }
+            Self::Primary => owned_protocol(format!("/tn-primary-kad-{chain_id}/0.0.1")),
+            Self::Worker(id) => owned_protocol(format!("/tn-worker-{id}-kad-{chain_id}/0.0.1")),
         }
     }
+}
+
+/// Bulk-transfer stream protocol, namespaced by `chain_id`.
+///
+/// Role-agnostic: primaries and workers run separate swarms, so (matching the
+/// pre-namespacing behaviour) only the chain id is folded in.
+pub(crate) fn stream_protocol(chain_id: u64) -> NetworkResult<StreamProtocol> {
+    owned_protocol(format!("/tn-stream-{chain_id}/0.0.1"))
+}
+
+/// Build an owned [`StreamProtocol`] from a runtime name, surfacing a malformed
+/// name (one that does not start with `/`) as a [`NetworkError`] instead of a panic.
+///
+/// The names this crate builds are always well formed, so the error path is not
+/// expected to fire; returning a result keeps the construction panic-free.
+fn owned_protocol(name: String) -> NetworkResult<StreamProtocol> {
+    StreamProtocol::try_from_owned(name).map_err(|e| NetworkError::ProtocolError(e.to_string()))
 }
 
 /// A channel for sending the response to an inbound RPC, bound to the peer that

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -130,6 +130,26 @@ pub(crate) fn stream_protocols(
     Ok(vec![stream_protocol(chain_id)?, network_type.sync_protocol(chain_id)?])
 }
 
+/// libp2p gossipsub protocol-id prefix, namespaced by `chain_id` so nodes on
+/// different chains can never negotiate a `/meshsub` gossip substream.
+///
+/// Gossipsub negotiates its own protocol id (libp2p's default `/meshsub/1.1.0`
+/// and `/meshsub/1.0.0`), independent of the req-res/kad/stream names above, so
+/// without folding the chain id in it is the one wire protocol two chains still
+/// share. Feeding this prefix to
+/// [`gossipsub::ConfigBuilder::protocol_id_prefix`](libp2p::gossipsub::ConfigBuilder::protocol_id_prefix)
+/// makes the advertised ids `/tn-meshsub-{chain_id}/1.1.0` and
+/// `/tn-meshsub-{chain_id}/1.0.0` (the builder appends the `/1.1.0` and `/1.0.0`
+/// version suffixes), so cross-chain peers fail multistream-select on gossip the
+/// same way they do on the other families.
+///
+/// The leading `/` is required: `protocol_id_prefix` does not prepend one, and a
+/// prefix without it is a malformed [`StreamProtocol`] that makes
+/// `ConfigBuilder::build` fail.
+pub(crate) fn gossip_protocol_id_prefix(chain_id: u64) -> String {
+    format!("/tn-meshsub-{chain_id}")
+}
+
 /// Build an owned [`StreamProtocol`] from a runtime name, surfacing a malformed
 /// name (one that does not start with `/`) as a [`NetworkError`] instead of a panic.
 ///

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -330,18 +330,22 @@ where
         )
         .await?;
 
-        // read the network config or use the default
-        let network_config = NetworkConfig::read_config(&self.tn_datadir)?;
+        // read the network config or use the default, then stamp the genesis chain id
+        // onto it so every wire protocol and gossip topic is chain-namespaced (issue
+        // #765). Genesis is the single source of truth; this one value is read by the
+        // network builder, the gossip handles, and the gossip-validation handlers.
+        let mut network_config = NetworkConfig::read_config(&self.tn_datadir)?;
+        network_config.set_chain_id(self.builder.tn_config.genesis().config.chain_id);
         self.spawn_node_networks(node_task_spawner, &network_config, epoch).await?;
         let primary_network_handle =
             self.primary_network_handle.as_ref().expect("primary network").clone();
         primary_network_handle
             .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::epoch_vote_topic())
+            .subscribe(tn_config::LibP2pConfig::epoch_vote_topic(network_config.chain_id()))
             .await?;
         primary_network_handle
             .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::consensus_output_topic())
+            .subscribe(tn_config::LibP2pConfig::consensus_output_topic(network_config.chain_id()))
             .await?;
         state_sync::spawn_epoch_record_collector(
             self.consensus_chain.clone(),
@@ -507,7 +511,8 @@ where
         });
 
         // primary network handle
-        self.primary_network_handle = Some(PrimaryNetworkHandle::new(primary_network_handle));
+        self.primary_network_handle =
+            Some(PrimaryNetworkHandle::new(primary_network_handle, network_config.chain_id()));
 
         // pass through the worker's RPC descriptor so peers can discover this
         // validator's JSON-RPC endpoint via kademlia. validators that did not
@@ -547,8 +552,12 @@ where
         });
 
         // set temporary task spawner - this is updated with each epoch
-        self.worker_network_handle =
-            Some(WorkerNetworkHandle::new(worker_network_handle, node_task_spawner.clone(), epoch));
+        self.worker_network_handle = Some(WorkerNetworkHandle::new(
+            worker_network_handle,
+            node_task_spawner.clone(),
+            epoch,
+            network_config.chain_id(),
+        ));
 
         Ok(())
     }

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -499,7 +499,7 @@ where
         network_handle
             .inner_handle()
             .subscribe_with_publishers(
-                tn_config::LibP2pConfig::primary_topic(),
+                tn_config::LibP2pConfig::primary_topic(consensus_config.chain_id()),
                 committee_keys.into_iter().collect(),
             )
             .await?;
@@ -672,14 +672,14 @@ where
         // update the authorized publishers for gossip every epoch
         network_handle
             .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::worker_txn_topic())
+            .subscribe(tn_config::LibP2pConfig::worker_txn_topic(consensus_config.chain_id()))
             .await?;
         // Get gossip from committee members about batches.
         // Useful for non-CVVs to prefetch and harmless for CVVs.
         network_handle
             .inner_handle()
             .subscribe_with_publishers(
-                tn_config::LibP2pConfig::worker_batch_topic(),
+                tn_config::LibP2pConfig::worker_batch_topic(consensus_config.chain_id()),
                 committee_keys.into_iter().collect(),
             )
             .await?;


### PR DESCRIPTION
Fixes #765.

## Problem

Two Telcoin networks are kept apart only by non-overlapping bootnodes and app-layer
validation, not by the protocol layer itself. Four protocol families carry no chain
component, so nodes on different chains can negotiate connections and share gossip meshes
until app-layer validation rejects the cross-talk:

- request-response: `/tn-primary/0.0.1`, `/tn-worker-{id}/0.0.1`
- kademlia: `/tn-primary-kad/0.0.1`, `/tn-worker-{id}-kad/0.0.1`
- stream: `/tn-stream/0.0.1`
- gossipsub topics: `tn-primary`, `tn-consensus-output`, `tn-epoch-vote`, `tn-worker`, `tn-txn`

Gossipsub is the widest bleed vector: topics are not baked into the behaviour, so all gossip
rides one global `/meshsub/1.1.0` mesh and isolation is purely the topic-string hash. Two
chains using these five names would form a shared mesh and gossip each other's messages.

## Fix

A coordinated hard cutover: fold the genesis chain id into all four families so the wire
layer itself keeps chains apart. Names become `/tn-primary-{chain_id}/0.0.1`,
`/tn-primary-kad-{chain_id}/0.0.1`, `/tn-stream-{chain_id}/0.0.1`, `tn-primary-{chain_id}`,
and so on.

Genesis is the single source of truth. The chain id (`genesis.config.chain_id`) is stamped
onto the network config once at node startup and read back everywhere a protocol or topic is
built:

- `LibP2pConfig` gains a `chain_id` field. It is `#[serde(skip)]`: genesis-derived, not an
  operator tunable, never written to (or read from) the config file, so it cannot desync from
  genesis. `NetworkConfig::set_chain_id` stamps it (from `self.builder.tn_config.genesis()`)
  right after `NetworkConfig::read_config` in `EpochManager::run`. That same config object is
  threaded into both the network swarms and the per-epoch `ConsensusConfig`, so one assignment
  propagates to every reader.
- The five `LibP2pConfig::*_topic` fns take a `chain_id: u64` and format `tn-...-{chain_id}`.
- `NetworkType::req_res_protocol` / `kad_protocol` take a `chain_id` and a new
  `types::stream_protocol(chain_id)` builds the (role-agnostic) stream name. All three now use
  `StreamProtocol::try_from_owned` and return `NetworkResult`, replacing the previous
  `StreamProtocol::new` / `.expect` (a const-fn over a `&'static str` cannot embed a runtime
  id, and the result keeps construction panic-free).
- The stream subsystem carried a single `const TN_STREAM_PROTOCOL`. That const is deleted and
  an owned `StreamProtocol` is threaded `ConsensusNetwork::new` → `TNBehavior::new` →
  `StreamBehavior` → `StreamHandler` → `TNStreamProtocol`.
- The two config-less gossip publish handles (`PrimaryNetworkHandle`, `WorkerNetworkHandle`)
  gain a `chain_id` field, stamped at construction; the gossip-validation handlers read it via
  `ConsensusConfig::chain_id()`. Publish and validate therefore read the same value.

`WorkerNetworkHandle::publish_txn` previously published to a hardcoded `"tn-txn"` literal
(bypassing `worker_txn_topic()`); it now uses the namespaced fn, so the published and
subscribed txn topics match.

### Why a field on `LibP2pConfig` rather than a new `ConsensusNetwork::new` parameter

The issue suggested a `chain_id` field so wire protocols and topics read one source; this PR
follows that. Reading the stamped value everywhere means a missed stamp degrades to a
self-consistent `0` namespace (no chain isolation) rather than a publish/validate split that
would break a node talking to itself. It also leaves `ConsensusNetwork::new`'s signature (and
its test call sites) untouched.

## Deployment (breaking wire change)

This changes multistream-select negotiation, so old and new nodes will not peer; every node
must upgrade together (a coordinated cutover, tied to a release or epoch boundary). There is
no version-negotiation fallback in the codebase, and this PR adds none. A dual-advertise
transition release (advertise both old and namespaced protocols, drop the old later) was
considered and is the alternative if a rolling upgrade is required; it is meaningfully more
scope and was not pursued for this hardening.

## Tests

- `tn-config`: new `gossip_topics_are_chain_namespaced` (all five topics + the
  different-id-different-topic property), `set_chain_id_is_read_back`, and
  `chain_id_is_never_persisted`. The last asserts the field is never serialized AND that a
  config file containing an explicit `chain_id: 999` is ignored on read (reads back `0`), so an
  operator cannot override genesis from disk.
- `tn-network-libp2p`: the `test_network_type_protocol_names` lock test now asserts the
  chain-namespaced req-res/kad/stream strings (still a peer-compatibility contract). The
  existing `test_primary_worker_protocol_isolation` still passes (role isolation holds under
  namespacing).
- `tn-worker`: new `test_batch_gossip_topic_is_chain_namespaced` stamps a non-zero chain id
  (2017) onto the fixture and asserts the handler accepts the `2017` topic but rejects a
  `chain-0`-namespaced message with `InvalidTopic`. This makes the gossip-enforcement path
  load-bearing: it fails if the validator ever hardcoded the namespace instead of reading it
  from config. Existing worker/primary gossip-enforcement tests updated to the new signatures.
- The 0-defaulting `From<NetworkHandle> for PrimaryNetworkHandle` (only ever used by a test) is
  now `#[cfg(test)]`-gated, so the only way to build a production handle is `new` with an
  explicit genesis chain id.

Verification on `main` @ `27de5398`:
- `cargo test --workspace --no-run`: compiles clean.
- `cargo test` for the affected crates: `tn-config` network tests (6), `tn-network-libp2p`
  protocol-lock + 14 stream + isolation tests, `tn-primary` and `tn-worker` gossip-enforcement
  tests all pass.
- `cargo +nightly fmt --check`: clean.
- CI clippy (`cargo +nightly clippy --locked --all --all-features -- -D warnings`): clean.

## Scope

Confirmed on `main` at `27de5398`. Spans `crates/config`, `crates/network-libp2p`,
`crates/consensus/{primary,worker}`, and `crates/node`. The three `tn_*` topic consts in
`network-libp2p/src/types.rs` (`WORKER_BATCH_TOPIC`, `PRIMARY_CERT_TOPIC`,
`CONSENSUS_HEADER_TOPIC`) are unused dead code and were left untouched.