### PR TITLE
fix(primary): report peer penalties for failed vote requests (#802)

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -147,10 +147,7 @@ impl From<&PrimaryNetworkError> for Option<Penalty> {
 fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
     match error {
         // mild
-        HeaderError::SyncBatches(_)
-        | HeaderError::TooNew { .. }
-        | HeaderError::Storage(_)
-        | HeaderError::UnknownExecutionResult(_) => Some(Penalty::Mild),
+        HeaderError::SyncBatches(_) | HeaderError::TooNew { .. } => Some(Penalty::Mild),
         // medium
         HeaderError::InvalidParents
         | HeaderError::WrongNumberOfParents(_, _)
@@ -171,8 +168,16 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         | HeaderError::InvalidParentTimestamp { .. }
         | HeaderError::UnkownWorkerId
         | HeaderError::UnknownAuthority(_) => Some(Penalty::Fatal),
-        // ignore
+        // ignore (local/transient, not the peer's fault)
+        //
+        // Storage is our own DB error, and UnknownExecutionResult means a peer is merely
+        // ahead of our execution while we catch up (the vote handler notes "this doesn't
+        // hurt"). Penalizing either would punish an honest peer for a local condition, and
+        // contradicts the sibling PrimaryNetworkError::Storage and *::Timeout arms that
+        // already map to None.
         HeaderError::PendingCertificateOneshot
+        | HeaderError::Storage(_)
+        | HeaderError::UnknownExecutionResult(_)
         | HeaderError::TNSend(_)
         | HeaderError::InvalidEpoch { .. }
         | HeaderError::ClosedWatchChannel => None,

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1288,6 +1288,19 @@ where
         self.task_spawner.spawn_task(task_name, async move {
             tokio::select! {
                 vote = request_handler.vote(peer, header, parents) => {
+                    // report penalty if any
+                    //
+                    // votes are consensus-critical, so a peer that returns a penalizable
+                    // error must pay the same reputational cost as on every other request
+                    // handler. Route the error through the central PrimaryNetworkError →
+                    // Penalty table before collapsing it into a response, instead of
+                    // silently dropping it.
+                    if let Err(ref e) = vote {
+                        if let Some(penalty) = e.into() {
+                            network_handle.report_penalty(peer, penalty).await;
+                        }
+                    }
+
                     let response = vote.into_response();
                     let _ = network_handle.handle.send_response(response, channel).await;
                 }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -496,6 +496,87 @@ async fn test_vote_fails_unknown_authority() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Regression for #802: the Byzantine errors the vote RPC returns must be penalizable.
+///
+/// `process_vote_request` now reports `(&err).into()` before collapsing the result into a
+/// response, exactly like every sibling request handler. That wiring only penalizes a
+/// misbehaving peer if the vote handler's error variants map to `Some(Penalty)` in the
+/// central `From<&PrimaryNetworkError>` table. Pin that contract here so a future error
+/// reshuffle that silently downgrades a vote error to `None` (re-opening #802 from the
+/// other side) is caught.
+#[tokio::test]
+async fn test_vote_byzantine_errors_are_penalizable() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    // A vote request whose peer is not the header's author -> PeerNotAuthor.
+    let header = committee
+        .header_builder_last_authority()
+        .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
+        .created_at(1) // parent is 0
+        .build();
+    let not_author = BlsPublicKey::default();
+    let err = handler
+        .vote(not_author, header, Vec::new())
+        .await
+        .expect_err("a vote whose peer is not the header author must fail");
+    assert_matches!(err, PrimaryNetworkError::InvalidHeader(HeaderError::PeerNotAuthor));
+    let penalty: Option<tn_network_libp2p::Penalty> = (&err).into();
+    assert_matches!(
+        penalty,
+        Some(tn_network_libp2p::Penalty::Fatal),
+        "a non-author vote must penalize the peer so process_vote_request can report it"
+    );
+
+    // A vote request authored by an authority outside the committee -> UnknownAuthority.
+    let wrong_authority = AuthorityIdentifier::dummy_for_test(100);
+    let header = committee
+        .header_builder_last_authority()
+        .author(wrong_authority.clone())
+        .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
+        .created_at(1) // parent is 0
+        .build();
+    let peer = *committee.last_authority().authority().protocol_key();
+    let err = handler
+        .vote(peer, header, Vec::new())
+        .await
+        .expect_err("a vote authored by an unknown authority must fail");
+    assert_matches!(
+        err,
+        PrimaryNetworkError::InvalidHeader(HeaderError::UnknownAuthority(ref a))
+            if *a == wrong_authority.to_string()
+    );
+    let penalty: Option<tn_network_libp2p::Penalty> = (&err).into();
+    assert_matches!(
+        penalty,
+        Some(tn_network_libp2p::Penalty::Fatal),
+        "an unknown-authority vote must penalize the peer"
+    );
+
+    Ok(())
+}
+
+/// #802 follow-through: header errors that reflect a LOCAL or transient condition (our own
+/// storage failure, or our execution lagging behind a peer that is merely ahead) must NOT
+/// penalize the peer now that the vote RPC is wired into the penalty pipeline. Pin the
+/// central table so these stay `None`, consistent with the sibling
+/// `PrimaryNetworkError::Storage` and `*::Timeout` arms.
+#[test]
+fn test_local_header_errors_are_not_penalized() {
+    let storage: PrimaryNetworkError = HeaderError::Storage(eyre::eyre!("local db failure")).into();
+    let penalty: Option<tn_network_libp2p::Penalty> = (&storage).into();
+    assert!(penalty.is_none(), "a local storage failure must not penalize the peer");
+
+    let exec_lag: PrimaryNetworkError =
+        HeaderError::UnknownExecutionResult(BlockNumHash::new(0, BlockHash::default())).into();
+    let penalty: Option<tn_network_libp2p::Penalty> = (&exec_lag).into();
+    assert!(
+        penalty.is_none(),
+        "a peer that is merely ahead of our execution must not be penalized"
+    );
+}
+
 /// Test that primary pub/sub is enforcing topics.
 #[tokio::test]
 async fn test_primary_batch_gossip_topics() {


### PR DESCRIPTION
Closes #802.

## Problem

`process_vote_request` was the only primary request handler that dropped penalizable
errors instead of routing them through the peer-penalty pipeline.  It evaluated a peer's
proposed header and then collapsed any error straight into a response via `into_response()`
and discarded it (`let _ = ...send_response(...)`).  A misbehaving validator could therefore
return penalizable errors on the consensus-critical vote RPC (voting for a header it did
not author, equivocation, malformed parents, ...) at zero reputational cost.

Every sibling handler already reports `(&err).into()` before building the response:
`process_request_for_missing_certs`, `process_consensus_output_request`,
`process_epoch_record_request`, `process_epoch_stream`, `process_gossip`, and
`process_inbound_stream`.  The vote handler was the sole omission.

## Changes

- **`crates/consensus/primary/src/network/mod.rs`**: in `process_vote_request`, report a
  penalty for a failed vote before collapsing the result into a response, mirroring the
  sibling handlers exactly.  The error is routed through the existing
  `From<&PrimaryNetworkError> for Option<Penalty>` table, which stays the single source of
  truth for which vote errors are penalizable and at what level (wrong author / unknown
  authority / equivocation -> `Fatal`).

- **`crates/consensus/primary/src/error/network.rs`**: reclassify two `HeaderError` arms
  in `penalty_from_header_error` from `Mild` to `None`.  Wiring votes into the pipeline newly
  activates these arms on the consensus-critical path, and both fire on local/transient
  conditions rather than peer misbehavior:
  - `Storage` — our own DB error; the peer is blameless.  Every other `Storage` variant in
    this table (`PrimaryNetworkError::Storage`, `CertificateError::Storage`,
    `CertManagerError::Storage`) already maps to `None`.
  - `UnknownExecutionResult` — returned only when our execution lags behind a peer that is
    merely ahead during catch-up;  the vote handler's own comment notes "this doesn't hurt",
    and the `*::Timeout` arms already map to `None`.

- **`crates/consensus/primary/src/tests/network_tests.rs`**: two regression tests:
  - `test_vote_byzantine_errors_are_penalizable`: the Byzantine vote errors (`PeerNotAuthor`,
    `UnknownAuthority`) map to `Some(Penalty::Fatal)` . . . the contract the wiring depends on.
  - `test_local_header_errors_are_not_penalized`: the reclassified `Storage` /
    `UnknownExecutionResult` errors map to `None`.

## Notes on scope and effect

- The response path is unchanged: the same `PrimaryResponse` is still returned to the peer;
  only the previously-dropped error is now also surfaced to the penalty pipeline.

- `penalty_from_header_error` is shared with the certificate path, so the two reclassified
  errors now map to `None` there as well . . . strictly less punitive and consistent with the
  table's existing intent (do not penalize a peer for our local conditions).

- **Equivocation severity (the issue's open question).** Equivocation maps to `Fatal`
  (`AlreadyVoted` / `AlreadyVotedForLaterRound`), so this restores reputational consequences
  for it.  Two caveats worth recording:
  - Vote RPCs are served to committee members, and exempt peers (committee validators /
    operator allowlist) bypass the score model in `apply_penalty` (`peers/peer.rs`):
    `Severe`/`Fatal` are suppressed to a `warn!` and not enforced.  So against an in-committee
    equivocator the practical bite of the restored penalty is a log line, not a ban . . . still
    an improvement over the prior silence, but not enforcement.
  - There is no economic slashing wired in the live Rust path (`Slash` / `applySlashes`
    exist only as a `sol!` / Solidity interface, with no Rust call site that builds a slash).
     The issue's hypothesis "Medium overall if vote equivocation is independently slashed at
    the consensus layer" is therefore not supported: reputation is the sole runtime
    consequence.  Severity stays High for reputation. Wiring economic deterrence (or applying
    enforced penalties to committee equivocators) is a reasonable follow-up, out of scope here.

## Verification

- `cargo clippy -p tn-primary --all-targets` — clean (0 warnings).
- `cargo test -p tn-primary` — the 16 `test_vote*` tests pass, plus the new
  `test_local_header_errors_are_not_penalized`.
- `cargo +nightly fmt` applied.
