### PR TITLE
refactor: replace hand-rolled Future impls with async fns

### DIFF
--- a/crates/batch-builder/Cargo.toml
+++ b/crates/batch-builder/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 tn-types = { workspace = true }
 tn-reth = { workspace = true }
 futures-util = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time"] }
+tokio = { workspace = true, features = ["sync", "time", "macros"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 eyre = { workspace = true }

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -18,13 +18,8 @@
 
 pub use batch::{build_batch, BatchBuilderOutput};
 use error::{BatchBuilderError, BatchBuilderResult};
-use futures_util::{FutureExt, StreamExt};
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::{Duration, Instant},
-};
+use futures_util::{future::OptionFuture, StreamExt};
+use std::time::{Duration, Instant};
 use tn_reth::{CanonStateNotificationStream, ChangedAccount, RethEnv, TxPool as _, WorkerTxPool};
 use tn_types::{
     error::BlockSealError, Address, BatchBuilderArgs, BatchSender, Epoch, SealedBlock, TaskSpawner,
@@ -255,103 +250,104 @@ impl BatchBuilder {
 ///
 /// If the broadcast stream is closed, the engine will attempt to execute all remaining tasks and
 /// any output that is queued.
-impl Future for BatchBuilder {
-    type Output = BatchBuilderResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
+impl BatchBuilder {
+    /// Run the batch builder event loop. Runs for the lifetime of the worker.
+    pub async fn run(mut self) -> BatchBuilderResult<()> {
+        // reproduces the original future's post-quorum-failure `break`: skip starting a build for
+        // exactly one iteration so the loop backs off (parks) before retrying, instead of
+        // immediately rebuilding the same (still-unmined) transactions.
+        let mut defer_build = false;
 
         // loop when a successful block is built
         loop {
-            // This is used as a "wake up" when canonical state updates.
-            while let Poll::Ready(Some(latest)) = this.state_changed.poll_next_unpin(cx) {
-                // NOTE: separate background task applies these changes to the pool
-                // regardless of pending_task
-                this.last_canonical_update = latest.tip().sealed_block().clone()
-            }
-
             // only propose one block at a time
-            if this.pending_task.is_none() {
+            if self.pending_task.is_none() && !defer_build {
                 // check for pending transactions
-                this.metrics.pending_pool_transactions.set(this.pool.pool_size().pending as f64);
-                if this.pool.pending_transactions().is_empty() {
+                self.metrics.pending_pool_transactions.set(self.pool.pool_size().pending as f64);
+                if self.pool.pending_transactions().is_empty() {
                     // reset interval to wake up after some time
                     //
                     // only need to reset here if there is no pending block being built
-                    this.max_delay_interval.reset();
-
-                    // tick interval to ensure it advances
-                    let _ = this.max_delay_interval.poll_tick(cx);
+                    self.max_delay_interval.reset();
 
                     // nothing pending
-                    break;
+                } else {
+                    // start building the next batch
+                    self.pending_task = Some(self.spawn_execution_task());
+
+                    // don't break so pending_task receiver gets polled
                 }
-
-                // start building the next batch
-                this.pending_task = Some(this.spawn_execution_task());
-
-                // don't break so pending_task receiver gets polled
             }
 
-            // poll receiver that returns mined transactions once the batch reaches quorum
-            if let Some(mut receiver) = this.pending_task.take() {
+            // consume the one-shot defer now that this build attempt has been skipped
+            defer_build = false;
+
+            tokio::select! {
+                // drain canonical updates first, then the in-flight build, then the periodic tick
+                biased;
+
+                // This is used as a "wake up" when canonical state updates.
+                Some(latest) = self.state_changed.next() => {
+                    // NOTE: separate background task applies these changes to the pool
+                    // regardless of pending_task
+                    self.last_canonical_update = latest.tip().sealed_block().clone()
+                }
+
+                // poll receiver that returns mined transactions once the batch reaches quorum
+                //
                 // poll here so waker is notified when ack received
-                match receiver.poll_unpin(cx) {
-                    Poll::Ready(res) => {
-                        debug!(target: "block-builder", ?res, "pending task complete");
-                        // ensure no fatal errors
-                        let MinedBatchResult { mined_transactions, changed_accounts } = res??;
+                Some(res) = OptionFuture::from(self.pending_task.as_mut()), if self.pending_task.is_some() => {
+                    // the build resolved; the original `take`s the receiver and only restores it
+                    // while it is still pending, so clear the slot here
+                    self.pending_task = None;
 
-                        // NOTE: empty vec returned for non-fatal error during block proposal
-                        if mined_transactions.is_empty() {
-                            // reset interval to prevent immediate re-wake from stale tick
-                            this.max_delay_interval.reset();
-                            let _ = this.max_delay_interval.poll_tick(cx);
+                    debug!(target: "block-builder", ?res, "pending task complete");
+                    // ensure no fatal errors
+                    let MinedBatchResult { mined_transactions, changed_accounts } = res??;
 
-                            // return pending and wait for canonical update to wake up again
-                            break;
-                        }
+                    // NOTE: empty vec returned for non-fatal error during block proposal
+                    if mined_transactions.is_empty() {
+                        // reset interval to prevent immediate re-wake from stale tick
+                        self.max_delay_interval.reset();
 
-                        debug!(target: "block-builder", "applying block builder's update");
-
-                        let base_fee_per_gas = this
-                            .last_canonical_update
-                            .base_fee_per_gas
-                            .unwrap_or_else(|| this.pool.get_pending_base_fee());
-
-                        // update pool to remove mined transactions
-                        this.pool.update_canonical_state(
-                            &this.last_canonical_update,
-                            base_fee_per_gas,
-                            Some(u128::MAX), // set max fee for blobs
-                            mined_transactions,
-                            changed_accounts,
-                        );
-
-                        // loop again to check for any other pending transactions
-                        // and possibly start building the next block
-                        //
-                        // NOTE: continuing here is important.
-                        // To prevent the following scenario, do not wait for task's waker:
-                        // - there were more transactions in the pool than could fit in the first
-                        //   block
-                        // - pending transaction notifications already drained
-                        // - have to wait for engine's next canonical update to wake up
+                        // return pending and wait for canonical update to wake up again
+                        defer_build = true;
                         continue;
                     }
 
-                    Poll::Pending => {
-                        this.pending_task = Some(receiver);
+                    debug!(target: "block-builder", "applying block builder's update");
 
-                        // break loop and return Poll::Pending
-                        break;
-                    }
+                    let base_fee_per_gas = self
+                        .last_canonical_update
+                        .base_fee_per_gas
+                        .unwrap_or_else(|| self.pool.get_pending_base_fee());
+
+                    // update pool to remove mined transactions
+                    self.pool.update_canonical_state(
+                        &self.last_canonical_update,
+                        base_fee_per_gas,
+                        Some(u128::MAX), // set max fee for blobs
+                        mined_transactions,
+                        changed_accounts,
+                    );
+
+                    // loop again to check for any other pending transactions
+                    // and possibly start building the next block
+                    //
+                    // NOTE: continuing here is important.
+                    // To prevent the following scenario, do not wait for task's waker:
+                    // - there were more transactions in the pool than could fit in the first
+                    //   block
+                    // - pending transaction notifications already drained
+                    // - have to wait for engine's next canonical update to wake up
+                    continue;
                 }
+
+                // periodic wake to check the pending pool; gated to no-build-in-flight to match the
+                // original, which only polled the interval while `pending_task` was `None`.
+                _ = self.max_delay_interval.tick(), if self.pending_task.is_none() => {}
             }
         }
-
-        // all output executed, yield back to runtime
-        Poll::Pending
     }
 }
 
@@ -478,7 +474,7 @@ mod tests {
         assert_eq!(pending_pool_len, 3);
 
         // spawn batch_builder once worker is ready
-        let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+        let _batch_builder = tokio::spawn(batch_builder.run());
 
         // wait for new batch
         let mut new_batch = None;
@@ -633,7 +629,7 @@ mod tests {
         assert_eq!(pending_pool_len, 3);
 
         // spawn batch_builder once worker is ready
-        let batch_builder_task = tokio::spawn(Box::pin(batch_builder));
+        let batch_builder_task = tokio::spawn(batch_builder.run());
 
         // plenty of time for block production
         let duration = std::time::Duration::from_secs(5);
@@ -798,7 +794,7 @@ mod tests {
         assert_eq!(pending_pool_len, 3);
 
         // spawn batch_builder once worker is ready
-        let _batch_builder_task = tokio::spawn(Box::pin(batch_builder));
+        let _batch_builder_task = tokio::spawn(batch_builder.run());
 
         // plenty of time for block production
         let duration = std::time::Duration::from_secs(5);

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -132,7 +132,7 @@ async fn test_make_batch_el_to_cl() {
     assert_eq!(pending_pool_len, 3);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //=== Test batch flow
@@ -294,7 +294,7 @@ async fn test_batch_builder_produces_valid_batches() {
     assert_eq!(pool_size.blob, 0);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //=== Test batch flow
@@ -456,7 +456,7 @@ async fn test_canonical_notification_updates_pool() {
     assert_eq!(pending_pool_len, 0);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //=== Test block flow

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,7 +17,7 @@ futures-util = { workspace = true }
 thiserror = { workspace = true }
 tn-types = { workspace = true }
 tn-reth = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time"] }
+tokio = { workspace = true, features = ["sync", "time", "macros"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 eyre = { workspace = true, optional = true }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,14 +12,9 @@ mod payload_builder;
 use crate::metrics::ENGINE_METRICS;
 use error::EngineResult;
 pub use error::TnEngineError;
-use futures::{Future, StreamExt};
-use futures_util::FutureExt;
+use futures::{future::OptionFuture, StreamExt};
 pub use payload_builder::execute_consensus_output;
-use std::{
-    collections::VecDeque,
-    pin::{pin, Pin},
-    task::{Context, Poll},
-};
+use std::collections::VecDeque;
 use tn_reth::{payload::BuildArguments, RethEnv};
 use tn_types::{
     gas_accumulator::GasAccumulator, ConsensusOutput, EngineUpdate, Noticer, SealedHeader,
@@ -189,97 +184,92 @@ impl ExecutorEngine {
 ///
 /// If the broadcast stream is closed, the engine will attempt to execute all remaining tasks and
 /// any output that is queued.
-impl Future for ExecutorEngine {
-    type Output = EngineResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        // check for shutdown signal
-        if pin!(&this.rx_shutdown).poll(cx).is_ready() {
-            info!(target: "engine", "received shutdown signal...");
-            // only return if there are no current tasks and the queue is empty
-            // otherwise, let the loop continue so any remaining tasks and queued output is
-            // executed
-            // rx_shutdown should continue to poll ready so once the queue is clear should shutdown.
-            if this.pending_task.is_none() && this.queued.is_empty() {
-                return Poll::Ready(Ok(()));
-            }
-        }
+impl ExecutorEngine {
+    /// Run the engine event loop until shutdown or the consensus stream closes.
+    pub async fn run(mut self) -> EngineResult<()> {
+        // tracks the consensus stream returning `None`; the engine keeps draining queued and
+        // in-flight work before finally shutting down.
+        let mut consensus_closed = false;
 
         loop {
-            // check if output is available from consensus to keep broadcast stream from "lagging"
-            match this.consensus_output_stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(output)) => {
-                    // queue the output for local execution
-                    this.queued.push_back(output);
-                    // backlog growth means execution is falling behind consensus
-                    ENGINE_METRICS.queued_outputs.set(this.queued.len() as f64);
+            // check for shutdown signal
+            if self.rx_shutdown.noticed() {
+                info!(target: "engine", "received shutdown signal...");
+                // only return if there are no current tasks and the queue is empty
+                // otherwise, let the loop continue so any remaining tasks and queued output is
+                // executed
+                // rx_shutdown should continue to poll ready so once the queue is clear should
+                // shutdown.
+                if self.pending_task.is_none() && self.queued.is_empty() {
+                    return Ok(());
                 }
-                Poll::Ready(None) => {
-                    // the stream has ended
-                    error!(target: "engine", "ConsensusOutput channel closed. Shutting down...");
+            }
 
-                    // only return if there are no current tasks and the queue is empty
-                    // otherwise, let the loop continue so any remaining tasks and queued output is
-                    // executed
-                    if this.pending_task.is_none() && this.queued.is_empty() {
-                        return Poll::Ready(Err(TnEngineError::ConsensusOutputStreamClosed));
-                    }
-                }
-
-                Poll::Pending => { /* nothing to do */ }
+            // the consensus stream closed: once the queue and in-flight task drain, shut down
+            // (the original re-checked this on every poll after observing the closed stream)
+            if consensus_closed && self.pending_task.is_none() && self.queued.is_empty() {
+                return Err(TnEngineError::ConsensusOutputStreamClosed);
             }
 
             // only insert task if there is none
             //
             // note: it's important that the previous consensus output finishes executing before
             // inserting the next task to ensure the parent sealed header is finalized
-            if this.pending_task.is_none() {
-                if this.queued.is_empty() {
-                    // nothing to insert
-                    break;
-                }
-
+            if self.pending_task.is_none() && !self.queued.is_empty() {
                 // ready to begin executing next round of consensus
-                this.pending_task = Some(this.spawn_execution_task());
+                self.pending_task = Some(self.spawn_execution_task());
             }
 
-            // poll receiver that returns output execution result
-            if let Some(mut receiver) = this.pending_task.take() {
-                match receiver.poll_unpin(cx) {
-                    Poll::Ready(res) => {
-                        debug!(target: "engine", ?res, "reciever for execution result polled ready");
-                        let finalized_header = res.map_err(Into::into).and_then(|res| res)?;
-                        // store last executed header in memory
-                        this.parent_header = finalized_header;
-                        ENGINE_METRICS.outputs_executed_total.increment(1);
-                        ENGINE_METRICS.canonical_height.set(this.parent_header.number as f64);
-                        ENGINE_METRICS.queued_outputs.set(this.queued.len() as f64);
+            tokio::select! {
+                // poll consensus first to keep the broadcast stream from "lagging"
+                biased;
 
-                        // check max_round to auto shutdown
-                        #[cfg(any(test, feature = "test-utils"))]
-                        if this.max_round.is_some()
-                            && this.has_reached_max_round(this.parent_header.nonce.into())
-                        {
-                            // immediately terminate if the specified max consensus round is reached
-                            return Poll::Ready(Ok(()));
-                        }
+                // wake on shutdown while otherwise idle; disabled once noticed (from then on the
+                // top-of-loop check owns the drain-and-return path).
+                _ = &self.rx_shutdown, if !self.rx_shutdown.noticed() => {}
 
-                        // allow loop to continue: poll broadcast stream for next output
+                // check if output is available from consensus to keep broadcast stream from "lagging"
+                output = self.consensus_output_stream.next(), if !consensus_closed => {
+                    output
+                        .map(|output| {
+                            // queue the output for local execution
+                            self.queued.push_back(output);
+                            // backlog growth means execution is falling behind consensus
+                            ENGINE_METRICS.queued_outputs.set(self.queued.len() as f64);
+                        })
+                        .unwrap_or_else(|| {
+                            // the stream has ended; the top-of-loop check returns the error once
+                            // the queue and in-flight task have drained.
+                            error!(target: "engine", "ConsensusOutput channel closed. Shutting down...");
+                            consensus_closed = true;
+                        });
+                }
+
+                // poll receiver that returns output execution result
+                Some(res) = OptionFuture::from(self.pending_task.as_mut()), if self.pending_task.is_some() => {
+                    debug!(target: "engine", ?res, "reciever for execution result polled ready");
+                    let finalized_header = res.map_err(Into::into).and_then(|res| res)?;
+                    // the in-flight task resolved; clear the slot so the next round can be spawned
+                    self.pending_task = None;
+                    // store last executed header in memory
+                    self.parent_header = finalized_header;
+                    ENGINE_METRICS.outputs_executed_total.increment(1);
+                    ENGINE_METRICS.canonical_height.set(self.parent_header.number as f64);
+                    ENGINE_METRICS.queued_outputs.set(self.queued.len() as f64);
+
+                    // check max_round to auto shutdown
+                    #[cfg(any(test, feature = "test-utils"))]
+                    if self.max_round.is_some()
+                        && self.has_reached_max_round(self.parent_header.nonce.into())
+                    {
+                        // immediately terminate if the specified max consensus round is reached
+                        return Ok(());
                     }
-                    Poll::Pending => {
-                        this.pending_task = Some(receiver);
 
-                        // break loop and return Poll::Pending
-                        break;
-                    }
+                    // allow loop to continue: poll broadcast stream for next output
                 }
             }
         }
-
-        // all output executed, yield back to runtime
-        Poll::Pending
     }
 }
 

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -187,7 +187,7 @@ async fn test_empty_output_skips_execution() -> eyre::Result<()> {
 
     // spawn engine task
     task_manager.spawn_task("Test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -300,7 +300,7 @@ async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()>
 
     // spawn engine task
     task_manager.spawn_task("Test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -480,7 +480,7 @@ async fn test_empty_output_increments_leader_count() -> eyre::Result<()> {
 
     // spawn engine task
     task_manager.spawn_task("Test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -816,7 +816,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     //
     // one output already queued up, one output waiting in broadcast stream
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -1325,7 +1325,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     //
     // one output already queued up, one output waiting in broadcast stream
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -1692,7 +1692,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
     //
     // one output already queued up, one output waiting in broadcast stream
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -1910,7 +1910,7 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
     //
     // one output already queued up, one output waiting in broadcast stream
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });
@@ -2202,7 +2202,7 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
 
     let (tx, rx) = oneshot::channel();
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         let _ = tx.send(res);
         Ok(())
     });

--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -17,17 +17,13 @@
 //! ExEx can detect the gap and reconcile via [`replay`](crate::replay).
 
 use crate::{Chain, TnExExEvent, TnExExNotification};
-use futures::StreamExt;
+use futures::stream::{self, select_all, select_with_strategy, PollNext, StreamExt, TryStreamExt};
 use reth_provider::CanonStateNotification;
-use std::{
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::sync::Arc;
 use tn_reth::CanonStateNotificationStream;
 use tn_types::{BlockNumber, Certificate, ConsensusOutput};
 use tokio::sync::{broadcast, mpsc, watch};
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream, ReceiverStream};
 use tracing::{debug, error, warn};
 
 /// Default notification channel capacity per ExEx.
@@ -44,12 +40,6 @@ struct ExExHandle {
     name: String,
     /// Bounded, non-blocking notification sender.
     notifications: mpsc::Sender<TnExExNotification>,
-    /// Bounded event receiver for progress reports from the ExEx.
-    ///
-    /// `FinishedHeight` is latest-wins, so a small bounded channel is sufficient
-    /// — the ExEx reports with a non-blocking `try_send`, and only the maximum
-    /// reported height matters.
-    events: mpsc::Receiver<TnExExEvent>,
     /// Highest durably-processed height reported by the ExEx, if any.
     finished_height: Option<BlockNumber>,
     /// Notifications dropped since the last successful delivery.
@@ -60,12 +50,8 @@ struct ExExHandle {
 }
 
 impl ExExHandle {
-    fn new(
-        name: String,
-        notifications: mpsc::Sender<TnExExNotification>,
-        events: mpsc::Receiver<TnExExEvent>,
-    ) -> Self {
-        Self { name, notifications, events, finished_height: None, dropped: 0 }
+    fn new(name: String, notifications: mpsc::Sender<TnExExNotification>) -> Self {
+        Self { name, notifications, finished_height: None, dropped: 0 }
     }
 
     /// Deliver a notification without ever blocking.
@@ -118,8 +104,9 @@ impl ExExHandle {
 
 /// The ExEx manager fans out lifecycle notifications to all registered ExExes.
 ///
-/// It implements [`Future`](std::future::Future) following the same pattern as `ExecutorEngine`.
-/// The manager runs for the lifetime of the node (spawned on `node_task_manager`).
+/// It is driven by [`TnExExManager::run`], an `async fn` following the same pattern as
+/// `ExecutorEngine`. The manager runs for the lifetime of the node (spawned on
+/// `node_task_manager`).
 pub struct TnExExManager {
     /// Subscription to canonical state notifications from reth's BlockchainProvider.
     canon_state_stream: CanonStateNotificationStream,
@@ -129,6 +116,11 @@ pub struct TnExExManager {
     consensus_output_stream: BroadcastStream<ConsensusOutput>,
     /// Per-ExEx delivery state (one per registered ExEx).
     exexes: Vec<ExExHandle>,
+    /// Per-ExEx event receivers for `FinishedHeight` reporting, indexed in step with `exexes`.
+    ///
+    /// `FinishedHeight` is latest-wins, so a small bounded channel is sufficient — the ExEx
+    /// reports with a non-blocking `try_send`, and only the maximum reported height matters.
+    event_rxs: Vec<mpsc::Receiver<TnExExEvent>>,
     /// Watch sender for the minimum finished height across all ExExes.
     min_finished_height_tx: watch::Sender<Option<BlockNumber>>,
     /// Highest canonical block delivered as `ChainExecuted`. Used to detect gaps
@@ -146,11 +138,8 @@ impl TnExExManager {
         exex_txs: Vec<(String, mpsc::Sender<TnExExNotification>)>,
         event_rxs: Vec<mpsc::Receiver<TnExExEvent>>,
     ) -> (Self, TnExExManagerHandle) {
-        let exexes: Vec<ExExHandle> = exex_txs
-            .into_iter()
-            .zip(event_rxs)
-            .map(|((name, tx), events)| ExExHandle::new(name, tx, events))
-            .collect();
+        let exexes: Vec<ExExHandle> =
+            exex_txs.into_iter().map(|(name, tx)| ExExHandle::new(name, tx)).collect();
         let (min_finished_height_tx, min_finished_height_rx) = watch::channel(None);
 
         let manager = Self {
@@ -158,6 +147,7 @@ impl TnExExManager {
             certs_stream: BroadcastStream::new(rx_certs),
             consensus_output_stream: BroadcastStream::new(rx_consensus_output),
             exexes,
+            event_rxs,
             min_finished_height_tx,
             last_canon_tip: None,
         };
@@ -167,6 +157,131 @@ impl TnExExManager {
         (manager, handle)
     }
 
+    /// Run the ExEx manager event loop for the lifetime of the node.
+    ///
+    /// The three notification sources and the per-ExEx event receivers are merged into a single
+    /// priority-ordered stream (certificates > consensus output > canonical state > events) and
+    /// folded over [`Router`], which fans each event out to every ExEx and recomputes the minimum
+    /// finished height. The loop ends with `Ok(())` when any source stream closes; it never errors.
+    pub async fn run(self) -> eyre::Result<()> {
+        let Self {
+            canon_state_stream,
+            certs_stream,
+            consensus_output_stream,
+            exexes,
+            event_rxs,
+            min_finished_height_tx,
+            last_canon_tip,
+        } = self;
+
+        let router = Router { exexes, min_finished_height_tx, last_canon_tip };
+
+        // Map each source into a `RouterEvent`. The three source streams carry a trailing `Closed`
+        // sentinel so a stream end terminates the fold (mirroring the old
+        // `Poll::Ready(None) => return Poll::Ready(Ok(()))`); the event streams carry none, since
+        // an ExEx dropping its event sender must not shut down the shared manager.
+        let certs = certs_stream
+            .map(RouterEvent::Cert)
+            .chain(stream::once(async { RouterEvent::Closed("certificates") }));
+        let consensus = consensus_output_stream
+            .map(RouterEvent::Consensus)
+            .chain(stream::once(async { RouterEvent::Closed("consensus output") }));
+        let canon = canon_state_stream
+            .map(RouterEvent::Canon)
+            .chain(stream::once(async { RouterEvent::Closed("canonical state") }));
+        let events = select_all(event_rxs.into_iter().enumerate().map(|(idx, rx)| {
+            ReceiverStream::new(rx).map(move |ev| RouterEvent::Event { idx, ev })
+        }));
+
+        // Biased priority certs > consensus > canon > events via a constant `PollNext::Left`, which
+        // drains the higher-priority stream fully before the next (matching the original sequential
+        // poll order, where each stream was drained to `Pending` before the next was polled).
+        let merged = select_with_strategy(
+            certs,
+            select_with_strategy(
+                consensus,
+                select_with_strategy(canon, events, prefer_left),
+                prefer_left,
+            ),
+            prefer_left,
+        );
+
+        // The fold ends only by observing a closed source stream (signalled as `StreamEnded`); it
+        // never yields a real error, so the result is discarded and the manager reports `Ok(())`.
+        let _ = merged
+            .map(Ok::<RouterEvent, StreamEnded>)
+            .try_fold(router, |mut router, event| async move {
+                router.handle(event)?;
+                Ok(router)
+            })
+            .await;
+
+        Ok(())
+    }
+}
+
+/// Always drains the higher-priority (left) stream first, giving the fixed source order
+/// certs > consensus output > canonical state > events.
+fn prefer_left(_: &mut ()) -> PollNext {
+    PollNext::Left
+}
+
+/// A single merged input to the [`TnExExManager`] event loop.
+enum RouterEvent {
+    /// A verified certificate (or a broadcast-lag marker) from the consensus-following path.
+    Cert(Result<Certificate, BroadcastStreamRecvError>),
+    /// A full consensus output (or a broadcast-lag marker) from the consensus-following path.
+    Consensus(Result<ConsensusOutput, BroadcastStreamRecvError>),
+    /// A canonical state notification from reth's `BlockchainProvider`.
+    Canon(CanonStateNotification),
+    /// A progress event from the ExEx at index `idx` in `exexes`.
+    Event { idx: usize, ev: TnExExEvent },
+    /// A source stream ended; the manager should stop.
+    Closed(&'static str),
+}
+
+/// Signals that a source stream closed, terminating the manager fold.
+struct StreamEnded;
+
+/// Fan-out and finished-height bookkeeping for the manager event loop (the manager's state minus
+/// its input streams), threaded through the fold in [`TnExExManager::run`].
+struct Router {
+    exexes: Vec<ExExHandle>,
+    min_finished_height_tx: watch::Sender<Option<BlockNumber>>,
+    last_canon_tip: Option<BlockNumber>,
+}
+
+impl Router {
+    /// Dispatch a single merged event; `Err(StreamEnded)` stops the fold.
+    fn handle(&mut self, event: RouterEvent) -> Result<(), StreamEnded> {
+        match event {
+            RouterEvent::Cert(res) => {
+                self.deliver_broadcast(res, "certificates", |cert| {
+                    TnExExNotification::CertificateAccepted { certificate: Box::new(cert) }
+                });
+                Ok(())
+            }
+            RouterEvent::Consensus(res) => {
+                self.deliver_broadcast(res, "consensus output", |output| {
+                    TnExExNotification::ConsensusOutput { output }
+                });
+                Ok(())
+            }
+            RouterEvent::Canon(notification) => {
+                self.handle_canon(notification);
+                Ok(())
+            }
+            RouterEvent::Event { idx, ev } => {
+                self.handle_event(idx, ev);
+                Ok(())
+            }
+            RouterEvent::Closed(which) => {
+                debug!(target: "exex::manager", stream = which, "stream ended");
+                Err(StreamEnded)
+            }
+        }
+    }
+
     /// Fan out a notification to all registered ExExes (non-blocking).
     fn fan_out(&mut self, notification: &TnExExNotification) {
         for handle in &mut self.exexes {
@@ -174,36 +289,86 @@ impl TnExExManager {
         }
     }
 
-    /// Handle a canonical commit: detect any block-number gap (reth drops
-    /// canonical-stream lag silently), surface it as `Lagged`, then deliver the
-    /// executed chain. Shared by the `Commit` and degraded `Reorg` arms.
+    /// Deliver a broadcast item, mapping it to its notification — or, when the broadcast lagged,
+    /// surfacing a `Lagged` marker so the contract is uniform across every manager-side input.
+    fn deliver_broadcast<T>(
+        &mut self,
+        res: Result<T, BroadcastStreamRecvError>,
+        kind: &str,
+        into_notification: impl FnOnce(T) -> TnExExNotification,
+    ) {
+        let notification = res.map(into_notification).unwrap_or_else(|err| match err {
+            BroadcastStreamRecvError::Lagged(missed) => {
+                warn!(target: "exex::manager", missed, "{kind} stream lagged; surfaced Lagged");
+                TnExExNotification::Lagged { missed }
+            }
+        });
+        self.fan_out(&notification);
+    }
+
+    /// Handle a canonical state notification.
+    fn handle_canon(&mut self, notification: CanonStateNotification) {
+        match notification {
+            // reth's canonical-state stream drops broadcast lag silently, so a starved manager can
+            // miss commits. `handle_canon_commit` detects the resulting discontinuity and surfaces
+            // a `Lagged` marker before delivering, so stateful ExExes reconcile rather
+            // than carry a silent hole.
+            CanonStateNotification::Commit { new } => self.handle_canon_commit(new),
+            // TN's BFT consensus has immediate finality, so reth should only ever emit `Commit`. A
+            // `Reorg` violates that invariant — log it loudly, but degrade gracefully by treating
+            // the new side as a commit. The manager is spawned once and never respawned, so
+            // panicking here (it previously did) would kill the shared fan-out for every ExEx for
+            // the node's lifetime.
+            //
+            // Note: `old` is discarded, and if `new`'s blocks are not strictly newer than the last
+            // delivered tip the downstream height-dedup (`dedup_chain_executed`) may drop this
+            // degraded commit. Acceptable precisely because the arm is unreachable under TN's
+            // immediate-finality consensus.
+            CanonStateNotification::Reorg { old, new } => {
+                error!(
+                    target: "exex::manager",
+                    old_blocks = old.len(),
+                    new_blocks = new.len(),
+                    "unexpected Reorg for finalized state; degrading to commit of the new side",
+                );
+                self.handle_canon_commit(new);
+            }
+        }
+    }
+
+    /// Handle a canonical commit: detect any block-number gap (reth drops canonical-stream lag
+    /// silently), surface it as `Lagged`, then deliver the executed chain. Shared by the `Commit`
+    /// and degraded `Reorg` arms.
     fn handle_canon_commit(&mut self, new: Arc<Chain>) {
         let range = new.range();
-        if let Some(missed) = canon_gap(&mut self.last_canon_tip, *range.start(), *range.end()) {
+        let first = *range.start();
+        canon_gap(&mut self.last_canon_tip, first, *range.end()).into_iter().for_each(|missed| {
             warn!(
                 target: "exex::manager",
                 missed,
-                first = *range.start(),
+                first,
                 "canonical ChainExecuted gap detected; surfacing Lagged",
             );
             self.fan_out(&TnExExNotification::Lagged { missed });
-        }
+        });
         self.fan_out(&TnExExNotification::ChainExecuted { new });
     }
 
-    /// Poll all event receivers for FinishedHeight updates and recompute the
-    /// minimum finished height across all ExExes.
-    fn poll_events(&mut self, cx: &mut Context<'_>) {
-        for handle in &mut self.exexes {
-            while let Poll::Ready(Some(event)) = handle.events.poll_recv(cx) {
-                match event {
-                    TnExExEvent::FinishedHeight(height) => {
-                        handle.finished_height = Some(height);
-                    }
-                }
+    /// Record an ExEx progress event, then recompute the minimum finished height.
+    fn handle_event(&mut self, idx: usize, event: TnExExEvent) {
+        match event {
+            TnExExEvent::FinishedHeight(height) => {
+                self.exexes
+                    .get_mut(idx)
+                    .into_iter()
+                    .for_each(|handle| handle.finished_height = Some(height));
             }
         }
+        self.recompute_min();
+    }
 
+    /// Recompute the minimum finished height across all ExExes and publish it.
+    fn recompute_min(&mut self) {
         // Minimum finished height: None if any ExEx hasn't reported yet.
         let min_height = self
             .exexes
@@ -215,100 +380,6 @@ impl TnExExManager {
             .flatten();
 
         self.min_finished_height_tx.send_replace(min_height);
-    }
-}
-
-impl futures::Future for TnExExManager {
-    type Output = eyre::Result<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        // Poll verified certificates stream (consensus-following path)
-        loop {
-            match this.certs_stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(cert))) => {
-                    let notification =
-                        TnExExNotification::CertificateAccepted { certificate: Box::new(cert) };
-                    this.fan_out(&notification);
-                }
-                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    // Surface the broadcast lag so the `Lagged` contract is uniform
-                    // across every manager-side input, not just the canon stream.
-                    this.fan_out(&TnExExNotification::Lagged { missed: n });
-                    warn!(target: "exex::manager", missed = n, "certificates stream lagged; surfaced Lagged");
-                }
-                Poll::Ready(None) => {
-                    debug!(target: "exex::manager", "certificates stream ended");
-                    return Poll::Ready(Ok(()));
-                }
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll consensus output stream (consensus-following path)
-        loop {
-            match this.consensus_output_stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(output))) => {
-                    let notification = TnExExNotification::ConsensusOutput { output };
-                    this.fan_out(&notification);
-                }
-                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))) => {
-                    this.fan_out(&TnExExNotification::Lagged { missed: n });
-                    warn!(target: "exex::manager", missed = n, "consensus output stream lagged; surfaced Lagged");
-                }
-                Poll::Ready(None) => {
-                    debug!(target: "exex::manager", "consensus output stream ended");
-                    return Poll::Ready(Ok(()));
-                }
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll canonical state stream
-        loop {
-            match this.canon_state_stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(notification)) => match notification {
-                    // reth's canonical-state stream drops broadcast lag silently,
-                    // so a starved manager can miss commits. `handle_canon_commit`
-                    // detects the resulting discontinuity and surfaces a `Lagged`
-                    // marker before delivering, so stateful ExExes reconcile rather
-                    // than carry a silent hole.
-                    CanonStateNotification::Commit { new } => this.handle_canon_commit(new),
-                    // TN's BFT consensus has immediate finality, so reth should
-                    // only ever emit `Commit`. A `Reorg` violates that invariant —
-                    // log it loudly, but degrade gracefully by treating the new
-                    // side as a commit. The manager is spawned once and never
-                    // respawned, so panicking here (it previously did) would kill
-                    // the shared fan-out for every ExEx for the node's lifetime.
-                    //
-                    // Note: `old` is discarded, and if `new`'s blocks are not
-                    // strictly newer than the last delivered tip the downstream
-                    // height-dedup (`dedup_chain_executed`) may drop this degraded
-                    // commit. Acceptable precisely because the arm is unreachable
-                    // under TN's immediate-finality consensus.
-                    CanonStateNotification::Reorg { old, new } => {
-                        error!(
-                            target: "exex::manager",
-                            old_blocks = old.len(),
-                            new_blocks = new.len(),
-                            "unexpected Reorg for finalized state; degrading to commit of the new side",
-                        );
-                        this.handle_canon_commit(new);
-                    }
-                },
-                Poll::Ready(None) => {
-                    debug!(target: "exex::manager", "canonical state stream ended");
-                    return Poll::Ready(Ok(()));
-                }
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll ExEx events
-        this.poll_events(cx);
-
-        Poll::Pending
     }
 }
 
@@ -399,8 +470,7 @@ mod tests {
     #[tokio::test]
     async fn full_channel_drops_then_surfaces_lagged_marker() {
         let (tx, mut rx) = mpsc::channel(2);
-        let (_event_tx, event_rx) = mpsc::channel(4);
-        let mut handle = ExExHandle::new("test".to_string(), tx, event_rx);
+        let mut handle = ExExHandle::new("test".to_string(), tx);
 
         // Fill the channel (capacity 2).
         handle.send(&filler());
@@ -428,8 +498,7 @@ mod tests {
     #[tokio::test]
     async fn delivers_without_lagged_when_not_full() {
         let (tx, mut rx) = mpsc::channel(4);
-        let (_event_tx, event_rx) = mpsc::channel(4);
-        let mut handle = ExExHandle::new("test".to_string(), tx, event_rx);
+        let mut handle = ExExHandle::new("test".to_string(), tx);
 
         handle.send(&filler());
         assert_eq!(handle.dropped, 0);

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -75,7 +75,7 @@ impl ExecutionNodeInner {
         // spawn tn engine
         self.reth_env.get_task_spawner().spawn_critical_task("consensus engine", async move {
             info!("Engine stated from block {block_num}/{block_hash}, consensus output {consensus_header:?}");
-            let res = tn_engine.await;
+            let res = tn_engine.run().await;
             match &res {
                 Ok(_) => {
                     info!(target: "engine", "TN Engine exited gracefully");
@@ -121,7 +121,7 @@ impl ExecutionNodeInner {
 
         // spawn batch builder task
         epoch_task_spawner.spawn_critical_task("batch builder", async move {
-            let res = batch_builder.await;
+            let res = batch_builder.run().await;
             info!(target: "tn::execution", ?res, "batch builder task exited");
             Ok(res?)
         });

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -446,7 +446,7 @@ where
             if exex_critical {
                 node_task_manager.get_spawner().spawn_critical_task(
                     "exex-manager",
-                    run_critical_exex_future("exex-manager".to_string(), manager),
+                    run_critical_exex_future("exex-manager".to_string(), manager.run()),
                 );
                 info!(target: "epoch-manager", "ExEx manager and tasks spawned (critical)");
             } else {
@@ -454,7 +454,7 @@ where
                 // loudly) but the node — host to an optional subsystem — stays up.
                 node_task_manager.get_spawner().spawn_task(
                     "exex-manager",
-                    run_isolated_exex_future("exex-manager".to_string(), manager),
+                    run_isolated_exex_future("exex-manager".to_string(), manager.run()),
                 );
                 info!(target: "epoch-manager", "ExEx manager and tasks spawned (isolated, non-critical)");
             }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -94,7 +94,7 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
     );
     let (tx, mut rx) = oneshot::channel();
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         debug!(target: "gas-test", ?res, "res:");
         let _ = tx.send(res);
         Ok(())
@@ -226,7 +226,7 @@ async fn test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
     );
     let (tx, mut rx) = oneshot::channel();
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         debug!(target: "gas-test", ?res, "res:");
         let _ = tx.send(res);
         Ok(())
@@ -394,7 +394,7 @@ async fn test_catchup_accumulator_partial_execution() -> eyre::Result<()> {
     );
     let (tx, mut rx) = oneshot::channel();
     task_manager.spawn_task("test task eng", async move {
-        let res = engine.await;
+        let res = engine.run().await;
         debug!(target: "gas-test", ?res, "partial res:");
         let _ = tx.send(res);
         Ok(())


### PR DESCRIPTION
## What

Replaces the three hand-rolled `impl Future` event loops with `async fn run`, per the standup decision to prefer async fns over hand-written Futures.

| Loop | Before | After |
|------|--------|-------|
| `ExecutorEngine` (`crates/engine`) | `impl Future` + manual `poll` | `async fn run` + `tokio::select!` |
| `BatchBuilder` (`crates/batch-builder`) | `impl Future` + manual `poll` | `async fn run` + `tokio::select!` |
| `TnExExManager` (`crates/exex`) | `impl Future` + manual `poll` | `async fn run` folding `select_with_strategy(..).try_fold(..)` |

## Details

- **ExecutorEngine / BatchBuilder** become `loop { tokio::select! { biased; .. } }`. `biased` preserves the original poll order (poll consensus / state-changes first to keep the broadcast stream from lagging); the outer loop preserves the greedy non-parking drain.  `BatchBuilder` keeps its post-quorum-failure backoff via a `defer_build` flag and gates the delay interval on `pending_task.is_none()` to match the original (which only polled the interval while idle).
- **TnExExManager** becomes a stream router: the three notification sources and the per-ExEx event receivers are merged via `select_with_strategy([certs, consensus, canon, select_all(event_rxs)], |_| PollNext::Left)` and folded over a `Router`.  The constant left-bias reproduces the original certs > consensus > canon > events priority and the drain-higher-fully-before-next ordering.  `ExExHandle` is split so the event receivers feed `select_all` while the notification senders stay in the fold accumulator for fan-out;  `poll_events`' `while let` drain becomes a per-event fold (the min-height computation was already a `try_fold`).
- **Cargo**: `tokio`'s `macros` feature added to `tn-engine` and `tn-batch-builder` (they use `tokio::select!`). `tn-exex` needs no new feature . . . it uses the `futures` stream router.

## Behavior

Faithful to the originals (each loop was adversarially reviewed against its `poll` body):  poll ordering, shutdown-drain, single-build gating, receiver restore-on-pending, broadcast `Lagged` surfacing, canonical-gap detection, and min-finished-height are preserved.  Known observability/timing deltas:

- `ExecutorEngine`: under a continuously-ready consensus stream `queued_outputs` may read marginally higher;  the closed-stream error logs once (not per poll).  The `if !consensus_closed` arm guard is required to avoid a busy-spin once the stream closes.
- `TnExExManager`: min-finished-height is recomputed per event rather than once per wake.  Benign: the watch receiver is currently dropped at the construction site.

## Test plan

- [x] build check: `tn-engine`, `tn-batch-builder`, `tn-exex`, `tn-node`
- [x] clippy with `--tests` (0 warnings)
- [x] nightly `fmt`
- [ ] run integration tests (they compile; not yet executed)
