### PR TITLE
feat(network): move the goodbye exchange to a dedicated peer-exchange protocol with embedded fallback (739, step 8)

### DIFF
--- a/crates/network-libp2p/src/codec.rs
+++ b/crates/network-libp2p/src/codec.rs
@@ -166,6 +166,21 @@ pub trait TNMessage:
     fn peer_exchange_msg(&self) -> Option<PeerExchangeMap>;
 }
 
+/// The codec for the dedicated peer-exchange goodbye protocol.
+///
+/// Both directions carry a bare [`PeerExchangeMap`]: the request is the disconnecting
+/// node's exchange map and the response is an ack (empty today, though the symmetric
+/// shape leaves room for a reciprocal exchange). Reuses the hardened length-prefixed
+/// snappy codec, so the goodbye path keeps the same bounded-read guarantees as the
+/// consensus RPCs.
+pub(crate) type PeerExchangeCodec = TNCodec<PeerExchangeMap, PeerExchangeMap>;
+
+impl TNMessage for PeerExchangeMap {
+    fn peer_exchange_msg(&self) -> Option<PeerExchangeMap> {
+        Some(self.clone())
+    }
+}
+
 /// The Telcoin Network request/response codec for consensus messages between peers.
 ///
 /// The codec reuses pre-allocated buffers to asynchronously read messages per the libp2p [Codec]

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -3,7 +3,7 @@
 //! This network is used by workers and primaries to reliably send consensus messages.
 
 use crate::{
-    codec::{TNCodec, TNMessage},
+    codec::{PeerExchangeCodec, TNCodec, TNMessage},
     error::NetworkError,
     kad::KadStore,
     metrics::{PeerManagerMetrics, SwarmMetrics},
@@ -57,6 +57,7 @@ mod network_tests;
 /// - `peer_manager`: Connection management and peer scoring
 /// - `gossipsub`: Flood publishing for certificates and batches
 /// - `req_res`: Point-to-point request-response messages
+/// - `peer_exchange`: Dedicated request-response protocol for the goodbye exchange
 /// - `kademlia`: Distributed hash table for peer discovery
 /// - `stream`: Stream-based bulk data transfer for state sync
 ///
@@ -76,6 +77,13 @@ where
     pub(crate) gossipsub: gossipsub::Behaviour,
     /// The request-response network behavior.
     pub(crate) req_res: request_response::Behaviour<C>,
+    /// Dedicated request-response behavior for the peer-exchange goodbye.
+    ///
+    /// Preferred over the [`PeerExchangeMap`] variants embedded in the consensus
+    /// request enums; goodbyes fall back to the embedded variant when the peer
+    /// has not upgraded yet. The embedded variants stay on the wire until the
+    /// coordinated `/0.0.2` protocol bump.
+    pub(crate) peer_exchange: request_response::Behaviour<PeerExchangeCodec>,
     /// Used for peer discovery.
     pub(crate) kademlia: kad::Behaviour<KadStore<DB>>,
     /// Stream-based sync behavior for bulk data transfer.
@@ -88,20 +96,50 @@ where
     DB: Database,
 {
     /// Create a new instance of Self.
+    ///
+    /// The request-response behaviours arrive as a `(consensus, peer_exchange)`
+    /// pair: the main consensus RPC behaviour and the dedicated goodbye behaviour.
     pub(crate) fn new(
         local_peer_id: PeerId,
         gossipsub: gossipsub::Behaviour,
-        req_res: request_response::Behaviour<C>,
+        req_res: (request_response::Behaviour<C>, request_response::Behaviour<PeerExchangeCodec>),
         kademlia: kad::Behaviour<KadStore<DB>>,
         peer_config: &PeerConfig,
         metrics: PeerManagerMetrics,
         stream_protocols: (StreamProtocol, StreamProtocol),
     ) -> Self {
         let peer_manager = PeerManager::new(local_peer_id, peer_config, metrics);
+        let (req_res, peer_exchange) = req_res;
         let (stream_legacy, stream_sync) = stream_protocols;
         let stream = StreamBehavior::new(stream_legacy, stream_sync);
-        Self { peer_manager, gossipsub, req_res, kademlia, stream }
+        Self { peer_manager, gossipsub, req_res, peer_exchange, kademlia, stream }
     }
+}
+
+/// A goodbye dispatched on the dedicated peer-exchange protocol, awaiting the ack.
+///
+/// Holds everything needed to fall back to the legacy embedded exchange if the
+/// peer turns out not to support the dedicated protocol.
+#[derive(Debug)]
+struct PendingGoodbye {
+    /// The exchange map, retained so an `UnsupportedProtocols` failure can resend
+    /// it as the embedded legacy variant.
+    exchange: PeerExchangeMap,
+    /// Notifies the disconnect-deadline task how the goodbye resolved.
+    ///
+    /// Dropping the sender wakes the task, which disconnects: the correct default
+    /// for every resolution except a legacy fallback.
+    notify: oneshot::Sender<GoodbyeOutcome>,
+}
+
+/// How a goodbye on the dedicated peer-exchange protocol resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GoodbyeOutcome {
+    /// The peer acked the exchange: safe to disconnect immediately.
+    Acked,
+    /// The peer does not support the dedicated protocol; the goodbye was re-sent
+    /// on the legacy embedded path, which owns the disconnect from here.
+    FellBack,
 }
 
 /// The network type for consensus messages.
@@ -138,6 +176,14 @@ where
     /// before disconnecting. This keeps track of the number of disconnects to ensure resources
     /// aren't starved while waiting for the peer's ack.
     pending_px_disconnects: HashMap<OutboundRequestId, PeerId>,
+    /// The collection of pending goodbyes on the dedicated peer-exchange protocol.
+    ///
+    /// Tracked separately from `pending_px_disconnects`: request ids are scoped to
+    /// the behaviour that issued them, so ids from the dedicated protocol could
+    /// collide with the legacy req-res ids. Each entry retains the exchange map so
+    /// a goodbye that fails with `UnsupportedProtocols` can fall back to the
+    /// legacy variant embedded in the consensus request enum.
+    pending_goodbyes: HashMap<OutboundRequestId, PendingGoodbye>,
     /// The collection of pending outbound requests.
     ///
     /// Callers include a oneshot channel for the network to return response. The caller is
@@ -290,6 +336,17 @@ where
             vec![(network_type.req_res_protocol(chain_id)?, ProtocolSupport::Full)],
             request_response::Config::default(),
         );
+
+        // Dedicated goodbye protocol: the same hardened codec under its own wire
+        // name, so the peer-exchange map no longer has to ride inside the consensus
+        // request enums. The embedded variants remain as the fallback for
+        // not-yet-upgraded peers until the coordinated `/0.0.2` bump.
+        let px_codec = PeerExchangeCodec::new(network_config.libp2p_config().max_rpc_message_size);
+        let peer_exchange = request_response::Behaviour::with_codec(
+            px_codec,
+            vec![(network_type.peer_exchange_protocol(chain_id)?, ProtocolSupport::Full)],
+            request_response::Config::default(),
+        );
         let peer_id: PeerId = keypair.public().into();
         let mut kad_config = libp2p::kad::Config::new(network_type.kad_protocol(chain_id)?);
         // manually add peers
@@ -337,7 +394,7 @@ where
         let mut behavior = TNBehavior::new(
             peer_id,
             gossipsub,
-            req_res,
+            (req_res, peer_exchange),
             kademlia,
             network_config.peer_config(),
             PeerManagerMetrics::new_for(&network_type),
@@ -379,6 +436,7 @@ where
         let (handle, commands) = tokio::sync::mpsc::channel(100);
         let config = network_config.libp2p_config().clone();
         let pending_px_disconnects = HashMap::with_capacity(config.max_px_disconnects);
+        let pending_goodbyes = HashMap::with_capacity(config.max_px_disconnects);
         let node_record = Self::create_node_record(external_addr, &key_config, network_pubkey, rpc);
 
         Ok(Self {
@@ -393,6 +451,7 @@ where
             config,
             connected_peers: VecDeque::new(),
             pending_px_disconnects,
+            pending_goodbyes,
             key_config,
             task_spawner,
             node_record,
@@ -519,8 +578,7 @@ where
             }
 
             // refresh in-flight gauges once per loop iteration (scrape-interval freshness)
-            self.metrics
-                .set_pending(self.pending_px_disconnects.len(), self.outbound_requests.len());
+            self.metrics.set_pending(self.goodbyes_in_flight(), self.outbound_requests.len());
         }
     }
 
@@ -534,6 +592,7 @@ where
             SwarmEvent::Behaviour(behavior) => match behavior {
                 TNBehaviorEvent::Gossipsub(event) => self.process_gossip_event(event)?,
                 TNBehaviorEvent::ReqRes(event) => self.process_reqres_event(event)?,
+                TNBehaviorEvent::PeerExchange(event) => self.process_peer_exchange_event(event)?,
                 TNBehaviorEvent::PeerManager(event) => self.process_peer_manager_event(event)?,
                 TNBehaviorEvent::Kademlia(event) => self.process_kad_event(event)?,
                 TNBehaviorEvent::Stream(event) => self.process_stream_event(event)?,
@@ -1149,6 +1208,162 @@ where
         Ok(())
     }
 
+    /// Process events from the dedicated peer-exchange goodbye protocol.
+    ///
+    /// Mirrors the legacy embedded peer-exchange handling in
+    /// [`Self::process_reqres_event`]: an inbound exchange updates the peer manager,
+    /// receives an empty ack, and triggers a reciprocal disconnect. Failures are
+    /// never penalized: a goodbye precedes a disconnect, so there is no
+    /// relationship left to protect. The one failure that changes course is
+    /// outbound `UnsupportedProtocols` (honest version skew, penalty-exempt): the
+    /// exchange is re-sent as the legacy variant embedded in the consensus request
+    /// enum so not-yet-upgraded peers still receive it.
+    fn process_peer_exchange_event(
+        &mut self,
+        event: ReqResEvent<PeerExchangeMap, PeerExchangeMap>,
+    ) -> NetworkResult<()> {
+        match event {
+            ReqResEvent::Message { peer, message, connection_id: _ } => match message {
+                request_response::Message::Request { request_id: _, request, channel } => {
+                    debug!(target: "network", ?peer, ?request, "processing peer exchange (dedicated protocol)");
+                    self.swarm.behaviour_mut().peer_manager.process_peer_exchange(request);
+                    // send empty ack and ignore errors
+                    let _ = self
+                        .swarm
+                        .behaviour_mut()
+                        .peer_exchange
+                        .send_response(channel, PeerExchangeMap::default());
+
+                    // initiate disconnect from this peer to prevent redial attempts
+                    debug!(target: "peer-manager", ?peer, "initiating reciprocal disconnect after px");
+                    self.swarm.behaviour_mut().peer_manager.disconnect_peer(peer, false);
+                }
+                request_response::Message::Response { request_id, response: _ } => {
+                    // goodbye acked: disconnect immediately (the ack payload is
+                    // reserved for a future reciprocal exchange and ignored today)
+                    if let Some(pending) = self.pending_goodbyes.remove(&request_id) {
+                        let _ = pending.notify.send(GoodbyeOutcome::Acked);
+                        let _ = self.swarm.disconnect_peer_id(peer);
+                    }
+                }
+            },
+            ReqResEvent::OutboundFailure { peer, request_id, error, connection_id: _ } => {
+                debug!(target: "network", ?peer, ?error, "Outbound failure for peer exchange");
+                if let Some(pending) = self.pending_goodbyes.remove(&request_id) {
+                    match &error {
+                        // Not penalized: honest version skew, the same class the main
+                        // req-res handler exempts. The peer predates the dedicated
+                        // protocol, so re-send the exchange as the embedded legacy
+                        // variant, which owns the disconnect from here.
+                        ReqResOutboundFailure::UnsupportedProtocols => {
+                            debug!(
+                                target: "peer-manager",
+                                ?peer,
+                                "peer exchange protocol unsupported - falling back to embedded exchange"
+                            );
+                            self.send_legacy_goodbye(peer, pending.exchange);
+                            let _ = pending.notify.send(GoodbyeOutcome::FellBack);
+                        }
+                        // Any other failure means no ack is coming: dropping the
+                        // notify sender wakes the deadline task, which disconnects.
+                        // No penalty: px supports discovery and failures are okay.
+                        ReqResOutboundFailure::DialFailure
+                        | ReqResOutboundFailure::ConnectionClosed
+                        | ReqResOutboundFailure::Io(_)
+                        | ReqResOutboundFailure::Timeout => {}
+                    }
+                }
+            }
+            ReqResEvent::InboundFailure { peer, request_id, error, connection_id: _ } => {
+                // never penalized: the exchange is best-effort and both sides
+                // disconnect afterwards regardless
+                debug!(target: "network", ?peer, ?request_id, ?error, "Inbound failure for peer exchange");
+            }
+            ReqResEvent::ResponseSent { peer, .. } => {
+                trace!(target: "network", ?peer, "peer exchange ack sent");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The number of graceful goodbyes currently awaiting resolution, across the
+    /// dedicated peer-exchange protocol and the embedded legacy path.
+    ///
+    /// Both paths share the `max_px_disconnects` budget so the combined pending
+    /// count keeps the original bound.
+    fn goodbyes_in_flight(&self) -> usize {
+        self.pending_goodbyes.len() + self.pending_px_disconnects.len()
+    }
+
+    /// Send a goodbye on the dedicated peer-exchange protocol and schedule the
+    /// disconnect.
+    ///
+    /// The spawned task disconnects once the goodbye resolves or after
+    /// `px_disconnect_timeout`, whichever comes first, unless the goodbye fell
+    /// back to the embedded legacy path, which schedules its own disconnect.
+    fn send_goodbye(&mut self, peer_id: PeerId, exchange: PeerExchangeMap) {
+        let (notify, done) = oneshot::channel();
+        let request_id =
+            self.swarm.behaviour_mut().peer_exchange.send_request(&peer_id, exchange.clone());
+        self.pending_goodbyes.insert(request_id, PendingGoodbye { exchange, notify });
+
+        let timeout = self.config.px_disconnect_timeout;
+        let handle = self.network_handle();
+
+        // spawn task
+        let task_name = format!("goodbye-{peer_id}");
+        self.task_spawner.spawn_task(task_name, async move {
+            // disconnect after the goodbye resolves (ack / failure / deadline)
+            // unless the legacy fallback took over the disconnect
+            let fell_back = tokio::time::timeout(timeout, done)
+                .await
+                .ok()
+                .and_then(|resolved| resolved.ok())
+                .is_some_and(|outcome| outcome == GoodbyeOutcome::FellBack);
+            if !fell_back {
+                let _ = handle.disconnect_peer(peer_id).await;
+            }
+            Ok(())
+        });
+    }
+
+    /// Send a goodbye as the [`PeerExchangeMap`] variant embedded in the legacy
+    /// consensus request enum.
+    ///
+    /// The fallback for peers that do not support the dedicated peer-exchange
+    /// protocol yet; removal is coordinated with the `/0.0.2` protocol bump.
+    fn send_legacy_goodbye(&mut self, peer_id: PeerId, peer_exchange: PeerExchangeMap) {
+        // guard: skip PX if peer already disconnected
+        if !self.swarm.is_connected(&peer_id) {
+            debug!(target: "peer-manager", ?peer_id, "peer already disconnected, skipping PX");
+        } else if self.goodbyes_in_flight() < self.config.max_px_disconnects {
+            // attempt to exchange peer information if limits allow
+            let (reply, done) = oneshot::channel();
+            let request_id =
+                self.swarm.behaviour_mut().req_res.send_request(&peer_id, peer_exchange.into());
+            self.outbound_requests.insert((peer_id, request_id), reply);
+
+            let timeout = self.config.px_disconnect_timeout;
+            let handle = self.network_handle();
+
+            // spawn task
+            let task_name = format!("peer-exchange-{peer_id}");
+            self.task_spawner.spawn_task(task_name, async move {
+                // ignore errors and disconnect after px attempt
+                let _res = tokio::time::timeout(timeout, done).await;
+                let _ = handle.disconnect_peer(peer_id).await;
+                Ok(())
+            });
+
+            // insert to pending px disconnects
+            self.pending_px_disconnects.insert(request_id, peer_id);
+        } else {
+            // too many px disconnects pending so disconnect without px
+            let _ = self.swarm.disconnect_peer_id(peer_id);
+        }
+    }
+
     /// Specific logic to accept gossip messages.
     ///
     /// Messages are only published by current committee nodes and must be within max size.
@@ -1230,30 +1445,11 @@ where
                 // guard: skip PX if peer already disconnected
                 if !self.swarm.is_connected(&peer_id) {
                     debug!(target: "peer-manager", ?peer_id, "peer already disconnected, skipping PX");
-                } else if self.pending_px_disconnects.len() < self.config.max_px_disconnects {
-                    // attempt to exchange peer information if limits allow
-                    let (reply, done) = oneshot::channel();
-                    let request_id = self
-                        .swarm
-                        .behaviour_mut()
-                        .req_res
-                        .send_request(&peer_id, peer_exchange.into());
-                    self.outbound_requests.insert((peer_id, request_id), reply);
-
-                    let timeout = self.config.px_disconnect_timeout;
-                    let handle = self.network_handle();
-
-                    // spawn task
-                    let task_name = format!("peer-exchange-{peer_id}");
-                    self.task_spawner.spawn_task(task_name, async move {
-                        // ignore errors and disconnect after px attempt
-                        let _res = tokio::time::timeout(timeout, done).await;
-                        let _ = handle.disconnect_peer(peer_id).await;
-                        Ok(())
-                    });
-
-                    // insert to pending px disconnects
-                    self.pending_px_disconnects.insert(request_id, peer_id);
+                } else if self.goodbyes_in_flight() < self.config.max_px_disconnects {
+                    // attempt to exchange peer information if limits allow,
+                    // preferring the dedicated protocol (falls back to the
+                    // embedded legacy variant on `UnsupportedProtocols`)
+                    self.send_goodbye(peer_id, peer_exchange);
                 } else {
                     // too many px disconnects pending so disconnect without px
                     let _ = self.swarm.disconnect_peer_id(peer_id);
@@ -1728,6 +1924,7 @@ where
         f.debug_struct("ConsensusNetwork")
             .field("authorized_publishers", &self.authorized_publishers)
             .field("pending_px_disconnects", &self.pending_px_disconnects)
+            .field("pending_goodbyes", &self.pending_goodbyes)
             .field("outbound_requests", &self.outbound_requests.len())
             .field("inbound_requests", &self.inbound_requests.len())
             .field("config", &self.config)

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -940,6 +940,15 @@ mod test {
             "/tn-primary-sync-2017/0.0.1"
         );
         assert_eq!(NetworkType::Worker(3).sync_protocol(7)?.as_ref(), "/tn-worker-3-sync-7/0.0.1");
+        // the per-role peer-exchange goodbye protocol is chain-namespaced as well
+        assert_eq!(
+            NetworkType::Primary.peer_exchange_protocol(2017)?.as_ref(),
+            "/tn-primary-peer-exchange-2017/0.0.1"
+        );
+        assert_eq!(
+            NetworkType::Worker(3).peer_exchange_protocol(7)?.as_ref(),
+            "/tn-worker-3-peer-exchange-7/0.0.1"
+        );
         // a stream node advertises the bulk-transfer protocol first, then the
         // per-role sync protocol; both carry the chain id, and the order is the
         // negotiation-preference contract (existing opens keep using the bulk one)

--- a/crates/network-libp2p/src/tests/codec_tests.rs
+++ b/crates/network-libp2p/src/tests/codec_tests.rs
@@ -5,8 +5,10 @@ use crate::{
     common::{TestPrimaryRequest, TestPrimaryResponse},
     TNCodec,
 };
-use libp2p::StreamProtocol;
-use tn_types::{Certificate, Header, HeaderDigest};
+use libp2p::{Multiaddr, StreamProtocol};
+use rand::{rngs::StdRng, SeedableRng};
+use std::collections::{HashMap, HashSet};
+use tn_types::{BlsKeypair, Certificate, Header, HeaderDigest, NetworkKeypair, NetworkPublicKey};
 
 #[tokio::test]
 async fn test_encode_decode_same_message() {
@@ -42,6 +44,48 @@ async fn test_encode_decode_same_message() {
     let decoded =
         codec.read_response(&protocol, &mut encoded.as_ref()).await.expect("read valid response");
     assert_eq!(decoded, response);
+}
+
+/// The dedicated peer-exchange goodbye codec round-trips a bare [`PeerExchangeMap`]
+/// in both directions: the request carries the disconnecting node's exchange map
+/// and the response carries the (empty today) ack.
+#[tokio::test]
+async fn test_peer_exchange_codec_round_trip() {
+    let max_chunk_size = 1024 * 1024; // 1mb
+    let mut codec = PeerExchangeCodec::new(max_chunk_size);
+    let protocol = StreamProtocol::new("/tn-test-peer-exchange");
+
+    // a representative goodbye payload
+    let mut rng = StdRng::from_seed([0; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    let net: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().clone().into();
+    let multiaddr: Multiaddr = "/ip4/127.0.0.1/udp/38300/quic-v1".parse().expect("valid multiaddr");
+    let exchange = PeerExchangeMap::from(HashMap::from([(bls, (net, HashSet::from([multiaddr])))]));
+
+    // encode and decode the exchange as the request
+    let mut encoded = Vec::new();
+    codec
+        .write_request(&protocol, &mut encoded, exchange.clone())
+        .await
+        .expect("write valid peer exchange request");
+    let decoded = codec
+        .read_request(&protocol, &mut encoded.as_ref())
+        .await
+        .expect("read valid peer exchange request");
+    assert_eq!(decoded, exchange);
+
+    // the empty ack round-trips as the response
+    let mut encoded = Vec::new();
+    let ack = PeerExchangeMap::default();
+    codec
+        .write_response(&protocol, &mut encoded, ack.clone())
+        .await
+        .expect("write valid peer exchange ack");
+    let decoded = codec
+        .read_response(&protocol, &mut encoded.as_ref())
+        .await
+        .expect("read valid peer exchange ack");
+    assert_eq!(decoded, ack);
 }
 
 #[tokio::test]

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1231,6 +1231,140 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
     Ok(())
 }
 
+/// A pruned peer that does not support the dedicated peer-exchange protocol still
+/// receives the goodbye.
+///
+/// The raw swarm below advertises only the legacy `/tn-primary-{chain}/0.0.1`
+/// req-res protocol, exactly the wire surface of a not-yet-upgraded node. The
+/// target's goodbye attempt on `/tn-primary-peer-exchange-{chain}/0.0.1` fails
+/// with `UnsupportedProtocols` (penalty-exempt) and must fall back to the
+/// `PeerExchange` variant embedded in the legacy request enum.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer() -> eyre::Result<()> {
+    tn_types::test_utils::init_test_tracing();
+    // 4 committee peers fill the target to its limit; validators are protected from
+    // pruning, so the raw legacy peer is deterministically the excess one
+    let committee = NonZeroUsize::new(5).unwrap();
+    let mut network_config = NetworkConfig::default();
+    network_config.peer_config_mut().target_num_peers = 4;
+    network_config.peer_config_mut().peer_excess_factor = 0.1;
+    network_config.peer_config_mut().excess_peers_reconnection_timeout = Duration::from_secs(10);
+    network_config.peer_config_mut().heartbeat_interval = TEST_HEARTBEAT_INTERVAL;
+    network_config.libp2p_config_mut().k_bucket_size = committee;
+
+    let (mut target_peer, mut other_peers, _task_manager) =
+        create_test_peers::<TestWorkerRequest, TestWorkerResponse>(
+            committee,
+            Some(network_config.clone()),
+        );
+
+    // spawn target network
+    let target_network = target_peer.network.take().expect("target network is some");
+    tokio::spawn(async move {
+        let res = target_network.run().await;
+        debug!(target: "network", ?res, "target network shutdown");
+    });
+    target_peer.network_handle.start_listening(target_peer.config.primary_address()).await?;
+    let target_addr = target_peer.config.primary_address();
+    let target_peer_bls = target_peer.config.key_config().primary_public_key();
+    let target_peer_net = target_peer.config.primary_networkkey();
+
+    // fill the target with protected committee peers
+    for peer in other_peers.iter_mut() {
+        let peer_network = peer.network.take().expect("peer network is some");
+        tokio::spawn(async move {
+            let res = peer_network.run().await;
+            debug!(target: "network", ?res, "peer network shutdown");
+        });
+        peer.network_handle.start_listening(peer.config.primary_address()).await?;
+        peer.network_handle
+            .add_explicit_peer(target_peer_bls, target_peer_net.clone(), target_addr.clone())
+            .await?;
+        target_peer
+            .network_handle
+            .add_explicit_peer(
+                peer.config.key_config().primary_public_key(),
+                peer.config.primary_networkkey(),
+                peer.config.primary_address(),
+            )
+            .await?;
+        peer.network_handle.dial_by_bls(target_peer_bls).await?;
+
+        // give time for connection to establish and libp2p state to stabilize
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // raw legacy peer: the target's main req-res protocol only, no dedicated
+    // peer-exchange protocol
+    let chain_id = network_config.libp2p_config().chain_id;
+    let raw_keypair = NetworkKeypair::generate_ed25519();
+    let raw_peer_id: PeerId = raw_keypair.public().into();
+    let legacy_codec = TNCodec::<TestWorkerRequest, TestWorkerResponse>::new(
+        network_config.libp2p_config().max_rpc_message_size,
+    );
+    let legacy_req_res = request_response::Behaviour::with_codec(
+        legacy_codec,
+        vec![(NetworkType::Primary.req_res_protocol(chain_id)?, ProtocolSupport::Full)],
+        request_response::Config::default(),
+    );
+    let mut raw_swarm = SwarmBuilder::with_existing_identity(raw_keypair)
+        .with_tokio()
+        .with_quic()
+        .with_behaviour(|_| legacy_req_res)
+        .map_err(|e| eyre!("raw swarm behaviour: {e:?}"))?
+        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(30)))
+        .build();
+
+    // excess dial: accepted (max_peers = ceil(4 * 1.1) = 5), then pruned with px
+    raw_swarm.dial(target_addr.clone())?;
+
+    // drive the raw swarm: capture the legacy embedded goodbye and ack it
+    let (goodbye_tx, goodbye_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut goodbye_tx = Some(goodbye_tx);
+        loop {
+            if let SwarmEvent::Behaviour(request_response::Event::Message {
+                message: request_response::Message::Request { request, channel, .. },
+                ..
+            }) = raw_swarm.select_next_some().await
+            {
+                if let TestWorkerRequest::PeerExchange(map) = request {
+                    let ack = TestWorkerResponse::from(PeerExchangeMap::default());
+                    let _ = raw_swarm.behaviour_mut().send_response(channel, ack);
+                    if let Some(tx) = goodbye_tx.take() {
+                        let _ = tx.send(map);
+                    }
+                }
+            }
+        }
+    });
+
+    // the target prunes the excess raw peer on a heartbeat; the goodbye must reach
+    // the legacy peer on the embedded path (which requires the dedicated-protocol
+    // attempt to have failed over)
+    let goodbye = timeout(Duration::from_secs(TEST_HEARTBEAT_INTERVAL * 10), goodbye_rx)
+        .await
+        .expect("legacy peer received the goodbye before timeout")?;
+    assert!(
+        !goodbye.0.is_empty(),
+        "the fallback goodbye should carry the target's known peers for discovery"
+    );
+
+    // the ack resolves the pending exchange and the target disconnects promptly
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut still_connected = true;
+    while still_connected && tokio::time::Instant::now() < deadline {
+        still_connected =
+            target_peer.network_handle.connected_peer_ids().await?.contains(&raw_peer_id);
+        if still_connected {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+    assert!(!still_connected, "target should disconnect the raw legacy peer after the goodbye");
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
     // Create a custom config with short halflife for quicker testing

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -108,6 +108,22 @@ impl NetworkType {
             Self::Worker(id) => owned_protocol(format!("/tn-worker-{id}-sync-{chain_id}/0.0.1")),
         }
     }
+
+    /// Peer-exchange goodbye wire protocol, isolated per role (and per worker) and
+    /// namespaced by `chain_id` so nodes on different chains never negotiate it.
+    ///
+    /// A dedicated request-response protocol for the [`PeerExchangeMap`](crate::PeerExchangeMap)
+    /// a node shares when it gracefully disconnects. Goodbyes prefer this protocol and fall
+    /// back to the variant embedded in the consensus request enums when the peer has not
+    /// upgraded yet (`UnsupportedProtocols` is penalty-exempt).
+    pub(crate) fn peer_exchange_protocol(&self, chain_id: u64) -> NetworkResult<StreamProtocol> {
+        match self {
+            Self::Primary => owned_protocol(format!("/tn-primary-peer-exchange-{chain_id}/0.0.1")),
+            Self::Worker(id) => {
+                owned_protocol(format!("/tn-worker-{id}-peer-exchange-{chain_id}/0.0.1"))
+            }
+        }
+    }
 }
 
 /// Bulk-transfer stream protocol, namespaced by `chain_id`.


### PR DESCRIPTION
Step 8 of #739.  The peer-exchange goodbye moves off the consensus request enums onto a dedicated small request-response protocol:

- `/tn-primary-peer-exchange-{chain_id}/0.0.1`
- `/tn-worker-{id}-peer-exchange-{chain_id}/0.0.1`

Goodbyes prefer the dedicated protocol and fall back to the `PeerExchange` variant embedded in the legacy request enum when the peer has not upgraded yet (outbound `UnsupportedProtocols`, which is already penalty-exempt).  The change is entirely inside `tn-network-libp2p`: zero consumer-crate edits, and no BCS enum variant is added, removed, or reordered.

## Why

The goodbye is the one message that forces the `From<PeerExchangeMap>` + `peer_exchange_msg()` bounds onto every consumer request/response enum through `TNMessage`, and the interception special-case in the req-res handler.  Extracting it to its own protocol is the prerequisite for dropping those bounds and the embedded variants at the coordinated `/0.0.2` bump (step 9).  It also gives the exchange its own wire identity so its traffic and failures are observable apart from consensus RPCs.

## Wire shape

Both directions carry a bare BCS `PeerExchangeMap` through the same hardened length-prefixed snappy codec (`TNCodec<PeerExchangeMap, PeerExchangeMap>`), so the goodbye path keeps the bounded-read guarantees from #742.  The request is the disconnecting node's exchange map; the response is an ack (empty today: the symmetric shape leaves room for a reciprocal exchange).  `impl TNMessage for PeerExchangeMap` satisfies the codec bounds; `From<PeerExchangeMap>` holds reflexively.

## Outbound path

`PeerEvent::DisconnectPeerX` now calls `send_goodbye`, which opens the dedicated protocol and tracks the attempt in a new `pending_goodbyes` map.  This map is deliberately separate from `pending_px_disconnects`: `OutboundRequestId`s are scoped to the behaviour that issued them, so ids from the dedicated behaviour could collide with legacy req-res ids in a shared map.  Each entry retains the exchange map (for the fallback resend) and a oneshot to the disconnect-deadline task.

Resolution matrix (disconnect discipline unchanged from the legacy path):

- **Ack received** → disconnect immediately (mirrors the legacy response arm).
- **`UnsupportedProtocols`** → re-send the exchange as the embedded legacy variant via `send_legacy_goodbye` (byte-for-byte the previous `DisconnectPeerX` body, including its own full `px_disconnect_timeout` window and the existing response/failure handling), and the dedicated-path deadline task stands down (`GoodbyeOutcome::FellBack`) so it cannot disconnect underneath the in-flight legacy attempt.
- **Any other failure** (dial / connection-closed / IO / timeout) → no ack is coming;  dropping the notify sender wakes the deadline task, which disconnects.  No penalty anywhere on the goodbye path — same class as the existing early-return exemption for px failures.

Both maps share the `max_px_disconnects` budget through `goodbyes_in_flight()`, which also feeds the existing pending-px gauge, so the combined bound and the metric keep their original meaning.

## Inbound path

A dedicated handler mirrors the legacy intercept exactly: process the exchange through the peer manager, send the empty ack, initiate the reciprocal disconnect.  The legacy intercept in `process_reqres_event` stays untouched so goodbyes from not-yet-upgraded peers keep working until step 9 removes them.

## Testing

- `test_network_type_protocol_names` pins the chain-namespaced protocol names (peer-compatibility contract).
- `test_peer_exchange_codec_round_trip` round-trips the exchange request and the empty ack through the dedicated codec.
- **`test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer`** (new e2e, and the first cross-version harness from the issue's rollout rules): a raw libp2p swarm advertising only the legacy `/tn-primary-{chain}/0.0.1` req-res protocol, the exact wire surface of a not-yet-upgraded node, dials a target whose peer slots are filled with prune-protected committee validators.  The target prunes it, the goodbye attempt on the dedicated protocol fails `UnsupportedProtocols`, and the test asserts the goodbye arrives as the embedded legacy variant (only reachable through the fallback), carries a non-empty exchange map, and is followed by a prompt disconnect.
- `test_peer_exchange_with_excess_peers` (existing) now exercises the dedicated-protocol happy path end to end, since both sides are upgraded nodes.

## Rollout

Dedicated-protocol goodbyes and embedded goodbyes coexist;  the fallback needs no capability cache because a goodbye is a single terminal exchange (the failed probe answers the question the cache would).  Step 9 stops sending the embedded variant, drops the `From<PeerExchangeMap>` / `peer_exchange_msg()` bounds from `TNMessage`, and removes the variants at the coordinated `/0.0.2` bump . . . BCS encodes variant indices, so no slot moves before then.