### PR TITLE
fix(network): attribute gossip faults to the accountable peer across the reject, worker, and primary paths (#819)

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -100,7 +100,6 @@ impl PrimaryNetworkError {
             | PrimaryNetworkError::Storage(_)
             | PrimaryNetworkError::InvalidRequest(_)
             | PrimaryNetworkError::Internal(_)
-            | PrimaryNetworkError::UnknownConsensusHeaderDigest(_)
             | PrimaryNetworkError::UnknownConsensusHeaderCert(_)
             | PrimaryNetworkError::UnknownConsensusOutput(_)
             | PrimaryNetworkError::PeerNotInCommittee(_)

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -73,6 +73,51 @@ pub(crate) enum PrimaryNetworkError {
     ConsensusChainError(ConsensusChainError),
 }
 
+impl PrimaryNetworkError {
+    /// Whether this fault is determined purely by the *content* of a gossip message — its BCS
+    /// encoding or its declared topic — and is therefore attributable to the message author
+    /// (`GossipMessage::source`) rather than the peer that relayed it.
+    ///
+    /// Mirrors `WorkerNetworkError::is_author_content_fault` (tn-worker) and is consulted only on
+    /// the gossip path (`PrimaryNetwork::process_gossip`): the network layer accepted and forwarded
+    /// the message after a shallow check, so an honest relayer could not have screened a
+    /// content-determined fault, and charging the relayer for it lets a Byzantine author ban honest
+    /// forwarders (see issues #801/#819). The request/response paths penalize the peer
+    /// unconditionally because there the peer *is* the originator.
+    ///
+    /// Restricted to the two `Fatal` faults authored by the gossip source and reachable from the
+    /// gossip handler: [`Self::Decode`] (`try_decode` of the payload) and [`Self::InvalidTopic`]
+    /// (the payload variant was published to the wrong topic). Every other variant is either
+    /// benign on the gossip path or concerns embedded certificate/consensus content whose signer
+    /// is carried inside the payload and is not necessarily the gossip source, so its existing
+    /// relayer/no-penalty attribution is left unchanged.
+    pub(crate) fn is_author_content_fault(&self) -> bool {
+        //
+        // explicitly match every variant so the classification is revisited with changes
+        //
+        match self {
+            PrimaryNetworkError::Decode(_) | PrimaryNetworkError::InvalidTopic => true,
+            PrimaryNetworkError::InvalidHeader(_)
+            | PrimaryNetworkError::Certificate(_)
+            | PrimaryNetworkError::StdIo(_)
+            | PrimaryNetworkError::Storage(_)
+            | PrimaryNetworkError::InvalidRequest(_)
+            | PrimaryNetworkError::Internal(_)
+            | PrimaryNetworkError::UnknownConsensusHeaderDigest(_)
+            | PrimaryNetworkError::UnknownConsensusHeaderCert(_)
+            | PrimaryNetworkError::UnknownConsensusOutput(_)
+            | PrimaryNetworkError::PeerNotInCommittee(_)
+            | PrimaryNetworkError::UnavailableEpoch(_)
+            | PrimaryNetworkError::UnavailableEpochDigest(_)
+            | PrimaryNetworkError::InvalidEpochRequest
+            | PrimaryNetworkError::Timeout(_)
+            | PrimaryNetworkError::UnknownStreamRequest(_)
+            | PrimaryNetworkError::StreamUnavailable(_)
+            | PrimaryNetworkError::ConsensusChainError(_) => false,
+        }
+    }
+}
+
 impl From<&PrimaryNetworkError> for Option<Penalty> {
     fn from(val: &PrimaryNetworkError) -> Self {
         //
@@ -176,5 +221,30 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         | HeaderError::TNSend(_)
         | HeaderError::InvalidEpoch { .. }
         | HeaderError::ClosedWatchChannel => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Finding 2 (#819): faults determined by the gossip envelope's content — a malformed payload
+    /// (`Decode`) or a wrong declared topic (`InvalidTopic`) — are the message author's, so the
+    /// gossip path charges the author rather than Fatal-banning the honest relaying peer (#801).
+    #[test]
+    fn author_content_faults_are_decode_and_invalid_topic() {
+        assert!(PrimaryNetworkError::Decode(BcsError::Eof).is_author_content_fault());
+        assert!(PrimaryNetworkError::InvalidTopic.is_author_content_fault());
+    }
+
+    /// Every other fault keeps its relayer / no-penalty attribution: transport and local faults
+    /// are not the author's, and embedded certificate/consensus content is signed by a party
+    /// carried inside the payload, not by the gossip source.
+    #[test]
+    fn non_envelope_faults_are_not_author_content() {
+        assert!(!PrimaryNetworkError::InvalidEpochRequest.is_author_content_fault());
+        assert!(!PrimaryNetworkError::UnknownConsensusOutput(0).is_author_content_fault());
+        assert!(!PrimaryNetworkError::InvalidRequest("bad".to_string()).is_author_content_fault());
+        assert!(!PrimaryNetworkError::Internal("boom".to_string()).is_author_content_fault());
     }
 }

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1264,8 +1264,8 @@ where
                     self.process_consensus_output_stream(peer, number, channel, cancel)
                 }
             },
-            NetworkEvent::Gossip(msg, relayer) => {
-                self.process_gossip(msg, relayer);
+            NetworkEvent::Gossip { message, relayer, author } => {
+                self.process_gossip(message, relayer, author);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = PrimaryResponse::Error(PrimaryRPCError(msg));
@@ -1542,7 +1542,12 @@ where
     }
 
     /// Process gossip from committee.
-    fn process_gossip(&self, msg: GossipMessage, relayer: Option<BlsPublicKey>) {
+    fn process_gossip(
+        &self,
+        msg: GossipMessage,
+        relayer: Option<BlsPublicKey>,
+        author: Option<BlsPublicKey>,
+    ) {
         // clone for spawned tasks
         let request_handler = self.request_handler.clone();
         let network_handle = self.network_handle.clone();
@@ -1553,10 +1558,16 @@ where
         self.task_spawner.spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "primary::network", ?e, "process_gossip");
-                // convert error into penalty to lower peer score; only attributable
-                // when the relaying peer's BLS identity has resolved
-                if let Some((relayer, penalty)) = relayer.zip((&e).into()) {
-                    network_handle.report_penalty(relayer, penalty).await;
+                // Charge the accountable peer, and only once its BLS identity has resolved. A
+                // content-determined fault (malformed payload / mis-topic) is the message
+                // author's: the network layer forwarded it after a shallow check, so an honest
+                // relayer could not have screened it, and banning the relayer lets a Byzantine
+                // author partition the mesh (issues #801/#819). Every other fault is the relaying
+                // peer's, as before. `zip` skips the penalty when that peer is unresolved or the
+                // error carries no penalty.
+                let charged = if e.is_author_content_fault() { author } else { relayer };
+                if let Some((peer, penalty)) = charged.zip((&e).into()) {
+                    network_handle.report_penalty(peer, penalty).await;
                 }
                 Err(e.into())
             } else {

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -277,8 +277,8 @@ where
                     warn!(target: "worker::network", "worker application received unexpected peer exchange message");
                 }
             },
-            NetworkEvent::Gossip(msg, relayer) => {
-                self.process_gossip(msg, relayer);
+            NetworkEvent::Gossip { message, relayer, author } => {
+                self.process_gossip(message, relayer, author);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = WorkerResponse::Error(message::WorkerRPCError(msg));
@@ -338,7 +338,12 @@ where
     }
 
     /// Process gossip from a worker.
-    fn process_gossip(&self, msg: GossipMessage, relayer: Option<BlsPublicKey>) {
+    fn process_gossip(
+        &self,
+        msg: GossipMessage,
+        relayer: Option<BlsPublicKey>,
+        author: Option<BlsPublicKey>,
+    ) {
         // clone for spawned tasks
         let request_handler = self.request_handler.clone();
         let network_handle = self.network_handle.clone();
@@ -348,19 +353,14 @@ where
         self.network_handle.get_task_spawner().spawn_task(task_name, async move {
             if let Err(e) = request_handler.process_gossip(&msg).await {
                 warn!(target: "worker::network", ?e, "process_gossip");
-                // A gossip fault is charged to the *relaying* peer, not the message
-                // author. Faults determined purely by message content (malformed
-                // encoding, mis-topic, ...) are the author's: the network layer
-                // accepted and forwarded this message after a shallow check, so an
-                // honest relayer could not have screened it. Banning the relayer for an
-                // author-content fault lets a Byzantine author ban honest validators and
-                // partition the gossip mesh (see issue #801). Penalize only when the
-                // fault is attributable to the relaying peer and its BLS identity has
-                // resolved.
-                let attributable =
-                    relayer.zip(e.penalty()).filter(|_| !e.is_author_content_fault());
-                if let Some((relayer, penalty)) = attributable {
-                    network_handle.report_penalty(relayer, penalty).await;
+                // Charge the accountable peer, and only once its BLS identity has resolved: the
+                // author for a content-determined fault (#819, guaranteed resolved on the
+                // restricted batch topic), the relaying peer for every other fault (#801).
+                // `is_author_content_fault` is the shared classifier; `zip` skips the penalty when
+                // that peer is unresolved or the error carries no penalty.
+                let charged = if e.is_author_content_fault() { author } else { relayer };
+                if let Some((peer, penalty)) = charged.zip(e.penalty()) {
+                    network_handle.report_penalty(peer, penalty).await;
                 }
                 Err(e.into())
             } else {

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -861,7 +861,6 @@ where
                 self.metrics.record_gossip_received();
                 // verify message was published by authorized node
                 let msg_acceptance = self.verify_gossip(&message);
-                let valid = msg_acceptance.is_accepted();
                 trace!(target: "network", ?msg_acceptance, "gossip message verification status");
 
                 // report message validation results to propagate valid messages
@@ -874,50 +873,102 @@ where
                 }
 
                 // process gossip in application layer
-                if valid {
-                    // A peer is `Connected` before its `NodeRecord` resolves its BLS
-                    // identity, so a live mesh neighbor can relay a message before
-                    // `peer_to_bls` can resolve it. Deliver the accepted payload
-                    // regardless and carry the relayer as `Option`: the author is
-                    // already authenticated by `verify_gossip`, the relayer identity
-                    // is only used for penalty attribution, and dropping here would
-                    // lose the message for good because gossipsub has already cached
-                    // `message_id` and will not re-deliver it once the identity
-                    // resolves. The consumer skips the (unattributable) penalty while
-                    // the relayer is unresolved.
-                    let relayer =
-                        self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source);
-                    if relayer.is_none() {
-                        debug!(
-                            target: "network",
-                            ?propagation_source,
-                            ?message_id,
-                            "delivering accepted gossip with unresolved relayer identity; consensus-layer penalty skipped"
-                        );
+                match msg_acceptance {
+                    GossipAcceptance::Accept => {
+                        // A peer is `Connected` before its `NodeRecord` resolves its BLS
+                        // identity, so a live mesh neighbor can relay a message before
+                        // `peer_to_bls` can resolve it. Deliver the accepted payload
+                        // regardless and carry the relayer as `Option`: the author is
+                        // already authenticated by `verify_gossip`, the relayer identity
+                        // is only used for penalty attribution, and dropping here would
+                        // lose the message for good because gossipsub has already cached
+                        // `message_id` and will not re-deliver it once the identity
+                        // resolves. The consumer skips the (unattributable) penalty while
+                        // the relayer is unresolved.
+                        let relayer =
+                            self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source);
+                        if relayer.is_none() {
+                            debug!(
+                                target: "network",
+                                ?propagation_source,
+                                ?message_id,
+                                "delivering accepted gossip with unresolved relayer identity; consensus-layer penalty skipped"
+                            );
+                        }
+                        // Resolve the author's BLS identity too. The message is already
+                        // authenticated, but deep validation in the application layer (the
+                        // worker's batch checks) runs after this `Accept`, and an
+                        // author-content fault it surfaces must be charged to the author,
+                        // not the forwarder (see issue #819). On a restricted topic
+                        // acceptance guarantees the author resolved; on an open topic it may
+                        // be `None`, in which case the consumer skips the author penalty.
+                        let author = message
+                            .source
+                            .as_ref()
+                            .and_then(|id| self.swarm.behaviour().peer_manager.peer_to_bls(id));
+                        // forward gossip to handler
+                        if let Err(e) = self
+                            .event_stream
+                            .try_send(accepted_gossip_event(message, relayer, author))
+                        {
+                            error!(target: "network", topics=?self.authorized_publishers.keys(), ?propagation_source, ?message_id, ?e, "failed to forward gossip!");
+                            // ignore failures at the epoch boundary
+                            // During epoch change the event_stream reciever can be closed.
+                            return Ok(());
+                        }
                     }
-                    // forward gossip to handler
-                    if let Err(e) =
-                        self.event_stream.try_send(accepted_gossip_event(message, relayer))
-                    {
-                        error!(target: "network", topics=?self.authorized_publishers.keys(), ?propagation_source, ?message_id, ?e, "failed to forward gossip!");
-                        // ignore failures at the epoch boundary
-                        // During epoch change the event_stream reciever can be closed.
-                        return Ok(());
+                    GossipAcceptance::Reject(reason) => {
+                        self.metrics.record_gossip_rejected();
+                        // Resolve both candidate culprits, then let `reason` decide accountability
+                        // (see `RejectReason::penalty`): an oversized payload is charged to the
+                        // relaying peer, an unauthorized author to the author, each only once its
+                        // identity has resolved. The relaying peer is never penalized for an
+                        // author fault (#801/#785).
+                        let relayer =
+                            self.swarm.behaviour().peer_manager.peer_to_bls(&propagation_source);
+                        let author_id = message.source;
+                        let author = author_id
+                            .as_ref()
+                            .and_then(|id| self.swarm.behaviour().peer_manager.peer_to_bls(id));
+                        let topic = &message.topic;
+                        match reason.penalty(relayer.is_some(), author.is_some()) {
+                            RejectPenalty::FatalRelayer => {
+                                warn!(
+                                    target: "network",
+                                    ?topic,
+                                    "oversized gossip - applying fatal penalty to propagation source: {propagation_source:?}"
+                                );
+                                self.swarm
+                                    .behaviour_mut()
+                                    .peer_manager
+                                    .process_penalty(propagation_source, Penalty::Fatal);
+                            }
+                            RejectPenalty::FatalAuthor => {
+                                // `author.is_some()` guarantees `author_id` is `Some`.
+                                if let Some(author_id) = author_id {
+                                    warn!(
+                                        target: "network",
+                                        ?author_id,
+                                        ?topic,
+                                        "unauthorized-author gossip - applying fatal penalty to the author, not the forwarding relayer: {propagation_source:?}"
+                                    );
+                                    self.swarm
+                                        .behaviour_mut()
+                                        .peer_manager
+                                        .process_penalty(author_id, Penalty::Fatal);
+                                }
+                            }
+                            RejectPenalty::Skip => {
+                                debug!(
+                                    target: "network",
+                                    ?reason,
+                                    ?topic,
+                                    ?propagation_source,
+                                    "rejecting gossip without an attributable penalty (unresolved relayer/author, or this node's committee-view lag)"
+                                );
+                            }
+                        }
                     }
-                } else {
-                    self.metrics.record_gossip_rejected();
-                    let GossipMessage { source, topic, .. } = message;
-                    warn!(
-                        target: "network",
-                        author = ?source,
-                        ?topic,
-                        "received invalid gossip - applying fatal penalty to propagation source: {:?}",
-                        propagation_source
-                    );
-                    self.swarm
-                        .behaviour_mut()
-                        .peer_manager
-                        .process_penalty(propagation_source, Penalty::Fatal);
                 }
             }
             GossipEvent::Subscribed { peer_id, topic } => {
@@ -1155,7 +1206,7 @@ where
     fn verify_gossip(&self, gossip: &GossipMessage) -> GossipAcceptance {
         // verify message size
         if gossip.data.len() > self.config.max_gossip_message_size {
-            return GossipAcceptance::Reject;
+            return GossipAcceptance::Reject(RejectReason::TooLarge);
         }
 
         let GossipMessage { topic, .. } = gossip;
@@ -1171,7 +1222,7 @@ where
         }) {
             GossipAcceptance::Accept
         } else {
-            GossipAcceptance::Reject
+            GossipAcceptance::Reject(RejectReason::UnauthorizedAuthor)
         }
     }
 
@@ -1693,18 +1744,68 @@ where
 ///
 /// This is necessary because libp2p does not impl `PartialEq` on [MessageAcceptance].
 /// This impl does not map to `MessageAcceptance::Ignore`.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum GossipAcceptance {
     /// The message is considered valid, and it should be delivered and forwarded to the network.
     Accept,
-    /// The message is considered invalid, and it should be rejected and trigger the P₄ penalty.
-    Reject,
+    /// The message is considered invalid, and it should be rejected. The [`RejectReason`]
+    /// records who is accountable for the rejection.
+    Reject(RejectReason),
 }
 
-impl GossipAcceptance {
-    /// Helper method indicating if the gossip message was accepted.
-    fn is_accepted(&self) -> bool {
-        *self == GossipAcceptance::Accept
+/// Why `verify_gossip` rejected a message.
+///
+/// The variant records *who* the fault is attributable to, which the reject path uses to decide
+/// whether the relaying peer may be penalized. Rejecting a message never propagates it, regardless
+/// of the reason; the distinction only governs peer scoring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RejectReason {
+    /// The payload exceeds `max_gossip_message_size`. The bound is a shared constant, so under
+    /// gossipsub `Strict` validation an honest peer computes the same verdict and never forwards
+    /// the message: a peer that forwards an oversized payload is itself misbehaving, so the
+    /// relaying peer is accountable.
+    TooLarge,
+    /// The message author is absent, has no resolved BLS identity, or is not an authorized
+    /// publisher for the topic. The fault is the author's, not the forwarder's: an honest relayer
+    /// merely forwarded content the author is responsible for, so the relaying peer is never
+    /// penalized (the reject-path analogue of #801/#785). The resolved author is charged instead;
+    /// an honest author authorized under a neighbouring committee view is spared by the committee
+    /// exemption in the peer manager.
+    UnauthorizedAuthor,
+}
+
+/// The peer-scoring outcome for a rejected gossip message. Rejecting never propagates the message;
+/// this only decides which peer, if any, is penalized.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RejectPenalty {
+    /// Fatally penalize the relaying peer (`propagation_source`).
+    FatalRelayer,
+    /// Fatally penalize the message author (`GossipMessage::source`).
+    FatalAuthor,
+    /// Do not penalize any peer.
+    Skip,
+}
+
+impl RejectReason {
+    /// Decide the peer-scoring outcome for this reject, given whether the relaying peer's and the
+    /// message author's BLS identities have resolved.
+    ///
+    /// An oversized payload is charged to the relaying peer: the size bound is a shared constant,
+    /// so under gossipsub `Strict` validation an honest peer computes the same verdict and never
+    /// forwards one, making a forwarded oversized payload relayer misbehavior. An unauthorized
+    /// author is charged to the *author*, never the forwarder — an honest relayer merely forwarded
+    /// content the author is responsible for (the reject-path analogue of #801/#785), and an honest
+    /// author authorized under a neighbouring committee view is spared downstream by the committee
+    /// exemption in the peer manager. Either penalty is skipped until the accountable peer's
+    /// identity resolves: unattributable otherwise (the same join-window race the Accept path
+    /// documents), which for the author also covers the anonymous-message and view-lag cases.
+    fn penalty(self, relayer_resolved: bool, author_resolved: bool) -> RejectPenalty {
+        match self {
+            RejectReason::TooLarge if relayer_resolved => RejectPenalty::FatalRelayer,
+            RejectReason::TooLarge => RejectPenalty::Skip,
+            RejectReason::UnauthorizedAuthor if author_resolved => RejectPenalty::FatalAuthor,
+            RejectReason::UnauthorizedAuthor => RejectPenalty::Skip,
+        }
     }
 }
 
@@ -1712,7 +1813,7 @@ impl From<GossipAcceptance> for MessageAcceptance {
     fn from(value: GossipAcceptance) -> Self {
         match value {
             GossipAcceptance::Accept => MessageAcceptance::Accept,
-            GossipAcceptance::Reject => MessageAcceptance::Reject,
+            GossipAcceptance::Reject(_) => MessageAcceptance::Reject,
         }
     }
 }
@@ -1777,6 +1878,7 @@ fn resolve_response<Res: TNMessage>(
 fn accepted_gossip_event<Req, Res>(
     message: GossipMessage,
     relayer: Option<BlsPublicKey>,
+    author: Option<BlsPublicKey>,
 ) -> NetworkEvent<Req, Res> {
-    NetworkEvent::Gossip(message, relayer)
+    NetworkEvent::Gossip { message, relayer, author }
 }

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -38,7 +38,8 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 
 | Location                                     | Trigger (immediate guard)                                                     | Severity |
 | -------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:828` | `verify_gossip` rejected (`!valid`) — invalid topic or unauthorized publisher | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:940` | `verify_gossip` rejected `TooLarge` (oversized payload) **and** the relaying peer's BLS has resolved (`RejectPenalty::FatalRelayer`) — the size bound is deterministic network-wide, so under `Strict` validation a peer that forwards an oversized payload is itself misbehaving | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:942` | `verify_gossip` rejected `UnauthorizedAuthor` (author absent / unresolved / unauthorized), or `TooLarge` from an unresolved relayer (`RejectPenalty::Skip`) — author-attributable or unattributable, so the forwarder is not penalized (issues #801/#819) | `None`   |
 | `crates/network-libp2p/src/consensus.rs:839` | `GossipEvent::GossipsubNotSupported { peer_id }`                              | `Fatal`  |
 | `crates/network-libp2p/src/consensus.rs:843` | `GossipEvent::SlowPeer { peer_id, failed_messages }`                          | `Mild`   |
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -934,7 +934,7 @@ async fn test_publish_to_one_peer() -> eyre::Result<()> {
         timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
 
     // assert gossip message
-    if let NetworkEvent::Gossip(msg, _) = event {
+    if let NetworkEvent::Gossip { message: msg, .. } = event {
         assert_eq!(msg.data, expected_result);
     } else {
         panic!("unexpected network event received");
@@ -993,7 +993,7 @@ async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<
         timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
 
     // assert gossip message and that the resolved relayer identity is carried
-    if let NetworkEvent::Gossip(msg, relayer) = event {
+    if let NetworkEvent::Gossip { message: msg, relayer, .. } = event {
         assert_eq!(msg.data, expected_result);
         assert_eq!(
             relayer,
@@ -1208,7 +1208,7 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
 
     while !received && start.elapsed() < timeout {
         match tokio::time::timeout(Duration::from_millis(500), nvv_events.recv()).await {
-            Ok(Some(NetworkEvent::Gossip(msg, from))) => {
+            Ok(Some(NetworkEvent::Gossip { message: msg, relayer: from, .. })) => {
                 assert_eq!(msg.data, expected_msg, "Gossip message data mismatch");
                 debug!(target: "network", ?from, "nvv received gossip from peer");
                 received = true;
@@ -2001,7 +2001,7 @@ async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()>
     publisher.publish(TEST_TOPIC.into(), expected.clone()).await?;
     let event =
         timeout(Duration::from_secs(2), next_peer_events.recv()).await?.expect("gossip received");
-    if let NetworkEvent::Gossip(msg, _) = event {
+    if let NetworkEvent::Gossip { message: msg, .. } = event {
         assert_eq!(msg.data, expected);
     } else {
         panic!("unexpected network event received");
@@ -2143,7 +2143,7 @@ async fn test_get_kad_records() -> eyre::Result<()> {
 
     // wait for gossip from disconnected peer
     match timeout(Duration::from_secs(5), nvv_events.recv()).await {
-        Ok(Some(NetworkEvent::Gossip(msg, _))) => {
+        Ok(Some(NetworkEvent::Gossip { message: msg, .. })) => {
             let GossipMessage { source, data, .. } = msg;
             assert_eq!(source, Some(target_peer_id));
             assert_eq!(data, expected_msg);
@@ -2712,8 +2712,12 @@ fn test_gossip_message() -> GossipMessage {
 fn accepted_gossip_with_unresolved_relayer_is_delivered() -> eyre::Result<()> {
     let message = test_gossip_message();
     let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
-        accepted_gossip_event(message.clone(), None);
-    assert_matches!(event, NetworkEvent::Gossip(delivered, None) if delivered.data == message.data);
+        accepted_gossip_event(message.clone(), None, None);
+    assert_matches!(
+        event,
+        NetworkEvent::Gossip { message: delivered, relayer: None, author: None }
+            if delivered.data == message.data
+    );
     Ok(())
 }
 
@@ -2723,7 +2727,53 @@ fn accepted_gossip_with_resolved_relayer_carries_identity() -> eyre::Result<()> 
     let bls = *BlsKeypair::generate(&mut StdRng::from_seed([9; 32])).public();
     let message = test_gossip_message();
     let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
-        accepted_gossip_event(message, Some(bls));
-    assert_matches!(event, NetworkEvent::Gossip(_, Some(got)) if got == bls);
+        accepted_gossip_event(message, Some(bls), None);
+    assert_matches!(event, NetworkEvent::Gossip { relayer: Some(got), .. } if got == bls);
     Ok(())
+}
+
+/// Regression for issue #819: a resolved author identity is carried on the delivered gossip
+/// event so the application layer can charge an author-content fault to the author rather than
+/// the forwarding relayer.
+#[test]
+fn accepted_gossip_carries_resolved_author_identity() -> eyre::Result<()> {
+    let author = *BlsKeypair::generate(&mut StdRng::from_seed([11; 32])).public();
+    let message = test_gossip_message();
+    let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
+        accepted_gossip_event(message, None, Some(author));
+    assert_matches!(event, NetworkEvent::Gossip { author: Some(got), .. } if got == author);
+    Ok(())
+}
+
+/// Finding 1 (#819): the network-layer reject path must never Fatal-ban the relaying peer for an
+/// author-attributable reject. An `UnauthorizedAuthor` reject charges the resolved author, and no
+/// one when the author is unresolved (anonymous message or this node's view lag) — but never the
+/// relayer, regardless of whether either identity has resolved.
+#[test]
+fn author_attributable_reject_charges_the_author_never_the_relayer() {
+    for relayer_resolved in [true, false] {
+        assert_eq!(
+            RejectReason::UnauthorizedAuthor.penalty(relayer_resolved, true),
+            RejectPenalty::FatalAuthor
+        );
+        assert_eq!(
+            RejectReason::UnauthorizedAuthor.penalty(relayer_resolved, false),
+            RejectPenalty::Skip
+        );
+    }
+}
+
+/// An oversized payload is the only relayer-attributable reject — the size bound is deterministic
+/// network-wide, so under `Strict` validation an honest peer never forwards one — and it is
+/// charged to the forwarder only once its BLS identity has resolved (the author's resolution is
+/// irrelevant), mirroring the Accept path's unresolved-relayer skip.
+#[test]
+fn oversized_reject_penalizes_only_a_resolved_relayer() {
+    for author_resolved in [true, false] {
+        assert_eq!(
+            RejectReason::TooLarge.penalty(true, author_resolved),
+            RejectPenalty::FatalRelayer
+        );
+        assert_eq!(RejectReason::TooLarge.penalty(false, author_resolved), RejectPenalty::Skip);
+    }
 }

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -202,6 +202,12 @@ impl<Res> ResponseChannel<Res> {
 }
 
 /// Events created from network activity.
+// The `Gossip` variant carries the payload plus two resolved BLS identities (relayer + author)
+// for penalty attribution, making it the largest variant. `NetworkEvent` is a short-lived message
+// moved across a small-capacity channel, so the per-slot size is immaterial, whereas boxing a
+// field would add a heap allocation to the hot gossip-delivery path; the peer-manager event enum
+// takes the same allowance (see `peers/types.rs`).
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum NetworkEvent<Req, Res> {
     /// Direct request from peer.
@@ -215,16 +221,27 @@ pub enum NetworkEvent<Req, Res> {
         /// The oneshot channel if the request gets cancelled at the network level.
         cancel: oneshot::Receiver<()>,
     },
-    /// Gossip message received, with the relaying peer's BLS identity when it
-    /// has resolved.
+    /// Gossip message received, with the relaying peer's and the author's BLS identities
+    /// when they have resolved.
     ///
-    /// The identity is `None` during the brief window after a peer joins the
-    /// gossipsub mesh and relays a message before its signed `NodeRecord`
-    /// (which carries the BLS key) has been resolved. The payload is delivered
-    /// regardless, because the message author is already authenticated during
-    /// gossip verification; the relayer identity is used only for penalty
-    /// attribution and a log label, never for the payload itself.
-    Gossip(GossipMessage, Option<BlsPublicKey>),
+    /// Both identities are `Option` because a peer is `Connected` — and can relay or author
+    /// gossip — before its signed `NodeRecord` (which carries the BLS key) has been resolved.
+    /// The payload is delivered regardless, because the message author is already authenticated
+    /// during gossip verification; the identities are used only for penalty attribution and a
+    /// log label, never for the payload itself.
+    ///
+    /// `relayer` (the forwarding `propagation_source`) and `author` (the publishing
+    /// `GossipMessage::source`) are distinct peers, and charging a content fault to the wrong
+    /// one bans honest peers (see issues #801/#819); they are named rather than positional so
+    /// the two cannot be transposed.
+    Gossip {
+        /// The gossip message payload.
+        message: GossipMessage,
+        /// BLS identity of the relaying peer (`propagation_source`), when resolved.
+        relayer: Option<BlsPublicKey>,
+        /// BLS identity of the message author (`GossipMessage::source`), when resolved.
+        author: Option<BlsPublicKey>,
+    },
     /// Send an error back the requester.
     Error(String, ResponseChannel<Res>),
     /// An inbound stream was established by a peer.


### PR DESCRIPTION
fix(network): attribute gossip faults to the accountable peer across the reject path, worker, and primary (#819)

## Summary

Closes #819.  Follow-up to #801/#812 (worker deep-validation layer) and #785 (Accept-path unresolved-relayer delivery).  #812 stopped the worker Fatal-banning the *relaying* peer for a message *author's* content fault, but three adjacent facets of the same author-vs-relayer misattribution remained in the gossip path:

1. the network-layer `Reject` branch still Fatal-banned the relayer for author-attributable rejects;
2. after #812 a deep author-content fault penalized *no one* (the author went uncharged);
3. the **primary** gossip path still Fatal-banned the relayer for author-content faults (`Decode` / `InvalidTopic`) — the same #801 bug on the sibling path.

Facet 3 is beyond #819's original text (which scoped the worker + network-reject paths) but the fix threads the author identity through the shared gossip event and touches the primary consumer, so leaving the identical honest-relayer ban on the adjacent path would be a half-fix;  it is included here.

This codebase configures **no gossipsub peer score** (no `with_peer_score` / `PeerScoreParams`), so the only consequence channel is TN's custom `PeerManager` penalty . . . there is no built-in mesh-scoring backstop.

## Finding 1: network-layer `Reject` branch Fatal-banned the relayer for author faults (medium)

`verify_gossip` rejects for oversized payload, unauthorized author, or unresolved-author (all determined by the *author*, not the forwarder) and `process_gossip_event` unconditionally Fatal-banned `propagation_source`.  Under gossipsub `Strict` validation a relayer only forwards what it accepted, so an honest relayer can only forward a message this node rejects when the two *disagree*: that happens for the author-authorized / author-BLS checks (epoch-boundary committee-view skew;  BLS-resolution race), but **not** for oversize, which is deterministic from a shared constant.

**Fix.** `verify_gossip` returns a typed `RejectReason`;  `RejectReason::penalty(relayer_resolved, author_resolved)` (unit-tested) charges an oversized payload from a *resolved* relayer to the forwarder (an honest peer never forwards a deterministically oversized payload), and charges an unauthorized author to the resolved *author* rather than the relayer, skipping either penalty while that peer's identity is unresolved (mirroring the #785 Accept path).  The relaying peer is never Fatal-banned for an author fault, and an honest author authorized under a neighbouring committee view is spared by the committee exemption in the peer manager.

## Finding 2: deep author-content fault penalized no one (low)

After #812 the worker stopped charging the relayer for `Bcs`/`InvalidTopic`/… faults from its deep validation, but nothing charged the author.  The accepted-gossip event now carries the author's resolved BLS alongside the relayer's, and the worker charges the accountable peer via the shared `is_author_content_fault` classifier . . . the resolved author for a content fault (guaranteed resolved on the restricted batch topic), the relayer otherwise.

## Primary path: same misattribution on the sibling gossip path (medium)

The primary's `process_gossip` charged the relayer for every fault, and `PrimaryNetworkError::Decode`/`InvalidTopic` map to `Fatal`.  On the open `consensus_output_topic` (any author accepted) a Byzantine authorized publisher's malformed/mis-topic gossip gets an honest non-committee relayer Fatal-banned.  Fixed by a new `PrimaryNetworkError::is_author_content_fault` (restricted to the two gossip-envelope faults authored by the source . . . `Decode` and `InvalidTopic`; embedded certificate/consensus faults are signed by a party inside the payload, not the gossip source, so their existing attribution is untouched) and the same author/relayer routing, using the author now plumbed through the event.

## Notable design choices

- **`NetworkEvent::Gossip` is now a named struct variant** `{ message, relayer, author }` (was `(GossipMessage, Option<BlsPublicKey>)`).  Charging a content fault to the wrong peer is the entire bug class, so the two identities are named rather than positional and cannot be transposed.
- **Attribution decisions are explicit, exhaustively-matched classifiers**: `RejectReason` / `RejectReason::penalty` at the network layer, and `is_author_content_fault` on each of `WorkerNetworkError` / `PrimaryNetworkError`.  Each `process_gossip` then selects author-vs-relayer from that single tested predicate — no bare boolean decides who gets banned in more than one place.

## Testing

- `RejectReason::penalty`: an `UnauthorizedAuthor` reject never penalizes the relayer (resolved or not);  an oversized reject is `Fatal` only for a resolved relayer.
- `accepted_gossip_event` carries the resolved author identity (new), alongside the existing relayer-carry regressions.
- `WorkerNetworkError::is_author_content_fault` (existing #801 test, unchanged) and a new `PrimaryNetworkError::is_author_content_fault` test pin exactly `Decode`/`InvalidTopic` as author faults.
- `cargocho build --tests` + targeted suites for `tn-network-libp2p`, `tn-worker`, `tn-primary` are clean (0 failed); fmt + clippy clean (no new warnings).

## Base

Branched off `origin/main` at `c8f7b062`. (The immediately prior HEAD `3f809525` had an unrelated compile error in `tn-primary` — a `.is_some()` on an already-unwrapped `u64` in `request_epoch_pack_inner` . . . that `c8f7b062` fixed by dropping the dead branch. This PR sits on the fixed base.)

## Relationship to prior work

Finding 1 is the reject-path analogue of #801/#785;  Finding 2 is the accountability residue #812 left open;  the primary fix extends #801's relayer-suppression to the sibling primary gossip path.  Related silent-drop/`PeerMissing` handling: #743.
