### PR TITLE
Hardening patches for consensus chain.

### DIFF
--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -785,7 +785,8 @@ async fn committed_round_after_restart() {
     let config = fixture.authorities().next().unwrap().consensus_config();
     let store = config.node_storage().clone();
     let temp_dir = TempDir::new().unwrap();
-    let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+    let consensus_chain =
+        ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
     let previous_epoch = EpochRecord {
         epoch: committee.epoch().saturating_sub(1),
         committee: committee.bls_keys().iter().copied().collect(),
@@ -1024,7 +1025,8 @@ async fn restart_with_new_committee() {
     let mut committee: Committee = fixture.committee();
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
     let temp_dir = TempDir::new().unwrap();
-    let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+    let consensus_chain =
+        ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
     let mut prev_epoch_digest = EpochDigest::default();
 
     // Run for a few epochs.

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -663,6 +663,7 @@ impl PrimaryNetworkHandle {
             | ConsensusChainError::NoCurrentEpoch
             | ConsensusChainError::EpochDbError(_)
             | ConsensusChainError::InvalidPackEpoch(_, _)
+            | ConsensusChainError::CantSaveAndNotAvailable(_)
             | ConsensusChainError::IO(_) => None,
         }
     }

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -269,7 +269,7 @@ mod tests {
     use tempfile::TempDir;
     use tn_network_libp2p::error::NetworkError;
     use tn_storage::consensus::ConsensusChain;
-    use tn_types::{max_batch_size, Batch, BlockHash, TaskManager, B256};
+    use tn_types::{max_batch_size, Batch, BlockHash, Committee, TaskManager, B256};
 
     #[tokio::test]
     async fn test_validate_batches_from_stream() {
@@ -450,7 +450,8 @@ mod tests {
         let fetcher = BatchFetcher::new(
             handle,
             db,
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain"),
             crate::metrics::WorkerMetrics::new_for_worker(0),
         );
 
@@ -473,7 +474,8 @@ mod tests {
         let fetcher = BatchFetcher::new(
             handle,
             db,
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain"),
             crate::metrics::WorkerMetrics::new_for_worker(0),
         );
 
@@ -509,7 +511,8 @@ mod tests {
         let fetcher = BatchFetcher::new(
             handle.clone(),
             db,
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain"),
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain"),
             crate::metrics::WorkerMetrics::new_for_worker(0),
         );
 

--- a/crates/consensus/worker/src/network/stream_codec.rs
+++ b/crates/consensus/worker/src/network/stream_codec.rs
@@ -134,7 +134,7 @@ mod tests {
     use snap::read::FrameDecoder;
     use std::io::Read;
     use tempfile::TempDir;
-    use tn_types::{max_batch_size, TaskManager};
+    use tn_types::{max_batch_size, Committee, TaskManager};
 
     /// Helper to write batch to buffer and return it
     async fn encode_batch_to_vec(batch: &Batch) -> Vec<u8> {
@@ -303,7 +303,8 @@ mod tests {
         let db = setup_batch_db(&batches);
         let temp_dir = TempDir::new().expect("tempdir");
         let consensus_chain =
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain");
 
         // collect digests
         let digests: BTreeSet<B256> = batches.iter().map(|b| b.digest()).collect();
@@ -343,7 +344,8 @@ mod tests {
         let db = setup_batch_db(&batches[..2]);
         let temp_dir = TempDir::new().expect("tempdir");
         let consensus_chain =
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain");
         consensus_chain.persist_current().await.expect("clean open");
 
         // request all 3 digests
@@ -366,7 +368,8 @@ mod tests {
         let digests: BTreeSet<B256> = BTreeSet::new();
         let temp_dir = TempDir::new().expect("tempdir");
         let consensus_chain =
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain");
 
         let mut output = Vec::new();
         send_batches_over_stream(&mut output, &db, &consensus_chain, &digests, 0)
@@ -387,7 +390,8 @@ mod tests {
         let db = setup_batch_db(&batches);
         let temp_dir = TempDir::new().expect("tempdir");
         let consensus_chain =
-            ConsensusChain::new(temp_dir.path().to_path_buf()).expect("consensus chain");
+            ConsensusChain::new(temp_dir.path().to_path_buf(), Committee::default())
+                .expect("consensus chain");
 
         let digests: BTreeSet<B256> = batches.iter().map(|b| b.digest()).collect();
         assert_eq!(digests.len(), batch_count);

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -47,7 +47,13 @@ where
     tokio::spawn(async move {
         // create the epoch manager
         let mut epoch_manager =
-            EpochManager::new(builder, tn_datadir, consensus_db, key_config, version).await?;
+            match EpochManager::new(builder, tn_datadir, consensus_db, key_config, version).await {
+                Ok(epoch_manager) => epoch_manager,
+                Err(err) => {
+                    tracing::error!("Error running node (creating EpochManager): {err}");
+                    return Err(err.into());
+                }
+            };
         let result = epoch_manager.run().await;
         if let Err(err) = &result {
             tracing::error!("Error running node: {err}");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -47,7 +47,7 @@ where
     tokio::spawn(async move {
         // create the epoch manager
         let mut epoch_manager =
-            EpochManager::new(builder, tn_datadir, consensus_db, key_config, version).await;
+            EpochManager::new(builder, tn_datadir, consensus_db, key_config, version).await?;
         let result = epoch_manager.run().await;
         if let Err(err) = &result {
             tracing::error!("Error running node: {err}");

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -51,7 +51,7 @@ where
                 Ok(epoch_manager) => epoch_manager,
                 Err(err) => {
                     tracing::error!("Error running node (creating EpochManager): {err}");
-                    return Err(err.into());
+                    return Err(err);
                 }
             };
         let result = epoch_manager.run().await;

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -230,15 +230,14 @@ where
         {
             committee_zero
         } else {
-            error!(target: "epoch-manager", "Unable to load commitee zero from the genesis committee!");
+            error!(target: "epoch-manager", "Unable to load committee zero from the genesis committee!");
             return Err(eyre::eyre!(
                 "unable to load committee zero (genesis committee), this is fatal"
             ));
         };
         let epochs_db_path = tn_datadir.epochs_db_path();
         let _ = std::fs::create_dir_all(&epochs_db_path);
-        let consensus_chain =
-            ConsensusChain::new(epochs_db_path, committee_zero).expect("open consensus DB");
+        let consensus_chain = ConsensusChain::new(epochs_db_path, committee_zero)?;
         // shutdown long-running node components
         let node_shutdown = Notifier::new();
 

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -226,10 +226,8 @@ where
         // Note this can only fail if the consensus DB is very broken (bad path for instance).
         // So we will panic for now, this will kill the node on startup for a critical error.
         let committee_zero = if let Ok(committee_zero) =
-            Config::load_from_path_or_default::<Committee>(
-                tn_datadir.committee_path(),
-                ConfigFmt::YAML,
-            ) {
+            Config::load_from_path::<Committee>(tn_datadir.committee_path(), ConfigFmt::YAML)
+        {
             committee_zero
         } else {
             error!(target: "epoch-manager", "Unable to load commitee zero from the genesis committee!");

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -222,12 +222,25 @@ where
         consensus_db: DB,
         key_config: KeyConfig,
         version_str: &'static str,
-    ) -> Self {
+    ) -> eyre::Result<Self> {
         // Note this can only fail if the consensus DB is very broken (bad path for instance).
         // So we will panic for now, this will kill the node on startup for a critical error.
+        let committee_zero = if let Ok(committee_zero) =
+            Config::load_from_path_or_default::<Committee>(
+                tn_datadir.committee_path(),
+                ConfigFmt::YAML,
+            ) {
+            committee_zero
+        } else {
+            error!(target: "epoch-manager", "Unable to load commitee zero from the genesis committee!");
+            return Err(eyre::eyre!(
+                "unable to load committee zero (genesis committee), this is fatal"
+            ));
+        };
         let epochs_db_path = tn_datadir.epochs_db_path();
         let _ = std::fs::create_dir_all(&epochs_db_path);
-        let consensus_chain = ConsensusChain::new(epochs_db_path).expect("open consensus DB");
+        let consensus_chain =
+            ConsensusChain::new(epochs_db_path, committee_zero).expect("open consensus DB");
         // shutdown long-running node components
         let node_shutdown = Notifier::new();
 
@@ -251,7 +264,7 @@ where
             BTreeMap::new()
         };
 
-        Self {
+        Ok(Self {
             builder,
             tn_datadir,
             primary_network_handle: None,
@@ -270,7 +283,7 @@ where
             bootstrap_servers,
             version_str,
             metrics: EpochMetrics::default(),
-        }
+        })
     }
 
     /// Build the process-lifetime components, then drive the epoch loop until shutdown.

--- a/crates/storage/src/archive/data_file.rs
+++ b/crates/storage/src/archive/data_file.rs
@@ -30,6 +30,17 @@ pub(crate) fn fsync_directory(path: &Path) -> Result<(), io::Error> {
     File::open(path)?.sync_all()
 }
 
+/// Create `dir` (and any missing parents) and fsync its parent so the new directory
+/// entry survives a crash. Best-effort fsync (matching the file-create path in
+/// `DataFile::open`); a redundant fsync when `dir` already exists is harmless.
+pub(crate) fn create_dir_synced(dir: &Path) -> Result<(), io::Error> {
+    std::fs::create_dir_all(dir)?;
+    if let Some(parent) = dir.parent() {
+        let _ = fsync_directory(parent);
+    }
+    Ok(())
+}
+
 /// Wrapper around a file that implements read and write buffers and manages
 /// them seamlessly via standard IO traits.
 #[derive(Debug)]

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -29,6 +29,7 @@ use tokio::{
 use tracing::{error, warn};
 
 use crate::{
+    archive::data_file::fsync_directory,
     consensus_pack::{ConsensusPack, PackError, DATA_NAME},
     epoch_records::{EpochDbError, EpochRecordDb},
 };
@@ -485,6 +486,11 @@ impl ConsensusChain {
                 // see the new on-disk pack.
                 self.recent_packs.lock().retain(|p| p.epoch() != epoch);
                 rename_err?;
+                // Make the epoch-{N} directory entry durable in base_path: this commits both
+                // the remove of any stale dir and the renamed-in import before we treat the
+                // import as complete. A failed fsync here means the import is not durable, so
+                // return the error and let it be retried by re-streaming.
+                fsync_directory(&self.base_path)?;
                 if replace_current {
                     // Do this directly, using get_static() will short circuit on the old pack...
                     *self.current_pack.lock() = ConsensusPack::open_static(&self.base_path, epoch)?;

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -466,10 +466,8 @@ impl ConsensusChain {
                 // Held through the remove+rename and cache invalidation below so new_epoch's
                 // open_append cannot observe the transient window where epoch-{N} is unlinked.
                 let _install = self.pack_install.lock().await;
-                let current_pack = self.current_pack.lock();
-                let replace_current = current_pack.epoch() == epoch;
+                let replace_current = self.current_pack.lock().epoch() == epoch;
                 drop(pack);
-                drop(current_pack);
                 // Make sure we don't have any cruft in the final dir.
                 if std::fs::exists(&base_dir).unwrap_or_default() {
                     // If this exists it is incomplete (see check at start of function).

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -16,7 +16,7 @@ use parking_lot::Mutex;
 use tn_types::{
     gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, CommittedSubDag,
     Committee, ConsensusChainReader, ConsensusChainWriter, ConsensusHeader, ConsensusHeaderDigest,
-    ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, ReadStream, Round,
+    ConsensusOutput, Epoch, EpochRecord, ReadStream, Round,
 };
 use tokio::{
     fs::File as AsyncFile,
@@ -286,7 +286,8 @@ pub struct ConsensusChain {
     /// Base path for files.
     base_path: PathBuf,
     /// Current pack for the epoch being written.
-    current_pack: Arc<Mutex<Option<ConsensusPack>>>,
+    /// It is in an Arc and Mutex so clones of ConsensusChain stay in sync.
+    current_pack: Arc<Mutex<ConsensusPack>>,
     /// Track the latest consensus that was saved.
     latest_consensus: LatestConsensus,
     /// Simple cache of recent pack files.
@@ -306,12 +307,33 @@ impl ConsensusChain {
     const PACK_CACHE_SIZE: usize = 10;
 
     /// Create a new empty consensus chain.
-    pub fn new(base_path: PathBuf) -> Result<ConsensusChain, ConsensusChainError> {
+    pub fn new(
+        base_path: PathBuf,
+        committee_zero: Committee,
+    ) -> Result<ConsensusChain, ConsensusChainError> {
         let latest_consensus = LatestConsensus::new(&base_path)?;
         // If we have a pack for the last epoch open it so we can read data early.
-        let current_pack = Arc::new(Mutex::new(
-            ConsensusPack::open_append_exists(&base_path, latest_consensus.epoch()).ok(),
-        ));
+
+        let current_pack = if latest_consensus.number() == 0 && latest_consensus.epoch() == 0 {
+            // If we are just starting then we need to pre-open the epoch 0 pack.
+            let previous_epoch = EpochRecord {
+                // If we can't find the record then we should be starting at epoch 0- use
+                // this filler.
+                epoch: 0,
+                committee: committee_zero.bls_keys().into_iter().collect(),
+                next_committee: committee_zero.bls_keys().into_iter().collect(),
+                ..Default::default()
+            };
+            Arc::new(Mutex::new(ConsensusPack::open_append(
+                &base_path,
+                previous_epoch,
+                committee_zero,
+            )?))
+        } else {
+            // If we are running already then we should have a pack for the latest epoch so Ok to
+            // error out here if it's missing.
+            Arc::new(Mutex::new(ConsensusPack::open_static(&base_path, latest_consensus.epoch())?))
+        };
         let recent_packs = Arc::new(Mutex::new(VecDeque::default()));
         let epochs = Arc::new(EpochRecordDb::open(&base_path)?);
         let pack_install = Arc::new(tokio::sync::Mutex::new(()));
@@ -323,16 +345,14 @@ impl ConsensusChain {
         base_path: PathBuf,
         committee: Committee,
     ) -> Result<ConsensusChain, ConsensusChainError> {
-        let me = Self::new(base_path)?;
+        let me = Self::new(base_path, committee.clone())?;
         let rec = EpochRecord {
             epoch: 0,
             committee: committee.bls_keys().iter().copied().collect(),
             next_committee: committee.bls_keys().iter().copied().collect(),
-            final_consensus: ConsensusNumHash::new(1000, ConsensusHeaderDigest::default()),
             ..Default::default()
         };
         me.new_epoch(rec.clone(), committee).await?;
-        me.epochs().save_record(rec).await?;
         Ok(me)
     }
 
@@ -351,21 +371,14 @@ impl ConsensusChain {
         if previous_epoch.epoch != committee.epoch().saturating_sub(1) {
             return Err(ConsensusChainError::PrevCommitteeEpochMismatch);
         }
-        if let Some(old_pack) = self.current_pack() {
-            if old_pack.epoch() == committee.epoch() {
-                return Ok(());
-            }
-            old_pack.persist().await?;
-            let mut recents = self.recent_packs.lock();
-            // Evict before pushing so the cache stays capped at PACK_CACHE_SIZE.
-            if recents.len() >= Self::PACK_CACHE_SIZE {
-                let _ = recents.pop_front();
-            }
-            recents.push_back(old_pack);
+        let old_pack = self.current_pack();
+        if old_pack.epoch() == committee.epoch() && !old_pack.is_static() {
+            return Ok(());
         }
+        old_pack.persist().await?;
         let pack = ConsensusPack::open_append(&self.base_path, previous_epoch, committee)?;
         pack.persist().await?; // Surface any open errors.
-        *self.current_pack.lock() = Some(pack);
+        *self.current_pack.lock() = pack;
         Ok(())
     }
 
@@ -446,15 +459,8 @@ impl ConsensusChain {
                 // Held through the remove+rename and cache invalidation below so new_epoch's
                 // open_append cannot observe the transient window where epoch-{N} is unlinked.
                 let _install = self.pack_install.lock().await;
-                let mut current_pack = self.current_pack.lock();
-                let replace_current = if let Some(current_pack) = &*current_pack {
-                    current_pack.epoch() == epoch
-                } else {
-                    false
-                };
-                if replace_current {
-                    *current_pack = None;
-                }
+                let current_pack = self.current_pack.lock();
+                let replace_current = current_pack.epoch() == epoch;
                 drop(pack);
                 drop(current_pack);
                 // Make sure we don't have any cruft in the final dir.
@@ -473,6 +479,10 @@ impl ConsensusChain {
                 // see the new on-disk pack.
                 self.recent_packs.lock().retain(|p| p.epoch() != epoch);
                 rename_err?;
+                if replace_current {
+                    // Do this directly, using get_static() will short circuit on the old pack...
+                    *self.current_pack.lock() = ConsensusPack::open_static(&self.base_path, epoch)?;
+                }
                 Ok(())
             }
             Err(e) => Err(e.into()),
@@ -523,36 +533,28 @@ impl ConsensusChain {
         let number = consensus.number();
         if number > self.latest_consensus.number() {
             let epoch = consensus.sub_dag().leader_epoch();
-            if let Some(pack) = &self.current_pack() {
-                if epoch != pack.epoch() {
-                    // The output's epoch does not match the current pack. Saving it would either
-                    // corrupt this pack or poison its async error channel. The pack
-                    // layer also rejects this (defense in depth), but the reject is asynchronous so
-                    // we must guard here to avoid advancing latest_consensus to a wrong-epoch
-                    // pointer for data that was never persisted.
-                    // This is an error and should not happen on a properly working node.
-                    error!(target: "consensus-chain", epoch, pack_epoch = pack.epoch(), number, "Refused to save consensus output: epoch does not match the current pack.");
-                    return Err(ConsensusChainError::InvalidPackEpoch(pack.epoch(), epoch));
-                } else {
-                    pack.save_consensus_output(consensus).await?;
-                    self.latest_consensus.update(epoch, number).await;
-                }
-            } else if let Ok(pack) = self.get_static(epoch).await {
-                // We may be replaying consensus from old epochs and not have a current pack to save
-                // too.
-                if pack.contains_consensus_header_number(number).await.unwrap_or_default() {
-                    // We should have this saved already if no current_pack but let's confirm before
-                    // we save the latest.
-                    self.latest_consensus.update(epoch, number).await;
-                } else {
-                    // Note this should not happen but don't want to kill node on an error since it
-                    // will hopefully self correct soon.
-                    warn!(target: "consensus-chain", epoch, number, "Failed to update latest consensus, data not in expected pack file.");
-                }
+            let pack = &self.current_pack();
+            if epoch != pack.epoch() {
+                // The output's epoch does not match the current pack. Saving it would either
+                // corrupt this pack or poison its async error channel. The pack
+                // layer also rejects this (defense in depth), but the reject is asynchronous so
+                // we must guard here to avoid advancing latest_consensus to a wrong-epoch
+                // pointer for data that was never persisted.
+                // This is an error and should not happen on a properly working node.
+                error!(target: "consensus-chain", epoch, pack_epoch = pack.epoch(), number, "Refused to save consensus output: epoch does not match the current pack.");
+                return Err(ConsensusChainError::InvalidPackEpoch(pack.epoch(), epoch));
             } else {
-                // Note this should not happen but don't want to kill node on an error since it will
-                // hopefully self correct soon.
-                warn!(target: "consensus-chain", epoch, number, "Failed to update latest consensus, pack file that should contain data is missing.");
+                if !pack.is_static() {
+                    // If this an open pack file then save.
+                    // Note, saving an output that is already in the pack is a no-op, not an error
+                    // so this is fine.
+                    pack.save_consensus_output(consensus).await?;
+                } else if !pack.contains_consensus_header_number(number).await.unwrap_or_default() {
+                    // If this is a static file and this output is missing this is an error...
+                    error!(target: "consensus-chain", epoch, number, "Failed to update latest consensus, data not in expected pack file.");
+                    return Err(ConsensusChainError::CantSaveAndNotAvailable(number));
+                }
+                self.latest_consensus.update(epoch, number).await;
             }
         }
         Ok(())
@@ -563,11 +565,7 @@ impl ConsensusChain {
         &self,
         number: u64,
     ) -> Result<ConsensusOutput, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            Ok(pack.get_consensus_output(number).await?)
-        } else {
-            Err(ConsensusChainError::NoCurrentEpoch)
-        }
+        Ok(self.current_pack().get_consensus_output(number).await?)
     }
 
     /// Retrieve a consensus header by digest.
@@ -576,10 +574,9 @@ impl ConsensusChain {
         epoch: Epoch,
         digest: ConsensusHeaderDigest,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            if epoch == pack.epoch() {
-                return Ok(pack.consensus_header_by_digest(digest).await);
-            }
+        let pack = &self.current_pack();
+        if epoch == pack.epoch() {
+            return Ok(pack.consensus_header_by_digest(digest).await);
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.consensus_header_by_digest(digest).await)
@@ -595,10 +592,9 @@ impl ConsensusChain {
         number: u64,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
         let epoch = self.epochs.number_to_epoch(number);
-        if let Some(pack) = &self.current_pack() {
-            if epoch == pack.epoch() {
-                return Ok(Some(pack.consensus_header_by_number(number).await?));
-            }
+        let pack = self.current_pack();
+        if epoch == pack.epoch() {
+            return Ok(Some(pack.consensus_header_by_number(number).await?));
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.consensus_header_by_number(number).await?))
@@ -614,10 +610,9 @@ impl ConsensusChain {
         number: u64,
     ) -> Result<Option<Vec<u8>>, ConsensusChainError> {
         let epoch = self.epochs.number_to_epoch(number);
-        if let Some(pack) = &self.current_pack() {
-            if epoch == pack.epoch() {
-                return Ok(Some(pack.get_consensus_output_bytes(number).await?));
-            }
+        let pack = self.current_pack();
+        if epoch == pack.epoch() {
+            return Ok(Some(pack.get_consensus_output_bytes(number).await?));
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.get_consensus_output_bytes(number).await?))
@@ -657,9 +652,8 @@ impl ConsensusChain {
 
     /// Resolve when the current epoch is fully persisted to storage.
     pub async fn persist_current(&self) -> Result<(), ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            pack.persist().await?;
-        }
+        let pack = &self.current_pack();
+        pack.persist().await?;
         self.latest_consensus.persist().await;
         Ok(())
     }
@@ -671,10 +665,9 @@ impl ConsensusChain {
         &self,
         epoch: Epoch,
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            if pack.epoch() == epoch {
-                return Ok(pack.latest_consensus_header().await);
-            }
+        let pack = &self.current_pack();
+        if pack.epoch() == epoch {
+            return Ok(pack.latest_consensus_header().await);
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.latest_consensus_header().await)
@@ -688,10 +681,9 @@ impl ConsensusChain {
         &self,
         epoch: Epoch,
     ) -> Result<HashMap<AuthorityIdentifier, Round>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            if pack.epoch() == epoch {
-                return Ok(pack.read_last_committed().await?);
-            }
+        let pack = &self.current_pack();
+        if pack.epoch() == epoch {
+            return Ok(pack.read_last_committed().await?);
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.read_last_committed().await?)
@@ -705,10 +697,9 @@ impl ConsensusChain {
         &self,
         epoch: Epoch,
     ) -> Result<Option<CommittedSubDag>, ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            if pack.epoch() == epoch {
-                return Ok(pack.read_latest_commit_with_final_reputation_scores().await?);
-            }
+        let pack = &self.current_pack();
+        if pack.epoch() == epoch {
+            return Ok(pack.read_latest_commit_with_final_reputation_scores().await?);
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.read_latest_commit_with_final_reputation_scores().await?)
@@ -737,11 +728,7 @@ impl ConsensusChain {
 
     /// True if the current epoch pack contains the batch for digest.
     pub async fn contains_current_batch(&self, digest: BlockHash) -> bool {
-        if let Some(pack) = &self.current_pack() {
-            pack.contains_batch(digest).await
-        } else {
-            false
-        }
+        self.current_pack().contains_batch(digest).await
     }
 
     /// Return a vector of batches matching the provided digests (if found).
@@ -768,24 +755,19 @@ impl ConsensusChain {
         last_executed_round: Round,
         rewards_counter: RewardsCounter,
     ) -> Result<(), ConsensusChainError> {
-        if let Some(pack) = &self.current_pack() {
-            Ok(pack.count_leaders(last_executed_round, rewards_counter).await?)
-        } else {
-            Err(ConsensusChainError::NoCurrentEpoch)
-        }
+        Ok(self.current_pack().count_leaders(last_executed_round, rewards_counter).await?)
     }
 
     /// Return a clone of the current pack.
-    fn current_pack(&self) -> Option<ConsensusPack> {
+    fn current_pack(&self) -> ConsensusPack {
         self.current_pack.lock().clone()
     }
 
     /// Get a static pack file from the cache if available or create and cache if not.
     async fn get_static(&self, epoch: Epoch) -> Result<ConsensusPack, PackError> {
-        if let Some(pack) = self.current_pack() {
-            if pack.epoch() == epoch {
-                return Ok(pack.clone());
-            }
+        let pack = self.current_pack();
+        if pack.epoch() == epoch {
+            return Ok(pack);
         }
         {
             let mut recents = self.recent_packs.lock();
@@ -940,6 +922,7 @@ pub enum ConsensusChainError {
     InvalidImport,
     StreamUnavailable,
     InvalidPackEpoch(Epoch, Epoch),
+    CantSaveAndNotAvailable(u64),
 }
 
 impl Error for ConsensusChainError {}
@@ -966,6 +949,9 @@ impl Display for ConsensusChainError {
             }
             ConsensusChainError::InvalidPackEpoch(pack_epoch, epoch) => {
                 write!(f, "Tried to save an output from epoch {epoch} into the current pack epoch {pack_epoch}")
+            }
+            ConsensusChainError::CantSaveAndNotAvailable(number) => {
+                write!(f, "Pack file is static and Consensus {number} missing, can't save")
             }
         }
     }
@@ -1155,7 +1141,8 @@ mod test {
             next_committee: committee.bls_keys().iter().copied().collect(),
             ..Default::default()
         };
-        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         // Save a few legitimate epoch-0 outputs.
@@ -1209,7 +1196,8 @@ mod test {
             ..Default::default()
         };
         // Create and load some data in initial file.
-        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         let num_outputs = 1000;
@@ -1236,7 +1224,8 @@ mod test {
         //drop(consensus_chain);
 
         let temp_dir2 = TempDir::with_prefix("test_consensus_pack2").expect("temp dir");
-        let consensus_chain2 = ConsensusChain::new(temp_dir2.path().to_owned()).unwrap();
+        let consensus_chain2 =
+            ConsensusChain::new(temp_dir2.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.epochs().save_record(epoch_record.clone()).await.expect("save epoch");
         let stream = consensus_chain.get_epoch_stream(0).await.unwrap();
         consensus_chain2
@@ -1245,8 +1234,10 @@ mod test {
             .unwrap();
         consensus_chain2.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
         for i in 0..num_outputs {
-            let output_db =
-                consensus_chain2.get_consensus_output_current(i as u64 + 1).await.unwrap();
+            let output_db = consensus_chain2
+                .get_consensus_output_current(i as u64 + 1)
+                .await
+                .expect(&format!("Failed to get on {i}"));
             let output = outputs.get(i as usize).unwrap();
             compare_outputs(&output_db, output);
         }
@@ -1268,7 +1259,8 @@ mod test {
             next_committee: committee.bls_keys().iter().copied().collect(),
             ..Default::default()
         };
-        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         // Save some outputs, keeping the originals to compare against.
@@ -1308,10 +1300,11 @@ mod test {
 
         // A fresh chain with no epoch opened has no data and returns Ok(None).
         let empty_dir = TempDir::with_prefix("test_output_bytes_empty").expect("temp dir");
-        let empty_chain = ConsensusChain::new(empty_dir.path().to_owned()).unwrap();
+        let empty_chain =
+            ConsensusChain::new(empty_dir.path().to_owned(), committee.clone()).unwrap();
         assert!(
-            empty_chain.consensus_output_bytes_by_number(1).await.expect("query ok").is_none(),
-            "missing data must return None"
+            empty_chain.consensus_output_bytes_by_number(1).await.is_err(),
+            "empty chain will should return a too high error"
         );
     }
 
@@ -1345,7 +1338,7 @@ mod test {
             next_committee: committee.bls_keys().iter().copied().collect(),
             ..Default::default()
         };
-        let source = ConsensusChain::new(source_dir.path().to_owned()).unwrap();
+        let source = ConsensusChain::new(source_dir.path().to_owned(), committee.clone()).unwrap();
         source.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         let num_outputs = 50;
@@ -1368,7 +1361,9 @@ mod test {
             // A fresh target each iteration guarantees `stream_import` does the real
             // remove+rename instead of returning early on an existing complete pack.
             let target_dir = TempDir::with_prefix("test_race_target").expect("temp dir");
-            let target = Arc::new(ConsensusChain::new(target_dir.path().to_owned()).unwrap());
+            let target = Arc::new(
+                ConsensusChain::new(target_dir.path().to_owned(), committee.clone()).unwrap(),
+            );
             let stream = source.get_epoch_stream(0).await.expect("source epoch stream");
 
             // Hammer `new_epoch` for the whole duration of the single concurrent
@@ -1384,7 +1379,6 @@ mod test {
                 tokio::spawn(async move {
                     let mut result = Ok(());
                     while !done.load(Ordering::Relaxed) {
-                        *target.current_pack.lock() = None;
                         if let Err(e) =
                             target.new_epoch(previous_epoch.clone(), committee.clone()).await
                         {
@@ -1413,7 +1407,6 @@ mod test {
             );
 
             // The imported epoch-0 pack must be complete and readable after all the racing.
-            *target.current_pack.lock() = None;
             let pack = target.get_static(0).await.expect("epoch-0 pack readable after race");
             let header = pack.latest_consensus_header().await.expect("epoch-0 has a final header");
             assert_eq!(header.number, epoch_record.final_consensus.number, "final header number");
@@ -1434,7 +1427,8 @@ mod test {
             ..Default::default()
         };
         // Create and load some data in initial file.
-        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
 
         let num_outputs = 100;
@@ -1526,7 +1520,8 @@ mod test {
 
         consensus_chain.persist_current().await.expect("persist chain");
         drop(consensus_chain);
-        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
         consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
         consensus_chain.epochs().save_record(previous_epoch.clone()).await.unwrap();
 

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -330,9 +330,15 @@ impl ConsensusChain {
                 committee_zero,
             )?))
         } else {
-            // If we are running already then we should have a pack for the latest epoch so Ok to
-            // error out here if it's missing.
-            Arc::new(Mutex::new(ConsensusPack::open_static(&base_path, latest_consensus.epoch())?))
+            // If we are running already then we should have a pack for the latest epoch so it is
+            // Ok to error out here if it is missing. Open it in append mode (not static): this
+            // runs trunc_and_heal to repair a torn write from a hard crash mid-epoch, and leaves
+            // the pack writable so the node can resume saving outputs for this epoch without
+            // waiting for new_epoch to flip a read-only pack to append.
+            Arc::new(Mutex::new(ConsensusPack::open_append_exists(
+                &base_path,
+                latest_consensus.epoch(),
+            )?))
         };
         let recent_packs = Arc::new(Mutex::new(VecDeque::default()));
         let epochs = Arc::new(EpochRecordDb::open(&base_path)?);
@@ -1240,6 +1246,67 @@ mod test {
                 .expect(&format!("Failed to get on {i}"));
             let output = outputs.get(i as usize).unwrap();
             compare_outputs(&output_db, output);
+        }
+    }
+
+    /// A node that crashes mid-epoch can leave the pack's data file longer than its indexes
+    /// (a torn write). On restart `ConsensusChain::new` must heal that pack rather than fail to
+    /// open, otherwise the node cannot restart. This opens the latest epoch with
+    /// `open_append_exists` (which runs `trunc_and_heal`); the old `open_static` path returned
+    /// `CorruptPack` here.
+    #[tokio::test]
+    async fn test_new_heals_torn_write_on_restart() {
+        use crate::consensus_pack::DATA_NAME;
+        use std::io::Write as _;
+
+        let temp_dir = TempDir::with_prefix("test_torn_write").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+
+        // Write a handful of outputs and persist, then drop the chain (clean on-disk state).
+        let mut outputs = Vec::new();
+        {
+            let consensus_chain =
+                ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
+            consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+            let mut parent = ConsensusHeader::default().digest();
+            for i in 0..5u64 {
+                let output =
+                    make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+                parent = output.digest().into();
+                outputs.push(output.clone());
+                consensus_chain.save_consensus_output(output).await.unwrap();
+            }
+            consensus_chain.persist_current().await.expect("persist");
+        }
+
+        // Simulate a torn write: append garbage to the data file so its length runs ahead of the
+        // indexes' tracked data-file length (exactly what files_consistent rejects).
+        {
+            let data_path = temp_dir.path().join("epoch-0").join(DATA_NAME);
+            let mut f =
+                std::fs::OpenOptions::new().append(true).open(&data_path).expect("open data file");
+            f.write_all(&[0xAB; 64]).expect("append garbage");
+            f.sync_all().expect("sync");
+        }
+
+        // Restart: new() must open + heal the latest epoch pack rather than erroring.
+        let reopened = ConsensusChain::new(temp_dir.path().to_owned(), committee.clone())
+            .expect("heal on open");
+        // All previously saved outputs are still readable after healing.
+        for (i, output) in outputs.iter().enumerate() {
+            let got = reopened
+                .get_consensus_output_current(i as u64 + 1)
+                .await
+                .expect("output readable after heal");
+            compare_outputs(&got, output);
         }
     }
 

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -1481,6 +1481,76 @@ mod test {
         }
     }
 
+    /// An observer that caught up via `stream_import` ends up with a *static* (read-only)
+    /// pack for the imported epoch as its current pack, while replaying that epoch's outputs
+    /// advances `latest_consensus` into it. On restart `ConsensusChain::new` takes the
+    /// "already running" branch (`latest_consensus` is no longer `0/0`) and must re-open the
+    /// imported epoch with `open_append_exists` rather than erroring. This locks in that
+    /// invariant: a node that only ever obtained an epoch by import can still restart and
+    /// serve the data.
+    #[tokio::test]
+    async fn test_new_reopens_imported_epoch_on_restart() {
+        // Build a complete epoch-0 pack on a source chain to stream from.
+        let source_dir = TempDir::with_prefix("test_import_restart_source").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let source = ConsensusChain::new(source_dir.path().to_owned(), committee.clone()).unwrap();
+        source.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        let num_outputs = 10u64;
+        let mut parent = ConsensusHeader::default().digest();
+        let mut outputs = Vec::new();
+        for i in 0..num_outputs {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            source.save_consensus_output(output).await.unwrap();
+        }
+        source.persist_current().await.expect("persist source");
+        let last = outputs.last().expect("at least one output").clone();
+        let mut epoch_record = previous_epoch.clone();
+        epoch_record.final_consensus = ConsensusNumHash::new(last.number(), last.digest());
+        source.epochs().save_record(epoch_record.clone()).await.expect("save epoch record");
+
+        let target_dir = TempDir::with_prefix("test_import_restart_target").expect("temp dir");
+        {
+            let target =
+                ConsensusChain::new(target_dir.path().to_owned(), committee.clone()).unwrap();
+            // Import epoch 0 from the source: the target's current pack becomes a static pack.
+            let stream = source.get_epoch_stream(0).await.expect("source epoch stream");
+            target
+                .stream_import(stream, &epoch_record, &previous_epoch, Duration::from_secs(5))
+                .await
+                .expect("stream import");
+            // Replay the imported outputs the way an executing observer would; this advances
+            // latest_consensus into the (static) imported epoch without rewriting the pack.
+            for output in &outputs {
+                target.save_consensus_output(output.clone()).await.expect("replay imported output");
+            }
+            target.persist_current().await.expect("persist target");
+        }
+
+        // Restart: new() must re-open the imported epoch (open_append_exists) and not error,
+        // even though the only on-disk pack for that epoch came from stream_import.
+        let reopened = ConsensusChain::new(target_dir.path().to_owned(), committee.clone())
+            .expect("reopen imported epoch on restart");
+        for output in &outputs {
+            let got = reopened
+                .get_consensus_output_current(output.number())
+                .await
+                .expect("imported output readable after restart");
+            compare_outputs(&got, output);
+        }
+    }
+
     #[tokio::test]
     async fn test_consensus_store_general() {
         let temp_dir = TempDir::with_prefix("test_consensus_pack").expect("temp dir");

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -32,7 +32,7 @@ use tokio::{
 use tracing::{debug, error, warn};
 
 use crate::archive::{
-    data_file::fsync_directory,
+    data_file::{create_dir_synced, fsync_directory},
     digest_index::index::HdxIndex,
     error::{fetch::FetchError, open::OpenError},
     fxhasher::FxHasher,
@@ -677,7 +677,7 @@ impl Inner {
     ) -> Result<Self, PackError> {
         let epoch = committee.epoch();
         let base_dir = path.as_ref().join(format!("epoch-{epoch}"));
-        let _ = std::fs::create_dir_all(&base_dir);
+        let _ = create_dir_synced(&base_dir);
         let pack_file = base_dir.join(Self::DATA_NAME);
         let have_pack = std::fs::exists(&pack_file).unwrap_or_default();
         let mut data: Pack<PackRecord> =
@@ -846,7 +846,7 @@ impl Inner {
             }
         }
         let base_dir = path.as_ref().join(format!("epoch-{epoch}"));
-        let _ = std::fs::create_dir_all(&base_dir);
+        let _ = create_dir_synced(&base_dir);
         let mut stream_iter = AsyncPackIter::<PackRecord, R>::open(stream, epoch as u64)
             .await
             .map_err(|e| PackError::ReadError(e.to_string()))?;

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -118,6 +118,7 @@ pub struct ConsensusPack {
     epoch: Epoch,
     committee: Committee,
     compression: PackCompression,
+    is_static: bool,
 }
 
 fn run_pack_loop(
@@ -215,6 +216,7 @@ impl ConsensusPack {
             epoch,
             committee,
             compression,
+            is_static: false,
         })
     }
 
@@ -234,6 +236,7 @@ impl ConsensusPack {
             epoch,
             committee,
             compression,
+            is_static: false,
         })
     }
 
@@ -255,6 +258,7 @@ impl ConsensusPack {
             epoch,
             committee,
             compression,
+            is_static: true,
         })
     }
 
@@ -291,7 +295,13 @@ impl ConsensusPack {
             epoch,
             committee,
             compression,
+            is_static: true,
         })
+    }
+
+    /// Is this packfile static- i.e. complete and read only.
+    pub fn is_static(&self) -> bool {
+        self.is_static
     }
 
     /// Return the epoch for this pack file.

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -25,6 +25,7 @@ use tokio::sync::{
 use tracing::error;
 
 use crate::archive::{
+    data_file::create_dir_synced,
     digest_index::index::HdxIndex,
     error::{fetch::FetchError, open::OpenError},
     fxhasher::FxHasher,
@@ -479,7 +480,7 @@ impl Inner {
 
     fn open_append<P: AsRef<Path>>(path: P, start_epoch: Epoch) -> Result<Self, EpochDbError> {
         let base_dir = path.as_ref();
-        let _ = std::fs::create_dir_all(base_dir);
+        let _ = create_dir_synced(base_dir);
         let have_records = std::fs::exists(base_dir.join(Self::RECORDS_NAME)).unwrap_or_default();
 
         let mut records = Pack::<EpochRecord>::open(


### PR DESCRIPTION
This addresses a save output gap and some directory syncs missing from pack file management.  It removes optional from current pack to close some gaps.

Addresses these two findings from an earlier scan:

### 6. `save_consensus_output` fallback silently drops un-persisted outputs and returns Ok
- **Severity (initial)**: Medium
- **Category**: Error Handling
- **Location**: `crates/storage/src/consensus.rs:499-515` (also `consensus.rs:296`, `consensus.rs:599-605`)
- **Claim**: When `current_pack` is `None` and the output is not found in the static pack (or `get_static` fails, or `contains_consensus_header_number` errors — swallowed by `unwrap_or_default()` at line 502), the function emits only a `warn!` and returns `Ok(())`. Callers (`state_sync::save_consensus` → executor handlers) treat `Ok` as durably persisted, then broadcast/sign the output. `current_pack` can be `None` outside the intended replay scenario because `ConsensusChain::new` (line 296) swallows `open_append_exists` errors with `.ok()` — a damaged pack at startup yields `None`, and live committed outputs would be acknowledged but never persisted. `persist_current()` (lines 599-605) is also a silent no-op when `current_pack` is `None`.
- **Key Question**: Is there a production sequence where `current_pack` is `None` while live (non-replay) outputs flow through `save_consensus_output`, and does caller behavior depend on `Ok` implying durability?
- **Relevant Files**: crates/storage/src/consensus.rs, crates/state-sync/src/lib.rs, crates/consensus/executor/src/subscriber.rs
- **Source**: tn-review

### 7. Epoch-level directory entries never fsynced in `base_path`
- **Severity (initial)**: Medium
- **Category**: Durability
- **Location**: `crates/storage/src/consensus.rs:431-446` (rename), `crates/storage/src/consensus_pack.rs:548` and `:769` (create_dir_all), `crates/storage/src/epoch_records.rs:482`
- **Claim**: The branch added `fsync_directory` for file creates/renames inside the archive layer, but nothing ever fsyncs `base_path` itself. (a) `ConsensusChain::stream_import` does `remove_dir_all(&base_dir)` then `rename(&path_base_dir, &base_dir)` with no `fsync_directory(&self.base_path)` — after power failure the delete can be durable while the rename dirent is not, leaving the epoch absent despite import success. (b) `open_append`/`stream_import`/`epoch_records::open_append` create the `epoch-N` directory via `create_dir_all` with no parent fsync, so a whole epoch's pack can vanish after power loss. Both recoverable by re-streaming from peers, but they defeat the durability guarantee `persist()`/`stream_import` claim.
- **Key Question**: After power failure between `stream_import`'s rename (or `open_append`'s `create_dir_all`) and journal commit, does node recovery detect the missing epoch dir and re-stream, and is loss of the node's own current-epoch pack (its `read_last_committed` crash-recovery source) tolerable?
- **Relevant Files**: crates/storage/src/consensus.rs, crates/storage/src/consensus_pack.rs, crates/storage/src/epoch_records.rs, crates/storage/src/archive/data_file.rs
- **Source**: tn-review
