### PR TITLE
(feat) CLI keytool set rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11435,6 +11435,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.23",
+ "url",
  "vergen 8.3.2",
 ]
 

--- a/crates/telcoin-network-cli/Cargo.toml
+++ b/crates/telcoin-network-cli/Cargo.toml
@@ -58,6 +58,7 @@ dirs-next = { workspace = true }
 bs58 = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tn-types = { workspace = true, features = ["test-utils"] }

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -139,6 +139,29 @@ telcoin-network keytool export-staking-args \
     --node-info /var/lib/telcoin/node-info.yaml
 ```
 
+### Advertising a JSON-RPC endpoint
+
+A node can advertise an optional JSON-RPC endpoint to peers over Kademlia so wallets and dapps can discover where to submit transactions. The endpoint is stored in `node-info.yaml` under `p2p_info.worker.rpc` and advertised by the worker network when the node runs.
+
+`keytool set-rpc` sets or clears that endpoint. It is a config-only edit — no keys are read and the BLS passphrase is ignored — so it requires an existing `node-info.yaml` under `--datadir`; run `keytool generate validator|observer` first (it errors with that hint otherwise).
+
+```bash
+telcoin-network keytool set-rpc \
+    --datadir /var/lib/telcoin \
+    --http https://validator.example.com:8545/ \
+    --ws wss://validator.example.com:8546/
+```
+
+`--http` is the required HTTP/HTTPS endpoint; `--ws` is the optional WebSocket endpoint. Both are validated with the same check node startup applies — `--http` must use the `http` or `https` scheme and `--ws` must use `ws` or `wss` — so a bad scheme fails immediately instead of being advertised and rejected by peers.
+
+Remove a previously-advertised endpoint with `--clear`:
+
+```bash
+telcoin-network keytool set-rpc --datadir /var/lib/telcoin --clear
+```
+
+`--clear` conflicts with `--http`/`--ws`, and omitting all flags is an error (`--http` is required unless `--clear`).
+
 ## Genesis ceremony
 
 The genesis ceremony runs once per network. One coordinator collects all validators' `node-info.yaml` files, runs the `genesis` command, and distributes the output to every participant.

--- a/crates/telcoin-network-cli/src/args/utils.rs
+++ b/crates/telcoin-network-cli/src/args/utils.rs
@@ -4,6 +4,7 @@ use eyre::OptionExt;
 use std::str::FromStr;
 use tn_reth::{dirs::DataDirPath, MaybePlatformPath};
 use tn_types::{Address, U256};
+use url::Url;
 
 /// Create a default path for the node.
 pub fn tn_platform_path(value: &str) -> eyre::Result<MaybePlatformPath<DataDirPath>> {
@@ -22,6 +23,16 @@ pub fn clap_address_parser(value: &str) -> eyre::Result<Address> {
     };
 
     Ok(address)
+}
+
+/// Parse a JSON-RPC endpoint URL from a string.
+///
+/// Used by `keytool set-rpc` for the `--http`/`--ws` endpoints advertised in
+/// `node-info.yaml`. Scheme validation (http/https, ws/wss) is left to
+/// [`tn_types::RpcInfo::validate`] so the CLI applies the exact check node
+/// startup runs.
+pub fn clap_url_parser(value: &str) -> eyre::Result<Url> {
+    Ok(Url::parse(value)?)
 }
 
 /// Parse 18 decimal U256 from string for ConsensusRegistry.

--- a/crates/telcoin-network-cli/src/args/utils.rs
+++ b/crates/telcoin-network-cli/src/args/utils.rs
@@ -27,7 +27,8 @@ pub fn clap_address_parser(value: &str) -> eyre::Result<Address> {
 
 /// Parse a JSON-RPC endpoint URL from a string.
 ///
-/// Used by `keytool set-rpc` for the `--http`/`--ws` endpoints advertised in
+/// Used by `keytool set-rpc` (`--http`/`--ws`) and `keytool generate
+/// validator|observer` (`--rpc-http`/`--rpc-ws`) for the endpoints advertised in
 /// `node-info.yaml`. Scheme validation (http/https, ws/wss) is left to
 /// [`tn_types::RpcInfo::validate`] so the CLI applies the exact check node
 /// startup runs.

--- a/crates/telcoin-network-cli/src/cli.rs
+++ b/crates/telcoin-network-cli/src/cli.rs
@@ -209,7 +209,7 @@ pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Key management.
     /// Generate or read keys for node management.
     #[command(name = "keytool")]
-    Keytool(keytool::KeyArgs),
+    Keytool(Box<keytool::KeyArgs>),
 
     /// Start the node
     #[command(name = "node")]

--- a/crates/telcoin-network-cli/src/keytool/generate.rs
+++ b/crates/telcoin-network-cli/src/keytool/generate.rs
@@ -154,7 +154,8 @@ pub struct KeygenArgs {
     #[arg(long = "rpc-http", value_name = "URL", value_parser = clap_url_parser)]
     pub rpc_http: Option<Url>,
 
-    /// Optional WebSocket JSON-RPC endpoint (e.g. wss://validator.example.com:8546/). Requires `--rpc-http`.
+    /// Optional WebSocket JSON-RPC endpoint (e.g. wss://validator.example.com:8546/). Requires
+    /// `--rpc-http`.
     #[arg(long = "rpc-ws", value_name = "URL", value_parser = clap_url_parser, requires = "rpc_http")]
     pub rpc_ws: Option<Url>,
 }

--- a/crates/telcoin-network-cli/src/keytool/generate.rs
+++ b/crates/telcoin-network-cli/src/keytool/generate.rs
@@ -1,10 +1,14 @@
 //! Generate subcommand
 
-use crate::{args::clap_address_parser, keytool::pop::PopArgs};
+use crate::{
+    args::{clap_address_parser, clap_url_parser},
+    keytool::{pop::PopArgs, set_rpc::build_worker_rpc},
+};
 use clap::{value_parser, Args, Subcommand};
 use tn_config::{Config, ConfigFmt, ConfigTrait as _, KeyConfig, NodeInfo, TelcoinDirs};
-use tn_types::{get_available_udp_port, Address, BlsPublicKey, Multiaddr, Protocol};
+use tn_types::{get_available_udp_port, Address, BlsPublicKey, Multiaddr, Protocol, RpcInfo};
 use tracing::info;
+use url::Url;
 
 /// Sign the proof of possession for `address` from `key_config` and write the
 /// PoP-derived fields (`bls_public_key`, `proof_of_possession`, `execution_address`)
@@ -142,6 +146,17 @@ pub struct KeygenArgs {
         value_delimiter = ','
     )]
     pub external_worker_addrs: Option<Vec<Multiaddr>>,
+
+    /// Optional HTTP(S) JSON-RPC endpoint to advertise to peers (e.g. https://validator.example.com:8545/).
+    ///
+    /// Recorded in node-info.yaml so wallets/dapps can discover where to submit transactions -
+    /// equivalent to running `keytool set-rpc` after generation. Omit to advertise no endpoint.
+    #[arg(long = "rpc-http", value_name = "URL", value_parser = clap_url_parser)]
+    pub rpc_http: Option<Url>,
+
+    /// Optional WebSocket JSON-RPC endpoint (e.g. wss://validator.example.com:8546/). Requires `--rpc-http`.
+    #[arg(long = "rpc-ws", value_name = "URL", value_parser = clap_url_parser, requires = "rpc_http")]
+    pub rpc_ws: Option<Url>,
 }
 
 impl KeygenArgs {
@@ -215,6 +230,7 @@ impl KeygenArgs {
         &self,
         tn_datadir: &TND,
         key_config: &KeyConfig,
+        worker_rpc: Option<RpcInfo>,
     ) -> eyre::Result<()> {
         let mut node_info = NodeInfo::default();
         /* Uncomment when multi-worker support is enabled
@@ -228,7 +244,9 @@ impl KeygenArgs {
 
         self.update_keys(&mut node_info, key_config)?;
 
-        // execution address is set inside `set_proof_of_possession` (called by `update_keys`)
+        // execution address is set inside `set_proof_of_possession` (called by `update_keys`);
+        // only `worker.rpc` is set here (update_keys owns the worker network key/address).
+        node_info.p2p_info.worker.rpc = worker_rpc;
         Config::write_to_path(tn_datadir.node_info_path(), &node_info, ConfigFmt::YAML)?;
 
         Ok(())
@@ -242,8 +260,12 @@ impl KeygenArgs {
     ) -> eyre::Result<()> {
         info!(target: "tn::generate_keys", "generating keys for full validator node");
         self.validate()?;
+        // validate the optional worker RPC endpoint up front (same check as `set-rpc` / node
+        // startup) so a bad scheme fails before any keys are written; None when `--rpc-http`
+        // is omitted.
+        let worker_rpc = build_worker_rpc(self.rpc_http.clone(), self.rpc_ws.clone())?;
         let key_config = KeyConfig::generate_and_save(tn_datadir, passphrase)?;
-        self.finish_execute(tn_datadir, &key_config)
+        self.finish_execute(tn_datadir, &key_config, worker_rpc)
     }
 
     /// Test-only twin of [`Self::execute`] that wraps the generated BLS key with an
@@ -257,7 +279,10 @@ impl KeygenArgs {
     ) -> eyre::Result<()> {
         info!(target: "tn::generate_keys", "generating keys for node with INSECURE test KDF");
         self.validate()?;
+        // validate the optional worker RPC endpoint up front, before any keys are written -
+        // mirrors `execute`'s fail-fast ordering.
+        let worker_rpc = build_worker_rpc(self.rpc_http.clone(), self.rpc_ws.clone())?;
         let key_config = KeyConfig::generate_and_save_insecure(tn_datadir, passphrase, rounds)?;
-        self.finish_execute(tn_datadir, &key_config)
+        self.finish_execute(tn_datadir, &key_config, worker_rpc)
     }
 }

--- a/crates/telcoin-network-cli/src/keytool/mod.rs
+++ b/crates/telcoin-network-cli/src/keytool/mod.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::{cli::Cli, NoArgs};
     use clap::Parser;
     use tn_config::{Config, ConfigFmt, ConfigTrait, NodeInfo};
-    use tn_types::{hex, verify_proof_of_possession_bls, Address, RpcInfo};
+    use tn_types::{hex, verify_proof_of_possession_bls, Address, BlsPublicKey, RpcInfo};
     use url::Url;
 
     /// Test that generate keys command works.
@@ -300,6 +300,8 @@ mod tests {
             name,
             external_primary_addr: None,
             external_worker_addrs: None,
+            rpc_http: None,
+            rpc_ws: None,
         }
     }
 
@@ -439,6 +441,167 @@ mod tests {
             derived.name.starts_with("node-"),
             "without --name the node name should derive from the BLS key, got: {}",
             derived.name
+        );
+    }
+
+    /// `generate validator --rpc-http .. --rpc-ws ..` writes the worker RPC
+    /// descriptor into `node-info.yaml` alongside the freshly minted identity:
+    /// the primary RPC stays unset and the BLS key, name, and execution address
+    /// are all populated (the late `worker.rpc` assignment does not clobber them).
+    #[tokio::test]
+    async fn test_generate_sets_worker_rpc() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+
+        let http = Url::parse("https://validator.example.com:8545/").expect("http url");
+        let ws = Url::parse("wss://validator.example.com:8546/").expect("ws url");
+        KeygenArgs {
+            address: new_test_address(),
+            rpc_http: Some(http.clone()),
+            rpc_ws: Some(ws.clone()),
+            ..keygen_args(None)
+        }
+        .execute(&datadir, None)
+        .expect("generate keys with rpc");
+
+        let node_info = Config::load_from_path::<NodeInfo>(
+            datadir.join("node-info.yaml").as_path(),
+            ConfigFmt::YAML,
+        )
+        .expect("node info loaded");
+
+        // worker rpc is exactly what we passed in.
+        assert_eq!(
+            node_info.p2p_info.worker.rpc,
+            Some(RpcInfo { http, ws: Some(ws) }),
+            "worker rpc should match the provided endpoints"
+        );
+        // the primary's rpc is never touched (the runtime never reads it).
+        assert!(node_info.p2p_info.primary.rpc.is_none(), "primary rpc must stay unset");
+        // identity fields are populated by fresh generation and survive the rpc assignment.
+        assert_ne!(
+            node_info.bls_public_key,
+            BlsPublicKey::default(),
+            "BLS public key must be populated"
+        );
+        assert!(
+            node_info.name.starts_with("node-"),
+            "node name must be derived from the BLS key, got: {}",
+            node_info.name
+        );
+        assert_eq!(
+            node_info.execution_address,
+            new_test_address(),
+            "execution address must be the one passed to generate"
+        );
+    }
+
+    /// `generate validator` without the RPC flags leaves the worker RPC descriptor
+    /// unset - the pre-flag default, so existing generation flows are unchanged.
+    #[tokio::test]
+    async fn test_generate_without_rpc_leaves_unset() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+        keygen_args(None).execute(&datadir, None).expect("generate keys without rpc");
+
+        let node_info = Config::load_from_path::<NodeInfo>(
+            datadir.join("node-info.yaml").as_path(),
+            ConfigFmt::YAML,
+        )
+        .expect("node info loaded");
+        assert!(
+            node_info.p2p_info.worker.rpc.is_none(),
+            "worker rpc should stay unset without --rpc-http"
+        );
+    }
+
+    /// `generate validator` validates the worker RPC endpoint *before* minting
+    /// keys: a non-http(s) scheme is rejected and no `node-info.yaml` is written,
+    /// proving the fail-fast ordering (a typo does not leave keys on disk).
+    #[tokio::test]
+    async fn test_generate_rejects_bad_rpc_scheme() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+
+        // a non-http(s) scheme parses as a URL but fails RpcInfo::validate.
+        let http = Url::parse("ftp://validator.example.com:8545/").expect("ftp url parses");
+        let err = KeygenArgs { rpc_http: Some(http), rpc_ws: None, ..keygen_args(None) }
+            .execute(&datadir, None)
+            .expect_err("generate must reject a non-http(s) scheme");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("invalid worker rpc endpoint"),
+            "error should wrap the validation failure, got: {msg}"
+        );
+
+        // fail-fast: validation runs before any keys / node-info are written.
+        assert!(
+            !datadir.join("node-info.yaml").exists(),
+            "no node-info.yaml should be written when the rpc endpoint is rejected"
+        );
+    }
+
+    /// The `generate validator` RPC flags are wired into clap under the namespaced
+    /// `--rpc-http` / `--rpc-ws` names: both parse together, `--rpc-ws` requires
+    /// `--rpc-http`, and the un-namespaced `--http` (set-rpc's name) is rejected
+    /// here - confirming the deliberate per-command rename.
+    #[test]
+    fn test_generate_rpc_cli_parses() {
+        // both rpc endpoints parse together.
+        assert!(
+            Cli::<NoArgs>::try_parse_from([
+                "telcoin-network",
+                "keytool",
+                "generate",
+                "validator",
+                "--datadir",
+                "/tmp/does-not-matter",
+                "--address",
+                "0",
+                "--rpc-http",
+                "https://validator.example.com:8545/",
+                "--rpc-ws",
+                "wss://validator.example.com:8546/",
+            ])
+            .is_ok(),
+            "`generate validator --rpc-http .. --rpc-ws ..` should parse"
+        );
+
+        // `--rpc-ws` without `--rpc-http` errors (requires), so a ws endpoint is
+        // never silently dropped for lack of an http endpoint.
+        assert!(
+            Cli::<NoArgs>::try_parse_from([
+                "telcoin-network",
+                "keytool",
+                "generate",
+                "validator",
+                "--datadir",
+                "/tmp/does-not-matter",
+                "--address",
+                "0",
+                "--rpc-ws",
+                "wss://validator.example.com:8546/",
+            ])
+            .is_err(),
+            "`--rpc-ws` without `--rpc-http` should error"
+        );
+
+        // the un-namespaced set-rpc name is not accepted by `generate` (confirms the rename).
+        assert!(
+            Cli::<NoArgs>::try_parse_from([
+                "telcoin-network",
+                "keytool",
+                "generate",
+                "validator",
+                "--datadir",
+                "/tmp/does-not-matter",
+                "--address",
+                "0",
+                "--http",
+                "https://validator.example.com:8545/",
+            ])
+            .is_err(),
+            "bare `--http` should be rejected by `generate` (it uses `--rpc-http`)"
         );
     }
 

--- a/crates/telcoin-network-cli/src/keytool/mod.rs
+++ b/crates/telcoin-network-cli/src/keytool/mod.rs
@@ -3,7 +3,8 @@
 mod export_staking_args;
 mod generate;
 mod pop;
-use self::{export_staking_args::ExportStakingArgs, generate::NodeType};
+mod set_rpc;
+use self::{export_staking_args::ExportStakingArgs, generate::NodeType, set_rpc::SetRpcArgs};
 use clap::{Args, Subcommand};
 use eyre::{eyre, Context};
 
@@ -34,6 +35,10 @@ pub enum KeySubcommand {
     /// Export hex-encoded staking arguments from node-info.yaml.
     #[command(name = "export-staking-args")]
     ExportStakingArgs(ExportStakingArgs),
+
+    /// Set or clear the worker JSON-RPC endpoint advertised in node-info.yaml.
+    #[command(name = "set-rpc")]
+    SetRpc(SetRpcArgs),
 }
 
 impl KeyArgs {
@@ -56,6 +61,9 @@ impl KeyArgs {
             KeySubcommand::ExportStakingArgs(args) => {
                 args.execute()?;
             }
+            // set or clear the worker rpc endpoint in node-info.yaml (config-only
+            // edit; does not use the BLS passphrase)
+            KeySubcommand::SetRpc(args) => args.execute(&datadir)?,
         }
 
         Ok(())
@@ -79,6 +87,17 @@ impl KeyArgs {
             }
         }
         self.execute(datadir, passphrase)
+    }
+
+    /// Whether this keytool invocation needs the BLS key passphrase up front.
+    ///
+    /// `generate validator|observer` encrypts a freshly minted BLS key and
+    /// `generate pop` decrypts the existing key to re-sign, so the binary must
+    /// have the passphrase available before dispatching them. `set-rpc` only
+    /// edits public config in `node-info.yaml` and never touches the BLS key, so
+    /// it must not be gated on a passphrase.
+    pub fn needs_passphrase(&self) -> bool {
+        !matches!(self.command, KeySubcommand::SetRpc(_))
     }
 
     /// Ensure the path exists, and if not, create it.
@@ -115,11 +134,15 @@ impl KeyArgs {
 
 #[cfg(test)]
 mod tests {
-    use super::{export_staking_args::ExportStakingArgs, generate::KeygenArgs, pop::PopArgs};
+    use super::{
+        export_staking_args::ExportStakingArgs, generate::KeygenArgs, pop::PopArgs,
+        set_rpc::SetRpcArgs,
+    };
     use crate::{cli::Cli, NoArgs};
     use clap::Parser;
     use tn_config::{Config, ConfigFmt, ConfigTrait, NodeInfo};
-    use tn_types::{hex, verify_proof_of_possession_bls, Address};
+    use tn_types::{hex, verify_proof_of_possession_bls, Address, RpcInfo};
+    use url::Url;
 
     /// Test that generate keys command works.
     /// This test also ensures that confy is able to
@@ -498,6 +521,200 @@ mod tests {
                 "0",
             ]);
             assert!(parsed.is_ok(), "`generate {name}` should parse");
+        }
+    }
+
+    /// `set-rpc --http .. --ws ..` writes the worker RPC descriptor into
+    /// `node-info.yaml` and touches nothing else: the primary RPC stays unset and
+    /// the node identity (BLS key, name, execution address) is unchanged.
+    #[tokio::test]
+    async fn test_set_rpc_sets_worker_rpc() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+        keygen_args(None).execute(&datadir, None).expect("generate keys");
+
+        let node_info_path = datadir.join("node-info.yaml");
+        let before = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
+            .expect("node info loaded before set-rpc");
+        // the worker starts with no advertised rpc.
+        assert!(before.p2p_info.worker.rpc.is_none(), "worker rpc should start unset");
+
+        let http = Url::parse("https://validator.example.com:8545/").expect("http url");
+        let ws = Url::parse("wss://validator.example.com:8546/").expect("ws url");
+        SetRpcArgs { http: Some(http.clone()), ws: Some(ws.clone()), clear: false }
+            .execute(&datadir)
+            .expect("set-rpc sets worker rpc");
+
+        let after = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
+            .expect("node info loaded after set-rpc");
+
+        // worker rpc is exactly what we passed in.
+        assert_eq!(
+            after.p2p_info.worker.rpc,
+            Some(RpcInfo { http, ws: Some(ws) }),
+            "worker rpc should match the provided endpoints"
+        );
+        // the primary's rpc is never touched (the runtime never reads it).
+        assert!(after.p2p_info.primary.rpc.is_none(), "primary rpc must stay unset");
+        // identity fields are untouched - this is a config-only edit.
+        assert_eq!(before.bls_public_key, after.bls_public_key, "BLS public key must not change");
+        assert_eq!(before.name, after.name, "node name must not change");
+        assert_eq!(
+            before.execution_address, after.execution_address,
+            "execution address must not change"
+        );
+    }
+
+    /// `set-rpc --clear` removes a previously-set worker RPC descriptor.
+    #[tokio::test]
+    async fn test_set_rpc_clear() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+        keygen_args(None).execute(&datadir, None).expect("generate keys");
+        let node_info_path = datadir.join("node-info.yaml");
+
+        // set, then clear.
+        let http = Url::parse("https://validator.example.com:8545/").expect("http url");
+        SetRpcArgs { http: Some(http), ws: None, clear: false }
+            .execute(&datadir)
+            .expect("set-rpc sets worker rpc");
+        let set = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
+            .expect("node info loaded after set");
+        assert!(set.p2p_info.worker.rpc.is_some(), "worker rpc should be set before clearing");
+
+        SetRpcArgs { http: None, ws: None, clear: true }
+            .execute(&datadir)
+            .expect("set-rpc clears worker rpc");
+        let cleared = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
+            .expect("node info loaded after clear");
+        assert!(cleared.p2p_info.worker.rpc.is_none(), "worker rpc should be cleared");
+    }
+
+    /// `set-rpc` errors with a "generate keys first" hint when `node-info.yaml`
+    /// is missing, rather than creating a fresh node-info with default identity.
+    #[tokio::test]
+    async fn test_set_rpc_missing_node_info_errors() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+        let http = Url::parse("https://validator.example.com:8545/").expect("http url");
+        let err = SetRpcArgs { http: Some(http), ws: None, clear: false }
+            .execute(&datadir)
+            .expect_err("set-rpc must error when node-info.yaml is missing");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("generate keys first"),
+            "missing node-info hint should tell the operator to generate keys first, got: {msg}"
+        );
+    }
+
+    /// `set-rpc` applies the same scheme validation node startup runs: a non-http
+    /// scheme parses as a URL but is rejected, and nothing is persisted.
+    #[tokio::test]
+    async fn test_set_rpc_rejects_bad_scheme() {
+        let tempdir = tempfile::TempDir::new().expect("tempdir created");
+        let datadir = tempdir.path().to_path_buf();
+        keygen_args(None).execute(&datadir, None).expect("generate keys");
+
+        // a non-http(s) scheme parses as a URL but fails RpcInfo::validate.
+        let http = Url::parse("ftp://validator.example.com:8545/").expect("ftp url parses");
+        let err = SetRpcArgs { http: Some(http), ws: None, clear: false }
+            .execute(&datadir)
+            .expect_err("set-rpc must reject a non-http(s) scheme");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("invalid worker rpc endpoint"),
+            "error should wrap the validation failure, got: {msg}"
+        );
+
+        // the rejected endpoint must not have been written.
+        let after = Config::load_from_path::<NodeInfo>(
+            datadir.join("node-info.yaml").as_path(),
+            ConfigFmt::YAML,
+        )
+        .expect("node info still loads");
+        assert!(after.p2p_info.worker.rpc.is_none(), "rejected endpoint must not be persisted");
+    }
+
+    /// The `set-rpc` clap relations: `--http` is required unless `--clear`, and
+    /// `--http`/`--ws` conflict with `--clear`.
+    #[test]
+    fn test_set_rpc_parse() {
+        // set with both endpoints parses.
+        assert!(
+            Cli::<NoArgs>::try_parse_from([
+                "telcoin-network",
+                "keytool",
+                "set-rpc",
+                "--http",
+                "https://validator.example.com:8545/",
+                "--ws",
+                "wss://validator.example.com:8546/",
+            ])
+            .is_ok(),
+            "`set-rpc --http .. --ws ..` should parse"
+        );
+
+        // clear parses on its own.
+        assert!(
+            Cli::<NoArgs>::try_parse_from(["telcoin-network", "keytool", "set-rpc", "--clear"])
+                .is_ok(),
+            "`set-rpc --clear` should parse"
+        );
+
+        // bare set-rpc errors: --http is required unless --clear.
+        assert!(
+            Cli::<NoArgs>::try_parse_from(["telcoin-network", "keytool", "set-rpc"]).is_err(),
+            "`set-rpc` with no flags should error (http required)"
+        );
+
+        // --clear and --http conflict.
+        assert!(
+            Cli::<NoArgs>::try_parse_from([
+                "telcoin-network",
+                "keytool",
+                "set-rpc",
+                "--clear",
+                "--http",
+                "https://validator.example.com:8545/",
+            ])
+            .is_err(),
+            "`set-rpc --clear --http ..` should error (conflict)"
+        );
+    }
+
+    /// The binary's passphrase gate keys off `KeyArgs::needs_passphrase`. A
+    /// config-only edit (`set-rpc`) must not require the BLS passphrase, while a
+    /// key-touching subcommand (`generate pop`) must.
+    #[test]
+    fn test_set_rpc_needs_no_passphrase() {
+        use crate::cli::Commands;
+
+        // set-rpc only edits public config: no passphrase required.
+        let cli =
+            Cli::<NoArgs>::try_parse_from(["telcoin-network", "keytool", "set-rpc", "--clear"])
+                .expect("set-rpc --clear parses");
+        match cli.command {
+            Commands::Keytool(keytool) => {
+                assert!(!keytool.needs_passphrase(), "set-rpc must not require the BLS passphrase")
+            }
+            _ => panic!("expected a keytool command"),
+        }
+
+        // generate pop decrypts the existing BLS key: passphrase required.
+        let cli = Cli::<NoArgs>::try_parse_from([
+            "telcoin-network",
+            "keytool",
+            "generate",
+            "pop",
+            "--address",
+            "0",
+        ])
+        .expect("generate pop parses");
+        match cli.command {
+            Commands::Keytool(keytool) => {
+                assert!(keytool.needs_passphrase(), "generate pop must require the BLS passphrase")
+            }
+            _ => panic!("expected a keytool command"),
         }
     }
 }

--- a/crates/telcoin-network-cli/src/keytool/set_rpc.rs
+++ b/crates/telcoin-network-cli/src/keytool/set_rpc.rs
@@ -27,7 +27,7 @@ use url::Url;
 /// Build a validated worker `RpcInfo` from the `--http`/`--ws` (or `--rpc-http`/`--rpc-ws`) flags.
 ///
 /// Returns `Ok(None)` when no HTTP endpoint was provided (nothing to advertise). Applies the same
-/// validation node startup runs (`node.rs:624`), so a bad scheme/length fails at CLI time. Shared by
+/// validation node startup runs (`node.rs`), so a bad scheme/length fails at CLI time. Shared by
 /// `set-rpc` and `generate validator|observer`.
 pub(crate) fn build_worker_rpc(
     http: Option<Url>,

--- a/crates/telcoin-network-cli/src/keytool/set_rpc.rs
+++ b/crates/telcoin-network-cli/src/keytool/set_rpc.rs
@@ -96,7 +96,7 @@ impl SetRpcArgs {
         } else {
             // clap guarantees --http is present unless --clear.
             let rpc = build_worker_rpc(self.http.clone(), self.ws.clone())?
-                .expect("clap requires --http unless --clear");
+                .ok_or_else(|| eyre::eyre!("clap requires --http unless --clear"))?;
             if node_info.p2p_info.worker.rpc.is_some() {
                 warn!(target: "tn::keytool", "overwriting existing worker RPC endpoint");
             }

--- a/crates/telcoin-network-cli/src/keytool/set_rpc.rs
+++ b/crates/telcoin-network-cli/src/keytool/set_rpc.rs
@@ -1,0 +1,98 @@
+//! `set-rpc` subcommand: set or clear the worker JSON-RPC endpoint advertised
+//! in `node-info.yaml`.
+//!
+//! A node advertises an optional JSON-RPC endpoint to peers over kademlia so
+//! wallets/dapps can discover where to submit transactions. That endpoint lives
+//! in `node_info.p2p_info.worker.rpc` (type `Option<RpcInfo>`). The runtime
+//! reads it at node startup, validates it, and hands it to the worker network
+//! for advertisement - this command only populates the config field.
+//!
+//! Unlike `generate validator|observer` or `generate pop`, this is a pure,
+//! unsigned config edit: it loads `node-info.yaml`, mutates the worker RPC
+//! descriptor, and writes it back. No keys are read and the BLS passphrase is
+//! ignored - the kademlia node record is signed at node startup, not here.
+
+use crate::args::clap_url_parser;
+use clap::Args;
+use eyre::WrapErr as _;
+use tn_config::{Config, ConfigFmt, ConfigTrait as _, NodeInfo, TelcoinDirs};
+use tn_types::RpcInfo;
+use tracing::{info, warn};
+use url::Url;
+
+/// Set or clear the worker JSON-RPC endpoint advertised in `node-info.yaml`.
+///
+/// `set-rpc --http URL [--ws URL]` sets the worker RPC descriptor;
+/// `set-rpc --clear` removes it. The endpoint is validated with the same check
+/// node startup applies, so a bad scheme fails here rather than at runtime.
+#[derive(Debug, Clone, Args)]
+pub struct SetRpcArgs {
+    /// HTTP(S) JSON-RPC endpoint to advertise (e.g. https://validator.example.com:8545/).
+    ///
+    /// Required unless `--clear`.
+    #[arg(
+        long,
+        value_name = "URL",
+        value_parser = clap_url_parser,
+        required_unless_present = "clear",
+        conflicts_with = "clear"
+    )]
+    pub http: Option<Url>,
+
+    /// Optional WebSocket JSON-RPC endpoint (e.g. wss://validator.example.com:8546/).
+    #[arg(long, value_name = "URL", value_parser = clap_url_parser, conflicts_with = "clear")]
+    pub ws: Option<Url>,
+
+    /// Remove any previously-set worker RPC endpoint instead of setting one.
+    #[arg(long)]
+    pub clear: bool,
+}
+
+impl SetRpcArgs {
+    /// Set or clear the worker RPC endpoint in `node-info.yaml`.
+    pub fn execute<TND: TelcoinDirs>(&self, dir: &TND) -> eyre::Result<()> {
+        // existing node-info - this is a config-only edit; error if absent so we
+        // never silently create a fresh node-info with default identity.
+        let mut node_info =
+            Config::load_from_path::<NodeInfo>(dir.node_info_path(), ConfigFmt::YAML).map_err(
+                |e| {
+                    eyre::eyre!(
+                        "could not load node-info.yaml at {}: {e}\n\
+                         hint: generate keys first with `keytool generate validator|observer`",
+                        dir.node_info_path().display()
+                    )
+                },
+            )?;
+
+        if self.clear {
+            if node_info.p2p_info.worker.rpc.take().is_some() {
+                warn!(target: "tn::keytool", "cleared existing worker RPC endpoint");
+            } else {
+                info!(target: "tn::keytool", "no worker RPC endpoint set; nothing to clear");
+            }
+        } else {
+            // clap guarantees `http` is `Some` whenever `--clear` is absent.
+            let http = self.http.clone().expect("clap requires --http unless --clear");
+            let rpc = RpcInfo { http, ws: self.ws.clone() };
+            // same validation node startup applies (node.rs:624) - fail fast.
+            rpc.validate().wrap_err("invalid worker rpc endpoint")?;
+            if node_info.p2p_info.worker.rpc.is_some() {
+                warn!(target: "tn::keytool", "overwriting existing worker RPC endpoint");
+            }
+            node_info.p2p_info.worker.rpc = Some(rpc);
+        }
+
+        Config::write_to_path(dir.node_info_path(), &node_info, ConfigFmt::YAML)?;
+        println!("OK  node-info.yaml updated: {}", dir.node_info_path().display());
+        match &node_info.p2p_info.worker.rpc {
+            Some(rpc) => {
+                println!("    worker rpc http: {}", rpc.http);
+                if let Some(ws) = &rpc.ws {
+                    println!("    worker rpc ws:   {ws}");
+                }
+            }
+            None => println!("    worker rpc: cleared"),
+        }
+        Ok(())
+    }
+}

--- a/crates/telcoin-network-cli/src/keytool/set_rpc.rs
+++ b/crates/telcoin-network-cli/src/keytool/set_rpc.rs
@@ -11,6 +11,10 @@
 //! unsigned config edit: it loads `node-info.yaml`, mutates the worker RPC
 //! descriptor, and writes it back. No keys are read and the BLS passphrase is
 //! ignored - the kademlia node record is signed at node startup, not here.
+//!
+//! The [`build_worker_rpc`] helper is the single source of truth for building
+//! and validating a worker RPC endpoint; it is shared with
+//! `generate validator|observer` so both commands apply identical validation.
 
 use crate::args::clap_url_parser;
 use clap::Args;
@@ -19,6 +23,25 @@ use tn_config::{Config, ConfigFmt, ConfigTrait as _, NodeInfo, TelcoinDirs};
 use tn_types::RpcInfo;
 use tracing::{info, warn};
 use url::Url;
+
+/// Build a validated worker `RpcInfo` from the `--http`/`--ws` (or `--rpc-http`/`--rpc-ws`) flags.
+///
+/// Returns `Ok(None)` when no HTTP endpoint was provided (nothing to advertise). Applies the same
+/// validation node startup runs (`node.rs:624`), so a bad scheme/length fails at CLI time. Shared by
+/// `set-rpc` and `generate validator|observer`.
+pub(crate) fn build_worker_rpc(
+    http: Option<Url>,
+    ws: Option<Url>,
+) -> eyre::Result<Option<RpcInfo>> {
+    match http {
+        Some(http) => {
+            let rpc = RpcInfo { http, ws };
+            rpc.validate().wrap_err("invalid worker rpc endpoint")?;
+            Ok(Some(rpc))
+        }
+        None => Ok(None),
+    }
+}
 
 /// Set or clear the worker JSON-RPC endpoint advertised in `node-info.yaml`.
 ///
@@ -71,11 +94,9 @@ impl SetRpcArgs {
                 info!(target: "tn::keytool", "no worker RPC endpoint set; nothing to clear");
             }
         } else {
-            // clap guarantees `http` is `Some` whenever `--clear` is absent.
-            let http = self.http.clone().expect("clap requires --http unless --clear");
-            let rpc = RpcInfo { http, ws: self.ws.clone() };
-            // same validation node startup applies (node.rs:624) - fail fast.
-            rpc.validate().wrap_err("invalid worker rpc endpoint")?;
+            // clap guarantees --http is present unless --clear.
+            let rpc = build_worker_rpc(self.http.clone(), self.ws.clone())?
+                .expect("clap requires --http unless --clear");
             if node_info.p2p_info.worker.rpc.is_some() {
                 warn!(target: "tn::keytool", "overwriting existing worker RPC endpoint");
             }

--- a/crates/telcoin-network-cli/src/passphrase.rs
+++ b/crates/telcoin-network-cli/src/passphrase.rs
@@ -87,11 +87,14 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
                 }
                 passphrase = Some(buffer.trim_end().to_string()).filter(|s| !s.is_empty());
             }
-            PassSource::Ask => match self.command {
-                Commands::Keytool(_) => {
+            PassSource::Ask => match &self.command {
+                Commands::Keytool(keytool) if keytool.needs_passphrase() => {
                     // Need to ask and confirm before it used to encrypt.
                     passphrase = read_passphrase();
                 }
+                // keytool subcommands that only edit public config (e.g. `set-rpc`)
+                // never touch the BLS key, so don't prompt for a passphrase.
+                Commands::Keytool(_) => {}
                 Commands::Db(_) => {} // DB diagnostics are read-only and do not require keys.
                 Commands::Genesis(_) => {} // Don't need the passphrase..
                 Commands::Node(_) => {
@@ -105,9 +108,15 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
                 passphrase = None;
             }
         }
-        // The `db` subcommand is a read-only inspection tool and never needs the BLS key.
-        let needs_passphrase = self.bls_passphrase_source.with_passphrase()
-            && !matches!(self.command, Commands::Db(_));
+        // The `db` subcommand is a read-only inspection tool and `keytool set-rpc`
+        // only edits public config; neither needs the BLS key passphrase.
+        let command_needs_passphrase = match &self.command {
+            Commands::Db(_) => false,
+            Commands::Keytool(keytool) => keytool.needs_passphrase(),
+            Commands::Genesis(_) | Commands::Node(_) => true,
+        };
+        let needs_passphrase =
+            self.bls_passphrase_source.with_passphrase() && command_needs_passphrase;
         if passphrase.is_none() && needs_passphrase {
             bail!(
                 "Error passphrase is required, see the option --bls-passphrase-source for options"


### PR DESCRIPTION
- Add `keytool set-rpc --http URL [--ws URL] | --clear` to set or clear `p2p_info.worker.rpc` in an existing `node-info.yaml`. Errors with a "generate keys first" hint if `node-info.yaml` is missing, instead of creating one.
- Add `--rpc-http`/`--rpc-ws` to `keytool generate validator|observer` so new nodes can set the endpoint during key generation in one step. Validation runs before any keys are minted, so a bad scheme leaves no `node-info.yaml` behind.
- Both commands validate through a shared `build_worker_rpc` helper (`http`/`https` for `--http`, `ws`/`wss` for `--ws`), matching the check node startup applies, so a bad scheme is caught at CLI time instead of at peer advertisement.
- `set-rpc` is a config-only edit — no keys read, BLS passphrase not required. `KeyArgs::needs_passphrase()` now distinguishes config-only keytool subcommands from key-touching ones (`generate validator|observer`, `generate pop`), and the passphrase-source gating in `passphrase.rs` checks it before prompting.
- Box `Commands::Keytool`'s payload to keep the `Commands` enum size down now that `KeyArgs` carries more variants.
- README: document `set-rpc` usage and the `--clear` behavior.

closes #901 