### PR TITLE
fix(worker): do not ban gossip relayer for author-content faults

### DIFF
--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -135,6 +135,55 @@ impl WorkerNetworkError {
             | WorkerNetworkError::Internal(_) => None,
         }
     }
+
+    /// Whether this fault is determined purely by the *content* of a message - its
+    /// encoding, declared topic, identity, or count - and is therefore attributable to
+    /// whoever authored that content rather than to the peer that delivered it.
+    ///
+    /// This distinction matters for gossip: the peer in hand is the relayer
+    /// (`propagation_source`), not the author, so an author-content fault must not
+    /// penalize it (see issue #801). Direct request/response paths penalize
+    /// unconditionally because there the peer *is* the originator of the content.
+    ///
+    /// These are the protocol-violation group that [`Self::penalty`] maps to
+    /// [`Penalty::Fatal`] (faults in a message's encoding, declared topic, identity, or
+    /// count). [`Self::BatchValidation`] is also `Fatal` for some subvariants but is
+    /// deliberately excluded: it arises only on the request/response path, where the
+    /// peer *is* the originator and penalizing it is correct. Of this set, only
+    /// [`Self::Bcs`] and [`Self::InvalidTopic`] are currently reachable from the gossip
+    /// handler; the rest are classified for forward-safety.
+    pub fn is_author_content_fault(&self) -> bool {
+        //
+        // explicitly match every error type so the classification is revisited with changes
+        //
+        match self {
+            // content-determined protocol violations
+            WorkerNetworkError::Bcs(_)
+            | WorkerNetworkError::InvalidTopic
+            | WorkerNetworkError::TooManyBatches { .. }
+            | WorkerNetworkError::UnexpectedBatch(_)
+            | WorkerNetworkError::DuplicateBatch(_)
+            | WorkerNetworkError::RequestHashMismatch => true,
+            // Not author-content faults on any current path. `BatchValidation` is
+            // content-determined, but only arises on the request/response path (where
+            // the peer is the originator, so its own penalty is correct) and never
+            // reaches the gossip handler; the rest are transport-peer behavior,
+            // timeouts, or faults local to this node.
+            WorkerNetworkError::BatchValidation(_)
+            | WorkerNetworkError::NonCommitteeBatch
+            | WorkerNetworkError::Internal(_)
+            | WorkerNetworkError::Timeout(_)
+            | WorkerNetworkError::Network(_)
+            | WorkerNetworkError::InvalidRequest(_)
+            | WorkerNetworkError::StreamClosed
+            | WorkerNetworkError::UnknownStreamRequest(_)
+            | WorkerNetworkError::StdIo(_)
+            | WorkerNetworkError::DBInsert(_)
+            | WorkerNetworkError::DBCommit(_)
+            | WorkerNetworkError::DBRead(_)
+            | WorkerNetworkError::BatchEpochMismatch(_, _) => false,
+        }
+    }
 }
 
 impl From<WorkerNetworkError> for Option<Penalty> {

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -348,9 +348,18 @@ where
         self.network_handle.get_task_spawner().spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "worker::network", ?e, "process_gossip");
-                // convert error into penalty to lower peer score; only attributable
-                // when the relaying peer's BLS identity has resolved
-                if let Some((relayer, penalty)) = relayer.zip(e.penalty()) {
+                // A gossip fault is charged to the *relaying* peer, not the message
+                // author. Faults determined purely by message content (malformed
+                // encoding, mis-topic, ...) are the author's: the network layer
+                // accepted and forwarded this message after a shallow check, so an
+                // honest relayer could not have screened it. Banning the relayer for an
+                // author-content fault lets a Byzantine author ban honest validators and
+                // partition the gossip mesh (see issue #801). Penalize only when the
+                // fault is attributable to the relaying peer and its BLS identity has
+                // resolved.
+                let attributable =
+                    relayer.zip(e.penalty()).filter(|_| !e.is_author_content_fault());
+                if let Some((relayer, penalty)) = attributable {
                     network_handle.report_penalty(relayer, penalty).await;
                 }
                 Err(e.into())

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -461,6 +461,51 @@ async fn test_stream_error_penalties() {
     assert!(penalty.is_none(), "StreamClosed should have no penalty");
 }
 
+/// Author-content faults (issue #801) must be classified so the gossip handler does not
+/// Fatal-ban the relaying peer for a fault that belongs to the message author.
+#[test]
+fn test_is_author_content_fault() {
+    // Faults determined by message content. These are exactly the Fatal
+    // protocol-violation variants; `Bcs` and `InvalidTopic` are the two reachable from
+    // the gossip handler, which previously Fatal-banned the innocent relayer.
+    let author_content = vec![
+        WorkerNetworkError::Bcs(bcs::Error::Eof),
+        WorkerNetworkError::InvalidTopic,
+        WorkerNetworkError::TooManyBatches { expected: 1, received: 5 },
+        WorkerNetworkError::UnexpectedBatch(B256::random()),
+        WorkerNetworkError::DuplicateBatch(B256::random()),
+        WorkerNetworkError::RequestHashMismatch,
+    ];
+    for err in author_content {
+        assert!(
+            err.is_author_content_fault(),
+            "{err:?} is determined by message content and must not penalize a relayer"
+        );
+        // every author-content fault is a Fatal protocol violation: this is exactly the
+        // ban the gossip handler now suppresses for the relaying peer.
+        let penalty: Option<Penalty> = err.into();
+        assert_matches!(penalty, Some(Penalty::Fatal));
+    }
+
+    // Faults attributable to the transport peer's behavior, or local to this node. The
+    // relayer is correctly penalized for these (when a penalty applies at all).
+    let not_author_content = vec![
+        WorkerNetworkError::StreamClosed,
+        WorkerNetworkError::NonCommitteeBatch,
+        WorkerNetworkError::Internal("boom".to_string()),
+        WorkerNetworkError::InvalidRequest("bad request".to_string()),
+        WorkerNetworkError::UnknownStreamRequest(B256::random()),
+        WorkerNetworkError::StdIo(std::io::Error::from(std::io::ErrorKind::ConnectionReset)),
+        // content-determined and Fatal for some subvariants, but only reachable on the
+        // request/response path (peer == originator), never via gossip (see #801).
+        WorkerNetworkError::BatchValidation(tn_types::BatchValidationError::EmptyBatch),
+        WorkerNetworkError::BatchEpochMismatch(1, 2),
+    ];
+    for err in not_author_content {
+        assert!(!err.is_author_content_fault(), "{err:?} is not a message-content fault");
+    }
+}
+
 // ============================================================================
 // Truncation & Peer Fallback Tests
 // ============================================================================


### PR DESCRIPTION
Closes #801.

## Problem

When the worker processes gossip, a processing error is converted to a peer
penalty and applied to the gossip's `relayer` (the `propagation_source`), not to
the message author. Several content faults map to `Penalty::Fatal`:

```rust
WorkerNetworkError::InvalidTopic
| WorkerNetworkError::Bcs(_)
| WorkerNetworkError::TooManyBatches { .. }
| WorkerNetworkError::UnexpectedBatch(_)
| WorkerNetworkError::DuplicateBatch(_)
| WorkerNetworkError::RequestHashMismatch => Some(Penalty::Fatal),
```

These are correct for direct request/response, where the peer in hand *is* the
originator of the content.  They are wrong for gossip: the network layer accepts
and forwards a message after only a shallow check (`verify_gossip` validates
message size, authorized publisher, and topic subscription, but does not BCS
decode the payload or match the inner gossip variant to the topic).  An honest
relayer therefore cannot screen out a payload that later fails the worker's deep
validation.  Banning that relayer hands a Byzantine (but authorized) author a way
to Fatal-ban honest validators by publishing malformed/mis-topic gossip, which
honest peers then propagate.  Cascading relayer bans can partition the gossip
mesh.

Of the Fatal content faults, only `Bcs` (failed BCS decode) and `InvalidTopic`
(decoded variant does not match the topic) are actually reachable from the
gossip handler today;  the rest arise on the request/response and stream paths.

## Fix

- `WorkerNetworkError::is_author_content_fault()` (new): an exhaustive
  classifier that returns `true` for faults determined purely by message content
  (the Fatal protocol-violation variants) and `false` for faults attributable to
  the transport peer's behavior or local to this node.  The exhaustive match means
  any new error variant forces an explicit classification decision.
- `process_gossip` now suppresses the relayer penalty for author-content faults:
  `relayer.zip(e.penalty()).filter(|_| !e.is_author_content_fault())`.  The
  message is still rejected and logged;  only the unjust ban of the relaying peer
  is removed. The request/response (`process_report_batch`) and stream
  (`process_request_batches_stream`) paths are unchanged and still penalize
  unconditionally, because there the peer is the content originator.

## Scope and follow-ups

This PR fixes the worker layer named in the issue.  Two structurally related items
are intentionally left out of scope:

- The network layer applies the same `Penalty::Fatal` to `propagation_source`
  when `verify_gossip` rejects a message
  (`crates/network-libp2p/src/consensus.rs`).  Because every node runs the same
  deterministic shallow check under gossipsub `ValidationMode::Strict`, an honest
  relayer that rejects a message never forwards it, so that path is a narrower
  vector (reachable mainly under epoch-boundary committee-view skew).  Different
  crate, different fault class . . . better tracked as its own issue.
- The Byzantine author is still not penalized for deep-validation faults: the
  network layer already reported `Accept` to gossipsub before the worker's deep
  check runs, so gossipsub's invalid-delivery scoring never fires.  Penalizing the
  author identity (rather than the relayer) is a separate enhancement.  Note: a
  *Mild* relayer penalty is deliberately **not** used here, since it would still
  accumulate against innocent downstream relayers and partition the mesh slowly.

## Testing

- New unit test `test_is_author_content_fault` locks the classification: the six
  Fatal content faults are author-content faults (and are exactly the ones that
  map to `Penalty::Fatal`), while transport/local faults . . . including the
  content-but-request/response-only `BatchValidation` and the no-penalty
  `BatchEpochMismatch` . . . are not.
- `cargo nextest run -p tn-worker` green (0 failed); `make fmt` clean.
