### PR TITLE
feat(network): cut the primary epoch-pack path over to the typed sync protocol with legacy fallback (739, step 6)

### DIFF
--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = [
     "time",
     "test-util",
 ] }
-tokio-util = { version = "0.7", features = ["compat"] }
+tokio-util = { version = "0.7", features = ["compat", "io"] }
 tracing = { workspace = true }
 tn-network-types = { workspace = true }
 tn-types = { workspace = true }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -15,7 +15,9 @@ use std::{
     time::Duration,
 };
 use tn_config::ConsensusConfig;
-use tn_network_libp2p::{GossipMessage, Stream};
+use tn_network_libp2p::{
+    write_frame, GossipMessage, PrimarySyncRequest, Stream, SyncFrame, SyncFrameError,
+};
 use tn_storage::{consensus::ConsensusChain, CertificateStore, VoteDigestStore};
 use tn_types::{
     ensure,
@@ -32,6 +34,13 @@ use tracing::{debug, error, info, warn};
 /// Prevents slow-reader attacks where a peer accepts a stream but never reads.
 /// Set to an arbitrary 10 seconds to read 16kb buffer.
 const SEND_STREAM_BUFFER_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Total timeout for serving an entire epoch pack over the sync protocol.
+///
+/// A backstop above the per-frame [`SEND_STREAM_BUFFER_TIMEOUT`]: a peer that
+/// drip-reads just fast enough to keep resetting the per-frame timer cannot pin
+/// the responder task (and the admission slot it holds) indefinitely.
+const SEND_SYNC_PACK_TIMEOUT: Duration = Duration::from_secs(200);
 
 /// Map to hold vote info to detect invalid votes, equivocation and cache responses in case of
 /// rerequests.
@@ -1210,5 +1219,67 @@ where
                 })
             }
         }
+    }
+
+    /// Serve an inbound epoch-pack sync exchange.
+    ///
+    /// The exchange has already been admitted against the concurrency caps and its
+    /// opening request frame read by the caller. This streams the pack via
+    /// [`send_sync_epoch_pack_over_stream`] under a total timeout. A send failure is
+    /// logged and best-effort signalled with [`SyncFrame::Err`] so the requester
+    /// stops waiting; it is not a peer fault, so no penalty is returned (metrics-only
+    /// during the item-6 rollout, like the legacy responder).
+    ///
+    /// [`send_sync_epoch_pack_over_stream`]: crate::network::sync_codec::send_sync_epoch_pack_over_stream
+    pub(super) async fn process_sync_epoch_pack_stream(
+        &self,
+        peer: BlsPublicKey,
+        mut stream: Stream,
+        epoch: Epoch,
+        consensus_chain: &ConsensusChain,
+    ) -> PrimaryNetworkResult<()> {
+        debug!(target: "primary::network", %peer, epoch, "serving inbound sync epoch pack stream");
+        let max_frame = crate::network::sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
+
+        // bound the whole serve; flatten the timeout's outer Result into the send's
+        let served = timeout(
+            SEND_SYNC_PACK_TIMEOUT,
+            crate::network::sync_codec::send_sync_epoch_pack_over_stream(
+                &mut stream,
+                consensus_chain,
+                epoch,
+                SEND_STREAM_BUFFER_TIMEOUT,
+                peer,
+            ),
+        )
+        .await
+        .map_err(PrimaryNetworkError::from)
+        .and_then(|served| served);
+
+        // a send failure or timeout is logged and best-effort signalled so the
+        // requester stops waiting; it is not a peer fault, so no penalty
+        if let Err(e) = served {
+            warn!(target: "primary::network", %peer, ?e, "failed to serve sync epoch pack stream");
+            // bound the best-effort error write: a peer that read the `Ack` then
+            // stopped reading would otherwise pin this responder task.
+            let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+            let _ = timeout(crate::network::SYNC_REQUEST_READ_TIMEOUT, async {
+                let _ = write_frame(
+                    &mut stream,
+                    &SyncFrame::<PrimarySyncRequest>::Err(SyncFrameError::Internal),
+                    &mut encode_buffer,
+                    &mut compressed_buffer,
+                    max_frame,
+                )
+                .await;
+            })
+            .await;
+        }
+
+        // attempt to close the stream gracefully, bounded so a peer that stops
+        // reading cannot pin this responder task on the FIN flush
+        let _ = timeout(crate::network::SYNC_REQUEST_READ_TIMEOUT, stream.close()).await;
+
+        Ok(())
     }
 }

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::{
     proposer::OurDigestMessage, state_sync::StateSynchronizer, ConsensusBus, ConsensusBusApp,
 };
-use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+use futures::{AsyncReadExt as _, AsyncWriteExt as _, StreamExt as _};
 use handler::RequestHandler;
 pub use message::{MissingCertificatesRequest, PrimaryRequest, PrimaryResponse};
 use message::{PrimaryGossip, PrimaryRPCError};
@@ -20,11 +20,13 @@ use parking_lot::Mutex;
 use tn_config::ConsensusConfig;
 use tn_network_libp2p::{
     error::NetworkError,
+    read_frame,
     types::{
         IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResponseMessage,
         NetworkResult,
     },
-    GossipMessage, Penalty, ResponseChannel, Stream, StreamKind,
+    write_frame, DenyReason, GossipMessage, Penalty, PrimarySyncRequest, ResponseChannel, Stream,
+    StreamError, StreamKind, SyncFrame, SyncFrameError,
 };
 use tn_network_types::{WorkerOthersBatchMessage, WorkerOwnBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{
@@ -42,6 +44,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{debug, info, warn};
 pub mod handler;
 mod message;
+mod sync_codec;
 
 #[cfg(test)]
 #[path = "../tests/network_tests.rs"]
@@ -78,6 +81,30 @@ const MAX_CONSENSUS_OUTPUT_STREAM_BYTES: usize = 512 * 1024 * 1024;
 
 /// Per-read timeout while draining a consensus-output stream (slow-peer guard).
 const CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Timeout for the responder's first sync frame (`Ack`/`Deny`) after the epoch-pack
+/// request frame is written. A peer that negotiated the sync protocol but does not
+/// answer (a pre-cutover node that registered the protocol but reads the stream on
+/// the legacy digest path) trips this and the requester falls back to legacy.
+const SYNC_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for reading the opening request frame of an inbound sync stream, and the
+/// bound on every best-effort trailing write (shed `Deny`, malformed `Err`). A peer
+/// that opens a sync stream but never sends its request, or applies receive
+/// backpressure and stops reading, cannot hold an admission slot indefinitely.
+const SYNC_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum number of network sync probe attempts per [`request_epoch_pack`] call
+/// before falling back to the legacy path.
+///
+/// This caps probe *attempts* (stream opens), not peers examined: a peer cached
+/// legacy-only this epoch is skipped with only a cache lookup (no network I/O) and
+/// does not count against the budget, so successive calls keep discovering newly
+/// upgraded peers without an all-legacy fleet ever spending more than this many
+/// sync opens per call.
+///
+/// [`request_epoch_pack`]: PrimaryNetworkHandle::request_epoch_pack
+const MAX_EPOCH_SYNC_PROBES: usize = 3;
 
 /// What a [`PendingStreamRequest`] should stream once the peer opens the stream.
 #[derive(Debug, Clone, Copy)]
@@ -165,12 +192,85 @@ impl PendingStreamRequest {
     }
 }
 
+/// The outcome of an epoch-pack fetch attempt over the typed sync protocol.
+enum EpochPackAttempt {
+    /// The peer served and the pack was imported into the consensus chain.
+    Imported,
+    /// The peer did not answer the sync exchange; fall back to legacy.
+    Unsupported,
+    /// The peer answered but the exchange failed; try the next peer.
+    Failed(NetworkError),
+}
+
+/// RAII guard for an admitted inbound sync epoch-pack stream.
+///
+/// Holds a global concurrency permit and counts toward the peer's per-peer
+/// in-flight total. Dropping it releases the global slot and decrements the
+/// per-peer count, so a finished or aborted exchange frees capacity for both the
+/// sync and legacy responder paths.
+#[derive(Debug)]
+struct SyncStreamPermit {
+    /// Global concurrency permit, released on drop.
+    _permit: OwnedSemaphorePermit,
+    /// Shared per-peer in-flight counter, decremented on drop.
+    peers: Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
+    /// The peer whose count this permit holds.
+    peer: BlsPublicKey,
+}
+
+impl Drop for SyncStreamPermit {
+    fn drop(&mut self) {
+        let mut peers = self.peers.lock();
+        if let Some(count) = peers.get_mut(&self.peer) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                peers.remove(&self.peer);
+            }
+        }
+    }
+}
+
+/// Try to admit one inbound sync epoch-pack stream for `peer`.
+///
+/// Acquires a global permit and admits only if the peer's combined in-flight
+/// count (legacy pending requests plus sync streams) is below
+/// [`MAX_PENDING_REQUESTS_PER_PEER`], so the per-peer cap holds across both paths.
+/// Returns `None` (shedding the global permit) when either cap is hit.
+///
+/// Locks `pending_epoch_requests` before `sync_stream_peers`; the legacy admission
+/// path takes the same order, so the two never deadlock.
+fn try_admit_sync(
+    semaphore: &Arc<Semaphore>,
+    pending: &Arc<Mutex<HashMap<PendingEpochRequestKey, PendingStreamRequest>>>,
+    sync_peers: &Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
+    peer: BlsPublicKey,
+) -> Option<SyncStreamPermit> {
+    let permit = semaphore.clone().try_acquire_owned().ok()?;
+    let pending_guard = pending.lock();
+    let legacy_count = pending_guard.keys().filter(|(p, _)| *p == peer).count();
+    let mut sync_guard = sync_peers.lock();
+    let sync_count = sync_guard.get(&peer).copied().unwrap_or(0);
+    (legacy_count + sync_count < MAX_PENDING_REQUESTS_PER_PEER).then(|| {
+        *sync_guard.entry(peer).or_insert(0) += 1;
+        SyncStreamPermit { _permit: permit, peers: sync_peers.clone(), peer }
+    })
+}
+
 /// Primary network specific handle.
 #[derive(Clone, Debug)]
 pub struct PrimaryNetworkHandle {
     handle: NetworkHandle<Req, Res>,
     /// The genesis chain id, used to namespace gossip topics this handle publishes.
     chain_id: u64,
+    /// Per-peer sync-protocol capability for epoch-pack fetch, learned by probing.
+    ///
+    /// Absent means not yet probed (try the sync protocol); `false` means the peer
+    /// did not answer a sync open (a pre-cutover peer that fails negotiation, or one
+    /// that negotiated but never `Ack`ed), so go straight to legacy; `true` means the
+    /// peer served (or is serving) the sync protocol. Cleared each epoch via
+    /// [`Self::clear_sync_capability`] so a peer upgraded over the rotation boundary
+    /// is re-probed.
+    sync_capability: Arc<Mutex<HashMap<BlsPublicKey, bool>>>,
 }
 
 // Test-only conversion that defaults the chain id to 0. Gated to tests so the only
@@ -180,19 +280,32 @@ pub struct PrimaryNetworkHandle {
 #[cfg(test)]
 impl From<NetworkHandle<Req, Res>> for PrimaryNetworkHandle {
     fn from(handle: NetworkHandle<Req, Res>) -> Self {
-        Self { handle, chain_id: 0 }
+        Self { handle, chain_id: 0, sync_capability: Arc::new(Mutex::new(HashMap::new())) }
     }
 }
 
 impl PrimaryNetworkHandle {
     /// Create a new instance of Self.
     pub fn new(handle: NetworkHandle<Req, Res>, chain_id: u64) -> Self {
-        Self { handle, chain_id }
+        Self { handle, chain_id, sync_capability: Arc::new(Mutex::new(HashMap::new())) }
     }
 
     //// Convenience method for creating a new Self for tests.
     pub fn new_for_test(sender: mpsc::Sender<NetworkCommand<Req, Res>>) -> Self {
-        Self { handle: NetworkHandle::new(sender), chain_id: 0 }
+        Self {
+            handle: NetworkHandle::new(sender),
+            chain_id: 0,
+            sync_capability: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Clear the per-peer epoch-pack sync-capability cache.
+    ///
+    /// Called at each epoch boundary: committees rotate and binaries are upgraded
+    /// there, so a peer that could only speak legacy last epoch is re-probed for
+    /// the sync protocol this epoch.
+    pub fn clear_sync_capability(&self) {
+        self.sync_capability.lock().clear();
     }
 
     /// Return a reference to the inner handle.
@@ -600,6 +713,27 @@ impl PrimaryNetworkHandle {
         record_timeout: Duration,
     ) -> NetworkResult<()> {
         let epoch = epoch_record.epoch;
+
+        // Step 6 (#739): a full epoch pack prefers the typed sync protocol, folding
+        // the legacy ack-plus-digest handshake into a single stream open. On failure
+        // it falls back to the legacy path below (per peer, penalty-exempt). The
+        // partial-prefix transfer has no sync request variant yet, so it stays on
+        // legacy.
+        if last_consensus_number.is_none()
+            && self
+                .request_epoch_pack_sync(
+                    epoch,
+                    epoch_record,
+                    previous_epoch,
+                    consensus_chain,
+                    record_timeout,
+                )
+                .await
+                .is_ok()
+        {
+            return Ok(());
+        }
+
         // Try up to three times (from three peers) to get consensus.
         // This could be a lot more complicated but this KISS method should work fine.
         // send request to negotiate stream
@@ -697,6 +831,229 @@ impl PrimaryNetworkHandle {
         Err(NetworkError::RPCError("Could not get the epoch pack file!".to_string()))
     }
 
+    /// Attempt to fetch and import a full epoch pack over the typed sync protocol.
+    ///
+    /// Probes up to [`MAX_EPOCH_SYNC_PROBES`] connected peers that are not cached
+    /// legacy-only this epoch, opening a `/tn-primary-sync` stream whose opening
+    /// frame carries the request. Returns `Ok(())` as soon as one peer serves a pack
+    /// that imports; otherwise `Err` so the caller falls back to the legacy path. A
+    /// peer that does not answer is cached legacy-only (skipping its probe next
+    /// time); the probe is penalty-exempt either way.
+    async fn request_epoch_pack_sync(
+        &self,
+        epoch: Epoch,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        consensus_chain: &ConsensusChain,
+        record_timeout: Duration,
+    ) -> NetworkResult<()> {
+        let peers = self.handle.connected_peers().await?;
+
+        // Probe candidate peers one at a time (the async analog of a short-circuiting
+        // fold): `filter` drops peers cached legacy-only this epoch for free, `take`
+        // bounds the network probe attempts, `then` runs each exchange and records its
+        // verdict in the capability cache, and `any` stops at the first peer whose pack
+        // imports (so no peer past the first success is probed).
+        let imported = futures::stream::iter(peers)
+            .filter(move |peer| {
+                let known_legacy = self.sync_capability.lock().get(peer) == Some(&false);
+                futures::future::ready(!known_legacy)
+            })
+            .take(MAX_EPOCH_SYNC_PROBES)
+            .then(move |peer| async move {
+                match self
+                    .sync_epoch_pack_from_peer(
+                        peer,
+                        epoch,
+                        epoch_record,
+                        previous_epoch,
+                        consensus_chain,
+                        record_timeout,
+                    )
+                    .await
+                {
+                    EpochPackAttempt::Imported => {
+                        self.sync_capability.lock().insert(peer, true);
+                        info!(
+                            target: "primary::network",
+                            %peer,
+                            epoch,
+                            "streamed epoch pack file over sync protocol"
+                        );
+                        true
+                    }
+                    EpochPackAttempt::Unsupported => {
+                        self.sync_capability.lock().insert(peer, false);
+                        debug!(
+                            target: "primary::network",
+                            %peer,
+                            "peer did not answer epoch pack sync; will fall back to legacy"
+                        );
+                        false
+                    }
+                    EpochPackAttempt::Failed(e) => {
+                        // the peer speaks sync but this exchange failed; keep it
+                        // sync-capable and try the next peer
+                        self.sync_capability.lock().insert(peer, true);
+                        warn!(
+                            target: "primary::network",
+                            %peer,
+                            epoch,
+                            ?e,
+                            "epoch pack sync exchange failed; trying next peer"
+                        );
+                        false
+                    }
+                }
+            })
+            .any(futures::future::ready)
+            .await;
+
+        imported.then_some(()).ok_or_else(|| {
+            NetworkError::RPCError(
+                "no peer served the epoch pack over the sync protocol".to_string(),
+            )
+        })
+    }
+
+    /// Run one epoch-pack sync exchange against `peer`, flattening the classified
+    /// outcome into a single [`EpochPackAttempt`].
+    async fn sync_epoch_pack_from_peer(
+        &self,
+        peer: BlsPublicKey,
+        epoch: Epoch,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        consensus_chain: &ConsensusChain,
+        record_timeout: Duration,
+    ) -> EpochPackAttempt {
+        self.try_sync_epoch_pack_exchange(
+            peer,
+            epoch,
+            epoch_record,
+            previous_epoch,
+            consensus_chain,
+            record_timeout,
+        )
+        .await
+        .map_or_else(|attempt| attempt, |()| EpochPackAttempt::Imported)
+    }
+
+    /// Open a `/tn-primary-sync` stream, write the [`PrimarySyncRequest::EpochPack`]
+    /// request in the opening frame, and stream the pack through
+    /// [`ConsensusChain::stream_import`].
+    ///
+    /// `Err(EpochPackAttempt::Unsupported)` means the peer did not answer the
+    /// protocol (negotiation failed, or it negotiated but never `Ack`ed), so the
+    /// caller falls back to legacy. `Err(EpochPackAttempt::Failed(_))` means a
+    /// transient or exchange-level error once the peer has proved sync-capable, so
+    /// the caller keeps it sync-capable and tries the next peer. A transport I/O
+    /// error during the open (`UpgradeIo`) is transient rather than a protocol
+    /// mismatch, so it maps to `Failed` instead of poisoning the capability cache.
+    async fn try_sync_epoch_pack_exchange(
+        &self,
+        peer: BlsPublicKey,
+        epoch: Epoch,
+        epoch_record: &EpochRecord,
+        previous_epoch: &EpochRecord,
+        consensus_chain: &ConsensusChain,
+        record_timeout: Duration,
+    ) -> Result<(), EpochPackAttempt> {
+        // open the sync stream, flattening the command-channel and stream-open
+        // results. Only a genuine negotiation failure (`UpgradeFailed`) is a
+        // pre-cutover peer that does not advertise the protocol -> Unsupported
+        // (penalty-exempt, cached legacy-only). A transient upgrade I/O error or any
+        // other open error is not proof the peer lacks sync -> try next peer.
+        let mut stream =
+            self.handle.open_stream(peer, StreamKind::Sync).await.and_then(|s| s).map_err(|e| {
+                match () {
+                    () if matches!(e, NetworkError::Stream(StreamError::UpgradeFailed)) => {
+                        EpochPackAttempt::Unsupported
+                    }
+                    () => EpochPackAttempt::Failed(e),
+                }
+            })?;
+
+        // write the request in the opening frame. Negotiation already succeeded, so
+        // the peer is sync-capable; a write failure is transient -> try next.
+        let max_frame = sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
+        let request = SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch });
+        let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        write_frame(&mut stream, &request, &mut encode_buffer, &mut compressed_buffer, max_frame)
+            .await
+            .and(stream.flush().await)
+            .map_err(|e| {
+                EpochPackAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "failed to write epoch pack sync request frame: {e}"
+                )))
+            })?;
+
+        // read the responder's first frame. A timeout (outer `Err`) means no `Ack`
+        // -> a peer that negotiated sync but does not serve it, so fall back to
+        // legacy. A read I/O error (inner `Err`) after negotiation is transient ->
+        // try the next peer, unless it is a clean close (a pre-cutover peer that shut
+        // the misread stream), which is also a fall-back-to-legacy signal.
+        let (mut decode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        let first = tokio::time::timeout(
+            SYNC_ACK_TIMEOUT,
+            read_frame::<_, PrimarySyncRequest>(
+                &mut stream,
+                &mut decode_buffer,
+                &mut compressed_buffer,
+                max_frame,
+            ),
+        )
+        .await
+        .map_err(|_elapsed| EpochPackAttempt::Unsupported)?
+        .map_err(|e| {
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::BrokenPipe
+            ) {
+                EpochPackAttempt::Unsupported
+            } else {
+                EpochPackAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "failed to read epoch pack sync ack frame: {e}"
+                )))
+            }
+        })?;
+
+        match first {
+            // accepted: reassemble the `Data`/`End` frames into a contiguous reader
+            // and import it. A bad pack is the peer's fault on the legacy path, but
+            // the sync path is metrics-only during rollout: classify it `Failed`
+            // (try next peer) without a penalty.
+            SyncFrame::Ack => consensus_chain
+                .stream_import(
+                    sync_codec::sync_pack_reader(stream),
+                    epoch_record,
+                    previous_epoch,
+                    record_timeout,
+                )
+                .await
+                .map_err(|e| {
+                    EpochPackAttempt::Failed(NetworkError::RPCError(format!(
+                        "failed to import epoch pack over sync stream: {e}"
+                    )))
+                }),
+            // sync-capable, but shedding load or lacking the pack: try next peer
+            SyncFrame::Deny(reason) => Err(EpochPackAttempt::Failed(NetworkError::RPCRetryable(
+                format!("peer denied epoch pack sync request: {reason:?}"),
+            ))),
+            SyncFrame::Err(err) => Err(EpochPackAttempt::Failed(NetworkError::RPCError(format!(
+                "peer aborted epoch pack sync exchange: {err:?}"
+            )))),
+            // a well-behaved responder never opens with these
+            SyncFrame::Req(_) | SyncFrame::Data(_) | SyncFrame::End => {
+                Err(EpochPackAttempt::Failed(NetworkError::ProtocolError(
+                    "unexpected opening sync frame from peer".to_string(),
+                )))
+            }
+        }
+    }
+
     /// Helper to convert a consensus chain error to penalty.
     /// This error does not have network knowledge so do it here for the
     /// streaming case vs with the error.
@@ -768,6 +1125,13 @@ pub struct PrimaryNetwork<DB, Events> {
     /// Wrapped in `Arc<Mutex>` so spawned stream tasks can look up the matching
     /// request after reading the correlation digest from the stream.
     pending_epoch_requests: Arc<Mutex<HashMap<PendingEpochRequestKey, PendingStreamRequest>>>,
+    /// Per-peer count of in-flight sync epoch-pack streams.
+    ///
+    /// The legacy per-peer count comes from `pending_epoch_requests`; this counts
+    /// the sync path's in-flight exchanges. Admission on either path checks the sum
+    /// against [`MAX_PENDING_REQUESTS_PER_PEER`], so the per-peer cap is the combined
+    /// limit across both paths.
+    sync_stream_peers: Arc<Mutex<HashMap<BlsPublicKey, usize>>>,
 }
 
 impl<DB, Events> PrimaryNetwork<DB, Events>
@@ -801,6 +1165,7 @@ where
             consensus_chain,
             epoch_stream_semaphore,
             pending_epoch_requests: pending_batch_requests,
+            sync_stream_peers: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 
@@ -898,17 +1263,7 @@ where
             }
             NetworkEvent::InboundStream { peer, kind, stream } => match kind {
                 StreamKind::Legacy => self.process_inbound_stream(peer, stream),
-                // the primary registers its sync protocol but opens no sync stream
-                // until the item-6 cutover; drop any unexpected inbound sync stream
-                // (metrics-only during rollout, no penalty)
-                StreamKind::Sync => {
-                    warn!(
-                        target: "primary::network",
-                        %peer,
-                        "dropping unexpected inbound sync stream (primary sync cutover is item 6)"
-                    );
-                    drop(stream);
-                }
+                StreamKind::Sync => self.process_inbound_sync_stream(peer, stream),
             },
         }
     }
@@ -1068,8 +1423,13 @@ where
 
         let mut pending_map = self.pending_epoch_requests.lock();
 
-        // check per-peer capacity
-        let peer_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
+        // check per-peer capacity. The cap is the combined limit across the legacy
+        // and sync paths, so add this peer's in-flight sync streams to its legacy
+        // pending count. Locks pending then sync_stream_peers, matching
+        // try_admit_sync's order so the two admission paths never deadlock.
+        let legacy_count = pending_map.keys().filter(|(p, _)| *p == peer).count();
+        let sync_count = self.sync_stream_peers.lock().get(&peer).copied().unwrap_or(0);
+        let peer_count = legacy_count + sync_count;
         if peer_count >= MAX_PENDING_REQUESTS_PER_PEER {
             info!(
                 target: "primary::network",
@@ -1237,6 +1597,126 @@ where
                 } else {
                     Ok(())
                 }
+        });
+    }
+
+    /// Process an inbound sync epoch-pack stream.
+    ///
+    /// Admission against the shared concurrency caps happens here on stream open:
+    /// the request rides in the opening frame, so there is no `(peer, digest)`
+    /// pending map for this path. A shedding responder writes
+    /// [`DenyReason::AtCapacity`] without reading so the requester retries elsewhere
+    /// immediately. Once admitted, the opening request frame is read (bounded by
+    /// [`SYNC_REQUEST_READ_TIMEOUT`]) and an `EpochPack` request is served by
+    /// [`RequestHandler::process_sync_epoch_pack_stream`]. The admission permit is
+    /// held for the lifetime of the spawned task.
+    fn process_inbound_sync_stream(&self, peer: BlsPublicKey, stream: Stream) {
+        // admit against the shared caps before spawning; the permit (if any) moves
+        // into the task and frees capacity on drop
+        let permit = try_admit_sync(
+            &self.epoch_stream_semaphore,
+            &self.pending_epoch_requests,
+            &self.sync_stream_peers,
+            peer,
+        );
+        let request_handler = self.request_handler.clone();
+        let consensus_chain = self.consensus_chain.clone();
+        let task_name = format!("sync-epoch-pack-{peer}");
+        self.task_spawner.spawn_task(task_name, async move {
+            let mut stream = stream;
+            let max_frame = sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
+            let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+
+            // shed load: deny without reading so the requester retries elsewhere
+            let Some(_permit) = permit else {
+                debug!(target: "primary::network", %peer, "denying inbound sync stream: at capacity");
+                // bound the best-effort shed write: a peer that applies receive
+                // backpressure and never reads must not stall this task.
+                let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, async {
+                    let _ = write_frame(
+                        &mut stream,
+                        &SyncFrame::<PrimarySyncRequest>::Deny(DenyReason::AtCapacity),
+                        &mut encode_buffer,
+                        &mut compressed_buffer,
+                        max_frame,
+                    )
+                    .await;
+                    let _ = stream.close().await;
+                })
+                .await;
+                return Ok(());
+            };
+
+            // read the opening request frame; a peer that never sends one (timeout)
+            // or sends a malformed one (io error) is dropped after releasing the
+            // permit. Collapse the timeout/io results rather than nesting matches.
+            let (mut decode_buffer, mut decompress_buffer) = (Vec::new(), Vec::new());
+            let request = tokio::time::timeout(
+                SYNC_REQUEST_READ_TIMEOUT,
+                read_frame::<_, PrimarySyncRequest>(
+                    &mut stream,
+                    &mut decode_buffer,
+                    &mut decompress_buffer,
+                    max_frame,
+                ),
+            )
+            .await
+            .ok()
+            .and_then(Result::ok);
+            let Some(request) = request else {
+                warn!(target: "primary::network", %peer, "no readable sync request frame");
+                let _ = stream.close().await;
+                return Ok(());
+            };
+
+            match request {
+                SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch }) => {
+                    request_handler
+                        .process_sync_epoch_pack_stream(peer, stream, epoch, &consensus_chain)
+                        .await?;
+                }
+                // `MissingCertificates` over sync is item 7; the primary registers
+                // the request type but does not serve it yet. Decline cleanly.
+                SyncFrame::Req(PrimarySyncRequest::MissingCertificates { .. }) => {
+                    debug!(target: "primary::network", %peer, "declining unimplemented sync request: missing certificates (item 7)");
+                    let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, async {
+                        let _ = write_frame(
+                            &mut stream,
+                            &SyncFrame::<PrimarySyncRequest>::Deny(DenyReason::Unavailable),
+                            &mut encode_buffer,
+                            &mut compressed_buffer,
+                            max_frame,
+                        )
+                        .await;
+                        let _ = stream.close().await;
+                    })
+                    .await;
+                }
+                // a well-behaved requester always opens with `Req`; anything else is
+                // malformed. Signal it and drop (metrics-only, no penalty).
+                SyncFrame::Ack
+                | SyncFrame::Deny(_)
+                | SyncFrame::Data(_)
+                | SyncFrame::End
+                | SyncFrame::Err(_) => {
+                    warn!(target: "primary::network", %peer, "unexpected opening sync frame from requester");
+                    // bound the best-effort error write so a non-reading peer cannot
+                    // pin the held admission permit on an unbounded write.
+                    let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, async {
+                        let _ = write_frame(
+                            &mut stream,
+                            &SyncFrame::<PrimarySyncRequest>::Err(SyncFrameError::Malformed),
+                            &mut encode_buffer,
+                            &mut compressed_buffer,
+                            max_frame,
+                        )
+                        .await;
+                        let _ = stream.close().await;
+                    })
+                    .await;
+                }
+            }
+            Ok(())
         });
     }
 }

--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -18,13 +18,13 @@
 use crate::error::PrimaryNetworkResult;
 use futures::{
     io::{AsyncRead as FuturesAsyncRead, AsyncWrite as FuturesAsyncWrite},
-    AsyncWriteExt as _,
+    AsyncWriteExt as _, TryStreamExt as _,
 };
 use std::time::Duration;
 use tn_network_libp2p::{read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{BlsPublicKey, Epoch};
-use tokio::io::{AsyncRead as TokioAsyncRead, AsyncReadExt as _};
+use tokio::io::AsyncRead as TokioAsyncRead;
 use tracing::debug;
 
 /// The raw pack bytes carried by a single [`SyncFrame::Data`] frame.
@@ -112,22 +112,29 @@ where
     R: TokioAsyncRead + Unpin + Send,
     S: FuturesAsyncWrite + Unpin + Send,
 {
-    let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
-    let mut buf = vec![0u8; SYNC_PACK_CHUNK_SIZE];
-    loop {
-        let n = reader.read(&mut buf).await?;
-        if n == 0 {
-            break;
-        }
-        write_one_frame(
-            stream,
-            &SyncFrame::Data(buf[..n].to_vec()),
-            &mut encode_buffer,
-            &mut compressed_buffer,
-            buffer_timeout,
-        )
-        .await?;
-    }
+    // Chunk the reader into fixed-capacity `Data` frames by folding a `ReaderStream`
+    // (yielding `Ok(<=SYNC_PACK_CHUNK_SIZE bytes)`, ending at EOF, surfacing a read
+    // error). The writer and the two scratch buffers ride the accumulator: this
+    // reuses the buffers across frames and keeps the writer's `&mut` out of the
+    // `FnMut` closure, whose returned future cannot borrow per-call captures. Each
+    // chunk's backing allocation is reclaimed into the `Data` frame without a copy.
+    let (stream, mut encode_buffer, mut compressed_buffer) =
+        tokio_util::io::ReaderStream::with_capacity(reader, SYNC_PACK_CHUNK_SIZE)
+            .try_fold(
+                (stream, Vec::new(), Vec::new()),
+                |(stream, mut encode_buffer, mut compressed_buffer), chunk| async move {
+                    write_one_frame(
+                        stream,
+                        &SyncFrame::Data(chunk.into()),
+                        &mut encode_buffer,
+                        &mut compressed_buffer,
+                        buffer_timeout,
+                    )
+                    .await?;
+                    Ok((stream, encode_buffer, compressed_buffer))
+                },
+            )
+            .await?;
 
     write_one_frame(
         stream,
@@ -230,6 +237,7 @@ where
 mod tests {
     use super::*;
     use tn_network_libp2p::SyncFrameError;
+    use tokio::io::AsyncReadExt as _;
 
     /// Frame `bytes` through [`write_pack_data_frames`] into an in-memory buffer.
     async fn frame_pack(bytes: &[u8]) -> Vec<u8> {

--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -1,0 +1,320 @@
+//! Frame codec for the primary's typed epoch-pack sync protocol.
+//!
+//! Step 6 of #739 cuts the full epoch-pack transfer over to the typed
+//! [`SyncFrame`] layer: the request travels in the opening
+//! [`SyncFrame::Req`](tn_network_libp2p::SyncFrame::Req) of a `/tn-primary-sync`
+//! stream and the responder answers [`SyncFrame::Ack`] then streams the raw pack
+//! bytes as a sequence of [`SyncFrame::Data`] frames terminated by
+//! [`SyncFrame::End`] (or a [`SyncFrame::Deny`] when the pack is not held).
+//!
+//! Unlike the worker's batch path — where each `Data` frame is one whole
+//! decodable [`Batch`](tn_types::Batch) — an epoch pack is a single opaque byte
+//! stream (`EpochMeta` followed by interleaved batch and consensus records). The
+//! responder therefore chunks the pack file into fixed-size `Data` frames and the
+//! requester reassembles them into a contiguous [`tokio::io::AsyncRead`] so the
+//! existing [`ConsensusChain::stream_import`](tn_storage::consensus::ConsensusChain::stream_import)
+//! verifier consumes it unchanged.
+
+use crate::error::PrimaryNetworkResult;
+use futures::{
+    io::{AsyncRead as FuturesAsyncRead, AsyncWrite as FuturesAsyncWrite},
+    AsyncWriteExt as _,
+};
+use std::time::Duration;
+use tn_network_libp2p::{read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame};
+use tn_storage::consensus::ConsensusChain;
+use tn_types::{BlsPublicKey, Epoch};
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncReadExt as _};
+use tracing::debug;
+
+/// The raw pack bytes carried by a single [`SyncFrame::Data`] frame.
+///
+/// A larger chunk means fewer frames (and fewer flushes) at the cost of a larger
+/// per-frame buffer on each side; 256 KiB keeps a full 512 MiB pack to a few
+/// thousand frames.
+const SYNC_PACK_CHUNK_SIZE: usize = 256 * 1024;
+
+/// Headroom added to [`SYNC_PACK_CHUNK_SIZE`] for the `SyncFrame` envelope (the
+/// enum tag and the `Data` length prefix) when bounding a decoded frame.
+const SYNC_PACK_FRAME_OVERHEAD: usize = 1024;
+
+/// The largest sync frame accepted on the primary epoch-pack stream: one `Data`
+/// frame carrying a pack chunk, plus envelope headroom. Unlike the worker's
+/// epoch-keyed bound, the pack is chunked at a fixed size, so this is constant.
+pub(crate) const MAX_SYNC_PACK_FRAME_SIZE: usize = SYNC_PACK_CHUNK_SIZE + SYNC_PACK_FRAME_OVERHEAD;
+
+/// Per-frame read timeout while reassembling the pack on the requester side. The
+/// whole import is also bounded by the caller's `record_timeout`; this guards a
+/// single stalled frame.
+const EPOCH_PACK_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Serve an accepted epoch-pack sync exchange over `stream`.
+///
+/// A full epoch pack is all-or-nothing: if the complete, verifiable pack is not
+/// held, the responder sheds with [`SyncFrame::Deny`]`(`[`DenyReason::Unavailable`]`)`
+/// so the requester retries another peer immediately instead of waiting out its
+/// ack timeout. Otherwise it writes [`SyncFrame::Ack`], streams the pack as
+/// [`SyncFrame::Data`] frames, and ends with [`SyncFrame::End`]. Each frame write
+/// is bounded by `buffer_timeout` so a peer that stops reading cannot stall the
+/// responder task on an unbounded write. The caller has already admitted the
+/// exchange against the concurrency caps and read the opening request frame.
+pub(crate) async fn send_sync_epoch_pack_over_stream<S>(
+    stream: &mut S,
+    consensus_chain: &ConsensusChain,
+    epoch: Epoch,
+    buffer_timeout: Duration,
+    peer: BlsPublicKey,
+) -> PrimaryNetworkResult<()>
+where
+    S: FuturesAsyncWrite + Unpin + Send,
+{
+    let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+
+    // the complete pack is not held: shed cleanly so the requester retries elsewhere
+    let Ok(mut epoch_stream) = consensus_chain.get_epoch_stream(epoch).await else {
+        debug!(target: "primary::network", %peer, epoch, "epoch pack unavailable; denying sync request");
+        write_one_frame(
+            stream,
+            &SyncFrame::Deny(DenyReason::Unavailable),
+            &mut encode_buffer,
+            &mut compressed_buffer,
+            buffer_timeout,
+        )
+        .await?;
+        return Ok(());
+    };
+
+    // accept and flush immediately so the requester sees the `Ack` within its ack
+    // timeout even when the first pack reads are slow
+    write_one_frame(
+        stream,
+        &SyncFrame::Ack,
+        &mut encode_buffer,
+        &mut compressed_buffer,
+        buffer_timeout,
+    )
+    .await?;
+
+    write_pack_data_frames(&mut epoch_stream, stream, buffer_timeout).await?;
+    Ok(())
+}
+
+/// Stream a pack reader as [`SyncFrame::Data`] frames terminated by
+/// [`SyncFrame::End`]. Does not write the opening `Ack` (the caller decides
+/// whether to accept); split out so the wire framing can be round-tripped in
+/// tests against [`sync_pack_reader`] without a [`ConsensusChain`] fixture.
+pub(crate) async fn write_pack_data_frames<R, S>(
+    reader: &mut R,
+    stream: &mut S,
+    buffer_timeout: Duration,
+) -> std::io::Result<()>
+where
+    R: TokioAsyncRead + Unpin + Send,
+    S: FuturesAsyncWrite + Unpin + Send,
+{
+    let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+    let mut buf = vec![0u8; SYNC_PACK_CHUNK_SIZE];
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        write_one_frame(
+            stream,
+            &SyncFrame::Data(buf[..n].to_vec()),
+            &mut encode_buffer,
+            &mut compressed_buffer,
+            buffer_timeout,
+        )
+        .await?;
+    }
+
+    write_one_frame(
+        stream,
+        &SyncFrame::End,
+        &mut encode_buffer,
+        &mut compressed_buffer,
+        buffer_timeout,
+    )
+    .await
+}
+
+/// Write a single frame and flush, bounding both on `buffer_timeout` so a
+/// non-reading peer cannot pin the writer on an unbounded write.
+async fn write_one_frame<S>(
+    stream: &mut S,
+    frame: &SyncFrame<PrimarySyncRequest>,
+    encode_buffer: &mut Vec<u8>,
+    compressed_buffer: &mut Vec<u8>,
+    buffer_timeout: Duration,
+) -> std::io::Result<()>
+where
+    S: FuturesAsyncWrite + Unpin + Send,
+{
+    tokio::time::timeout(buffer_timeout, async {
+        write_frame(stream, frame, encode_buffer, compressed_buffer, MAX_SYNC_PACK_FRAME_SIZE)
+            .await?;
+        stream.flush().await
+    })
+    .await
+    .map_err(|_elapsed| {
+        std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout writing epoch pack sync frame")
+    })?
+}
+
+/// Reassemble the [`SyncFrame::Data`] frames of an accepted epoch-pack exchange
+/// into a contiguous [`tokio::io::AsyncRead`] terminating at [`SyncFrame::End`].
+///
+/// The caller has already read the opening [`SyncFrame::Ack`]; this reads the
+/// `Data`/`End` stream. An [`SyncFrame::Err`] frame or any out-of-place frame
+/// surfaces as a read error so the importer aborts. The returned reader is fed
+/// directly to
+/// [`ConsensusChain::stream_import`](tn_storage::consensus::ConsensusChain::stream_import).
+pub(crate) fn sync_pack_reader<S>(stream: S) -> impl TokioAsyncRead + Unpin + Send
+where
+    S: FuturesAsyncRead + Unpin + Send + 'static,
+{
+    let frames = futures::stream::unfold(
+        (stream, Vec::new(), Vec::new()),
+        |(mut stream, mut decode_buffer, mut compressed_buffer)| async move {
+            let chunk =
+                next_pack_chunk(&mut stream, &mut decode_buffer, &mut compressed_buffer).await;
+            let state = (stream, decode_buffer, compressed_buffer);
+            // Result<Option<bytes>> -> Option<Result<bytes>>: `End` stops the
+            // stream, `Data` yields a chunk, an error yields one error item
+            chunk.transpose().map(|item| (item.map(std::io::Cursor::new), state))
+        },
+    );
+    tokio_util::io::StreamReader::new(Box::pin(frames))
+}
+
+/// Read the next pack chunk from an accepted exchange: `Ok(Some(bytes))` for a
+/// `Data` frame, `Ok(None)` for `End`, `Err` for an aborted or malformed stream.
+async fn next_pack_chunk<S>(
+    stream: &mut S,
+    decode_buffer: &mut Vec<u8>,
+    compressed_buffer: &mut Vec<u8>,
+) -> std::io::Result<Option<Vec<u8>>>
+where
+    S: FuturesAsyncRead + Unpin + Send,
+{
+    let frame = tokio::time::timeout(
+        EPOCH_PACK_FRAME_TIMEOUT,
+        read_frame::<_, PrimarySyncRequest>(
+            stream,
+            decode_buffer,
+            compressed_buffer,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        ),
+    )
+    .await
+    .map_err(|_elapsed| {
+        std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout reading epoch pack sync frame")
+    })??;
+
+    match frame {
+        SyncFrame::Data(bytes) => Ok(Some(bytes)),
+        SyncFrame::End => Ok(None),
+        SyncFrame::Err(err) => {
+            Err(std::io::Error::other(format!("peer aborted epoch pack sync stream: {err:?}")))
+        }
+        // a well-behaved responder never sends these once streaming
+        SyncFrame::Ack | SyncFrame::Deny(_) | SyncFrame::Req(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "unexpected sync frame during epoch pack stream",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tn_network_libp2p::SyncFrameError;
+
+    /// Frame `bytes` through [`write_pack_data_frames`] into an in-memory buffer.
+    async fn frame_pack(bytes: &[u8]) -> Vec<u8> {
+        let mut reader = std::io::Cursor::new(bytes.to_vec());
+        let mut out = Vec::new();
+        write_pack_data_frames(&mut reader, &mut out, Duration::from_secs(5))
+            .await
+            .expect("frame pack");
+        out
+    }
+
+    /// Reassemble framed bytes through [`sync_pack_reader`].
+    async fn read_back(framed: Vec<u8>) -> std::io::Result<Vec<u8>> {
+        let mut reader = sync_pack_reader(futures::io::Cursor::new(framed));
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await?;
+        Ok(out)
+    }
+
+    /// The responder's `Data`+`End` framing round-trips through the requester's
+    /// reassembly reader across multiple chunk boundaries: the reconstructed pack
+    /// bytes are byte-for-byte the original. This is the cross-version wire
+    /// contract between an item-6 responder and an item-6 requester.
+    #[tokio::test]
+    async fn sync_pack_round_trip_multi_chunk() {
+        // two full chunks plus a partial one, so the reader spans frame boundaries
+        let original: Vec<u8> =
+            (0..(SYNC_PACK_CHUNK_SIZE * 2 + 1234)).map(|i| (i % 251) as u8).collect();
+        let framed = frame_pack(&original).await;
+        let received = read_back(framed).await.expect("read back");
+        assert_eq!(received, original);
+    }
+
+    /// An empty pack streams only `End`; the reader yields zero bytes cleanly.
+    #[tokio::test]
+    async fn sync_pack_round_trip_empty() {
+        let framed = frame_pack(&[]).await;
+        let received = read_back(framed).await.expect("read back");
+        assert!(received.is_empty());
+    }
+
+    /// An `Err` frame mid-stream surfaces as a read error so `stream_import` aborts.
+    #[tokio::test]
+    async fn sync_pack_reader_rejects_err_frame() {
+        let mut framed = Vec::new();
+        let (mut enc, mut comp) = (Vec::new(), Vec::new());
+        write_frame(
+            &mut framed,
+            &SyncFrame::<PrimarySyncRequest>::Data(vec![1, 2, 3]),
+            &mut enc,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("write data");
+        write_frame(
+            &mut framed,
+            &SyncFrame::<PrimarySyncRequest>::Err(SyncFrameError::Internal),
+            &mut enc,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("write err");
+        assert!(read_back(framed).await.is_err(), "an Err frame must surface as a read error");
+    }
+
+    /// An out-of-place control frame (e.g. a second `Ack`) is a protocol
+    /// violation and surfaces as a read error.
+    #[tokio::test]
+    async fn sync_pack_reader_rejects_unexpected_frame() {
+        let mut framed = Vec::new();
+        let (mut enc, mut comp) = (Vec::new(), Vec::new());
+        write_frame(
+            &mut framed,
+            &SyncFrame::<PrimarySyncRequest>::Ack,
+            &mut enc,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("write ack");
+        assert!(
+            read_back(framed).await.is_err(),
+            "an unexpected control frame mid-stream must surface as a read error"
+        );
+    }
+}

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -924,6 +924,46 @@ async fn test_send_partial_epoch_over_stream() {
     assert_eq!(&sent_more[..sent.len()], &sent[..], "smaller prefix must prefix the larger one");
 }
 
+/// A full epoch pack the responder does not hold is shed with
+/// `Deny(Unavailable)`, so a sync requester retries another peer immediately
+/// instead of waiting out its ack timeout. (The `Ack`+`Data`+`End` happy path is
+/// unit-tested in `sync_codec` and exercised end-to-end by the ignored
+/// observer-pack-import e2e test.)
+#[tokio::test]
+async fn test_sync_epoch_pack_unavailable_denies() {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { handler, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+    let peer = BlsPublicKey::default();
+
+    // epoch 0 has no finalized pack, so the responder cannot serve a full epoch pack
+    let mut out: Vec<u8> = Vec::new();
+    crate::network::sync_codec::send_sync_epoch_pack_over_stream(
+        &mut out,
+        handler.consensus_chain(),
+        0,
+        Duration::from_secs(5),
+        peer,
+    )
+    .await
+    .expect("serving an unavailable pack sheds cleanly without erroring");
+
+    // the first (and only) frame must be Deny(Unavailable)
+    let (mut dec, mut comp) = (Vec::new(), Vec::new());
+    let frame = tn_network_libp2p::read_frame::<_, tn_network_libp2p::PrimarySyncRequest>(
+        &mut futures::io::Cursor::new(out),
+        &mut dec,
+        &mut comp,
+        crate::network::sync_codec::MAX_SYNC_PACK_FRAME_SIZE,
+    )
+    .await
+    .expect("read deny frame");
+    assert_matches!(
+        frame,
+        tn_network_libp2p::SyncFrame::Deny(tn_network_libp2p::DenyReason::Unavailable)
+    );
+}
+
 /// A peer that re-requests the same epoch while an entry is already pending must not be
 /// able to reset the cleanup timer. If the replacement path rearmed `created_at`, a peer
 /// could re-request every 20s and hold a slot forever. This test exercises the

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -525,6 +525,11 @@ where
 
         Self::wait_for_network_peers(network_handle.inner_handle(), "primary network").await?;
 
+        // re-probe each peer's epoch-pack sync capability this epoch: committees
+        // rotate and binaries are upgraded at the boundary, so a peer that could
+        // only speak legacy last epoch may now serve the sync protocol (739, step 6)
+        network_handle.clear_sync_capability();
+
         // spawn primary network
         PrimaryNetwork::new(
             rx_event_stream,


### PR DESCRIPTION
# feat(network): cut the primary epoch-pack path over to the typed sync protocol with legacy fallback (739, step 6)

## Summary

Step 6 of #739. Step 5 (#781) cut the worker batch path over to the typed sync-frame layer; the primary stayed fully legacy and dropped any inbound sync stream with a warning. This PR cuts the primary's **full epoch-pack** transfer over to the sync protocol, with a **penalty-exempt fallback to legacy** for any peer that does not speak it.

The result folds the legacy two-roundtrip handshake (a `StreamEpoch` request-response that returns an `ack`, then a raw `/tn-stream` open onto which the requester writes a 32-byte correlation digest) into a **single stream open** whose opening `SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch })` carries the request itself.

Scope is deliberately the full epoch pack only: `PrimarySyncRequest` has `EpochPack` and `MissingCertificates`, and the latter is step 7. The partial-prefix transfer (`StreamEpochPartial`) and the single consensus-output stream (`StreamConsensusOutput`) have no sync request variant, so they stay on the legacy path here. No `SyncFrame` / `PrimarySyncRequest` variant is added, reordered, or removed, so `frame_tags_are_stable` / `request_tags_are_stable` stay green and the wire format is unchanged.

`request_epoch_pack`'s public signature is preserved, so the state-sync retry loop (`crates/state-sync/src/consensus.rs`) that drives it is untouched.

## What changed

### Requester (primary `network/mod.rs`)

- `request_epoch_pack_inner` gains a sync-first prelude for the full-epoch case: before the existing legacy loop, it calls `request_epoch_pack_sync`, which enumerates connected peers and, for each peer not cached legacy-only this epoch, opens a `/tn-primary-sync` stream, writes `SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch })`, reads the response (`Ack`, then `Data` frames terminated by `End`), and imports it. It returns as soon as one peer's pack imports.
- **The legacy `send_request_any` ack-plus-digest loop below is byte-for-byte unchanged.** The sync attempt is a pure prelude: on any failure it falls through to the proven legacy path, so a mixed or all-legacy fleet keeps working exactly as before.
- An `EpochPackAttempt` enum classifies each exchange:
  - `Imported` -> the peer served a pack that verified and imported; cache it sync-capable, done.
  - `Unsupported` -> the peer never answered (negotiation failed = a pre-cutover peer, or it negotiated sync but sent no `Ack`); cache it legacy-only and skip its probe for the rest of the epoch.
  - `Failed` -> the exchange failed after the peer proved sync-capable (`Deny` / `Err` / mid-stream error, or a transient I/O error opening or writing the stream); keep it sync-capable and try the next peer.
- A per-peer `sync_capability` cache (`Arc<Mutex<HashMap<BlsPublicKey, bool>>>`) on `PrimaryNetworkHandle` avoids re-probing a known legacy-only peer every request. It is **cleared each epoch** (`clear_sync_capability`, called at the per-epoch primary network setup) so a peer upgraded across the committee-rotation boundary is re-probed.
- The probe is bounded to `MAX_EPOCH_SYNC_PROBES` (3) sync exchanges per call (cached legacy-only peers are skipped for free and do not count), so on an all-legacy fleet the prelude never delays the legacy fetch for long while still discovering newly upgraded peers across successive calls.
- The sync probe is **penalty-exempt**, and a transient transport error never demotes a sync-capable peer: a genuine negotiation failure surfaces as `StreamError::UpgradeFailed` and maps to `Unsupported` (fall back, cache legacy-only), while a transport I/O error during the open surfaces as the distinct `StreamError::UpgradeIo` and maps to `Failed` (try the next peer, peer stays sync-capable). Neither scores the peer.

### Pack data path (primary `network/sync_codec.rs`, new)

Unlike the worker, whose every `Data` frame is one whole decodable `Batch`, an epoch pack is a single opaque byte stream (`EpochMeta` then interleaved batch and consensus records). So:

- The responder chunks the pack file (`get_epoch_stream`) into fixed-size `SyncFrame::Data` frames (256 KiB) terminated by `SyncFrame::End`.
- The requester reassembles those `Data` frames into a contiguous `tokio::io::AsyncRead` (`sync_pack_reader`, a `StreamReader` over the frame stream) and feeds it directly to the existing `ConsensusChain::stream_import`, which verifies and imports the pack incrementally exactly as the legacy path does. Nothing in storage changes.

Because the pack is chunked at a fixed size, the per-frame bound (`MAX_SYNC_PACK_FRAME_SIZE`) is a constant, so unlike the worker the primary handle needs no epoch field.

### Responder (primary `network/mod.rs`, `handler.rs`, `sync_codec.rs`)

- Inbound streams now dispatch on the negotiated `StreamKind`: `Legacy` -> the existing digest-correlation reader; `Sync` -> the new `process_inbound_sync_stream` (it previously dropped the stream with a warning).
- Because the sync request travels in the stream's opening frame (no prior request-response ack), admission against the concurrency caps moves to stream-open time:
  - `try_admit_sync` acquires the **shared** `epoch_stream_semaphore` (so the global `MAX_CONCURRENT_EPOCH_STREAMS` cap is the combined legacy+sync limit) and checks the peer's combined in-flight count (legacy pending entries plus sync streams) against `MAX_PENDING_REQUESTS_PER_PEER`. The legacy admission path (`accept_stream_request`) likewise adds the peer's in-flight sync-stream count to its legacy count, so the per-peer cap is enforced **symmetrically across both paths** (both lock `pending_epoch_requests` before `sync_stream_peers`, so they never deadlock). A `SyncStreamPermit` RAII guard releases the global slot and decrements the per-peer count on drop.
  - A shedding responder writes `SyncFrame::Deny(DenyReason::AtCapacity)` without reading, so the requester gives up immediately and tries elsewhere instead of waiting out its ack timeout.
- Once admitted, the opening `Req` frame is read (bounded by `SYNC_REQUEST_READ_TIMEOUT`). A full epoch pack is all-or-nothing, so if the complete pack is not held the responder sheds with `SyncFrame::Deny(DenyReason::Unavailable)`; otherwise it serves `Ack` + one `Data` frame per pack chunk + `End` via `send_sync_epoch_pack_over_stream`.
- A `MissingCertificates` sync request is declined with `Deny(DenyReason::Unavailable)`: the primary registers the request type but does not serve it until step 7.
- Responder errors are **metrics-only** during the rollout (logged, best-effort `SyncFrame::Err`, no penalty), matching the step-3 stream-failure policy and the legacy responder. Every best-effort trailing write (shed `Deny`, malformed `Err`, internal `Err`, final close) is bounded by a timeout so a non-reading peer cannot stall the responder task on an unbounded write.

### Plumbing

- `PrimaryNetworkHandle::clear_sync_capability` is called at the per-epoch primary network setup (`crates/node/src/manager/node/start_epoch.rs`), the same epoch-boundary refresh the worker uses for its cache.
- `tn-primary` gains the `tokio-util` `io` feature for `StreamReader` (used to present the reassembled pack as an `AsyncRead`).

## Cross-version behaviour

| requester | responder | outcome |
|---|---|---|
| item-6 (sync-first) | item-6 with the pack | sync exchange, single open |
| item-6 | item-6 without the pack | `Deny(Unavailable)` -> requester tries the next peer / falls back; no penalty |
| item-6 | pre-item-6 (no sync open served) | no `Ack` (or negotiation fails) -> requester falls back to legacy; no penalty |
| pre-item-6 (legacy-only) | item-6 | responder still accepts the legacy `/tn-stream` open |

## Wire protocol

- Each `SyncFrame` is one length-prefixed, snappy-compressed `encode_message` unit; the BCS enum discriminant is the frame tag (pinned by `frame_tags_are_stable` / `request_tags_are_stable` from step 4).
- The epoch pack is streamed as `Ack` + a sequence of `Data` frames (each a 256 KiB pack chunk) + `End`. Every frame is bounded by `MAX_SYNC_PACK_FRAME_SIZE` (chunk size + 1 KiB envelope headroom), so a peer cannot force an oversized allocation.

## Tests

- New `sync_codec` round-trip tests proving the responder framing and the requester reassembly agree on the wire across chunk boundaries: `sync_pack_round_trip_multi_chunk` (two full chunks plus a partial), `sync_pack_round_trip_empty`, and `sync_pack_reader_rejects_err_frame` / `sync_pack_reader_rejects_unexpected_frame` (an aborted or out-of-place frame surfaces as a read error so `stream_import` aborts).
- `test_sync_epoch_pack_unavailable_denies`: a responder that does not hold the complete pack sheds with `Deny(Unavailable)` rather than erroring. The `Ack`+`Data`+`End` happy path is exercised end-to-end by the (ignored) observer-pack-import e2e test.

## Gates (all green)

- `cargo +nightly-2026-03-20 fmt --check`
- `cargo test -p tn-primary` (162 passed, 1 ignored)
- `cargo clippy -p tn-primary --all-features --all-targets` (0 warnings; the changed crate and its consumers compile clean)
- `cargo doc --no-deps -p tn-primary` with `RUSTDOCFLAGS=-D warnings`
- `cargo check -p tn-node` (the per-epoch `clear_sync_capability` call site)

Toolchain: build/test stable 1.94; fmt/clippy nightly-2026-03-20. Build with `-j 2` (the dev-dep tree OOMs at default `-j`).

## Note on encoding compatibility

BCS encodes enum variant indices: no `SyncFrame` / `PrimarySyncRequest` variant is reordered or removed here, and no new variant is added. The coordinated `/0.0.2` bump and legacy freeze remain step 9.
