### PR TITLE
fix(primary): clear a pre-existing `never_loop` lint and a broken intra-doc link

### DIFF
--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -32,7 +32,7 @@ pub struct Bullshark {
     pub num_sub_dags_per_schedule: u32,
     /// The leader election schedule to be used when need to find a round's leader
     pub leader_schedule: LeaderSchedule,
-    /// The bad node stake threshold for [LeaderSwapBoard].
+    /// The bad node stake threshold for [`LeaderSwapTable`].
     pub bad_nodes_stake_threshold: u64,
 }
 

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -738,40 +738,29 @@ async fn test_gc_round_update_during_fetch() {
     cb.certificate_fetcher().send(CertificateFetcherCommand::Kick).await.unwrap();
 
     // next fetch should use updated gc round
-    loop {
-        match timeout(Duration::from_secs(2), fake_receiver.recv()).await {
-            Ok(Some(NetworkCommand::SendRequest {
-                peer,
-                request: PrimaryRequest::MissingCertificates { inner },
-                reply,
-            })) => {
-                let (_lower_bound, skip_rounds) = inner.get_bounds().unwrap();
-                // verify skip_rounds don't include rounds <= 5
-                for rounds in skip_rounds.values() {
-                    assert!(rounds.iter().all(|&r| r > 5), "should not fetch rounds <= GC round");
-                }
+    let Ok(Some(NetworkCommand::SendRequest {
+        peer,
+        request: PrimaryRequest::MissingCertificates { inner },
+        reply,
+    })) = timeout(Duration::from_secs(2), fake_receiver.recv()).await
+    else {
+        panic!("Should receive fetch request with updated GC round but timedout");
+    };
 
-                reply
-                    .send(Ok(NetworkResponseMessage {
-                        peer,
-                        result: PrimaryResponse::RequestedCertificates(
-                            all_certificates
-                                .iter()
-                                .filter(|c| c.header().round() > 5)
-                                .cloned()
-                                .collect(),
-                        ),
-                    }))
-                    .unwrap();
-
-                // break here to prevent timeout
-                break;
-            }
-            _ => {
-                panic!("Should receive fetch request with updated GC round but timedout");
-            }
-        }
+    let (_lower_bound, skip_rounds) = inner.get_bounds().unwrap();
+    // verify skip_rounds don't include rounds <= 5
+    for rounds in skip_rounds.values() {
+        assert!(rounds.iter().all(|&r| r > 5), "should not fetch rounds <= GC round");
     }
+
+    reply
+        .send(Ok(NetworkResponseMessage {
+            peer,
+            result: PrimaryResponse::RequestedCertificates(
+                all_certificates.iter().filter(|c| c.header().round() > 5).cloned().collect(),
+            ),
+        }))
+        .unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Two small, unrelated, non-behavioural lint fixes in `tn-primary`. Each currently
fails a workspace-wide gate on `main`:

- `cargo clippy --workspace --all-features --all-targets` errors on a
  `clippy::never_loop` (deny-by-default) in a primary test.
- `cargo doc --no-deps -D warnings` errors on a broken intra-doc link in
  `bullshark.rs`.

Neither is related to any in-flight feature work; they surfaced from recent
merges. Splitting them out keeps feature PRs' diffs clean.

## Changes

### `consensus/bullshark.rs`: broken intra-doc link

The `bad_nodes_stake_threshold` field doc linked `[LeaderSwapBoard]`, a type that
has since been renamed to `LeaderSwapTable`. The dangling link fails
`cargo doc -D warnings`. Repointed to `` [`LeaderSwapTable`] `` (already in scope
in this module via `use crate::consensus::{… LeaderSwapTable …}`).

### `tests/certificate_fetcher_tests.rs`: `never_loop`

The "next fetch should use updated gc round" assertion wrapped a single
`fake_receiver.recv()` in

```rust
loop {
    match timeout(..).await {
        Ok(Some(NetworkCommand::SendRequest { .. })) => { ..; break; }
        _ => panic!(".."),
    }
}
```

which always exits on the first iteration, tripping `clippy::never_loop`.
Rewritten as a `let … else { panic!(..) }`, which expresses "expect exactly this
message or fail" directly and drops the loop, the `break`, and the match.

## Gates

- `cargo +nightly-2026-03-20 fmt --check` — clean
- `cargo clippy --workspace --all-features --all-targets`: **now clean** (this `never_loop` was the only deny blocking it)
- `cargo doc --no-deps -D warnings -p tn-primary` — clean (the `LeaderSwapTable` link resolves)
- `cargo test -p tn-primary --lib` — 111 passed, 0 failed (the rewritten assertion still passes)

Toolchain: build/test stable 1.94; fmt/clippy nightly-2026-03-20.

Note: a full-workspace `cargo doc --no-deps -D warnings` still trips a separate,
pre-existing issue in `tn-test-utils` (a broken `MIN_PROTOCOL_BASE_FEE` link and a
missing crate-level doc), unrelated to this change and left for a follow-up.