### PR TITLE
feat(network): cut the worker batch path over to the typed sync protocol with legacy fallback (739, step 5)

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -25,7 +25,7 @@ use tn_network_libp2p::{
         IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResponseMessage,
         NetworkResult,
     },
-    GossipMessage, Penalty, ResponseChannel, Stream,
+    GossipMessage, Penalty, ResponseChannel, Stream, StreamKind,
 };
 use tn_network_types::{WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{
@@ -398,8 +398,9 @@ impl PrimaryNetworkHandle {
                     "peer ack for stream request"
                 );
 
-                // open raw stream then write request_digest for correlation
-                let mut stream = self.handle.open_stream(peer).await??;
+                // open raw stream then write request_digest for correlation. The
+                // primary still uses the legacy path; its sync cutover is item 6.
+                let mut stream = self.handle.open_stream(peer, StreamKind::Legacy).await??;
                 stream.write_all(request_digest.as_slice()).await.map_err(|e| {
                     NetworkError::RPCError(format!("failed to write request digest: {e}"))
                 })?;
@@ -629,9 +630,20 @@ where
                     Ok(())
                 });
             }
-            NetworkEvent::InboundStream { peer, stream } => {
-                self.process_inbound_stream(peer, stream);
-            }
+            NetworkEvent::InboundStream { peer, kind, stream } => match kind {
+                StreamKind::Legacy => self.process_inbound_stream(peer, stream),
+                // the primary registers its sync protocol but opens no sync stream
+                // until the item-6 cutover; drop any unexpected inbound sync stream
+                // (metrics-only during rollout, no penalty)
+                StreamKind::Sync => {
+                    warn!(
+                        target: "primary::network",
+                        %peer,
+                        "dropping unexpected inbound sync stream (primary sync cutover is item 6)"
+                    );
+                    drop(stream);
+                }
+            },
         }
     }
 

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -5,18 +5,22 @@
 //! context.
 
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
+    sync::Arc,
     time::Duration,
 };
 
 use futures::{AsyncRead, AsyncWriteExt as _};
+use parking_lot::Mutex;
 use tn_network_libp2p::{
     error::NetworkError,
+    read_frame,
     types::{NetworkHandle, NetworkResponseMessage, NetworkResult},
-    Penalty,
+    write_frame, Penalty, StreamError, StreamKind, SyncFrame, WorkerSyncRequest,
 };
 use tn_types::{
-    encode, max_batch_size, Batch, BlockHash, BlsPublicKey, Epoch, SealedBatch, TaskSpawner, B256,
+    encode, max_batch_size, try_decode, Batch, BlockHash, BlsPublicKey, Epoch, SealedBatch,
+    TaskSpawner, B256,
 };
 use tracing::{debug, warn};
 
@@ -28,11 +32,37 @@ use crate::{
 /// Timeout for streaming a single batch from peer. Batches capped at 1MB.
 const BATCH_STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Timeout for the responder's first sync frame (`Ack`/`Deny`) after the request
+/// frame is written. A peer that negotiated the sync protocol but does not answer
+/// (e.g. an item-4 node that registered the protocol but reads the stream on the
+/// legacy digest path) trips this and the requester falls back to legacy.
+const SYNC_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Headroom added to `max_batch_size` for the sync-frame envelope (the `SyncFrame`
+/// enum tag and the `Data` length prefix) when bounding a decoded frame.
+const SYNC_FRAME_OVERHEAD: usize = 1024;
+
 /// Maximum number of retries through the full peer list in `request_batches()`.
 const MAX_BATCH_REQUEST_RETRIES: usize = 3;
 
 /// Delay between retry attempts in `request_batches()` to give semaphores time to release.
 const BATCH_REQUEST_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// The largest sync frame accepted for `epoch`: a `Data` frame carrying one
+/// encoded batch, plus envelope headroom.
+pub(crate) fn max_sync_frame_size(epoch: Epoch) -> usize {
+    max_batch_size(epoch).saturating_add(SYNC_FRAME_OVERHEAD)
+}
+
+/// The outcome of a sync-protocol batch fetch attempt.
+enum SyncAttempt {
+    /// The peer served the requested batches over the sync protocol.
+    Fetched(Vec<(BlockHash, Batch)>),
+    /// The peer did not answer the sync exchange; fall back to legacy.
+    Unsupported,
+    /// The peer answered but the exchange failed; try the next peer.
+    Failed(NetworkError),
+}
 
 /// The wrapper around worker-specific network calls.
 #[derive(Clone, Debug)]
@@ -43,12 +73,21 @@ pub struct WorkerNetworkHandle {
     task_spawner: TaskSpawner,
     /// The current epoch for this node.
     epoch: Epoch,
+    /// Per-peer sync-protocol capability, learned by probing.
+    ///
+    /// Absent means not yet probed (try the sync protocol); `false` means the
+    /// peer did not answer a sync open (a pre-item-4 peer that fails negotiation,
+    /// or an item-4 peer that registered the protocol but does not serve it), so
+    /// go straight to legacy; `true` means the peer served a sync exchange. The
+    /// cache is reset each epoch ([`Self::update_epoch`]) so a peer upgraded over
+    /// the rotation boundary is re-probed.
+    sync_capability: Arc<Mutex<HashMap<BlsPublicKey, bool>>>,
 }
 
 impl WorkerNetworkHandle {
     /// Create a new instance of [Self].
     pub fn new(handle: NetworkHandle<Req, Res>, task_spawner: TaskSpawner, epoch: Epoch) -> Self {
-        Self { handle, task_spawner, epoch }
+        Self { handle, task_spawner, epoch, sync_capability: Arc::new(Mutex::new(HashMap::new())) }
     }
 
     /// Return a reference to the task spawner.
@@ -204,13 +243,246 @@ impl WorkerNetworkHandle {
         }
     }
 
-    /// Request batches from a single peer via stream.
+    /// Request batches from a single peer, preferring the typed sync protocol.
+    ///
+    /// Unless the peer is cached as legacy-only, this first attempts a
+    /// `/tn-worker-{id}-sync` exchange that folds the request into the opening
+    /// stream frame. If the peer does not answer that exchange — it fails
+    /// negotiation (a pre-item-4 peer), or it negotiated the protocol but sent no
+    /// `Ack` (an item-4 peer that registered the protocol without serving it) —
+    /// the peer is cached as legacy-only and the request falls back to the legacy
+    /// `RequestBatchesStream` ack-plus-digest path. The sync probe is
+    /// penalty-exempt, so falling back never lowers the peer's score.
+    async fn request_batches_from_peer(
+        &self,
+        peer: BlsPublicKey,
+        batch_digests: &BTreeSet<BlockHash>,
+    ) -> NetworkResult<Vec<(BlockHash, Batch)>> {
+        // sanity check - should never happen
+        if batch_digests.is_empty() {
+            warn!(target: "worker::network", "requested empty batches from peer!");
+            return Ok(vec![]);
+        }
+
+        // a peer known not to serve sync skips the probe entirely this epoch
+        if self.sync_capability.lock().get(&peer) == Some(&false) {
+            return self.request_batches_from_peer_legacy(peer, batch_digests).await;
+        }
+
+        match self.request_batches_from_peer_sync(peer, batch_digests).await {
+            SyncAttempt::Fetched(batches) => {
+                self.sync_capability.lock().insert(peer, true);
+                Ok(batches)
+            }
+            SyncAttempt::Unsupported => {
+                self.sync_capability.lock().insert(peer, false);
+                debug!(
+                    target: "worker::network",
+                    %peer,
+                    "peer did not answer sync, falling back to legacy batch request"
+                );
+                self.request_batches_from_peer_legacy(peer, batch_digests).await
+            }
+            SyncAttempt::Failed(e) => {
+                // the peer speaks sync but this exchange failed; try the next peer
+                self.sync_capability.lock().insert(peer, true);
+                Err(e)
+            }
+        }
+    }
+
+    /// Attempt a batch fetch over the typed sync protocol.
+    ///
+    /// Opens a `/tn-worker-{id}-sync` stream, writes the request in the opening
+    /// [`SyncFrame::Req`] frame, and reads the response: an [`SyncFrame::Ack`]
+    /// followed by [`SyncFrame::Data`] frames terminated by [`SyncFrame::End`].
+    /// Returns [`SyncAttempt::Unsupported`] when the peer does not answer (so the
+    /// caller falls back to legacy), [`SyncAttempt::Fetched`] on success, or
+    /// [`SyncAttempt::Failed`] when the peer answered but the exchange failed.
+    async fn request_batches_from_peer_sync(
+        &self,
+        peer: BlsPublicKey,
+        batch_digests: &BTreeSet<BlockHash>,
+    ) -> SyncAttempt {
+        self.try_sync_batch_exchange(peer, batch_digests)
+            .await
+            .map_or_else(|attempt| attempt, SyncAttempt::Fetched)
+    }
+
+    /// Run one sync exchange, yielding the fetched batches or the classified
+    /// non-fetch outcome.
+    ///
+    /// `Err(SyncAttempt::Unsupported)` means the peer did not answer the protocol
+    /// (negotiation failed, or it negotiated but never sent `Ack`), so the caller
+    /// falls back to legacy. `Err(SyncAttempt::Failed(_))` means a transient or
+    /// exchange-level error once the peer has proved sync-capable, so the caller
+    /// keeps it sync-capable and tries the next peer. A transport I/O error during
+    /// the open (`UpgradeIo`) is transient rather than a protocol mismatch, so it
+    /// maps to `Failed` instead of poisoning the per-epoch capability cache.
+    async fn try_sync_batch_exchange(
+        &self,
+        peer: BlsPublicKey,
+        batch_digests: &BTreeSet<BlockHash>,
+    ) -> Result<Vec<(BlockHash, Batch)>, SyncAttempt> {
+        // open the sync stream, flattening the command-channel and stream-open
+        // results. Only a genuine negotiation failure (`UpgradeFailed`) is a
+        // pre-item-4 peer that does not advertise the protocol -> Unsupported
+        // (penalty-exempt, cached legacy-only). A transient upgrade I/O error or
+        // any other open error is not proof the peer lacks sync -> try next peer.
+        let mut stream =
+            self.handle.open_stream(peer, StreamKind::Sync).await.and_then(|s| s).map_err(|e| {
+                match () {
+                    () if matches!(e, NetworkError::Stream(StreamError::UpgradeFailed)) => {
+                        SyncAttempt::Unsupported
+                    }
+                    () => SyncAttempt::Failed(e),
+                }
+            })?;
+
+        // write the request in the opening frame. Negotiation already succeeded,
+        // so the peer is sync-capable; a write failure is transient -> try next.
+        let max_frame = max_sync_frame_size(self.epoch());
+        let request = SyncFrame::Req(WorkerSyncRequest::Batches {
+            batch_digests: batch_digests.clone(),
+            epoch: self.epoch(),
+        });
+        let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        write_frame(&mut stream, &request, &mut encode_buffer, &mut compressed_buffer, max_frame)
+            .await
+            .and(stream.flush().await)
+            .map_err(|e| {
+                SyncAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "failed to write sync request frame: {e}"
+                )))
+            })?;
+
+        // read the responder's first frame. A timeout (outer `Err`) means no `Ack`
+        // -> an item-4 peer that negotiated sync but does not serve it, so fall
+        // back to legacy. A read I/O error (inner `Err`) after negotiation is
+        // transient -> try the next peer.
+        let (mut decode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        let first = tokio::time::timeout(
+            SYNC_ACK_TIMEOUT,
+            read_frame::<_, WorkerSyncRequest>(
+                &mut stream,
+                &mut decode_buffer,
+                &mut compressed_buffer,
+                max_frame,
+            ),
+        )
+        .await
+        .map_err(|_elapsed| SyncAttempt::Unsupported)?
+        .map_err(|e| {
+            SyncAttempt::Failed(NetworkError::RPCRetryable(format!(
+                "failed to read sync ack frame: {e}"
+            )))
+        })?;
+
+        match first {
+            SyncFrame::Ack => self
+                .read_sync_batches(&mut stream, batch_digests)
+                .await
+                .map_err(SyncAttempt::Failed),
+            // sync-capable, but shedding load or lacking the data: try next peer
+            SyncFrame::Deny(reason) => Err(SyncAttempt::Failed(NetworkError::RPCRetryable(
+                format!("peer denied sync batch request: {reason:?}"),
+            ))),
+            SyncFrame::Err(err) => Err(SyncAttempt::Failed(NetworkError::RPCError(format!(
+                "peer aborted sync batch exchange: {err:?}"
+            )))),
+            // a well-behaved responder never opens with these
+            SyncFrame::Req(_) | SyncFrame::Data(_) | SyncFrame::End => Err(SyncAttempt::Failed(
+                NetworkError::ProtocolError("unexpected opening sync frame from peer".to_string()),
+            )),
+        }
+    }
+
+    /// Read `Data` frames terminated by `End` from an accepted sync exchange,
+    /// decoding and validating each batch as it arrives.
+    ///
+    /// Mirrors the legacy reader's validation: every batch must have been
+    /// requested, none may repeat, and the running total may not exceed the
+    /// request. Each frame read is bounded by [`BATCH_STREAM_TIMEOUT`].
+    pub(crate) async fn read_sync_batches<S: AsyncRead + Unpin + Send>(
+        &self,
+        stream: &mut S,
+        requested_digests: &BTreeSet<BlockHash>,
+    ) -> NetworkResult<Vec<(BlockHash, Batch)>> {
+        let max_frame = max_sync_frame_size(self.epoch());
+        let (mut decode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        let mut batches = Vec::with_capacity(requested_digests.len());
+        let mut received_digests = HashSet::with_capacity(requested_digests.len());
+
+        loop {
+            let frame = tokio::time::timeout(
+                BATCH_STREAM_TIMEOUT,
+                read_frame::<_, WorkerSyncRequest>(
+                    stream,
+                    &mut decode_buffer,
+                    &mut compressed_buffer,
+                    max_frame,
+                ),
+            )
+            .await
+            .map_err(|_| {
+                warn!(target: "worker::network", "timeout reading sync batch frame");
+                NetworkError::Timeout
+            })?
+            .map_err(|e| NetworkError::RPCError(format!("failed to read sync frame: {e}")))?;
+
+            match frame {
+                SyncFrame::Data(bytes) => {
+                    // running total must not exceed the request
+                    if batches.len() >= requested_digests.len() {
+                        return Err(NetworkError::ProtocolError(format!(
+                            "Peer sent too many batches: expected {}",
+                            requested_digests.len()
+                        )));
+                    }
+                    let batch: Batch = try_decode(&bytes).map_err(|e| {
+                        NetworkError::ProtocolError(format!("failed to decode sync batch: {e}"))
+                    })?;
+                    let batch_digest = batch.digest();
+
+                    // validate batch was requested
+                    if !requested_digests.contains(&batch_digest) {
+                        return Err(NetworkError::ProtocolError(format!(
+                            "Peer sent unexpected batch with digest {batch_digest}"
+                        )));
+                    }
+                    // validate batch is unique (no duplicates)
+                    if !received_digests.insert(batch_digest) {
+                        return Err(NetworkError::ProtocolError(format!(
+                            "Peer sent duplicate batch with digest {batch_digest}"
+                        )));
+                    }
+                    batches.push((batch_digest, batch));
+                }
+                SyncFrame::End => break,
+                SyncFrame::Err(err) => {
+                    return Err(NetworkError::RPCError(format!(
+                        "peer aborted sync batch stream: {err:?}"
+                    )))
+                }
+                // a well-behaved responder never sends these mid-stream
+                SyncFrame::Ack | SyncFrame::Deny(_) | SyncFrame::Req(_) => {
+                    return Err(NetworkError::ProtocolError(
+                        "unexpected sync frame during batch stream".to_string(),
+                    ))
+                }
+            }
+        }
+
+        Ok(batches)
+    }
+
+    /// Request batches from a single peer over the legacy `/tn-stream` path.
     ///
     /// This method:
     /// 1. Sends a `RequestBatchesStream` request to negotiate
     /// 2. If accepted, opens a stream with the request digest for correlation
     /// 3. Reads and validates batches from the stream in real-time
-    async fn request_batches_from_peer(
+    async fn request_batches_from_peer_legacy(
         &self,
         peer: BlsPublicKey,
         batch_digests: &BTreeSet<BlockHash>,
@@ -250,7 +522,7 @@ impl WorkerNetworkHandle {
                 );
 
                 // open raw stream then write request_digest for correlation
-                let mut stream = self.handle.open_stream(peer).await??;
+                let mut stream = self.handle.open_stream(peer, StreamKind::Legacy).await??;
                 stream.write_all(request_digest.as_slice()).await.map_err(|e| {
                     NetworkError::RPCError(format!("failed to write request digest: {e}"))
                 })?;
@@ -401,8 +673,13 @@ impl WorkerNetworkHandle {
     }
 
     /// Update the current epoch.
+    ///
+    /// Also clears the per-peer sync capability cache: committees rotate at the
+    /// boundary and binaries are upgraded there, so a peer that could only speak
+    /// legacy last epoch is re-probed for the sync protocol this epoch.
     pub fn update_epoch(&mut self, epoch: Epoch) {
         self.epoch = epoch;
+        self.sync_capability.lock().clear();
     }
 
     /// Helper method to digest missing batch request before initiating stream.
@@ -423,7 +700,12 @@ impl WorkerNetworkHandle {
     /// nothing.
     pub fn new_for_test(task_spawner: TaskSpawner) -> Self {
         let (tx, _rx) = tokio::sync::mpsc::channel(5);
-        Self { handle: NetworkHandle::new(tx), task_spawner, epoch: 0 }
+        Self {
+            handle: NetworkHandle::new(tx),
+            task_spawner,
+            epoch: 0,
+            sync_capability: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 
     /// Publicly available for tests.

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -12,11 +12,14 @@ use crate::{
 use futures::AsyncWriteExt as _;
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
-use tn_network_libp2p::{GossipMessage, Stream};
+use tn_network_libp2p::{
+    write_frame, GossipMessage, Stream, SyncFrame, SyncFrameError, WorkerSyncRequest,
+};
 use tn_network_types::{WorkerOthersBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
 use tn_types::{
-    ensure, now, try_decode, BatchValidation, BlsPublicKey, Database, SealedBatch, WorkerId, B256,
+    ensure, now, try_decode, BatchValidation, BlsPublicKey, Database, Epoch, SealedBatch, WorkerId,
+    B256,
 };
 use tracing::{debug, warn};
 
@@ -234,6 +237,74 @@ where
             Err(_elapsed) => {
                 warn!(target: "worker::network", %peer, ?request_digest, "sending batches stream timed out");
             }
+        }
+
+        // attempt to close the stream gracefully
+        let _ = stream.close().await;
+
+        Ok(())
+    }
+
+    /// Serve an admitted inbound sync batch exchange.
+    ///
+    /// The opening [`SyncFrame::Req`] has already been read and validated by the
+    /// caller, and the exchange has been admitted against the concurrency caps.
+    /// This writes the [`SyncFrame::Ack`], streams the requested batches as
+    /// [`SyncFrame::Data`] frames, and ends the stream with [`SyncFrame::End`].
+    ///
+    /// A send failure or storage error is logged and best-effort signalled to the
+    /// requester with a [`SyncFrame::Err`] so it stops waiting; it is not a peer
+    /// fault, so no penalty is returned. Like the legacy responder, the sync
+    /// responder reports errors metrics-only during the item-5 rollout.
+    pub(super) async fn process_sync_batches_stream(
+        &self,
+        peer: BlsPublicKey,
+        mut stream: Stream,
+        batch_digests: BTreeSet<B256>,
+        epoch: Epoch,
+        consensus_chain: &ConsensusChain,
+    ) -> WorkerNetworkResult<()> {
+        debug!(
+            target: "worker::network",
+            %peer,
+            batch_count = batch_digests.len(),
+            epoch,
+            "serving inbound sync batch stream"
+        );
+
+        let store = self.consensus_config.node_storage();
+        let max_frame = crate::network::handle::max_sync_frame_size(epoch);
+
+        // set timeout to prevent slow-read attack; flatten the timeout's outer
+        // `Result` into the send's so a single error path handles both
+        let served = tokio::time::timeout(
+            SEND_STREAM_TIMEOUT,
+            stream_codec::send_sync_batches_over_stream(
+                &mut stream,
+                store,
+                consensus_chain,
+                &batch_digests,
+                epoch,
+                max_frame,
+            ),
+        )
+        .await
+        .map_err(WorkerNetworkError::from)
+        .and_then(|sent| sent);
+
+        // a send failure or timeout is logged and best-effort signalled so the
+        // requester stops waiting; it is not a peer fault, so no penalty
+        if let Err(e) = served {
+            warn!(target: "worker::network", %peer, ?e, "failed to serve sync batch stream");
+            let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+            let _ = write_frame(
+                &mut stream,
+                &SyncFrame::<WorkerSyncRequest>::Err(SyncFrameError::Internal),
+                &mut encode_buffer,
+                &mut compressed_buffer,
+                max_frame,
+            )
+            .await;
         }
 
         // attempt to close the stream gracefully

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -1,7 +1,8 @@
 //! Worker network implementation.
 
 use error::WorkerNetworkError;
-use futures::AsyncReadExt as _;
+use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+use handle::max_sync_frame_size;
 pub use handle::WorkerNetworkHandle;
 use handler::RequestHandler;
 pub use message::{WorkerRequest, WorkerResponse};
@@ -12,7 +13,10 @@ use std::{
     time::{Duration, Instant},
 };
 use tn_config::ConsensusConfig;
-use tn_network_libp2p::{types::NetworkEvent, GossipMessage, ResponseChannel, Stream};
+use tn_network_libp2p::{
+    read_frame, types::NetworkEvent, write_frame, DenyReason, GossipMessage, ResponseChannel,
+    Stream, StreamKind, SyncFrame, SyncFrameError, WorkerSyncRequest,
+};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     BatchValidation, BlockHash, BlsPublicKey, Database, Epoch, SealedBatch, TaskError, TaskSpawner,
@@ -57,6 +61,12 @@ pub const MAX_BATCH_DIGESTS_PER_REQUEST: usize = 500;
 ///
 /// Prevents a single malicious peer from filling all global slots.
 pub const MAX_PENDING_REQUESTS_PER_PEER: usize = 2;
+
+/// Timeout for reading the opening request frame of an inbound sync stream.
+///
+/// A peer that opens a sync stream but never sends its request frame trips this
+/// and the stream is dropped, so it cannot hold an admission slot indefinitely.
+const SYNC_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Tracks a pending batch stream request awaiting stream establishment.
 // pub for IT
@@ -105,6 +115,61 @@ impl PendingBatchStream {
     }
 }
 
+/// RAII guard for an admitted sync batch stream.
+///
+/// Holds a global concurrency permit and counts toward the peer's per-peer
+/// in-flight total. Dropping it releases the global slot and decrements the
+/// per-peer count, so a finished or aborted exchange frees capacity for both
+/// the sync and legacy paths.
+#[derive(Debug)]
+struct SyncStreamPermit {
+    /// Global concurrency permit, released on drop.
+    _permit: OwnedSemaphorePermit,
+    /// Shared per-peer in-flight counter, decremented on drop.
+    peers: Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
+    /// The peer whose count this permit holds.
+    peer: BlsPublicKey,
+}
+
+impl Drop for SyncStreamPermit {
+    fn drop(&mut self) {
+        let mut peers = self.peers.lock();
+        if let Some(count) = peers.get_mut(&self.peer) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                peers.remove(&self.peer);
+            }
+        }
+    }
+}
+
+/// Try to admit one inbound sync batch stream for `peer`.
+///
+/// Acquires a global permit and admits only if the peer's combined in-flight
+/// count (legacy pending requests plus sync streams) is below
+/// [`MAX_PENDING_REQUESTS_PER_PEER`], so the per-peer cap holds across both
+/// paths. Returns `None` (shedding the global permit) when either cap is hit.
+///
+/// Locks `pending_batch_requests` before `sync_stream_peers`; the legacy
+/// admission path takes the same order, so the two never deadlock.
+fn try_admit_sync(
+    semaphore: &Arc<Semaphore>,
+    pending: &Arc<Mutex<HashMap<PendingBatchRequestKey, PendingBatchStream>>>,
+    sync_peers: &Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
+    peer: BlsPublicKey,
+) -> Option<SyncStreamPermit> {
+    let permit = semaphore.clone().try_acquire_owned().ok()?;
+    let pending_guard = pending.lock();
+    let legacy_count = pending_guard.keys().filter(|(p, _)| *p == peer).count();
+    let mut sync_guard = sync_peers.lock();
+    let sync_count = sync_guard.get(&peer).copied().unwrap_or(0);
+    if legacy_count + sync_count >= MAX_PENDING_REQUESTS_PER_PEER {
+        return None;
+    }
+    *sync_guard.entry(peer).or_insert(0) += 1;
+    Some(SyncStreamPermit { _permit: permit, peers: sync_peers.clone(), peer })
+}
+
 /// Handle inter-node communication between primaries.
 #[derive(Debug)]
 pub struct WorkerNetwork<DB, Events> {
@@ -120,7 +185,17 @@ pub struct WorkerNetwork<DB, Events> {
     /// request after reading the correlation digest from the stream.
     pending_batch_requests: Arc<Mutex<HashMap<PendingBatchRequestKey, PendingBatchStream>>>,
     /// Semaphore bounding total concurrent batch stream operations (pending + active).
+    ///
+    /// Shared by the legacy and sync responder paths so the global concurrency cap
+    /// of [`MAX_CONCURRENT_BATCH_STREAMS`] is the combined limit across both.
     batch_stream_semaphore: Arc<Semaphore>,
+    /// Per-peer count of in-flight sync batch streams.
+    ///
+    /// The legacy per-peer count comes from `pending_batch_requests`; this counts
+    /// the sync path's in-flight exchanges. Admission on either path checks the
+    /// sum against [`MAX_PENDING_REQUESTS_PER_PEER`], so the per-peer cap is the
+    /// combined limit across both paths.
+    sync_stream_peers: Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
     /// Access to the consensus chain.
     consensus_chain: ConsensusChain,
 }
@@ -147,6 +222,7 @@ where
             request_handler,
             pending_batch_requests: Arc::new(Mutex::new(HashMap::new())),
             batch_stream_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_BATCH_STREAMS)),
+            sync_stream_peers: Arc::new(Mutex::new(HashMap::new())),
             consensus_chain,
         }
     }
@@ -215,9 +291,10 @@ where
                     },
                 );
             }
-            NetworkEvent::InboundStream { peer, stream } => {
-                self.process_inbound_stream(peer, stream);
-            }
+            NetworkEvent::InboundStream { peer, kind, stream } => match kind {
+                StreamKind::Legacy => self.process_inbound_stream(peer, stream),
+                StreamKind::Sync => self.process_inbound_sync_stream(peer, stream),
+            },
         }
     }
 
@@ -317,8 +394,14 @@ where
                 Ok(permit) => {
                     let mut pending_map = self.pending_batch_requests.lock();
 
-                    // check per-peer capacity
-                    let peer_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
+                    // check per-peer capacity. The cap is the combined limit
+                    // across the legacy and sync paths, so add this peer's
+                    // in-flight sync streams to its legacy pending count. Locks
+                    // pending then sync_stream_peers, matching try_admit_sync's
+                    // order so the two admission paths never deadlock.
+                    let legacy_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
+                    let sync_count = self.sync_stream_peers.lock().get(&peer).copied().unwrap_or(0);
+                    let peer_count = legacy_count + sync_count;
                     if peer_count >= MAX_PENDING_REQUESTS_PER_PEER {
                         debug!(
                             target: "worker::network",
@@ -444,6 +527,131 @@ where
                 } else {
                     Ok(())
                 }
+        });
+    }
+
+    /// Process an inbound sync-protocol batch stream.
+    ///
+    /// The request travels in the opening [`SyncFrame::Req`] frame (no prior
+    /// request-response ack), so admission against the shared concurrency caps
+    /// happens here on stream open. A shedding responder writes
+    /// [`DenyReason::AtCapacity`] without reading, so the requester gives up
+    /// immediately and tries elsewhere. Once admitted, the opening request frame
+    /// is read (bounded by [`SYNC_REQUEST_READ_TIMEOUT`]) and the batches are
+    /// served by [`RequestHandler::process_sync_batches_stream`]. The admission
+    /// permit is held for the lifetime of the spawned task.
+    fn process_inbound_sync_stream(&self, peer: BlsPublicKey, stream: Stream) {
+        // admit against the shared caps before spawning; the permit (if any) moves
+        // into the task and frees capacity on drop
+        let permit = try_admit_sync(
+            &self.batch_stream_semaphore,
+            &self.pending_batch_requests,
+            &self.sync_stream_peers,
+            peer,
+        );
+        let request_handler = self.request_handler.clone();
+        let consensus_chain = self.consensus_chain.clone();
+        let epoch = self.network_handle.epoch();
+        let task_name = format!("sync-batches-{peer}");
+        self.network_handle.get_task_spawner().spawn_task(task_name, async move {
+            let mut stream = stream;
+            let max_frame = max_sync_frame_size(epoch);
+            let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+
+            // shed load: deny without reading so the requester retries elsewhere
+            let Some(_permit) = permit else {
+                debug!(target: "worker::network", %peer, "denying inbound sync stream: at capacity");
+                // bound the best-effort shed write: a peer that applies receive
+                // backpressure and never reads must not stall this task (no permit
+                // is held here, but the spawned task would otherwise linger).
+                let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, async {
+                    let _ = write_frame(
+                        &mut stream,
+                        &SyncFrame::<WorkerSyncRequest>::Deny(DenyReason::AtCapacity),
+                        &mut encode_buffer,
+                        &mut compressed_buffer,
+                        max_frame,
+                    )
+                    .await;
+                    let _ = stream.close().await;
+                })
+                .await;
+                return Ok(());
+            };
+
+            // read the opening request frame; a peer that never sends one (timeout)
+            // or sends a malformed one (io error) is dropped after releasing the
+            // permit. Collapse the timeout/io results rather than nesting matches.
+            let (mut decode_buffer, mut decompress_buffer) = (Vec::new(), Vec::new());
+            let request = tokio::time::timeout(
+                SYNC_REQUEST_READ_TIMEOUT,
+                read_frame::<_, WorkerSyncRequest>(
+                    &mut stream,
+                    &mut decode_buffer,
+                    &mut decompress_buffer,
+                    max_frame,
+                ),
+            )
+            .await
+            .ok()
+            .and_then(Result::ok);
+            let Some(request) = request else {
+                warn!(target: "worker::network", %peer, "no readable sync request frame");
+                let _ = stream.close().await;
+                return Ok(());
+            };
+
+            match request {
+                SyncFrame::Req(WorkerSyncRequest::Batches { batch_digests, epoch: req_epoch }) => {
+                    // cap to the node's max, mirroring the legacy responder
+                    let batch_digests: BTreeSet<B256> =
+                        if batch_digests.len() > MAX_BATCH_DIGESTS_PER_REQUEST {
+                            warn!(
+                                target: "worker::network",
+                                %peer,
+                                requested = batch_digests.len(),
+                                max = MAX_BATCH_DIGESTS_PER_REQUEST,
+                                "truncating oversized sync batch request"
+                            );
+                            batch_digests.into_iter().take(MAX_BATCH_DIGESTS_PER_REQUEST).collect()
+                        } else {
+                            batch_digests
+                        };
+                    request_handler
+                        .process_sync_batches_stream(
+                            peer,
+                            stream,
+                            batch_digests,
+                            req_epoch,
+                            &consensus_chain,
+                        )
+                        .await?;
+                }
+                // a well-behaved requester always opens with `Req`; anything else
+                // is malformed. Signal it and drop (metrics-only, no penalty).
+                SyncFrame::Ack
+                | SyncFrame::Deny(_)
+                | SyncFrame::Data(_)
+                | SyncFrame::End
+                | SyncFrame::Err(_) => {
+                    warn!(target: "worker::network", %peer, "unexpected opening sync frame from requester");
+                    // bound the best-effort error write so a non-reading peer
+                    // cannot pin the held admission permit on an unbounded write.
+                    let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, async {
+                        let _ = write_frame(
+                            &mut stream,
+                            &SyncFrame::<WorkerSyncRequest>::Err(SyncFrameError::Malformed),
+                            &mut encode_buffer,
+                            &mut compressed_buffer,
+                            max_frame,
+                        )
+                        .await;
+                        let _ = stream.close().await;
+                    })
+                    .await;
+                }
+            }
+            Ok(())
         });
     }
 

--- a/crates/consensus/worker/src/network/stream_codec.rs
+++ b/crates/consensus/worker/src/network/stream_codec.rs
@@ -11,8 +11,9 @@ use crate::batch_fetcher::get_batches_local;
 use super::error::{WorkerNetworkError, WorkerNetworkResult};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use std::collections::BTreeSet;
+use tn_network_libp2p::{write_frame, SyncFrame, WorkerSyncRequest};
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{max_batch_size, Batch, Database, Epoch, B256};
+use tn_types::{encode, max_batch_size, Batch, Database, Epoch, B256};
 
 /// Max number of batch digests per chunk.
 /// Batch db reads are chunked to limit the amount of batches in memory.
@@ -122,6 +123,73 @@ where
     Ok(())
 }
 
+/// Serve an accepted sync batch exchange over `stream`.
+///
+/// Writes a [`SyncFrame::Ack`], then one [`SyncFrame::Data`] frame per batch
+/// found in storage (looked up in chunks), terminated by a [`SyncFrame::End`].
+/// Each `Data` payload is the BCS-encoded [`Batch`]; the frame layer adds its own
+/// length prefix and compression, bounded by `max_frame`.
+///
+/// Mirrors [`send_batches_over_stream`]'s partial-DB behaviour: only batches
+/// present in storage are streamed, so a requester tolerant of partial results
+/// fetches the rest elsewhere. The caller has already admitted the exchange
+/// against the concurrency caps and read the opening request frame.
+pub(crate) async fn send_sync_batches_over_stream<DB, S>(
+    stream: &mut S,
+    store: &DB,
+    consensus_chain: &ConsensusChain,
+    batch_digests: &BTreeSet<B256>,
+    epoch: Epoch,
+    max_frame: usize,
+) -> WorkerNetworkResult<()>
+where
+    DB: Database,
+    S: AsyncWrite + Unpin + Send,
+{
+    let max_size = max_batch_size(epoch);
+
+    // reusable buffers for the frame layer
+    let mut encode_buffer = Vec::with_capacity(max_size);
+    let mut compressed_buffer = Vec::with_capacity(snap::raw::max_compress_len(max_size));
+
+    // accept the exchange before streaming any data
+    write_frame(
+        stream,
+        &SyncFrame::<WorkerSyncRequest>::Ack,
+        &mut encode_buffer,
+        &mut compressed_buffer,
+        max_frame,
+    )
+    .await?;
+
+    // stream each found batch as its own Data frame (chunked DB reads)
+    let digests: Vec<_> = batch_digests.iter().copied().collect();
+    for chunk in digests.chunks(BATCH_DIGESTS_READ_CHUNK_SIZE) {
+        let batches: Vec<_> = get_batches_local(epoch, chunk, store, consensus_chain).await?;
+        for batch in &batches {
+            let frame = SyncFrame::<WorkerSyncRequest>::Data(encode(batch));
+            write_frame(stream, &frame, &mut encode_buffer, &mut compressed_buffer, max_frame)
+                .await?;
+        }
+
+        // flush per chunk
+        stream.flush().await?;
+    }
+
+    // orderly end of the response stream
+    write_frame(
+        stream,
+        &SyncFrame::<WorkerSyncRequest>::End,
+        &mut encode_buffer,
+        &mut compressed_buffer,
+        max_frame,
+    )
+    .await?;
+    stream.flush().await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -134,7 +202,19 @@ mod tests {
     use snap::read::FrameDecoder;
     use std::io::Read;
     use tempfile::TempDir;
+    use tn_network_libp2p::read_frame;
     use tn_types::{max_batch_size, TaskManager};
+
+    /// Read the opening [`SyncFrame::Ack`] a sync responder writes, asserting it
+    /// is in fact an `Ack`, leaving the cursor positioned at the first `Data`
+    /// frame for [`WorkerNetworkHandle::read_sync_batches`].
+    async fn read_sync_ack(cursor: &mut Cursor<Vec<u8>>, max_frame: usize) {
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        let first = read_frame::<_, WorkerSyncRequest>(cursor, &mut dec, &mut comp, max_frame)
+            .await
+            .expect("read ack frame");
+        assert!(matches!(first, SyncFrame::Ack), "responder opens with Ack");
+    }
 
     /// Helper to write batch to buffer and return it
     async fn encode_batch_to_vec(batch: &Batch) -> Vec<u8> {
@@ -411,5 +491,107 @@ mod tests {
         assert_eq!(result.len(), batch_count);
         let received_digests: BTreeSet<B256> = result.iter().map(|(d, _)| *d).collect();
         assert_eq!(received_digests, digests);
+    }
+
+    /// The sync responder's `Ack`+`Data`+`End` framing round-trips through the
+    /// requester's `read_sync_batches` reader: every served batch is received,
+    /// validated, and matched to its digest. This is the cross-version contract
+    /// between an item-5 responder and an item-5 requester.
+    #[tokio::test]
+    async fn test_send_receive_sync_roundtrip() {
+        let batches = create_test_batches(3);
+        let db = setup_batch_db(&batches);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+        let digests: BTreeSet<B256> = batches.iter().map(|b| b.digest()).collect();
+        let max_frame = crate::network::handle::max_sync_frame_size(0);
+
+        // responder serializes Ack + one Data frame per batch + End
+        let mut output = Vec::new();
+        send_sync_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0, max_frame)
+            .await
+            .expect("serve sync batches");
+
+        // requester reads the opening Ack, then the Data/End stream
+        let mut cursor = Cursor::new(output);
+        read_sync_ack(&mut cursor, max_frame).await;
+
+        let task_manager = TaskManager::default();
+        let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
+        let result =
+            handle.read_sync_batches(&mut cursor, &digests).await.expect("read sync batches");
+
+        assert_eq!(result.len(), batches.len());
+        let received: BTreeSet<B256> = result.iter().map(|(d, _)| *d).collect();
+        assert_eq!(received, digests);
+    }
+
+    /// A responder that holds only a subset of the requested batches serves those
+    /// it has and still ends the stream cleanly; the requester accepts the
+    /// partial result without error (mirrors the legacy partial-DB behaviour).
+    #[tokio::test]
+    async fn test_send_receive_sync_partial_db() {
+        let batches = create_test_batches(3);
+        // only the first two batches are in the DB
+        let db = setup_batch_db(&batches[..2]);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+        consensus_chain.persist_current().await.expect("clean open");
+
+        // request all three digests
+        let digests: BTreeSet<B256> = batches.iter().map(|b| b.digest()).collect();
+        let max_frame = crate::network::handle::max_sync_frame_size(0);
+
+        let mut output = Vec::new();
+        send_sync_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0, max_frame)
+            .await
+            .expect("serve sync batches");
+
+        let mut cursor = Cursor::new(output);
+        read_sync_ack(&mut cursor, max_frame).await;
+
+        let task_manager = TaskManager::default();
+        let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
+        let result =
+            handle.read_sync_batches(&mut cursor, &digests).await.expect("read sync batches");
+
+        // only the two batches present in the DB are served
+        let expected: BTreeSet<B256> = batches[..2].iter().map(|b| b.digest()).collect();
+        let received: BTreeSet<B256> = result.iter().map(|(d, _)| *d).collect();
+        assert_eq!(received, expected);
+    }
+
+    /// Multi-chunk sync serve (>200 batches): the responder emits one Data frame
+    /// per batch across chunk boundaries and the requester reassembles them all.
+    #[tokio::test]
+    async fn test_send_receive_sync_multi_chunk() {
+        let batch_count = BATCH_DIGESTS_READ_CHUNK_SIZE + 50;
+        let batches = create_test_batches(batch_count);
+        let db = setup_batch_db(&batches);
+        let temp_dir = TempDir::new().expect("tempdir");
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+        let digests: BTreeSet<B256> = batches.iter().map(|b| b.digest()).collect();
+        assert_eq!(digests.len(), batch_count);
+        let max_frame = crate::network::handle::max_sync_frame_size(0);
+
+        let mut output = Vec::new();
+        send_sync_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0, max_frame)
+            .await
+            .expect("serve sync batches");
+
+        let mut cursor = Cursor::new(output);
+        read_sync_ack(&mut cursor, max_frame).await;
+
+        let task_manager = TaskManager::default();
+        let handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
+        let result =
+            handle.read_sync_batches(&mut cursor, &digests).await.expect("read sync batches");
+
+        assert_eq!(result.len(), batch_count);
+        let received: BTreeSet<B256> = result.iter().map(|(d, _)| *d).collect();
+        assert_eq!(received, digests);
     }
 }

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -4,8 +4,9 @@ use assert_matches::assert_matches;
 use std::{collections::BTreeSet, sync::Arc};
 use tn_batch_validator::NoopBatchValidator;
 use tn_network_libp2p::{
+    error::NetworkError,
     types::{NetworkCommand, NetworkHandle, NetworkResponseMessage},
-    GossipMessage, Penalty, TopicHash,
+    GossipMessage, Penalty, StreamError, StreamKind, TopicHash,
 };
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
@@ -44,6 +45,26 @@ fn create_test_types() -> TestTypes {
         WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0);
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
+}
+
+/// Deny a sync-protocol `OpenStream` command, simulating a legacy-only peer so
+/// the requester falls back to the legacy `RequestBatchesStream` path.
+///
+/// Since item 5 makes the worker requester open a `/tn-worker-{id}-sync` stream
+/// first, every legacy-flow test must answer that probe. Returning
+/// [`StreamError::UpgradeFailed`] is exactly what a pre-item-4 peer's failed
+/// negotiation surfaces, so the requester caches the peer as legacy-only and the
+/// rest of the test drives the unchanged legacy handshake. A non-sync command is
+/// returned untouched for the test's own loop to handle.
+fn deny_sync_open(
+    command: NetworkCommand<WorkerRequest, WorkerResponse>,
+) -> Option<NetworkCommand<WorkerRequest, WorkerResponse>> {
+    if let NetworkCommand::OpenStream { kind: StreamKind::Sync, reply, .. } = command {
+        let _ = reply.send(Err(NetworkError::Stream(StreamError::UpgradeFailed)));
+        None
+    } else {
+        Some(command)
+    }
 }
 
 // ============================================================================
@@ -128,6 +149,7 @@ async fn test_batch_gossip_triggers_stream_request() {
     // recv commands
     let expected_peer = committee.last_authority().primary_public_key();
     while let Some(command) = network_commands_rx.recv().await {
+        let Some(command) = deny_sync_open(command) else { continue };
         match command {
             NetworkCommand::ConnectedPeers { reply } => {
                 // request_batches calls this first
@@ -181,6 +203,7 @@ async fn test_batch_gossip_stream_accepted_opens_stream() {
     let mut stream_request_acked = false;
 
     while let Some(command) = network_commands_rx.recv().await {
+        let Some(command) = deny_sync_open(command) else { continue };
         match command {
             NetworkCommand::ConnectedPeers { reply } => {
                 reply.send(vec![expected_peer]).expect("peer sent");
@@ -202,8 +225,9 @@ async fn test_batch_gossip_stream_accepted_opens_stream() {
                     _ => panic!("expected RequestBatchesStream, got {:?}", request),
                 }
             }
-            NetworkCommand::OpenStream { peer, reply } => {
-                // Verify OpenStream is called after ack
+            NetworkCommand::OpenStream { peer, reply, .. } => {
+                // the sync probe was denied above, so this is the legacy open
+                // after the ack
                 assert!(stream_request_acked, "OpenStream should come after ack");
                 assert_eq!(peer, expected_peer);
                 // Don't complete the stream - just verify command was sent
@@ -283,20 +307,23 @@ async fn test_request_batches_peer_rejects_tries_next() {
 
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {
+            let Some(cmd) = deny_sync_open(cmd) else { continue };
             match cmd {
                 NetworkCommand::ConnectedPeers { reply } => {
                     reply.send(vec![peer1, peer2]).expect("send peers");
                 }
-                NetworkCommand::SendRequest { request, reply, .. } => {
-                    if let WorkerRequest::RequestBatchesStream { .. } = request {
-                        // both peers reject
-                        reply
-                            .send(Ok(NetworkResponseMessage {
-                                peer: peer1,
-                                result: WorkerResponse::RequestBatchesStream { ack: false },
-                            }))
-                            .expect("send reject");
-                    }
+                NetworkCommand::SendRequest {
+                    request: WorkerRequest::RequestBatchesStream { .. },
+                    reply,
+                    ..
+                } => {
+                    // both peers reject
+                    reply
+                        .send(Ok(NetworkResponseMessage {
+                            peer: peer1,
+                            result: WorkerResponse::RequestBatchesStream { ack: false },
+                        }))
+                        .expect("send reject");
                 }
                 _ => {}
             }
@@ -409,26 +436,29 @@ async fn test_request_batches_truncates_oversized_digests() {
 
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {
+            let Some(cmd) = deny_sync_open(cmd) else { continue };
             match cmd {
                 NetworkCommand::ConnectedPeers { reply } => {
                     reply.send(vec![peer1]).expect("send peers");
                 }
-                NetworkCommand::SendRequest { request, reply, .. } => {
-                    if let WorkerRequest::RequestBatchesStream { batch_digests, .. } = request {
-                        // assert truncation happened
-                        assert_eq!(
-                            batch_digests.len(),
-                            MAX_BATCH_DIGESTS_PER_REQUEST,
-                            "digests should be truncated to MAX_BATCH_DIGESTS_PER_REQUEST (500)"
-                        );
-                        // reject to end the test
-                        reply
-                            .send(Ok(NetworkResponseMessage {
-                                peer: peer1,
-                                result: WorkerResponse::RequestBatchesStream { ack: false },
-                            }))
-                            .expect("send reject");
-                    }
+                NetworkCommand::SendRequest {
+                    request: WorkerRequest::RequestBatchesStream { batch_digests, .. },
+                    reply,
+                    ..
+                } => {
+                    // assert truncation happened
+                    assert_eq!(
+                        batch_digests.len(),
+                        MAX_BATCH_DIGESTS_PER_REQUEST,
+                        "digests should be truncated to MAX_BATCH_DIGESTS_PER_REQUEST (500)"
+                    );
+                    // reject to end the test
+                    reply
+                        .send(Ok(NetworkResponseMessage {
+                            peer: peer1,
+                            result: WorkerResponse::RequestBatchesStream { ack: false },
+                        }))
+                        .expect("send reject");
                 }
                 _ => {}
             }
@@ -653,31 +683,34 @@ async fn test_retry_succeeds_after_initial_rejection() {
         let mut stream_accepted = false;
 
         while let Some(cmd) = rx.recv().await {
+            let Some(cmd) = deny_sync_open(cmd) else { continue };
             match cmd {
                 NetworkCommand::ConnectedPeers { reply } => {
                     connected_peers_count += 1;
                     reply.send(vec![peer1]).expect("send peers");
                 }
-                NetworkCommand::SendRequest { request, reply, .. } => {
-                    if let WorkerRequest::RequestBatchesStream { .. } = request {
-                        if connected_peers_count <= 1 {
-                            // first attempt: reject
-                            reply
-                                .send(Ok(NetworkResponseMessage {
-                                    peer: peer1,
-                                    result: WorkerResponse::RequestBatchesStream { ack: false },
-                                }))
-                                .expect("send reject");
-                        } else {
-                            // second attempt: accept
-                            reply
-                                .send(Ok(NetworkResponseMessage {
-                                    peer: peer1,
-                                    result: WorkerResponse::RequestBatchesStream { ack: true },
-                                }))
-                                .expect("send accept");
-                            stream_accepted = true;
-                        }
+                NetworkCommand::SendRequest {
+                    request: WorkerRequest::RequestBatchesStream { .. },
+                    reply,
+                    ..
+                } => {
+                    if connected_peers_count <= 1 {
+                        // first attempt: reject
+                        reply
+                            .send(Ok(NetworkResponseMessage {
+                                peer: peer1,
+                                result: WorkerResponse::RequestBatchesStream { ack: false },
+                            }))
+                            .expect("send reject");
+                    } else {
+                        // second attempt: accept
+                        reply
+                            .send(Ok(NetworkResponseMessage {
+                                peer: peer1,
+                                result: WorkerResponse::RequestBatchesStream { ack: true },
+                            }))
+                            .expect("send accept");
+                        stream_accepted = true;
                     }
                 }
                 NetworkCommand::OpenStream { reply, .. } => {
@@ -729,27 +762,30 @@ async fn test_request_batches_peer_fallback_preserves_digests() {
     tokio::spawn(async move {
         let mut request_count = 0u32;
         while let Some(cmd) = rx.recv().await {
+            let Some(cmd) = deny_sync_open(cmd) else { continue };
             match cmd {
                 NetworkCommand::ConnectedPeers { reply } => {
                     reply.send(vec![peer1, peer2]).expect("send peers");
                 }
-                NetworkCommand::SendRequest { request, reply, .. } => {
-                    if let WorkerRequest::RequestBatchesStream { batch_digests, .. } = request {
-                        request_count += 1;
-                        // both peer1 and peer2 should receive exactly 3 digests
-                        assert_eq!(
-                            batch_digests.len(),
-                            expected_count,
-                            "peer {request_count} should receive all {expected_count} digests"
-                        );
-                        // reject to trigger fallback to next peer
-                        reply
-                            .send(Ok(NetworkResponseMessage {
-                                peer: peer2,
-                                result: WorkerResponse::RequestBatchesStream { ack: false },
-                            }))
-                            .unwrap();
-                    }
+                NetworkCommand::SendRequest {
+                    request: WorkerRequest::RequestBatchesStream { batch_digests, .. },
+                    reply,
+                    ..
+                } => {
+                    request_count += 1;
+                    // both peer1 and peer2 should receive exactly 3 digests
+                    assert_eq!(
+                        batch_digests.len(),
+                        expected_count,
+                        "peer {request_count} should receive all {expected_count} digests"
+                    );
+                    // reject to trigger fallback to next peer
+                    reply
+                        .send(Ok(NetworkResponseMessage {
+                            peer: peer2,
+                            result: WorkerResponse::RequestBatchesStream { ack: false },
+                        }))
+                        .unwrap();
                 }
                 _ => {}
             }

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -791,7 +791,7 @@ where
                 let rpcs = self.swarm.behaviour().peer_manager.all_rpcs();
                 send_or_log_error!(reply, rpcs, "GetAllValidatorRpcs");
             }
-            NetworkCommand::OpenStream { peer, reply } => {
+            NetworkCommand::OpenStream { peer, kind, reply } => {
                 // Look up the peer's PeerId from their BLS key
                 let (peer_id, addrs) = match self.swarm.behaviour().peer_manager.auth_to_peer(peer)
                 {
@@ -816,7 +816,7 @@ where
                 // Pass the reply channel directly to the stream behavior.
                 // The stream (or error) will be returned to the caller via oneshot
                 // without any intermediate tracking.
-                self.swarm.behaviour_mut().stream.open_stream(peer_id, addrs, reply);
+                self.swarm.behaviour_mut().stream.open_stream(peer_id, kind, addrs, reply);
             }
             #[cfg(test)]
             NetworkCommand::KadStoreGet { key, reply } => {
@@ -1325,18 +1325,21 @@ where
     /// This handles inbound and outbound stream events for bulk data transfer.
     fn process_stream_event(&mut self, event: StreamEvent) -> NetworkResult<()> {
         match event {
-            StreamEvent::InboundStream { peer, stream } => {
+            StreamEvent::InboundStream { peer, kind, stream } => {
                 debug!(
                     target: "network",
                     ?peer,
+                    ?kind,
                     "inbound stream received"
                 );
-                // Forward raw stream to application layer
+                // Forward raw stream to application layer, tagged with the
+                // negotiated protocol so it routes to the sync or legacy reader.
                 if let Some(bls) = self.swarm.behaviour().peer_manager.peer_to_bls(&peer) {
-                    if let Err(e) = self
-                        .event_stream
-                        .try_send(NetworkEvent::InboundStream { peer: bls, stream })
-                    {
+                    if let Err(e) = self.event_stream.try_send(NetworkEvent::InboundStream {
+                        peer: bls,
+                        kind,
+                        stream,
+                    }) {
                         error!(target: "network", ?e, "failed to forward inbound stream");
                     }
                 } else {

--- a/crates/network-libp2p/src/lib.rs
+++ b/crates/network-libp2p/src/lib.rs
@@ -30,7 +30,7 @@ pub mod types;
 pub use codec::{decode_message, encode_message, TNCodec, TNMessage};
 pub use consensus::ConsensusNetwork;
 pub use peers::{PeerExchangeMap, Penalty};
-pub use stream::StreamError;
+pub use stream::{StreamError, StreamKind};
 pub use sync::{
     read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame, SyncFrameError,
     WorkerSyncRequest,

--- a/crates/network-libp2p/src/stream/behavior.rs
+++ b/crates/network-libp2p/src/stream/behavior.rs
@@ -20,6 +20,7 @@ use crate::{
     stream::{
         handler::{HandlerCommand, StreamHandler, StreamHandlerEvent},
         upgrade::{StreamError, StreamFailure},
+        StreamKind,
     },
     types::{NetworkResult, NetworkType},
 };
@@ -53,6 +54,10 @@ pub(crate) enum StreamEvent {
     InboundStream {
         /// The peer that opened the stream.
         peer: PeerId,
+        /// The protocol the inbound stream negotiated, so the application routes
+        /// a sync stream to the [`SyncFrame`](crate::sync::SyncFrame) layer and a
+        /// legacy stream to the digest reader.
+        kind: StreamKind,
         /// The established stream for reading/writing data.
         stream: Stream,
     },
@@ -87,6 +92,8 @@ enum OpenPhase {
 struct PendingOpen {
     /// The peer to open the stream to.
     peer: PeerId,
+    /// Which protocol this open negotiates.
+    kind: StreamKind,
     /// Known dial addresses, used if the peer is not connected.
     addrs: Vec<Multiaddr>,
     /// Channel for returning the established stream (or error) to the caller.
@@ -113,9 +120,11 @@ struct InboundWindow {
 /// error if the peer cannot be reached or the open times out. Inbound streams
 /// are rate limited per peer, and failures are classified for peer scoring.
 pub(crate) struct StreamBehavior {
-    /// Protocols every connection handler advertises (legacy `/tn-stream` first,
-    /// then the per-role sync protocol), cloned into each new handler.
-    protocols: Vec<StreamProtocol>,
+    /// The legacy `/tn-stream` protocol, advertised first by each handler.
+    legacy: StreamProtocol,
+    /// The per-role sync protocol, advertised second by each handler and used to
+    /// classify an inbound stream's negotiated protocol.
+    sync: StreamProtocol,
     /// Events to emit to the swarm/application.
     events: VecDeque<StreamEvent>,
     /// Outbound opens being driven to completion.
@@ -145,9 +154,9 @@ impl StreamBehavior {
     /// existing opens keep negotiating it, followed by the role's sync protocol,
     /// so a responder also accepts inbound sync streams.
     pub(crate) fn new(network_type: NetworkType) -> Self {
-        let protocols = vec![TN_STREAM_PROTOCOL, network_type.sync_protocol()];
         Self {
-            protocols,
+            legacy: TN_STREAM_PROTOCOL,
+            sync: network_type.sync_protocol(),
             events: VecDeque::new(),
             pending: Vec::new(),
             connected: HashSet::new(),
@@ -165,6 +174,7 @@ impl StreamBehavior {
     pub(crate) fn open_stream(
         &mut self,
         peer: PeerId,
+        kind: StreamKind,
         addrs: Vec<Multiaddr>,
         reply: oneshot::Sender<NetworkResult<Stream>>,
     ) {
@@ -173,12 +183,12 @@ impl StreamBehavior {
                 let _ = reply.send(Err(NetworkError::Stream(StreamError::TooManyPending)));
             }
             () if self.connected.contains(&peer) => {
-                self.queue_open(peer, addrs, reply, OpenPhase::Connected)
+                self.queue_open(peer, kind, addrs, reply, OpenPhase::Connected)
             }
             () if addrs.is_empty() => {
                 let _ = reply.send(Err(NetworkError::Stream(StreamError::NotConnected)));
             }
-            () => self.queue_open(peer, addrs, reply, OpenPhase::NeedsDial),
+            () => self.queue_open(peer, kind, addrs, reply, OpenPhase::NeedsDial),
         }
     }
 
@@ -186,12 +196,14 @@ impl StreamBehavior {
     fn queue_open(
         &mut self,
         peer: PeerId,
+        kind: StreamKind,
         addrs: Vec<Multiaddr>,
         reply: oneshot::Sender<NetworkResult<Stream>>,
         phase: OpenPhase,
     ) {
         self.pending.push(PendingOpen {
             peer,
+            kind,
             addrs,
             reply,
             deadline: Instant::now() + OPEN_DEADLINE,
@@ -289,7 +301,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: &Multiaddr,
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new(self.protocols.clone()))
+        Ok(StreamHandler::new(self.legacy.clone(), self.sync.clone()))
     }
 
     fn handle_established_outbound_connection(
@@ -300,7 +312,7 @@ impl NetworkBehaviour for StreamBehavior {
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(StreamHandler::new(self.protocols.clone()))
+        Ok(StreamHandler::new(self.legacy.clone(), self.sync.clone()))
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
@@ -332,7 +344,7 @@ impl NetworkBehaviour for StreamBehavior {
         event: <Self::ConnectionHandler as ConnectionHandler>::ToBehaviour,
     ) {
         match event {
-            StreamHandlerEvent::InboundStream { stream } => {
+            StreamHandlerEvent::InboundStream { kind, stream } => {
                 if self.inbound_rate_limited(peer_id) {
                     // drop the stream; report for scoring
                     self.push_event(StreamEvent::InboundFailure {
@@ -340,7 +352,7 @@ impl NetworkBehaviour for StreamBehavior {
                         failure: StreamFailure::InboundRateLimited,
                     });
                 } else {
-                    self.push_event(StreamEvent::InboundStream { peer: peer_id, stream });
+                    self.push_event(StreamEvent::InboundStream { peer: peer_id, kind, stream });
                 }
             }
             StreamHandlerEvent::OutboundFailure { failure } => {
@@ -369,7 +381,7 @@ impl NetworkBehaviour for StreamBehavior {
             return Poll::Ready(ToSwarm::NotifyHandler {
                 peer_id: open.peer,
                 handler: NotifyHandler::Any,
-                event: HandlerCommand::OpenStream { reply: open.reply },
+                event: HandlerCommand::OpenStream { kind: open.kind, reply: open.reply },
             });
         }
 
@@ -407,18 +419,14 @@ mod tests {
 
     #[tokio::test]
     async fn registers_sync_protocol_after_legacy() {
-        // a worker advertises its per-worker sync protocol, legacy first
+        // a worker carries the legacy protocol and its per-worker sync protocol
         let worker = StreamBehavior::new(NetworkType::Worker(3));
-        assert_eq!(
-            worker.protocols,
-            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-worker-3-sync/0.0.1")]
-        );
-        // a primary advertises its own sync protocol, legacy first
+        assert_eq!(worker.legacy, TN_STREAM_PROTOCOL);
+        assert_eq!(worker.sync, StreamProtocol::new("/tn-worker-3-sync/0.0.1"));
+        // a primary carries the legacy protocol and its own sync protocol
         let primary = StreamBehavior::new(NetworkType::Primary);
-        assert_eq!(
-            primary.protocols,
-            vec![TN_STREAM_PROTOCOL, StreamProtocol::new("/tn-primary-sync/0.0.1")]
-        );
+        assert_eq!(primary.legacy, TN_STREAM_PROTOCOL);
+        assert_eq!(primary.sync, StreamProtocol::new("/tn-primary-sync/0.0.1"));
     }
 
     #[tokio::test]
@@ -428,7 +436,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
 
         // not connected and no addresses to dial: explicit error, nothing queued
-        behavior.open_stream(peer, Vec::new(), tx);
+        behavior.open_stream(peer, StreamKind::Legacy, Vec::new(), tx);
 
         let result = rx.await.expect("reply delivered");
         assert!(matches!(result, Err(NetworkError::Stream(StreamError::NotConnected))));
@@ -442,7 +450,7 @@ mod tests {
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
 
-        behavior.open_stream(peer, Vec::new(), tx);
+        behavior.open_stream(peer, StreamKind::Legacy, Vec::new(), tx);
 
         assert_eq!(behavior.pending.len(), 1);
         assert!(matches!(behavior.pending[0].phase, OpenPhase::Connected));
@@ -454,7 +462,7 @@ mod tests {
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
 
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
 
         assert_eq!(behavior.pending.len(), 1);
         assert!(matches!(behavior.pending[0].phase, OpenPhase::NeedsDial));
@@ -467,12 +475,12 @@ mod tests {
         behavior.connected.insert(peer);
         for _ in 0..MAX_PENDING_OPENS {
             let (tx, _rx) = oneshot::channel();
-            behavior.open_stream(peer, Vec::new(), tx);
+            behavior.open_stream(peer, StreamKind::Legacy, Vec::new(), tx);
         }
         assert_eq!(behavior.pending.len(), MAX_PENDING_OPENS);
 
         let (tx, rx) = oneshot::channel();
-        behavior.open_stream(peer, Vec::new(), tx);
+        behavior.open_stream(peer, StreamKind::Legacy, Vec::new(), tx);
 
         let result = rx.await.expect("reply delivered");
         assert!(matches!(result, Err(NetworkError::Stream(StreamError::TooManyPending))));
@@ -483,7 +491,7 @@ mod tests {
         let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
         behavior.pending[0].phase = OpenPhase::AwaitingConnection;
 
         behavior.on_connected(peer);
@@ -500,7 +508,7 @@ mod tests {
         let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, _rx) = oneshot::channel();
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
         assert!(matches!(behavior.pending[0].phase, OpenPhase::NeedsDial));
 
         behavior.on_connected(peer);
@@ -513,7 +521,7 @@ mod tests {
         let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
         behavior.pending[0].phase = OpenPhase::AwaitingConnection;
 
         behavior.on_dial_failed(peer);
@@ -528,7 +536,7 @@ mod tests {
         let mut behavior = StreamBehavior::new(NetworkType::Primary);
         let peer = PeerId::random();
         let (tx, rx) = oneshot::channel();
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
         // force the deadline into the past
         behavior.pending[0].deadline = Instant::now() - Duration::from_secs(1);
 
@@ -573,7 +581,7 @@ mod tests {
         let peer = PeerId::random();
         behavior.connected.insert(peer);
         let (tx, _rx) = oneshot::channel();
-        behavior.open_stream(peer, vec![addr()], tx);
+        behavior.open_stream(peer, StreamKind::Legacy, vec![addr()], tx);
         assert!(matches!(behavior.pending[0].phase, OpenPhase::Connected));
 
         behavior.on_disconnected(peer);

--- a/crates/network-libp2p/src/stream/handler.rs
+++ b/crates/network-libp2p/src/stream/handler.rs
@@ -17,7 +17,10 @@ use tokio::sync::oneshot;
 
 use crate::{
     error::NetworkError,
-    stream::upgrade::{StreamError, StreamFailure, TNStreamProtocol},
+    stream::{
+        upgrade::{StreamError, StreamFailure, TNStreamProtocol},
+        StreamKind,
+    },
     types::NetworkResult,
 };
 
@@ -40,9 +43,22 @@ const MAX_HANDLER_EVENTS: usize = 256;
 pub(crate) enum HandlerCommand {
     /// Open an outbound stream, returning it through the provided channel.
     OpenStream {
+        /// Which protocol the open negotiates ([`StreamKind::Legacy`] or
+        /// [`StreamKind::Sync`]).
+        kind: StreamKind,
         /// Channel for returning the established stream directly to the caller.
         reply: oneshot::Sender<NetworkResult<Stream>>,
     },
+}
+
+/// An in-flight outbound open, carried as the substream's open info so the
+/// handler can answer the caller and classify a failure with the open's kind.
+#[derive(Debug)]
+pub(crate) struct OutboundOpen {
+    /// Which protocol this open negotiates.
+    kind: StreamKind,
+    /// Channel for returning the established stream (or error) to the caller.
+    reply: oneshot::Sender<NetworkResult<Stream>>,
 }
 
 /// Events from handler to behavior.
@@ -50,6 +66,8 @@ pub(crate) enum HandlerCommand {
 pub(crate) enum StreamHandlerEvent {
     /// An inbound stream was successfully established.
     InboundStream {
+        /// The protocol the inbound stream negotiated.
+        kind: StreamKind,
         /// The established stream.
         stream: Stream,
     },
@@ -69,11 +87,12 @@ pub(crate) enum StreamHandlerEvent {
 /// is bounded by [`STREAM_OPEN_TIMEOUT`]; failures are classified and reported
 /// to the behaviour for scoring.
 pub(crate) struct StreamHandler {
-    /// Protocols advertised for inbound listen and outbound opens (legacy
-    /// `/tn-stream` first, then the per-role sync protocol).
-    protocols: Vec<StreamProtocol>,
-    /// Pending outbound stream reply channels.
-    pending_outbound: VecDeque<oneshot::Sender<NetworkResult<Stream>>>,
+    /// The legacy `/tn-stream` protocol, advertised first on inbound listen.
+    legacy: StreamProtocol,
+    /// The per-role sync protocol, advertised second on inbound listen.
+    sync: StreamProtocol,
+    /// Pending outbound opens.
+    pending_outbound: VecDeque<OutboundOpen>,
     /// Events to send to the behavior.
     events: VecDeque<StreamHandlerEvent>,
 }
@@ -88,9 +107,24 @@ impl std::fmt::Debug for StreamHandler {
 }
 
 impl StreamHandler {
-    /// Create a new stream handler advertising `protocols` on this connection.
-    pub(crate) fn new(protocols: Vec<StreamProtocol>) -> Self {
-        Self { protocols, pending_outbound: VecDeque::new(), events: VecDeque::new() }
+    /// Create a new stream handler advertising the legacy and sync protocols on
+    /// this connection.
+    pub(crate) fn new(legacy: StreamProtocol, sync: StreamProtocol) -> Self {
+        Self { legacy, sync, pending_outbound: VecDeque::new(), events: VecDeque::new() }
+    }
+
+    /// The single protocol an outbound open of `kind` advertises.
+    fn protocol_for(&self, kind: StreamKind) -> StreamProtocol {
+        match kind {
+            StreamKind::Legacy => self.legacy.clone(),
+            StreamKind::Sync => self.sync.clone(),
+        }
+    }
+
+    /// The upgrade an inbound listen advertises: both protocols (legacy first),
+    /// carrying the sync protocol so a negotiated inbound stream is classified.
+    fn listen_upgrade(&self) -> TNStreamProtocol {
+        TNStreamProtocol::new(vec![self.legacy.clone(), self.sync.clone()], self.sync.clone())
     }
 
     /// Queue an event to the behaviour, dropping it if the buffer is saturated.
@@ -109,7 +143,7 @@ fn classify_outbound(error: StreamUpgradeError<Infallible>) -> (StreamFailure, S
         StreamUpgradeError::NegotiationFailed => {
             (StreamFailure::UnsupportedProtocol, StreamError::UpgradeFailed)
         }
-        StreamUpgradeError::Io(e) => (StreamFailure::Io(e.kind()), StreamError::UpgradeFailed),
+        StreamUpgradeError::Io(e) => (StreamFailure::Io(e.kind()), StreamError::UpgradeIo),
         // `TNStreamProtocol`'s upgrade error is `Infallible`, so `Apply` is unconstructable.
         StreamUpgradeError::Apply(infallible) => match infallible {},
     }
@@ -121,19 +155,19 @@ impl ConnectionHandler for StreamHandler {
     type InboundProtocol = TNStreamProtocol;
     type OutboundProtocol = TNStreamProtocol;
     type InboundOpenInfo = ();
-    type OutboundOpenInfo = oneshot::Sender<NetworkResult<Stream>>;
+    type OutboundOpenInfo = OutboundOpen;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(TNStreamProtocol::new(self.protocols.clone()), ())
+        SubstreamProtocol::new(self.listen_upgrade(), ())
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
         match event {
-            HandlerCommand::OpenStream { reply } => {
+            HandlerCommand::OpenStream { kind, reply } => {
                 if self.pending_outbound.len() >= MAX_PENDING_OUTBOUND {
                     let _ = reply.send(Err(NetworkError::Stream(StreamError::TooManyPending)));
                 } else {
-                    self.pending_outbound.push_back(reply);
+                    self.pending_outbound.push_back(OutboundOpen { kind, reply });
                 }
             }
         }
@@ -151,25 +185,37 @@ impl ConnectionHandler for StreamHandler {
     ) {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
-                protocol: stream,
+                protocol: (stream, kind),
                 ..
             }) => {
-                self.push_event(StreamHandlerEvent::InboundStream { stream });
+                self.push_event(StreamHandlerEvent::InboundStream { kind, stream });
             }
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                 protocol: stream,
-                info: reply,
+                info: OutboundOpen { reply, .. },
                 ..
             }) => {
-                // Return the stream directly to the caller via oneshot
+                // Return the stream directly to the caller via oneshot. The
+                // caller chose the protocol, so it already knows the kind.
                 let _ = reply.send(Ok(stream));
             }
-            ConnectionEvent::DialUpgradeError(DialUpgradeError { info: reply, error }) => {
-                // Return the error to the caller and report the classified
-                // failure to the behaviour for scoring.
+            ConnectionEvent::DialUpgradeError(DialUpgradeError {
+                info: OutboundOpen { kind, reply },
+                error,
+            }) => {
+                // Return the error to the caller, which drives its fallback.
                 let (failure, stream_error) = classify_outbound(error);
                 let _ = reply.send(Err(NetworkError::Stream(stream_error)));
-                self.push_event(StreamHandlerEvent::OutboundFailure { failure });
+                // A sync open that fails negotiation only means the peer does not
+                // speak the sync protocol yet; the caller falls back to legacy, so
+                // the probe is penalty-exempt (the issue's "Severe suppressed for
+                // new-protocol negotiation failure while a fallback exists"). Every
+                // other failure, and every legacy failure, is still reported.
+                let penalty_exempt_probe = matches!(kind, StreamKind::Sync)
+                    && matches!(failure, StreamFailure::UnsupportedProtocol);
+                if !penalty_exempt_probe {
+                    self.push_event(StreamHandlerEvent::OutboundFailure { failure });
+                }
             }
             _ => {}
         }
@@ -190,14 +236,14 @@ impl ConnectionHandler for StreamHandler {
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
         }
 
-        // Request outbound streams, bounding negotiation with a timeout.
-        if let Some(reply) = self.pending_outbound.pop_front() {
+        // Request outbound streams, bounding negotiation with a timeout. The open
+        // advertises only the chosen protocol, so a sync open negotiates sync (or
+        // fails) instead of silently falling back to legacy at the wire level.
+        if let Some(open) = self.pending_outbound.pop_front() {
+            let upgrade =
+                TNStreamProtocol::new(vec![self.protocol_for(open.kind)], self.sync.clone());
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(
-                    TNStreamProtocol::new(self.protocols.clone()),
-                    reply,
-                )
-                .with_timeout(STREAM_OPEN_TIMEOUT),
+                protocol: SubstreamProtocol::new(upgrade, open).with_timeout(STREAM_OPEN_TIMEOUT),
             });
         }
 
@@ -225,6 +271,6 @@ mod tests {
 
         let (failure, error) = classify_outbound(StreamUpgradeError::Io(io::Error::other("boom")));
         assert!(matches!(failure, StreamFailure::Io(_)));
-        assert!(matches!(error, StreamError::UpgradeFailed));
+        assert!(matches!(error, StreamError::UpgradeIo));
     }
 }

--- a/crates/network-libp2p/src/stream/mod.rs
+++ b/crates/network-libp2p/src/stream/mod.rs
@@ -17,3 +17,22 @@ mod upgrade;
 
 pub(crate) use behavior::{StreamBehavior, StreamEvent};
 pub use upgrade::StreamError;
+
+/// Which bulk-stream protocol an exchange uses.
+///
+/// An outbound open names the protocol it wants to negotiate; an inbound stream
+/// reports the protocol that was negotiated. The two protocols share the same
+/// raw-stream upgrade but are read differently by the application: the legacy
+/// path correlates by a 32-byte request digest, the sync path carries the typed
+/// [`SyncFrame`](crate::sync::SyncFrame) layer with the request in its first
+/// frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamKind {
+    /// The legacy `/tn-stream/0.0.1` raw stream, correlated to a prior
+    /// request-response handshake by a written request digest.
+    Legacy,
+    /// The per-role typed sync protocol (`/tn-primary-sync/0.0.1` or
+    /// `/tn-worker-{id}-sync/0.0.1`), carrying the [`SyncFrame`](crate::sync::SyncFrame)
+    /// layer.
+    Sync,
+}

--- a/crates/network-libp2p/src/stream/upgrade.rs
+++ b/crates/network-libp2p/src/stream/upgrade.rs
@@ -4,28 +4,35 @@ use std::{
     future::{ready, Ready},
 };
 
-use crate::Penalty;
+use crate::{stream::StreamKind, Penalty};
 
 /// Protocol upgrade for streaming data.
 ///
 /// Advertises one or more protocols for negotiation, in dialer-preference
-/// order. Both inbound and outbound upgrades simply return the raw stream
-/// regardless of which protocol negotiated; application-layer correlation (e.g.
-/// writing a request digest, or the typed [`SyncFrame`](crate::sync::SyncFrame)
-/// layer) is handled by the caller after the stream is established.
+/// order. An inbound listen advertises both the legacy `/tn-stream` and the
+/// per-role sync protocol and reports which one negotiated, so the application
+/// can route a sync stream to the [`SyncFrame`](crate::sync::SyncFrame) layer
+/// and a legacy stream to the digest-correlation reader. An outbound open
+/// advertises a single chosen protocol, so the caller already knows which kind
+/// it asked for. Both upgrades return the raw stream; the framing is the
+/// caller's concern.
 #[derive(Debug, Clone)]
 pub(crate) struct TNStreamProtocol {
-    /// Protocols advertised for negotiation, in dialer-preference order. The
-    /// legacy `/tn-stream/0.0.1` is first so existing opens keep negotiating it;
-    /// the per-role sync protocol follows so a responder also accepts it.
+    /// Protocols advertised for negotiation, in dialer-preference order. For an
+    /// inbound listen this is `[legacy, sync]` (legacy first, so existing opens
+    /// keep negotiating it); for an outbound open it is the single chosen
+    /// protocol.
     protocols: Vec<StreamProtocol>,
+    /// The per-role sync protocol, used to classify the negotiated protocol of
+    /// an inbound stream as [`StreamKind::Sync`] versus [`StreamKind::Legacy`].
+    sync: StreamProtocol,
 }
 
 impl TNStreamProtocol {
-    /// Create an upgrade advertising `protocols`, in order (legacy first), for
-    /// both inbound listen and outbound open negotiation.
-    pub(crate) fn new(protocols: Vec<StreamProtocol>) -> Self {
-        Self { protocols }
+    /// Create an upgrade advertising `protocols`, in order, with `sync` as the
+    /// per-role sync protocol used to classify an inbound negotiation.
+    pub(crate) fn new(protocols: Vec<StreamProtocol>, sync: StreamProtocol) -> Self {
+        Self { protocols, sync }
     }
 }
 
@@ -39,18 +46,17 @@ impl UpgradeInfo for TNStreamProtocol {
 }
 
 impl InboundUpgrade<Stream> for TNStreamProtocol {
-    type Output = Stream;
+    type Output = (Stream, StreamKind);
     type Error = Infallible;
     type Future = Ready<Result<Self::Output, Self::Error>>;
 
-    // The negotiated protocol (`_protocol`) is intentionally discarded for now:
-    // every accepted inbound stream is handed to the application as a raw stream
-    // and read on the legacy digest-correlation path. Once a sync stream can
-    // actually arrive (the step-5 cutover adds the first opener), this is the
-    // seam that must branch on `_protocol` to route a sync-framed stream to the
-    // `SyncFrame` layer instead of the digest reader.
-    fn upgrade_inbound(self, stream: Stream, _protocol: Self::Info) -> Self::Future {
-        ready(Ok(stream))
+    // Classify the negotiated protocol so the application routes a sync-framed
+    // stream to the `SyncFrame` layer and a legacy stream to the digest reader.
+    // Only the legacy and sync protocols are ever advertised, so anything that
+    // is not the sync protocol is the legacy one.
+    fn upgrade_inbound(self, stream: Stream, protocol: Self::Info) -> Self::Future {
+        let kind = if protocol == self.sync { StreamKind::Sync } else { StreamKind::Legacy };
+        ready(Ok((stream, kind)))
     }
 }
 
@@ -59,7 +65,8 @@ impl OutboundUpgrade<Stream> for TNStreamProtocol {
     type Error = Infallible;
     type Future = Ready<Result<Self::Output, Self::Error>>;
 
-    // logic in application layer
+    // The caller chose the single advertised protocol, so the negotiated info is
+    // redundant; correlation and framing are the application layer's concern.
     fn upgrade_outbound(self, stream: Stream, _: Self::Info) -> Self::Future {
         ready(Ok(stream))
     }
@@ -68,8 +75,14 @@ impl OutboundUpgrade<Stream> for TNStreamProtocol {
 /// Errors returned to the caller of an outbound stream open.
 #[derive(Debug)]
 pub enum StreamError {
-    /// The protocol upgrade failed during stream negotiation.
+    /// The protocol upgrade failed during stream negotiation: the peer advertised
+    /// none of the offered protocols.
     UpgradeFailed,
+    /// A transport I/O error occurred during stream negotiation. Distinct from
+    /// [`StreamError::UpgradeFailed`]: the peer may well speak the protocol, so a
+    /// caller probing protocol support should treat this as transient rather than
+    /// as "unsupported".
+    UpgradeIo,
     /// The peer was not connected and could not be dialed (no known address).
     NotConnected,
     /// The open attempt timed out before a stream was established.
@@ -82,6 +95,7 @@ impl std::fmt::Display for StreamError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UpgradeFailed => write!(f, "Protocol upgrade failed"),
+            Self::UpgradeIo => write!(f, "I/O error during stream negotiation"),
             Self::NotConnected => write!(f, "Peer not connected and could not be dialed"),
             Self::Timeout => write!(f, "Timed out before a stream was established"),
             Self::TooManyPending => write!(f, "Too many pending stream opens"),
@@ -156,7 +170,7 @@ mod tests {
     fn protocol_info_preserves_order() {
         let legacy = StreamProtocol::new("/tn-stream/0.0.1");
         let sync = StreamProtocol::new("/tn-primary-sync/0.0.1");
-        let upgrade = TNStreamProtocol::new(vec![legacy.clone(), sync.clone()]);
+        let upgrade = TNStreamProtocol::new(vec![legacy.clone(), sync.clone()], sync.clone());
         let advertised: Vec<_> = upgrade.protocol_info().collect();
         assert_eq!(advertised, vec![legacy, sync]);
     }

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -1,7 +1,8 @@
 //! Constants and trait implementations for network compatibility.
 
 use crate::{
-    codec::TNMessage, error::NetworkError, peers::Penalty, GossipMessage, PeerExchangeMap,
+    codec::TNMessage, error::NetworkError, peers::Penalty, stream::StreamKind, GossipMessage,
+    PeerExchangeMap,
 };
 pub use libp2p::gossipsub::MessageId;
 use libp2p::{
@@ -168,11 +169,15 @@ pub enum NetworkEvent<Req, Res> {
     Error(String, ResponseChannel<Res>),
     /// An inbound stream was established by a peer.
     ///
-    /// The application is responsible for reading any correlation data
-    /// (e.g. request digest) from the raw stream.
+    /// The application routes the raw stream by `kind`: a [`StreamKind::Legacy`]
+    /// stream is read on the digest-correlation path, a [`StreamKind::Sync`]
+    /// stream carries the typed [`SyncFrame`](crate::sync::SyncFrame) layer with
+    /// the request in its first frame.
     InboundStream {
         /// The peer that opened the stream.
         peer: BlsPublicKey,
+        /// The protocol the inbound stream negotiated.
+        kind: StreamKind,
         /// The established raw p2p stream for reading data.
         stream: Stream,
     },
@@ -396,11 +401,16 @@ where
     },
     /// Open a raw stream to a peer for bulk data transfer.
     ///
-    /// Called after a successful request-response negotiation. The caller
-    /// is responsible for writing any correlation data to the stream.
+    /// A [`StreamKind::Legacy`] open negotiates `/tn-stream` and the caller writes
+    /// a correlation digest; a [`StreamKind::Sync`] open negotiates the per-role
+    /// sync protocol and the caller writes a [`SyncFrame`](crate::sync::SyncFrame)
+    /// request. A sync open that fails negotiation is penalty-exempt so the caller
+    /// can fall back to legacy.
     OpenStream {
         /// The peer to open the stream to.
         peer: BlsPublicKey,
+        /// Which protocol the open negotiates.
+        kind: StreamKind,
         /// Channel for returning the established stream to application layer.
         reply: oneshot::Sender<NetworkResult<Stream>>,
     },
@@ -684,12 +694,19 @@ where
 
     /// Open a raw stream to a peer for bulk data transfer.
     ///
-    /// Called after a successful request-response negotiation. The caller is
-    /// responsible for writing any application-layer correlation data (e.g.
-    /// request digest) to the stream after it is established.
-    pub async fn open_stream(&self, peer: BlsPublicKey) -> NetworkResult<NetworkResult<Stream>> {
+    /// `kind` selects the protocol: [`StreamKind::Legacy`] negotiates `/tn-stream`
+    /// (the caller then writes a correlation digest), [`StreamKind::Sync`]
+    /// negotiates the per-role sync protocol (the caller then writes a
+    /// [`SyncFrame`](crate::sync::SyncFrame) request). A sync open that fails
+    /// negotiation returns an error without penalizing the peer, so the caller can
+    /// fall back to the legacy path.
+    pub async fn open_stream(
+        &self,
+        peer: BlsPublicKey,
+        kind: StreamKind,
+    ) -> NetworkResult<NetworkResult<Stream>> {
         let (reply, rx) = oneshot::channel();
-        self.sender.send(NetworkCommand::OpenStream { peer, reply }).await?;
+        self.sender.send(NetworkCommand::OpenStream { peer, kind, reply }).await?;
         rx.await.map_err(Into::into)
     }
 


### PR DESCRIPTION
## Summary

Step 5 of #739. The typed sync-frame layer registered in step 4 (#768) was inert: a worker advertised `/tn-worker-{id}-sync/0.0.1` but never opened it, so every batch fetch still ran the legacy `/tn-stream` ack-plus-digest handshake. This PR flips the worker batch path over to the sync protocol as the **first** real opener, with a **penalty-exempt fallback to legacy** for any peer that does not speak it.

The result folds the legacy two-roundtrip handshake (a `RequestBatchesStream` request-response that returns an `ack`, then a raw stream open onto which the requester writes a 32-byte correlation digest) into a **single stream open** whose opening `SyncFrame::Req` carries the request itself.

The primary path is untouched and stays fully legacy; its cutover is step 6.

## What changed

### Requester (worker `network/handle.rs`)
- `request_batches_from_peer` now prefers the sync protocol. Unless the peer is cached as legacy-only this epoch, it opens a `/tn-worker-{id}-sync` stream, writes `SyncFrame::Req(WorkerSyncRequest::Batches { .. })` in the opening frame, and reads the response (`Ack`, then `Data` frames terminated by `End`).
- A `SyncAttempt` enum classifies the outcome:
  - `Fetched`: the peer served the batches → cache it sync-capable.
  - `Unsupported`: the peer never answered (negotiation failed = a pre-item-4 peer, or it negotiated sync but sent no `Ack` = an item-4 peer that registered the protocol without serving it) → cache it legacy-only and fall back to the legacy path.
  - `Failed`: the exchange failed after the peer proved sync-capable (`Deny`/`Err`/mid-stream error), or a transient transport error occurred (an I/O error opening or writing the stream, distinct from a protocol mismatch) → keep it sync-capable and try the next peer.
- A per-peer `sync_capability` cache (`Arc<Mutex<HashMap<BlsPublicKey, bool>>>`) avoids re-probing a known legacy-only peer every request. It is **cleared on `update_epoch`** so a peer upgraded across the committee-rotation boundary is re-probed.
- The sync probe is **penalty-exempt**, and a transient transport error never demotes a sync-capable peer: a genuine negotiation failure surfaces as `StreamError::UpgradeFailed` and maps to `Unsupported` (fall back, cache legacy-only), while a transport I/O error during the open surfaces as the distinct `StreamError::UpgradeIo` and maps to `Failed` (try the next peer, peer stays sync-capable, cache not poisoned). Neither scores the peer.

### Responder (worker `network/mod.rs`, `handler.rs`, `stream_codec.rs`)
- Inbound streams now dispatch on the negotiated `StreamKind`: `Legacy` → the existing digest-correlation reader, `Sync` → the new `process_inbound_sync_stream`.
- Because the sync request travels in the stream's opening frame (no prior request-response ack), admission against the concurrency caps moves to stream-open time:
  - `try_admit_sync` acquires the **shared** `batch_stream_semaphore` (so the global `MAX_CONCURRENT_BATCH_STREAMS` cap is the combined legacy+sync limit) and checks the peer's combined in-flight count (legacy pending + sync in-flight) against `MAX_PENDING_REQUESTS_PER_PEER`. The legacy admission path (`process_request_batches_stream`) likewise adds the peer's in-flight sync-stream count to its legacy count, so the per-peer cap is enforced **symmetrically across both paths** (both lock `pending_batch_requests` before `sync_stream_peers`, so they never deadlock). A `SyncStreamPermit` RAII guard releases the global slot and decrements the per-peer count on drop.
  - A shedding responder writes `SyncFrame::Deny(DenyReason::AtCapacity)` without reading, so the requester gives up immediately and tries elsewhere instead of waiting out its ack timeout. Both the shed write and the malformed-frame `Err` write are bounded by `SYNC_REQUEST_READ_TIMEOUT` so a non-reading peer cannot stall the responder task on an unbounded write.
- Once admitted, the opening `Req` frame is read (bounded by `SYNC_REQUEST_READ_TIMEOUT`), the digest set is capped to `MAX_BATCH_DIGESTS_PER_REQUEST`, and `send_sync_batches_over_stream` serves `Ack` + one `Data` frame per found batch (chunked DB reads) + `End`. It mirrors the legacy responder's partial-DB tolerance: only batches present in storage are streamed.
- Responder errors are **metrics-only** during the rollout (logged, best-effort `SyncFrame::Err`, no penalty), matching the step-3 stream-failure policy and the legacy responder.

### Plumbing (`network-libp2p`)
- `open_stream` / `NetworkCommand::OpenStream` / `HandlerCommand::OpenStream` / `NetworkEvent::InboundStream` / `StreamEvent::InboundStream` now carry a `StreamKind` (`Legacy` | `Sync`).
- An **outbound** open advertises the single chosen protocol (so a sync open negotiates sync or fails, instead of silently negotiating legacy at the wire level); an **inbound** listen advertises both (legacy first) and the upgrade reports which negotiated, so the application routes the stream.
- `classify_outbound` distinguishes a genuine negotiation failure (`StreamError::UpgradeFailed`: the peer speaks none of our protocols) from a transport I/O error during negotiation (the new `StreamError::UpgradeIo`), so the requester falls back on the former but retries on the latter rather than caching a flapping-but-capable peer as legacy-only.
- A sync open whose negotiation fails (`UnsupportedProtocol`) is **not** reported as an outbound failure for scoring (the caller falls back); every other failure, and every legacy failure, is still reported.

### Primary (`primary/network/mod.rs`)
- Compile-only follow-through: opens `StreamKind::Legacy` and routes inbound `Legacy` to its existing reader. An unexpected inbound `Sync` stream (the primary registers the protocol but opens none until step 6) is dropped with a warning, no penalty.

## Cross-version behaviour

| requester | responder | outcome |
|---|---|---|
| item-5 (sync-first) | item-5 | sync exchange, single open |
| item-5 | item-4 (registered, not served) | no `Ack` → requester falls back to legacy; no penalty |
| item-5 | pre-item-4 (no protocol) | negotiation fails → requester falls back to legacy; no penalty |
| pre-item-5 (legacy-only) | item-5 | responder still accepts the legacy `/tn-stream` open |

## Wire protocol

- Each `SyncFrame` is one length-prefixed, snappy-compressed `encode_message` unit; the BCS enum discriminant is the frame tag (pinned by `frame_tags_are_stable` / `request_tags_are_stable` from step 4).
- A `Data` payload is a BCS-encoded `Batch`; the frame layer adds its own length prefix and compression.
- Every frame is bounded by `max_sync_frame_size(epoch) = max_batch_size(epoch) + 1 KiB` envelope headroom, so a peer cannot force an oversized allocation.

## Tests

- New `stream_codec` round-trip tests proving the item-5 responder serializer and the item-5 requester reader agree on the wire: `test_send_receive_sync_roundtrip`, `test_send_receive_sync_partial_db` (responder holds a subset), `test_send_receive_sync_multi_chunk` (>200 batches, multiple chunks).
- The six legacy-flow IT tests now answer the sync probe via a small `deny_sync_open` helper that returns `StreamError::UpgradeFailed` (exactly what a pre-item-4 peer's failed negotiation produces), so they keep exercising the legacy fallback path end-to-end.

## Gates (all green)

- `cargo +nightly-2026-03-20 fmt --check`
- `cargo test -p tn-network-libp2p` (181), `-p tn-worker` (28 lib + 32 IT), `-p tn-primary` (111 lib + 40 IT)
- `cargo clippy -p tn-network-libp2p -p tn-worker --all-features --all-targets` and `cargo clippy -p tn-primary --all-features --lib` — the changed crates and their consumers compile clean
- `cargo doc --no-deps -D warnings -p tn-network-libp2p -p tn-worker`

Toolchain: build/test stable 1.94; fmt/clippy nightly-2026-03-20. Build with `-j 2` (the dev-dep tree OOMs at default `-j`).

A workspace-wide `cargo clippy --all-targets` and `cargo doc --no-deps -D warnings` each trip one **pre-existing** `tn-primary` issue outside this diff, a `never_loop` in `src/tests/certificate_fetcher_tests.rs` and a broken `[LeaderSwapBoard]` intra-doc link in `src/consensus/bullshark.rs`, both unrelated to the worker batch-sync cutover.

## Note on encoding compatibility

BCS encodes enum variant indices: no `SyncFrame` / `WorkerSyncRequest` variant is reordered or removed here. The coordinated `/0.0.2` bump and legacy freeze remain step 9.