### PR TITLE
fix(worker): retry transient RPC errors instead of treating them as  rejections (#747)

### DIFF
--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -94,6 +94,9 @@ impl WorkerNetworkHandle {
                 "Got wrong response, not a report batch is peer exchange!".to_string(),
             )),
             WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
+            WorkerResponse::RecoverableError(WorkerRPCError(s)) => {
+                Err(NetworkError::RPCRetryable(s))
+            }
         }
     }
 
@@ -274,6 +277,9 @@ impl WorkerNetworkHandle {
                 "Got wrong response: peer exchange instead of stream ack".to_string(),
             )),
             WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
+            WorkerResponse::RecoverableError(WorkerRPCError(s)) => {
+                Err(NetworkError::RPCRetryable(s))
+            }
         }
     }
 

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 
+use crate::network::error::WorkerNetworkError;
 use serde::{Deserialize, Serialize};
 use tn_network_libp2p::{PeerExchangeMap, TNMessage};
 use tn_types::{BlockHash, Epoch, SealedBatch};
@@ -95,14 +96,64 @@ pub enum WorkerResponse {
     },
     /// RPC error while handling request.
     ///
-    /// This is an application-layer error response.
+    /// This is an application-layer error response. The requester should treat
+    /// it as a permanent rejection and not retry.
     Error(WorkerRPCError),
+    /// Retryable RPC error while handling request.
+    ///
+    /// This is an application-layer error response for a transient,
+    /// responder-side condition (a momentary batch-store write failure,
+    /// internal channel pressure during an epoch transition). The request is
+    /// likely to succeed in the future, so the requester should retry rather
+    /// than give up on the peer.
+    RecoverableError(WorkerRPCError),
 }
 
 impl WorkerResponse {
-    /// Helper method if the response is an error.
+    /// Helper method if the response is an error (permanent or recoverable).
     pub fn is_err(&self) -> bool {
-        matches!(self, WorkerResponse::Error(_))
+        matches!(self, WorkerResponse::Error(_) | WorkerResponse::RecoverableError(_))
+    }
+
+    /// Classify a [`WorkerNetworkError`] into the response a responder returns to
+    /// the requester.
+    ///
+    /// Transient, responder-side conditions become [`WorkerResponse::RecoverableError`]
+    /// so the requester retries; everything else becomes a permanent
+    /// [`WorkerResponse::Error`]. This is the type-level distinction between an
+    /// explicit rejection and a one-off remote failure: without it, a peer that
+    /// hit a momentary internal error would be treated identically to a peer
+    /// that deliberately rejected the batch.
+    pub(crate) fn into_error_ref(error: &WorkerNetworkError) -> Self {
+        match error {
+            // transient, responder-side conditions - a retry may clear them
+            WorkerNetworkError::Internal(_)
+            | WorkerNetworkError::Timeout(_)
+            | WorkerNetworkError::Network(_)
+            | WorkerNetworkError::StreamClosed
+            | WorkerNetworkError::DBInsert(_)
+            | WorkerNetworkError::DBCommit(_)
+            | WorkerNetworkError::DBRead(_)
+            | WorkerNetworkError::StdIo(_) => {
+                Self::RecoverableError(WorkerRPCError(error.to_string()))
+            }
+            // permanent rejections - an identical request would be rejected the
+            // same way (invalid batch/request, protocol violation, or a
+            // committee/epoch view mismatch for this request)
+            WorkerNetworkError::Bcs(_)
+            | WorkerNetworkError::BatchValidation(_)
+            | WorkerNetworkError::NonCommitteeBatch
+            | WorkerNetworkError::InvalidRequest(_)
+            | WorkerNetworkError::InvalidTopic
+            | WorkerNetworkError::TooManyBatches { .. }
+            | WorkerNetworkError::UnexpectedBatch(_)
+            | WorkerNetworkError::DuplicateBatch(_)
+            | WorkerNetworkError::UnknownStreamRequest(_)
+            | WorkerNetworkError::RequestHashMismatch
+            | WorkerNetworkError::BatchEpochMismatch(_, _) => {
+                Self::Error(WorkerRPCError(error.to_string()))
+            }
+        }
     }
 }
 
@@ -119,5 +170,30 @@ pub struct WorkerRPCError(pub String);
 impl From<PeerExchangeMap> for WorkerResponse {
     fn from(value: PeerExchangeMap) -> Self {
         Self::PeerExchange { peers: value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkerNetworkError, WorkerResponse};
+
+    /// A transient, responder-side condition is reported as recoverable so the
+    /// requester retries instead of treating the peer as having rejected the
+    /// batch. Regression coverage for the rejection-versus-transient conflation.
+    #[test]
+    fn transient_internal_error_is_recoverable() {
+        let err = WorkerNetworkError::Internal("failed to write to batch store".to_string());
+        assert!(matches!(
+            WorkerResponse::into_error_ref(&err),
+            WorkerResponse::RecoverableError(_)
+        ));
+    }
+
+    /// An explicit rejection (reporter is outside the committee) stays a
+    /// permanent error so the requester does not pointlessly retry.
+    #[test]
+    fn non_committee_batch_is_permanent_error() {
+        let err = WorkerNetworkError::NonCommitteeBatch;
+        assert!(matches!(WorkerResponse::into_error_ref(&err), WorkerResponse::Error(_)));
     }
 }

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -241,11 +241,14 @@ where
                     let response = match res {
                         Ok(()) => WorkerResponse::ReportBatch,
                         Err(err) => {
-                            let error = err.to_string();
+                            // classify transient responder-side conditions as
+                            // recoverable so the requester retries instead of
+                            // treating this as a permanent rejection
+                            let response = WorkerResponse::into_error_ref(&err);
                             if let Some(penalty) = err.into() {
                                 network_handle.report_penalty(peer, penalty).await;
                             }
-                            WorkerResponse::Error(message::WorkerRPCError(error))
+                            response
                         }
                     };
                     let _ = network_handle.inner_handle().send_response(response, channel).await;
@@ -374,12 +377,15 @@ where
             let msg = match response {
                 Ok(msg) => msg,
                 Err(err) => {
-                    let error = err.to_string();
+                    // classify transient responder-side conditions as recoverable
+                    // so the requester retries instead of treating this as a
+                    // permanent rejection
+                    let response = WorkerResponse::into_error_ref(&err);
                     if let Some(penalty) = err.into() {
                         network_handle.report_penalty(peer, penalty).await;
                     }
 
-                    WorkerResponse::Error(message::WorkerRPCError(error))
+                    response
                 }
             };
 

--- a/crates/consensus/worker/src/quorum_waiter.rs
+++ b/crates/consensus/worker/src/quorum_waiter.rs
@@ -72,8 +72,15 @@ impl QuorumWaiter {
     /// Report a batch to a single peer with retry-and-backoff for transient network errors.
     ///
     /// - `Ok(deliver)` — peer accepted the batch
-    /// - `Err(Rejected)` — peer explicitly rejected (RPCError), no retry
+    /// - `Err(Rejected)` — peer explicitly rejected ([`NetworkError::RPCError`]), no retry
     /// - `Err(Network)` — all retry attempts exhausted
+    ///
+    /// Transient errors are retried with exponential backoff before resolving to
+    /// `Err(Network)`. This includes transport failures and a responder's
+    /// [`NetworkError::RPCRetryable`], the recoverable counterpart of
+    /// `RPCError`: a one-off responder-side condition (a momentary batch-store
+    /// write failure, channel pressure during an epoch transition) must land on
+    /// the retry path, not the no-retry rejection path.
     async fn waiter(
         bls: BlsPublicKey,
         network: WorkerNetworkHandle,
@@ -238,13 +245,9 @@ impl QuorumWaiterTrait for QuorumWaiter {
             })
             .await;
 
-            let res = match timeout_res {
-                Ok(res) => match res {
-                    Ok(()) => Ok(()),
-                    Err(e) => Err(e),
-                },
-                Err(_elapsed) => Err(QuorumWaiterError::Timeout),
-            };
+            // collapse the timeout outcome into the quorum result: an elapsed
+            // timeout becomes `Timeout`, otherwise flatten to the inner result.
+            let res = timeout_res.map_err(|_elapsed| QuorumWaiterError::Timeout).flatten();
 
             // success or failure, this measures broadcast + quorum latency
             metrics.record_quorum_wait(quorum_start.elapsed());

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -672,9 +672,10 @@ async fn test_recoverable_error_exhausts_retries_as_network() {
     });
 
     // Retries exhausted → AntiQuorum (network failure), not QuorumRejected.
-    match tokio::time::timeout(Duration::from_secs(5), attest_handle).await {
-        Err(_) => panic!("should not timeout waiting for quorum waiter"),
-        Ok(Ok(r)) => assert_matches!(r, Err(QuorumWaiterError::AntiQuorum)),
-        Ok(Err(_)) => panic!("unexpected recv error!"),
-    }
+    let outcome = tokio::time::timeout(Duration::from_secs(5), attest_handle)
+        .await
+        .expect("should not timeout waiting for quorum waiter")
+        .map_err(QuorumWaiterError::from)
+        .and_then(|inner| inner);
+    assert_matches!(outcome, Err(QuorumWaiterError::AntiQuorum));
 }

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -559,3 +559,122 @@ async fn test_network_error_all_retries_exhausted() {
         Ok(Err(_)) => panic!("unexpected recv error!"),
     }
 }
+
+/// Regression test for issue #747: a responder's `RecoverableError` (a transient,
+/// recoverable condition such as a momentary batch-store write failure) must be
+/// retried, not treated as a permanent rejection. Every peer returns a
+/// recoverable error on its first attempt and accepts on retry, so quorum is
+/// only reachable if recoverable errors land on the retry path.
+#[tokio::test]
+async fn test_recoverable_error_retry_then_quorum() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .build();
+    let committee = fixture.committee();
+    let my_primary = fixture.authorities().next().unwrap();
+    let task_manager = TaskManager::default();
+
+    // setup network
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network =
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+    let quorum_waiter = QuorumWaiter::new(
+        my_primary.authority().clone(),
+        committee.clone(),
+        network,
+        WorkerMetrics::new_for_worker(0),
+    );
+
+    // Make a batch.
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain).seal_slow();
+
+    let timeout = Duration::from_secs(10);
+    let attest_handle =
+        quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
+
+    // Background handler: every peer returns a recoverable error first, accepts on retry.
+    tokio::spawn(async move {
+        let mut attempt_count: HashMap<BlsPublicKey, u32> = HashMap::new();
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { peer, reply, .. } => {
+                    let count = attempt_count.entry(peer).or_insert(0);
+                    *count += 1;
+                    let result = if *count == 1 {
+                        WorkerResponse::RecoverableError(WorkerRPCError(
+                            "failed to write to batch store".to_string(),
+                        ))
+                    } else {
+                        WorkerResponse::ReportBatch
+                    };
+                    let _ = reply.send(Ok(NetworkResponseMessage { peer, result }));
+                }
+                _ => panic!("unexpected network command!"),
+            }
+        }
+    });
+
+    // All peers accept on retry → quorum reached despite the initial recoverable errors.
+    assert!(attest_handle.await.unwrap().is_ok());
+}
+
+/// Regression test for issue #747: a responder that keeps returning
+/// `RecoverableError` exhausts retries and is counted as a network failure
+/// (`AntiQuorum`), never as rejected stake (`QuorumRejected`). With four
+/// committee members, three rejecting peers would trip `QuorumRejected`, so this
+/// distinguishes "transient, retries exhausted" from "explicitly rejected".
+#[tokio::test]
+async fn test_recoverable_error_exhausts_retries_as_network() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .build();
+    let committee = fixture.committee();
+    let my_primary = fixture.authorities().next().unwrap();
+    let task_manager = TaskManager::default();
+
+    // setup network
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network =
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0);
+    let quorum_waiter = QuorumWaiter::new(
+        my_primary.authority().clone(),
+        committee.clone(),
+        network,
+        WorkerMetrics::new_for_worker(0),
+    );
+
+    // Make a batch.
+    let chain = test_chain_spec_arc();
+    let sealed_batch = batch(chain).seal_slow();
+
+    let timeout = Duration::from_secs(10);
+    let attest_handle =
+        quorum_waiter.verify_batch(sealed_batch.clone(), timeout, &task_manager.get_spawner());
+
+    // Background handler: every attempt from every peer returns a recoverable error.
+    tokio::spawn(async move {
+        while let Some(cmd) = network_rx.recv().await {
+            match cmd {
+                NetworkCommand::SendRequest { peer, reply, .. } => {
+                    let _ = reply.send(Ok(NetworkResponseMessage {
+                        peer,
+                        result: WorkerResponse::RecoverableError(WorkerRPCError(
+                            "failed to write to batch store".to_string(),
+                        )),
+                    }));
+                }
+                _ => panic!("unexpected network command!"),
+            }
+        }
+    });
+
+    // Retries exhausted → AntiQuorum (network failure), not QuorumRejected.
+    match tokio::time::timeout(Duration::from_secs(5), attest_handle).await {
+        Err(_) => panic!("should not timeout waiting for quorum waiter"),
+        Ok(Ok(r)) => assert_matches!(r, Err(QuorumWaiterError::AntiQuorum)),
+        Ok(Err(_)) => panic!("unexpected recv error!"),
+    }
+}

--- a/crates/network-libp2p/src/error.rs
+++ b/crates/network-libp2p/src/error.rs
@@ -73,9 +73,23 @@ pub enum NetworkError {
     /// Failed to build swarm with behavior.
     #[error("SwarmBuilder::with_behaviour failed somehow.")]
     BuildSwarm,
-    /// Request/response RPC Error
+    /// Request/response RPC Error.
+    ///
+    /// A permanent, application-layer rejection from the responder. The
+    /// requester must not retry: the responder will reject an identical request
+    /// the same way (invalid payload, protocol violation, wrong response type).
     #[error("{0}")]
     RPCError(String),
+    /// Retryable request/response RPC error.
+    ///
+    /// The responder hit a transient, recoverable condition (a momentary
+    /// batch-store write failure, internal channel pressure during an epoch
+    /// transition) rather than rejecting the request on its merits. A requester
+    /// should retry with backoff instead of permanently giving up on the peer.
+    /// This is the counterpart of [`NetworkError::RPCError`], which is a
+    /// permanent rejection.
+    #[error("{0}")]
+    RPCRetryable(String),
     /// If a request is made to "any" peer and no peers are currently connected.
     #[error("No connected peers")]
     NoPeers,


### PR DESCRIPTION
  ## Summary

  `NetworkError::RPCError(String)` was the single application-layer RPC error
  variant, and the worker `QuorumWaiter` used it as the discriminator between
  "peer rejected this, do not retry" and "transient remote error, retry with
  backoff." Transient, recoverable conditions on the responder side (a
  batch-store write failure, an internal channel failure during an epoch
  transition) were mapped into that same `RPCError` string, so the requester
  classified them as a permanent rejection and stopped retrying that peer,
  even though a single retry would likely have cleared the failure.

  This PR distinguishes "explicit rejection" from "transient remote error" at
  the type level, so the responder's transient conditions land on the retry
  path instead of the no-retry rejection path.

  Closes #747.

  ## Root cause

  The flow that conflated the two cases:

  1. A transient responder-side failure in `process_report_batch` became
  `WorkerNetworkError::Internal(...)`
  (`crates/consensus/worker/src/network/handler.rs`).
  2. The responder stringified any error into
  `WorkerResponse::Error(WorkerRPCError(String))`
  (`crates/consensus/worker/src/network/mod.rs`).
  3. The requester mapped that back to `NetworkError::RPCError(String)`
  (`crates/consensus/worker/src/network/handle.rs`).
  4. `QuorumWaiter::waiter` treated `RPCError` as a permanent rejection
  (`WaiterError::Rejected`, no retry), while every other error variant was
  retried with backoff (`crates/consensus/worker/src/quorum_waiter.rs`).

  So a responder that hit a momentary batch-store or channel error was treated
  identically to one that deliberately rejected the batch.

  ## Fix

  Carry the rejection-versus-transient distinction through the type system,
  mirroring the pattern the primary network already uses
  (`PrimaryResponse::RecoverableError` + `PrimaryResponse::into_error_ref`):

  - **`network-libp2p`**: add `NetworkError::RPCRetryable(String)` as the
  retryable counterpart of `RPCError`. `RPCError` keeps its meaning (permanent
  rejection, no retry).
  - **worker `message.rs`**: add
  `WorkerResponse::RecoverableError(WorkerRPCError)` and
  `WorkerResponse::into_error_ref(&WorkerNetworkError)`, which classifies each
  `WorkerNetworkError` as either recoverable or a permanent rejection
  (exhaustive match, so new error variants must be classified deliberately).
  - **worker `mod.rs`**: the responder builds its error response through
  `into_error_ref(&err)`, so transient conditions are sent as
  `RecoverableError`.
  - **worker `handle.rs`**: the requester maps `RecoverableError` to
  `NetworkError::RPCRetryable` (and `Error` to `RPCError`, unchanged).
  - **worker `quorum_waiter.rs`**: no behavior code change is needed.
  `RPCRetryable` is not `RPCError`, so it falls into the existing
  retry-with-backoff arm and only resolves to `WaiterError::Network` after
  retries are exhausted, never to `WaiterError::Rejected`. The doc comment is
  updated to make the contract explicit.

  This keeps the retry policy where it belongs (the `QuorumWaiter`, which owns
  the backoff loop and metrics) and only adds the type-level signal it was
  missing.

  ### Transient vs permanent classification

  `into_error_ref` routes these to `RecoverableError` (requester retries):

  `Internal`, `Timeout`, `Network`, `StreamClosed`, `DBInsert`, `DBCommit`,
  `DBRead`, `StdIo`.

  Everything else stays a permanent `Error` (requester does not retry): `Bcs`,
  `BatchValidation`, `NonCommitteeBatch`, `InvalidRequest`, `InvalidTopic`,
  `TooManyBatches`, `UnexpectedBatch`, `DuplicateBatch`,
  `UnknownStreamRequest`, `RequestHashMismatch`, `BatchEpochMismatch`. These
  are decisions the peer would make the same way on an identical retry
  (invalid batch or request, protocol violation, or a committee/epoch view
  mismatch for this request).

  ## Compatibility note

  `WorkerResponse::RecoverableError` is appended to the end of the enum, so
  existing BCS variant indices are preserved. A pre-fix node still cannot
  decode the new variant, so this wants a coordinated worker upgrade. This is
  the same property the primary network's `RecoverableError` already carries
  on `main`, and it is consistent with the project's existing breaking-wire
  changes. No version-negotiation machinery is added, for parity with how the
  primary handles it.

  ## Testing

  - New unit tests for the classifier: a transient `Internal` error is
  reported as recoverable, and a `NonCommitteeBatch` rejection stays
  permanent.
  - New `QuorumWaiter` regression tests: a `RecoverableError` on the first
  attempt is retried and reaches quorum, and a peer that keeps returning
  `RecoverableError` exhausts its retries and is counted as `AntiQuorum`,
  never `QuorumRejected`.
  - Full suites pass: `tn-network-libp2p` (171), the worker classifier unit
  tests, and the `quorum_waiter` integration tests (11). `cargo fmt` and
  `clippy` are clean for the touched crates.

  ## Scope

  Touches `crates/network-libp2p` (the error type) and
  `crates/consensus/worker` (the producer and the consumer). The root cause
  was the under-specified error type in the network crate, now split into a
  permanent and a retryable variant.