### PR TITLE
feat(node): per-worker readiness endpoint at GET /health/workers (#712)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11704,6 +11704,8 @@ dependencies = [
  "rand 0.9.2",
  "reth-metrics",
  "roaring 0.10.12",
+ "serde",
+ "serde_json",
  "state-sync",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,6 +35,8 @@ jsonrpsee = { workspace = true }
 roaring = { workspace = true }
 metrics = { workspace = true }
 reth-metrics = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 metrics-util = { workspace = true }

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -111,6 +111,16 @@ impl ExecutionNode {
         !self.internal.read().await.workers.is_empty()
     }
 
+    /// Returns true if the worker identified by `worker_id` has been initialized.
+    ///
+    /// A worker's components (RPC server + transaction pool) are created once on
+    /// the node's first epoch and are not torn down across epoch transitions, so
+    /// this reflects "this worker is up and accepting transactions" rather than
+    /// any per-epoch state. Backs the `/health/workers` readiness endpoint.
+    pub async fn is_worker_initialized(&self, worker_id: WorkerId) -> bool {
+        self.internal.read().await.workers.get(worker_id as usize).is_some()
+    }
+
     /// Batch maker
     pub async fn start_batch_builder(
         &self,

--- a/crates/node/src/health.rs
+++ b/crates/node/src/health.rs
@@ -1,30 +1,120 @@
-//! Simple TCP healthcheck endpoint for monitoring service availability.
+//! Simple TCP health/readiness endpoints for monitoring service availability.
 //!
-//! Implements a minimal HTTP/1.1 server that responds with status 200 to all requests.
-//! This is designed for integration with GCP load balancers and similar health monitoring systems.
+//! Implements a minimal HTTP/1.1 server with two routes on a single port:
+//! - any path except `/health/workers` -> liveness: a fixed `200 OK` (the process is up), matching
+//!   the original unconditional behavior.
+//! - `GET /health/workers` -> readiness: a `200 OK` carrying a JSON envelope that reports, per
+//!   worker, whether the worker is accepting transactions.
+//!
+//! The readiness route is the contract a stateless worker gateway polls to
+//! decide whether to forward RPC traffic to this node (see issue #712). The
+//! endpoint always answers `200`; the JSON body is the machine-readable signal,
+//! so the gateway (not the node) is responsible for translating "not accepting"
+//! into a client-facing `503`.
 
-use std::net::SocketAddr;
+use std::{future::Future, net::SocketAddr, time::Duration};
 
-use tn_types::TaskSpawner;
-use tokio::{io::AsyncWriteExt, net::TcpListener};
+use serde::Serialize;
+use tn_types::{TaskSpawner, WorkerId, DEFAULT_WORKER_ID};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    time::timeout,
+};
 use tracing::info;
 
-/// Minimal HTTP health check responder for service monitoring.
+/// Request path that serves the per-worker readiness envelope.
+const WORKERS_PATH: &str = "/health/workers";
+
+/// Version of the `/health/workers` payload envelope. Bump when the shape
+/// changes so the gateway parser can stay forward-compatible.
+const READINESS_VERSION: u32 = 1;
+
+/// Bound on bytes read while parsing the request line. The HTTP request-target
+/// always fits well within this, so a single read suffices to route.
+const REQUEST_READ_BUF: usize = 1024;
+
+/// Upper bound on waiting for a client's request before falling back to the
+/// liveness response, so a slow or idle client cannot stall the synchronous
+/// accept loop and starve other probes.
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Upper bound on the readiness probe so a contended engine lock (e.g. held by
+/// a writer during an epoch transition) cannot stall the accept loop. On
+/// timeout the worker is reported not-ready (fail-closed).
+const READINESS_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Fixed liveness response: the process is up. Returned for every path other
+/// than the readiness route (and for empty or malformed requests).
+const LIVENESS_RESPONSE: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
+
+/// Fallback body used only if the readiness payload (impossibly) fails to
+/// serialize: report no ready workers so the gateway fails closed.
+const READINESS_FALLBACK: &str = r#"{"version":1,"workers":[]}"#;
+
+/// Readiness of a single worker, as reported by `GET /health/workers`.
+#[derive(Debug, Serialize)]
+struct WorkerReadiness {
+    /// The worker's id (its index in the node's worker set; v1 is always `0`).
+    worker_id: WorkerId,
+    /// Whether the worker is up and accepting transactions.
+    ///
+    /// True once the worker's RPC server + transaction pool are initialized.
+    /// These are created on the node's first epoch and are not torn down across
+    /// epoch transitions, so this stays true for the life of the process once
+    /// the node has started. A node that is down answers no request at all,
+    /// which the polling gateway treats as not-ready (fail-closed).
+    accepting_transactions: bool,
+}
+
+/// Versioned envelope served at `GET /health/workers`.
 ///
-/// Binds to a TCP port and responds with HTTP 200 to any connection.
-/// Uses raw TCP sockets for minimal overhead and dependencies.
+/// The `workers` array maps onto the node's worker set (indexed by worker id)
+/// and ships with exactly one entry (worker `0`) today; the method-aware
+/// routing follow-up can extend the per-worker fields without breaking the
+/// envelope shape.
+#[derive(Debug, Serialize)]
+struct NodeReadiness {
+    /// Envelope version; see [`READINESS_VERSION`].
+    version: u32,
+    /// Readiness for each known worker.
+    workers: Vec<WorkerReadiness>,
+}
+
+impl NodeReadiness {
+    /// Build the v1 single-worker envelope.
+    fn single_worker(worker_id: WorkerId, accepting_transactions: bool) -> Self {
+        Self {
+            version: READINESS_VERSION,
+            workers: vec![WorkerReadiness { worker_id, accepting_transactions }],
+        }
+    }
+}
+
+/// Serialize the v1 readiness body for worker `0` given its accepting state.
+fn readiness_json(accepting_transactions: bool) -> String {
+    let readiness = NodeReadiness::single_worker(DEFAULT_WORKER_ID, accepting_transactions);
+    serde_json::to_string(&readiness).unwrap_or_else(|_| READINESS_FALLBACK.to_string())
+}
+
+/// Minimal HTTP health/readiness responder for service monitoring.
+///
+/// Binds to a TCP port and serves the liveness and `/health/workers` readiness
+/// routes. Uses raw TCP sockets for minimal overhead and dependencies.
 ///
 /// # Security Considerations
 ///
-/// This endpoint accepts connections from any source and responds unconditionally.
+/// This endpoint accepts connections from any source. Liveness responds
+/// unconditionally; readiness reports only worker-id and an accepting flag (no
+/// sensitive internals).
 ///
 /// Node operators must ensure the endpoint is protected by a firewall.
-/// This service is off by default, but can be enabled through the CLI node command.
-/// Each connection is handled synchronously in the main accept loop.
-/// No connection limits or rate limiting are implemented.
-/// Connections are immediately closed after sending response.
+/// This service is off by default, but can be enabled through the CLI node
+/// command. Each connection is handled synchronously in the accept loop, with a
+/// read timeout so a slow client cannot stall the loop. No connection limits or
+/// rate limiting are implemented. Connections are closed after the response.
 ///
-/// To enable on node startup, use `telcoin-network node --enable-healthcheck`.
+/// To enable on node startup, use `telcoin-network node --healthcheck <PORT>`.
 /// See `telcoin-network-cli::node` for more info.
 #[derive(Debug)]
 pub(crate) struct HealthcheckServer;
@@ -32,22 +122,35 @@ pub(crate) struct HealthcheckServer;
 impl HealthcheckServer {
     /// Spawns the health check server task and returns the bound address.
     ///
-    /// Binds to port specified by `HEALTHCHECK_TCP_PORT` environment variable,
-    /// or lets the OS assign a port if unset or set to 0.
+    /// Binds to the given `port` (or lets the OS assign one if `0`).
+    ///
+    /// `worker_ready` is polled per readiness request to learn whether worker
+    /// `0` is accepting transactions. It is a closure (rather than a concrete
+    /// node handle) so the server stays decoupled from the engine and unit
+    /// testable; the production call site captures the [`ExecutionNode`] handle.
+    ///
+    /// [`ExecutionNode`]: crate::engine::ExecutionNode
     ///
     /// # Network Binding
     ///
     /// Binds to 0.0.0.0 (all interfaces) to allow external health checkers.
-    /// This makes the service accessible on all network interfaces including public IPs.
+    /// This makes the service accessible on all network interfaces including
+    /// public IPs.
     ///
     /// # Protocol
     ///
-    /// Implements minimal HTTP/1.1 with a fixed response:
-    /// - Status: 200 OK
-    /// - Body: "OK" (2 bytes)
-    /// - No request parsing or validation
-    /// - No custom headers to avoid information disclosure
-    pub(crate) async fn spawn(task_spawner: TaskSpawner, port: u16) -> eyre::Result<SocketAddr> {
+    /// Implements minimal HTTP/1.1 with two routes:
+    /// - liveness (any other path): `200 OK`, body `"OK"`.
+    /// - `GET /health/workers`: `200 OK`, `application/json` readiness envelope.
+    pub(crate) async fn spawn<F, Fut>(
+        task_spawner: TaskSpawner,
+        port: u16,
+        worker_ready: F,
+    ) -> eyre::Result<SocketAddr>
+    where
+        F: Fn() -> Fut + Send + 'static,
+        Fut: Future<Output = bool> + Send,
+    {
         // IMPORTANT: use firewall to protect this endpoint
         let addr: SocketAddr = ([0, 0, 0, 0], port).into();
         let listener = TcpListener::bind(addr).await?;
@@ -55,20 +158,54 @@ impl HealthcheckServer {
         info!(target: "epoch-manager", ?listen_on, "healthcheck listening");
 
         task_spawner.spawn_critical_task("healthcheck", async move {
-            // minimal valid HTTP
-            let response = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
-
-            // accept loop - no connection limits or timeouts
+            // accept loop - no connection limits; bounded read timeout per conn
             while let Ok((mut socket, _)) = listener.accept().await {
-                // write response, ignore errors (client disconnect, etc.)
-                // then drop connection
-                let _ = socket.write_all(response).await;
+                // read the request with a bounded timeout so a slow or idle
+                // client cannot stall the loop; treat a timeout/error/empty
+                // read as "no path" and fall through to the liveness response.
+                let mut buf = [0u8; REQUEST_READ_BUF];
+                let n = timeout(REQUEST_READ_TIMEOUT, socket.read(&mut buf))
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or(0);
+
+                // route on the request-line path; readiness for the workers
+                // path, liveness for everything else (preserves prior behavior)
+                if request_path(&buf[..n]).is_some_and(|path| path == WORKERS_PATH) {
+                    // bound the readiness probe too: if it cannot resolve
+                    // quickly (e.g. the engine lock is held during an epoch
+                    // transition) report not-ready rather than stalling the loop
+                    let accepting =
+                        timeout(READINESS_PROBE_TIMEOUT, worker_ready()).await.unwrap_or(false);
+                    let body = readiness_json(accepting);
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                } else {
+                    // write liveness response, ignore errors (client disconnect)
+                    let _ = socket.write_all(LIVENESS_RESPONSE).await;
+                }
             }
             Ok(())
         });
 
         Ok(listen_on)
     }
+}
+
+/// Extract the request-target (path) from the first line of an HTTP request.
+///
+/// Returns `None` when `request` is not valid UTF-8 or has no well-formed
+/// request line (`METHOD SP PATH SP VERSION`).
+fn request_path(request: &[u8]) -> Option<&str> {
+    let line = std::str::from_utf8(request).ok()?.lines().next()?;
+    let target = line.split_whitespace().nth(1)?;
+    // ignore any query string so e.g. `/health/workers?probe=1` still routes
+    Some(target.split_once('?').map_or(target, |(path, _query)| path))
 }
 
 #[cfg(test)]
@@ -79,8 +216,22 @@ mod tests {
         net::TcpStream,
     };
 
-    use crate::health::HealthcheckServer;
+    use super::{readiness_json, request_path, HealthcheckServer};
     use tn_types::{get_available_tcp_port, TaskManager};
+
+    /// Send `request` to the spawned server at `addr` and return the response.
+    async fn roundtrip(addr: std::net::SocketAddr, request: &[u8]) -> eyre::Result<String> {
+        tokio::time::timeout(Duration::from_millis(500), async move {
+            let mut stream = TcpStream::connect(addr).await?;
+            stream.write_all(request).await?;
+            let mut response = vec![0u8; 1024];
+            let n = stream.read(&mut response).await?;
+            response.truncate(n);
+            Ok::<String, eyre::Error>(String::from_utf8_lossy(&response).into_owned())
+        })
+        .await
+        .expect("response received")
+    }
 
     #[tokio::test]
     async fn test_tcp_healthcheck() -> eyre::Result<()> {
@@ -88,46 +239,96 @@ mod tests {
         let task_spawner = task_manager.get_spawner();
 
         let port = get_available_tcp_port("127.0.0.1").expect("tcp port assigned by host");
-        // spawn server and get the bound address
-        let addr = HealthcheckServer::spawn(task_spawner.clone(), port).await?;
+        // liveness path never polls the readiness probe
+        let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { false }).await?;
 
         // give server time to start listening
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        tokio::time::timeout(Duration::from_millis(500), async move {
-            // request healthcheck
-            let mut stream = TcpStream::connect(addr).await?;
+        let response = roundtrip(addr, b"GET / HTTP/1.1\r\n\r\n").await?;
 
-            // send minimal HTTP request
-            stream.write_all(b"GET / HTTP/1.1\r\n\r\n").await?;
-
-            // read response
-            let mut response = vec![0u8; 1024];
-            let n = stream.read(&mut response).await?;
-            response.truncate(n);
-            let response_str = String::from_utf8_lossy(&response);
-
-            // verify http status line
-            assert!(
-                response_str.starts_with("HTTP/1.1 200 OK"),
-                "Expected 200 OK, got: {}",
-                response_str
-            );
-
-            // verify body
-            assert!(response_str.ends_with("OK"), "Expected body 'OK', got: {}", response_str);
-
-            // verify content-length header
-            assert!(
-                response_str.contains("Content-Length: 2"),
-                "Missing or incorrect Content-Length header"
-            );
-
-            Ok::<(), eyre::Error>(())
-        })
-        .await
-        .expect("response received")?;
+        // verify http status line
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "Expected 200 OK, got: {}", response);
+        // verify body
+        assert!(response.ends_with("OK"), "Expected body 'OK', got: {}", response);
+        // verify content-length header
+        assert!(
+            response.contains("Content-Length: 2"),
+            "Missing or incorrect Content-Length header"
+        );
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_health_workers_reports_not_ready() -> eyre::Result<()> {
+        let task_manager = TaskManager::default();
+        let task_spawner = task_manager.get_spawner();
+
+        let port = get_available_tcp_port("127.0.0.1").expect("tcp port assigned by host");
+        let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { false }).await?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let response = roundtrip(addr, b"GET /health/workers HTTP/1.1\r\n\r\n").await?;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "Expected 200 OK, got: {}", response);
+        assert!(
+            response.contains("Content-Type: application/json"),
+            "Expected json content type, got: {}",
+            response
+        );
+        let body = response.split("\r\n\r\n").nth(1).expect("response has a body");
+        assert_eq!(
+            body,
+            r#"{"version":1,"workers":[{"worker_id":0,"accepting_transactions":false}]}"#
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_health_workers_reports_ready() -> eyre::Result<()> {
+        let task_manager = TaskManager::default();
+        let task_spawner = task_manager.get_spawner();
+
+        let port = get_available_tcp_port("127.0.0.1").expect("tcp port assigned by host");
+        let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { true }).await?;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let response = roundtrip(addr, b"GET /health/workers HTTP/1.1\r\n\r\n").await?;
+
+        let body = response.split("\r\n\r\n").nth(1).expect("response has a body");
+        assert_eq!(
+            body,
+            r#"{"version":1,"workers":[{"worker_id":0,"accepting_transactions":true}]}"#
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_readiness_payload_contract() {
+        // lock the exact wire contract: snake_case keys, version 1, one worker
+        assert_eq!(
+            readiness_json(true),
+            r#"{"version":1,"workers":[{"worker_id":0,"accepting_transactions":true}]}"#,
+        );
+        assert_eq!(
+            readiness_json(false),
+            r#"{"version":1,"workers":[{"worker_id":0,"accepting_transactions":false}]}"#,
+        );
+    }
+
+    #[test]
+    fn test_request_path_parsing() {
+        assert_eq!(request_path(b"GET /health/workers HTTP/1.1\r\n\r\n"), Some("/health/workers"));
+        assert_eq!(request_path(b"POST /health/workers HTTP/1.1\r\n\r\n"), Some("/health/workers"));
+        assert_eq!(
+            request_path(b"GET /health/workers?probe=1 HTTP/1.1\r\n\r\n"),
+            Some("/health/workers")
+        );
+        assert_eq!(request_path(b"GET / HTTP/1.1\r\n\r\n"), Some("/"));
+        assert_eq!(request_path(b""), None);
+        assert_eq!(request_path(b"garbage"), None);
     }
 }

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -375,7 +375,14 @@ where
 
         // spawn node healthcheck service if enabled
         if let Some(port) = self.builder.healthcheck {
-            let _ = HealthcheckServer::spawn(node_task_manager.get_spawner(), port).await;
+            // probe worker 0's readiness per request; capture the engine handle
+            let engine = engine.clone();
+            let worker_ready = move || {
+                let engine = engine.clone();
+                async move { engine.is_worker_initialized(DEFAULT_WORKER_ID).await }
+            };
+            let _ =
+                HealthcheckServer::spawn(node_task_manager.get_spawner(), port, worker_ready).await;
         }
 
         // spawn prometheus metrics endpoint if enabled


### PR DESCRIPTION
## Summary

First PR of the worker-gateway effort (#712). It adds the node-side readiness
contract that the gateway will poll. This PR is deliberately small and
self-contained: it defines the wire contract the remaining three PRs build
against, so it is worth landing (and reviewing the contract) first.

No new runtime behavior is enabled by default: the healthcheck service is still
off unless `--healthcheck <PORT>` is set, and the existing liveness response is
unchanged.

## What it does

- Adds a `GET /health/workers` route to the existing healthcheck server
  (`crates/node/src/health.rs`), served on the **same port** as the liveness
  check. It returns a versioned JSON envelope reporting, per worker, whether the
  worker is accepting transactions.
- Liveness is preserved: any path other than `/health/workers` still returns the
  fixed `200 OK` / `OK`, exactly as before.

### Wire contract (v1)

```json
{ "version": 1, "workers": [ { "worker_id": 0, "accepting_transactions": true } ] }
```

The envelope is versioned and the `workers` field is a list from day one, so the
method-aware routing follow-up can add per-worker fields (epoch, sync, queue
depth) and additional workers without breaking the gateway's parser. v1 reports
exactly one entry, worker `0`, matching what nodes run today.

## Semantics of `accepting_transactions` (please confirm)

Worth a careful look, because the ground truth shifted under the original
proposal. The proposal said this flag should "flip false after `close_epoch()`
clears the accumulator." That framing was based on the pre-`#737` epoch-manager
layout. After the "Breakdown epoch manager (#737)" refactor, the code says
something different:

- The worker's **RPC server and transaction pool accept transactions
  continuously**. They are initialized once and are **not** torn down across
  epoch transitions.
- The only epoch-scoped machinery is the **batch builder**, whose lifetime lives
  in a local `epoch_task_manager` (`run_epoch.rs`) and is aborted at each
  boundary. Nothing observable (no field, atomic, or watch) mirrors "epoch
  active," and the pool keeps accepting across the transition (txs queue for the
  next epoch).
- Worker-side signals are not usable: `eth_syncing` is hardcoded `false` on
  `WorkerNetwork`, and the pool has no "paused/accepting" flag.

So v1 defines `accepting_transactions` as **"this worker's components are
initialized"**:

- `false` during startup, before the node has brought up the worker's RPC + pool;
- `true` once they are up (and it stays true, since they are not torn down);
- a node that is down answers no request at all, which the polling gateway treats
  as not-ready (fail-closed).

This is the cheapest, most honest signal given the current code, and it carries
real startup information. If you would rather have readiness also drop during
epoch transitions (the issue's "readiness lost on epoch transition" wording),
that is a clean follow-up: it means adding a per-worker flag at the `run_epoch`
open/close seams. I left it out of PR 1 because it is new instrumentation, a
larger blast radius, and arguably misreports (the pool is still queuing txs
during a transition). Happy to add it if you want the stricter semantics.

## Implementation notes

- New `ExecutionNode::is_worker_initialized(worker_id)` accessor, mirroring the
  existing `are_workers_initialized()`.
- The healthcheck accept loop now reads the request to route by path. It
  previously read nothing and replied `200` to any bytes, so routing required
  adding a read. Both the read and the readiness probe are bounded by timeouts
  (2s and 1s); on timeout the worker is reported not-ready (fail-closed), so a
  slow client or a lock held during an epoch transition cannot stall the
  single-threaded accept loop. The route ignores any query string.
- `HealthcheckServer::spawn` takes a readiness probe closure rather than the
  engine handle, keeping the server decoupled from the engine and unit testable;
  the call site in `manager/node.rs` captures `engine.clone()` and reads
  `is_worker_initialized` per request.
- Adds `serde` + `serde_json` to the `tn-node` crate (it had no serde before).
- Drive-by doc fix: the flag is `--healthcheck`, not `--enable-healthcheck` (the
  old health.rs doc comment was stale).

## Out of scope (later PRs)

- PR 2: the `bin/worker-gateway/` crate skeleton + proxy core.
- PR 3: edge protections (rate limits, request-size limits, tx sanity checks).
- PR 4: observability + deployment (Prometheus, Dockerfile, k8s/HPA examples).

## Testing

- `test_health_workers_reports_ready` / `test_health_workers_reports_not_ready`:
  end-to-end over a TCP socket with a trivial readiness probe; assert the `200`,
  the `application/json` content type, and the exact JSON body for both states.
- `test_readiness_payload_contract`: locks the exact wire bytes (snake_case keys,
  `version: 1`, single worker) for both the true and false cases.
- `test_request_path_parsing`: unit test for the request-line path parser,
  including a query-string case.
- `test_tcp_healthcheck`: the existing liveness test, updated for the new spawn
  signature; still asserts the unchanged liveness `200 OK` / `OK`.

## Open questions for the maintainer

1. Endpoint path: I went with `GET /health/workers` on the liveness port, as
   proposed. Flag if you would prefer a different path or a dedicated port.
2. `accepting_transactions` semantics: confirm the init-based definition above,
   or ask for the epoch-gated variant (follow-up).
