### PR TITLE
feat(node): source worker pool base fee from the gas accumulator

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -46,6 +46,8 @@ tn-test-utils = { workspace = true }
 tn-network-types = { workspace = true }
 tempfile = { workspace = true }
 tn-test-utils-committee = { workspace = true }
+# enable test-utils feature for WorkerNetworkHandle::new_for_test in IT tests
+tn-worker = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -46,7 +46,6 @@ tn-test-utils = { workspace = true }
 tn-network-types = { workspace = true }
 tempfile = { workspace = true }
 tn-test-utils-committee = { workspace = true }
-# enable test-utils feature for WorkerNetworkHandle::new_for_test in IT tests
 tn-worker = { workspace = true, features = ["test-utils"] }
 
 [lints]

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -20,7 +20,6 @@ use tn_types::{
     gas_accumulator::{BaseFeeContainer, GasAccumulator},
     Address, BatchSender, BatchValidation, BlockHeader, BlsPublicKey, ConsensusHeaderDigest,
     ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId,
-    MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::mpsc;
@@ -137,6 +136,7 @@ impl ExecutionNodeInner {
         worker_id: WorkerId,
         network_handle: WorkerNetworkHandle,
         engine_to_primary: EP,
+        base_fee: u64,
     ) -> eyre::Result<()>
     where
         EP: EngineToPrimary + Send + Sync + 'static,
@@ -146,7 +146,7 @@ impl ExecutionNodeInner {
         let network =
             WorkerNetwork::new(self.reth_env.chainspec(), network_handle, self.tn_config.version);
         let mut tx_pool_latest = transaction_pool.block_info();
-        tx_pool_latest.pending_basefee = MIN_PROTOCOL_BASE_FEE;
+        tx_pool_latest.pending_basefee = base_fee;
         let last_seen = self.reth_env.finalized_block_hash_number_for_startup()?;
         tx_pool_latest.last_seen_block_hash = last_seen.hash;
         tx_pool_latest.last_seen_block_number = last_seen.number;
@@ -173,6 +173,21 @@ impl ExecutionNodeInner {
         }
         self.workers.push(components);
         Ok(())
+    }
+
+    /// Update the pending base fee on a worker's transaction pool.
+    ///
+    /// Called every epoch so the pool charges the base fee the accumulator currently holds for
+    /// the worker. This covers the respawn path, where `initialize_worker_components` is skipped
+    /// but the base fee for the new epoch must still take effect. No-op if the worker's components
+    /// have not been initialized yet.
+    pub(super) fn set_worker_base_fee(&self, worker_id: WorkerId, base_fee: u64) {
+        if let Some(worker) = self.workers.get(worker_id as usize) {
+            let pool = worker.pool();
+            let mut block_info = pool.block_info();
+            block_info.pending_basefee = base_fee;
+            pool.set_block_info(block_info);
+        }
     }
 
     /// Respawn any tasks on the worker network when we get a new epoch task manager.

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -90,12 +90,24 @@ impl ExecutionNode {
         worker_id: WorkerId,
         network_handle: WorkerNetworkHandle,
         engine_to_primary: EP,
+        base_fee: u64,
     ) -> eyre::Result<()>
     where
         EP: EngineToPrimary + Send + Sync + 'static,
     {
         let mut guard = self.internal.write().await;
-        guard.initialize_worker_components(worker_id, network_handle, engine_to_primary).await
+        guard
+            .initialize_worker_components(worker_id, network_handle, engine_to_primary, base_fee)
+            .await
+    }
+
+    /// Update the pending base fee on a worker's transaction pool.
+    ///
+    /// Called every epoch so the pool charges the accumulator's current base fee for the worker,
+    /// including on the respawn path where [`Self::initialize_worker_components`] is skipped.
+    pub async fn set_worker_base_fee(&self, worker_id: WorkerId, base_fee: u64) {
+        let guard = self.internal.read().await;
+        guard.set_worker_base_fee(worker_id, base_fee);
     }
 
     /// Respawn any tasks on the worker network when we get a new epoch task manager.

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -370,7 +370,10 @@ where
     ) -> eyre::Result<WorkerNode<DB>> {
         // only support one worker for now (with id 0) - otherwise, loop here
         let worker_id = DEFAULT_WORKER_ID;
-        let base_fee = gas_accumulator.base_fee(worker_id);
+        let base_fee_container = gas_accumulator.base_fee(worker_id);
+        // u64 snapshot of the worker's base fee for the transaction pool. Base fee is constant
+        // within an epoch, so a snapshot taken at epoch start is valid for the whole epoch.
+        let base_fee = base_fee_container.base_fee();
 
         // update the network handle's task spawner for reporting batches in the epoch
         {
@@ -392,6 +395,7 @@ where
                         worker_id,
                         network_handle.clone(),
                         engine_to_primary,
+                        base_fee,
                     )
                     .await?;
             } else {
@@ -401,6 +405,11 @@ where
             }
         }
 
+        // Ensure the worker's transaction pool charges the accumulator's base fee for this epoch.
+        // On the init path above the pool was created with this value; this call additionally
+        // covers the respawn path, where initialization is skipped.
+        engine.set_worker_base_fee(worker_id, base_fee).await;
+
         let network_handle = self
             .worker_network_handle
             .as_ref()
@@ -408,7 +417,11 @@ where
             .clone();
 
         let validator = engine
-            .new_batch_validator(&worker_id, base_fee, consensus_config.committee().epoch())
+            .new_batch_validator(
+                &worker_id,
+                base_fee_container,
+                consensus_config.committee().epoch(),
+            )
             .await;
         self.spawn_worker_network_for_epoch(
             consensus_config,

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -22,15 +22,18 @@ use tn_primary::{
     ConsensusBus,
 };
 use tn_reth::{test_utils::seeded_genesis_from_random_batches, RethChainSpec};
+use tn_rpc::{EngineToPrimary, RpcNodeInfo};
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils::{
     create_signed_certificates_for_rounds, default_test_execution_node, CommitteeFixture,
 };
 use tn_types::{
-    adiri_genesis, gas_accumulator::GasAccumulator, Batch, ConsensusHeaderDigest, ConsensusNumHash,
-    ExecHeader, Notifier, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, B256,
-    DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    adiri_genesis, gas_accumulator::GasAccumulator, Batch, ConsensusHeader, ConsensusHeaderDigest,
+    ConsensusNumHash, Epoch, EpochCertificate, EpochDigest, EpochRecord, ExecHeader, Notifier,
+    SealedHeader, TaskManager, TnReceiver as _, TnSender as _, WorkerId, B256,
+    DEFAULT_BAD_NODES_STAKE_THRESHOLD, MIN_PROTOCOL_BASE_FEE,
 };
+use tn_worker::WorkerNetworkHandle;
 use tokio::{
     sync::{mpsc, oneshot},
     time::timeout,
@@ -168,6 +171,78 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
     // assert rewards
     assert_eq!(expected, gas_accumulator.rewards_counter().get_address_counts());
     assert_eq!(expected, recovered.rewards_counter().get_address_counts());
+
+    Ok(())
+}
+
+/// No-op [`EngineToPrimary`] for tests that only need worker components initialized.
+///
+/// These methods back the `tn` RPC namespace, which `initialize_worker_components` registers but
+/// never calls during setup (and these tests never issue RPC requests), so the bodies are
+/// `unreachable!`.
+struct NoopEngineToPrimary;
+
+impl EngineToPrimary for NoopEngineToPrimary {
+    fn get_latest_consensus_block(&self) -> ConsensusHeader {
+        unreachable!("EngineToPrimary RPC is not exercised in this test")
+    }
+
+    async fn epoch(
+        &self,
+        _epoch: Option<Epoch>,
+        _hash: Option<EpochDigest>,
+    ) -> Option<(EpochRecord, EpochCertificate)> {
+        unreachable!("EngineToPrimary RPC is not exercised in this test")
+    }
+
+    fn node_info(&self) -> &RpcNodeInfo {
+        unreachable!("EngineToPrimary RPC is not exercised in this test")
+    }
+}
+
+/// PR1a: a worker's transaction pool charges the base fee supplied at epoch setup (the
+/// accumulator's per-worker value) instead of a hardcoded `MIN_PROTOCOL_BASE_FEE`, and
+/// `set_worker_base_fee` updates it for the every-epoch (respawn) path.
+#[tokio::test]
+async fn test_worker_pool_base_fee_sourced_from_accumulator() -> eyre::Result<()> {
+    let temp_dir = TempDir::with_prefix("test_worker_pool_base_fee").unwrap();
+    let chain: Arc<RethChainSpec> = Arc::new(adiri_genesis().into());
+
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        &temp_dir.path().join("reth"),
+        None,
+    )?;
+
+    // keep the task manager alive for the test so the worker RPC + network tasks keep running.
+    let task_manager = TaskManager::default();
+    let network_handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
+
+    let worker_id: WorkerId = 0;
+    // a deliberately non-MIN value: proves the pool no longer hardcodes MIN_PROTOCOL_BASE_FEE.
+    let base_fee = MIN_PROTOCOL_BASE_FEE + 1234;
+
+    execution_node
+        .initialize_worker_components(worker_id, network_handle, NoopEngineToPrimary, base_fee)
+        .await?;
+
+    let pool = execution_node.get_worker_transaction_pool(&worker_id).await?;
+    assert_eq!(
+        pool.block_info().pending_basefee,
+        base_fee,
+        "worker pool base fee should equal the value passed at setup",
+    );
+
+    // the every-epoch setter updates the pool (covers the respawn path where init is skipped).
+    let new_fee = base_fee + 50;
+    execution_node.set_worker_base_fee(worker_id, new_fee).await;
+    let pool = execution_node.get_worker_transaction_pool(&worker_id).await?;
+    assert_eq!(
+        pool.block_info().pending_basefee,
+        new_fee,
+        "set_worker_base_fee should update the worker pool base fee",
+    );
 
     Ok(())
 }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -200,7 +200,7 @@ impl EngineToPrimary for NoopEngineToPrimary {
     }
 }
 
-/// PR1a: a worker's transaction pool charges the base fee supplied at epoch setup (the
+/// A worker's transaction pool charges the base fee supplied at epoch setup (the
 /// accumulator's per-worker value) instead of a hardcoded `MIN_PROTOCOL_BASE_FEE`, and
 /// `set_worker_base_fee` updates it for the every-epoch (respawn) path.
 #[tokio::test]
@@ -220,7 +220,7 @@ async fn test_worker_pool_base_fee_sourced_from_accumulator() -> eyre::Result<()
     let network_handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
 
     let worker_id: WorkerId = 0;
-    // a deliberately non-MIN value: proves the pool no longer hardcodes MIN_PROTOCOL_BASE_FEE.
+    // a deliberately non-MIN value: proves the pool does't hardcodes MIN_PROTOCOL_BASE_FEE.
     let base_fee = MIN_PROTOCOL_BASE_FEE + 1234;
 
     execution_node

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -205,7 +205,7 @@ impl EngineToPrimary for NoopEngineToPrimary {
 /// `set_worker_base_fee` updates it for the every-epoch (respawn) path.
 #[tokio::test]
 async fn test_worker_pool_base_fee_sourced_from_accumulator() -> eyre::Result<()> {
-    let temp_dir = TempDir::with_prefix("test_worker_pool_base_fee").unwrap();
+    let temp_dir = TempDir::with_prefix("test_worker_pool_base_fee")?;
     let chain: Arc<RethChainSpec> = Arc::new(adiri_genesis().into());
 
     let execution_node = default_test_execution_node(
@@ -220,7 +220,7 @@ async fn test_worker_pool_base_fee_sourced_from_accumulator() -> eyre::Result<()
     let network_handle = WorkerNetworkHandle::new_for_test(task_manager.get_spawner());
 
     let worker_id: WorkerId = 0;
-    // a deliberately non-MIN value: proves the pool does't hardcodes MIN_PROTOCOL_BASE_FEE.
+    // a deliberately non-MIN value: proves the pool doesn't hardcodes MIN_PROTOCOL_BASE_FEE.
     let base_fee = MIN_PROTOCOL_BASE_FEE + 1234;
 
     execution_node


### PR DESCRIPTION
* Worker transaction pool now takes its `pending_basefee` from the gas accumulator's per-worker value at epoch setup instead of the hardcoded `MIN_PROTOCOL_BASE_FEE`. The `u64` is snapshotted at epoch start, which is valid since the base fee is constant within an epoch.
* Added `ExecutionNode::set_worker_base_fee` (and the inner equivalent), called on every epoch start so the respawn path (where `initialize_worker_components` is skipped) still picks up the new epoch's base fee. No-ops when the worker isn't initialized yet.
* `new_batch_validator` now receives the `BaseFeeContainer` directly rather than the unwrapped `u64`.
* Added `test_worker_pool_base_fee_sourced_from_accumulator` covering both the init path and the every-epoch setter, plus a `NoopEngineToPrimary` test helper. Enabled the `tn-worker/test-utils` feature for IT tests.

closes #791 