### PR TITLE
Add server side calls to retrieve consensus bytes for an entire ConsensusOutput.

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -2,7 +2,7 @@
 
 use super::CertManagerError;
 use tn_network_libp2p::Penalty;
-use tn_storage::StoreError;
+use tn_storage::{consensus::ConsensusChainError, StoreError};
 use tn_types::{
     error::{CertificateError, HeaderError},
     BcsError, BlockHash, BlsPublicKey, ConsensusHeaderDigest, Epoch, EpochDigest,
@@ -68,6 +68,9 @@ pub(crate) enum PrimaryNetworkError {
     /// A requested pack file stream is not available.
     #[error("Pack file is not available to stream for epoch {0}")]
     StreamUnavailable(Epoch),
+    /// Pass through from the consesus chain.
+    #[error("ConsensusChainError {0}")]
+    ConsensusChainError(ConsensusChainError),
 }
 
 impl From<&PrimaryNetworkError> for Option<Penalty> {
@@ -132,6 +135,7 @@ impl From<&PrimaryNetworkError> for Option<Penalty> {
             | PrimaryNetworkError::Storage(_)
             | PrimaryNetworkError::Timeout(_)
             | PrimaryNetworkError::StreamUnavailable(_)
+            | PrimaryNetworkError::ConsensusChainError(_)
             | PrimaryNetworkError::Internal(_) => None,
         }
     }

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -41,6 +41,9 @@ pub(crate) enum PrimaryNetworkError {
     /// Unknown consensus header certificate.
     #[error("Unknown consensus header certificate for: {0}")]
     UnknownConsensusHeaderCert(ConsensusHeaderDigest),
+    /// Unknown consensus output (raw bytes) for the requested number.
+    #[error("Unknown consensus output: {0}")]
+    UnknownConsensusOutput(u64),
     /// Peer that is not committee published invalid gosip.
     /// Temparily disabled, will be back soon.
     #[error("Peer {0} is not in the committee!")]
@@ -112,9 +115,10 @@ impl From<&PrimaryNetworkError> for Option<Penalty> {
                 | CertManagerError::ChannelClosed
                 | CertManagerError::TNSend(_) => None,
             },
-            // Benign "miss": observers legitimately request not-yet-served headers.
+            // Benign "miss": observers legitimately request not-yet-served headers/outputs.
             // No penalty so honest sync flows are not banned during catch-up.
-            PrimaryNetworkError::UnknownConsensusHeaderDigest(_) => None,
+            PrimaryNetworkError::UnknownConsensusHeaderDigest(_)
+            | PrimaryNetworkError::UnknownConsensusOutput(_) => None,
             PrimaryNetworkError::InvalidRequest(_)
             | PrimaryNetworkError::UnknownStreamRequest(_)
             | PrimaryNetworkError::UnknownConsensusHeaderCert(_) => Some(Penalty::Mild),

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -895,7 +895,8 @@ where
         match self.consensus_chain.consensus_output_bytes_by_number(number).await {
             Ok(Some(bytes)) => Ok(bytes),
             // Missing locally, or the requested number is outside the pack's range.
-            _ => Err(PrimaryNetworkError::UnknownConsensusOutput(number)),
+            Ok(None) => Err(PrimaryNetworkError::UnknownConsensusOutput(number)),
+            Err(e) => Err(PrimaryNetworkError::ConsensusChainError(e)),
         }
     }
 

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::{CertManagerError, PrimaryNetworkError, PrimaryNetworkResult},
-    network::{message::PrimaryGossip, PendingEpochStream},
+    network::{message::PrimaryGossip, PendingStreamRequest, StreamRequestKind},
     state_sync::{CertificateCollector, StateSynchronizer},
     ConsensusBusApp, NodeMode,
 };
@@ -871,10 +871,12 @@ where
     ///
     /// Returns the full pack-file encoded output for `number` so a peer can reconstruct the
     /// [`tn_types::ConsensusOutput`] (batches + consensus header) without a separate batch fetch.
-    pub(super) async fn retrieve_consensus_output(
+    /// The bytes are streamed to the requesting peer (see `send_consensus_output_over_stream`),
+    /// because a single output can exceed the request/response message-size limit.
+    pub(super) async fn consensus_output_bytes(
         &self,
         number: u64,
-    ) -> PrimaryNetworkResult<PrimaryResponse> {
+    ) -> PrimaryNetworkResult<Vec<u8>> {
         let mut my_number = self.consensus_chain.latest_consensus_number();
         // If we are behind then wait up to two seconds to catch up.
         let mut count = 0;
@@ -891,7 +893,7 @@ where
             }
         }
         match self.consensus_chain.consensus_output_bytes_by_number(number).await {
-            Ok(Some(bytes)) => Ok(PrimaryResponse::ConsensusOutput(Arc::new(bytes))),
+            Ok(Some(bytes)) => Ok(bytes),
             // Missing locally, or the requested number is outside the pack's range.
             _ => Err(PrimaryNetworkError::UnknownConsensusOutput(number)),
         }
@@ -1008,11 +1010,53 @@ where
         Ok(())
     }
 
-    /// Process request to open stream for an epoch pack.
+    /// Send a single consensus output's raw bytes over a stream.
+    ///
+    /// If the output is unavailable locally, the stream is simply closed with no bytes; the
+    /// requesting peer observes EOF and retries another peer.
+    pub(super) async fn send_consensus_output_over_stream<S>(
+        &self,
+        mut stream: S,
+        number: u64,
+        buffer_timeout: Duration,
+        peer: BlsPublicKey,
+    ) -> PrimaryNetworkResult<()>
+    where
+        S: AsyncWrite + Unpin + Send,
+    {
+        match self.consensus_output_bytes(number).await {
+            Ok(bytes) => {
+                // write in chunks so a single timeout bounds a slow reader
+                for chunk in bytes.chunks(16 * 1024) {
+                    timeout(buffer_timeout, stream.write_all(chunk)).await??;
+                }
+            }
+            Err(e) => {
+                // Benign miss (e.g. not-yet-served during catch-up): close with no bytes so the
+                // peer retries elsewhere. Closing below also handles the unavailable case.
+                debug!(
+                    target: "primary::network",
+                    %peer,
+                    ?number,
+                    ?e,
+                    "consensus output unavailable for stream; closing with no bytes"
+                );
+            }
+        }
+
+        // attempt to close the stream gracefully
+        if let Err(e) = stream.close().await {
+            tracing::warn!(target: "primary::network", %peer, ?number, ?e, "stream close failed");
+        }
+
+        Ok(())
+    }
+
+    /// Process request to open a stream for an epoch pack or a single consensus output.
     pub(super) async fn process_request_epoch_stream(
         &self,
         peer: BlsPublicKey,
-        pending_request: Option<PendingEpochStream>,
+        pending_request: Option<PendingStreamRequest>,
         stream: Stream,
         request_digest: B256,
         consensus_chain: &ConsensusChain,
@@ -1029,26 +1073,50 @@ where
             return Err(PrimaryNetworkError::UnknownStreamRequest(request_digest));
         };
 
-        // process request to send batches through stream
-        debug!(
-            target: "primary::network",
-            %peer,
-            ?request_digest,
-            epoch = request.epoch,
-            "processing inbound epoch stream"
-        );
+        match request.kind() {
+            StreamRequestKind::EpochPack(epoch) => {
+                debug!(
+                    target: "primary::network",
+                    %peer,
+                    ?request_digest,
+                    epoch,
+                    "processing inbound epoch stream"
+                );
 
-        // set timeout to prevent slow-read attack
-        Self::send_epoch_over_stream(
-            stream,
-            consensus_chain,
-            request.epoch,
-            SEND_STREAM_BUFFER_TIMEOUT,
-            peer,
-        )
-        .await
-        .inspect_err(
-            |e| warn!(target: "primary::network", %peer, ?e, "failed to send epoch over stream"),
-        )
+                // set timeout to prevent slow-read attack
+                Self::send_epoch_over_stream(
+                    stream,
+                    consensus_chain,
+                    epoch,
+                    SEND_STREAM_BUFFER_TIMEOUT,
+                    peer,
+                )
+                .await
+                .inspect_err(|e| {
+                    warn!(target: "primary::network", %peer, ?e, "failed to send epoch over stream")
+                })
+            }
+            StreamRequestKind::ConsensusOutput(number) => {
+                debug!(
+                    target: "primary::network",
+                    %peer,
+                    ?request_digest,
+                    number,
+                    "processing inbound consensus output stream"
+                );
+
+                // set timeout to prevent slow-read attack
+                self.send_consensus_output_over_stream(
+                    stream,
+                    number,
+                    SEND_STREAM_BUFFER_TIMEOUT,
+                    peer,
+                )
+                .await
+                .inspect_err(|e| {
+                    warn!(target: "primary::network", %peer, ?e, "failed to send consensus output over stream")
+                })
+            }
+        }
     }
 }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -867,6 +867,36 @@ where
         Ok(PrimaryResponse::ConsensusHeader(Arc::new(header)))
     }
 
+    /// Retrieve the raw (serialized) consensus output bytes from local storage.
+    ///
+    /// Returns the full pack-file encoded output for `number` so a peer can reconstruct the
+    /// [`tn_types::ConsensusOutput`] (batches + consensus header) without a separate batch fetch.
+    pub(super) async fn retrieve_consensus_output(
+        &self,
+        number: u64,
+    ) -> PrimaryNetworkResult<PrimaryResponse> {
+        let mut my_number = self.consensus_chain.latest_consensus_number();
+        // If we are behind then wait up to two seconds to catch up.
+        let mut count = 0;
+        if number.saturating_sub(my_number) < 4 {
+            // Only wait if we are close.
+            while my_number < number {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                my_number = self.consensus_chain.latest_consensus_number();
+                if count >= 20 {
+                    // Don't wait more than 2 seconds for this to show up.
+                    return Err(PrimaryNetworkError::UnknownConsensusOutput(number));
+                }
+                count += 1;
+            }
+        }
+        match self.consensus_chain.consensus_output_bytes_by_number(number).await {
+            Ok(Some(bytes)) => Ok(PrimaryResponse::ConsensusOutput(Arc::new(bytes))),
+            // Missing locally, or the requested number is outside the pack's range.
+            _ => Err(PrimaryNetworkError::UnknownConsensusOutput(number)),
+        }
+    }
+
     /// Retrieve an epoch record from local storage.
     pub(super) async fn retrieve_epoch_record(
         &self,

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -117,6 +117,15 @@ pub enum PrimaryRequest {
         /// Block hash requesting if not None.
         hash: ConsensusHeaderDigest,
     },
+    /// Request the raw (serialized) consensus output bytes for a consensus chain number.
+    ///
+    /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output
+    /// (batches + consensus header) rather than just the header, so a peer can reconstruct
+    /// the [`tn_types::ConsensusOutput`] without separately fetching its batches.
+    ConsensusOutput {
+        /// The consensus chain number being requested.
+        number: u64,
+    },
     /// Exchange peer information.
     ///
     /// This "request" is sent to peers when this node disconnects
@@ -236,6 +245,8 @@ pub enum PrimaryResponse {
     MissingParents(Vec<HeaderDigest>),
     /// The requested consensus header.
     ConsensusHeader(Arc<ConsensusHeader>),
+    /// The requested raw (serialized) consensus output bytes.
+    ConsensusOutput(Arc<Vec<u8>>),
     /// The requested epoch record and certificate.
     EpochRecord { record: EpochRecord, certificate: EpochCertificate },
     /// Exchange peer information.
@@ -287,6 +298,7 @@ impl PrimaryResponse {
             | PrimaryNetworkError::InvalidTopic
             | PrimaryNetworkError::UnknownConsensusHeaderDigest(_)
             | PrimaryNetworkError::UnknownConsensusHeaderCert(_)
+            | PrimaryNetworkError::UnknownConsensusOutput(_)
             | PrimaryNetworkError::Timeout(_)
             | PrimaryNetworkError::UnknownStreamRequest(_)
             | PrimaryNetworkError::StreamUnavailable(_)

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -303,6 +303,7 @@ impl PrimaryResponse {
             | PrimaryNetworkError::Timeout(_)
             | PrimaryNetworkError::UnknownStreamRequest(_)
             | PrimaryNetworkError::StreamUnavailable(_)
+            | PrimaryNetworkError::ConsensusChainError(_)
             | PrimaryNetworkError::InvalidEpochRequest => {
                 Self::Error(PrimaryRPCError(error.to_string()))
             }

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -117,15 +117,6 @@ pub enum PrimaryRequest {
         /// Block hash requesting if not None.
         hash: ConsensusHeaderDigest,
     },
-    /// Request the raw (serialized) consensus output bytes for a consensus chain number.
-    ///
-    /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output
-    /// (batches + consensus header) rather than just the header, so a peer can reconstruct
-    /// the [`tn_types::ConsensusOutput`] without separately fetching its batches.
-    ConsensusOutput {
-        /// The consensus chain number being requested.
-        number: u64,
-    },
     /// Exchange peer information.
     ///
     /// This "request" is sent to peers when this node disconnects
@@ -147,6 +138,18 @@ pub enum PrimaryRequest {
     StreamEpoch {
         /// The epoch we are requesting consensus data for.
         epoch: Epoch,
+    },
+    /// Request to stream the raw (serialized) consensus output bytes for a consensus chain number.
+    ///
+    /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output
+    /// (batches + consensus header) rather than just the header, so a peer can reconstruct
+    /// the [`tn_types::ConsensusOutput`] without separately fetching its batches.
+    ///
+    /// The output is streamed (rather than returned via request/response) because a single
+    /// output can exceed the request/response codec's message size limit.
+    StreamConsensusOutput {
+        /// The consensus chain number being requested.
+        number: u64,
     },
 }
 
@@ -245,8 +248,6 @@ pub enum PrimaryResponse {
     MissingParents(Vec<HeaderDigest>),
     /// The requested consensus header.
     ConsensusHeader(Arc<ConsensusHeader>),
-    /// The requested raw (serialized) consensus output bytes.
-    ConsensusOutput(Arc<Vec<u8>>),
     /// The requested epoch record and certificate.
     EpochRecord { record: EpochRecord, certificate: EpochCertificate },
     /// Exchange peer information.
@@ -260,12 +261,12 @@ pub enum PrimaryResponse {
     /// This is an application-layer error response.
     /// This error is likely to succeed in the future and can be retried.
     RecoverableError(PrimaryRPCError),
-    /// Response to stream-based epoch request.
+    /// Response to a stream-based request (epoch pack or single consensus output).
     ///
     /// If `ack` is true, the requestor should open a stream with the
-    /// request digest in the header. The responder will send the epoch pack
-    /// over that stream.
-    RequestEpochStream {
+    /// request digest in the header. The responder will send the requested
+    /// data over that stream.
+    StreamRequestAck {
         /// Whether the request is accepted.
         ack: bool,
     },

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -207,6 +207,9 @@ impl PrimaryNetworkHandle {
             PrimaryResponse::ConsensusHeader(_consensus_header) => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is consensus header!".to_string(),
             )),
+            PrimaryResponse::ConsensusOutput(_bytes) => Err(NetworkError::RPCError(
+                "Got wrong response, not a vote is consensus output!".to_string(),
+            )),
             PrimaryResponse::EpochRecord { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is epoch record!".to_string(),
             )),
@@ -608,6 +611,9 @@ where
                 PrimaryRequest::ConsensusHeader { number, hash } => {
                     self.process_consensus_output_request(peer, number, hash, channel, cancel)
                 }
+                PrimaryRequest::ConsensusOutput { number } => {
+                    self.process_consensus_output_bytes_request(peer, number, channel, cancel)
+                }
                 PrimaryRequest::PeerExchange { .. } => {
                     warn!(target: "primary::network", "primary application received unexpected peer exchange message");
                 }
@@ -730,6 +736,48 @@ where
                             );
                         }
                         let response = header.into_response();
+                        let _ = network_handle.handle.send_response(response, channel).await;
+                    }
+                // cancel notification from network layer
+                _ = cancel => (),
+            }
+            Ok(())
+        });
+    }
+
+    /// Attempt to retrieve raw consensus output bytes from the database.
+    fn process_consensus_output_bytes_request(
+        &self,
+        peer: BlsPublicKey,
+        number: u64,
+        channel: ResponseChannel<PrimaryResponse>,
+        cancel: oneshot::Receiver<()>,
+    ) {
+        // clone for spawned tasks
+        let request_handler = self.request_handler.clone();
+        let network_handle = self.network_handle.clone();
+        let task_name = format!("ConsensusOutputBytesReq-{peer}");
+        self.task_spawner.spawn_task(task_name, async move {
+            tokio::select! {
+                output =
+                    request_handler.retrieve_consensus_output(number) => {
+                        // Route through the central PrimaryNetworkError → Penalty mapping
+                        // so every handler in this file applies penalties consistently.
+                        // The only reachable variant from this path is
+                        // UnknownConsensusOutput, which the central table maps to None —
+                        // peers legitimately request not-yet-served outputs during catch-up.
+                        if let Err(ref e) = output {
+                            if let Some(penalty) = e.into() {
+                                network_handle.report_penalty(peer, penalty).await;
+                            }
+                            let my_number = request_handler.consensus_chain().latest_consensus_number();
+                            tracing::debug!(
+                                target: "primary::network",
+                                ?e, ?my_number, ?number, ?peer,
+                                "consensus output request could not be served"
+                            );
+                        }
+                        let response = output.into_response();
                         let _ = network_handle.handle.send_response(response, channel).await;
                     }
                 // cancel notification from network layer

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -10,8 +10,7 @@ use std::{
 };
 
 use crate::{
-    error::PrimaryNetworkResult, proposer::OurDigestMessage, state_sync::StateSynchronizer,
-    ConsensusBus, ConsensusBusApp,
+    proposer::OurDigestMessage, state_sync::StateSynchronizer, ConsensusBus, ConsensusBusApp,
 };
 use futures::{AsyncReadExt as _, AsyncWriteExt as _};
 use handler::RequestHandler;
@@ -71,12 +70,49 @@ pub const MAX_CONCURRENT_EPOCH_STREAMS: usize = 5;
 /// Prevents a single malicious peer from filling all global slots.
 pub const MAX_PENDING_REQUESTS_PER_PEER: usize = 2;
 
-/// Tracks a pending epoch pack stream request awaiting stream establishment.
+/// Maximum bytes the client will read from a single consensus-output stream.
+///
+/// Generous upper bound: comfortably above any realistic single output, but caps an
+/// unbounded or malicious stream.
+const MAX_CONSENSUS_OUTPUT_STREAM_BYTES: usize = 16 * 1024 * 1024;
+
+/// Per-read timeout while draining a consensus-output stream (slow-peer guard).
+const CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What a [`PendingStreamRequest`] should stream once the peer opens the stream.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamRequestKind {
+    /// Stream the full pack file for an epoch.
+    EpochPack(Epoch),
+    /// Stream the raw bytes for a single consensus output (by consensus chain number).
+    ConsensusOutput(u64),
+}
+
+/// Correlation digest for an epoch-pack stream request.
+fn epoch_stream_digest(epoch: Epoch) -> B256 {
+    let mut hasher = tn_types::DefaultHashFunction::new();
+    hasher.update(&epoch.to_le_bytes());
+    B256::from_slice(hasher.finalize().as_bytes())
+}
+
+/// Correlation digest for a single consensus-output stream request.
+///
+/// Domain-separated from [`epoch_stream_digest`] so epoch `N` and output `N` never collide in
+/// the pending-request map for a given peer.
+fn consensus_output_stream_digest(number: u64) -> B256 {
+    let mut hasher = tn_types::DefaultHashFunction::new();
+    hasher.update(b"consensus-output");
+    hasher.update(&number.to_le_bytes());
+    B256::from_slice(hasher.finalize().as_bytes())
+}
+
+/// Tracks a pending stream request (epoch pack or single consensus output) awaiting stream
+/// establishment.
 // pub for IT
 #[derive(Debug)]
-pub struct PendingEpochStream {
-    /// The epoch which produced these batches.
-    epoch: Epoch,
+pub struct PendingStreamRequest {
+    /// What to stream once the peer opens the correlated stream.
+    kind: StreamRequestKind,
     /// When this request was created (for timeout cleanup).
     created_at: Instant,
     /// Semaphore permit held for the lifetime of this request (pending + active).
@@ -87,22 +123,27 @@ pub struct PendingEpochStream {
 /// Key for pending requests: (peer_bls, request_digest)
 type PendingEpochRequestKey = (BlsPublicKey, B256);
 
-impl PendingEpochStream {
-    /// Create a new pending batch stream.
-    pub fn new(epoch: Epoch, permit: OwnedSemaphorePermit) -> Self {
-        Self { epoch, created_at: Instant::now(), _permit: permit }
+impl PendingStreamRequest {
+    /// Create a new pending stream request.
+    pub fn new(kind: StreamRequestKind, permit: OwnedSemaphorePermit) -> Self {
+        Self { kind, created_at: Instant::now(), _permit: permit }
+    }
+
+    /// What this pending request will stream.
+    pub fn kind(&self) -> StreamRequestKind {
+        self.kind
     }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-impl PendingEpochStream {
-    /// Create a pending batch stream with a custom `created_at` for testing stale cleanup.
+impl PendingStreamRequest {
+    /// Create a pending stream request with a custom `created_at` for testing stale cleanup.
     pub fn new_with_created_at(
-        epoch: Epoch,
+        kind: StreamRequestKind,
         permit: OwnedSemaphorePermit,
         created_at: Instant,
     ) -> Self {
-        Self { epoch, created_at, _permit: permit }
+        Self { kind, created_at, _permit: permit }
     }
 }
 
@@ -207,17 +248,14 @@ impl PrimaryNetworkHandle {
             PrimaryResponse::ConsensusHeader(_consensus_header) => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is consensus header!".to_string(),
             )),
-            PrimaryResponse::ConsensusOutput(_bytes) => Err(NetworkError::RPCError(
-                "Got wrong response, not a vote is consensus output!".to_string(),
-            )),
             PrimaryResponse::EpochRecord { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is epoch record!".to_string(),
             )),
             PrimaryResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is peer exchange!".to_string(),
             )),
-            PrimaryResponse::RequestEpochStream { .. } => Err(NetworkError::RPCError(
-                "Got wrong response, not a vote is epoch stream!".to_string(),
+            PrimaryResponse::StreamRequestAck { .. } => Err(NetworkError::RPCError(
+                "Got wrong response, not a vote is stream ack!".to_string(),
             )),
         }
     }
@@ -310,56 +348,137 @@ impl PrimaryNetworkHandle {
 
     /// Request the raw (serialized) consensus output bytes for `number` from a specific peer.
     ///
-    /// Returns the pack-file encoded output (batches + consensus header). The caller is
-    /// responsible for deserializing it (with the epoch's committee) and verifying the result;
-    /// the bytes cannot be cheaply validated at the network layer.
+    /// Returns the pack-file encoded output (batches + consensus header). A single output can
+    /// exceed the request/response message-size limit, so the bytes are streamed: this negotiates
+    /// the stream via RPC, then opens a stream and reads the bytes. The caller is responsible for
+    /// deserializing the result (with the epoch's committee) and verifying it; the bytes cannot be
+    /// cheaply validated at the network layer.
     pub async fn request_consensus_output_from_peer(
         &self,
         peer: BlsPublicKey,
         number: u64,
     ) -> NetworkResult<Vec<u8>> {
-        let request = PrimaryRequest::ConsensusOutput { number };
-        let res = self.handle.send_request(request, peer).await?;
-        let res = res.await??.result;
-        match res {
-            PrimaryResponse::ConsensusOutput(bytes) => Ok(Arc::unwrap_or_clone(bytes)),
-            PrimaryResponse::Error(PrimaryRPCError(s)) => Err(NetworkError::RPCError(s)),
-            _ => Err(NetworkError::RPCError(
-                "Got wrong response, not a consensus output!".to_string(),
-            )),
+        let request = PrimaryRequest::StreamConsensusOutput { number };
+        let request_digest = consensus_output_stream_digest(number);
+        let resp = self.handle.send_request(request, peer).await?.await??;
+        let PrimaryResponse::StreamRequestAck { ack } = resp.result else {
+            return Err(NetworkError::RPCError(
+                "Got wrong response, not a stream ack!".to_string(),
+            ));
+        };
+        if !ack {
+            return Err(NetworkError::RPCError(
+                "peer declined consensus output stream request".to_string(),
+            ));
         }
+        let bytes = self.stream_consensus_output(peer, request_digest).await?;
+        if bytes.is_empty() {
+            return Err(NetworkError::RPCError(
+                "peer streamed an empty consensus output".to_string(),
+            ));
+        }
+        Ok(bytes)
     }
 
     /// Request the raw (serialized) consensus output bytes for `number` from a random peer,
     /// trying up to three times from three different peers.
     ///
-    /// Returns the pack-file encoded output (batches + consensus header). The caller is
-    /// responsible for deserializing it (with the epoch's committee) and verifying the result;
-    /// the bytes cannot be cheaply validated at the network layer.
+    /// Returns the pack-file encoded output (batches + consensus header). A single output can
+    /// exceed the request/response message-size limit, so the bytes are streamed (see
+    /// [`Self::request_consensus_output_from_peer`]). The caller is responsible for deserializing
+    /// the result (with the epoch's committee) and verifying it; the bytes cannot be cheaply
+    /// validated at the network layer.
     pub async fn request_consensus_output(&self, number: u64) -> NetworkResult<Vec<u8>> {
         const TIMEOUT: Duration = Duration::from_secs(10);
-        let request = PrimaryRequest::ConsensusOutput { number };
+        let request = PrimaryRequest::StreamConsensusOutput { number };
+        let request_digest = consensus_output_stream_digest(number);
         // Try up to three times (from three peers) to get the output.
         // This could be a lot more complicated but this KISS method should work fine.
         for _ in 0..3 {
-            let res = self.handle.send_request_any(request.clone()).await?;
-            let res = match tokio::time::timeout(TIMEOUT, res).await {
-                Ok(r) => r,
-                Err(_) => {
-                    tracing::warn!(target: "primary::network", ?number, "request_consensus_output timed out waiting for peer response");
+            let dispatch = match self.handle.send_request_any(request.clone()).await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    warn!(target: "primary::network", ?e, ?number, "send_request_any failed; retrying");
                     continue;
                 }
             };
-            let res = res?;
-            if let Ok(NetworkResponseMessage {
-                peer: _,
-                result: PrimaryResponse::ConsensusOutput(bytes),
-            }) = res
-            {
-                return Ok(Arc::unwrap_or_clone(bytes));
+            let resp = match tokio::time::timeout(TIMEOUT, dispatch).await {
+                Ok(Ok(Ok(r))) => r,
+                Ok(Ok(Err(e))) => {
+                    warn!(target: "primary::network", ?e, ?number, "peer responded with error; retrying");
+                    continue;
+                }
+                Ok(Err(e)) => {
+                    warn!(target: "primary::network", ?e, ?number, "peer dropped response channel; retrying");
+                    continue;
+                }
+                Err(_) => {
+                    warn!(target: "primary::network", ?number, "request_consensus_output timed out waiting for peer response");
+                    continue;
+                }
+            };
+            let PrimaryResponse::StreamRequestAck { ack } = resp.result else {
+                continue;
+            };
+            if !ack {
+                continue;
+            }
+            match self.stream_consensus_output(resp.peer, request_digest).await {
+                Ok(bytes) if !bytes.is_empty() => return Ok(bytes),
+                Ok(_) => {
+                    warn!(target: "primary::network", ?number, peer = %resp.peer, "peer streamed an empty consensus output; retrying");
+                }
+                Err(e) => {
+                    warn!(target: "primary::network", ?e, ?number, peer = %resp.peer, "failed to stream consensus output; retrying");
+                }
             }
         }
         Err(NetworkError::RPCError("Could not get the consensus output!".to_string()))
+    }
+
+    /// Open a stream to `peer`, write the correlation digest, and read the streamed consensus
+    /// output bytes to EOF.
+    async fn stream_consensus_output(
+        &self,
+        peer: BlsPublicKey,
+        request_digest: B256,
+    ) -> NetworkResult<Vec<u8>> {
+        let mut stream = self.handle.open_stream(peer).await??;
+        stream
+            .write_all(request_digest.as_slice())
+            .await
+            .map_err(|e| NetworkError::RPCError(format!("failed to write request digest: {e}")))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| NetworkError::RPCError(format!("failed to flush request digest: {e}")))?;
+
+        let mut out = Vec::new();
+        let mut buf = vec![0u8; 16 * 1024];
+        loop {
+            let n = match tokio::time::timeout(
+                CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT,
+                stream.read(&mut buf[..]),
+            )
+            .await
+            {
+                Ok(Ok(n)) => n,
+                Ok(Err(e)) => {
+                    return Err(NetworkError::RPCError(format!("stream read failed: {e}")))
+                }
+                Err(_) => return Err(NetworkError::RPCError("stream read timed out".to_string())),
+            };
+            if n == 0 {
+                break;
+            }
+            if out.len() + n > MAX_CONSENSUS_OUTPUT_STREAM_BYTES {
+                return Err(NetworkError::RPCError(
+                    "consensus output stream exceeded maximum size".to_string(),
+                ));
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        Ok(out)
     }
 
     /// Request consensus header from a random peer up to three times from three different peers.
@@ -397,7 +516,7 @@ impl PrimaryNetworkHandle {
     /// Attempt to get an epoch pack file from any peer via stream.
     ///
     /// This method:
-    /// 1. Sends a `RequestEpochStream` request to negotiate
+    /// 1. Sends a `StreamEpoch` request to negotiate
     /// 2. If accepted, opens a stream with the request digest for correlation
     /// 3. Reads and validates batches from the stream in real-time
     pub async fn request_epoch_pack(
@@ -412,9 +531,7 @@ impl PrimaryNetworkHandle {
         // This could be a lot more complicated but this KISS method should work fine.
         // send request to negotiate stream
         let request = PrimaryRequest::StreamEpoch { epoch };
-        let mut hasher = tn_types::DefaultHashFunction::new();
-        hasher.update(&epoch.to_le_bytes());
-        let request_digest = B256::from_slice(hasher.finalize().as_bytes());
+        let request_digest = epoch_stream_digest(epoch);
 
         for _ in 0..3 {
             // send request and await response from peer
@@ -440,7 +557,7 @@ impl PrimaryNetworkHandle {
             };
             if let NetworkResponseMessage {
                 peer,
-                result: PrimaryResponse::RequestEpochStream { ack },
+                result: PrimaryResponse::StreamRequestAck { ack },
             } = resp
             {
                 // continue if denied to try next peer
@@ -562,13 +679,15 @@ pub struct PrimaryNetwork<DB, Events> {
     task_spawner: TaskSpawner,
     /// Hold a reference to the consensus chain.
     consensus_chain: ConsensusChain,
-    /// Semaphore bounding total concurrent epoch pack stream operations (pending + active).
+    /// Semaphore bounding total concurrent stream operations (pending + active), shared by epoch
+    /// pack and single consensus-output streams.
     epoch_stream_semaphore: Arc<Semaphore>,
-    /// Pending epoch pack requests awaiting stream from requestor.
+    /// Pending stream requests (epoch pack or single consensus output) awaiting stream from
+    /// requestor.
     ///
     /// Wrapped in `Arc<Mutex>` so spawned stream tasks can look up the matching
     /// request after reading the correlation digest from the stream.
-    pending_epoch_requests: Arc<Mutex<HashMap<PendingEpochRequestKey, PendingEpochStream>>>,
+    pending_epoch_requests: Arc<Mutex<HashMap<PendingEpochRequestKey, PendingStreamRequest>>>,
 }
 
 impl<DB, Events> PrimaryNetwork<DB, Events>
@@ -665,9 +784,6 @@ where
                 PrimaryRequest::ConsensusHeader { number, hash } => {
                     self.process_consensus_output_request(peer, number, hash, channel, cancel)
                 }
-                PrimaryRequest::ConsensusOutput { number } => {
-                    self.process_consensus_output_bytes_request(peer, number, channel, cancel)
-                }
                 PrimaryRequest::PeerExchange { .. } => {
                     warn!(target: "primary::network", "primary application received unexpected peer exchange message");
                 }
@@ -676,6 +792,9 @@ where
                 }
                 PrimaryRequest::StreamEpoch { epoch } => {
                     self.process_epoch_stream(peer, epoch, channel, cancel)
+                }
+                PrimaryRequest::StreamConsensusOutput { number } => {
+                    self.process_consensus_output_stream(peer, number, channel, cancel)
                 }
             },
             NetworkEvent::Gossip(msg, propagation_source) => {
@@ -799,48 +918,6 @@ where
         });
     }
 
-    /// Attempt to retrieve raw consensus output bytes from the database.
-    fn process_consensus_output_bytes_request(
-        &self,
-        peer: BlsPublicKey,
-        number: u64,
-        channel: ResponseChannel<PrimaryResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        // clone for spawned tasks
-        let request_handler = self.request_handler.clone();
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("ConsensusOutputBytesReq-{peer}");
-        self.task_spawner.spawn_task(task_name, async move {
-            tokio::select! {
-                output =
-                    request_handler.retrieve_consensus_output(number) => {
-                        // Route through the central PrimaryNetworkError → Penalty mapping
-                        // so every handler in this file applies penalties consistently.
-                        // The only reachable variant from this path is
-                        // UnknownConsensusOutput, which the central table maps to None —
-                        // peers legitimately request not-yet-served outputs during catch-up.
-                        if let Err(ref e) = output {
-                            if let Some(penalty) = e.into() {
-                                network_handle.report_penalty(peer, penalty).await;
-                            }
-                            let my_number = request_handler.consensus_chain().latest_consensus_number();
-                            tracing::debug!(
-                                target: "primary::network",
-                                ?e, ?my_number, ?number, ?peer,
-                                "consensus output request could not be served"
-                            );
-                        }
-                        let response = output.into_response();
-                        let _ = network_handle.handle.send_response(response, channel).await;
-                    }
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
-        });
-    }
-
     /// Attempt to retrieve consensus chain header from the database.
     fn process_epoch_record_request(
         &self,
@@ -874,6 +951,86 @@ where
         });
     }
 
+    /// Reserve a global concurrency slot for a stream request and register it in the pending map.
+    ///
+    /// Returns whether the request was accepted. Acceptance requires both an available semaphore
+    /// permit (global concurrency) and the peer being under its per-peer pending limit. The permit
+    /// is moved into the [`PendingStreamRequest`] and held for the lifetime of the request.
+    fn accept_stream_request(
+        &self,
+        peer: BlsPublicKey,
+        request_digest: B256,
+        kind: StreamRequestKind,
+    ) -> bool {
+        // acquire semaphore permit (non-blocking) for global concurrency
+        let Ok(permit) = self.epoch_stream_semaphore.clone().try_acquire_owned() else {
+            return false;
+        };
+
+        let mut pending_map = self.pending_epoch_requests.lock();
+
+        // check per-peer capacity
+        let peer_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
+        if peer_count >= MAX_PENDING_REQUESTS_PER_PEER {
+            info!(
+                target: "primary::network",
+                %peer,
+                peer_count,
+                "rejecting stream request: per-peer limit reached"
+            );
+            // permit drops here, freeing the slot
+            return false;
+        }
+
+        // If the same peer re-requests the same data while a prior entry is still
+        // pending, preserve the original `created_at` so the cleanup timer is not
+        // rearmed. Without this, a peer could hold a slot indefinitely by re-requesting
+        // before the 30s timeout. A second stream open is still punished as a protocol
+        // violation.
+        let created_at = pending_map
+            .get(&(peer, request_digest))
+            .map(|p| p.created_at)
+            .unwrap_or_else(Instant::now);
+        let pending = PendingStreamRequest { kind, created_at, _permit: permit };
+        if pending_map.insert((peer, request_digest), pending).is_some() {
+            debug!(
+                target: "primary::network",
+                %peer,
+                ?request_digest,
+                ?kind,
+                "pending stream request replaced with identical request"
+            );
+        }
+        debug!(
+            target: "primary::network",
+            %peer,
+            ?request_digest,
+            ?kind,
+            "pending stream request accepted"
+        );
+        true
+    }
+
+    /// Spawn a task to send a [`PrimaryResponse::StreamRequestAck`] for a stream negotiation.
+    fn send_stream_ack(
+        &self,
+        ack: bool,
+        channel: ResponseChannel<PrimaryResponse>,
+        cancel: oneshot::Receiver<()>,
+        task_name: String,
+    ) {
+        let msg = PrimaryResponse::StreamRequestAck { ack };
+        let network_handle = self.network_handle.clone();
+        self.task_spawner.spawn_task(task_name, async move {
+            // send response or cancel
+            tokio::select! {
+                _ = network_handle.inner_handle().send_response(msg, channel) => (),
+                _ = cancel => (),
+            }
+            Ok(())
+        });
+    }
+
     /// Process a request to stream an epoch pack file.
     fn process_epoch_stream(
         &self,
@@ -882,83 +1039,27 @@ where
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {
-        // acquire semaphore permit (non-blocking) for global concurrency
-        let ack = match self.epoch_stream_semaphore.clone().try_acquire_owned() {
-            Ok(permit) => {
-                let mut pending_map = self.pending_epoch_requests.lock();
+        let request_digest = epoch_stream_digest(epoch);
+        let ack =
+            self.accept_stream_request(peer, request_digest, StreamRequestKind::EpochPack(epoch));
+        self.send_stream_ack(ack, channel, cancel, format!("process-request-epoch-{peer}"));
+    }
 
-                // check per-peer capacity
-                let peer_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
-                if peer_count >= MAX_PENDING_REQUESTS_PER_PEER {
-                    info!(
-                        target: "primary::network",
-                        %peer,
-                        peer_count,
-                        "rejecting batch stream request: per-peer limit reached"
-                    );
-                    // permit drops here, freeing the slot
-                    false
-                } else {
-                    let mut hasher = tn_types::DefaultHashFunction::new();
-                    hasher.update(&epoch.to_le_bytes());
-                    let request_digest = B256::from_slice(hasher.finalize().as_bytes());
-                    // If the same peer re-requests the same epoch while a prior entry
-                    // is still pending, preserve the original `created_at` so the
-                    // cleanup timer is not rearmed. Without this, a peer could hold a
-                    // slot indefinitely by re-requesting before the 30s timeout.
-                    // A second stream open is still punished as a protocol violation.
-                    let created_at = pending_map
-                        .get(&(peer, request_digest))
-                        .map(|p| p.created_at)
-                        .unwrap_or_else(Instant::now);
-                    let pending = PendingEpochStream { epoch, created_at, _permit: permit };
-                    if pending_map.insert((peer, request_digest), pending).is_some() {
-                        debug!(
-                            target: "primary::network",
-                            %peer,
-                            ?request_digest,
-                            epoch,
-                            "pending epoch stream request replaced with identical epoch request"
-                        );
-                    }
-                    debug!(
-                        target: "primary::network",
-                        %peer,
-                        ?request_digest,
-                        epoch,
-                        "pending epoch stream request accepted"
-                    );
-                    true
-                }
-            }
-            Err(_) => false,
-        };
-
-        let response: PrimaryNetworkResult<PrimaryResponse> =
-            Ok(PrimaryResponse::RequestEpochStream { ack });
-        // send response
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("process-request-epoch-{peer}");
-        self.task_spawner.spawn_task(task_name, async move {
-            let msg = match response {
-                Ok(msg) => msg,
-                Err(err) => {
-                    let error = err.to_string();
-                    if let Some(penalty) = (&err).into() {
-                        network_handle.report_penalty(peer, penalty).await;
-                    }
-
-                    PrimaryResponse::Error(message::PrimaryRPCError(error))
-                }
-            };
-
-            // send response or cancel
-            tokio::select! {
-                _ = network_handle.inner_handle().send_response(msg, channel) => (),
-                _ = cancel => (),
-            }
-            Ok(())
-        });
+    /// Process a request to stream a single consensus output's raw bytes.
+    fn process_consensus_output_stream(
+        &self,
+        peer: BlsPublicKey,
+        number: u64,
+        channel: ResponseChannel<PrimaryResponse>,
+        cancel: oneshot::Receiver<()>,
+    ) {
+        let request_digest = consensus_output_stream_digest(number);
+        let ack = self.accept_stream_request(
+            peer,
+            request_digest,
+            StreamRequestKind::ConsensusOutput(number),
+        );
+        self.send_stream_ack(ack, channel, cancel, format!("process-request-output-{peer}"));
     }
 
     /// Process gossip from committee.

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -74,7 +74,8 @@ pub const MAX_PENDING_REQUESTS_PER_PEER: usize = 2;
 ///
 /// Generous upper bound: comfortably above any realistic single output, but caps an
 /// unbounded or malicious stream.
-const MAX_CONSENSUS_OUTPUT_STREAM_BYTES: usize = 16 * 1024 * 1024;
+/// TODO- replace with a size from consensus.  See Issue 782.
+const MAX_CONSENSUS_OUTPUT_STREAM_BYTES: usize = 512 * 1024 * 1024;
 
 /// Per-read timeout while draining a consensus-output stream (slow-peer guard).
 const CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(10);

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -308,6 +308,60 @@ impl PrimaryNetworkHandle {
         Err(NetworkError::RPCError("Could not get the consensus header!".to_string()))
     }
 
+    /// Request the raw (serialized) consensus output bytes for `number` from a specific peer.
+    ///
+    /// Returns the pack-file encoded output (batches + consensus header). The caller is
+    /// responsible for deserializing it (with the epoch's committee) and verifying the result;
+    /// the bytes cannot be cheaply validated at the network layer.
+    pub async fn request_consensus_output_from_peer(
+        &self,
+        peer: BlsPublicKey,
+        number: u64,
+    ) -> NetworkResult<Vec<u8>> {
+        let request = PrimaryRequest::ConsensusOutput { number };
+        let res = self.handle.send_request(request, peer).await?;
+        let res = res.await??.result;
+        match res {
+            PrimaryResponse::ConsensusOutput(bytes) => Ok(Arc::unwrap_or_clone(bytes)),
+            PrimaryResponse::Error(PrimaryRPCError(s)) => Err(NetworkError::RPCError(s)),
+            _ => Err(NetworkError::RPCError(
+                "Got wrong response, not a consensus output!".to_string(),
+            )),
+        }
+    }
+
+    /// Request the raw (serialized) consensus output bytes for `number` from a random peer,
+    /// trying up to three times from three different peers.
+    ///
+    /// Returns the pack-file encoded output (batches + consensus header). The caller is
+    /// responsible for deserializing it (with the epoch's committee) and verifying the result;
+    /// the bytes cannot be cheaply validated at the network layer.
+    pub async fn request_consensus_output(&self, number: u64) -> NetworkResult<Vec<u8>> {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        let request = PrimaryRequest::ConsensusOutput { number };
+        // Try up to three times (from three peers) to get the output.
+        // This could be a lot more complicated but this KISS method should work fine.
+        for _ in 0..3 {
+            let res = self.handle.send_request_any(request.clone()).await?;
+            let res = match tokio::time::timeout(TIMEOUT, res).await {
+                Ok(r) => r,
+                Err(_) => {
+                    tracing::warn!(target: "primary::network", ?number, "request_consensus_output timed out waiting for peer response");
+                    continue;
+                }
+            };
+            let res = res?;
+            if let Ok(NetworkResponseMessage {
+                peer: _,
+                result: PrimaryResponse::ConsensusOutput(bytes),
+            }) = res
+            {
+                return Ok(Arc::unwrap_or_clone(bytes));
+            }
+        }
+        Err(NetworkError::RPCError("Could not get the consensus output!".to_string()))
+    }
+
     /// Request consensus header from a random peer up to three times from three different peers.
     pub async fn request_epoch_cert(
         &self,

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -92,6 +92,7 @@ pub enum StreamRequestKind {
 /// Correlation digest for an epoch-pack stream request.
 fn epoch_stream_digest(epoch: Epoch) -> B256 {
     let mut hasher = tn_types::DefaultHashFunction::new();
+    hasher.update(b"epoch-stream");
     hasher.update(&epoch.to_le_bytes());
     B256::from_slice(hasher.finalize().as_bytes())
 }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -20,7 +20,12 @@ use std::{
 use tempfile::TempDir;
 use tn_config::Parameters;
 use tn_network_libp2p::{GossipMessage, TopicHash};
-use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
+use tn_storage::{
+    consensus::{ConsensusChain, ConsensusChainError},
+    consensus_pack::PackError,
+    mem_db::MemDatabase,
+    tables::Votes,
+};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
@@ -188,7 +193,12 @@ async fn test_retrieve_consensus_output() {
     // A number we do not have is a benign miss: it errors and carries no penalty.
     let err =
         handler.consensus_output_bytes(999).await.expect_err("unknown consensus output must error");
-    assert_matches!(err, PrimaryNetworkError::UnknownConsensusOutput(999));
+    assert_matches!(
+        err,
+        PrimaryNetworkError::ConsensusChainError(ConsensusChainError::PackError(
+            PackError::ConsensusNumberTooHigh
+        ))
+    );
     let penalty: Option<tn_network_libp2p::Penalty> = (&err).into();
     assert!(penalty.is_none(), "an unknown consensus output must not penalize the peer");
 }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -24,8 +24,9 @@ use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
-    BlsPublicKey, Certificate, ConsensusHeaderDigest, ConsensusNumHash, Database, Epoch, EpochVote,
-    ExecHeader, Hash as _, HeaderDigest, SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
+    BlsPublicKey, Certificate, CommittedSubDag, ConsensusHeaderDigest, ConsensusNumHash, Database,
+    Epoch, EpochVote, ExecHeader, Hash as _, HeaderDigest, ReputationScores, SealedHeader,
+    TaskManager, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -152,6 +153,51 @@ async fn create_test_types_at_epoch(path: &Path, epoch: Epoch) -> TestTypes {
     let handler =
         RequestHandler::new(config.clone(), cb.app().clone(), synchronizer, consensus_chain);
     TestTypes { committee, handler, parent, consensus_bus, task_manager }
+}
+
+#[tokio::test]
+async fn test_retrieve_consensus_output() {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+    let committee_obj = committee.committee();
+
+    // Populate a few consensus outputs in the epoch-0 pack. Numbers start at 1 so each is greater
+    // than the latest consensus number and is actually saved (mirror of storage_tests.rs).
+    for number in 1..=3u64 {
+        let cert = Certificate::default();
+        let sub_dag = CommittedSubDag::new(
+            vec![cert.clone()],
+            cert,
+            number,
+            ReputationScores::new(&committee_obj),
+            None,
+        );
+        handler.consensus_chain().write_subdag_for_test(number, sub_dag).await;
+    }
+
+    // The server serves the raw output bytes for every stored number.
+    for number in 1..=3u64 {
+        let resp = handler
+            .retrieve_consensus_output(number)
+            .await
+            .expect("stored consensus output should be served");
+        match resp {
+            PrimaryResponse::ConsensusOutput(bytes) => {
+                assert!(!bytes.is_empty(), "served output {number} bytes must not be empty");
+            }
+            other => panic!("expected ConsensusOutput response for {number}, got {other:?}"),
+        }
+    }
+
+    // A number we do not have is a benign miss: it errors and carries no penalty.
+    let err = handler
+        .retrieve_consensus_output(999)
+        .await
+        .expect_err("unknown consensus output must error");
+    assert_matches!(err, PrimaryNetworkError::UnknownConsensusOutput(999));
+    let penalty: Option<tn_network_libp2p::Penalty> = (&err).into();
+    assert!(penalty.is_none(), "an unknown consensus output must not penalize the peer");
 }
 
 #[tokio::test]

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     error::PrimaryNetworkError,
     network::{
         message::{ConsensusResult, PrimaryGossip, PrimaryResponse},
-        MissingCertificatesRequest, PendingEpochStream, RequestHandler,
+        MissingCertificatesRequest, PendingStreamRequest, RequestHandler, StreamRequestKind,
         MAX_CONCURRENT_EPOCH_STREAMS, PENDING_REQUEST_TIMEOUT,
     },
     state_sync::StateSynchronizer,
@@ -178,26 +178,65 @@ async fn test_retrieve_consensus_output() {
 
     // The server serves the raw output bytes for every stored number.
     for number in 1..=3u64 {
-        let resp = handler
-            .retrieve_consensus_output(number)
+        let bytes = handler
+            .consensus_output_bytes(number)
             .await
             .expect("stored consensus output should be served");
-        match resp {
-            PrimaryResponse::ConsensusOutput(bytes) => {
-                assert!(!bytes.is_empty(), "served output {number} bytes must not be empty");
-            }
-            other => panic!("expected ConsensusOutput response for {number}, got {other:?}"),
-        }
+        assert!(!bytes.is_empty(), "served output {number} bytes must not be empty");
     }
 
     // A number we do not have is a benign miss: it errors and carries no penalty.
-    let err = handler
-        .retrieve_consensus_output(999)
-        .await
-        .expect_err("unknown consensus output must error");
+    let err =
+        handler.consensus_output_bytes(999).await.expect_err("unknown consensus output must error");
     assert_matches!(err, PrimaryNetworkError::UnknownConsensusOutput(999));
     let penalty: Option<tn_network_libp2p::Penalty> = (&err).into();
     assert!(penalty.is_none(), "an unknown consensus output must not penalize the peer");
+}
+
+/// The server-side stream send writes exactly the stored output bytes and closes the stream.
+/// An unknown number closes the stream with no bytes (the client observes EOF and retries).
+#[tokio::test]
+async fn test_send_consensus_output_over_stream() {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+    let committee_obj = committee.committee();
+    let peer = BlsPublicKey::default();
+
+    for number in 1..=3u64 {
+        let cert = Certificate::default();
+        let sub_dag = CommittedSubDag::new(
+            vec![cert.clone()],
+            cert,
+            number,
+            ReputationScores::new(&committee_obj),
+            None,
+        );
+        handler.consensus_chain().write_subdag_for_test(number, sub_dag).await;
+    }
+
+    // streamed bytes for a stored output must match the bytes returned by the lookup
+    for number in 1..=3u64 {
+        let expected = handler
+            .consensus_output_bytes(number)
+            .await
+            .expect("stored consensus output should be served");
+        let mut streamed: Vec<u8> = Vec::new();
+        handler
+            .send_consensus_output_over_stream(&mut streamed, number, Duration::from_secs(5), peer)
+            .await
+            .expect("streaming a stored output should succeed");
+        assert_eq!(streamed, expected, "streamed bytes must match stored output {number}");
+        assert!(!streamed.is_empty(), "streamed output {number} must not be empty");
+    }
+
+    // an unknown number streams nothing (graceful EOF) rather than erroring the send
+    let mut streamed: Vec<u8> = Vec::new();
+    handler
+        .send_consensus_output_over_stream(&mut streamed, 999, Duration::from_secs(5), peer)
+        .await
+        .expect("streaming an unknown output closes gracefully");
+    assert!(streamed.is_empty(), "unknown output must stream zero bytes");
 }
 
 #[tokio::test]
@@ -816,18 +855,19 @@ async fn test_behind_consensus_genuinely_behind() {
 #[tokio::test]
 async fn test_pending_epoch_stream_replacement_preserves_created_at() {
     let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EPOCH_STREAMS));
-    let mut pending_map: HashMap<(BlsPublicKey, B256), PendingEpochStream> = HashMap::new();
+    let mut pending_map: HashMap<(BlsPublicKey, B256), PendingStreamRequest> = HashMap::new();
 
     let peer = BlsPublicKey::default();
     let digest = B256::random();
     let key = (peer, digest);
     let epoch: u32 = 7;
+    let kind = StreamRequestKind::EpochPack(epoch);
 
     // initial insertion at T0, where T0 is just past the cleanup horizon so we can
     // assert eviction without waiting on wall-clock time
     let t0 = Instant::now() - PENDING_REQUEST_TIMEOUT - Duration::from_secs(1);
     let permit = semaphore.clone().try_acquire_owned().expect("permit available");
-    pending_map.insert(key, PendingEpochStream::new_with_created_at(epoch, permit, t0));
+    pending_map.insert(key, PendingStreamRequest::new_with_created_at(kind, permit, t0));
 
     // simulate a re-request: production code looks up the existing entry's
     // `created_at` and reuses it when building the replacement
@@ -835,7 +875,7 @@ async fn test_pending_epoch_stream_replacement_preserves_created_at() {
     let preserved_created_at =
         pending_map.get(&key).map(|p| p.created_at).unwrap_or_else(Instant::now);
     let replacement =
-        PendingEpochStream { epoch, created_at: preserved_created_at, _permit: new_permit };
+        PendingStreamRequest { kind, created_at: preserved_created_at, _permit: new_permit };
     assert!(pending_map.insert(key, replacement).is_some(), "expected replacement");
 
     // the replacement must carry the original `created_at`, not a fresh one

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -1186,6 +1186,69 @@ mod test {
         }
     }
 
+    #[tokio::test]
+    async fn test_consensus_output_bytes_by_number() {
+        use crate::{archive::pack::PackCompression, consensus_pack::bytes_to_output};
+        use std::io::Cursor;
+        use tokio::io::BufReader;
+
+        let temp_dir = TempDir::with_prefix("test_output_bytes").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        // Save some outputs, keeping the originals to compare against.
+        let num_outputs = 10;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output = make_test_output(&committee, i % 4, chain.clone(), (i as u64) + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            consensus_chain.save_consensus_output(output).await.unwrap();
+        }
+
+        // Each saved number returns Some(bytes) that decode back to the original output.
+        for i in 0..num_outputs {
+            let number = i as u64 + 1;
+            let bytes = consensus_chain
+                .consensus_output_bytes_by_number(number)
+                .await
+                .expect("query ok")
+                .expect("bytes present");
+            assert!(!bytes.is_empty(), "bytes for {number} should not be empty");
+            // Packs are always written with ZStd, mirror get_consensus_output's decode path.
+            let reader = BufReader::new(Cursor::new(bytes));
+            let decoded =
+                bytes_to_output(reader, PackCompression::ZStd, Duration::from_secs(5), &committee)
+                    .await
+                    .expect("decode output bytes");
+            compare_outputs(&decoded, &outputs[i]);
+        }
+
+        // A number below the pack's start is out of range and must error.
+        assert!(
+            consensus_chain.consensus_output_bytes_by_number(0).await.is_err(),
+            "number below start must error"
+        );
+
+        // A fresh chain with no epoch opened has no data and returns Ok(None).
+        let empty_dir = TempDir::with_prefix("test_output_bytes_empty").expect("temp dir");
+        let empty_chain = ConsensusChain::new(empty_dir.path().to_owned()).unwrap();
+        assert!(
+            empty_chain.consensus_output_bytes_by_number(1).await.expect("query ok").is_none(),
+            "missing data must return None"
+        );
+    }
+
     /// Regression test for the `pack_install` lock.
     ///
     /// A validator that restarts while behind runs two subsystems against the same

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -597,6 +597,25 @@ impl ConsensusChain {
         }
     }
 
+    /// Retrieve the raw consensus output bytes by number.
+    pub async fn consensus_output_bytes_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<Vec<u8>>, ConsensusChainError> {
+        let epoch = self.epochs.number_to_epoch(number);
+        if let Some(pack) = &self.current_pack() {
+            if epoch == pack.epoch() {
+                return Ok(Some(pack.get_consensus_output_bytes(number).await?));
+            }
+        }
+        if let Ok(pack) = self.get_static(epoch).await {
+            Ok(Some(pack.get_consensus_output_bytes(number).await?))
+        } else {
+            // Don't have this epoch data.
+            Ok(None)
+        }
+    }
+
     /// Return true if we have a complete pack file for epoch_record.
     pub async fn is_epoch_complete(&self, epoch_record: &EpochRecord) -> bool {
         match self.consensus_header_by_number(epoch_record.final_consensus.number).await {
@@ -788,6 +807,10 @@ impl ConsensusChainReader for ConsensusChain {
         number: u64,
     ) -> eyre::Result<Option<ConsensusHeader>> {
         ConsensusChain::consensus_header_by_number(self, number).await.map_err(Into::into)
+    }
+
+    async fn consensus_output_bytes_by_number(&self, number: u64) -> eyre::Result<Option<Vec<u8>>> {
+        ConsensusChain::consensus_output_bytes_by_number(self, number).await.map_err(Into::into)
     }
 
     async fn consensus_header_latest(&self) -> eyre::Result<Option<ConsensusHeader>> {

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -333,6 +333,17 @@ impl ConsensusPack {
         bytes_to_output(reader, self.compression, Duration::from_secs(5), &self.committee).await
     }
 
+    /// Load and return the pack file bytes for consensus output form this epoch.
+    pub async fn get_consensus_output_bytes(&self, number: u64) -> Result<Vec<u8>, PackError> {
+        self.get_error()?;
+        let (tx, rx) = oneshot::channel();
+        if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
+            rx.await.map_err(|_| PackError::ReceiveFailed)?
+        } else {
+            Err(PackError::SendFailed)
+        }
+    }
+
     /// True if consensus header by digest is found by digest.
     pub async fn contains_consensus_header_number(&self, number: u64) -> Result<bool, PackError> {
         self.get_error()?;

--- a/crates/types/src/consensus_chain_traits.rs
+++ b/crates/types/src/consensus_chain_traits.rs
@@ -58,6 +58,12 @@ pub trait ConsensusChainReader: Send + Sync + Clone + 'static {
         number: u64,
     ) -> impl Future<Output = eyre::Result<Option<ConsensusHeader>>> + Send;
 
+    /// Retrieve the raw consensus output bytes by global number.
+    fn consensus_output_bytes_by_number(
+        &self,
+        number: u64,
+    ) -> impl Future<Output = eyre::Result<Option<Vec<u8>>>> + Send;
+
     /// Retrieve the most recent consensus header that was executed.
     fn consensus_header_latest(
         &self,


### PR DESCRIPTION
Expose the server side of pulling the pack formatted bytes for a ConsensusOutput.  This is a step in improving syncing within the current epoch.  Should also reduce server load, can just read and send bytes- no real processing on the server.