### PR TITLE
fix(primary): out-of-bounds peer index when logging invalid fetched certs (#822)

### DIFF
--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -476,7 +476,7 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
 
     loop {
         tokio::select! {
-            Some(result) = rx_results.recv() => {
+            Some((peer, result)) = rx_results.recv() => {
                 if let Ok(certificates) = result {
                     if !certificates.is_empty() {
                         debug!(target: "primary::cert_fetcher",
@@ -488,7 +488,7 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
                             validate_fetched_certificate(cert).map_err(|e| {
                                 error!(
                                     target: "primary::cert_fetcher",
-                                    peer=?peers[peer_index],
+                                    peer=?peer,
                                     "cert fetch received invalid genesis cert from peer"
                                 );
                                 e.into()
@@ -554,13 +554,16 @@ fn spawn_peer_fetch<F: MissingCertFetcher>(
     peer: BlsPublicKey,
     request: MissingCertificatesRequest,
     network: F,
-    tx_results: tokio::sync::mpsc::UnboundedSender<CertManagerResult<Vec<Certificate>>>,
+    tx_results: tokio::sync::mpsc::UnboundedSender<(
+        BlsPublicKey,
+        CertManagerResult<Vec<Certificate>>,
+    )>,
     cancel_signal: Noticer,
 ) {
     task_spawner.spawn_task(format!("fetch-cert-{peer}"), async move {
         tokio::select! {
             result = network.fetch_missing_certificates(peer, request) => {
-                let _ = tx_results.send(result.map_err(Into::into));
+                let _ = tx_results.send((peer, result.map_err(Into::into)));
             }
             _ = cancel_signal => {
                 // cancelled - another peer succeeded

--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -147,8 +147,15 @@ impl MissingCertificatesRequest {
             .map(|(k, serialized)| {
                 let rounds = RoaringBitmap::deserialize_from(&serialized[..])?
                     .into_iter()
-                    .map(|r| self.exclusive_lower_bound + r as Round)
-                    .collect::<BTreeSet<Round>>();
+                    .map(|r| {
+                        // r: u32 == Round; reject rather than wrap (release) or panic (debug)
+                        self.exclusive_lower_bound.checked_add(r).ok_or_else(|| {
+                            PrimaryNetworkError::InvalidRequest(
+                                "skip round exceeds u32 round space".into(),
+                            )
+                        })
+                    })
+                    .collect::<PrimaryNetworkResult<BTreeSet<Round>>>()?;
                 Ok((k.clone(), rounds))
             })
             .collect::<PrimaryNetworkResult<BTreeMap<_, _>>>()?;

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     certificate_fetcher::{
-        CertificateFetcher, CertificateFetcherCommand, FetchTask, MissingCertFetcher,
+        fetch_from_peers, CertificateFetcher, CertificateFetcherCommand, FetchTask,
+        MissingCertFetcher,
     },
     error::CertManagerError,
     network::MissingCertificatesRequest,
@@ -971,4 +972,55 @@ async fn test_fetch_task_replacement() {
     let result = std::pin::Pin::new(&mut fetch_task).poll(&mut cx);
     assert!(matches!(result, std::task::Poll::Ready(Ok(()))));
     assert!(fetch_task.is_none(), "FetchTask should be empty after completion");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_invalid_cert_from_sole_peer_does_not_panic() {
+    init_test_tracing();
+    let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let task_manager = TaskManager::default();
+
+    let (network, mut fetch_rx) = MockFetcher::new();
+
+    // build one real certificate, then mark it genesis so `validate_fetched_certificate` rejects
+    // it: genesis certs are generated locally and always valid, a peer must never send one
+    let genesis_certs = Certificate::genesis(&fixture.committee());
+    let genesis_parents: BTreeSet<_> = genesis_certs.iter().map(|c| c.digest()).collect();
+    let (_, headers) = fixture.headers_round(1, &genesis_parents);
+    let mut bad_cert = fixture.certificate(headers.first().expect("round 1 produced a header"));
+    bad_cert.set_signature_verification_state(SignatureVerificationState::Genesis);
+
+    // the sole peer answers with the invalid certificate, then signals that it did so
+    let (answered_tx, answered_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        if let Some((_peer, _request, reply)) = fetch_rx.recv().await {
+            let _ = reply.send(Ok(vec![bad_cert]));
+            let _ = answered_tx.send(());
+        }
+    });
+
+    // regression (#822): with a single peer, `peer_index` already equals `peers.len()` when the
+    // response arrives, so logging the rejected cert used to panic on `peers[peer_index]`.
+    // `fetch_from_peers` has no single-peer error-return path, so post-fix it keeps waiting and
+    // the timeout elapses; pre-fix it panics before this future can complete.
+    let outcome = timeout(
+        Duration::from_secs(2),
+        fetch_from_peers(
+            network,
+            vec![BlsPublicKey::default()],
+            MissingCertificatesRequest::default(),
+            task_manager.get_spawner(),
+            Duration::from_millis(100),
+        ),
+    )
+    .await;
+
+    // positive signal that the invalid response was actually delivered, so the rejection/logging
+    // path ran (this is where the pre-fix `peers[peer_index]` panic fires); without it the timeout
+    // assertion alone could pass vacuously if the mock stopped delivering.
+    let delivered = timeout(Duration::from_secs(1), answered_rx).await.ok().and_then(Result::ok);
+    assert!(delivered.is_some(), "sole peer never delivered its response");
+    // and the fix means we reached that path without panicking; the fetch stays pending, so the
+    // outer timeout elapses rather than returning a value.
+    assert!(outcome.is_err(), "fetch_from_peers should still be pending, got {outcome:?}");
 }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -11,6 +11,7 @@ use crate::{
     ConsensusBus, ConsensusBusApp, NodeMode, RecentBlocks,
 };
 use assert_matches::assert_matches;
+use roaring::RoaringBitmap;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     path::Path,
@@ -55,6 +56,25 @@ fn test_missing_certs_request() {
         missing_req.get_bounds().expect("decode missing bounds");
     assert_eq!(expected_gc_round, decoded_gc_round);
     assert_eq!(expected_skip_rounds, decoded_skip_rounds);
+}
+
+#[test]
+// for primary::network::message
+fn test_missing_certs_request_skip_round_overflow() {
+    let mut serialized = Vec::new();
+    [1u32, 2]
+        .into_iter()
+        .collect::<RoaringBitmap>()
+        .serialize_into(&mut serialized)
+        .expect("serialize skip rounds");
+    // `exclusive_lower_bound + 2` exceeds u32::MAX and must surface as an invalid request
+    // instead of wrapping (release) or panicking (debug) on peer-supplied input
+    let missing_req = MissingCertificatesRequest {
+        exclusive_lower_bound: Round::MAX - 1,
+        skip_rounds: vec![(AuthorityIdentifier::dummy_for_test(0), serialized)],
+        max_response_size: 10,
+    };
+    assert_matches!(missing_req.get_bounds(), Err(PrimaryNetworkError::InvalidRequest(_)));
 }
 
 /// The type for holding testng components.


### PR DESCRIPTION
**Addresses**: #822 (correctness findings 1 and 4; adds the finding-6 regression test)

## Title

fix(primary): out-of-bounds peer index when logging invalid fetched certs (#822)

## Description

#811 (the MissingCertificates sync cutover) is now on `main`, so the findings from its
review (#822) are live.  This PR fixes the two correctness defects and adds the missing
regression coverage:

- [x] **Out-of-bounds panic in `fetch_from_peers` error logging** (#822 finding 1, High).
  The invalid-cert error closure logged `peers[peer_index]`, but `peer_index` is the index
  of the *next peer to spawn*, not the responder.  With a single fetchable peer it already
  equals `peers.len()` when the first response arrives, so a peer returning a genesis-state
  certificate panicked the fetch task, and certificate catch-up stalled on every retry.
  Even in bounds the logged peer was the wrong one.  The responding `BlsPublicKey` is now
  threaded through the results channel and logged directly; the index access is gone.
- [x] **`get_bounds` skip-round overflow on untrusted input** (#822 finding 4, Low).
  `exclusive_lower_bound + r as Round` on a peer-supplied RoaringBitmap wrapped in release
  and panicked in debug.  Now `checked_add`, surfacing as `PrimaryNetworkError::InvalidRequest`
  through the existing malformed-request path (and dropping the `as` cast).
- [x] **Regression tests** (#822 finding 6).
  - `test_invalid_cert_from_sole_peer_does_not_panic` drives `fetch_from_peers` (via the
    existing `MockFetcher` seam) with a single peer returning a genesis-state certificate:
    pre-fix it panics on `peers[peer_index]`;  post-fix it stays pending and the test's
    timeout elapses cleanly.
  - `test_missing_certs_request_skip_round_overflow` feeds a skip round that overflows the
    `u32` round space and asserts `InvalidRequest` rather than a wrap/panic.

### Findings deliberately not in this PR

- **Finding 2** (per-response 64.5 MiB accept cap x concurrent requester fan-out, Medium):
  a design decision about the requester's memory envelope, not a clear bug.  Best resolved by
  the maintainers (document the worst case, or cap concurrent in-flight fetches).  I leave it for a
  separate discussion to keep this PR to unambiguous correctness fixes.
- **Finding 3** (each served certificate BCS-encoded twice on the responder hot path, Low):
  a safe optimization in `sync_codec.rs`;  worth a focused follow-up rather than mixing an
  optimization into a correctness fix.
- **Finding 5** (`max_response_size`): on `main` the sync path now sets it to `0` with an
  explanatory comment, so it is benign;  no change needed.
