### PR TITLE
fix: return error instead of panicking on non-validator vote path

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -175,6 +175,7 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         HeaderError::PendingCertificateOneshot
         | HeaderError::TNSend(_)
         | HeaderError::InvalidEpoch { .. }
+        | HeaderError::NotCommitteeMember
         | HeaderError::ClosedWatchChannel => None,
     }
 }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -401,7 +401,7 @@ where
             if vote_info.vote_digest == header.digest().into() {
                 let vote = Vote::new(
                     &header,
-                    self.consensus_config.authority_id().expect("only validators can vote"),
+                    self.consensus_config.authority_id().ok_or(HeaderError::NotCommitteeMember)?,
                     self.consensus_config.key_config(),
                 );
 
@@ -707,7 +707,9 @@ where
                     // Make sure we don't vote twice for the same authority in the same epoch/round.
                     let vote = Vote::new(
                         &header,
-                        self.consensus_config.authority_id().expect("only validators can vote"),
+                        self.consensus_config
+                            .authority_id()
+                            .ok_or(HeaderError::NotCommitteeMember)?,
                         self.consensus_config.key_config(),
                     );
                     if vote.digest() != vote_info.vote_digest() {
@@ -757,7 +759,7 @@ where
         // this node hasn't voted yet
         let vote = Vote::new(
             &header,
-            self.consensus_config.authority_id().expect("only validators can vote"),
+            self.consensus_config.authority_id().ok_or(HeaderError::NotCommitteeMember)?,
             self.consensus_config.key_config(),
         );
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -11,6 +11,7 @@ use crate::{
     ConsensusBus, ConsensusBusApp, NodeMode, RecentBlocks,
 };
 use assert_matches::assert_matches;
+use rand::{rngs::StdRng, SeedableRng};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     path::Path,
@@ -18,7 +19,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tempfile::TempDir;
-use tn_config::Parameters;
+use tn_config::{ConsensusConfig, KeyConfig, Parameters};
 use tn_network_libp2p::{GossipMessage, TopicHash};
 use tn_storage::{
     consensus::{ConsensusChain, ConsensusChainError},
@@ -29,10 +30,10 @@ use tn_storage::{
 use tn_test_utils_committee::{AuthorityFixture, CommitteeFixture};
 use tn_types::{
     encode, error::HeaderError, now, to_intent_message, AuthorityIdentifier, BlockHash,
-    BlockHeader, BlockNumHash, BlsPublicKey, BlsSigner as _, Certificate, CommittedSubDag,
-    ConsensusHeaderDigest, ConsensusNumHash, ConsensusResult, Database, Epoch, EpochVote,
-    ExecHeader, Hash as _, HeaderDigest, ReputationScores, Round, SealedHeader, TaskManager,
-    VoteDigest, VoteInfo, B256,
+    BlockHeader, BlockNumHash, BlsKeypair, BlsPublicKey, BlsSigner as _, Certificate,
+    CommittedSubDag, ConsensusHeaderDigest, ConsensusNumHash, ConsensusResult, Database, Epoch,
+    EpochVote, ExecHeader, Hash as _, HeaderDigest, ReputationScores, Round, SealedHeader,
+    TaskManager, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -271,6 +272,74 @@ async fn test_vote_succeeds() -> eyre::Result<()> {
     let res = handler.vote(peer, header, parents).await;
     debug!(target: "primary::handler_tests", ?res);
     assert!(res.is_ok());
+    Ok(())
+}
+
+/// Regression test for issue #803: a node that is **not** a member of the current committee must
+/// reject an inbound vote request with a graceful error instead of panicking. The vote path
+/// previously called `authority_id().expect("only validators can vote")`, which aborts the whole
+/// process for any non-validator that reaches it (e.g. an observer served a misrouted request).
+#[tokio::test]
+async fn test_vote_non_committee_member_returns_error() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let committee = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+
+    // Build a ConsensusConfig keyed by an identity that is NOT in the committee, so that
+    // `authority_id()` is `None` (a non-validator / observer node). Reuse the fixture's
+    // genesis-aligned `Config` and `NetworkConfig`, swapping only the signing key.
+    let base = committee.first_authority().consensus_config();
+    let outsider_key =
+        KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
+    let config = ConsensusConfig::new_with_committee_for_test(
+        base.config().clone(),
+        MemDatabase::default(),
+        outsider_key,
+        committee.committee(),
+        base.network_config().clone(),
+    )?;
+    assert!(config.authority_id().is_none(), "outsider key must not be a committee member");
+
+    // Build the handler against the outsider config, mirroring `create_test_types_with_params`.
+    let cb = ConsensusBus::new();
+    let task_manager = TaskManager::default();
+    let synchronizer =
+        StateSynchronizer::new(config.clone(), cb.clone(), task_manager.get_spawner());
+    synchronizer.spawn(&task_manager);
+
+    // Seed the latest execution result to genesis so a round-1 header passes execution checks.
+    let parent = SealedHeader::seal_slow(ExecHeader::default());
+    let mut recent = RecentBlocks::new(1);
+    recent.push_latest(
+        0,
+        ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+        Some(parent.clone()),
+    );
+    cb.app().recent_blocks().send_replace(recent);
+
+    let consensus_chain =
+        ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.committee())
+            .await
+            .unwrap();
+    let handler =
+        RequestHandler::new(config.clone(), cb.app().clone(), synchronizer, consensus_chain);
+
+    // A valid round-1 header proposed by a real committee member (identical to test_vote_succeeds),
+    // so the request passes the peer/author and header validation and reaches the former panic
+    // site.
+    let header = committee
+        .header_builder_last_authority()
+        .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
+        .created_at(1) // parent is 0
+        .build();
+    let peer = *committee.last_authority().authority().protocol_key();
+
+    // The non-validator must return a graceful error rather than panicking.
+    let res = handler.vote(peer, header, vec![]).await;
+    debug!(target: "primary::handler_tests", ?res);
+    assert_matches!(res, Err(PrimaryNetworkError::InvalidHeader(HeaderError::NotCommitteeMember)));
+
+    // keep the synchronizer's task alive until the vote has been processed
+    drop(task_manager);
     Ok(())
 }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -208,6 +208,9 @@ pub enum HeaderError {
     /// The author is not in the current committee.
     #[error("Received message from unknown authority {0}")]
     UnknownAuthority(String),
+    /// This node is not a member of the current committee and cannot vote.
+    #[error("This node is not a committee member and cannot vote")]
+    NotCommitteeMember,
     /// Worker's ID is not in the cache.
     #[error("Header has an unknown worker ID")]
     UnkownWorkerId,


### PR DESCRIPTION
Fixes #803.

## Problem

`vote()` and `vote_inner()` in the primary network handler each called
`self.consensus_config.authority_id().expect("only validators can vote")` (three sites).
`authority_id()` returns `None` for any node that is not a member of the current committee
(an observer / non-validator). The `RequestHandler` that serves the inbound vote RPC is
constructed and spawned on every node, and there is no upstream gate that filters the vote
path by this node's own committee membership. A committee peer (misrouted or malicious) can
therefore drive a non-validator node into that `expect` and crash it: a remote panic / node
halt. Even where current routing makes this unlikely, an RPC handler that processes peer
input should never panic, and the `expect` also violates the no-`expect`-on-runtime-conditions
convention.

## Changes

- Add `HeaderError::NotCommitteeMember` ("This node is not a committee member and cannot
  vote").
- Replace the three `.expect("only validators can vote")` calls in
  `crates/consensus/primary/src/network/handler.rs` with
  `.ok_or(HeaderError::NotCommitteeMember)?`. A non-validator now returns a graceful error
  instead of aborting the process. The `?` converts to `PrimaryNetworkError` through the
  existing `InvalidHeader(#[from] HeaderError)` conversion, so no signature changes are
  needed.
- Classify `NotCommitteeMember` as no penalty in `penalty_from_header_error`. The failure is
  this node's own non-membership, so the honest requesting peer must not be penalized for it.
  Reusing the existing `UnknownAuthority` variant (which maps to `Penalty::Fatal`) would have
  wrongly banned the requesting peer.
- Add `test_vote_non_committee_member_returns_error`: it builds a handler whose
  `authority_id()` is `None` (an outsider key over the same committee) and asserts that a
  valid vote request returns `Err(NotCommitteeMember)` rather than panicking. This test aborts
  the process under the old code and passes only with the fix.

## Notes

- No behavior change for validators. When the node is in the committee, `.ok_or(..)?` yields
  the identical `AuthorityIdentifier` that `.expect()` returned.
- All three sites are guarded (the quick recast path, the same-round re-vote path, and the
  fresh-vote path), so any future caller of these paths is also panic-safe.
