### PR TITLE
Allow partial pack file streaming.

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -25,7 +25,7 @@ use tn_types::{
     error::{CertificateError, HeaderError, HeaderResult},
     now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlsPublicKey, Certificate,
     ConsensusHeader, ConsensusHeaderDigest, Database, Epoch, EpochCertificate, EpochDigest,
-    EpochRecord, Hash as _, Header, HeaderDigest, ProtocolSignature, Round,
+    EpochRecord, Hash as _, Header, HeaderDigest, ProtocolSignature, ReadStream, Round,
     SignatureVerificationState, TnSender as _, Vote, B256,
 };
 use tokio::{io::AsyncReadExt, sync::Mutex as TokioMutex, time::timeout};
@@ -979,11 +979,18 @@ where
         &self.consensus_chain
     }
 
-    /// Send epoch pack file over stream.
-    async fn send_epoch_over_stream<S>(
+    /// Send an epoch pack file over a stream.
+    ///
+    /// `stop_number` selects what is sent and is the ONLY difference from the client's perspective
+    /// between a full and a partial transfer:
+    /// - `None`: stream the complete (finished) epoch pack, exactly as before.
+    /// - `Some(n)`: stream only the verifiable prefix up to and including consensus number `n`
+    ///   (used for the in-progress current epoch).
+    pub(super) async fn send_epoch_over_stream<S>(
         mut stream: S,
         consensus_chain: &ConsensusChain,
         epoch: Epoch,
+        stop_number: Option<u64>,
         buffer_timeout: Duration,
         peer: BlsPublicKey,
     ) -> PrimaryNetworkResult<()>
@@ -991,16 +998,42 @@ where
         S: AsyncWrite + Unpin + Send,
     {
         let mut bytes = vec![0_u8; 16 * 1024]; // Use a 16kb read buffer.
-        let mut epoch_stream = consensus_chain
-            .get_epoch_stream(epoch)
-            .await
-            .map_err(|_| PrimaryNetworkError::StreamUnavailable(epoch))?;
+                                               // `limit` bounds how many data-file bytes we send. `None` streams to EOF (whole epoch);
+                                               // `Some(end)` streams `[0, end)` — the prefix containing outputs up to `stop_number`.
+        let (mut epoch_stream, limit): (Box<dyn ReadStream>, Option<u64>) = match stop_number {
+            None => (
+                consensus_chain
+                    .get_epoch_stream(epoch)
+                    .await
+                    .map_err(|_| PrimaryNetworkError::StreamUnavailable(epoch))?,
+                None,
+            ),
+            Some(number) => {
+                let (epoch_stream, end) = consensus_chain
+                    .get_partial_epoch_stream(epoch, number)
+                    .await
+                    .map_err(|_| PrimaryNetworkError::StreamUnavailable(epoch))?;
+                (epoch_stream, Some(end))
+            }
+        };
+        let mut sent: u64 = 0;
         loop {
-            let n = epoch_stream.read(&mut bytes[..]).await?;
+            // Cap the next read so a partial transfer never sends past `limit`.
+            let to_read = match limit {
+                Some(limit) => {
+                    if sent >= limit {
+                        break;
+                    }
+                    std::cmp::min(bytes.len() as u64, limit - sent) as usize
+                }
+                None => bytes.len(),
+            };
+            let n = epoch_stream.read(&mut bytes[..to_read]).await?;
             if n == 0 {
                 break;
             }
             timeout(buffer_timeout, stream.write_all(&bytes[..n])).await??;
+            sent += n as u64;
         }
 
         // attempt to close the stream gracefully
@@ -1089,12 +1122,37 @@ where
                     stream,
                     consensus_chain,
                     epoch,
+                    None,
                     SEND_STREAM_BUFFER_TIMEOUT,
                     peer,
                 )
                 .await
                 .inspect_err(|e| {
                     warn!(target: "primary::network", %peer, ?e, "failed to send epoch over stream")
+                })
+            }
+            StreamRequestKind::EpochPackPartial { epoch, last_consensus_number } => {
+                debug!(
+                    target: "primary::network",
+                    %peer,
+                    ?request_digest,
+                    epoch,
+                    stop_number = last_consensus_number,
+                    "processing inbound partial epoch stream"
+                );
+
+                // set timeout to prevent slow-read attack
+                Self::send_epoch_over_stream(
+                    stream,
+                    consensus_chain,
+                    epoch,
+                    Some(last_consensus_number),
+                    SEND_STREAM_BUFFER_TIMEOUT,
+                    peer,
+                )
+                .await
+                .inspect_err(|e| {
+                    warn!(target: "primary::network", %peer, ?e, "failed to send partial epoch over stream")
                 })
             }
             StreamRequestKind::ConsensusOutput(number) => {

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -139,6 +139,18 @@ pub enum PrimaryRequest {
         /// The epoch we are requesting consensus data for.
         epoch: Epoch,
     },
+    /// Request to stream a verifiable PREFIX of an epoch's pack file, stopping after the consensus
+    /// output with `last_consensus_number`.
+    ///
+    /// Unlike [`Self::StreamEpoch`] (which streams a complete epoch), this streams the in-progress
+    /// current epoch up to an already-committed, verifiable point. The number is a chain consensus
+    /// header number, not a pack-relative index.
+    StreamEpochPartial {
+        /// The epoch we are requesting consensus data for.
+        epoch: Epoch,
+        /// The final (inclusive) consensus header number to stream up to.
+        last_consensus_number: u64,
+    },
     /// Request to stream the raw (serialized) consensus output bytes for a consensus chain number.
     ///
     /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -139,18 +139,6 @@ pub enum PrimaryRequest {
         /// The epoch we are requesting consensus data for.
         epoch: Epoch,
     },
-    /// Request to stream a verifiable PREFIX of an epoch's pack file, stopping after the consensus
-    /// output with `last_consensus_number`.
-    ///
-    /// Unlike [`Self::StreamEpoch`] (which streams a complete epoch), this streams the in-progress
-    /// current epoch up to an already-committed, verifiable point. The number is a chain consensus
-    /// header number, not a pack-relative index.
-    StreamEpochPartial {
-        /// The epoch we are requesting consensus data for.
-        epoch: Epoch,
-        /// The final (inclusive) consensus header number to stream up to.
-        last_consensus_number: u64,
-    },
     /// Request to stream the raw (serialized) consensus output bytes for a consensus chain number.
     ///
     /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output
@@ -162,6 +150,18 @@ pub enum PrimaryRequest {
     StreamConsensusOutput {
         /// The consensus chain number being requested.
         number: u64,
+    },
+    /// Request to stream a verifiable PREFIX of an epoch's pack file, stopping after the consensus
+    /// output with `last_consensus_number`.
+    ///
+    /// Unlike [`Self::StreamEpoch`] (which streams a complete epoch), this streams the in-progress
+    /// current epoch up to an already-committed, verifiable point. The number is a chain consensus
+    /// header number, not a pack-relative index.
+    StreamEpochPartial {
+        /// The epoch we are requesting consensus data for.
+        epoch: Epoch,
+        /// The final (inclusive) consensus header number to stream up to.
+        last_consensus_number: u64,
     },
 }
 

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -83,28 +83,45 @@ const CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(10);
 /// What a [`PendingStreamRequest`] should stream once the peer opens the stream.
 #[derive(Debug, Clone, Copy)]
 pub enum StreamRequestKind {
-    /// Stream the full pack file for an epoch.
+    /// Stream the full (finished) pack file for an epoch.
     EpochPack(Epoch),
+    /// Stream a verifiable PREFIX of an epoch's pack file, up to and including the consensus
+    /// output with `last_consensus_number` (used for the in-progress current epoch).
+    EpochPackPartial {
+        /// The epoch we are streaming consensus data for.
+        epoch: Epoch,
+        /// The final (inclusive) consensus header number to stream up to.
+        last_consensus_number: u64,
+    },
     /// Stream the raw bytes for a single consensus output (by consensus chain number).
     ConsensusOutput(u64),
 }
 
-/// Correlation digest for an epoch-pack stream request.
-fn epoch_stream_digest(epoch: Epoch) -> B256 {
-    let mut hasher = tn_types::DefaultHashFunction::new();
-    hasher.update(b"epoch-stream");
-    hasher.update(&epoch.to_le_bytes());
-    B256::from_slice(hasher.finalize().as_bytes())
-}
-
 /// Correlation digest for a single consensus-output stream request.
 ///
-/// Domain-separated from [`epoch_stream_digest`] so epoch `N` and output `N` never collide in
-/// the pending-request map for a given peer.
-fn consensus_output_stream_digest(number: u64) -> B256 {
+/// Each kind is domain-separated so distinct requests never collide in the pending map:
+/// - `EpochPack(epoch)` hashes only the epoch — byte-for-byte the original full-stream scheme, so
+///   existing full-stream clients are unaffected.
+/// - `EpochPackPartial { epoch, n }` additionally mixes in the stop number, giving it a distinct
+///   digest from the full-epoch request.
+/// - `ConsensusOutput(n)` is tagged so output `N` never collides with epoch `N`.
+fn stream_request_digest(kind: &StreamRequestKind) -> B256 {
     let mut hasher = tn_types::DefaultHashFunction::new();
-    hasher.update(b"consensus-output");
-    hasher.update(&number.to_le_bytes());
+    match kind {
+        StreamRequestKind::EpochPack(epoch) => {
+            hasher.update(b"epoch-pack");
+            hasher.update(&epoch.to_le_bytes());
+        }
+        StreamRequestKind::EpochPackPartial { epoch, last_consensus_number } => {
+            hasher.update(b"epoch-pack-partial");
+            hasher.update(&epoch.to_le_bytes());
+            hasher.update(&last_consensus_number.to_le_bytes());
+        }
+        StreamRequestKind::ConsensusOutput(number) => {
+            hasher.update(b"consensus-output");
+            hasher.update(&number.to_le_bytes());
+        }
+    }
     B256::from_slice(hasher.finalize().as_bytes())
 }
 
@@ -361,7 +378,7 @@ impl PrimaryNetworkHandle {
         number: u64,
     ) -> NetworkResult<Vec<u8>> {
         let request = PrimaryRequest::StreamConsensusOutput { number };
-        let request_digest = consensus_output_stream_digest(number);
+        let request_digest = stream_request_digest(&StreamRequestKind::ConsensusOutput(number));
         let resp = self.handle.send_request(request, peer).await?.await??;
         let PrimaryResponse::StreamRequestAck { ack } = resp.result else {
             return Err(NetworkError::RPCError(
@@ -393,7 +410,7 @@ impl PrimaryNetworkHandle {
     pub async fn request_consensus_output(&self, number: u64) -> NetworkResult<Vec<u8>> {
         const TIMEOUT: Duration = Duration::from_secs(10);
         let request = PrimaryRequest::StreamConsensusOutput { number };
-        let request_digest = consensus_output_stream_digest(number);
+        let request_digest = stream_request_digest(&StreamRequestKind::ConsensusOutput(number));
         // Try up to three times (from three peers) to get the output.
         // This could be a lot more complicated but this KISS method should work fine.
         for _ in 0..3 {
@@ -515,7 +532,7 @@ impl PrimaryNetworkHandle {
         self.handle.connected_peer_count().await
     }
 
-    /// Attempt to get an epoch pack file from any peer via stream.
+    /// Attempt to get a complete epoch pack file from any peer via stream.
     ///
     /// This method:
     /// 1. Sends a `StreamEpoch` request to negotiate
@@ -528,12 +545,64 @@ impl PrimaryNetworkHandle {
         consensus_chain: &ConsensusChain,
         record_timeout: Duration,
     ) -> NetworkResult<()> {
+        self.request_epoch_pack_inner(
+            epoch_record,
+            previous_epoch,
+            consensus_chain,
+            None,
+            record_timeout,
+        )
+        .await
+    }
+
+    /// Attempt to get a verifiable PREFIX of an epoch's pack file from any peer via stream,
+    /// stopping after consensus number `last_consensus_number`.
+    ///
+    /// Behaves exactly like [`Self::request_epoch_pack`] but negotiates a partial transfer. The
+    /// caller must supply an `epoch_record` whose `final_consensus` matches the partial stop point
+    /// so the streamed prefix verifies. Used to fetch the in-progress current epoch up to a
+    /// known point.
+    pub async fn request_partial_epoch_pack(
+        &self,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        consensus_chain: &ConsensusChain,
+        last_consensus_number: u64,
+        record_timeout: Duration,
+    ) -> NetworkResult<()> {
+        self.request_epoch_pack_inner(
+            epoch_record,
+            previous_epoch,
+            consensus_chain,
+            Some(last_consensus_number),
+            record_timeout,
+        )
+        .await
+    }
+
+    /// Shared implementation for full ([`Self::request_epoch_pack`]) and partial
+    /// ([`Self::request_partial_epoch_pack`]) epoch pack streaming. `last_consensus_number` selects
+    /// the request variant and correlation digest; everything else is identical.
+    async fn request_epoch_pack_inner(
+        &self,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        consensus_chain: &ConsensusChain,
+        last_consensus_number: Option<u64>,
+        record_timeout: Duration,
+    ) -> NetworkResult<()> {
         let epoch = epoch_record.epoch;
         // Try up to three times (from three peers) to get consensus.
         // This could be a lot more complicated but this KISS method should work fine.
         // send request to negotiate stream
-        let request = PrimaryRequest::StreamEpoch { epoch };
-        let request_digest = epoch_stream_digest(epoch);
+        let (request, kind) = match last_consensus_number {
+            None => (PrimaryRequest::StreamEpoch { epoch }, StreamRequestKind::EpochPack(epoch)),
+            Some(last_consensus_number) => (
+                PrimaryRequest::StreamEpochPartial { epoch, last_consensus_number },
+                StreamRequestKind::EpochPackPartial { epoch, last_consensus_number },
+            ),
+        };
+        let request_digest = stream_request_digest(&kind);
 
         for _ in 0..3 {
             // send request and await response from peer
@@ -793,8 +862,16 @@ where
                     self.process_epoch_record_request(peer, epoch, hash, channel, cancel)
                 }
                 PrimaryRequest::StreamEpoch { epoch } => {
-                    self.process_epoch_stream(peer, epoch, channel, cancel)
+                    self.process_epoch_stream(peer, epoch, None, channel, cancel)
                 }
+                PrimaryRequest::StreamEpochPartial { epoch, last_consensus_number } => self
+                    .process_epoch_stream(
+                        peer,
+                        epoch,
+                        Some(last_consensus_number),
+                        channel,
+                        cancel,
+                    ),
                 PrimaryRequest::StreamConsensusOutput { number } => {
                     self.process_consensus_output_stream(peer, number, channel, cancel)
                 }
@@ -1034,16 +1111,25 @@ where
     }
 
     /// Process a request to stream an epoch pack file.
+    ///
+    /// `last_consensus_number` is `None` for a full-epoch transfer and `Some(n)` to stream only the
+    /// verifiable prefix up to consensus number `n` (the in-progress current epoch).
     fn process_epoch_stream(
         &self,
         peer: BlsPublicKey,
         epoch: Epoch,
+        last_consensus_number: Option<u64>,
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {
-        let request_digest = epoch_stream_digest(epoch);
-        let ack =
-            self.accept_stream_request(peer, request_digest, StreamRequestKind::EpochPack(epoch));
+        let kind = match last_consensus_number {
+            None => StreamRequestKind::EpochPack(epoch),
+            Some(last_consensus_number) => {
+                StreamRequestKind::EpochPackPartial { epoch, last_consensus_number }
+            }
+        };
+        let request_digest = stream_request_digest(&kind);
+        let ack = self.accept_stream_request(peer, request_digest, kind);
         self.send_stream_ack(ack, channel, cancel, format!("process-request-epoch-{peer}"));
     }
 
@@ -1055,12 +1141,9 @@ where
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {
-        let request_digest = consensus_output_stream_digest(number);
-        let ack = self.accept_stream_request(
-            peer,
-            request_digest,
-            StreamRequestKind::ConsensusOutput(number),
-        );
+        let kind = StreamRequestKind::ConsensusOutput(number);
+        let request_digest = stream_request_digest(&kind);
+        let ack = self.accept_stream_request(peer, request_digest, kind);
         self.send_stream_ack(ack, channel, cancel, format!("process-request-output-{peer}"));
     }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -857,6 +857,72 @@ async fn test_behind_consensus_genuinely_behind() {
     assert!(result, "genuinely behind node should be detected");
 }
 
+/// Server-side partial epoch streaming: `send_epoch_over_stream` with `Some(stop_number)` must
+/// emit exactly the verifiable prefix (every output up to and including the stop number) of the
+/// in-progress current epoch, and a later cutoff must extend that same prefix.
+#[tokio::test]
+async fn test_send_partial_epoch_over_stream() {
+    use tokio::io::AsyncReadExt as _;
+
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+    let committee_obj = committee.committee();
+    let peer = *committee.first_authority().authority().protocol_key();
+
+    // Populate the in-progress (never finalized) epoch-0 pack with some outputs.
+    let num_outputs = 15u64;
+    for number in 1..=num_outputs {
+        let cert = Certificate::default();
+        let sub_dag = CommittedSubDag::new(
+            vec![cert.clone()],
+            cert,
+            number,
+            ReputationScores::new(&committee_obj),
+            None,
+        );
+        handler.consensus_chain().write_subdag_for_test(number, sub_dag).await;
+    }
+
+    // The server streams a partial prefix up to consensus number `k`.
+    let k = 9u64;
+    let mut sent = Vec::new();
+    RequestHandler::<MemDatabase>::send_epoch_over_stream(
+        &mut sent,
+        handler.consensus_chain(),
+        0,
+        Some(k),
+        Duration::from_secs(10),
+        peer,
+    )
+    .await
+    .expect("send partial epoch stream");
+
+    // The streamed bytes must equal exactly the verifiable prefix the chain exposes — i.e. the
+    // data file truncated at `output_end(k)`.
+    let (stream, len) =
+        handler.consensus_chain().get_partial_epoch_stream(0, k).await.expect("partial stream");
+    let mut expected = Vec::new();
+    stream.take(len).read_to_end(&mut expected).await.unwrap();
+    assert_eq!(sent.len() as u64, len, "streamed byte count must equal the partial cutoff");
+    assert_eq!(sent, expected, "streamed bytes must equal the verifiable prefix");
+
+    // A later cutoff streams strictly more, and the smaller prefix is a true prefix of it.
+    let mut sent_more = Vec::new();
+    RequestHandler::<MemDatabase>::send_epoch_over_stream(
+        &mut sent_more,
+        handler.consensus_chain(),
+        0,
+        Some(num_outputs),
+        Duration::from_secs(10),
+        peer,
+    )
+    .await
+    .expect("send larger partial stream");
+    assert!(sent_more.len() > sent.len(), "a later cutoff must stream more bytes");
+    assert_eq!(&sent_more[..sent.len()], &sent[..], "smaller prefix must prefix the larger one");
+}
+
 /// A peer that re-requests the same epoch while an entry is already pending must not be
 /// able to reset the cleanup timer. If the replacement path rearmed `created_at`, a peer
 /// could re-request every 20s and hold a slot forever. This test exercises the

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -530,10 +530,11 @@ impl ConsensusChain {
     ) -> Result<(Box<dyn ReadStream>, u64), ConsensusChainError> {
         let pack =
             self.get_static(epoch).await.map_err(|_| ConsensusChainError::StreamUnavailable)?;
-        // Flush so the bytes up to the requested output are on disk before we open a raw file
-        // handle (the current epoch's pack may still be buffering later appends).
-        pack.persist().await?;
         let end = pack.consensus_output_end(last_consensus_number).await?;
+        // Flush (no fsync) so every byte counted in `end` is written to the file and thus visible
+        // to the separate AsyncFile handle opened below. Visibility, not durability — avoids the
+        // expensive network-triggerable fsync on the live pack.
+        pack.flush_data().await?;
         let base_dir = self.base_path.join(format!("epoch-{epoch}"));
         let stream = AsyncFile::open(base_dir.join(DATA_NAME)).await?;
         Ok((Box::new(stream), end))

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -514,6 +514,31 @@ impl ConsensusChain {
         }
     }
 
+    /// Return a stream reader for the data file of `epoch` together with the number of bytes that
+    /// should be sent to deliver a verifiable PREFIX of the pack: every consensus output up to and
+    /// including `last_consensus_number` (a chain consensus number, not a pack-relative index).
+    ///
+    /// Unlike [`Self::get_epoch_stream`], this does NOT require the epoch pack to be complete, so
+    /// it can stream the in-progress current epoch up to an already-persisted, verifiable
+    /// point. The returned byte length is the `output_end` offset of `last_consensus_number`;
+    /// the caller streams `[0, len)` of the data file. The pack is persisted first so those
+    /// bytes are flushed to disk.
+    pub async fn get_partial_epoch_stream(
+        &self,
+        epoch: Epoch,
+        last_consensus_number: u64,
+    ) -> Result<(Box<dyn ReadStream>, u64), ConsensusChainError> {
+        let pack =
+            self.get_static(epoch).await.map_err(|_| ConsensusChainError::StreamUnavailable)?;
+        // Flush so the bytes up to the requested output are on disk before we open a raw file
+        // handle (the current epoch's pack may still be buffering later appends).
+        pack.persist().await?;
+        let end = pack.consensus_output_end(last_consensus_number).await?;
+        let base_dir = self.base_path.join(format!("epoch-{epoch}"));
+        let stream = AsyncFile::open(base_dir.join(DATA_NAME)).await?;
+        Ok((Box::new(stream), end))
+    }
+
     /// Save all the batches and consensus header from the ConsensusOutput the pack file for the
     /// current epoch. This should be called "in-order" as consensus is executed.
     pub async fn save_consensus_output(
@@ -1250,6 +1275,73 @@ mod test {
             let output = outputs.get(i as usize).unwrap();
             compare_outputs(&output_db, output);
         }
+    }
+
+    /// A partial stream of the in-progress (incomplete) current epoch must deliver a verifiable
+    /// prefix: importing `[0, output_end(k))` yields exactly outputs `1..=k`.
+    #[tokio::test]
+    async fn test_consensus_partial_stream() {
+        use tokio::io::AsyncReadExt as _;
+
+        let temp_dir = TempDir::with_prefix("test_partial_src").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        // Save outputs but DO NOT finish the epoch — this is the in-progress current epoch.
+        let num_outputs = 20u64;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            consensus_chain.save_consensus_output(output).await.unwrap();
+        }
+
+        // Stream a verifiable prefix up to consensus number `k` (well before the latest).
+        let k = 12u64;
+        let (stream, len) = consensus_chain
+            .get_partial_epoch_stream(0, k)
+            .await
+            .expect("partial stream of in-progress epoch");
+        // The network layer enforces the byte limit; emulate that here with `take(len)`.
+        let limited = stream.take(len);
+
+        // The importer verifies against an epoch record whose final_consensus is the stop point.
+        let cutoff = &outputs[(k - 1) as usize];
+        assert_eq!(cutoff.number(), k);
+        let mut partial_record = previous_epoch.clone();
+        partial_record.final_consensus = ConsensusNumHash::new(cutoff.number(), cutoff.digest());
+
+        let temp_dir2 = TempDir::with_prefix("test_partial_dst").expect("temp dir");
+        let consensus_chain2 = ConsensusChain::new(temp_dir2.path().to_owned()).unwrap();
+        consensus_chain2
+            .stream_import(limited, &partial_record, &previous_epoch, Duration::from_secs(5))
+            .await
+            .expect("import verifiable partial prefix");
+        consensus_chain2.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        // Outputs 1..=k are present and match.
+        for i in 0..k {
+            let output_db =
+                consensus_chain2.get_consensus_output_current(i + 1).await.expect("prefix output");
+            compare_outputs(&output_db, &outputs[i as usize]);
+        }
+        // Nothing past the cutoff was streamed.
+        assert!(
+            consensus_chain2.get_consensus_output_current(k + 1).await.is_err(),
+            "outputs past the partial cutoff must not be present"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -100,6 +100,7 @@ enum PackMessage {
     ConsensusHeaderNumber(u64, oneshot::Sender<Result<ConsensusHeader, PackError>>),
     Persist(oneshot::Sender<Result<(), PackError>>),
     BytesForConsensus(u64, oneshot::Sender<Result<Vec<u8>, PackError>>),
+    OutputEndForConsensus(u64, oneshot::Sender<Result<u64, PackError>>),
     ReadLastCommitted(oneshot::Sender<Result<HashMap<AuthorityIdentifier, Round>, PackError>>),
     ReadLatestFinalRep(oneshot::Sender<Result<Option<CommittedSubDag>, PackError>>),
     ContainsBatch(B256, oneshot::Sender<bool>),
@@ -150,6 +151,9 @@ fn run_pack_loop(
             }
             PackMessage::BytesForConsensus(number, tx) => {
                 let _ = tx.send(inner.bytes_for_consensus(number));
+            }
+            PackMessage::OutputEndForConsensus(number, tx) => {
+                let _ = tx.send(inner.output_end_for_consensus(number));
             }
             PackMessage::ReadLastCommitted(tx) => {
                 let _ = tx.send(inner.read_last_committed());
@@ -338,6 +342,20 @@ impl ConsensusPack {
         self.get_error()?;
         let (tx, rx) = oneshot::channel();
         if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
+            rx.await.map_err(|_| PackError::ReceiveFailed)?
+        } else {
+            Err(PackError::SendFailed)
+        }
+    }
+
+    /// Return the byte offset in the data file just past the end of the consensus output for
+    /// `number`. Streaming `[0, output_end)` of the data file yields a verifiable prefix of the
+    /// pack containing every output up to and including `number` (plus the data header). Errors
+    /// if `number` is outside the range this pack contains.
+    pub async fn consensus_output_end(&self, number: u64) -> Result<u64, PackError> {
+        self.get_error()?;
+        let (tx, rx) = oneshot::channel();
+        if self.tx.send(PackMessage::OutputEndForConsensus(number, tx)).await.is_ok() {
             rx.await.map_err(|_| PackError::ReceiveFailed)?
         } else {
             Err(PackError::SendFailed)
@@ -1061,6 +1079,23 @@ impl Inner {
             .read_bytes(output_start, output_end)
             .map_err(|e| PackError::ReadError(e.to_string()))?;
         Ok(bytes)
+    }
+
+    /// Return the byte offset in the data file just past the end of the consensus output for
+    /// `number` (the `output_end` of its index entry). Range-checked like `bytes_for_consensus`.
+    fn output_end_for_consensus(&mut self, number: u64) -> Result<u64, PackError> {
+        if number < self.epoch_meta.start_consensus_number {
+            return Err(PackError::ConsensusNumberTooLow);
+        }
+        if number >= self.epoch_meta.start_consensus_number + self.consensus_pos_idx.len() as u64 {
+            return Err(PackError::ConsensusNumberTooHigh);
+        }
+        let rec_pos_idx = number.saturating_sub(self.epoch_meta.start_consensus_number);
+        let pos = self
+            .consensus_pos_idx
+            .load(rec_pos_idx)
+            .map_err(|e| PackError::ReadError(e.to_string()))?;
+        Ok(pos.output_end)
     }
 
     /// Return the latest consensus header by reading directly from the pack index,

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -108,6 +108,9 @@ enum PackMessage {
     CountLeaders(Round, RewardsCounter, oneshot::Sender<Result<(), PackError>>),
     LatestConsensusHeader(oneshot::Sender<Option<ConsensusHeader>>),
     Shutdown,
+    // Flush the write buffer to the data file WITHOUT fsync, so freshly appended bytes
+    /// become visible to other file handles on the same file (visibility, not durability).
+    FlushData(oneshot::Sender<Result<(), PackError>>),
 }
 
 /// Manage a single pack file of consensus data (typically one epoch os the consensus chain).
@@ -176,6 +179,9 @@ fn run_pack_loop(
             PackMessage::Shutdown => {
                 let _ = inner.persist();
                 break;
+            }
+            PackMessage::FlushData(tx) => {
+                let _ = tx.send(inner.flush_data());
             }
         }
     }
@@ -413,6 +419,17 @@ impl ConsensusPack {
         self.get_error()?;
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(PackMessage::Persist(tx)).await;
+        rx.await.map_err(|_| match &*self.error.borrow() {
+            Some(e) => e.clone(),
+            None => PackError::ReceiveFailed,
+        })?
+    }
+
+    // public handle method (sibling of `persist`, consensus_pack.rs:412):
+    pub async fn flush_data(&self) -> Result<(), PackError> {
+        self.get_error()?;
+        let (tx, rx) = oneshot::channel();
+        let _ = self.tx.send(PackMessage::FlushData(tx)).await;
         rx.await.map_err(|_| match &*self.error.borrow() {
             Some(e) => e.clone(),
             None => PackError::ReceiveFailed,
@@ -1054,6 +1071,14 @@ impl Inner {
             self.consensus_pos_idx.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
             self.consensus_digests.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
             self.batch_digests.sync().map_err(|e| PackError::PersistError(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    // Inner method (sibling of Inner::persist, consensus_pack.rs:1051) — flush only, no syncs:
+    fn flush_data(&mut self) -> Result<(), PackError> {
+        if !self.data.read_only() {
+            self.data.flush().map_err(|e| PackError::PersistError(e.to_string()))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Builds on previous PR to add the ability stream a partial pack file (for catching up quickly in the current epoch).

Still foundational, not used yet.