### PR TITLE
fix(network): deliver accepted gossip when relaying peer's BLS is unresolved

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -799,8 +799,8 @@ where
                     self.process_consensus_output_stream(peer, number, channel, cancel)
                 }
             },
-            NetworkEvent::Gossip(msg, propagation_source) => {
-                self.process_gossip(msg, propagation_source);
+            NetworkEvent::Gossip(msg, relayer) => {
+                self.process_gossip(msg, relayer);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = PrimaryResponse::Error(PrimaryRPCError(msg));
@@ -1065,18 +1065,21 @@ where
     }
 
     /// Process gossip from committee.
-    fn process_gossip(&self, msg: GossipMessage, propagation_source: BlsPublicKey) {
+    fn process_gossip(&self, msg: GossipMessage, relayer: Option<BlsPublicKey>) {
         // clone for spawned tasks
         let request_handler = self.request_handler.clone();
         let network_handle = self.network_handle.clone();
-        let task_name = format!("ProcessGossip-{}-{propagation_source}", msg.topic);
+        let relayer_label =
+            relayer.as_ref().map_or_else(|| "unresolved".to_string(), |bls| bls.to_string());
+        let task_name = format!("ProcessGossip-{}-{relayer_label}", msg.topic);
         // spawn task to process gossip
         self.task_spawner.spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "primary::network", ?e, "process_gossip");
-                // convert error into penalty to lower peer score
-                if let Some(penalty) = (&e).into() {
-                    network_handle.report_penalty(propagation_source, penalty).await;
+                // convert error into penalty to lower peer score; only attributable
+                // when the relaying peer's BLS identity has resolved
+                if let Some((relayer, penalty)) = relayer.zip((&e).into()) {
+                    network_handle.report_penalty(relayer, penalty).await;
                 }
                 Err(e.into())
             } else {

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -201,8 +201,8 @@ where
                     warn!(target: "worker::network", "worker application received unexpected peer exchange message");
                 }
             },
-            NetworkEvent::Gossip(msg, propagation_source) => {
-                self.process_gossip(msg, propagation_source);
+            NetworkEvent::Gossip(msg, relayer) => {
+                self.process_gossip(msg, relayer);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = WorkerResponse::Error(message::WorkerRPCError(msg));
@@ -261,17 +261,20 @@ where
     }
 
     /// Process gossip from a worker.
-    fn process_gossip(&self, msg: GossipMessage, propagation_source: BlsPublicKey) {
+    fn process_gossip(&self, msg: GossipMessage, relayer: Option<BlsPublicKey>) {
         // clone for spawned tasks
         let request_handler = self.request_handler.clone();
         let network_handle = self.network_handle.clone();
-        let task_name = format!("process-gossip-{propagation_source}");
+        let relayer_label =
+            relayer.as_ref().map_or_else(|| "unresolved".to_string(), |bls| bls.to_string());
+        let task_name = format!("process-gossip-{relayer_label}");
         self.network_handle.get_task_spawner().spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "worker::network", ?e, "process_gossip");
-                // convert error into penalty to lower peer score
-                if let Some(penalty) = e.penalty() {
-                    network_handle.report_penalty(propagation_source, penalty).await;
+                // convert error into penalty to lower peer score; only attributable
+                // when the relaying peer's BLS identity has resolved
+                if let Some((relayer, penalty)) = relayer.zip(e.penalty()) {
+                    network_handle.report_penalty(relayer, penalty).await;
                 }
                 Err(e.into())
             } else {

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -859,34 +859,32 @@ where
                 if valid {
                     // A peer is `Connected` before its `NodeRecord` resolves its BLS
                     // identity, so a live mesh neighbor can relay a message before
-                    // `peer_to_bls` can resolve it. This is rare on a warm node but
-                    // reachable, so handle the unresolved case explicitly instead of
-                    // dropping an accepted message with no trace.
-                    if let Some(bls) =
-                        self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source)
-                    {
-                        // forward gossip to handler
-                        if let Err(e) =
-                            self.event_stream.try_send(NetworkEvent::Gossip(message, bls))
-                        {
-                            error!(target: "network", topics=?self.authorized_publishers.keys(), ?propagation_source, ?message_id, ?e, "failed to forward gossip!");
-                            // ignore failures at the epoch boundary
-                            // During epoch change the event_stream reciever can be closed.
-                            return Ok(());
-                        }
-                    } else {
-                        // The message was accepted into the mesh (and re-propagated),
-                        // but this node cannot yet resolve the relaying peer's BLS
-                        // identity, so it is not delivered to the local consensus
-                        // layer. Warn so the drop is observable rather than silent;
-                        // the node recovers the payload via sync once the identity
-                        // resolves.
-                        warn!(
+                    // `peer_to_bls` can resolve it. Deliver the accepted payload
+                    // regardless and carry the relayer as `Option`: the author is
+                    // already authenticated by `verify_gossip`, the relayer identity
+                    // is only used for penalty attribution, and dropping here would
+                    // lose the message for good because gossipsub has already cached
+                    // `message_id` and will not re-deliver it once the identity
+                    // resolves. The consumer skips the (unattributable) penalty while
+                    // the relayer is unresolved.
+                    let relayer =
+                        self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source);
+                    if relayer.is_none() {
+                        debug!(
                             target: "network",
                             ?propagation_source,
                             ?message_id,
-                            "accepted gossip not delivered locally: relaying peer's BLS identity is not yet resolved"
+                            "delivering accepted gossip with unresolved relayer identity; consensus-layer penalty skipped"
                         );
+                    }
+                    // forward gossip to handler
+                    if let Err(e) =
+                        self.event_stream.try_send(accepted_gossip_event(message, relayer))
+                    {
+                        error!(target: "network", topics=?self.authorized_publishers.keys(), ?propagation_source, ?message_id, ?e, "failed to forward gossip!");
+                        // ignore failures at the epoch boundary
+                        // During epoch change the event_stream reciever can be closed.
+                        return Ok(());
                     }
                 } else {
                     self.metrics.record_gossip_rejected();
@@ -1752,4 +1750,19 @@ fn resolve_response<Res: TNMessage>(
     resolved
         .map(|peer| NetworkResponseMessage { peer, result: response })
         .ok_or(NetworkError::PeerUnresolved)
+}
+
+/// Build the application event for an accepted gossip message.
+///
+/// `relayer` is the relaying peer's BLS identity, or `None` while its
+/// `NodeRecord` has not yet resolved. The accepted payload is delivered in
+/// either case: the author is already authenticated during gossip verification,
+/// and dropping an unresolved-relayer message would lose it permanently because
+/// gossipsub has already cached its `message_id`. The relayer is carried so the
+/// consumer can attribute a penalty only when the identity is known.
+fn accepted_gossip_event<Req, Res>(
+    message: GossipMessage,
+    relayer: Option<BlsPublicKey>,
+) -> NetworkEvent<Req, Res> {
+    NetworkEvent::Gossip(message, relayer)
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -867,9 +867,14 @@ async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<
     let event =
         timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
 
-    // assert gossip message
-    if let NetworkEvent::Gossip(msg, _) = event {
+    // assert gossip message and that the resolved relayer identity is carried
+    if let NetworkEvent::Gossip(msg, relayer) = event {
         assert_eq!(msg.data, expected_result);
+        assert_eq!(
+            relayer,
+            Some(target_peer_bls),
+            "resolved relayer's BLS identity must be attached to the delivered gossip"
+        );
     } else {
         panic!("unexpected network event received");
     }
@@ -2560,5 +2565,40 @@ fn resolved_response_attaches_identity_to_payload() -> eyre::Result<()> {
     let NetworkResponseMessage { peer, result } = resolve_response(Some(bls), response.clone())?;
     assert_eq!(peer, bls);
     assert_eq!(result, response);
+    Ok(())
+}
+
+/// A minimal accepted gossip payload for delivery-mapping tests.
+fn test_gossip_message() -> GossipMessage {
+    GossipMessage {
+        source: None,
+        data: Vec::from("gossip-payload".as_bytes()),
+        sequence_number: None,
+        topic: TopicHash::from_raw(TEST_TOPIC),
+    }
+}
+
+/// Regression for issue #776: an accepted gossip message whose relaying peer's
+/// BLS identity has not yet resolved must still be delivered (carried as
+/// `None`), never dropped. The author is authenticated during gossip
+/// verification, and gossipsub will not re-deliver the `message_id` once the
+/// identity resolves, so dropping here would lose the message for good.
+#[test]
+fn accepted_gossip_with_unresolved_relayer_is_delivered() -> eyre::Result<()> {
+    let message = test_gossip_message();
+    let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
+        accepted_gossip_event(message.clone(), None);
+    assert_matches!(event, NetworkEvent::Gossip(delivered, None) if delivered.data == message.data);
+    Ok(())
+}
+
+/// A resolved relayer identity is attached to the delivered gossip event.
+#[test]
+fn accepted_gossip_with_resolved_relayer_carries_identity() -> eyre::Result<()> {
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
+    let message = test_gossip_message();
+    let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
+        accepted_gossip_event(message, Some(bls));
+    assert_matches!(event, NetworkEvent::Gossip(_, Some(got)) if got == bls);
     Ok(())
 }

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -162,8 +162,16 @@ pub enum NetworkEvent<Req, Res> {
         /// The oneshot channel if the request gets cancelled at the network level.
         cancel: oneshot::Receiver<()>,
     },
-    /// Gossip message received and propagation source.
-    Gossip(GossipMessage, BlsPublicKey),
+    /// Gossip message received, with the relaying peer's BLS identity when it
+    /// has resolved.
+    ///
+    /// The identity is `None` during the brief window after a peer joins the
+    /// gossipsub mesh and relays a message before its signed `NodeRecord`
+    /// (which carries the BLS key) has been resolved. The payload is delivered
+    /// regardless, because the message author is already authenticated during
+    /// gossip verification; the relayer identity is used only for penalty
+    /// attribution and a log label, never for the payload itself.
+    Gossip(GossipMessage, Option<BlsPublicKey>),
     /// Send an error back the requester.
     Error(String, ResponseChannel<Res>),
     /// An inbound stream was established by a peer.


### PR DESCRIPTION
Closes #776.

## Summary

When an authenticated gossip message is accepted but the relaying peer's BLS
identity has not yet resolved, we dropped the message locally and emitted a
warning. The drop is unnecessary: `propagation_source` is used only for penalty
attribution and a log label, never for the payload itself, and the message
author is already authenticated by `verify_gossip`. This delivers the accepted
payload anyway and carries the relayer identity as `Option`, which removes both
the dropped delivery and the warning burst seen on cold restart.

This implements **Option A** from the issue, which the maintainer confirmed is
sufficient ("If the message is valid and published by an authority, then I think
it's fine to deliver to the application layer during the brief resolution
window").

## Why the local drop was unnecessary

- The relayer identity is not part of the payload. The consumers use the second
  field of `NetworkEvent::Gossip` for exactly two things: a task-name log label
  and `report_penalty(relayer, penalty)` when deeper processing fails.
- The payload decode ignores the relayer entirely.
- Dropping was a definite loss: gossipsub records the `message_id` in its 60s
  duplicate cache before the app event, so it never re-delivers that id locally
  even after the identity resolves. The message was recovered only later and more
  expensively by pull-based sync.

## Changes

- `crates/network-libp2p/src/types.rs`: `NetworkEvent::Gossip` now carries
  `Option<BlsPublicKey>` (the relaying peer's BLS identity, `None` while
  unresolved).
- `crates/network-libp2p/src/consensus.rs`: deliver the accepted payload
  unconditionally instead of dropping it; the "accepted gossip not delivered
  locally" `warn!` is removed and replaced with a `debug!` note for the
  penalty-skipped case. Delivery now goes through a small `accepted_gossip_event`
  helper so the unresolved-relayer case is deterministically testable.
- `crates/consensus/primary/src/network/mod.rs` and
  `crates/consensus/worker/src/network/mod.rs`: `process_gossip` takes
  `Option<BlsPublicKey>`. The consensus-layer penalty is applied only when the
  relayer has resolved (`relayer.zip(penalty)`); it is unattributable otherwise.
  The task-name label renders an unresolved relayer as `unresolved`.

## Penalty behavior (the windowed tradeoff)

During the brief resolution window, a relayer that forwards a payload which
later fails deeper processing escapes the consensus-layer penalty. This is low
risk: the author is already authenticated by `verify_gossip`, and the relayer
remains subject to gossipsub peer scoring (the invalid-gossip path still applies
a fatal penalty to the propagation source unchanged).

## Tests

- `crates/network-libp2p/src/tests/network_tests.rs`:
  - `accepted_gossip_with_unresolved_relayer_is_delivered` — regression guard
    that an accepted message with an unresolved relayer is delivered (carried as
    `None`), never dropped.
  - `accepted_gossip_with_resolved_relayer_carries_identity` — the resolved
    identity is attached.
  - `test_msg_verification_ignores_unauthorized_publisher` extended to assert the
    resolved relayer's BLS identity is carried through the real gossip path.

The unresolved-relayer state is a brief, non-deterministic resolution-window
race that cannot be reproduced reliably through the live-network harness (a
connected mesh neighbor resolves via the on-connect record push), so the
delivery invariant is guarded by the focused unit tests above, mirroring the
`resolve_response` unit tests added for the sibling response-path fix in #743 /
#754.

### Gates

- `cargo check -p tn-network-libp2p -p tn-primary -p tn-worker` — green
- `cargo clippy --all-targets -p tn-network-libp2p -- -D warnings` — green
- `cargo clippy --lib -p tn-primary -p tn-worker -- -D warnings` — green
- `cargo fmt --check` — clean
- tests: tn-network-libp2p 183 passed, tn-worker 57 passed, tn-primary 153
  passed (0 failed)

## Out of scope (follow-up)

The worker txn topic subscribes with no publisher allowlist
(`subscribe(worker_txn_topic)` vs `subscribe_with_publishers` for batches), so a
non-committee relayer that never publishes a resolvable `NodeRecord` could warn
indefinitely with no sync backstop. This change removes the warning regardless,
but the underlying never-resolves case is distinct and worth a separate decision
on whether to gate or rate-limit that path.
