### PR TITLE
feat(batch-validator): take a u64 base-fee snapshot

### DIFF
--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -16,10 +16,10 @@ use tn_reth::{
 };
 use tn_storage::{open_db, tables::NodeBatchesCache};
 use tn_types::{
-    gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    test_genesis, Address, Batch, BatchValidation, Bytes, Certificate, CertifiedBatch,
-    CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database, Encodable2718,
-    GenesisAccount, ReputationScores, SealedBatch, TaskManager, MIN_PROTOCOL_BASE_FEE, U160, U256,
+    gas_accumulator::GasAccumulator, test_genesis, Address, Batch, BatchValidation, Bytes,
+    Certificate, CertifiedBatch, CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database,
+    Encodable2718, GenesisAccount, ReputationScores, SealedBatch, TaskManager,
+    MIN_PROTOCOL_BASE_FEE, U160, U256,
 };
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
 use tokio::time::timeout;
@@ -151,13 +151,8 @@ async fn test_make_batch_el_to_cl() {
     let sealed_batch = sealed_batch.unwrap();
 
     // ensure batch validator succeeds
-    let batch_validator = BatchValidator::new(
-        reth_env.clone(),
-        Some(txpool.clone()),
-        0,
-        BaseFeeContainer::default(),
-        0,
-    );
+    let batch_validator =
+        BatchValidator::new(reth_env.clone(), Some(txpool.clone()), 0, MIN_PROTOCOL_BASE_FEE, 0);
 
     let valid_batch_result = batch_validator.validate_batch(sealed_batch.clone());
     assert!(valid_batch_result.is_ok());
@@ -329,13 +324,8 @@ async fn test_batch_builder_produces_valid_batches() {
     let _ = ack.send(Ok(()));
 
     // validate first batch
-    let batch_validator = BatchValidator::new(
-        reth_env.clone(),
-        Some(txpool.clone()),
-        0,
-        BaseFeeContainer::default(),
-        0,
-    );
+    let batch_validator =
+        BatchValidator::new(reth_env.clone(), Some(txpool.clone()), 0, MIN_PROTOCOL_BASE_FEE, 0);
 
     let valid_batch_result = batch_validator.validate_batch(first_batch.clone());
     assert!(valid_batch_result.is_ok());
@@ -534,13 +524,8 @@ async fn test_canonical_notification_updates_pool() {
     let _ = ack.send(Ok(()));
 
     // validate batch
-    let batch_validator = BatchValidator::new(
-        reth_env.clone(),
-        Some(txpool.clone()),
-        0,
-        BaseFeeContainer::default(),
-        0,
-    );
+    let batch_validator =
+        BatchValidator::new(reth_env.clone(), Some(txpool.clone()), 0, MIN_PROTOCOL_BASE_FEE, 0);
 
     let valid_batch_result = batch_validator.validate_batch(first_batch.clone());
     assert!(valid_batch_result.is_ok());

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -633,36 +633,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validator_uses_u64_base_fee() {
-        // A validator built from a plain u64 base fee accepts a batch whose base fee matches and
-        // rejects one that does not -- exercising the BaseFeeContainer -> u64 conversion.
-        let tmp_dir = TempDir::new().unwrap();
-        let task_manager = TaskManager::default();
-        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
-        let reth_env =
-            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
-                .unwrap();
-        let tx_pool = reth_env.init_txn_pool().unwrap();
-
-        // pin the validator to a deliberately non-MIN base fee
-        let expected_fee = MIN_PROTOCOL_BASE_FEE + 500;
-        let validator = BatchValidator::new(reth_env, Some(tx_pool), 0, expected_fee, 0);
-
-        let (mut batch, _) = next_valid_sealed_batch(chain).split();
-
-        // matching base fee is accepted
-        batch.base_fee_per_gas = expected_fee;
-        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
-
-        // mismatched base fee is rejected
-        batch.base_fee_per_gas = expected_fee + 1;
-        assert_matches!(
-            validator.validate_batch(batch.seal_slow()),
-            Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
-        );
-    }
-
-    #[tokio::test]
     async fn test_invalid_tx_eip4844() {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -3,9 +3,8 @@
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use tn_reth::{recover_raw_transaction, recover_signed_transaction, RethEnv, WorkerTxPool};
 use tn_types::{
-    gas_accumulator::BaseFeeContainer, max_batch_gas, max_batch_size, BatchValidation,
-    BatchValidationError, BlockHash, Epoch, SealedBatch, TransactionSigned, TransactionTrait as _,
-    WorkerId,
+    max_batch_gas, max_batch_size, BatchValidation, BatchValidationError, BlockHash, Epoch,
+    SealedBatch, TransactionSigned, TransactionTrait as _, WorkerId,
 };
 
 /// Type convenience for implementing block validation errors.
@@ -24,8 +23,11 @@ pub struct BatchValidator {
     tx_pool: Option<WorkerTxPool>,
     /// Worker id for this validator.
     worker_id: WorkerId,
-    /// Current base fee for this validators worker.
-    base_fee: BaseFeeContainer,
+    /// Base fee for this validator's worker for the current epoch.
+    ///
+    /// Base fee is constant within an epoch and the validator is recreated each epoch, so this is
+    /// a plain `u64` snapshot taken at epoch start rather than a shared container.
+    base_fee: u64,
     /// Epoch we are validating for.
     epoch: Epoch,
 }
@@ -110,7 +112,7 @@ impl BatchValidator {
         reth_env: RethEnv,
         tx_pool: Option<WorkerTxPool>,
         worker_id: WorkerId,
-        base_fee: BaseFeeContainer,
+        base_fee: u64,
         epoch: Epoch,
     ) -> Self {
         Self { reth_env, tx_pool, worker_id, base_fee, epoch }
@@ -184,7 +186,7 @@ impl BatchValidator {
 
     /// Validate the block's basefee
     fn validate_basefee(&self, base_fee: u64) -> BatchValidationResult<()> {
-        let expected_base_fee = self.base_fee.base_fee();
+        let expected_base_fee = self.base_fee;
         if base_fee != expected_base_fee {
             Err(BatchValidationError::InvalidBaseFee { expected_base_fee, base_fee })
         } else {
@@ -305,7 +307,7 @@ mod tests {
             RethEnv::new_for_temp_chain(chain.clone(), path, task_manager, None).unwrap();
         let tx_pool = reth_env.init_txn_pool().unwrap();
         let validator =
-            BatchValidator::new(reth_env, Some(tx_pool.clone()), 0, BaseFeeContainer::default(), 0);
+            BatchValidator::new(reth_env, Some(tx_pool.clone()), 0, MIN_PROTOCOL_BASE_FEE, 0);
         let valid_batch = next_valid_sealed_batch(chain);
 
         // block validator
@@ -626,6 +628,36 @@ mod tests {
         batch.base_fee_per_gas = badfee;
         assert_matches!(
             validator.validate_batch(batch.clone().seal_slow()),
+            Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validator_uses_u64_base_fee() {
+        // A validator built from a plain u64 base fee accepts a batch whose base fee matches and
+        // rejects one that does not -- exercising the BaseFeeContainer -> u64 conversion.
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+                .unwrap();
+        let tx_pool = reth_env.init_txn_pool().unwrap();
+
+        // pin the validator to a deliberately non-MIN base fee
+        let expected_fee = MIN_PROTOCOL_BASE_FEE + 500;
+        let validator = BatchValidator::new(reth_env, Some(tx_pool), 0, expected_fee, 0);
+
+        let (mut batch, _) = next_valid_sealed_batch(chain).split();
+
+        // matching base fee is accepted
+        batch.base_fee_per_gas = expected_fee;
+        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
+
+        // mismatched base fee is rejected
+        batch.base_fee_per_gas = expected_fee + 1;
+        assert_matches!(
+            validator.validate_batch(batch.seal_slow()),
             Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
         );
     }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -17,9 +17,9 @@ use tn_reth::{
 };
 use tn_rpc::{EngineToPrimary, TelcoinNetworkRpcExt, TelcoinNetworkRpcExtApiServer};
 use tn_types::{
-    gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    Address, BatchSender, BatchValidation, BlockHeader, BlsPublicKey, ConsensusHeaderDigest,
-    ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId,
+    gas_accumulator::GasAccumulator, Address, BatchSender, BatchValidation, BlockHeader,
+    BlsPublicKey, ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer,
+    SealedHeader, TaskSpawner, WorkerId,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::mpsc;
@@ -204,7 +204,7 @@ impl ExecutionNodeInner {
     pub(super) fn new_batch_validator(
         &self,
         worker_id: &WorkerId,
-        base_fee: BaseFeeContainer,
+        base_fee: u64,
         epoch: Epoch,
     ) -> Arc<dyn BatchValidation> {
         // retrieve handle to transaction pool to submit gossip transactions to validators

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -21,9 +21,9 @@ use tn_reth::{
 };
 use tn_rpc::EngineToPrimary;
 use tn_types::{
-    gas_accumulator::{BaseFeeContainer, GasAccumulator},
-    BatchSender, BatchValidation, BlsPublicKey, ConsensusHeaderDigest, ConsensusOutput,
-    EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader, TaskSpawner, WorkerId,
+    gas_accumulator::GasAccumulator, BatchSender, BatchValidation, BlsPublicKey,
+    ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader,
+    TaskSpawner, WorkerId,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::{mpsc, RwLock};
@@ -212,7 +212,7 @@ impl ExecutionNode {
     pub async fn new_batch_validator(
         &self,
         worker_id: &WorkerId,
-        base_fee: BaseFeeContainer,
+        base_fee: u64,
         epoch: Epoch,
     ) -> Arc<dyn BatchValidation> {
         let guard = self.internal.read().await;

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -370,10 +370,10 @@ where
     ) -> eyre::Result<WorkerNode<DB>> {
         // only support one worker for now (with id 0) - otherwise, loop here
         let worker_id = DEFAULT_WORKER_ID;
-        let base_fee_container = gas_accumulator.base_fee(worker_id);
-        // u64 snapshot of the worker's base fee for the transaction pool. Base fee is constant
-        // within an epoch, so a snapshot taken at epoch start is valid for the whole epoch.
-        let base_fee = base_fee_container.base_fee();
+        // u64 snapshot of the worker's base fee, used by both the transaction pool and the batch
+        // validator. Base fee is constant within an epoch, so a snapshot taken at epoch start is
+        // valid for the whole epoch.
+        let base_fee = gas_accumulator.base_fee(worker_id).base_fee();
 
         // update the network handle's task spawner for reporting batches in the epoch
         {
@@ -417,11 +417,7 @@ where
             .clone();
 
         let validator = engine
-            .new_batch_validator(
-                &worker_id,
-                base_fee_container,
-                consensus_config.committee().epoch(),
-            )
+            .new_batch_validator(&worker_id, base_fee, consensus_config.committee().epoch())
             .await;
         self.spawn_worker_network_for_epoch(
             consensus_config,


### PR DESCRIPTION
* `BatchValidator` now stores a plain `u64` base fee instead of a `BaseFeeContainer`. Base fee is fixed per epoch and the validator is rebuilt each epoch, so a snapshot taken at epoch start is valid for its whole lifetime.
* `new_batch_validator` (on `ExecutionNode` and `ExecutionNodeInner`) takes `u64`; the `BaseFeeContainer` import is gone from the engine modules.
* `start_epoch` snapshots the worker base fee to `u64` once and passes it to both the tx pool and the validator, dropping the redundant container read.
* Added `test_validator_uses_u64_base_fee`: accepts a batch whose base fee matches the snapshot, rejects one that doesn't.

closes #793 