### PR TITLE
Make sure to only count a consensus sig once per validator.

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -10,16 +10,13 @@ use std::{
 };
 use tn_config::ConsensusConfig;
 use tn_network_types::{local::LocalNetwork, PrimaryToWorkerClient};
-use tn_primary::{
-    network::{ConsensusResult, PrimaryNetworkHandle},
-    ConsensusBus, ConsensusBusApp, NodeMode,
-};
+use tn_primary::{network::PrimaryNetworkHandle, ConsensusBus, ConsensusBusApp, NodeMode};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     encode, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash, BlsSigner as _,
     CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusHeaderDigest,
-    ConsensusOutput, Database, Hash as _, Noticer, TaskManager, TaskSpawner, Timestamp,
-    TimestampSec, TnReceiver, TnSender,
+    ConsensusOutput, ConsensusResult, Database, Hash as _, Noticer, TaskManager, TaskSpawner,
+    Timestamp, TimestampSec, TnReceiver, TnSender,
 };
 use tracing::{debug, error, info, instrument, warn};
 

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -269,15 +269,15 @@ where
                         // possible and don't want to do the cert verify if we can
                         // skip it.  So this seems like the place.  And of course
                         // close any windows to double counting a signature.
-                        let mut guard = self.consensus_certs.lock();
+                        let guard = self.consensus_certs.lock();
                         if guard.get(&consensus_result_hash).and_then(|set| set.get(&key)).is_some()
                         {
                             // We have already counted this signature so ignore.
                             return Ok(());
                         }
-                        // An argument could be made to do this outside the lock.  This would mean
-                        // it happens on duplicates but holds the lock for
-                        // less time.
+                        drop(guard);
+                        // Drop the lock for the expensive verify op. If a dup gets through the Set
+                        // will still only count it once.
                         ensure!(
                             signature
                                 .verify_secure(&to_intent_message(consensus_result_hash), &key),
@@ -286,6 +286,7 @@ where
                         // Once we have seen 1/3 + 1 committe members have signed this it should be
                         // valid.
                         enough_sigs = (committee.len() / 3) + 1;
+                        let mut guard = self.consensus_certs.lock();
                         let set = guard.entry(consensus_result_hash).or_default();
                         set.insert(key);
                         sigs = set.len();
@@ -303,9 +304,13 @@ where
                         // sure it is valid. Receivers will count on
                         // this being verified.
                         info!(target: "primary", "got new consensus {number}/{hash}");
-                        self.consensus_bus
-                            .last_published_consensus_num_hash()
-                            .send_replace((epoch, number, hash));
+                        self.consensus_bus.publish_consensus_num_hash_if_newer(epoch, number, hash);
+                        // Note a malicious committee member could put memory pressure on this map
+                        // by publishing a lot of invalid results.  This
+                        // would require an actual malicious
+                        // validator (closed set- unlikely) and a LOT of data before the real
+                        // consesus is detected and the map cleared so
+                        // ignoring for now.
                         self.consensus_certs.lock().clear();
                     }
                 } else {

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -287,6 +287,16 @@ where
                         // valid.
                         enough_sigs = (committee.len() / 3) + 1;
                         let mut guard = self.consensus_certs.lock();
+                        if guard.len() > 20 {
+                            // Small sanity check to make it more difficult for a malicious
+                            // committee member to fill up
+                            // consensus_certs.  Attempt to evict any records that don't appear
+                            // relavent when more that 20 entries
+                            // (should not have this many under normal conditions).
+                            // We would expect a malicious validator to flood a lot of singleton
+                            // results.
+                            guard.retain(|k, s| *k == consensus_result_hash || s.len() > 1);
+                        }
                         let set = guard.entry(consensus_result_hash).or_default();
                         set.insert(key);
                         sigs = set.len();
@@ -305,12 +315,6 @@ where
                         // this being verified.
                         info!(target: "primary", "got new consensus {number}/{hash}");
                         self.consensus_bus.publish_consensus_num_hash_if_newer(epoch, number, hash);
-                        // Note a malicious committee member could put memory pressure on this map
-                        // by publishing a lot of invalid results.  This
-                        // would require an actual malicious
-                        // validator (closed set- unlikely) and a LOT of data before the real
-                        // consesus is detected and the map cleared so
-                        // ignoring for now.
                         self.consensus_certs.lock().clear();
                     }
                 } else {
@@ -960,6 +964,13 @@ where
     /// Return a reference to the `ConsensusChain`.
     pub(super) fn consensus_chain(&self) -> &ConsensusChain {
         &self.consensus_chain
+    }
+
+    /// Number of tracked consensus-result digests. Test-only accessor used to assert the
+    /// `consensus_certs` eviction bound (see the `PrimaryGossip::Consensus` handler).
+    #[cfg(test)]
+    pub(crate) fn consensus_certs_len(&self) -> usize {
+        self.consensus_certs.lock().len()
     }
 
     /// Send epoch pack file over stream.

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -1,9 +1,6 @@
 //! Handle specific request types received from the network.
 
-use super::{
-    message::{ConsensusResult, MissingCertificatesRequest},
-    PrimaryResponse,
-};
+use super::{message::MissingCertificatesRequest, PrimaryResponse};
 use crate::{
     error::{CertManagerError, PrimaryNetworkError, PrimaryNetworkResult},
     network::{message::PrimaryGossip, PendingEpochStream},
@@ -13,7 +10,7 @@ use crate::{
 use futures::{AsyncWrite, AsyncWriteExt as _};
 use parking_lot::Mutex;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -23,10 +20,10 @@ use tn_storage::{consensus::ConsensusChain, CertificateStore, VoteDigestStore};
 use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
-    now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlsPublicKey, Certificate,
-    ConsensusHeader, ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochDigest,
-    EpochRecord, Hash as _, Header, HeaderDigest, ProtocolSignature, Round,
-    SignatureVerificationState, TnSender as _, Vote, B256,
+    now, to_intent_message, try_decode, AuthorityIdentifier, BlsPublicKey, Certificate,
+    ConsensusHeader, ConsensusHeaderDigest, ConsensusResult, ConsensusResultDigest, Database,
+    Epoch, EpochCertificate, EpochDigest, EpochRecord, Hash as _, Header, HeaderDigest,
+    ProtocolSignature, Round, SignatureVerificationState, TnSender as _, Vote, B256,
 };
 use tokio::{io::AsyncReadExt, sync::Mutex as TokioMutex, time::timeout};
 use tracing::{debug, error, info, warn};
@@ -63,7 +60,7 @@ pub(crate) struct RequestHandler<DB> {
     /// Used to stop validator equivocation early.
     auth_last_vote: Arc<AuthEquivocationMap>,
     /// Track consensus headers until we hit a simple quorum then send on.
-    consensus_certs: Arc<Mutex<HashMap<BlockHash, u32>>>,
+    consensus_certs: Arc<Mutex<HashMap<ConsensusResultDigest, HashSet<BlsPublicKey>>>>,
     /// Access to the consensus chain data.
     consensus_chain: ConsensusChain,
 }
@@ -265,37 +262,51 @@ where
                         committee.contains(&key),
                         PrimaryNetworkError::PeerNotInCommittee(Box::new(key))
                     );
-                    ensure!(
-                        signature.verify_secure(&to_intent_message(consensus_result_hash), &key),
-                        PrimaryNetworkError::UnknownConsensusHeaderCert(hash)
-                    );
-                    // Once we have seen 1/3 + 1 committe members have signed this it should be
-                    // valid.
-                    let enough_sigs = (committee.len() / 3) + 1;
-                    let sigs = self.consensus_certs.lock().get(&consensus_result_hash).copied();
-                    if let Some(sigs) = sigs {
-                        if (sigs + 1) as usize >= enough_sigs {
-                            if self.behind_consensus(epoch, round, Some(number)).await {
-                                warn!(target: "primary", "consensus result indicates we are behind, go to catchup mode!");
-                                self.consensus_certs.lock().clear();
-                                return Ok(());
-                            }
-
-                            // Make sure we don't get old gossip and go backwards.
-                            // number has to be greater than old_number due to an early check so
-                            // this is safe Only send this when we are
-                            // sure it is valid. Receivers will count on
-                            // this being verified.
-                            info!(target: "primary", "got new consensus {number}/{hash}");
-                            self.consensus_bus
-                                .last_published_consensus_num_hash()
-                                .send_replace((epoch, number, hash));
-                            self.consensus_certs.lock().clear();
-                        } else {
-                            self.consensus_certs.lock().insert(consensus_result_hash, sigs + 1);
+                    let sigs;
+                    let enough_sigs;
+                    {
+                        // Trying to walk the line on keeping this lock non-async, held as short as
+                        // possible and don't want to do the cert verify if we can
+                        // skip it.  So this seems like the place.  And of course
+                        // close any windows to double counting a signature.
+                        let mut guard = self.consensus_certs.lock();
+                        if guard.get(&consensus_result_hash).and_then(|set| set.get(&key)).is_some()
+                        {
+                            // We have already counted this signature so ignore.
+                            return Ok(());
                         }
-                    } else {
-                        self.consensus_certs.lock().insert(consensus_result_hash, 1);
+                        // An argument could be made to do this outside the lock.  This would mean
+                        // it happens on duplicates but holds the lock for
+                        // less time.
+                        ensure!(
+                            signature
+                                .verify_secure(&to_intent_message(consensus_result_hash), &key),
+                            PrimaryNetworkError::UnknownConsensusHeaderCert(hash)
+                        );
+                        // Once we have seen 1/3 + 1 committe members have signed this it should be
+                        // valid.
+                        enough_sigs = (committee.len() / 3) + 1;
+                        let set = guard.entry(consensus_result_hash).or_default();
+                        set.insert(key);
+                        sigs = set.len();
+                    }
+                    if sigs >= enough_sigs {
+                        if self.behind_consensus(epoch, round, Some(number)).await {
+                            warn!(target: "primary", "consensus result indicates we are behind, go to catchup mode!");
+                            self.consensus_certs.lock().clear();
+                            return Ok(());
+                        }
+
+                        // Make sure we don't get old gossip and go backwards.
+                        // number has to be greater than old_number due to an early check so
+                        // this is safe Only send this when we are
+                        // sure it is valid. Receivers will count on
+                        // this being verified.
+                        info!(target: "primary", "got new consensus {number}/{hash}");
+                        self.consensus_bus
+                            .last_published_consensus_num_hash()
+                            .send_replace((epoch, number, hash));
+                        self.consensus_certs.lock().clear();
                     }
                 } else {
                     // Not sure we can sanity check this epoch.  However if it is bogus the code

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -9,56 +9,10 @@ use std::{
 };
 use tn_network_libp2p::{types::IntoRpcError, PeerExchangeMap, TNMessage};
 use tn_types::{
-    error::HeaderError, AuthorityIdentifier, BlockHash, BlsPublicKey, BlsSignature, Certificate,
-    ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochCertificate, EpochDigest, EpochRecord,
-    EpochVote, Header, HeaderDigest, Round, Vote, B256,
+    error::HeaderError, AuthorityIdentifier, Certificate, ConsensusHeader, ConsensusHeaderDigest,
+    ConsensusResult, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote, Header,
+    HeaderDigest, Round, Vote,
 };
-
-/// Info that is published (via gossip) by validators once they reach consensus.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
-pub struct ConsensusResult {
-    // epoch for this result (i.e. the current epoch)
-    pub epoch: Epoch,
-    // reound for epoch that consensus was reached on
-    pub round: Round,
-    /// the consensus header block number
-    pub number: u64,
-    /// hash of the consensus header that was reached
-    pub hash: ConsensusHeaderDigest,
-    /// the validator that produced this result
-    pub validator: BlsPublicKey,
-    /// the signature of the validator publishing this record
-    /// see digest() below, this is a signature over the hash of the epoch, round, number and hash
-    /// fields
-    pub signature: BlsSignature,
-}
-
-impl ConsensusResult {
-    /// Return the digest of the data fields (epoch, round, number and hash).
-    /// This will be the same for all validadors and is what signature signs
-    /// (verifying all the data fields not just the hash).
-    pub fn digest(&self) -> BlockHash {
-        Self::digest_data(self.epoch, self.round, self.number, self.hash)
-    }
-
-    /// Return the digest of the data fields (epoch, round, number and hash).
-    /// Used for generating the signature of the raw data.
-    /// This will be the same for all validadors and is what signature signs
-    /// (verifying all the data fields not just the hash).
-    pub fn digest_data(
-        epoch: Epoch,
-        round: Round,
-        number: u64,
-        hash: ConsensusHeaderDigest,
-    ) -> BlockHash {
-        let mut hasher = tn_types::DefaultHashFunction::new();
-        hasher.update(&epoch.to_be_bytes());
-        hasher.update(&round.to_be_bytes());
-        hasher.update(&number.to_be_bytes());
-        hasher.update(hash.as_ref());
-        B256::from_slice(hasher.finalize().as_bytes())
-    }
-}
 
 /// Primary messages on the gossip network.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -35,15 +35,14 @@ use tn_storage::{
 };
 use tn_types::{
     encode, BlsPublicKey, BlsSignature, Certificate, ConsensusHeader, ConsensusHeaderDigest,
-    Database, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote, Header, HeaderDigest,
-    Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, B256,
+    ConsensusResult, Database, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote,
+    Header, HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, B256,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{debug, info, warn};
 pub mod handler;
 mod message;
-pub use message::ConsensusResult;
 
 #[cfg(test)]
 #[path = "../tests/network_tests.rs"]

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -926,3 +926,52 @@ async fn test_consensus_result_duplicate_signature_counted_once() -> eyre::Resul
     );
     Ok(())
 }
+
+/// A single committee member flooding distinct singleton results must not grow `consensus_certs`
+/// without bound: once the map exceeds the 20-entry threshold the handler evicts singleton
+/// entries that are not the result currently being processed. The eviction must also not break
+/// legitimate aggregation — a real quorum still publishes afterward.
+#[tokio::test]
+async fn test_consensus_certs_eviction_bounds_map() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, consensus_bus, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    let (epoch, round) = (0u32, 1u32);
+    let quorum = committee.committee().size() / 3 + 1;
+    let authorities: Vec<_> = committee.authorities().collect();
+    assert!(authorities.len() >= quorum, "need at least a quorum of authorities");
+
+    // Flood: 50 distinct one-signature results from a single validator. Each distinct hash maps
+    // to a distinct digest → a new singleton entry, none of which reach quorum, so the map is
+    // never cleared by a publish during the flood.
+    for _ in 0..50 {
+        let hash = ConsensusHeaderDigest::from(B256::random());
+        let msg = signed_consensus_gossip(authorities[0], epoch, round, 1, hash);
+        handler.process_gossip(&msg).await?;
+    }
+
+    // The eviction bound must cap the map well below the 50 distinct inputs (≤ 21: the
+    // threshold of 20 plus the in-flight entry inserted after the retain).
+    assert!(
+        handler.consensus_certs_len() <= 21,
+        "consensus_certs must stay bounded under a singleton flood, got {}",
+        handler.consensus_certs_len(),
+    );
+
+    // A legitimate result must still reach quorum and publish after the eviction path has run.
+    let hash_l = ConsensusHeaderDigest::from(B256::random());
+    for auth in authorities.iter().take(quorum) {
+        let msg = signed_consensus_gossip(auth, epoch, round, 2, hash_l);
+        handler.process_gossip(&msg).await?;
+    }
+    assert_eq!(
+        consensus_bus.published_consensus_num_hash(),
+        (epoch, 2, hash_l),
+        "a legitimate quorum must publish even after singleton eviction",
+    );
+    // Publishing clears the map.
+    assert_eq!(handler.consensus_certs_len(), 0, "map must be cleared after a publish");
+
+    Ok(())
+}

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     error::PrimaryNetworkError,
     network::{
         message::{PrimaryGossip, PrimaryResponse},
-        MissingCertificatesRequest, PendingEpochStream, RequestHandler,
+        MissingCertificatesRequest, PendingStreamRequest, RequestHandler, StreamRequestKind,
         MAX_CONCURRENT_EPOCH_STREAMS, PENDING_REQUEST_TIMEOUT,
     },
     state_sync::StateSynchronizer,
@@ -20,13 +20,19 @@ use std::{
 use tempfile::TempDir;
 use tn_config::Parameters;
 use tn_network_libp2p::{GossipMessage, TopicHash};
-use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
+use tn_storage::{
+    consensus::{ConsensusChain, ConsensusChainError},
+    consensus_pack::PackError,
+    mem_db::MemDatabase,
+    tables::Votes,
+};
 use tn_test_utils_committee::{AuthorityFixture, CommitteeFixture};
 use tn_types::{
     encode, error::HeaderError, now, to_intent_message, AuthorityIdentifier, BlockHash,
-    BlockHeader, BlockNumHash, BlsPublicKey, BlsSigner as _, Certificate, ConsensusHeaderDigest,
-    ConsensusNumHash, ConsensusResult, Database, Epoch, EpochVote, ExecHeader, Hash as _,
-    HeaderDigest, Round, SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
+    BlockHeader, BlockNumHash, BlsPublicKey, BlsSigner as _, Certificate, CommittedSubDag,
+    ConsensusHeaderDigest, ConsensusNumHash, ConsensusResult, Database, Epoch, EpochVote,
+    ExecHeader, Hash as _, HeaderDigest, ReputationScores, Round, SealedHeader, TaskManager,
+    VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::PrimaryNetworkError,
     network::{
-        message::{ConsensusResult, PrimaryGossip, PrimaryResponse},
+        message::{PrimaryGossip, PrimaryResponse},
         MissingCertificatesRequest, PendingEpochStream, RequestHandler,
         MAX_CONCURRENT_EPOCH_STREAMS, PENDING_REQUEST_TIMEOUT,
     },
@@ -21,11 +21,12 @@ use tempfile::TempDir;
 use tn_config::Parameters;
 use tn_network_libp2p::{GossipMessage, TopicHash};
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, tables::Votes};
-use tn_test_utils_committee::CommitteeFixture;
+use tn_test_utils_committee::{AuthorityFixture, CommitteeFixture};
 use tn_types::{
-    error::HeaderError, now, AuthorityIdentifier, BlockHash, BlockHeader, BlockNumHash,
-    BlsPublicKey, Certificate, ConsensusHeaderDigest, ConsensusNumHash, Database, Epoch, EpochVote,
-    ExecHeader, Hash as _, HeaderDigest, SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
+    encode, error::HeaderError, now, to_intent_message, AuthorityIdentifier, BlockHash,
+    BlockHeader, BlockNumHash, BlsPublicKey, BlsSigner as _, Certificate, ConsensusHeaderDigest,
+    ConsensusNumHash, ConsensusResult, Database, Epoch, EpochVote, ExecHeader, Hash as _,
+    HeaderDigest, Round, SealedHeader, TaskManager, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -817,4 +818,111 @@ async fn test_pending_epoch_stream_replacement_preserves_created_at() {
         MAX_CONCURRENT_EPOCH_STREAMS,
         "dropping the evicted pending entry must release its semaphore permit"
     );
+}
+
+// ============================================================================
+// Consensus Result Signature Aggregation Tests
+// ============================================================================
+// These tests cover how the handler counts the validator signatures gossiped for a
+// consensus result. A result is only "published" (forwarded to followers) once a quorum of
+// *distinct* validators have signed it, and each validator must count at most once.
+
+/// Build a gossip message carrying a [`ConsensusResult`] signed by `auth` over the given
+/// `(epoch, round, number, hash)` tuple. Mirrors how the subscriber publishes results: the
+/// signature is over `to_intent_message(ConsensusResult::digest_data(..))`.
+fn signed_consensus_gossip(
+    auth: &AuthorityFixture<MemDatabase>,
+    epoch: Epoch,
+    round: Round,
+    number: u64,
+    hash: ConsensusHeaderDigest,
+) -> GossipMessage {
+    let digest = ConsensusResult::digest_data(epoch, round, number, hash);
+    let config = auth.consensus_config();
+    let key_config = config.key_config();
+    let signature = key_config.request_signature_direct(&encode(&to_intent_message(digest)));
+    let validator = key_config.public_key();
+    let result = ConsensusResult { epoch, round, number, hash, validator, signature };
+    let data = encode(&PrimaryGossip::Consensus(Box::new(result)));
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::consensus_output_topic());
+    GossipMessage { source: None, data, sequence_number: None, topic }
+}
+
+/// A quorum (`1/3 + 1`) of distinct validators signing the same consensus result must cause
+/// the handler to publish it, and not before. This also pins the entry-creation path: the
+/// very first signature must be recorded (a regression here would mean a quorum is never
+/// reached and the result is never published).
+#[tokio::test]
+async fn test_consensus_result_publishes_on_quorum() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, consensus_bus, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    let (epoch, round, number) = (0u32, 1u32, 1u64);
+    let hash = ConsensusHeaderDigest::from(B256::random());
+    let quorum = committee.committee().size() / 3 + 1;
+    let authorities: Vec<_> = committee.authorities().collect();
+    assert!(authorities.len() >= quorum, "need at least a quorum of authorities");
+
+    // Feed distinct signers one at a time; nothing should publish until the quorum-th.
+    for (seen, auth) in authorities.iter().take(quorum).enumerate() {
+        let msg = signed_consensus_gossip(auth, epoch, round, number, hash);
+        handler.process_gossip(&msg).await?;
+
+        if seen + 1 < quorum {
+            assert_eq!(
+                consensus_bus.published_consensus_num_hash(),
+                (0, 0, ConsensusHeaderDigest::default()),
+                "must not publish before a quorum of distinct signers ({} of {quorum})",
+                seen + 1,
+            );
+        }
+    }
+
+    assert_eq!(
+        consensus_bus.published_consensus_num_hash(),
+        (epoch, number, hash),
+        "result must be published once a quorum of distinct signers is reached",
+    );
+    Ok(())
+}
+
+/// The same validator gossiping a result repeatedly must be counted once. Replaying one
+/// signer more times than the quorum must not publish; only adding the remaining *distinct*
+/// signers may.
+#[tokio::test]
+async fn test_consensus_result_duplicate_signature_counted_once() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, consensus_bus, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    let (epoch, round, number) = (0u32, 1u32, 1u64);
+    let hash = ConsensusHeaderDigest::from(B256::random());
+    let quorum = committee.committee().size() / 3 + 1;
+    let authorities: Vec<_> = committee.authorities().collect();
+    assert!(authorities.len() >= quorum, "need at least a quorum of authorities");
+
+    // Replay the first signer's result more than `quorum` times. If duplicates were counted,
+    // this alone would reach quorum and publish — it must not.
+    let dup = signed_consensus_gossip(authorities[0], epoch, round, number, hash);
+    for _ in 0..quorum + 1 {
+        handler.process_gossip(&dup).await?;
+    }
+    assert_eq!(
+        consensus_bus.published_consensus_num_hash(),
+        (0, 0, ConsensusHeaderDigest::default()),
+        "repeated signatures from one validator must count once and stay below quorum",
+    );
+
+    // Add the remaining distinct signers (signer 0 already counted once) to reach quorum.
+    for auth in authorities.iter().take(quorum).skip(1) {
+        let msg = signed_consensus_gossip(auth, epoch, round, number, hash);
+        handler.process_gossip(&msg).await?;
+    }
+    assert_eq!(
+        consensus_bus.published_consensus_num_hash(),
+        (epoch, number, hash),
+        "a quorum of distinct signers must publish even after duplicates were ignored",
+    );
+    Ok(())
 }

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -7,7 +7,7 @@
 //! if not directly participating in consesus.
 
 use super::{CommittedSubDag, ConsensusOutput};
-use crate::{crypto, Certificate, Digest, Hash, B256};
+use crate::{crypto, BlsPublicKey, BlsSignature, Certificate, Digest, Epoch, Hash, Round, B256};
 use serde::{Deserialize, Serialize};
 
 /// Header for the consensus chain.
@@ -111,6 +111,57 @@ impl ConsensusNumHash {
     pub const fn new(number: u64, hash: ConsensusHeaderDigest) -> Self {
         Self { number, hash }
     }
+}
+
+/// Info that is published (via gossip) by validators once they reach consensus.
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct ConsensusResult {
+    // epoch for this result (i.e. the current epoch)
+    pub epoch: Epoch,
+    // reound for epoch that consensus was reached on
+    pub round: Round,
+    /// the consensus header block number
+    pub number: u64,
+    /// hash of the consensus header that was reached
+    pub hash: ConsensusHeaderDigest,
+    /// the validator that produced this result
+    pub validator: BlsPublicKey,
+    /// the signature of the validator publishing this record
+    /// see digest() below, this is a signature over the hash of the epoch, round, number and hash
+    /// fields
+    pub signature: BlsSignature,
+}
+
+impl ConsensusResult {
+    /// Return the digest of the data fields (epoch, round, number and hash).
+    /// This will be the same for all validadors and is what signature signs
+    /// (verifying all the data fields not just the hash).
+    pub fn digest(&self) -> ConsensusResultDigest {
+        Self::digest_data(self.epoch, self.round, self.number, self.hash)
+    }
+
+    /// Return the digest of the data fields (epoch, round, number and hash).
+    /// Used for generating the signature of the raw data.
+    /// This will be the same for all validadors and is what signature signs
+    /// (verifying all the data fields not just the hash).
+    pub fn digest_data(
+        epoch: Epoch,
+        round: Round,
+        number: u64,
+        hash: ConsensusHeaderDigest,
+    ) -> ConsensusResultDigest {
+        let mut hasher = crate::DefaultHashFunction::new();
+        hasher.update(&epoch.to_be_bytes());
+        hasher.update(&round.to_be_bytes());
+        hasher.update(&number.to_be_bytes());
+        hasher.update(hash.as_ref());
+        ConsensusResultDigest(Digest { digest: hasher.finalize().into() })
+    }
+}
+
+crate::crypto::digest_newtype! {
+    /// Digest of a [`ConsensusResult`].
+    pub struct ConsensusResultDigest;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes https://github.com/Telcoin-Association/telcoin-network/issues/713

Also added a Digest type for ConsensusResult which resulted in ConsensusResult moving to the tn-types crate.