### PR TITLE
refactor: push non-validator txns to committee via RPC instead of gossip

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -417,6 +417,7 @@ mod tests {
             store.clone(),
             timeout,
             WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+            Vec::new(),
         );
         block_provider.spawn_batch_builder("test batch builder", &task_manager);
 

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -372,8 +372,8 @@ mod tests {
     use tn_storage::{open_db, tables::NodeBatchesCache};
     use tn_types::{
         gas_accumulator::GasAccumulator, test_genesis, Bytes, Certificate, CommittedSubDag,
-        ConsensusHeaderDigest, ConsensusOutput, Database, GenesisAccount, TaskManager,
-        MIN_PROTOCOL_BASE_FEE, U160, U256,
+        ConsensusHeaderDigest, ConsensusOutput, Database, GenesisAccount, NoopTxnForwarder,
+        TaskManager, MIN_PROTOCOL_BASE_FEE, U160, U256,
     };
     use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
     use tokio::time::timeout;
@@ -417,6 +417,7 @@ mod tests {
             store.clone(),
             timeout,
             WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+            Arc::new(NoopTxnForwarder),
             Vec::new(),
         );
         block_provider.spawn_batch_builder("test batch builder", &task_manager);

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -19,7 +19,8 @@ use tn_types::{
     gas_accumulator::{BaseFeeContainer, GasAccumulator},
     test_genesis, Address, Batch, BatchValidation, Bytes, Certificate, CertifiedBatch,
     CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database, Encodable2718,
-    GenesisAccount, ReputationScores, SealedBatch, TaskManager, MIN_PROTOCOL_BASE_FEE, U160, U256,
+    GenesisAccount, NoopTxnForwarder, ReputationScores, SealedBatch, TaskManager,
+    MIN_PROTOCOL_BASE_FEE, U160, U256,
 };
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
 use tokio::time::timeout;
@@ -51,6 +52,7 @@ async fn test_make_batch_el_to_cl() {
         store.clone(),
         timeout,
         WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+        Arc::new(NoopTxnForwarder),
         Vec::new(),
     );
     batch_provider.spawn_batch_builder("test builder", &task_manager);

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -51,6 +51,7 @@ async fn test_make_batch_el_to_cl() {
         store.clone(),
         timeout,
         WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+        Vec::new(),
     );
     batch_provider.spawn_batch_builder("test builder", &task_manager);
 

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -170,11 +170,6 @@ impl LibP2pConfig {
     pub fn worker_batch_topic(chain_id: u64) -> String {
         format!("tn-worker-{chain_id}")
     }
-
-    /// Return the worker-transaction gossip topic for `chain_id`.
-    pub fn worker_txn_topic(chain_id: u64) -> String {
-        format!("tn-txn-{chain_id}")
-    }
 }
 
 impl Default for LibP2pConfig {
@@ -568,7 +563,6 @@ hostname: "my-validator"
         assert_eq!(LibP2pConfig::consensus_output_topic(2017), "tn-consensus-output-2017");
         assert_eq!(LibP2pConfig::epoch_vote_topic(2017), "tn-epoch-vote-2017");
         assert_eq!(LibP2pConfig::worker_batch_topic(2017), "tn-worker-2017");
-        assert_eq!(LibP2pConfig::worker_txn_topic(2017), "tn-txn-2017");
         // a different chain id yields a different topic
         assert_ne!(LibP2pConfig::primary_topic(1), LibP2pConfig::primary_topic(2));
     }

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -19,8 +19,8 @@ use tn_network_libp2p::{
     write_frame, Penalty, StreamError, StreamKind, SyncFrame, WorkerSyncRequest,
 };
 use tn_types::{
-    encode, max_batch_size, try_decode, Batch, BlockHash, BlsPublicKey, Epoch, SealedBatch,
-    TaskSpawner, B256,
+    encode, max_batch_size, try_decode, Batch, BlockHash, BlsPublicKey, Epoch, RpcInfo,
+    SealedBatch, TaskSpawner, B256,
 };
 use tracing::{debug, warn};
 
@@ -122,36 +122,16 @@ impl WorkerNetworkHandle {
         Ok(())
     }
 
-    /// Push transactions (as raw bytes) to a committee member via direct RPC.
+    /// Snapshot of every committee validator's advertised JSON-RPC endpoint, discovered over
+    /// kademlia.
     ///
-    /// Use this when not a committee member so a committee validator can include the
-    /// transactions in a batch. This replaces the previous gossip broadcast (issue #804):
-    /// the request is routed to `peer_bls` over the (KAD-discovered) request/response
-    /// protocol instead of flooded on a gossip topic.
-    pub(crate) async fn report_txns(
+    /// A non-committee ("observer") worker uses this to forward the transactions it accepts to
+    /// the validators that own them (issue #804), instead of pushing them over the worker
+    /// protocol. Returns an empty list if no validator has advertised an endpoint.
+    pub(crate) async fn get_all_validator_rpcs(
         &self,
-        peer_bls: BlsPublicKey,
-        transactions: Vec<Vec<u8>>,
-    ) -> NetworkResult<()> {
-        let request = WorkerRequest::ReportTxns { transactions };
-        let res = self.handle.send_request(request, peer_bls).await?;
-        let res = res.await??.result;
-        match res {
-            WorkerResponse::ReportTxns => Ok(()),
-            WorkerResponse::ReportBatch => Err(NetworkError::RPCError(
-                "Got wrong response, not a report txns is report batch!".to_string(),
-            )),
-            WorkerResponse::RequestBatchesStream { .. } => Err(NetworkError::RPCError(
-                "Got wrong response, not a report txns is stream ack!".to_string(),
-            )),
-            WorkerResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
-                "Got wrong response, not a report txns is peer exchange!".to_string(),
-            )),
-            WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
-            WorkerResponse::RecoverableError(WorkerRPCError(s)) => {
-                Err(NetworkError::RPCRetryable(s))
-            }
-        }
+    ) -> NetworkResult<Vec<(BlsPublicKey, RpcInfo)>> {
+        self.handle.get_all_validator_rpcs().await
     }
 
     /// Report a new batch to a peer.
@@ -165,9 +145,6 @@ impl WorkerNetworkHandle {
         let res = res.await??.result;
         match res {
             WorkerResponse::ReportBatch => Ok(()),
-            WorkerResponse::ReportTxns => Err(NetworkError::RPCError(
-                "Got wrong response, not a report batch is report txns!".to_string(),
-            )),
             WorkerResponse::RequestBatchesStream { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a report batch is stream ack!".to_string(),
             )),
@@ -600,9 +577,6 @@ impl WorkerNetworkHandle {
             }
             WorkerResponse::ReportBatch => Err(NetworkError::RPCError(
                 "Got wrong response: report batch instead of stream ack".to_string(),
-            )),
-            WorkerResponse::ReportTxns => Err(NetworkError::RPCError(
-                "Got wrong response: report txns instead of stream ack".to_string(),
             )),
             WorkerResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
                 "Got wrong response: peer exchange instead of stream ack".to_string(),

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -122,12 +122,36 @@ impl WorkerNetworkHandle {
         Ok(())
     }
 
-    /// Publish a transaction (as raw bytes) worker network.
-    /// Do this when not a committee member so a CVV can include the txn.
-    pub(crate) async fn publish_txn(&self, txn: Vec<u8>) -> NetworkResult<()> {
-        let data = encode(&WorkerGossip::Txn(txn));
-        self.handle.publish(tn_config::LibP2pConfig::worker_txn_topic(self.chain_id), data).await?;
-        Ok(())
+    /// Push transactions (as raw bytes) to a committee member via direct RPC.
+    ///
+    /// Use this when not a committee member so a committee validator can include the
+    /// transactions in a batch. This replaces the previous gossip broadcast (issue #804):
+    /// the request is routed to `peer_bls` over the (KAD-discovered) request/response
+    /// protocol instead of flooded on a gossip topic.
+    pub(crate) async fn report_txns(
+        &self,
+        peer_bls: BlsPublicKey,
+        transactions: Vec<Vec<u8>>,
+    ) -> NetworkResult<()> {
+        let request = WorkerRequest::ReportTxns { transactions };
+        let res = self.handle.send_request(request, peer_bls).await?;
+        let res = res.await??.result;
+        match res {
+            WorkerResponse::ReportTxns => Ok(()),
+            WorkerResponse::ReportBatch => Err(NetworkError::RPCError(
+                "Got wrong response, not a report txns is report batch!".to_string(),
+            )),
+            WorkerResponse::RequestBatchesStream { .. } => Err(NetworkError::RPCError(
+                "Got wrong response, not a report txns is stream ack!".to_string(),
+            )),
+            WorkerResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
+                "Got wrong response, not a report txns is peer exchange!".to_string(),
+            )),
+            WorkerResponse::Error(WorkerRPCError(s)) => Err(NetworkError::RPCError(s)),
+            WorkerResponse::RecoverableError(WorkerRPCError(s)) => {
+                Err(NetworkError::RPCRetryable(s))
+            }
+        }
     }
 
     /// Report a new batch to a peer.
@@ -141,6 +165,9 @@ impl WorkerNetworkHandle {
         let res = res.await??.result;
         match res {
             WorkerResponse::ReportBatch => Ok(()),
+            WorkerResponse::ReportTxns => Err(NetworkError::RPCError(
+                "Got wrong response, not a report batch is report txns!".to_string(),
+            )),
             WorkerResponse::RequestBatchesStream { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a report batch is stream ack!".to_string(),
             )),
@@ -573,6 +600,9 @@ impl WorkerNetworkHandle {
             }
             WorkerResponse::ReportBatch => Err(NetworkError::RPCError(
                 "Got wrong response: report batch instead of stream ack".to_string(),
+            )),
+            WorkerResponse::ReportTxns => Err(NetworkError::RPCError(
+                "Got wrong response: report txns instead of stream ack".to_string(),
             )),
             WorkerResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
                 "Got wrong response: peer exchange instead of stream ack".to_string(),

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -28,15 +28,6 @@ use tracing::{debug, warn};
 /// Set for 500MB through emerging market worse-case 20MB/s upload
 const SEND_STREAM_TIMEOUT: Duration = Duration::from_secs(200);
 
-/// Maximum number of transactions accepted in a single [`WorkerRequest::ReportTxns`].
-///
-/// A legitimately built batch is gas-bounded to far fewer transactions than this
-/// (`max_batch_gas` / a transaction's intrinsic gas), so this only rejects abusive
-/// requests that pack the RPC frame with transactions to amplify signature-recovery work
-/// on the recipient. Over-limit requests are rejected and penalized so peer scoring can
-/// throttle a flooder (parity with the gossip mesh's peer scoring).
-const MAX_TXNS_PER_REPORT: usize = 5_000;
-
 /// The type that handles requests from peers.
 ///
 /// An instance is cloned for each request and used in a spawned task.
@@ -137,37 +128,6 @@ where
                             tracing::error!(target: "worker:network", "failed to get gossipped batch {batch_hash}: {e}");
                         }
                     }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Process transactions pushed by a peer for committee inclusion.
-    ///
-    /// This is the RPC replacement for the retired `WorkerGossip::Txn` path (issue #804):
-    /// only committee members act, and each keeps only the transactions that fall in its
-    /// own committee shard via `submit_txn_if_mine`. A non-committee recipient (or a member
-    /// that cannot locate its own slot) simply ignores the request.
-    pub(super) async fn process_report_txns(
-        &self,
-        transactions: Vec<Vec<u8>>,
-    ) -> WorkerNetworkResult<()> {
-        ensure!(
-            transactions.len() <= MAX_TXNS_PER_REPORT,
-            WorkerNetworkError::InvalidRequest(format!(
-                "ReportTxns exceeds max transactions: {} > {MAX_TXNS_PER_REPORT}",
-                transactions.len()
-            ))
-        );
-        if let Some(authority) = self.consensus_config.authority() {
-            let committee = self.consensus_config.committee();
-            let authorities = committee.authorities();
-            let size = authorities.len();
-            if let Some(slot) = authorities.into_iter().position(|auth| &auth == authority) {
-                for tx_bytes in &transactions {
-                    self.validator.submit_txn_if_mine(tx_bytes, size as u64, slot as u64);
                 }
             }
         }
@@ -363,15 +323,6 @@ where
         msg: &GossipMessage,
     ) -> WorkerNetworkResult<()> {
         self.process_gossip(msg).await
-    }
-
-    /// Publicly available for tests.
-    /// See [Self::process_report_txns].
-    pub async fn pub_process_report_txns(
-        &self,
-        transactions: Vec<Vec<u8>>,
-    ) -> WorkerNetworkResult<()> {
-        self.process_report_txns(transactions).await
     }
 
     /// Publicly available for tests.

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -28,6 +28,15 @@ use tracing::{debug, warn};
 /// Set for 500MB through emerging market worse-case 20MB/s upload
 const SEND_STREAM_TIMEOUT: Duration = Duration::from_secs(200);
 
+/// Maximum number of transactions accepted in a single [`WorkerRequest::ReportTxns`].
+///
+/// A legitimately built batch is gas-bounded to far fewer transactions than this
+/// (`max_batch_gas` / a transaction's intrinsic gas), so this only rejects abusive
+/// requests that pack the RPC frame with transactions to amplify signature-recovery work
+/// on the recipient. Over-limit requests are rejected and penalized so peer scoring can
+/// throttle a flooder (parity with the gossip mesh's peer scoring).
+const MAX_TXNS_PER_REPORT: usize = 5_000;
+
 /// The type that handles requests from peers.
 ///
 /// An instance is cloned for each request and used in a spawned task.
@@ -130,23 +139,35 @@ where
                     }
                 }
             }
-            WorkerGossip::Txn(tx_bytes) => {
-                ensure!(
-                    topic.to_string().eq(&tn_config::LibP2pConfig::worker_txn_topic(
-                        self.consensus_config.chain_id()
-                    )),
-                    WorkerNetworkError::InvalidTopic
-                );
-                if let Some(authority) = self.consensus_config.authority() {
-                    let committee = self.consensus_config.committee();
-                    let authorities = committee.authorities();
-                    let size = authorities.len();
-                    for (slot, auth) in authorities.into_iter().enumerate() {
-                        if &auth == authority {
-                            self.validator.submit_txn_if_mine(&tx_bytes, size as u64, slot as u64);
-                            break;
-                        }
-                    }
+        }
+
+        Ok(())
+    }
+
+    /// Process transactions pushed by a peer for committee inclusion.
+    ///
+    /// This is the RPC replacement for the retired `WorkerGossip::Txn` path (issue #804):
+    /// only committee members act, and each keeps only the transactions that fall in its
+    /// own committee shard via `submit_txn_if_mine`. A non-committee recipient (or a member
+    /// that cannot locate its own slot) simply ignores the request.
+    pub(super) async fn process_report_txns(
+        &self,
+        transactions: Vec<Vec<u8>>,
+    ) -> WorkerNetworkResult<()> {
+        ensure!(
+            transactions.len() <= MAX_TXNS_PER_REPORT,
+            WorkerNetworkError::InvalidRequest(format!(
+                "ReportTxns exceeds max transactions: {} > {MAX_TXNS_PER_REPORT}",
+                transactions.len()
+            ))
+        );
+        if let Some(authority) = self.consensus_config.authority() {
+            let committee = self.consensus_config.committee();
+            let authorities = committee.authorities();
+            let size = authorities.len();
+            if let Some(slot) = authorities.into_iter().position(|auth| &auth == authority) {
+                for tx_bytes in &transactions {
+                    self.validator.submit_txn_if_mine(tx_bytes, size as u64, slot as u64);
                 }
             }
         }
@@ -342,6 +363,15 @@ where
         msg: &GossipMessage,
     ) -> WorkerNetworkResult<()> {
         self.process_gossip(msg).await
+    }
+
+    /// Publicly available for tests.
+    /// See [Self::process_report_txns].
+    pub async fn pub_process_report_txns(
+        &self,
+        transactions: Vec<Vec<u8>>,
+    ) -> WorkerNetworkResult<()> {
+        self.process_report_txns(transactions).await
     }
 
     /// Publicly available for tests.

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -59,19 +59,6 @@ pub enum WorkerRequest {
         /// The peer information being exchanged.
         peers: PeerExchangeMap,
     },
-    /// Push transactions to a committee member for inclusion in a batch.
-    ///
-    /// Sent by non-committee workers so a committee validator can include the
-    /// transactions they accept, replacing the previous gossip broadcast. Each
-    /// recipient independently keeps only the transactions that fall in its own
-    /// committee shard (see `submit_txn_if_mine`).
-    ///
-    /// Appended last so that adding it does not shift the serialized variant
-    /// discriminants of the existing variants (wire compatibility).
-    ReportTxns {
-        /// The raw (encoded) transactions being submitted.
-        transactions: Vec<Vec<u8>>,
-    },
 }
 
 impl From<PeerExchangeMap> for WorkerRequest {
@@ -118,11 +105,6 @@ pub enum WorkerResponse {
     /// likely to succeed in the future, so the requester should retry rather
     /// than give up on the peer.
     RecoverableError(WorkerRPCError),
-    /// Status 200 response when a peer accepts pushed transactions.
-    ///
-    /// Appended last so that adding it does not shift the serialized variant
-    /// discriminants of the existing variants (wire compatibility).
-    ReportTxns,
 }
 
 impl WorkerResponse {

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -10,10 +10,8 @@ use tn_types::{BlockHash, Epoch, SealedBatch};
 /// Worker messages on the gossip network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WorkerGossip {
-    /// A new is available.
+    /// A new batch digest is available so non-committee peers can fetch it.
     Batch(Epoch, BlockHash),
-    /// Transaction- published so a committee member can include in a batch.
-    Txn(Vec<u8>),
 }
 
 // impl TNMessage trait for types
@@ -61,6 +59,19 @@ pub enum WorkerRequest {
         /// The peer information being exchanged.
         peers: PeerExchangeMap,
     },
+    /// Push transactions to a committee member for inclusion in a batch.
+    ///
+    /// Sent by non-committee workers so a committee validator can include the
+    /// transactions they accept, replacing the previous gossip broadcast. Each
+    /// recipient independently keeps only the transactions that fall in its own
+    /// committee shard (see `submit_txn_if_mine`).
+    ///
+    /// Appended last so that adding it does not shift the serialized variant
+    /// discriminants of the existing variants (wire compatibility).
+    ReportTxns {
+        /// The raw (encoded) transactions being submitted.
+        transactions: Vec<Vec<u8>>,
+    },
 }
 
 impl From<PeerExchangeMap> for WorkerRequest {
@@ -107,6 +118,11 @@ pub enum WorkerResponse {
     /// likely to succeed in the future, so the requester should retry rather
     /// than give up on the peer.
     RecoverableError(WorkerRPCError),
+    /// Status 200 response when a peer accepts pushed transactions.
+    ///
+    /// Appended last so that adding it does not shift the serialized variant
+    /// discriminants of the existing variants (wire compatibility).
+    ReportTxns,
 }
 
 impl WorkerResponse {

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -263,6 +263,9 @@ where
                 WorkerRequest::ReportBatch { sealed_batch } => {
                     self.process_report_batch(peer, sealed_batch, channel, cancel);
                 }
+                WorkerRequest::ReportTxns { transactions } => {
+                    self.process_report_txns(peer, transactions, channel, cancel);
+                }
                 WorkerRequest::RequestBatchesStream { batch_digests, epoch } => {
                     self.process_request_batches_stream(
                         peer,
@@ -321,6 +324,44 @@ where
                             // classify transient responder-side conditions as
                             // recoverable so the requester retries instead of
                             // treating this as a permanent rejection
+                            let response = WorkerResponse::into_error_ref(&err);
+                            if let Some(penalty) = err.into() {
+                                network_handle.report_penalty(peer, penalty).await;
+                            }
+                            response
+                        }
+                    };
+                    let _ = network_handle.inner_handle().send_response(response, channel).await;
+                },
+                // cancel notification from network layer
+                _ = cancel => (),
+            }
+            Ok(())
+        });
+    }
+
+    /// Process transactions pushed by a peer for committee inclusion.
+    ///
+    /// Spawn a task that hands the transactions to the request handler and acks the peer.
+    fn process_report_txns(
+        &self,
+        peer: BlsPublicKey,
+        transactions: Vec<Vec<u8>>,
+        channel: ResponseChannel<WorkerResponse>,
+        cancel: oneshot::Receiver<()>,
+    ) {
+        // clone for spawned tasks
+        let request_handler = self.request_handler.clone();
+        let network_handle = self.network_handle.clone();
+        self.network_handle.get_task_spawner().spawn_task("process-report-txns", async move {
+            tokio::select! {
+                res = request_handler.process_report_txns(transactions) => {
+                    let response = match res {
+                        Ok(()) => WorkerResponse::ReportTxns,
+                        Err(err) => {
+                            // classify transient responder-side conditions as recoverable so
+                            // the requester retries instead of treating this as a rejection,
+                            // and penalize a peer whose request was invalid (e.g. oversized)
                             let response = WorkerResponse::into_error_ref(&err);
                             if let Some(penalty) = err.into() {
                                 network_handle.report_penalty(peer, penalty).await;

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -263,9 +263,6 @@ where
                 WorkerRequest::ReportBatch { sealed_batch } => {
                     self.process_report_batch(peer, sealed_batch, channel, cancel);
                 }
-                WorkerRequest::ReportTxns { transactions } => {
-                    self.process_report_txns(peer, transactions, channel, cancel);
-                }
                 WorkerRequest::RequestBatchesStream { batch_digests, epoch } => {
                     self.process_request_batches_stream(
                         peer,
@@ -324,44 +321,6 @@ where
                             // classify transient responder-side conditions as
                             // recoverable so the requester retries instead of
                             // treating this as a permanent rejection
-                            let response = WorkerResponse::into_error_ref(&err);
-                            if let Some(penalty) = err.into() {
-                                network_handle.report_penalty(peer, penalty).await;
-                            }
-                            response
-                        }
-                    };
-                    let _ = network_handle.inner_handle().send_response(response, channel).await;
-                },
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
-        });
-    }
-
-    /// Process transactions pushed by a peer for committee inclusion.
-    ///
-    /// Spawn a task that hands the transactions to the request handler and acks the peer.
-    fn process_report_txns(
-        &self,
-        peer: BlsPublicKey,
-        transactions: Vec<Vec<u8>>,
-        channel: ResponseChannel<WorkerResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        // clone for spawned tasks
-        let request_handler = self.request_handler.clone();
-        let network_handle = self.network_handle.clone();
-        self.network_handle.get_task_spawner().spawn_task("process-report-txns", async move {
-            tokio::select! {
-                res = request_handler.process_report_txns(transactions) => {
-                    let response = match res {
-                        Ok(()) => WorkerResponse::ReportTxns,
-                        Err(err) => {
-                            // classify transient responder-side conditions as recoverable so
-                            // the requester retries instead of treating this as a rejection,
-                            // and penalize a peer whose request was invalid (e.g. oversized)
                             let response = WorkerResponse::into_error_ref(&err);
                             if let Some(penalty) = err.into() {
                                 network_handle.report_penalty(peer, penalty).await;

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -10,10 +10,8 @@ use crate::{
     quorum_waiter::{QuorumWaiter, QuorumWaiterTrait},
     WorkerNetworkHandle,
 };
-use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use std::{sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
-use tn_network_libp2p::error::NetworkError;
 use tn_network_types::{local::LocalNetwork, WorkerOwnBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{
     consensus::ConsensusChain,
@@ -21,18 +19,12 @@ use tn_storage::{
 };
 use tn_types::{
     error::BlockSealError, BatchReceiver, BatchSender, BatchValidation, BlsPublicKey, Database,
-    SealedBatch, TaskManager, WorkerId,
+    SealedBatch, TaskManager, TxnForwarder, WorkerId,
 };
 use tracing::{error, info, instrument, warn};
 
 /// The default channel capacity for each channel of the worker.
 pub const CHANNEL_CAPACITY: usize = 1_000;
-
-/// Maximum number of attempts to push transactions to a single committee member.
-const MAX_TXN_PUSH_ATTEMPTS: u32 = 3;
-
-/// Base backoff between transaction-push retries (doubles each attempt).
-const TXN_PUSH_RETRY_BACKOFF: Duration = Duration::from_millis(200);
 
 /// Spawn the worker.
 ///
@@ -42,6 +34,7 @@ pub fn new_worker<DB: Database>(
     validator: Arc<dyn BatchValidation>,
     consensus_config: ConsensusConfig<DB>,
     network_handle: WorkerNetworkHandle,
+    forwarder: Arc<dyn TxnForwarder>,
     consensus_chain: ConsensusChain,
 ) -> Worker<DB, QuorumWaiter> {
     info!(target: "worker::worker", "Boot worker node with id {} key {:?}", id, consensus_config.key_config().primary_public_key());
@@ -65,6 +58,7 @@ pub fn new_worker<DB: Database>(
         &consensus_config,
         consensus_config.local_network().clone(),
         network_handle.clone(),
+        forwarder,
     );
 
     // NOTE: This log entry is used to compute performance.
@@ -83,6 +77,7 @@ fn new_worker_internal<DB: Database>(
     consensus_config: &ConsensusConfig<DB>,
     client: LocalNetwork,
     network_handle: WorkerNetworkHandle,
+    forwarder: Arc<dyn TxnForwarder>,
 ) -> Worker<DB, QuorumWaiter> {
     info!(target: "worker::worker", "Starting handler for transactions");
 
@@ -98,15 +93,16 @@ fn new_worker_internal<DB: Database>(
         )
     });
 
-    // Committee validators to push accepted transactions to when this node is not a CVV.
-    // A non-committee node (`authority()` is `None`) pushes to every committee member; a
-    // committee member excludes itself.
-    let committee_txn_targets = match consensus_config.authority() {
-        Some(authority) => {
-            consensus_config.committee().others_keys_except(authority.protocol_key())
-        }
-        None => consensus_config.committee().bls_keys().into_iter().collect(),
-    };
+    // Committee BLS keys in slot order (index == committee slot). A non-committee ("observer")
+    // worker forwards each transaction it accepts to the JSON-RPC endpoint advertised by the
+    // validator whose slot owns the sender, matching `submit_txn_if_mine` so nonce ordering is
+    // preserved (issue #804).
+    let committee_slots: Vec<BlsPublicKey> = consensus_config
+        .committee()
+        .authorities()
+        .iter()
+        .map(|authority| authority.protocol_key().clone())
+        .collect();
 
     Worker::new(
         id,
@@ -115,7 +111,8 @@ fn new_worker_internal<DB: Database>(
         consensus_config.node_storage().clone(),
         consensus_config.parameters().batch_vote_timeout,
         network_handle,
-        committee_txn_targets,
+        forwarder,
+        committee_slots,
     )
 }
 
@@ -138,12 +135,14 @@ pub struct Worker<DB, QW> {
     timeout: Duration,
     /// Worker network handle.
     network_handle: WorkerNetworkHandle,
-    /// Committee validators to push accepted transactions to when this node is not a
-    /// committee voting validator.
+    /// Forwards transactions this node accepts to committee validators over their advertised
+    /// JSON-RPC endpoints when this node is not a committee voting validator (issue #804).
+    forwarder: Arc<dyn TxnForwarder>,
+    /// Committee BLS keys in slot order (index == committee slot).
     ///
-    /// Populated once per epoch at construction (issue #804): non-CVV workers push the
-    /// transactions they accept to these peers over RPC instead of gossiping them.
-    committee_txn_targets: Vec<BlsPublicKey>,
+    /// Populated once per epoch at construction: a non-CVV worker forwards each transaction it
+    /// accepts to the validator whose slot owns the sender, so nonce ordering is preserved.
+    committee_slots: Vec<BlsPublicKey>,
     /// Prometheus metrics for this worker.
     metrics: WorkerMetrics,
 }
@@ -162,7 +161,8 @@ impl<DB: Clone, QW: Clone> Clone for Worker<DB, QW> {
             rx_batches: None,
             timeout: self.timeout,
             network_handle: self.network_handle.clone(),
-            committee_txn_targets: self.committee_txn_targets.clone(),
+            forwarder: self.forwarder.clone(),
+            committee_slots: self.committee_slots.clone(),
             metrics: self.metrics.clone(),
         }
     }
@@ -183,7 +183,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         store: DB,
         timeout: Duration,
         network_handle: WorkerNetworkHandle,
-        committee_txn_targets: Vec<BlsPublicKey>,
+        forwarder: Arc<dyn TxnForwarder>,
+        committee_slots: Vec<BlsPublicKey>,
     ) -> Self {
         let (tx_batches, rx_batches) = tokio::sync::mpsc::channel(1000);
         Self {
@@ -195,7 +196,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             rx_batches: Some(rx_batches),
             timeout,
             network_handle,
-            committee_txn_targets,
+            forwarder,
+            committee_slots,
             metrics: WorkerMetrics::new_for_worker(id),
         }
     }
@@ -231,87 +233,46 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         self.tx_batches.clone()
     }
 
-    /// Send all the txns in `sealed_batch` to committee validators so they can be included
+    /// Forward all the txns in `sealed_batch` to committee validators so they can be included
     /// in blocks. Use this when not a CVV so that transactions you accept can be included.
     ///
-    /// Replaces the previous gossip broadcast with a direct RPC push to each committee
-    /// validator (issue #804). The push is best-effort and runs on a background task so
-    /// batch production is never stalled by a slow or unreachable committee member; each
-    /// recipient independently keeps only the transactions in its own shard.
+    /// Replaces the previous gossip broadcast (issue #804): each transaction is forwarded to the
+    /// JSON-RPC endpoint the owning validator advertised on its worker record, discovered over
+    /// kademlia. Forwarding is best-effort and runs on a background task so batch production is
+    /// never stalled by a slow or unreachable validator.
     pub async fn disburse_txns(&self, sealed_batch: SealedBatch) -> Result<(), BlockSealError> {
         let transactions = sealed_batch.batch.transactions;
-        if transactions.is_empty() || self.committee_txn_targets.is_empty() {
+        if transactions.is_empty() {
             return Ok(());
         }
 
         let network_handle = self.network_handle.clone();
-        let targets = self.committee_txn_targets.clone();
+        let forwarder = self.forwarder.clone();
+        let committee_slots = self.committee_slots.clone();
         self.network_handle.get_task_spawner().spawn_task("disburse-txns", async move {
-            Self::push_txns_to_committee(&network_handle, &targets, transactions).await;
+            match network_handle.get_all_validator_rpcs().await {
+                Ok(validator_rpcs) if !validator_rpcs.is_empty() => {
+                    forwarder.forward_txns(transactions, committee_slots, validator_rpcs);
+                }
+                Ok(_) => {
+                    warn!(
+                        target: "worker::batch_provider",
+                        "no committee validator has advertised a JSON-RPC endpoint; \
+                         cannot forward accepted transactions"
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        target: "worker::batch_provider",
+                        ?err,
+                        "failed to discover validator JSON-RPC endpoints for transaction forwarding"
+                    );
+                }
+            }
             Ok(())
         });
 
         Ok(())
-    }
-
-    /// Push `transactions` to every committee validator in `targets` over RPC concurrently.
-    /// Best-effort: a member that cannot be reached (after retries) simply does not receive
-    /// the transactions this round.
-    async fn push_txns_to_committee(
-        network_handle: &WorkerNetworkHandle,
-        targets: &[BlsPublicKey],
-        transactions: Vec<Vec<u8>>,
-    ) {
-        let mut sends: FuturesUnordered<_> = targets
-            .iter()
-            .map(|&peer| {
-                let network_handle = network_handle.clone();
-                let transactions = transactions.clone();
-                async move { Self::push_txns_to_peer(&network_handle, peer, transactions).await }
-            })
-            .collect();
-
-        while sends.next().await.is_some() {}
-    }
-
-    /// Push `transactions` to a single committee member, retrying transient RPC errors with
-    /// exponential backoff (mirroring the batch-report path so a peer that is briefly
-    /// unreachable at an epoch boundary is not skipped). A permanent rejection
-    /// ([`NetworkError::RPCError`]) is not retried. Both give-up outcomes only warn-log,
-    /// since transaction disbursal is best-effort.
-    async fn push_txns_to_peer(
-        network_handle: &WorkerNetworkHandle,
-        peer: BlsPublicKey,
-        transactions: Vec<Vec<u8>>,
-    ) {
-        for attempt in 0..MAX_TXN_PUSH_ATTEMPTS {
-            match network_handle.report_txns(peer, transactions.clone()).await {
-                Ok(()) => return,
-                // permanent rejection - do not retry
-                Err(NetworkError::RPCError(msg)) => {
-                    warn!(
-                        target: "worker::batch_provider",
-                        %peer,
-                        %msg,
-                        "committee member rejected transaction push"
-                    );
-                    return;
-                }
-                // transient error (RPCRetryable / transport) - retry with backoff
-                Err(err) => {
-                    if attempt + 1 < MAX_TXN_PUSH_ATTEMPTS {
-                        tokio::time::sleep(TXN_PUSH_RETRY_BACKOFF * 2u32.pow(attempt)).await;
-                    } else {
-                        warn!(
-                            target: "worker::batch_provider",
-                            %peer,
-                            ?err,
-                            "failed to push transactions to committee member after retries"
-                        );
-                    }
-                }
-            }
-        }
     }
 
     /// Seal and broadcast the current batch.

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -101,7 +101,7 @@ fn new_worker_internal<DB: Database>(
         .committee()
         .authorities()
         .iter()
-        .map(|authority| authority.protocol_key().clone())
+        .map(|authority| *authority.protocol_key())
         .collect();
 
     Worker::new(
@@ -176,6 +176,7 @@ impl<DB, QW> std::fmt::Debug for Worker<DB, QW> {
 
 impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
     /// Create an instance of `Self`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: WorkerId,
         quorum_waiter: Option<QW>,

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -10,21 +10,29 @@ use crate::{
     quorum_waiter::{QuorumWaiter, QuorumWaiterTrait},
     WorkerNetworkHandle,
 };
+use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use std::{sync::Arc, time::Duration};
 use tn_config::ConsensusConfig;
+use tn_network_libp2p::error::NetworkError;
 use tn_network_types::{local::LocalNetwork, WorkerOwnBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{
     consensus::ConsensusChain,
     tables::{NodeBatchesCache, OurNodeBatchesCache},
 };
 use tn_types::{
-    error::BlockSealError, BatchReceiver, BatchSender, BatchValidation, Database, SealedBatch,
-    TaskManager, WorkerId,
+    error::BlockSealError, BatchReceiver, BatchSender, BatchValidation, BlsPublicKey, Database,
+    SealedBatch, TaskManager, WorkerId,
 };
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 /// The default channel capacity for each channel of the worker.
 pub const CHANNEL_CAPACITY: usize = 1_000;
+
+/// Maximum number of attempts to push transactions to a single committee member.
+const MAX_TXN_PUSH_ATTEMPTS: u32 = 3;
+
+/// Base backoff between transaction-push retries (doubles each attempt).
+const TXN_PUSH_RETRY_BACKOFF: Duration = Duration::from_millis(200);
 
 /// Spawn the worker.
 ///
@@ -90,6 +98,16 @@ fn new_worker_internal<DB: Database>(
         )
     });
 
+    // Committee validators to push accepted transactions to when this node is not a CVV.
+    // A non-committee node (`authority()` is `None`) pushes to every committee member; a
+    // committee member excludes itself.
+    let committee_txn_targets = match consensus_config.authority() {
+        Some(authority) => {
+            consensus_config.committee().others_keys_except(authority.protocol_key())
+        }
+        None => consensus_config.committee().bls_keys().into_iter().collect(),
+    };
+
     Worker::new(
         id,
         quorum_waiter,
@@ -97,6 +115,7 @@ fn new_worker_internal<DB: Database>(
         consensus_config.node_storage().clone(),
         consensus_config.parameters().batch_vote_timeout,
         network_handle,
+        committee_txn_targets,
     )
 }
 
@@ -119,6 +138,12 @@ pub struct Worker<DB, QW> {
     timeout: Duration,
     /// Worker network handle.
     network_handle: WorkerNetworkHandle,
+    /// Committee validators to push accepted transactions to when this node is not a
+    /// committee voting validator.
+    ///
+    /// Populated once per epoch at construction (issue #804): non-CVV workers push the
+    /// transactions they accept to these peers over RPC instead of gossiping them.
+    committee_txn_targets: Vec<BlsPublicKey>,
     /// Prometheus metrics for this worker.
     metrics: WorkerMetrics,
 }
@@ -137,6 +162,7 @@ impl<DB: Clone, QW: Clone> Clone for Worker<DB, QW> {
             rx_batches: None,
             timeout: self.timeout,
             network_handle: self.network_handle.clone(),
+            committee_txn_targets: self.committee_txn_targets.clone(),
             metrics: self.metrics.clone(),
         }
     }
@@ -157,6 +183,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         store: DB,
         timeout: Duration,
         network_handle: WorkerNetworkHandle,
+        committee_txn_targets: Vec<BlsPublicKey>,
     ) -> Self {
         let (tx_batches, rx_batches) = tokio::sync::mpsc::channel(1000);
         Self {
@@ -168,6 +195,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             rx_batches: Some(rx_batches),
             timeout,
             network_handle,
+            committee_txn_targets,
             metrics: WorkerMetrics::new_for_worker(id),
         }
     }
@@ -203,15 +231,87 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         self.tx_batches.clone()
     }
 
-    /// Send all the txns in sealed_batch to CVVs so they can be included in blocks.
-    /// Use this when not a CVV so that transactions you accept can be included in a block.
+    /// Send all the txns in `sealed_batch` to committee validators so they can be included
+    /// in blocks. Use this when not a CVV so that transactions you accept can be included.
+    ///
+    /// Replaces the previous gossip broadcast with a direct RPC push to each committee
+    /// validator (issue #804). The push is best-effort and runs on a background task so
+    /// batch production is never stalled by a slow or unreachable committee member; each
+    /// recipient independently keeps only the transactions in its own shard.
     pub async fn disburse_txns(&self, sealed_batch: SealedBatch) -> Result<(), BlockSealError> {
-        for txn in sealed_batch.batch.transactions {
-            if let Err(err) = self.network_handle.publish_txn(txn).await {
-                error!(target: "worker::batch_provider", "Error publishing transaction: {err}");
+        let transactions = sealed_batch.batch.transactions;
+        if transactions.is_empty() || self.committee_txn_targets.is_empty() {
+            return Ok(());
+        }
+
+        let network_handle = self.network_handle.clone();
+        let targets = self.committee_txn_targets.clone();
+        self.network_handle.get_task_spawner().spawn_task("disburse-txns", async move {
+            Self::push_txns_to_committee(&network_handle, &targets, transactions).await;
+            Ok(())
+        });
+
+        Ok(())
+    }
+
+    /// Push `transactions` to every committee validator in `targets` over RPC concurrently.
+    /// Best-effort: a member that cannot be reached (after retries) simply does not receive
+    /// the transactions this round.
+    async fn push_txns_to_committee(
+        network_handle: &WorkerNetworkHandle,
+        targets: &[BlsPublicKey],
+        transactions: Vec<Vec<u8>>,
+    ) {
+        let mut sends: FuturesUnordered<_> = targets
+            .iter()
+            .map(|&peer| {
+                let network_handle = network_handle.clone();
+                let transactions = transactions.clone();
+                async move { Self::push_txns_to_peer(&network_handle, peer, transactions).await }
+            })
+            .collect();
+
+        while sends.next().await.is_some() {}
+    }
+
+    /// Push `transactions` to a single committee member, retrying transient RPC errors with
+    /// exponential backoff (mirroring the batch-report path so a peer that is briefly
+    /// unreachable at an epoch boundary is not skipped). A permanent rejection
+    /// ([`NetworkError::RPCError`]) is not retried. Both give-up outcomes only warn-log,
+    /// since transaction disbursal is best-effort.
+    async fn push_txns_to_peer(
+        network_handle: &WorkerNetworkHandle,
+        peer: BlsPublicKey,
+        transactions: Vec<Vec<u8>>,
+    ) {
+        for attempt in 0..MAX_TXN_PUSH_ATTEMPTS {
+            match network_handle.report_txns(peer, transactions.clone()).await {
+                Ok(()) => return,
+                // permanent rejection - do not retry
+                Err(NetworkError::RPCError(msg)) => {
+                    warn!(
+                        target: "worker::batch_provider",
+                        %peer,
+                        %msg,
+                        "committee member rejected transaction push"
+                    );
+                    return;
+                }
+                // transient error (RPCRetryable / transport) - retry with backoff
+                Err(err) => {
+                    if attempt + 1 < MAX_TXN_PUSH_ATTEMPTS {
+                        tokio::time::sleep(TXN_PUSH_RETRY_BACKOFF * 2u32.pow(attempt)).await;
+                    } else {
+                        warn!(
+                            target: "worker::batch_provider",
+                            %peer,
+                            ?err,
+                            "failed to push transactions to committee member after retries"
+                        );
+                    }
+                }
             }
         }
-        Ok(())
     }
 
     /// Seal and broadcast the current batch.

--- a/crates/consensus/worker/tests/it/batch_provider_tests.rs
+++ b/crates/consensus/worker/tests/it/batch_provider_tests.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 use tn_network_types::{local::LocalNetwork, MockWorkerToPrimary};
 use tn_reth::test_utils::transaction;
 use tn_storage::{open_db, tables::NodeBatchesCache};
-use tn_types::{test_chain_spec_arc, Batch, Database, TaskManager};
+use tn_types::{test_chain_spec_arc, Batch, Database, NoopTxnForwarder, TaskManager};
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
 
 #[tokio::test]
@@ -29,6 +29,7 @@ async fn make_batch() {
         store.clone(),
         timeout,
         WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+        Arc::new(NoopTxnForwarder),
         Vec::new(),
     );
 

--- a/crates/consensus/worker/tests/it/batch_provider_tests.rs
+++ b/crates/consensus/worker/tests/it/batch_provider_tests.rs
@@ -29,6 +29,7 @@ async fn make_batch() {
         store.clone(),
         timeout,
         WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+        Vec::new(),
     );
 
     // Send enough transactions to seal a batch.

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -1,7 +1,10 @@
 //! Test network handler tests.
 
 use assert_matches::assert_matches;
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    sync::{Arc, Mutex},
+};
 use tn_batch_validator::NoopBatchValidator;
 use tn_network_libp2p::{
     error::NetworkError,
@@ -10,7 +13,9 @@ use tn_network_libp2p::{
 };
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::{BlsPublicKey, SealedBatch, TaskManager, B256};
+use tn_types::{
+    BatchValidation, BatchValidationError, BlsPublicKey, SealedBatch, TaskManager, B256,
+};
 use tn_worker::{
     PendingBatchStream, RequestHandler, WorkerGossip, WorkerNetworkError, WorkerNetworkHandle,
     WorkerRequest, WorkerResponse, MAX_BATCH_DIGESTS_PER_REQUEST, MAX_CONCURRENT_BATCH_STREAMS,
@@ -56,6 +61,42 @@ fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
         WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, chain_id);
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
+}
+
+/// Like [`create_test_types`], but installs a custom batch validator so a test can
+/// observe how the handler routes transactions to `submit_txn_if_mine`.
+fn create_test_types_with_validator(validator: Arc<dyn BatchValidation>) -> TestTypes {
+    let committee = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let authority = committee.first_authority();
+    let config = authority.consensus_config();
+    let task_manager = TaskManager::default();
+    let (tx, network_commands_rx) = mpsc::channel(10);
+    let network_handle =
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
+    let handler = RequestHandler::new(0, validator, config, network_handle);
+    TestTypes { committee, handler, task_manager, network_commands_rx }
+}
+
+/// A batch validator that records every `submit_txn_if_mine` call so tests can assert
+/// how the request handler routes pushed transactions.
+#[derive(Debug, Default)]
+struct RecordingValidator {
+    /// `(tx_bytes, committee_size, committee_slot)` for each call, in order.
+    calls: Arc<Mutex<Vec<(Vec<u8>, u64, u64)>>>,
+}
+
+impl BatchValidation for RecordingValidator {
+    fn validate_batch(&self, _batch: SealedBatch) -> Result<(), BatchValidationError> {
+        Ok(())
+    }
+
+    fn submit_txn_if_mine(&self, tx_bytes: &[u8], committee_size: u64, committee_slot: u64) {
+        self.calls.lock().expect("recording lock").push((
+            tx_bytes.to_vec(),
+            committee_size,
+            committee_slot,
+        ));
+    }
 }
 
 /// Deny a sync-protocol `OpenStream` command, simulating a legacy-only peer so
@@ -120,20 +161,71 @@ async fn test_batch_gossip_topics() {
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
 
-    // Test swapped topics, must fail.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
+    // A batch gossiped on any other topic must be rejected as an invalid topic.
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic(0));
     let bad_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
-    let gossip = WorkerGossip::Txn(vec![]);
-    let data = tn_types::encode(&gossip);
-    let bad_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
-    assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
+}
 
-    // Use the correct topic for a txn and make sure it works.
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_txn_topic(0));
-    let good_msg = GossipMessage { source: None, data, sequence_number: None, topic };
-    assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
+// ============================================================================
+// Report Txns Tests
+// ============================================================================
+
+/// A committee member offers every pushed transaction to `submit_txn_if_mine` exactly
+/// once, in order, tagged with this node's own committee size and slot (issue #804: the
+/// RPC replacement for the retired `WorkerGossip::Txn` path).
+#[tokio::test]
+async fn test_process_report_txns_routes_each_txn_to_own_slot() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
+    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
+
+    let txns: Vec<Vec<u8>> = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    // committee member accepts the pushed txns
+    assert!(handler.pub_process_report_txns(txns.clone()).await.is_ok());
+
+    let recorded = calls.lock().expect("recording lock");
+    // each txn is offered to submit_txn_if_mine exactly once, in order
+    assert_eq!(recorded.len(), txns.len(), "one submit per pushed txn");
+    // every call carries this node's own (stable) committee size + slot, and the slot is a
+    // valid committee index
+    let (_, size, slot) = recorded[0];
+    assert!(size >= 1, "committee size is non-zero");
+    assert!(slot < size, "own slot is a valid committee index");
+    for (i, (bytes, sz, sl)) in recorded.iter().enumerate() {
+        assert_eq!(bytes, &txns[i], "txn {i} bytes preserved and ordered");
+        assert_eq!(*sz, size, "committee size stable across txns");
+        assert_eq!(*sl, slot, "own slot stable across txns");
+    }
+}
+
+/// An empty push is a no-op that still succeeds.
+#[tokio::test]
+async fn test_process_report_txns_empty_is_ok() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
+    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
+
+    assert!(handler.pub_process_report_txns(Vec::new()).await.is_ok());
+    assert!(calls.lock().expect("recording lock").is_empty(), "no submits for an empty push");
+}
+
+/// A push whose transaction count exceeds the per-request cap is rejected as an invalid
+/// request (which the dispatcher turns into a peer penalty) and does no per-txn work.
+#[tokio::test]
+async fn test_process_report_txns_rejects_oversized() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
+    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
+
+    // above MAX_TXNS_PER_REPORT (5_000); empty payloads suffice since the cap is checked
+    // before any decoding/recovery
+    let txns = vec![Vec::new(); 5_001];
+    assert_matches!(
+        handler.pub_process_report_txns(txns).await,
+        Err(WorkerNetworkError::InvalidRequest(_))
+    );
+    assert!(calls.lock().expect("recording lock").is_empty(), "no submits for a rejected push");
 }
 
 /// The handler validates gossip topics against the chain id from its config, not a

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -1,10 +1,7 @@
 //! Test network handler tests.
 
 use assert_matches::assert_matches;
-use std::{
-    collections::BTreeSet,
-    sync::{Arc, Mutex},
-};
+use std::{collections::BTreeSet, sync::Arc};
 use tn_batch_validator::NoopBatchValidator;
 use tn_network_libp2p::{
     error::NetworkError,
@@ -13,9 +10,7 @@ use tn_network_libp2p::{
 };
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::CommitteeFixture;
-use tn_types::{
-    BatchValidation, BatchValidationError, BlsPublicKey, SealedBatch, TaskManager, B256,
-};
+use tn_types::{BlsPublicKey, SealedBatch, TaskManager, B256};
 use tn_worker::{
     PendingBatchStream, RequestHandler, WorkerGossip, WorkerNetworkError, WorkerNetworkHandle,
     WorkerRequest, WorkerResponse, MAX_BATCH_DIGESTS_PER_REQUEST, MAX_CONCURRENT_BATCH_STREAMS,
@@ -61,42 +56,6 @@ fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
         WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, chain_id);
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
-}
-
-/// Like [`create_test_types`], but installs a custom batch validator so a test can
-/// observe how the handler routes transactions to `submit_txn_if_mine`.
-fn create_test_types_with_validator(validator: Arc<dyn BatchValidation>) -> TestTypes {
-    let committee = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
-    let authority = committee.first_authority();
-    let config = authority.consensus_config();
-    let task_manager = TaskManager::default();
-    let (tx, network_commands_rx) = mpsc::channel(10);
-    let network_handle =
-        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
-    let handler = RequestHandler::new(0, validator, config, network_handle);
-    TestTypes { committee, handler, task_manager, network_commands_rx }
-}
-
-/// A batch validator that records every `submit_txn_if_mine` call so tests can assert
-/// how the request handler routes pushed transactions.
-#[derive(Debug, Default)]
-struct RecordingValidator {
-    /// `(tx_bytes, committee_size, committee_slot)` for each call, in order.
-    calls: Arc<Mutex<Vec<(Vec<u8>, u64, u64)>>>,
-}
-
-impl BatchValidation for RecordingValidator {
-    fn validate_batch(&self, _batch: SealedBatch) -> Result<(), BatchValidationError> {
-        Ok(())
-    }
-
-    fn submit_txn_if_mine(&self, tx_bytes: &[u8], committee_size: u64, committee_slot: u64) {
-        self.calls.lock().expect("recording lock").push((
-            tx_bytes.to_vec(),
-            committee_size,
-            committee_slot,
-        ));
-    }
 }
 
 /// Deny a sync-protocol `OpenStream` command, simulating a legacy-only peer so
@@ -165,67 +124,6 @@ async fn test_batch_gossip_topics() {
     let topic = TopicHash::from_raw(tn_config::LibP2pConfig::epoch_vote_topic(0));
     let bad_msg = GossipMessage { source: None, data, sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&bad_msg).await.is_err());
-}
-
-// ============================================================================
-// Report Txns Tests
-// ============================================================================
-
-/// A committee member offers every pushed transaction to `submit_txn_if_mine` exactly
-/// once, in order, tagged with this node's own committee size and slot (issue #804: the
-/// RPC replacement for the retired `WorkerGossip::Txn` path).
-#[tokio::test]
-async fn test_process_report_txns_routes_each_txn_to_own_slot() {
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
-    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
-
-    let txns: Vec<Vec<u8>> = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
-    // committee member accepts the pushed txns
-    assert!(handler.pub_process_report_txns(txns.clone()).await.is_ok());
-
-    let recorded = calls.lock().expect("recording lock");
-    // each txn is offered to submit_txn_if_mine exactly once, in order
-    assert_eq!(recorded.len(), txns.len(), "one submit per pushed txn");
-    // every call carries this node's own (stable) committee size + slot, and the slot is a
-    // valid committee index
-    let (_, size, slot) = recorded[0];
-    assert!(size >= 1, "committee size is non-zero");
-    assert!(slot < size, "own slot is a valid committee index");
-    for (i, (bytes, sz, sl)) in recorded.iter().enumerate() {
-        assert_eq!(bytes, &txns[i], "txn {i} bytes preserved and ordered");
-        assert_eq!(*sz, size, "committee size stable across txns");
-        assert_eq!(*sl, slot, "own slot stable across txns");
-    }
-}
-
-/// An empty push is a no-op that still succeeds.
-#[tokio::test]
-async fn test_process_report_txns_empty_is_ok() {
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
-    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
-
-    assert!(handler.pub_process_report_txns(Vec::new()).await.is_ok());
-    assert!(calls.lock().expect("recording lock").is_empty(), "no submits for an empty push");
-}
-
-/// A push whose transaction count exceeds the per-request cap is rejected as an invalid
-/// request (which the dispatcher turns into a peer penalty) and does no per-txn work.
-#[tokio::test]
-async fn test_process_report_txns_rejects_oversized() {
-    let calls = Arc::new(Mutex::new(Vec::new()));
-    let validator = Arc::new(RecordingValidator { calls: calls.clone() });
-    let TestTypes { handler, task_manager: _, .. } = create_test_types_with_validator(validator);
-
-    // above MAX_TXNS_PER_REPORT (5_000); empty payloads suffice since the cap is checked
-    // before any decoding/recovery
-    let txns = vec![Vec::new(); 5_001];
-    assert_matches!(
-        handler.pub_process_report_txns(txns).await,
-        Err(WorkerNetworkError::InvalidRequest(_))
-    );
-    assert!(calls.lock().expect("recording lock").is_empty(), "no submits for a rejected push");
 }
 
 /// The handler validates gossip topics against the chain id from its config, not a

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -25,8 +25,9 @@ use std::{
     sync::{Condvar, Mutex},
     time::Duration,
 };
+use tn_config::{Config, ConfigFmt, ConfigTrait as _, NodeInfo};
 use tn_types::{
-    address, get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address,
+    address, get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address, RpcInfo,
 };
 use tokio::runtime::Builder;
 use tracing::{error, info};
@@ -364,6 +365,27 @@ pub(crate) fn start_validator_with_args(
     setup_log_dir(&mut command, instance, test, run);
 
     command.spawn().expect("failed to execute")
+}
+
+/// Advertise a validator's JSON-RPC endpoint on its worker record.
+///
+/// The genesis ceremony leaves `p2p_info.worker.rpc` unset, and a non-committee node
+/// forwards accepted transactions to whatever endpoints committee validators advertise
+/// (issue #804); with none advertised, observer-submitted transactions are dropped.
+/// Call this between the config ceremony and `start_validator`, passing the same
+/// `rpc_port` the validator will serve `--http` on; the node re-signs the record from
+/// its `node-info.yaml` at startup, so editing the file is sufficient.
+pub(crate) fn advertise_worker_rpc(
+    base_dir: &Path,
+    instance: usize,
+    rpc_port: u16,
+) -> eyre::Result<()> {
+    let path = base_dir.join(format!("validator-{}", instance + 1)).join("node-info.yaml");
+    let mut node_info = Config::load_from_path::<NodeInfo>(&path, ConfigFmt::YAML)?;
+    node_info.p2p_info.worker.rpc =
+        Some(RpcInfo { http: format!("http://127.0.0.1:{rpc_port}").parse()?, ws: None });
+    Config::write_to_path(&path, &node_info, ConfigFmt::YAML)?;
+    Ok(())
 }
 
 /// Start a process running an observer node.

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -2,9 +2,10 @@
 
 use super::common::{kill_child, ProcessGuard};
 use crate::common::{
-    address_from_word, get_balance, get_balance_above_with_retry, get_block, get_block_number,
-    get_key, get_latest_consensus_header_number, get_node_info, get_positive_balance_with_retry,
-    network_advancing, send_and_confirm, send_tel, start_observer, start_validator, WEI_PER_TEL,
+    address_from_word, advertise_worker_rpc, get_balance, get_balance_above_with_retry, get_block,
+    get_block_number, get_key, get_latest_consensus_header_number, get_node_info,
+    get_positive_balance_with_retry, network_advancing, send_and_confirm, send_tel, start_observer,
+    start_validator, WEI_PER_TEL,
 };
 use e2e_tests::config_local_testnet;
 use escargot::CargoRun;
@@ -386,6 +387,9 @@ fn test_restarts_observer() -> eyre::Result<()> {
         let rpc_port = get_available_tcp_port("127.0.0.1")
             .expect("Failed to get an ephemeral rpc port for child!");
         client_urls[i].push_str(&format!(":{rpc_port}"));
+        // The observer forwards accepted txns to the committee's advertised RPC
+        // endpoints; without this the forward has no targets and txns are dropped.
+        advertise_worker_rpc(&temp_path, i, rpc_port)?;
         guard.push(start_validator(i, &bin, &temp_path, rpc_port, "observer", 0));
     }
     let obs_rpc_port = get_available_tcp_port("127.0.0.1")

--- a/crates/e2e-tests/tests/it/sync.rs
+++ b/crates/e2e-tests/tests/it/sync.rs
@@ -9,8 +9,8 @@ use tokio::time::Instant;
 use tracing::info;
 
 use crate::common::{
-    address_from_word, get_key, get_latest_consensus_header_number, network_advancing,
-    send_and_confirm, start_observer, start_validator, ProcessGuard,
+    address_from_word, advertise_worker_rpc, get_key, get_latest_consensus_header_number,
+    network_advancing, send_and_confirm, start_observer, start_validator, ProcessGuard,
 };
 
 /// Epoch duration (in seconds) used by the pack-import test. Mirrors the value used by
@@ -66,6 +66,9 @@ async fn test_observer_pack_imports_after_epoch_close_inner() -> eyre::Result<()
         let rpc_port = get_available_tcp_port("127.0.0.1")
             .expect("Failed to get an ephemeral rpc port for child!");
         client_urls[i].push_str(&format!(":{rpc_port}"));
+        // The late-joining observer forwards accepted txns to the committee's advertised
+        // RPC endpoints; without this the forward has no targets and txns are dropped.
+        advertise_worker_rpc(&temp_path, i, rpc_port)?;
         guard.push(start_validator(i, &bin, &temp_path, rpc_port, "observer_pack_import", 0));
     }
 

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -616,8 +616,9 @@ where
     /// committee peers — the peer manager drops dials to peers already connected — then waits
     /// for peers before spawning the network on the epoch-scoped spawner.
     ///
-    /// Two topics are subscribed: the worker transaction topic, and the batch topic restricted to
-    /// committee publishers so non-CVVs can prefetch batches (harmless for CVVs).
+    /// The batch topic is subscribed, restricted to committee publishers so non-CVVs can
+    /// prefetch batches (harmless for CVVs). Non-CVVs push the transactions they accept to
+    /// the committee over RPC rather than gossiping them (issue #804).
     #[allow(clippy::too_many_arguments)]
     async fn spawn_worker_network_for_epoch(
         &mut self,
@@ -687,12 +688,7 @@ where
 
         Self::wait_for_network_peers(network_handle.inner_handle(), "worker network").await?;
 
-        // update the authorized publishers for gossip every epoch
-        network_handle
-            .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::worker_txn_topic(consensus_config.chain_id()))
-            .await?;
-        // Get gossip from committee members about batches.
+        // Get gossip from committee members about batches every epoch.
         // Useful for non-CVVs to prefetch and harmless for CVVs.
         network_handle
             .inner_handle()

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -34,9 +34,12 @@ use tn_primary::{
     network::{PrimaryNetwork, PrimaryNetworkHandle},
     ConsensusBus, NodeMode, StateSynchronizer,
 };
-use tn_reth::system_calls::{
-    ConsensusRegistry::{self, EpochInfo},
-    EpochState,
+use tn_reth::{
+    system_calls::{
+        ConsensusRegistry::{self, EpochInfo},
+        EpochState,
+    },
+    WorkerRpcForwarder,
 };
 use tn_rpc::RpcNodeInfo;
 use tn_types::{
@@ -434,11 +437,18 @@ where
         )
         .await?;
 
+        // Observer transaction forwarding: a non-committee worker forwards each transaction it
+        // accepts to the JSON-RPC endpoint of the validator that owns it, discovered over
+        // kademlia (issue #804).
+        let forwarder =
+            Arc::new(WorkerRpcForwarder::new(network_handle.get_task_spawner().clone()));
+
         let worker = WorkerNode::new(
             worker_id,
             consensus_config.clone(),
             network_handle.clone(),
             validator,
+            forwarder,
             self.consensus_chain.clone(),
         );
 

--- a/crates/node/src/worker.rs
+++ b/crates/node/src/worker.rs
@@ -3,7 +3,7 @@ use crate::manager::WORKER_TASK_BASE;
 use std::sync::Arc;
 use tn_config::ConsensusConfig;
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{BatchValidation, Database as ConsensusDatabase, WorkerId};
+use tn_types::{BatchValidation, Database as ConsensusDatabase, TxnForwarder, WorkerId};
 use tn_worker::{new_worker, quorum_waiter::QuorumWaiter, Worker, WorkerNetworkHandle};
 use tokio::sync::RwLock;
 
@@ -18,6 +18,9 @@ pub struct WorkerNodeInner<CDB> {
     network_handle: WorkerNetworkHandle,
     /// The batch validator.
     validator: Arc<dyn BatchValidation>,
+    /// Forwards accepted transactions to committee validators' JSON-RPC endpoints when this
+    /// node is not a committee voting validator.
+    forwarder: Arc<dyn TxnForwarder>,
     /// The consensus chain.
     consensus_chain: ConsensusChain,
 }
@@ -34,6 +37,7 @@ impl<CDB: ConsensusDatabase> WorkerNodeInner<CDB> {
             self.validator.clone(),
             self.consensus_config.clone(),
             self.network_handle.clone(),
+            self.forwarder.clone(),
             self.consensus_chain.clone(),
         );
 
@@ -52,10 +56,17 @@ impl<CDB: ConsensusDatabase> WorkerNode<CDB> {
         consensus_config: ConsensusConfig<CDB>,
         network_handle: WorkerNetworkHandle,
         validator: Arc<dyn BatchValidation>,
+        forwarder: Arc<dyn TxnForwarder>,
         consensus_chain: ConsensusChain,
     ) -> WorkerNode<CDB> {
-        let inner =
-            WorkerNodeInner { id, consensus_config, network_handle, validator, consensus_chain };
+        let inner = WorkerNodeInner {
+            id,
+            consensus_config,
+            network_handle,
+            validator,
+            forwarder,
+            consensus_chain,
+        };
 
         Self { internal: Arc::new(RwLock::new(inner)) }
     }

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -12,13 +12,38 @@
 //! [`submit_txn_if_mine`]: tn_types::BatchValidation::submit_txn_if_mine
 
 use crate::recover_raw_transaction;
-use alloy::providers::{Provider as _, RootProvider};
+use alloy::{
+    providers::{Provider as _, RootProvider},
+    transports::{RpcError, TransportErrorKind},
+};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 use tn_types::{BlsPublicKey, RpcInfo, TaskSpawner, TxnForwarder};
+use tokio::time::timeout;
 use tracing::{debug, warn};
+
+/// Bounds a single validator's `eth_sendRawTransaction` round-trip so one unresponsive endpoint
+/// cannot stall the fallback chain; on timeout the forward tries the next validator.
+const FORWARD_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bounds the total time spent forwarding one transaction across all its fallback validators, so a
+/// whole unresponsive committee cannot make a single transaction cost `committee_size` back-to-back
+/// [`FORWARD_SEND_TIMEOUT`]s. When it elapses the transaction is left unforwarded and the next one
+/// proceeds.
+const FORWARD_TX_BUDGET: Duration = Duration::from_secs(15);
+
+/// JSON-RPC error codes reth returns for a validator-local, transient condition (a full pool,
+/// `-32003`, or an internal/IO error, `-32603`) rather than a verdict on the transaction itself.
+/// The forward falls through to the next advertised validator on these, since another validator
+/// may still accept the transaction.
+const TRANSIENT_RPC_CODES: [i64; 2] = [-32003, -32603];
+
+/// Substring of reth's `eth_sendRawTransaction` error message when the transaction is already in a
+/// validator's pool (`code -32000`). Treated as a successful delivery, not a failure to retry.
+const ALREADY_KNOWN_MESSAGE: &str = "already known";
 
 /// Forwards observer transactions to validators over their advertised JSON-RPC endpoints.
 #[derive(Clone)]
@@ -117,34 +142,69 @@ impl TxnForwarder for WorkerRpcForwarder {
                 let owner = owning_validator(tx, committee_size, &committee_slots);
                 let ordered = owner.into_iter().chain(fallbacks.iter().cloned());
 
-                let mut tried = BTreeSet::new();
-                let mut forwarded = false;
-                for key in ordered {
-                    if !tried.insert(key) {
-                        continue;
-                    }
-                    let Some(provider) = providers.get(&key) else {
-                        continue;
-                    };
-                    match provider.send_raw_transaction(tx.as_slice()).await {
-                        Ok(_) => {
-                            forwarded = true;
-                            break;
+                // Bound the whole fallback chain for this transaction: even if every advertised
+                // validator accepts the connection but never answers, one transaction cannot cost
+                // more than `FORWARD_TX_BUDGET` before the next transaction proceeds.
+                let outcome = timeout(FORWARD_TX_BUDGET, async {
+                    let mut tried = BTreeSet::new();
+                    let mut result = ForwardOutcome::NoEndpointReached;
+                    for key in ordered {
+                        if !tried.insert(key) {
+                            continue;
                         }
-                        Err(err) => {
-                            debug!(
-                                target: "worker::forward",
-                                %err,
-                                "failed to forward transaction to a validator RPC; trying next"
-                            );
+                        let Some(provider) = providers.get(&key) else {
+                            continue;
+                        };
+                        // Bound each validator's round-trip: an endpoint that accepts the
+                        // connection but never answers must not stall the whole fallback chain.
+                        let disposition = timeout(
+                            FORWARD_SEND_TIMEOUT,
+                            provider.send_raw_transaction(tx.as_slice()),
+                        )
+                        .await
+                        .map_or_else(
+                            |_elapsed| Disposition::TryNext("send timed out".to_string()),
+                            |res| res.err().map_or(Disposition::Delivered, classify_error),
+                        );
+
+                        match disposition {
+                            // Delivered, or a considered rejection every validator would repeat:
+                            // either way this transaction is done, so stop the fallback chain.
+                            Disposition::Delivered => {
+                                result = ForwardOutcome::Delivered;
+                                break;
+                            }
+                            Disposition::Rejected(reason) => {
+                                result = ForwardOutcome::Rejected(reason);
+                                break;
+                            }
+                            // Endpoint-local problem (timeout, transport error, full pool): the
+                            // transaction's fate is unknown here, so try the next validator.
+                            Disposition::TryNext(reason) => {
+                                debug!(
+                                    target: "worker::forward",
+                                    reason = %reason,
+                                    "validator RPC did not accept the forwarded transaction; trying next"
+                                );
+                            }
                         }
                     }
-                }
-                if !forwarded {
-                    warn!(
+                    result
+                })
+                .await
+                .unwrap_or(ForwardOutcome::NoEndpointReached);
+
+                match outcome {
+                    ForwardOutcome::Delivered => {}
+                    ForwardOutcome::Rejected(reason) => warn!(
+                        target: "worker::forward",
+                        reason = %reason,
+                        "a validator rejected the forwarded transaction; not retrying other validators"
+                    ),
+                    ForwardOutcome::NoEndpointReached => warn!(
                         target: "worker::forward",
                         "could not forward transaction to any advertised validator RPC"
-                    );
+                    ),
                 }
             }
             Ok(())
@@ -166,6 +226,53 @@ fn owning_validator(
     bytes.copy_from_slice(&sender.as_slice()[0..8]);
     let slot = (u64::from_le_bytes(bytes) % committee_size) as usize;
     committee_slots.get(slot).cloned()
+}
+
+/// What to do after one timed attempt to forward a transaction to one validator.
+#[derive(Debug, PartialEq, Eq)]
+enum Disposition {
+    /// The validator accepted the transaction, or it was already in a validator's pool.
+    Delivered,
+    /// The validator returned a considered rejection of the transaction itself (bad nonce,
+    /// underpriced, invalid, wrong fork). No other validator will accept it either.
+    Rejected(String),
+    /// This endpoint gave no verdict (timeout, transport error, or a transient full pool); the
+    /// transaction may still be accepted by another validator.
+    TryNext(String),
+}
+
+/// Terminal result of forwarding one transaction across the ordered validators.
+#[derive(Debug, PartialEq, Eq)]
+enum ForwardOutcome {
+    /// A validator accepted it (or already had it).
+    Delivered,
+    /// A validator gave a considered rejection, so the chain was stopped without delivery.
+    Rejected(String),
+    /// No advertised validator gave a verdict (all timed out or were unreachable).
+    NoEndpointReached,
+}
+
+/// Classify a failed `send_raw_transaction` by whether the server returned a JSON-RPC error (a
+/// verdict about the transaction) or the transport failed (an endpoint problem).
+fn classify_error(err: RpcError<TransportErrorKind>) -> Disposition {
+    err.as_error_resp().map(|payload| (payload.code, payload.message.to_string())).map_or_else(
+        || Disposition::TryNext(err.to_string()),
+        |(code, message)| classify_server_error(code, message),
+    )
+}
+
+/// Classify a server-side JSON-RPC rejection of a forwarded transaction.
+fn classify_server_error(code: i64, message: String) -> Disposition {
+    if TRANSIENT_RPC_CODES.contains(&code) {
+        // A full pool or an internal error is validator-local; another validator may accept it.
+        Disposition::TryNext(message)
+    } else if message.to_ascii_lowercase().contains(ALREADY_KNOWN_MESSAGE) {
+        // Already in a validator's pool: the transaction is delivered.
+        Disposition::Delivered
+    } else {
+        // Every validator shares consensus state, so a considered rejection repeats everywhere.
+        Disposition::Rejected(format!("code {code}: {message}"))
+    }
 }
 
 #[cfg(test)]
@@ -219,6 +326,31 @@ mod tests {
 
         assert_eq!(second.len(), 1);
         assert_eq!(cached_urls(&forwarder), vec!["http://127.0.0.1:8545/".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn classify_server_error_maps_reth_rejections() -> eyre::Result<()> {
+        // A duplicate ("already known", code -32000) is a delivery, not a failure to retry.
+        assert_eq!(
+            classify_server_error(-32000, "already known".to_string()),
+            Disposition::Delivered
+        );
+        // A full pool (code -32003) is transient: fall through to the next validator.
+        assert_eq!(
+            classify_server_error(-32003, "txpool is full".to_string()),
+            Disposition::TryNext("txpool is full".to_string())
+        );
+        // An internal error (code -32603) is also validator-local: try the next validator.
+        assert_eq!(
+            classify_server_error(-32603, "database error".to_string()),
+            Disposition::TryNext("database error".to_string())
+        );
+        // A considered rejection (nonce too low, code -32000) stops the fallback chain.
+        assert!(matches!(
+            classify_server_error(-32000, "nonce too low: next nonce 42, tx nonce 41".to_string()),
+            Disposition::Rejected(_)
+        ));
         Ok(())
     }
 }

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -187,11 +187,7 @@ mod tests {
     }
 
     fn cached_urls(forwarder: &WorkerRpcForwarder) -> Vec<String> {
-        forwarder
-            .providers
-            .lock()
-            .map(|cache| cache.keys().cloned().collect())
-            .unwrap_or_default()
+        forwarder.providers.lock().map(|cache| cache.keys().cloned().collect()).unwrap_or_default()
     }
 
     #[test]

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -57,7 +57,7 @@ impl TxnForwarder for WorkerRpcForwarder {
             for (key, rpc) in &validator_rpcs {
                 match rpc.http.as_str().parse() {
                     Ok(url) => {
-                        providers.insert(key.clone(), ProviderBuilder::new().connect_http(url));
+                        providers.insert(*key, ProviderBuilder::new().connect_http(url));
                     }
                     Err(err) => {
                         debug!(
@@ -89,7 +89,7 @@ impl TxnForwarder for WorkerRpcForwarder {
                 let mut tried = BTreeSet::new();
                 let mut forwarded = false;
                 for key in ordered {
-                    if !tried.insert(key.clone()) {
+                    if !tried.insert(key) {
                         continue;
                     }
                     let Some(provider) = providers.get(&key) else {

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -1,0 +1,138 @@
+//! Forward transactions accepted by a non-committee ("observer") worker to the committee.
+//!
+//! Instead of pushing raw transaction bytes over the libp2p worker protocol, an observer
+//! forwards each transaction to the JSON-RPC endpoint the owning validator advertised on its
+//! worker record (issue #804), so the submitter gets the same RPC experience they would get
+//! talking to a validator directly. Routing mirrors [`submit_txn_if_mine`]: a transaction is
+//! sent to the validator whose committee slot owns the sender, so all transactions from one
+//! account converge on a single validator and nonce ordering is preserved. A validator that has
+//! not advertised an endpoint (or is momentarily unreachable) is skipped in favor of one that
+//! has.
+//!
+//! [`submit_txn_if_mine`]: tn_types::BatchValidation::submit_txn_if_mine
+
+use crate::recover_raw_transaction;
+use alloy::providers::{Provider as _, ProviderBuilder};
+use std::collections::{BTreeMap, BTreeSet};
+use tn_types::{BlsPublicKey, RpcInfo, TaskSpawner, TxnForwarder};
+use tracing::{debug, warn};
+
+/// Forwards observer transactions to validators over their advertised JSON-RPC endpoints.
+#[derive(Clone)]
+pub struct WorkerRpcForwarder {
+    /// Spawner used to run the (best-effort, non-blocking) forward on a background task.
+    task_spawner: TaskSpawner,
+}
+
+impl std::fmt::Debug for WorkerRpcForwarder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WorkerRpcForwarder")
+    }
+}
+
+impl WorkerRpcForwarder {
+    /// Create a new forwarder that runs forwards on `task_spawner`.
+    pub fn new(task_spawner: TaskSpawner) -> Self {
+        Self { task_spawner }
+    }
+}
+
+impl TxnForwarder for WorkerRpcForwarder {
+    fn forward_txns(
+        &self,
+        transactions: Vec<Vec<u8>>,
+        committee_slots: Vec<BlsPublicKey>,
+        validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
+    ) {
+        let committee_size = committee_slots.len() as u64;
+        if transactions.is_empty() || committee_size == 0 || validator_rpcs.is_empty() {
+            return;
+        }
+
+        self.task_spawner.spawn_task("forward-txns", async move {
+            // Build one HTTP provider per advertised validator, keyed by BLS key. A malformed
+            // URL is dropped here so the per-transaction loop only sees usable endpoints. The
+            // endpoint string is reparsed into the exact URL type the provider expects.
+            let mut providers = BTreeMap::new();
+            for (key, rpc) in &validator_rpcs {
+                match rpc.http.as_str().parse() {
+                    Ok(url) => {
+                        providers.insert(key.clone(), ProviderBuilder::new().connect_http(url));
+                    }
+                    Err(err) => {
+                        debug!(
+                            target: "worker::forward",
+                            endpoint = %rpc.http,
+                            %err,
+                            "skipping validator with an unparseable RPC endpoint"
+                        );
+                    }
+                }
+            }
+            if providers.is_empty() {
+                warn!(
+                    target: "worker::forward",
+                    "no usable validator RPC endpoints; dropping forwarded transactions"
+                );
+                return Ok(());
+            }
+            // Fallback order: every usable endpoint, so a transaction whose owning validator has
+            // not advertised (or is unreachable) can still reach the committee.
+            let fallbacks: Vec<BlsPublicKey> = providers.keys().cloned().collect();
+
+            for tx in &transactions {
+                // Route by sender so all transactions from one account land on the same
+                // validator (matches `submit_txn_if_mine`), then fall back to any endpoint.
+                let owner = owning_validator(tx, committee_size, &committee_slots);
+                let ordered = owner.into_iter().chain(fallbacks.iter().cloned());
+
+                let mut tried = BTreeSet::new();
+                let mut forwarded = false;
+                for key in ordered {
+                    if !tried.insert(key.clone()) {
+                        continue;
+                    }
+                    let Some(provider) = providers.get(&key) else {
+                        continue;
+                    };
+                    match provider.send_raw_transaction(tx.as_slice()).await {
+                        Ok(_) => {
+                            forwarded = true;
+                            break;
+                        }
+                        Err(err) => {
+                            debug!(
+                                target: "worker::forward",
+                                %err,
+                                "failed to forward transaction to a validator RPC; trying next"
+                            );
+                        }
+                    }
+                }
+                if !forwarded {
+                    warn!(
+                        target: "worker::forward",
+                        "could not forward transaction to any advertised validator RPC"
+                    );
+                }
+            }
+            Ok(())
+        });
+    }
+}
+
+/// Return the BLS key of the committee slot that owns `tx_bytes`, matching the receiver-side
+/// routing in `submit_txn_if_mine`. Returns `None` if the transaction cannot be recovered or the
+/// derived slot is out of range.
+fn owning_validator(
+    tx_bytes: &[u8],
+    committee_size: u64,
+    committee_slots: &[BlsPublicKey],
+) -> Option<BlsPublicKey> {
+    let recovered = recover_raw_transaction(tx_bytes).ok()?;
+    let sender = recovered.signer();
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&sender.as_slice()[0..8]);
+    let slot = (u64::from_le_bytes(bytes) % committee_size) as usize;
+    committee_slots.get(slot).cloned()
+}

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -12,8 +12,11 @@
 //! [`submit_txn_if_mine`]: tn_types::BatchValidation::submit_txn_if_mine
 
 use crate::recover_raw_transaction;
-use alloy::providers::{Provider as _, ProviderBuilder};
-use std::collections::{BTreeMap, BTreeSet};
+use alloy::providers::{Provider as _, RootProvider};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, Mutex},
+};
 use tn_types::{BlsPublicKey, RpcInfo, TaskSpawner, TxnForwarder};
 use tracing::{debug, warn};
 
@@ -22,6 +25,11 @@ use tracing::{debug, warn};
 pub struct WorkerRpcForwarder {
     /// Spawner used to run the (best-effort, non-blocking) forward on a background task.
     task_spawner: TaskSpawner,
+    /// HTTP providers cached per advertised endpoint so consecutive batch seals reuse the
+    /// underlying connection pool instead of paying a fresh TCP+TLS handshake per validator
+    /// per seal. Entries for endpoints that are no longer advertised are evicted on each
+    /// forward, so the cache stays bounded by the current committee's advertisement set.
+    providers: Arc<Mutex<BTreeMap<String, RootProvider>>>,
 }
 
 impl std::fmt::Debug for WorkerRpcForwarder {
@@ -33,7 +41,48 @@ impl std::fmt::Debug for WorkerRpcForwarder {
 impl WorkerRpcForwarder {
     /// Create a new forwarder that runs forwards on `task_spawner`.
     pub fn new(task_spawner: TaskSpawner) -> Self {
-        Self { task_spawner }
+        Self { task_spawner, providers: Arc::new(Mutex::new(BTreeMap::new())) }
+    }
+
+    /// Resolve the advertised endpoints to providers, reusing cached ones where the endpoint
+    /// is unchanged. A malformed URL is dropped here so the per-transaction loop only sees
+    /// usable endpoints. The endpoint string is reparsed into the exact URL type the provider
+    /// expects. `RootProvider` needs no fillers: the transactions are already signed raw
+    /// bytes, and `send_raw_transaction` submits them as-is.
+    fn cached_providers(
+        &self,
+        validator_rpcs: &[(BlsPublicKey, RpcInfo)],
+    ) -> BTreeMap<BlsPublicKey, RootProvider> {
+        let mut cache = self.providers.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let advertised: BTreeSet<String> =
+            validator_rpcs.iter().map(|(_, rpc)| rpc.http.to_string()).collect();
+        cache.retain(|url, _| advertised.contains(url));
+        validator_rpcs
+            .iter()
+            .filter_map(|(key, rpc)| {
+                let url = rpc.http.to_string();
+                cache
+                    .get(&url)
+                    .cloned()
+                    .or_else(|| match url.parse() {
+                        Ok(parsed) => {
+                            let provider = RootProvider::new_http(parsed);
+                            cache.insert(url, provider.clone());
+                            Some(provider)
+                        }
+                        Err(err) => {
+                            debug!(
+                                target: "worker::forward",
+                                endpoint = %rpc.http,
+                                %err,
+                                "skipping validator with an unparseable RPC endpoint"
+                            );
+                            None
+                        }
+                    })
+                    .map(|provider| (*key, provider))
+            })
+            .collect()
     }
 }
 
@@ -49,37 +98,19 @@ impl TxnForwarder for WorkerRpcForwarder {
             return;
         }
 
-        self.task_spawner.spawn_task("forward-txns", async move {
-            // Build one HTTP provider per advertised validator, keyed by BLS key. A malformed
-            // URL is dropped here so the per-transaction loop only sees usable endpoints. The
-            // endpoint string is reparsed into the exact URL type the provider expects.
-            let mut providers = BTreeMap::new();
-            for (key, rpc) in &validator_rpcs {
-                match rpc.http.as_str().parse() {
-                    Ok(url) => {
-                        providers.insert(*key, ProviderBuilder::new().connect_http(url));
-                    }
-                    Err(err) => {
-                        debug!(
-                            target: "worker::forward",
-                            endpoint = %rpc.http,
-                            %err,
-                            "skipping validator with an unparseable RPC endpoint"
-                        );
-                    }
-                }
-            }
-            if providers.is_empty() {
-                warn!(
-                    target: "worker::forward",
-                    "no usable validator RPC endpoints; dropping forwarded transactions"
-                );
-                return Ok(());
-            }
-            // Fallback order: every usable endpoint, so a transaction whose owning validator has
-            // not advertised (or is unreachable) can still reach the committee.
-            let fallbacks: Vec<BlsPublicKey> = providers.keys().cloned().collect();
+        let providers = self.cached_providers(&validator_rpcs);
+        if providers.is_empty() {
+            warn!(
+                target: "worker::forward",
+                "no usable validator RPC endpoints; dropping forwarded transactions"
+            );
+            return;
+        }
+        // Fallback order: every usable endpoint, so a transaction whose owning validator has
+        // not advertised (or is unreachable) can still reach the committee.
+        let fallbacks: Vec<BlsPublicKey> = providers.keys().cloned().collect();
 
+        self.task_spawner.spawn_task("forward-txns", async move {
             for tx in &transactions {
                 // Route by sender so all transactions from one account land on the same
                 // validator (matches `submit_txn_if_mine`), then fall back to any endpoint.
@@ -135,4 +166,63 @@ fn owning_validator(
     bytes.copy_from_slice(&sender.as_slice()[0..8]);
     let slot = (u64::from_le_bytes(bytes) % committee_size) as usize;
     committee_slots.get(slot).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+    use tn_types::{BlsKeypair, TaskManager};
+
+    fn test_forwarder() -> WorkerRpcForwarder {
+        WorkerRpcForwarder::new(TaskManager::default().get_spawner())
+    }
+
+    fn test_key(seed: u8) -> BlsPublicKey {
+        *BlsKeypair::generate(&mut StdRng::from_seed([seed; 32])).public()
+    }
+
+    fn test_rpc(url: &str) -> eyre::Result<RpcInfo> {
+        Ok(RpcInfo { http: url.parse()?, ws: None })
+    }
+
+    fn cached_urls(forwarder: &WorkerRpcForwarder) -> Vec<String> {
+        forwarder
+            .providers
+            .lock()
+            .map(|cache| cache.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn cached_providers_resolves_every_advertised_endpoint() -> eyre::Result<()> {
+        let forwarder = test_forwarder();
+        let rpcs = vec![
+            (test_key(1), test_rpc("http://127.0.0.1:8545")?),
+            (test_key(2), test_rpc("http://127.0.0.1:8546")?),
+        ];
+
+        let resolved = forwarder.cached_providers(&rpcs);
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(cached_urls(&forwarder).len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_providers_reuses_cache_and_evicts_stale_endpoints() -> eyre::Result<()> {
+        let forwarder = test_forwarder();
+        let live = (test_key(1), test_rpc("http://127.0.0.1:8545")?);
+        let stale = (test_key(2), test_rpc("http://127.0.0.1:8546")?);
+        let first = forwarder.cached_providers(&[live.clone(), stale]);
+        assert_eq!(first.len(), 2);
+
+        // A repeat advertisement resolves from the cache without growing it; the endpoint
+        // that is no longer advertised is evicted.
+        let second = forwarder.cached_providers(&[live]);
+
+        assert_eq!(second.len(), 1);
+        assert_eq!(cached_urls(&forwarder), vec!["http://127.0.0.1:8545/".to_string()]);
+        Ok(())
+    }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -169,9 +169,11 @@ pub use txn_pool::*;
 use worker::WorkerNetwork;
 pub mod error;
 mod evm;
+pub mod forward;
 pub mod rpc_server_args;
 pub mod system_calls;
 pub mod worker;
+
 #[cfg(not(feature = "faucet"))]
 pub use evm::TIMELOCK_DURATION;
 pub use evm::{
@@ -179,6 +181,7 @@ pub use evm::{
     grantMintRoleCall, hasMintRoleCall, mintCall, revokeMintRoleCall, totalSupplyCall,
     BLS_G1_PRECOMPILE_ADDRESS, TELCOIN_PRECOMPILE_ADDRESS,
 };
+pub use forward::WorkerRpcForwarder;
 
 #[cfg(any(feature = "test-utils", test))]
 pub mod test_utils;

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -4,7 +4,8 @@
 //! have reached quorum.
 
 use crate::{
-    crypto, encode, Address, BlockHash, Epoch, ExecHeader, TimestampSec, MIN_PROTOCOL_BASE_FEE,
+    crypto, encode, Address, BlockHash, BlsPublicKey, Epoch, ExecHeader, RpcInfo, TimestampSec,
+    MIN_PROTOCOL_BASE_FEE,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -209,6 +210,51 @@ pub trait BatchValidation: Send + Sync + Debug {
     /// Submit a transaction (as bytes) for inclusion in a batch.
     /// Will only submit if the txn hash fits the provided committee slot.
     fn submit_txn_if_mine(&self, tx_bytes: &[u8], committee_size: u64, committee_slot: u64);
+}
+
+/// Forwards accepted transactions to committee validators over their advertised JSON-RPC
+/// endpoints.
+///
+/// A non-committee ("observer") worker cannot include the transactions it accepts in a batch
+/// itself, so it forwards them to the committee. Instead of pushing over the libp2p worker
+/// protocol, the observer forwards each transaction to the JSON-RPC endpoint the owning
+/// validator advertised on its worker record (issue #804), so the submitter gets the same RPC
+/// experience they would get talking to a validator directly.
+///
+/// Implementations are best-effort and must not block: forwarding runs on a background task so
+/// batch production is never stalled by a slow or unreachable validator.
+pub trait TxnForwarder: Send + Sync + Debug {
+    /// Forward `transactions` to the validators that own them.
+    ///
+    /// `committee_slots` holds the committee's BLS public keys in slot order (index = committee
+    /// slot); a transaction is routed to the validator whose slot owns the sender, matching
+    /// [`BatchValidation::submit_txn_if_mine`] so all transactions from one account converge on a
+    /// single validator and nonce ordering is preserved. `validator_rpcs` is the set of
+    /// currently-known advertised endpoints; a validator that has not advertised an endpoint is
+    /// skipped in favor of one that has.
+    fn forward_txns(
+        &self,
+        transactions: Vec<Vec<u8>>,
+        committee_slots: Vec<BlsPublicKey>,
+        validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
+    );
+}
+
+/// A [`TxnForwarder`] that drops every transaction.
+///
+/// Committee voting validators never forward (they include transactions directly), so they can
+/// be constructed with this; it is also convenient in tests that do not exercise forwarding.
+#[derive(Clone, Debug, Default)]
+pub struct NoopTxnForwarder;
+
+impl TxnForwarder for NoopTxnForwarder {
+    fn forward_txns(
+        &self,
+        _transactions: Vec<Vec<u8>>,
+        _committee_slots: Vec<BlsPublicKey>,
+        _validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
+    ) {
+    }
 }
 
 /// Block validation error types


### PR DESCRIPTION
## Summary

Closes #804. Non-committee (non-CVV) workers no longer **gossip** the transactions they accept.  Instead they **push them directly to the committee validators over the existing request/response RPC** (routed to each validator by BLS key via KAD-discovered addresses), replacing the fire-and-forget `worker_txn` gossip topic with targeted, acked, retried delivery.

Inclusion semantics are unchanged: each committee member still keeps only the transactions in its own shard (`submit_txn_if_mine`, `sender_addr % committee_size == slot`), so an account's transactions still all land on one validator and nonce ordering is preserved.

## Changes

- **New RPC message** (`worker/network/message.rs`): `WorkerRequest::ReportTxns { transactions }` + `WorkerResponse::ReportTxns` ack.  Both are **appended at the end** of their enums so the change does not shift the serialized (BCS) variant discriminants of the existing variants — batch-sync / peer-exchange / report-batch RPC stay wire-compatible across versions.  Removed `WorkerGossip::Txn` (the gossip enum is now batch-only).
- **Send side** (`worker/worker.rs`): `disburse_txns` fans the accepted transactions out to every committee validator on a background task (`push_txns_to_committee`), one concurrent RPC per member, so batch production is never stalled by a slow/unreachable member.  Each per-member send retries transient errors with exponential backoff (`push_txns_to_peer`, mirroring `QuorumWaiter`), and does not retry a permanent rejection.  Committee push targets are captured once per epoch at construction (mirroring how `QuorumWaiter` captures the committee);  a non-CVV targets all members, a CVV excludes itself.
- **Handle** (`worker/network/handle.rs`): `publish_txn` → `report_txns(peer, transactions)`, mirroring `report_batch`.
- **Receive side** (`worker/network/handler.rs`, `mod.rs`): new `process_report_txns` + dispatcher mirroring `process_report_batch`.  Only committee members act; each re-derives its own slot and routes each txn through `submit_txn_if_mine`.  A request whose transaction count exceeds `MAX_TXNS_PER_REPORT` (well above any gas-bounded batch) is rejected as an invalid request and the peer is penalized, so peer scoring can throttle a flooder (parity with the gossip mesh's scoring).  Non-committee recipients ignore the request.
- **Removed gossip wiring**: `LibP2pConfig::worker_txn_topic` (`config/network.rs`) and its `subscribe(...)` in `start_epoch.rs`.  The batch gossip topic is untouched.

## Tests

- New unit tests for the receive path: a committee member offers every pushed txn to `submit_txn_if_mine` exactly once, in order, with its own committee size/slot;  an empty push is a no-op;  an over-cap push is rejected.
- Updated `test_batch_gossip_topics` (retired txn-topic cases removed;  batch topic enforcement kept).
- Full `tn-worker` suite green;  `make clippy` clean on the touched crates;  the e2e `test_restarts_observer` (observer submits a txn → a validator confirms it) passes on the new path.

## Deployment note

Existing worker RPC (batch sync, peer exchange, report batch) is wire-compatible across versions because the new variants are appended.  During a rolling upgrade the **new** non-validator→committee txn push is simply unavailable between a mixed pair (an old node can't decode `ReportTxns`;  a new node no longer subscribes to the txn gossip topic), so non-validator transaction submission may be degraded until nodes are upgraded (e.g. at an epoch boundary).  Consensus itself is unaffected.  I'd be happy to keep the gossip path for one release as a transition bridge if preferred.

## Possible follow-up (kept out to keep this a clean transport swap)

- Per-slot targeting: the sender could compute each txn's owning slot and push only to that one validator (1 RPC instead of N) rather than pushing to all members and letting each filter.
