### PR TITLE
fix: evict oldest bans/disconnects on overflow, not newest (#799)

### DIFF
--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -20,7 +20,6 @@ use crate::{
 use libp2p::{Multiaddr, PeerId};
 use rand::seq::SliceRandom as _;
 use std::{
-    cmp::Reverse,
     collections::{BinaryHeap, HashMap, HashSet},
     net::IpAddr,
     time::{Duration, Instant},
@@ -992,32 +991,36 @@ impl AllPeers {
         (action, pruned_peers)
     }
 
-    /// Filter peers based on connection status.
+    /// Filter peers by connection status and return the `excess` OLDEST of them to prune.
     ///
-    /// This creates a min-heap with the excess number of peers.
+    /// Builds a bounded max-heap keyed by `instant`, so the heap's top is the NEWEST collected
+    /// peer. Once the heap is full, a candidate replaces that top only when the candidate is
+    /// older, so the heap converges on the `excess` oldest peers. Callers evict exactly these
+    /// entries, which keeps the freshest bans/disconnects and drops only stale ones (issue #799).
     /// Used by Self::prune_banned_peers and Self::prune_disconnected_peers.
     fn collect_excess_peers<F>(
         &self,
         excess: usize,
         filter: F,
-    ) -> BinaryHeap<(Reverse<Instant>, PeerIdentity, Vec<IpAddr>)>
+    ) -> BinaryHeap<(Instant, PeerIdentity, Vec<IpAddr>)>
     where
         F: Fn(&ConnectionStatus) -> Option<Instant>,
     {
-        // collection of peers to prune
+        // collection of peers to prune (the oldest `excess`)
         let mut excess_peers = BinaryHeap::with_capacity(excess);
 
         for (id, peer) in &self.peers {
             if let Some(instant) = filter(peer.connection_status()) {
-                // min-heap sorted by instant (oldest first)
-                let entry = (Reverse(instant), *id, peer.known_ip_addresses().collect::<Vec<_>>());
+                // max-heap by instant: the heap's top (peek) is the NEWEST collected peer
+                let entry = (instant, *id, peer.known_ip_addresses().collect::<Vec<_>>());
 
                 if excess_peers.len() < excess {
                     // fill the heap until `excess` elements
                     excess_peers.push(entry);
-                } else if let Some(current_max) = excess_peers.peek() {
-                    // if peer's banned instant is older, replace it
-                    if entry.0 < current_max.0 {
+                } else if let Some(current_newest) = excess_peers.peek() {
+                    // retain the OLDEST `excess`: drop the newest held entry whenever an older
+                    // candidate appears, so recently banned/disconnected peers survive pruning
+                    if entry.0 < current_newest.0 {
                         excess_peers.pop();
                         excess_peers.push(entry);
                     }

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -735,6 +735,99 @@ fn test_pruning_logic() {
     assert_eq!(pruned.len(), expected); // 1 peer should be pruned
 }
 
+/// Regression guard for issue #799: overflow pruning must evict the OLDEST bans and keep the
+/// NEWEST. The heap previously stored `Reverse(instant)`, so it retained and then evicted the
+/// freshest bans instead. That let a peer banned moments ago be dropped from the ban set and
+/// reconnect (ban evasion). `test_pruning_logic` only asserts the pruned *count*, so it cannot
+/// catch the inverted direction; this test pins down exactly *which* peers survive.
+#[test]
+fn test_prune_banned_evicts_oldest_not_newest() {
+    let config = PeerConfig::default();
+    let excess = 5;
+    let peer_num = config.max_banned_peers + excess;
+    let mut all_peers = create_all_peers(None);
+
+    // rank 1..=peer_num: a larger rank is an OLDER ban (instant further in the past), so the
+    // `excess` largest ranks are the oldest bans and must be the ones pruned.
+    let mut banned = Vec::with_capacity(peer_num);
+    for rank in 1..=peer_num {
+        let peer_id = PeerId::random();
+        all_peers.update_connection_status(
+            &peer_id,
+            NewConnectionStatus::Disconnecting { banned: true },
+        );
+        all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+        all_peers.update_connection_status(&peer_id, NewConnectionStatus::Banned);
+
+        if let Some(peer) = all_peers.get_peer_mut(&peer_id) {
+            if matches!(peer.connection_status(), ConnectionStatus::Banned { .. }) {
+                peer.set_connection_status(ConnectionStatus::Banned {
+                    instant: Instant::now() - Duration::from_secs(rank as u64),
+                });
+            }
+        }
+        banned.push((rank, peer_id));
+    }
+    assert_eq!(all_peers.banned_peers.total(), peer_num);
+
+    // the triggering peer is disconnected (not banned), so it does not affect the banned count:
+    // exactly `excess` bans are pruned, down to `max_banned_peers`.
+    all_peers.register_disconnected(&PeerId::random());
+    assert_eq!(all_peers.banned_peers.total(), config.max_banned_peers);
+
+    // the `excess` OLDEST bans (rank > max_banned_peers) are gone; every newer ban survives.
+    for (rank, peer_id) in &banned {
+        let still_banned = all_peers.peer_banned(peer_id);
+        if *rank > config.max_banned_peers {
+            assert!(!still_banned, "oldest ban (rank {rank}) should have been pruned");
+        } else {
+            assert!(still_banned, "recent ban (rank {rank}) must survive pruning");
+        }
+    }
+}
+
+/// Companion to `test_prune_banned_evicts_oldest_not_newest`: the disconnected caller shares the
+/// same `collect_excess_peers` helper, so it must likewise keep the newest disconnected peers and
+/// evict the oldest. Guards against the two prune callers diverging in future refactors.
+#[test]
+fn test_prune_disconnected_evicts_oldest_not_newest() {
+    let config = PeerConfig::default();
+    let excess = 5;
+    let peer_num = config.max_disconnected_peers + excess;
+    let mut all_peers = create_all_peers(None);
+
+    // rank 1..=peer_num: a larger rank is an OLDER disconnect.
+    let mut disconnected = Vec::with_capacity(peer_num);
+    for rank in 1..=peer_num {
+        let peer_id = PeerId::random();
+        all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+        if let Some(peer) = all_peers.get_peer_mut(&peer_id) {
+            if matches!(peer.connection_status(), ConnectionStatus::Disconnected { .. }) {
+                peer.set_connection_status(ConnectionStatus::Disconnected {
+                    instant: Instant::now() - Duration::from_secs(rank as u64),
+                });
+            }
+        }
+        disconnected.push((rank, peer_id));
+    }
+    assert_eq!(all_peers.disconnected_peers, peer_num);
+
+    // the triggering peer is itself disconnected (instant ~now, the newest), so it joins the set
+    // and `excess + 1` of the oldest are pruned: ranks >= max_disconnected_peers.
+    all_peers.register_disconnected(&PeerId::random());
+    assert_eq!(all_peers.disconnected_peers, config.max_disconnected_peers);
+
+    for (rank, peer_id) in &disconnected {
+        let retained = all_peers.get_peer(peer_id).is_some();
+        if *rank >= config.max_disconnected_peers {
+            assert!(!retained, "oldest disconnect (rank {rank}) should have been pruned");
+        } else {
+            assert!(retained, "recent disconnect (rank {rank}) must survive pruning");
+        }
+    }
+}
+
 #[test]
 fn test_is_validator() {
     ensure_score_config(None);


### PR DESCRIPTION
## Summary

`collect_excess_peers` (`crates/network-libp2p/src/peers/all_peers.rs`) is used by
`prune_banned_peers` and `prune_disconnected_peers` to choose which peers to evict when the
banned/disconnected set grows past its cap.  It built a `BinaryHeap` keyed by
`Reverse(instant)`. Because `BinaryHeap` is a max-heap, the `Reverse` wrapper made the heap top
the *oldest* instant, and the replace condition `entry.0 < current_max.0` then swapped in
*newer* candidates.  Net effect: the heap retained the `excess` **newest** peers, and the callers
evict exactly the heap's contents, so the freshest bans were dropped first while stale bans were
kept.

Impact: when `banned_peers.total()` exceeds `max_banned_peers`, a sybil/overflow attacker who
floods the ban set gets their just-issued ban evicted and can reconnect (ban evasion / weakened
DoS protection).  The doc comments said "oldest first", but the `Reverse` + `<` combination did the
opposite.

## Fix

- Drop the `Reverse` wrapper so the heap is an ordinary max-heap keyed by `Instant` (top = the
  newest collected peer).  The existing `entry.0 < current_newest.0` replace condition then retains
  the `excess` **oldest** peers, which the callers evict, keeping the freshest bans/disconnects.
- Remove the now-unused `std::cmp::Reverse` import.
- Rewrite the misleading doc/inline comments to describe the actual (max-heap, retain-oldest)
  behavior.

The two callers iterate the returned heap order-independently (`for (_, id, ips) in ...`), so the
element-type change from `Reverse<Instant>` to `Instant` does not affect them.

## Tests

- `test_prune_banned_evicts_oldest_not_newest` (regression guard for #799): overflows the banned
  set with peers of known, distinct ages and asserts that the `excess` **oldest** bans are pruned
  while every newer ban survives.
- `test_prune_disconnected_evicts_oldest_not_newest`: the same property for the disconnected
  caller, which shares `collect_excess_peers`.

Both new tests **fail on the pre-fix code** with "recent ban (rank 1) must survive pruning" and
pass after the fix.  The pre-existing `test_pruning_logic` only checked the pruned *count*, never
*which* peers were pruned, which is why the inverted direction shipped undetected.

## Checklist

- [x] `collect_excess_peers` retains the oldest `excess` peers; callers evict the oldest, keep the newest
- [x] unused `cmp::Reverse` import removed
- [x] doc/inline comments corrected
- [x] regression tests added (fail before, pass after)
- [x] `cargo +nightly-2026-03-20 fmt` clean
- [x] `cargo +nightly-2026-03-20 clippy -p tn-network-libp2p --all-features --all-targets` clean (0 warnings)
- [x] `tn-network-libp2p` prune tests pass

Closes #799.
