### PR TITLE
fix: stop remove_validator_ip from over-decrementing banned total (#809)

### DIFF
--- a/crates/network-libp2p/src/peers/banned.rs
+++ b/crates/network-libp2p/src/peers/banned.rs
@@ -62,6 +62,11 @@ impl BannedPeers {
     /// This method is a precaution to ensure a committee member's IP address won't become
     /// blocked during initial connection. It's possible the IP address becomes banned again,
     /// but the validator won't be disconnected because it is a trusted peer.
+    ///
+    /// This only mutates `banned_peers_by_ip`. The peer-level `total` is owned by
+    /// [`Self::remove_banned_peer`] and is deliberately left untouched here: removing an IP-map
+    /// entry unbans no peer, so decrementing `total` per entry over-counts the unban and, across
+    /// committee rotations, floors `total` at 0 and silently disables ban-set pruning (issue #809).
     pub(super) fn remove_validator_ip(
         &mut self,
         peer_id: &PeerId,
@@ -70,9 +75,8 @@ impl BannedPeers {
         debug!(target: "peer-manager", ips=?self.banned_peers_by_ip, "filtering banned ips for validators");
         for ip in ip_addresses {
             debug!(target: "peer-manager", ?ip, "removing banned ip for validator");
-            if let Some((_, _)) = self.banned_peers_by_ip.remove_entry(&ip) {
+            if self.banned_peers_by_ip.remove(&ip).is_some() {
                 warn!(target: "peer-manager", ?peer_id, "removed banned ip address associated with validator");
-                self.total = self.total.saturating_sub(1);
             }
         }
     }

--- a/crates/network-libp2p/src/tests/banned_peers.rs
+++ b/crates/network-libp2p/src/tests/banned_peers.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::common::{ensure_score_config, random_ip_addr};
-use libp2p::{multiaddr::Protocol, Multiaddr};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use std::net::Ipv4Addr;
 
 /// Helper function to create a peer with specific IP addresses.
@@ -249,4 +249,68 @@ fn test_saturating_operations() {
     assert_eq!(banned_peers.total(), 0);
     // assert ip unbanned
     assert!(!banned_peers.ip_banned(&ip));
+}
+
+/// Regression for #809: `remove_validator_ip` is an IP-map cleanup and must not change the
+/// peer-level `total`. This mirrors the committee-rotation path: a banned validator is first
+/// unbanned by `remove_banned_peer` (the single, correct `-1`), then its lingering count-0 IP
+/// entries are swept by `remove_validator_ip`. Previously that sweep decremented `total` once
+/// per removed entry, over-counting the unban by the validator's IP count.
+#[test]
+fn test_remove_validator_ip_does_not_decrement_total() {
+    let mut banned_peers = BannedPeers::default();
+
+    // three unrelated background bans so a spurious decrement is visible rather than floored to
+    // 0 by saturating_sub
+    for _ in 0..3 {
+        let background = create_peer_with_ips(vec![random_ip_addr()]);
+        banned_peers.add_banned_peer(&background);
+    }
+    assert_eq!(banned_peers.total(), 3);
+
+    // a validator whose two IPs are present in the banned-ip map
+    let ip_a = random_ip_addr();
+    let ip_b = random_ip_addr();
+    let validator = create_peer_with_ips(vec![ip_a, ip_b]);
+    banned_peers.add_banned_peer(&validator);
+    assert_eq!(banned_peers.total(), 4);
+
+    // the rotation path unbans the peer first; this owns the single, correct decrement and leaves
+    // the two IP keys behind at count 0
+    banned_peers.remove_banned_peer(vec![ip_a, ip_b].into_iter());
+    assert_eq!(banned_peers.total(), 3, "remove_banned_peer owns the single -1");
+
+    // then the validator-IP cleanup sweeps those count-0 entries. it must not touch `total`.
+    // before the fix this decremented once per entry, driving total to 1.
+    banned_peers.remove_validator_ip(&PeerId::random(), vec![ip_a, ip_b].into_iter());
+
+    assert_eq!(banned_peers.total(), 3, "remove_validator_ip must not change the banned total");
+    // and it still does its real job: the validator's IP entries are gone from the map (asserted
+    // directly because a count-0 entry is indistinguishable from an absent one via ip_banned)
+    assert!(!banned_peers.banned_peers_by_ip.contains_key(&ip_a));
+    assert!(!banned_peers.banned_peers_by_ip.contains_key(&ip_b));
+}
+
+/// Regression for #809 (co-located variant): clearing a never-banned committee member's IP must
+/// not decrement `total` even when that IP entry exists because a different, still-banned peer
+/// shares it. This is why guarding only the call site is insufficient: the spurious decrement
+/// also fires for members that were never banned.
+#[test]
+fn test_remove_validator_ip_for_never_banned_member_preserves_total() {
+    let mut banned_peers = BannedPeers::default();
+    let shared_ip = random_ip_addr();
+
+    // a still-banned peer occupying the shared IP (below the per-IP block threshold)
+    let attacker = create_peer_with_ips(vec![shared_ip]);
+    banned_peers.add_banned_peer(&attacker);
+    assert_eq!(banned_peers.total(), 1);
+
+    // a never-banned committee member co-located on the same IP gets its validator IP cleared
+    banned_peers.remove_validator_ip(&PeerId::random(), vec![shared_ip].into_iter());
+
+    assert_eq!(
+        banned_peers.total(),
+        1,
+        "clearing a never-banned validator IP must not change the banned total"
+    );
 }


### PR DESCRIPTION
## What

`BannedPeers::remove_validator_ip` is an IP-map cleanup: its job is to clear a
committee member's IPs from `banned_peers_by_ip` so a validator's IP is not blocked.
It also decremented the peer-level `total` once for **every IP entry** it removed
(`banned.rs:75`).   Removing an IP-map entry unbans no peer, so that decrement is wrong
in every call path.

`total` is only ever written by `add_banned_peer` (+1) and `remove_banned_peer` (-1);
the bug added a spurious third write in `remove_validator_ip` (pre-fix `banned.rs:75`)
that this PR removes.  `total` is never re-derived from the live peer set, so the error
is not self-correcting.   It feeds
`prune_banned_peers`, which sizes the prune **entirely** from `total()`
(`all_peers.rs:1033`).   Across committee rotations the over-decrements accumulate
monotonically and `saturating_sub` floors `total` at 0, so `excess` is always 0,
pruning never fires, and the banned-peer set grows unbounded, defeating the stated
"prevent exhausting memory" purpose.

Two ways the spurious decrement is reached:
1. A banned committee member at a rotation is unbanned by `remove_banned_peer` (correct
   `-1`), then `apply_committee_membership` (`all_peers.rs:1212`) runs
   `remove_validator_ip` over its lingering count-0 IP keys, decrementing `total` by an
   extra `K` (the member's known-IP count).
2. A never-banned member co-located on an IP with a still-banned peer: clearing the
   member's IP wipes the shared entry and decrements `total` even though the member
   contributed nothing.   (This is why guarding only the call site is insufficient.)

## Change

- `crates/network-libp2p/src/peers/banned.rs`: delete the `self.total -= 1` from
  `remove_validator_ip`;  the method now only mutates `banned_peers_by_ip`
  (`remove_entry` -> `remove`, since both halves were discarded).   Doc comment updated to
  record the invariant: `total` is owned by `remove_banned_peer` and must not be touched
  here.
- `crates/network-libp2p/src/tests/banned_peers.rs`: two regression tests -
  `test_remove_validator_ip_does_not_decrement_total` (mirrors the rotation path: ban,
  `remove_banned_peer`, then `remove_validator_ip`; asserts `total` unchanged) and
  `test_remove_validator_ip_for_never_banned_member_preserves_total` (the co-located
  variant).  Both fail on the pre-fix code and pass after.

## Notes

- Independent of #807 (the #799 heap-direction fix): that PR touches
  `collect_excess_peers` in `all_peers.rs`;  this one touches only `banned.rs` plus its
  unit tests, so there is no file overlap or conflict.
- Optional follow-up (not included, to keep this minimal): have `remove_banned_peer`
  drop count-0 keys so the map does not retain stale zero entries.

Closes #809.
