### PR TITLE
This uses partial pack downloads to speed up intra-epoch syncing.

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -145,19 +145,35 @@ impl<DB: Database> Subscriber<DB> {
             // before run_epoch() winds down.
             return Ok(());
         }
-        let consensus_output = self
-            .fetch_batches(
+        // Prefer a verified output from the consensus chain: it already contains the full output
+        // (with batches), so we can skip the separate worker-network batch fetch during
+        // bulk catch-up. Falls back to fetching batches when the output is not staged (e.g.
+        // live tail).
+        let number = consensus_header.number;
+        let consensus_output = if let Ok(Some(output)) =
+            self.inner.consensus_chain.consensus_output_by_number(number).await
+        {
+            output
+        } else {
+            self.fetch_batches(
                 consensus_header.sub_dag.clone(),
                 consensus_header.parent_hash,
-                consensus_header.number,
+                number,
             )
-            .await?;
+            .await?
+        };
 
         let mut consensus_chain = self.inner.consensus_chain.clone();
         // This save will essentially mark this consensus output as written in stone (added to the
         // consensus chain). This does NOT imply execution although it will be sent off for
         // execution.
         save_consensus(consensus_output.clone(), &mut consensus_chain).await?;
+
+        // Once we've drained through the staged partial pack's final output, it has all been
+        // written to the main pack in order — drop the staging dir.
+        if self.inner.consensus_chain.staging_final() == Some(number) {
+            self.inner.consensus_chain.clear_staging();
+        }
 
         let last_round = consensus_output.leader_round();
 

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -667,10 +667,29 @@ impl PrimaryNetworkHandle {
                     "stream opened - reading and validating epoch pack file..."
                 );
 
-                if let Err(err) = consensus_chain
-                    .stream_import(stream.compat(), epoch_record, previous_epoch, record_timeout)
-                    .await
-                {
+                // A full request imports into the live epoch dir (completed epochs); a partial
+                // request imports into a side "staging" dir so it cannot race the in-order build of
+                // the current epoch's main pack.
+                let import_result = if last_consensus_number.is_some() {
+                    consensus_chain
+                        .import_partial_to_staging(
+                            stream.compat(),
+                            epoch_record,
+                            previous_epoch,
+                            record_timeout,
+                        )
+                        .await
+                } else {
+                    consensus_chain
+                        .stream_import(
+                            stream.compat(),
+                            epoch_record,
+                            previous_epoch,
+                            record_timeout,
+                        )
+                        .await
+                };
+                if let Err(err) = import_result {
                     if let Some(penalty) = Self::consensus_chain_error_to_penalty(&err) {
                         self.report_penalty(peer, penalty).await;
                     }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -12,14 +12,18 @@ use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusHeaderCache};
 use tn_types::{
-    ConsensusHeaderDigest, Database as TNDatabase, Epoch, EpochRecord, Noticer, TaskSpawner,
-    TnReceiver, TnSender as _,
+    ConsensusHeaderDigest, ConsensusNumHash, Database as TNDatabase, Epoch, EpochRecord, Noticer,
+    TaskSpawner, TnReceiver, TnSender as _,
 };
 use tracing::{debug, error, info, warn};
 
 /// How long to wait before retrying a failed pack file download.
 const PACK_DOWNLOAD_RETRY_SECS: u64 = 5;
 const PACK_RECORD_TIMEOUT_SECS: u64 = 10;
+/// Minimum number of consensus outputs we must be behind on the in-progress current epoch before
+/// bulk-downloading a verified partial pack (into staging) rather than crawling headers one at a
+/// time. Small gaps stay on the cheap header-by-header path.
+const PARTIAL_PACK_CATCHUP_THRESHOLD: u64 = 5;
 
 enum ConsensusHeaderResult {
     Done,
@@ -115,6 +119,96 @@ async fn request_epochs(
                     .await;
             }
             previous_epoch_record = epoch_record;
+        }
+    }
+}
+
+/// Bulk fast-path for catching up the in-progress current epoch.
+///
+/// When far behind the latest *verified* gossip point, stream a verifiable PREFIX of the current
+/// epoch's pack (up to `number`) into a side STAGING directory via
+/// [`PrimaryNetworkHandle::request_partial_epoch_pack`]. The staged pack is read-only and lives in
+/// its own dir — it is NEVER swapped over the live `epoch-{N}` dir — so importing it cannot race
+/// the node's own in-order pack build. The forward drain ([`catch_up_consensus_from_to`]) then
+/// sources headers/outputs from staging.
+///
+/// `(epoch, number, hash)` comes from verified consensus gossip, so `hash` is a trustworthy stop
+/// point. The bail conditions keep this from firing on a live validator, for completed epochs, or
+/// for small gaps the header path handles cheaply.
+async fn try_partial_pack_catch_up(
+    consensus_bus: &ConsensusBusApp,
+    network: &PrimaryNetworkHandle,
+    consensus_chain: &ConsensusChain,
+    epoch: Epoch,
+    number: u64,
+    hash: ConsensusHeaderDigest,
+) -> bool {
+    // An active validator builds the epoch itself; never run there.
+    if consensus_bus.is_active_cvv() {
+        return false;
+    }
+    // Dedup concurrent attempts.
+    if consensus_chain.already_streaming_epoch(epoch) || consensus_chain.staging_final().is_some() {
+        return false;
+    }
+    // Only for the in-progress current epoch; completed epochs use the full-pack path.
+    if consensus_chain.epochs().record_by_epoch(epoch).await.is_some() {
+        return false;
+    }
+    // Only worth a bulk download when far behind; small gaps stay on the header path.
+    let our_latest = consensus_chain
+        .latest_consensus_header_from_pack(epoch)
+        .await
+        .ok()
+        .flatten()
+        .map(|h| h.number)
+        .unwrap_or(0);
+    if number.saturating_sub(our_latest) <= PARTIAL_PACK_CATCHUP_THRESHOLD {
+        return false;
+    }
+    // The previous epoch is complete; reuse the synthetic-for-epoch-0 shape `request_epochs` uses.
+    let maybe_previous = if epoch == 0 {
+        consensus_chain.epochs().record_by_epoch(0).await.map(|r| EpochRecord {
+            committee: r.committee.clone(),
+            next_committee: r.committee.clone(),
+            ..EpochRecord::default()
+        })
+    } else {
+        consensus_chain.epochs().record_by_epoch(epoch.saturating_sub(1)).await
+    };
+    let Some(previous_epoch_record) = maybe_previous else {
+        return false;
+    };
+    // Only `.epoch` and `.final_consensus` are used for verification; the streamed pack carries and
+    // self-verifies its own committee.
+    let epoch_record = EpochRecord {
+        epoch,
+        committee: previous_epoch_record.next_committee.clone(),
+        final_consensus: ConsensusNumHash::new(number, hash),
+        parent_hash: previous_epoch_record.digest(),
+        ..EpochRecord::default()
+    };
+    info!(target: "state-sync", epoch, number, our_latest, "bulk catching up current epoch via partial pack stream (staging)");
+    match network
+        .request_partial_epoch_pack(
+            &epoch_record,
+            &previous_epoch_record,
+            consensus_chain,
+            number,
+            Duration::from_secs(PACK_RECORD_TIMEOUT_SECS),
+        )
+        .await
+    {
+        Ok(()) => {
+            // Nudge the forward drain to consume the staged prefix.
+            if let Ok(Some(header)) = consensus_chain.consensus_header_by_number(number).await {
+                consensus_bus.send_last_consensus_header_if_newer(header);
+            }
+            true
+        }
+        Err(e) => {
+            warn!(target: "state-sync", epoch, number, ?e, "partial pack catch-up failed; falling back to header-by-header");
+            false
         }
     }
 }
@@ -326,20 +420,29 @@ async fn manage_new_consensus<DB: TNDatabase>(
     let consensus_chain_clone = consensus_chain.clone();
     if first_gossipped_epoch.is_none() {
         *first_gossipped_epoch = Some(epoch);
-    }
-    // Note that the way tasks is used is open to "races" but this is a simple throttle for not
-    // firing too many fetch tasks so not worth the overhead of using a full lock here.  I.e.
-    // one more or less task won't matter.
-    let task_num = tasks.load(Ordering::Relaxed);
-    // Skip for now, this number will be subsumed by gossip once enough tasks end.
-    if task_num < 6 {
+        // On the first epoch we will try to do partial pack download to buld retrieve consensus.
         let end_number = last_number.unwrap_or_default();
-        *last_number = Some(number + 1);
-        let tasks_clone = tasks.clone();
-        tasks.fetch_add(1, Ordering::Relaxed);
-        task_spawner.spawn_task(
-            format!("backfilling epoch {epoch} consensus from {number}/{hash} to {end_number}"),
-            async move {
+        let consensus_bus = consensus_bus.clone();
+        let network = network.clone();
+        let consensus_chain = consensus_chain.clone();
+        task_spawner.spawn_task(format!("partial pack catchup epoch {epoch}"), async move {
+            // Bulk fast-path: if we're far behind on the in-progress current epoch, stream a verified
+            // partial pack into staging in one shot instead of only crawling headers.
+            if !try_partial_pack_catch_up(
+                &consensus_bus,
+                &network,
+                &consensus_chain,
+                epoch,
+                number,
+                hash,
+            )
+            .await
+            {
+                info!(target: "state-sync", "Failed to initialize a bulk current epoch {epoch} download, falling back to backwards download");
+                // If this fails then try to do "normal" backwards download.
+                // Note we do this no matter the tasks count "for free"
+                // This should be atypical and must happen and the task count is a loose metric
+                // to avoid tasks running amock anyway.
                 get_consensus_header_range(
                     number,
                     hash,
@@ -350,10 +453,38 @@ async fn manage_new_consensus<DB: TNDatabase>(
                     end_number,
                 )
                 .await;
-                tasks_clone.fetch_sub(1, Ordering::Relaxed);
-                Ok(())
-            },
-        );
+            }
+            Ok(())
+        });
+    } else {
+        // Note that the way tasks is used is open to "races" but this is a simple throttle for not
+        // firing too many fetch tasks so not worth the overhead of using a full lock here.  I.e.
+        // one more or less task won't matter.
+        let task_num = tasks.load(Ordering::Relaxed);
+        // Skip for now, this number will be subsumed by gossip once enough tasks end.
+        if task_num < 6 {
+            let end_number = last_number.unwrap_or_default();
+            *last_number = Some(number + 1);
+            let tasks_clone = tasks.clone();
+            tasks.fetch_add(1, Ordering::Relaxed);
+            task_spawner.spawn_task(
+                format!("backfilling epoch {epoch} consensus from {number}/{hash} to {end_number}"),
+                async move {
+                    get_consensus_header_range(
+                        number,
+                        hash,
+                        &db_clone,
+                        &consensus_bus_clone,
+                        &network_clone,
+                        &consensus_chain_clone,
+                        end_number,
+                    )
+                    .await;
+                    tasks_clone.fetch_sub(1, Ordering::Relaxed);
+                    Ok(())
+                },
+            );
+        }
     }
 
     if *current_fetch_epoch < epoch {

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -420,7 +420,7 @@ async fn manage_new_consensus<DB: TNDatabase>(
     let consensus_chain_clone = consensus_chain.clone();
     if first_gossipped_epoch.is_none() {
         *first_gossipped_epoch = Some(epoch);
-        // On the first epoch we will try to do partial pack download to buld retrieve consensus.
+        // On the first epoch we will try to do partial pack download to build retrieve consensus.
         let end_number = last_number.unwrap_or_default();
         let consensus_bus = consensus_bus.clone();
         let network = network.clone();

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -315,6 +315,7 @@ async fn catch_up_consensus_from_to<DB: Database>(
             // Block already in local ConsensusChain DB (e.g., processed before a restart).
             // Use it to advance the parent-chain verification; execution will be skipped below
             // since number <= consensus_chain.latest_consensus_number().
+            // Note this will include staged current epoch output.
             header
         } else {
             if number > last_consensus_height + 1 {

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -1669,6 +1669,120 @@ mod test {
         );
     }
 
+    /// With the in-progress epoch open as `current_pack` but only built up to `k`, reads for
+    /// numbers in `(k, m]` must FALL THROUGH to the staged prefix rather than erroring out of
+    /// the current-pack branch. Covers the output, header, and bytes read paths.
+    #[tokio::test]
+    async fn test_reads_fall_through_to_staging_for_open_epoch() {
+        use tokio::io::AsyncReadExt as _;
+
+        let src_dir = TempDir::with_prefix("test_staging_shadow_src").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+
+        // Source: a full in-progress epoch 0 with `num_outputs` outputs.
+        let source = ConsensusChain::new(src_dir.path().to_owned()).unwrap();
+        source.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+        let num_outputs = 20u64;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            source.save_consensus_output(output).await.unwrap();
+        }
+
+        // Build a verified prefix up to `m` to stage into the destination.
+        let m = 12u64;
+        let (stream, len) = source.get_partial_epoch_stream(0, m).await.expect("partial stream");
+        let limited = stream.take(len);
+        let cutoff = &outputs[(m - 1) as usize];
+        let mut partial_record = previous_epoch.clone();
+        partial_record.final_consensus = ConsensusNumHash::new(cutoff.number(), cutoff.digest());
+
+        // Destination: open epoch 0 as the live current pack and build it ONLY up to `k` (k < m),
+        // in order — exactly the state a catching-up node is in.
+        let dst_dir = TempDir::with_prefix("test_staging_shadow_dst").expect("temp dir");
+        let dest = ConsensusChain::new(dst_dir.path().to_owned()).unwrap();
+        dest.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+        let k = 5u64;
+        for i in 0..k {
+            dest.save_consensus_output(outputs[i as usize].clone()).await.unwrap();
+        }
+        dest.import_partial_to_staging(
+            limited,
+            &partial_record,
+            &previous_epoch,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("staging import of verified prefix");
+        assert_eq!(dest.staging_final(), Some(m));
+
+        // Sanity: the live epoch-0 pack really only holds 1..=k — numbers in (k, m] are NOT in it,
+        // so any successful read of them below must have come from staging.
+        assert!(dest.get_consensus_output_current(k).await.is_ok());
+        assert!(
+            dest.get_consensus_output_current(k + 1).await.is_err(),
+            "live current pack must not contain numbers past k"
+        );
+
+        // 1..=k come from the live current pack; (k, m] fall through to staging (the fix). All
+        // three read paths must behave the same.
+        for j in 1..=m {
+            let out = dest
+                .consensus_output_by_number(j)
+                .await
+                .expect("output read should not error")
+                .expect("output should be present (current pack or staging)");
+            compare_outputs(&out, &outputs[(j - 1) as usize]);
+
+            let header = dest
+                .consensus_header_by_number(j)
+                .await
+                .expect("header read should not error")
+                .expect("header should be present (current pack or staging)");
+            assert_eq!(header.number, j);
+
+            assert!(
+                dest.consensus_output_bytes_by_number(j)
+                    .await
+                    .expect("bytes read should not error")
+                    .is_some(),
+                "output bytes should be present (current pack or staging)"
+            );
+        }
+
+        // A number held by neither the live pack nor the staged prefix surfaces an error.
+        assert!(
+            dest.consensus_output_by_number(m + 1).await.is_err(),
+            "a number past both the live pack and staging should error"
+        );
+
+        // After clearing staging, the previously staging-served numbers are gone again, but the
+        // live pack's own numbers remain.
+        dest.clear_staging();
+        assert!(
+            dest.consensus_output_by_number(k + 1).await.is_err(),
+            "after clear_staging, numbers past k are no longer available"
+        );
+        let out = dest
+            .consensus_output_by_number(k)
+            .await
+            .expect("read should not error")
+            .expect("live pack number still present");
+        compare_outputs(&out, &outputs[(k - 1) as usize]);
+    }
+
     /// `stream_import` must be a no-op (and crucially must NOT truncate) when we already hold the
     /// requested final consensus header — including a PARTIAL request whose final is behind our
     /// latest. Guards the anti-truncation early-return.

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -280,6 +280,14 @@ impl LatestConsensus {
     }
 }
 
+/// A verified prefix of an in-progress epoch streamed from a peer, held in a side directory for
+/// catch-up reads. `final_number` is the highest consensus number it contains.
+#[derive(Debug, Clone)]
+struct StagingPack {
+    pack: ConsensusPack,
+    final_number: u64,
+}
+
 /// Implement a databse for consensus data.
 #[derive(Debug, Clone)]
 pub struct ConsensusChain {
@@ -299,6 +307,13 @@ pub struct ConsensusChain {
     /// (not the `parking_lot::Mutex` used for the other fields). Always acquired *before*
     /// `current_pack`/`recent_packs` to keep a single lock order and avoid deadlock.
     pack_install: Arc<tokio::sync::Mutex<()>>,
+    /// Read-only "staging" pack holding a verified PREFIX of an (in-progress) epoch streamed from
+    /// a peer for catch-up. Unlike `current_pack`, this lives in its own `staging-{epoch}`
+    /// directory and is NEVER renamed over the live `epoch-{N}` dir, so importing it cannot
+    /// race the in-order build of the main pack. Outputs are read from here during catch-up,
+    /// then written to the main pack in order through the normal save path; cleared once
+    /// drained.
+    staging: Arc<Mutex<Option<StagingPack>>>,
 }
 
 impl ConsensusChain {
@@ -315,7 +330,19 @@ impl ConsensusChain {
         let recent_packs = Arc::new(Mutex::new(VecDeque::default()));
         let epochs = Arc::new(EpochRecordDb::open(&base_path)?);
         let pack_install = Arc::new(tokio::sync::Mutex::new(()));
-        Ok(Self { base_path, current_pack, latest_consensus, recent_packs, epochs, pack_install })
+        // Any staging dirs left from a previous run are stale; start clean. The staging pack only
+        // ever holds transient, re-fetchable catch-up data.
+        Self::remove_all_staging_dirs(&base_path);
+        let staging = Arc::new(Mutex::new(None));
+        Ok(Self {
+            base_path,
+            current_pack,
+            latest_consensus,
+            recent_packs,
+            epochs,
+            pack_install,
+            staging,
+        })
     }
 
     /// Create a new empty consensus chain with a dummy epoch 0 pack ready.
@@ -392,12 +419,17 @@ impl ConsensusChain {
         let epoch = epoch_record.epoch;
         let epoch_final_hash = epoch_record.final_consensus.hash;
         if let Ok(pack) = self.get_static(epoch).await {
-            if let Some(last_header) = pack.latest_consensus_header().await {
-                if epoch_record.final_consensus.number == last_header.number
-                    && epoch_final_hash == last_header.digest()
-                {
-                    // If we already have a complete pack file then we are done, no need to
-                    // stream...
+            // Idempotency / anti-truncation guard: if we already contain the requested final
+            // consensus header, there is nothing to import. Checking *by number* (rather than only
+            // the pack's latest header) means a PARTIAL request whose final is `(n, hash)` is a
+            // no-op when we already hold `n` — even inside a longer pack — so we never
+            // remove+rename `epoch-{N}` down to a shorter prefix and truncate data. For
+            // a number we don't have, this lookup errors, so an incomplete pack still
+            // streams as before.
+            if let Ok(have) =
+                pack.consensus_header_by_number(epoch_record.final_consensus.number).await
+            {
+                if have.digest() == epoch_final_hash {
                     return Ok(());
                 }
             }
@@ -540,6 +572,90 @@ impl ConsensusChain {
         Ok((Box::new(stream), end))
     }
 
+    /// Remove any leftover `staging-*` directories under `base_path` (stale from a prior run).
+    fn remove_all_staging_dirs(base_path: &Path) {
+        if let Ok(entries) = std::fs::read_dir(base_path) {
+            for entry in entries.flatten() {
+                if entry.file_name().to_str().is_some_and(|n| n.starts_with("staging-")) {
+                    let _ = std::fs::remove_dir_all(entry.path());
+                }
+            }
+        }
+    }
+
+    /// Import a verified PARTIAL pack (a prefix of an in-progress epoch streamed from a peer) into
+    /// a side "staging" directory and keep it open for reading.
+    ///
+    /// This intentionally does NOT use [`Self::stream_import`] (which removes+renames the live
+    /// `epoch-{N}` dir): the staged pack lives in `staging-{epoch}` and is only ever read, so a
+    /// node that is concurrently building the same epoch in order (via
+    /// [`Self::save_consensus_output`]) cannot race it. Verifies the streamed prefix ends
+    /// exactly at `epoch_record.final_consensus`.
+    pub async fn import_partial_to_staging<R: AsyncRead + Unpin>(
+        &self,
+        stream: R,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        timeout: Duration,
+    ) -> Result<(), ConsensusChainError> {
+        let epoch = epoch_record.epoch;
+        let staging_base = self.base_path.join(format!("staging-{epoch}"));
+        // Start from a clean staging dir; previous attempts (if any) are stale.
+        let _ = std::fs::remove_dir_all(&staging_base);
+        std::fs::create_dir_all(&staging_base)?;
+        let final_number = epoch_record.final_consensus.number;
+        let pack = ConsensusPack::stream_import(
+            &staging_base,
+            stream,
+            epoch,
+            previous_epoch,
+            final_number,
+            timeout,
+        )
+        .await?;
+        pack.persist().await?;
+        // The chain was verified link-by-link as it streamed; confirm the prefix ends exactly at
+        // the requested final consensus so the staged data is trustworthy.
+        match pack.latest_consensus_header().await {
+            Some(last)
+                if last.number == final_number
+                    && last.digest() == epoch_record.final_consensus.hash => {}
+            Some(_) => {
+                let _ = std::fs::remove_dir_all(&staging_base);
+                return Err(ConsensusChainError::InvalidImport);
+            }
+            None => {
+                let _ = std::fs::remove_dir_all(&staging_base);
+                return Err(ConsensusChainError::EmptyImport);
+            }
+        }
+        *self.staging.lock() = Some(StagingPack { pack, final_number });
+        Ok(())
+    }
+
+    /// The highest consensus number held by the staging pack, if any.
+    pub fn staging_final(&self) -> Option<u64> {
+        self.staging.lock().as_ref().map(|s| s.final_number)
+    }
+
+    /// Read a full consensus output (with batches) from the staging pack, if it covers `number`.
+    /// Used for module unit tests.
+    #[cfg(test)]
+    async fn staging_consensus_output(&self, number: u64) -> Option<ConsensusOutput> {
+        let pack = self.staging.lock().as_ref().map(|s| s.pack.clone())?;
+        pack.get_consensus_output(number).await.ok()
+    }
+
+    /// Drop the staging pack and remove its directory. Safe to call when none is staged.
+    pub fn clear_staging(&self) {
+        let staged = self.staging.lock().take();
+        if let Some(staged) = staged {
+            let epoch = staged.pack.epoch();
+            drop(staged);
+            let _ = std::fs::remove_dir_all(self.base_path.join(format!("staging-{epoch}")));
+        }
+    }
+
     /// Save all the batches and consensus header from the ConsensusOutput the pack file for the
     /// current epoch. This should be called "in-order" as consensus is executed.
     pub async fn save_consensus_output(
@@ -609,6 +725,8 @@ impl ConsensusChain {
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.consensus_header_by_digest(digest).await)
+        } else if let Some(staging) = self.staging() {
+            Ok(staging.pack.consensus_header_by_digest(digest).await)
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -628,6 +746,29 @@ impl ConsensusChain {
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.consensus_header_by_number(number).await?))
+        } else if let Some(staging) = self.staging() {
+            Ok(Some(staging.pack.consensus_header_by_number(number).await?))
+        } else {
+            // Don't have this epoch data.
+            Ok(None)
+        }
+    }
+
+    /// Retrieve the consensus output by number.
+    pub async fn consensus_output_by_number(
+        &self,
+        number: u64,
+    ) -> Result<Option<ConsensusOutput>, ConsensusChainError> {
+        let epoch = self.epochs.number_to_epoch(number);
+        if let Some(pack) = &self.current_pack() {
+            if epoch == pack.epoch() {
+                return Ok(Some(pack.get_consensus_output(number).await?));
+            }
+        }
+        if let Ok(pack) = self.get_static(epoch).await {
+            Ok(Some(pack.get_consensus_output(number).await?))
+        } else if let Some(staging) = self.staging() {
+            Ok(Some(staging.pack.get_consensus_output(number).await?))
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -647,6 +788,8 @@ impl ConsensusChain {
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.get_consensus_output_bytes(number).await?))
+        } else if let Some(staging) = self.staging() {
+            Ok(Some(staging.pack.get_consensus_output_bytes(number).await?))
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -806,6 +949,11 @@ impl ConsensusChain {
         self.current_pack.lock().clone()
     }
 
+    /// Return a clone of the current pack.
+    fn staging(&self) -> Option<StagingPack> {
+        self.staging.lock().clone()
+    }
+
     /// Get a static pack file from the cache if available or create and cache if not.
     async fn get_static(&self, epoch: Epoch) -> Result<ConsensusPack, PackError> {
         if let Some(pack) = self.current_pack() {
@@ -849,6 +997,13 @@ impl ConsensusChainReader for ConsensusChain {
 
     async fn consensus_output_bytes_by_number(&self, number: u64) -> eyre::Result<Option<Vec<u8>>> {
         ConsensusChain::consensus_output_bytes_by_number(self, number).await.map_err(Into::into)
+    }
+
+    async fn consensus_output_by_number(
+        &self,
+        number: u64,
+    ) -> eyre::Result<Option<ConsensusOutput>> {
+        ConsensusChain::consensus_output_by_number(self, number).await.map_err(Into::into)
     }
 
     async fn consensus_header_latest(&self) -> eyre::Result<Option<ConsensusHeader>> {
@@ -1343,6 +1498,153 @@ mod test {
             consensus_chain2.get_consensus_output_current(k + 1).await.is_err(),
             "outputs past the partial cutoff must not be present"
         );
+    }
+
+    /// `import_partial_to_staging` must produce a readable verified prefix in a side dir WITHOUT
+    /// touching the live `epoch-{N}` dir, and `clear_staging` must remove it.
+    #[tokio::test]
+    async fn test_import_partial_to_staging() {
+        use tokio::io::AsyncReadExt as _;
+
+        let src_dir = TempDir::with_prefix("test_staging_src").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let source = ConsensusChain::new(src_dir.path().to_owned()).unwrap();
+        source.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+        let num_outputs = 20u64;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            source.save_consensus_output(output).await.unwrap();
+        }
+
+        // Build the partial prefix stream up to `k` from the source's in-progress epoch.
+        let k = 12u64;
+        let (stream, len) = source.get_partial_epoch_stream(0, k).await.expect("partial stream");
+        let limited = stream.take(len);
+        let cutoff = &outputs[(k - 1) as usize];
+        let mut partial_record = previous_epoch.clone();
+        partial_record.final_consensus = ConsensusNumHash::new(cutoff.number(), cutoff.digest());
+
+        // Import into a DESTINATION chain's staging area. The destination has the epoch open but
+        // empty (no outputs written) — staging must not disturb its live `epoch-0` dir.
+        let dst_dir = TempDir::with_prefix("test_staging_dst").expect("temp dir");
+        let dest = ConsensusChain::new(dst_dir.path().to_owned()).unwrap();
+        dest.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        dest.import_partial_to_staging(
+            limited,
+            &partial_record,
+            &previous_epoch,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("staging import of verified prefix");
+
+        assert_eq!(dest.staging_final(), Some(k), "staging final should be k");
+        // Staged outputs (with batches) are readable and match the source.
+        for i in 0..k {
+            let staged = dest.staging_consensus_output(i + 1).await.expect("staged output present");
+            compare_outputs(&staged, &outputs[i as usize]);
+        }
+        // Past the staged cutoff there is nothing.
+        assert!(dest.staging_consensus_output(k + 1).await.is_none());
+        // The live epoch-0 pack was untouched (still empty — staging is a separate dir).
+        assert!(
+            dest.get_consensus_output_current(1).await.is_err(),
+            "staging import must not write into the live epoch dir"
+        );
+        let staging_path = dst_dir.path().join("staging-0");
+        assert!(std::fs::exists(&staging_path).unwrap_or(false), "staging dir should exist");
+
+        // clear_staging drops the pack and removes the dir.
+        dest.clear_staging();
+        assert_eq!(dest.staging_final(), None);
+        assert!(dest.staging_consensus_output(1).await.is_none());
+        assert!(
+            !std::fs::exists(&staging_path).unwrap_or(true),
+            "staging dir should be removed after clear_staging"
+        );
+    }
+
+    /// `stream_import` must be a no-op (and crucially must NOT truncate) when we already hold the
+    /// requested final consensus header — including a PARTIAL request whose final is behind our
+    /// latest. Guards the anti-truncation early-return.
+    #[tokio::test]
+    async fn test_stream_import_idempotent_no_truncation() {
+        let temp_dir = TempDir::with_prefix("test_import_idempotent").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned()).unwrap();
+        consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+
+        let num_outputs = 20u64;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output =
+                make_test_output(&committee, (i % 4) as usize, chain.clone(), i + 1, parent);
+            parent = output.digest().into();
+            outputs.push(output.clone());
+            consensus_chain.save_consensus_output(output).await.unwrap();
+        }
+        consensus_chain.persist_current().await.expect("persist");
+
+        // A partial import whose final (`k`) is BEHIND our latest must early-return without
+        // touching the pack. The stream is never read, so an empty reader is fine.
+        let k = 12u64;
+        let cutoff = &outputs[(k - 1) as usize];
+        let mut partial_record = previous_epoch.clone();
+        partial_record.final_consensus = ConsensusNumHash::new(cutoff.number(), cutoff.digest());
+        consensus_chain
+            .stream_import(
+                tokio::io::empty(),
+                &partial_record,
+                &previous_epoch,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("partial import of data we already hold must be Ok");
+
+        // Every output is still present — nothing was truncated to the partial prefix.
+        for i in 0..num_outputs {
+            consensus_chain
+                .get_consensus_output_current(i + 1)
+                .await
+                .expect("output still present after no-op partial import");
+        }
+
+        // An exact full-final no-op is also Ok.
+        let last = outputs.last().unwrap();
+        let mut full_record = previous_epoch.clone();
+        full_record.final_consensus = ConsensusNumHash::new(last.number(), last.digest());
+        consensus_chain
+            .stream_import(
+                tokio::io::empty(),
+                &full_record,
+                &previous_epoch,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("exact full import of data we already hold must be Ok");
     }
 
     #[tokio::test]

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -378,6 +378,7 @@ impl ConsensusChain {
         if previous_epoch.epoch != committee.epoch().saturating_sub(1) {
             return Err(ConsensusChainError::PrevCommitteeEpochMismatch);
         }
+        let epoch = committee.epoch();
         if let Some(old_pack) = self.current_pack() {
             if old_pack.epoch() == committee.epoch() {
                 return Ok(());
@@ -393,6 +394,14 @@ impl ConsensusChain {
         let pack = ConsensusPack::open_append(&self.base_path, previous_epoch, committee)?;
         pack.persist().await?; // Surface any open errors.
         *self.current_pack.lock() = Some(pack);
+        if let Some(staging_epoch) = self.staging_epoch() {
+            // If we have moved past the staging pack then clear it.
+            // Should get cleared in the normal course but this is
+            // stopgap just in case.
+            if staging_epoch < epoch {
+                self.clear_staging();
+            }
+        }
         Ok(())
     }
 
@@ -591,6 +600,7 @@ impl ConsensusChain {
     /// node that is concurrently building the same epoch in order (via
     /// [`Self::save_consensus_output`]) cannot race it. Verifies the streamed prefix ends
     /// exactly at `epoch_record.final_consensus`.
+    /// NOTE: This is intended to be called ONCE and is currently not tolerant of multiple calls.
     pub async fn import_partial_to_staging<R: AsyncRead + Unpin>(
         &self,
         stream: R,
@@ -636,6 +646,11 @@ impl ConsensusChain {
     /// The highest consensus number held by the staging pack, if any.
     pub fn staging_final(&self) -> Option<u64> {
         self.staging.lock().as_ref().map(|s| s.final_number)
+    }
+
+    /// The epoch of the staging pack, if any.
+    pub fn staging_epoch(&self) -> Option<Epoch> {
+        self.staging.lock().as_ref().map(|s| s.pack.epoch())
     }
 
     /// Read a full consensus output (with batches) from the staging pack, if it covers `number`.
@@ -720,13 +735,31 @@ impl ConsensusChain {
     ) -> Result<Option<ConsensusHeader>, ConsensusChainError> {
         if let Some(pack) = &self.current_pack() {
             if epoch == pack.epoch() {
-                return Ok(pack.consensus_header_by_digest(digest).await);
+                return match pack.consensus_header_by_digest(digest).await {
+                    Some(r) => Ok(Some(r)),
+                    None => {
+                        if let Some(staging) = self.staging() {
+                            // Fallback check on staging before returning an error.
+                            if let Some(r) = staging.pack.consensus_header_by_digest(digest).await {
+                                Ok(Some(r))
+                            } else {
+                                Ok(None)
+                            }
+                        } else {
+                            Ok(None)
+                        }
+                    }
+                };
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(pack.consensus_header_by_digest(digest).await)
         } else if let Some(staging) = self.staging() {
-            Ok(staging.pack.consensus_header_by_digest(digest).await)
+            if epoch == staging.pack.epoch() {
+                Ok(staging.pack.consensus_header_by_digest(digest).await)
+            } else {
+                Ok(None)
+            }
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -741,13 +774,32 @@ impl ConsensusChain {
         let epoch = self.epochs.number_to_epoch(number);
         if let Some(pack) = &self.current_pack() {
             if epoch == pack.epoch() {
-                return Ok(Some(pack.consensus_header_by_number(number).await?));
+                return match pack.consensus_header_by_number(number).await {
+                    Ok(r) => Ok(Some(r)),
+                    Err(e) => {
+                        if let Some(staging) = self.staging() {
+                            // Fallback check on staging before returning an error.
+                            if let Ok(r) = staging.pack.consensus_header_by_number(number).await {
+                                Ok(Some(r))
+                            } else {
+                                Err(e.into())
+                            }
+                        } else {
+                            Err(e.into())
+                        }
+                    }
+                };
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.consensus_header_by_number(number).await?))
         } else if let Some(staging) = self.staging() {
-            Ok(Some(staging.pack.consensus_header_by_number(number).await?))
+            // Don't expose any staging errors.
+            if epoch == staging.pack.epoch() {
+                Ok(staging.pack.consensus_header_by_number(number).await.ok())
+            } else {
+                Ok(None)
+            }
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -762,13 +814,33 @@ impl ConsensusChain {
         let epoch = self.epochs.number_to_epoch(number);
         if let Some(pack) = &self.current_pack() {
             if epoch == pack.epoch() {
-                return Ok(Some(pack.get_consensus_output(number).await?));
+                return match pack.get_consensus_output(number).await {
+                    Ok(r) => Ok(Some(r)),
+                    Err(e) => {
+                        if let Some(staging) = self.staging() {
+                            // Fallback check on staging before returning an error.
+                            if let Ok(r) = staging.pack.get_consensus_output(number).await {
+                                Ok(Some(r))
+                            } else {
+                                Err(e.into())
+                            }
+                        } else {
+                            Err(e.into())
+                        }
+                    }
+                };
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.get_consensus_output(number).await?))
         } else if let Some(staging) = self.staging() {
-            Ok(Some(staging.pack.get_consensus_output(number).await?))
+            // Note we don't want to expose staging errors, we either find the record or we don't at
+            // this point.
+            if epoch == staging.pack.epoch() {
+                Ok(staging.pack.get_consensus_output(number).await.ok())
+            } else {
+                Ok(None)
+            }
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -783,13 +855,32 @@ impl ConsensusChain {
         let epoch = self.epochs.number_to_epoch(number);
         if let Some(pack) = &self.current_pack() {
             if epoch == pack.epoch() {
-                return Ok(Some(pack.get_consensus_output_bytes(number).await?));
+                return match pack.get_consensus_output_bytes(number).await {
+                    Ok(r) => Ok(Some(r)),
+                    Err(e) => {
+                        if let Some(staging) = self.staging() {
+                            // Fallback check on staging before returning an error.
+                            if let Ok(r) = staging.pack.get_consensus_output_bytes(number).await {
+                                Ok(Some(r))
+                            } else {
+                                Err(e.into())
+                            }
+                        } else {
+                            Err(e.into())
+                        }
+                    }
+                };
             }
         }
         if let Ok(pack) = self.get_static(epoch).await {
             Ok(Some(pack.get_consensus_output_bytes(number).await?))
         } else if let Some(staging) = self.staging() {
-            Ok(Some(staging.pack.get_consensus_output_bytes(number).await?))
+            if epoch == staging.pack.epoch() {
+                // Do not expose staging errors, find data or not.
+                Ok(staging.pack.get_consensus_output_bytes(number).await.ok())
+            } else {
+                Ok(None)
+            }
         } else {
             // Don't have this epoch data.
             Ok(None)
@@ -949,7 +1040,7 @@ impl ConsensusChain {
         self.current_pack.lock().clone()
     }
 
-    /// Return a clone of the current pack.
+    /// Return a clone of the staging pack.
     fn staging(&self) -> Option<StagingPack> {
         self.staging.lock().clone()
     }

--- a/crates/types/src/consensus_chain_traits.rs
+++ b/crates/types/src/consensus_chain_traits.rs
@@ -64,6 +64,12 @@ pub trait ConsensusChainReader: Send + Sync + Clone + 'static {
         number: u64,
     ) -> impl Future<Output = eyre::Result<Option<Vec<u8>>>> + Send;
 
+    /// Retrieve a full consensus output (with batches) by global number.
+    fn consensus_output_by_number(
+        &self,
+        number: u64,
+    ) -> impl Future<Output = eyre::Result<Option<ConsensusOutput>>> + Send;
+
     /// Retrieve the most recent consensus header that was executed.
     fn consensus_header_latest(
         &self,


### PR DESCRIPTION
Uses code from previous PR to allow downloading a partial pack file.  This will be MUCH faster when many consensus headers behind to sync the current epoch.