### PR TITLE
Do not penalize UnsupportedProtocols; guard against self-dial/self-penalty (#777)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -89,13 +89,14 @@ where
 {
     /// Create a new instance of Self.
     pub(crate) fn new(
+        local_peer_id: PeerId,
         gossipsub: gossipsub::Behaviour,
         req_res: request_response::Behaviour<C>,
         kademlia: kad::Behaviour<KadStore<DB>>,
         peer_config: &PeerConfig,
         metrics: PeerManagerMetrics,
     ) -> Self {
-        let peer_manager = PeerManager::new(peer_config, metrics);
+        let peer_manager = PeerManager::new(local_peer_id, peer_config, metrics);
         let stream = StreamBehavior::new();
         Self { peer_manager, gossipsub, req_res, kademlia, stream }
     }
@@ -317,6 +318,7 @@ where
 
         // create custom behavior
         let mut behavior = TNBehavior::new(
+            peer_id,
             gossipsub,
             req_res,
             kademlia,
@@ -1058,16 +1060,15 @@ where
                             .peer_manager
                             .process_penalty(peer, Penalty::Mild);
                     }
-                    // Severe = 5 strikes covers the typical rolling-upgrade window where
-                    // a peer sees <=5 req-res handshakes per halflife. Demote to Medium
-                    // if telemetry shows version-skewed peers banned during normal
-                    // upgrades.
+                    // Not penalized. Failing to negotiate a common protocol is honest
+                    // version/role skew (the peer runs a different/older/role-distinct
+                    // protocol set), not misbehavior — the same not-the-peer's-fault
+                    // class as `DialFailure`/`ConnectionClosed` above. Penalizing it
+                    // bans not-yet-upgraded peers during rolling upgrades and would turn
+                    // the #765 chain-id protocol split into a network partition. Warn for
+                    // operator visibility only.
                     ReqResOutboundFailure::UnsupportedProtocols => {
-                        warn!(target: "network", ?peer, ?request_id, "outbound failure: unsupported protocol");
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Severe);
+                        warn!(target: "network", ?peer, ?request_id, "outbound failure: unsupported protocol (not penalized)");
                     }
                 }
 
@@ -1101,20 +1102,14 @@ where
                                 .process_penalty(peer, Penalty::Medium);
                         }
                     },
-                    // Severe = 5 strikes covers the typical rolling-upgrade window where
-                    // a peer sees <=5 req-res handshakes per halflife. Demote to Medium
-                    // if telemetry shows version-skewed peers banned during normal
-                    // upgrades.
+                    // Not penalized. The local peer supports none of the protocols the
+                    // remote requested: honest version/role skew, not misbehavior (the
+                    // inbound mirror of the outbound arm above). Penalizing it bans
+                    // not-yet-upgraded peers during rolling upgrades and is a prerequisite
+                    // blocker for the #765 chain-id protocol split. Warn for operator
+                    // visibility only.
                     ReqResInboundFailure::UnsupportedProtocols => {
-                        warn!(target: "network", ?peer, ?request_id, ?error, "inbound failure: unsupported protocol");
-
-                        // the local peer supports none of the protocols requested by the remote
-                        // Severe (not Fatal) so version skew during rolling upgrades does not
-                        // instantly ban a peer that is otherwise well-behaved.
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Severe);
+                        warn!(target: "network", ?peer, ?request_id, ?error, "inbound failure: unsupported protocol (not penalized)");
                     }
                     ReqResInboundFailure::Timeout | ReqResInboundFailure::ConnectionClosed => {
                         // peer dropped or stalled mid-request — expected on WAN, no penalty

--- a/crates/network-libp2p/src/peers/behavior.rs
+++ b/crates/network-libp2p/src/peers/behavior.rs
@@ -31,6 +31,14 @@ impl NetworkBehaviour for PeerManager {
         //
         // ensure PeerId isn't banned if known and register dial attempt
         if let Some(peer_id) = maybe_peer {
+            // refuse to dial our own identity. Kademlia can auto-dial an address
+            // it learned for a peer id (e.g. our own record re-learned via a
+            // hairpin address); if that id is ours, deny it here before a
+            // self-connection is established.
+            if self.is_local_peer(&peer_id) {
+                debug!(target: "peer-manager", ?peer_id, "denying outbound connection to local peer id");
+                return Err(ConnectionDenied::new("refusing to dial self"));
+            }
             // PeerManager and Kad may initiate dials
             // intercept kad dial attempts, sanitize, and register
             if self.dial_attempt_already_registered(&peer_id) {
@@ -84,6 +92,13 @@ impl NetworkBehaviour for PeerManager {
         remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         trace!(target: "peer-manager", ?peer, ?remote_addr, "inbound connection established");
+        // drop a self-connection (loopback/hairpin back to our own id) without
+        // scoring it. The inbound peer id is only known at this stage, so this is
+        // the earliest point an inbound self-connection can be rejected.
+        if self.is_local_peer(&peer) {
+            debug!(target: "peer-manager", ?peer, ?remote_addr, "denying inbound self-connection");
+            return Err(ConnectionDenied::new("self-connection: remote peer id is our own"));
+        }
         // ensure banned peers are not accepted
         if self.peer_banned(&peer) {
             return Err(ConnectionDenied::new("peer is banned"));
@@ -101,6 +116,12 @@ impl NetworkBehaviour for PeerManager {
         _port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         trace!(target: "peer-manager", ?peer, ?addr, "outbound connection established");
+        // drop a self-connection without scoring it (backstop for the pending
+        // guard in case a self-dial still reaches the established stage).
+        if self.is_local_peer(&peer) {
+            debug!(target: "peer-manager", ?peer, ?addr, "denying outbound self-connection");
+            return Err(ConnectionDenied::new("self-connection: remote peer id is our own"));
+        }
         if self.peer_banned(&peer) {
             error!(target: "peer-manager", ?peer, ?addr, "established outbound connection with banned peer - disconnecting...");
             return Err(ConnectionDenied::new("peer is banned"));

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -33,6 +33,14 @@ mod peer_manager;
 
 /// The type to manage peers.
 pub(crate) struct PeerManager {
+    /// This swarm's own peer id.
+    ///
+    /// Used to recognise and ignore the node's own identity on the dial,
+    /// discovery, connection, and penalty paths so a self-connection (e.g. a
+    /// learned hairpin address routed back to our own id) is never dialed or
+    /// scored. Primary and each worker run separate swarms with distinct
+    /// keypairs, so each `PeerManager` holds exactly one local id.
+    local_peer_id: PeerId,
     /// Config
     config: PeerConfig,
     /// The interval to perform maintenance.
@@ -78,7 +86,11 @@ pub(crate) struct PeerManager {
 
 impl PeerManager {
     /// Create a new instance of Self.
-    pub(crate) fn new(config: &PeerConfig, metrics: PeerManagerMetrics) -> Self {
+    pub(crate) fn new(
+        local_peer_id: PeerId,
+        config: &PeerConfig,
+        metrics: PeerManagerMetrics,
+    ) -> Self {
         let heartbeat =
             tokio::time::interval(tokio::time::Duration::from_secs(config.heartbeat_interval));
 
@@ -93,6 +105,7 @@ impl PeerManager {
         init_peer_score_config(config.score_config);
 
         Self {
+            local_peer_id,
             config: *config,
             heartbeat,
             peers,
@@ -135,6 +148,17 @@ impl PeerManager {
         multiaddrs: Vec<Multiaddr>,
         reply: Option<oneshot::Sender<NetworkResult<()>>>,
     ) {
+        // never dial our own identity (e.g. a self entry that reached the
+        // discovery/dial path via a learned hairpin address). Report success so
+        // retrying callers (`dial_peer_bls`) treat it as a no-op, not a failure
+        // to back off on.
+        if self.is_local_peer(&peer_id) {
+            debug!(target: "peer-manager", ?peer_id, "skipping dial request for local peer id");
+            if let Some(reply) = reply {
+                send_or_log_error!(reply, Ok(()), "DialPeer- Self", peer = peer_id);
+            }
+            return;
+        }
         // return early if peer is banned, connected, or currently being dialed
         if let Some(peer) = self.peers.get_peer(&peer_id) {
             match peer.connection_status() {
@@ -345,6 +369,15 @@ impl PeerManager {
         })
     }
 
+    /// Whether `peer_id` is this swarm's own identity.
+    ///
+    /// A self-connection (the node dialing its own peer id, e.g. via a learned
+    /// hairpin address) is not a real peer: it must never be dialed, registered
+    /// for discovery, accepted as a connection, or penalized.
+    pub(super) fn is_local_peer(&self, peer_id: &PeerId) -> bool {
+        &self.local_peer_id == peer_id
+    }
+
     /// Check if the peer id is banned or associated with any banned ip addresses.
     ///
     /// This is called before accepting new connections. Also checks that the peer
@@ -383,6 +416,14 @@ impl PeerManager {
     /// Some reports are propagated to libp2p network layer. Caller is responsible
     /// for specifying the severity of the penalty to apply.
     pub(crate) fn process_penalty(&mut self, peer_id: PeerId, penalty: Penalty) {
+        // Never penalize our own identity. A self-connection (e.g. a learned
+        // hairpin address routed back to our own peer id) must not feed the
+        // score model and ban the node's own worker. Guard before recording the
+        // metric so a self-event does not pollute penalty counts.
+        if self.is_local_peer(&peer_id) {
+            debug!(target: "peer-manager", ?peer_id, "skipping penalty for local peer id");
+            return;
+        }
         self.metrics.record_penalty(&penalty);
         let action = self.peers.process_penalty(&peer_id, penalty);
 
@@ -804,11 +845,17 @@ impl PeerManager {
     /// Check if peer is eligible for discovery.
     ///
     /// A peer is eligible if:
+    /// - it is not this node's own identity
     /// - it has at least one valid ip address (ipv4/ipv6)
     /// - none of its ip addresses are banned
     /// - it can be dialed (not connected/dialing/banned)
     fn eligible_for_discovery(&self, info: &PeerInfo) -> bool {
-        self.has_valid_unbanned_ips(&info.addrs) && self.peers.can_dial(&info.peer_id)
+        // never add our own identity to the discovery feed; a self entry (learned
+        // via kad closest-peers or peer exchange) would otherwise be selected for
+        // a self-dial during the heartbeat.
+        !self.is_local_peer(&info.peer_id)
+            && self.has_valid_unbanned_ips(&info.addrs)
+            && self.peers.can_dial(&info.peer_id)
     }
 
     /// Process newly discovered peers for potential dial attempts.

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -50,10 +50,10 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 | `crates/network-libp2p/src/consensus.rs:946` | `OutboundFailure::Io(e)` with transport-flap `e.kind()` (Reset/Aborted/Timed/EOF/Pipe/Interrupted) | `None`   |
 | `crates/network-libp2p/src/consensus.rs:946` | `OutboundFailure::Io(e)` other kinds (codec violation, e.g. `io::Error::other`)                    | `Medium` |
 | `crates/network-libp2p/src/consensus.rs:961` | `OutboundFailure::Timeout`                                                                         | `Mild`   |
-| `crates/network-libp2p/src/consensus.rs:973` | `OutboundFailure::UnsupportedProtocols`                                                            | `Severe` |
+| `crates/network-libp2p/src/consensus.rs:1071` | `OutboundFailure::UnsupportedProtocols` (honest version/role skew — warn only) | `None` |
 | `crates/network-libp2p/src/consensus.rs:973` | `InboundFailure::Io(e)` with transport-flap `e.kind()`                                             | `None`   |
 | `crates/network-libp2p/src/consensus.rs:973` | `InboundFailure::Io(e)` other kinds (codec violation)                                              | `Medium` |
-| `crates/network-libp2p/src/consensus.rs:992` | `InboundFailure::UnsupportedProtocols`                                                             | `Severe` |
+| `crates/network-libp2p/src/consensus.rs:1112` | `InboundFailure::UnsupportedProtocols` (honest version/role skew — warn only) | `None` |
 | `crates/network-libp2p/src/consensus.rs:995` | `InboundFailure::Timeout` / `InboundFailure::ConnectionClosed`                                     | `None`   |
 
 `InboundFailure::ResponseOmission` is explicitly a no-op (local error). See restraint invariants below.
@@ -251,6 +251,8 @@ These are deliberate tolerances for benign failures. Changing any of these from
 - All `PackError` IO/load/persist/internal variants — local failures. `crates/consensus/primary/src/network/mod.rs:460-476`.
 - `ConsensusChainError::StreamUnavailable` / `NoCurrentEpoch` / `EpochDbError` / `IO` — local failures during epoch pack streaming. `crates/consensus/primary/src/network/mod.rs:484-487`.
 - A rejected kad put record from a banned source/publisher with `record.publisher.is_some()` — no extra penalty is stacked on top of the existing ban. `crates/network-libp2p/src/consensus.rs:1375-1388`.
+- `OutboundFailure::UnsupportedProtocols` / `InboundFailure::UnsupportedProtocols` — honest version/role skew (multistream-select found no common protocol), not misbehavior; warn only, no penalty. Precondition for the #765 chain-id protocol split, which intentionally makes old/new nodes fail to peer. `crates/network-libp2p/src/consensus.rs:1071,1112`. The stream-path mirror (`StreamFailure::UnsupportedProtocol`) is likewise `None`. `crates/network-libp2p/src/stream/upgrade.rs`.
+- The node's own peer id — `PeerManager::process_penalty` short-circuits before the score model when the target is the local identity, so a self-connection (e.g. a learned hairpin address routed back to our own id) can never ban the node's own worker. `crates/network-libp2p/src/peers/manager.rs` (`is_local_peer`). Self-connections are also denied earlier on the dial/discovery/connection paths so they do not reach the penalty path at all.
 
 ## 7. Ban Lifecycle
 

--- a/crates/network-libp2p/src/stream/upgrade.rs
+++ b/crates/network-libp2p/src/stream/upgrade.rs
@@ -104,8 +104,10 @@ impl StreamFailure {
             Self::DialFailure => None,
             // stalled open
             Self::Timeout => Some(Penalty::Mild),
-            // the peer speaks none of our stream protocols
-            Self::UnsupportedProtocol => Some(Penalty::Severe),
+            // the peer speaks none of our stream protocols: honest version/role
+            // skew, not a fault — not penalized, like `DialFailure` (mirrors the
+            // request-response `UnsupportedProtocols` arm in `consensus.rs`).
+            Self::UnsupportedProtocol => None,
             // transport flaps on WAN are not faults; other IO is likely a violation
             Self::Io(kind) => match kind {
                 std::io::ErrorKind::ConnectionReset
@@ -129,12 +131,13 @@ mod tests {
     use std::io::ErrorKind;
 
     /// The stream penalty taxonomy must mirror the request-response one: transport
-    /// faults are not penalized, stalls are mild, unsupported protocols are severe.
+    /// faults are not penalized, stalls are mild, and unsupported protocols are
+    /// honest version/role skew (not penalized, like `DialFailure`).
     #[test]
     fn penalty_mapping_mirrors_reqres() {
         assert!(StreamFailure::DialFailure.penalty().is_none());
         assert!(matches!(StreamFailure::Timeout.penalty(), Some(Penalty::Mild)));
-        assert!(matches!(StreamFailure::UnsupportedProtocol.penalty(), Some(Penalty::Severe)));
+        assert!(StreamFailure::UnsupportedProtocol.penalty().is_none());
         assert!(matches!(StreamFailure::InboundRateLimited.penalty(), Some(Penalty::Medium)));
         // transport flaps on WAN are not the peer's fault
         assert!(StreamFailure::Io(ErrorKind::ConnectionReset).penalty().is_none());

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -754,6 +754,130 @@ async fn test_primary_worker_protocol_isolation() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Issue #777 Part A: a peer whose only req/res failures are `UnsupportedProtocols`
+/// must never be penalized or banned.
+///
+/// Failing to negotiate a common protocol is honest version/role skew, not
+/// misbehavior. Reusing the cross-role setup from
+/// `test_primary_worker_protocol_isolation`, the primary (`/tn-primary/*`) and the
+/// worker (`/tn-worker-0/*`) connect at the transport but cannot negotiate a
+/// req/res protocol, so every request surfaces `OutboundFailure::UnsupportedProtocols`.
+/// Pre-fix each one applied `Penalty::Severe` (−10); the requests below would drive
+/// the score past `min_score_before_ban` (−50) and ban an otherwise-healthy peer.
+#[tokio::test]
+async fn test_unsupported_protocol_does_not_penalize() -> eyre::Result<()> {
+    let mut network_config = NetworkConfig::default();
+    network_config.peer_config_mut().heartbeat_interval = TEST_HEARTBEAT_INTERVAL;
+
+    let all_nodes =
+        CommitteeFixture::builder(MemDatabase::default).with_network_config(network_config).build();
+    let mut authorities = all_nodes.authorities();
+    let config_1 = authorities.next().expect("first authority").consensus_config();
+    let config_2 = authorities.next().expect("second authority").consensus_config();
+    let (tx1, _events_1) = mpsc::channel(10);
+    let (tx2, _events_2) = mpsc::channel(10);
+    let task_manager = TaskManager::default();
+
+    // peer1: PRIMARY role
+    let primary_network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_1.network_config(),
+        tx1,
+        config_1.key_config().clone(),
+        config_1.key_config().primary_network_keypair().clone(),
+        MemDatabase::default(),
+        task_manager.get_spawner(),
+        NetworkType::Primary,
+        config_1.primary_address(),
+        None,
+    )
+    .expect("primary network created");
+    let primary = primary_network.network_handle();
+    tokio::spawn(async move {
+        primary_network.run().await.expect("primary network run failed!");
+    });
+
+    // peer2: WORKER role
+    let worker_network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_2.network_config(),
+        tx2,
+        config_2.key_config().clone(),
+        config_2.key_config().worker_network_keypair().clone(),
+        MemDatabase::default(),
+        task_manager.get_spawner(),
+        NetworkType::Worker(0),
+        config_2.worker_address(),
+        None,
+    )
+    .expect("worker network created");
+    let worker = worker_network.network_handle();
+    tokio::spawn(async move {
+        worker_network.run().await.expect("worker network run failed!");
+    });
+
+    primary.start_listening(config_1.primary_address()).await?;
+    worker.start_listening(config_2.worker_address()).await?;
+    let worker_addr = worker.listeners().await?.first().expect("worker listen addr").clone();
+    let worker_peer_id = worker.local_peer_id().await?;
+    let worker_bls = config_2.key_config().primary_public_key();
+
+    // primary dials the worker across roles and establishes the transport connection
+    primary
+        .add_explicit_peer(
+            worker_bls,
+            config_2.key_config().worker_network_public_key(),
+            worker_addr,
+        )
+        .await?;
+    primary.dial_by_bls(worker_bls).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert!(
+        primary.connected_peer_ids().await?.contains(&worker_peer_id),
+        "transport connection across roles should establish"
+    );
+
+    // the primary's view of the worker's score before any failed requests
+    let score_before = primary.peer_score(worker_peer_id).await?.expect("worker tracked");
+
+    // fire enough cross-role requests that, pre-fix, 6 * Severe (−10) = −60 would
+    // cross the ban threshold (−50)
+    for _ in 0..6 {
+        let reply =
+            primary.send_request(TestWorkerRequest::MissingBatches(vec![]), worker_bls).await?;
+        let res = timeout(Duration::from_secs(5), reply).await?.expect("reply channel");
+        assert_matches!(
+            res,
+            Err(NetworkError::Outbound(_)),
+            "cross-role req/res must fail to negotiate a protocol"
+        );
+    }
+
+    // allow any (erroneous) penalty + a heartbeat to propagate
+    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL + 1)).await;
+
+    // the worker is neither penalized nor banned: still connected, score unchanged
+    assert!(
+        primary.connected_peer_ids().await?.contains(&worker_peer_id),
+        "peer must not be disconnected for unsupported-protocol failures"
+    );
+    let score_after = primary.peer_score(worker_peer_id).await?.expect("worker still tracked");
+    assert_eq!(
+        score_before, score_after,
+        "unsupported-protocol failures must not change the peer's score (before={score_before}, after={score_after})"
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_publish_to_one_peer() -> eyre::Result<()> {
     // start honest cvv network

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -31,6 +31,7 @@ fn create_test_peer_manager(network_config: Option<NetworkConfig>) -> PeerManage
     let authority_1 = authorities.next().expect("first authority");
     let config = authority_1.consensus_config();
     PeerManager::new(
+        PeerId::random(),
         config.network_config().peer_config(),
         crate::metrics::PeerManagerMetrics::new_for(&crate::types::NetworkType::Primary),
     )
@@ -560,6 +561,7 @@ async fn test_is_validator() {
     let authority_1 = authorities.next().expect("first authority");
     let config = authority_1.consensus_config();
     let mut peer_manager = PeerManager::new(
+        PeerId::random(),
         config.network_config().peer_config(),
         crate::metrics::PeerManagerMetrics::new_for(&crate::types::NetworkType::Primary),
     );
@@ -1033,6 +1035,101 @@ async fn test_process_peers_for_discovery_filters_duplicates() {
     // should only have one entry
     assert_eq!(peer_manager.discovery_peers.len(), 1);
     assert_eq!(peer_manager.discovery_peers.remove(&peer_id), Some(vec![addr]));
+}
+
+// Regression (issue #777 Part B): the node's own peer id must never be added to
+// the discovery feed. A self entry (learned via kad closest-peers or peer
+// exchange) would otherwise be selected for a self-dial during the heartbeat.
+#[tokio::test]
+async fn test_self_id_filtered_from_discovery() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let local = peer_manager.local_peer_id;
+    let other = PeerId::random();
+    let addr = create_multiaddr(None);
+
+    // our own id is not eligible; a normal peer is
+    assert!(!peer_manager
+        .eligible_for_discovery(&PeerInfo { peer_id: local, addrs: vec![addr.clone()] }));
+    assert!(peer_manager
+        .eligible_for_discovery(&PeerInfo { peer_id: other, addrs: vec![addr.clone()] }));
+
+    // feeding self + a normal peer through the discovery sink registers only the
+    // normal peer
+    peer_manager.process_peers_for_discovery(vec![
+        PeerInfo { peer_id: local, addrs: vec![addr.clone()] },
+        PeerInfo { peer_id: other, addrs: vec![addr.clone()] },
+    ]);
+    assert!(!peer_manager.discovery_peers.contains_key(&local));
+    assert_eq!(peer_manager.discovery_peers.remove(&other), Some(vec![addr]));
+}
+
+// Regression (issue #777 Part B): routing the node's own peer id through the
+// dial path is a no-op (no dial request, no self-penalty) and reports success so
+// retrying callers do not treat it as a failure.
+#[tokio::test]
+async fn test_self_dial_request_is_noop() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let local = peer_manager.local_peer_id;
+    // mirror the observed hairpin address (192.168.8.1)
+    let hairpin = create_multiaddr(Some(IpAddr::V4(Ipv4Addr::new(192, 168, 8, 1))));
+    let (sender, receiver) = oneshot::channel();
+
+    peer_manager.dial_peer(local, vec![hairpin], Some(sender));
+
+    // no dial request was queued
+    assert!(peer_manager.next_dial_request().is_none());
+    // the caller is told the no-op succeeded (so `dial_peer_bls` does not retry)
+    let result = timeout(Duration::from_millis(500), receiver).await.unwrap().unwrap();
+    assert!(result.is_ok());
+    // the node never scored or tracked itself
+    assert!(!peer_manager.peer_banned(&local));
+    assert!(peer_manager.peer_score(&local).is_none());
+}
+
+// Regression (issue #777 Part B): a penalty targeting the node's own id is a
+// no-op, even a `Fatal` one — a self-connection can never ban the node.
+#[tokio::test]
+async fn test_self_penalty_is_noop() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let local = peer_manager.local_peer_id;
+
+    peer_manager.process_penalty(local, Penalty::Fatal);
+
+    assert!(!peer_manager.peer_banned(&local));
+    assert!(peer_manager.peer_score(&local).is_none());
+    let events = collect_all_events(&mut peer_manager);
+    assert!(extract_events(&events, |e| matches!(e, PeerEvent::Banned(_))).is_empty());
+}
+
+// Regression (issue #777 Part B): a self-connection is denied without scoring at
+// the connection-establishment handlers. The pending-outbound guard is the
+// precise fix for kad auto-dialing our own re-learned record; the established
+// handlers are the backstop. A normal peer is still accepted.
+#[tokio::test]
+async fn test_self_connection_denied() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let local = peer_manager.local_peer_id;
+    let other = PeerId::random();
+    let connection_id = ConnectionId::new_unchecked(0);
+    let addr = create_multiaddr(None);
+
+    // kad-initiated dial of our own id is denied at the pending stage
+    assert!(peer_manager
+        .handle_pending_outbound_connection(connection_id, Some(local), &[], Endpoint::Dialer)
+        .is_err());
+    // a normal peer is allowed to be dialed
+    assert!(peer_manager
+        .handle_pending_outbound_connection(connection_id, Some(other), &[], Endpoint::Dialer)
+        .is_ok());
+
+    // an inbound self-connection (loopback/hairpin) is dropped
+    assert!(peer_manager
+        .handle_established_inbound_connection(connection_id, local, &addr, &addr)
+        .is_err());
+
+    // and no self-penalty was ever recorded by any of the above
+    assert!(!peer_manager.peer_banned(&local));
+    assert!(peer_manager.peer_score(&local).is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #777. Stops a live `adiri` observer node from banning honest peers, including its own worker identity, off the back of libp2p req/res `UnsupportedProtocols` failures.  Two independent defects, fixed together:

- **Part A** — `Outbound/InboundFailure::UnsupportedProtocols` was scored `Penalty::Severe`.  Failing to negotiate a common protocol is honest version/role skew, not misbehavior, so it is now **not penalized** (warn-only), grouped with the existing no-penalty `DialFailure`/`ConnectionClosed` arms.
- **Part B** — the node dialed and then penalized **its own peer id** (worker swarm) via a learned hairpin address that libp2p's peer-id self-dial check missed.  There was no self-dial / self-penalty guard anywhere in the crate. Added one, in depth.

This is a prerequisite for landing #765 (`chain-id-protocol`): that change intentionally makes old/new nodes fail to peer with `UnsupportedProtocols`. With the old `Severe` mapping, the #765 rollout would have every node *ban* (and DHT-poison) every not-yet-upgraded peer, turning a clean non-peering into a network partition.

## Part A — do not penalize `UnsupportedProtocols`

`multistream-select` finding no common protocol means the peer runs a different/older/role-distinct protocol set . . . the textbook honest-skew condition, and the same not-the-peer's-fault class as `DialFailure`/`ConnectionClosed`. The codebase already commits to this contract elsewhere (`test_pre_upgrade_record_accepted_with_default_rpc`).

- `consensus.rs` outbound + inbound `UnsupportedProtocols` arms: drop `process_penalty(peer, Penalty::Severe)`, keep the `warn!` (now labelled `(not penalized)`) for operator visibility.
- `stream/upgrade.rs`: `StreamFailure::UnsupportedProtocol.penalty()` → `None`, keeping the stream taxonomy a mirror of the req/res one; `penalty_mapping_mirrors_reqres` updated to assert `.is_none()`.
- `peers/penalty.md`: rows for both `UnsupportedProtocols` entries → `None`, plus a restraint-invariant note.

## Part B — guard against self-dial / self-penalty

The committee dial loop already self-filters by BLS key at the app layer (`start_epoch.rs`), so the self-dial enters purely via the kad/discovery path, which is keyed on `PeerId` and had no self-check.  `PeerManager` did not even hold its own peer id.

Keystone: thread the swarm's own `peer_id` (already computed in `ConsensusNetwork::new`) into `PeerManager` and add an `is_local_peer` predicate.  Each swarm (primary and each worker) builds its own `PeerManager` with its own keypair-derived id, so a per-swarm single-id guard naturally covers every one of the node's identities . . . no multi-id allowlist needed.  Defense in depth, source and sink:

- **Penalty sink (central):** `PeerManager::process_penalty` short-circuits before the score model (and before the metric) for the local id . . . covers every penalty call site (gossip / kad / req-res) in one place.
- **Dial source:** `dial_peer` skips the local id and reports success, so retrying callers (`dial_peer_bls`) treat it as a no-op rather than a failure to back off on.
- **Discovery source:** `eligible_for_discovery` excludes the local id, so a self entry learned via kad closest-peers or peer exchange never enters the discovery feed.
- **Connection sink:** `handle_pending_outbound_connection` denies a dial to the local id (the precise fix for kad auto-dialing our own re-learned record); `handle_established_{inbound,outbound}_connection` deny a self-connection that still reaches the established stage (the inbound peer id is only known there). None of these call `process_penalty`, so the self-connection is dropped without scoring.

## Tests

- `stream/upgrade.rs::penalty_mapping_mirrors_reqres` — asserts `UnsupportedProtocol` is no longer penalized.
- `network_tests.rs::test_unsupported_protocol_does_not_penalize` — cross-role primary↔worker req/res produces real `UnsupportedProtocols` outbound failures; 6 of them (pre-fix 6 × Severe = −60, past the −50 ban threshold) leave the peer connected with an unchanged score.
- `tests/peer_manager.rs` — `test_self_id_filtered_from_discovery`, `test_self_dial_request_is_noop`, `test_self_penalty_is_noop`, `test_self_connection_denied`.

## CI

Run against the repo's pinned nightly (`nightly-2026-03-20`) and stable test toolchain:

- [x] `cargo +nightly-2026-03-20 fmt --all -- --check` — clean
- [x] `cargo +nightly-2026-03-20 clippy -p tn-network-libp2p --all-features --all-targets --locked -- -D warnings` — zero warnings
- [x] `cargo test -p tn-network-libp2p --lib` — 176 passed, 0 failed
