### PR TITLE
feat(node):  seed base fee from chain on sync/restart instead of recomputing

### DIFF
--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -633,6 +633,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validator_uses_u64_base_fee() {
+        // A validator built from a plain u64 base fee accepts a batch whose base fee matches and
+        // rejects one that does not -- exercising the BaseFeeContainer -> u64 conversion.
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+                .unwrap();
+        let tx_pool = reth_env.init_txn_pool().unwrap();
+
+        // pin the validator to a deliberately non-MIN base fee
+        let expected_fee = MIN_PROTOCOL_BASE_FEE + 500;
+        let validator = BatchValidator::new(reth_env, Some(tx_pool), 0, expected_fee, 0);
+
+        let (mut batch, _) = next_valid_sealed_batch(chain).split();
+
+        // matching base fee is accepted
+        batch.base_fee_per_gas = expected_fee;
+        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
+
+        // mismatched base fee is rejected
+        batch.base_fee_per_gas = expected_fee + 1;
+        assert_matches!(
+            validator.validate_batch(batch.seal_slow()),
+            Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
+        );
+    }
+
+    #[tokio::test]
     async fn test_invalid_tx_eip4844() {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -633,36 +633,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validator_uses_u64_base_fee() {
-        // A validator built from a plain u64 base fee accepts a batch whose base fee matches and
-        // rejects one that does not -- exercising the BaseFeeContainer -> u64 conversion.
-        let tmp_dir = TempDir::new().unwrap();
-        let task_manager = TaskManager::default();
-        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
-        let reth_env =
-            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
-                .unwrap();
-        let tx_pool = reth_env.init_txn_pool().unwrap();
-
-        // pin the validator to a deliberately non-MIN base fee
-        let expected_fee = MIN_PROTOCOL_BASE_FEE + 500;
-        let validator = BatchValidator::new(reth_env, Some(tx_pool), 0, expected_fee, 0);
-
-        let (mut batch, _) = next_valid_sealed_batch(chain).split();
-
-        // matching base fee is accepted
-        batch.base_fee_per_gas = expected_fee;
-        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
-
-        // mismatched base fee is rejected
-        batch.base_fee_per_gas = expected_fee + 1;
-        assert_matches!(
-            validator.validate_batch(batch.seal_slow()),
-            Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
-        );
-    }
-
-    #[tokio::test]
     async fn test_invalid_tx_eip4844() {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -179,8 +179,7 @@ pub async fn catchup_accumulator(
 
             // difficulty contains the worker id and batch index:
             // `U256::from(payload.batch_index << 16 | payload.worker_id as usize)`
-            let lower64 = current.difficulty.into_limbs()[0];
-            let worker_id = (lower64 & 0xffff) as u16;
+            let worker_id = worker_id_from_header(&current);
             gas_accumulator.inc_block(worker_id, gas, limit);
         }
 

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use eyre::{eyre, WrapErr as _};
 use state_sync::{request_missing_packs, spawn_fetch_consensus, spawn_fetch_recent_consensus};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use tn_config::{Config, ConfigFmt, ConfigTrait as _, KeyConfig, NetworkConfig, TelcoinDirs};
 use tn_network_libp2p::{types::NetworkEvent, ConsensusNetwork};
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode, QueChannel};
@@ -30,8 +30,8 @@ use tn_storage::{consensus::ConsensusChain, open_db, DatabaseType};
 use tn_types::{
     deconstruct_nonce, gas_accumulator::GasAccumulator, BlsPublicKey, BootstrapServer, Committee,
     ConsensusHeader, ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput,
-    Database as TNDatabase, EngineUpdate, Epoch, Notifier, TaskError, TaskManager, TaskSpawner,
-    TimestampSec, DEFAULT_WORKER_ID, MIN_PROTOCOL_BASE_FEE,
+    Database as TNDatabase, EngineUpdate, Epoch, Notifier, SealedHeader, TaskError, TaskManager,
+    TaskSpawner, TimestampSec, WorkerId, DEFAULT_WORKER_ID, MIN_PROTOCOL_BASE_FEE,
 };
 use tn_worker::{WorkerNetworkHandle, WorkerRequest, WorkerResponse};
 use tokio::sync::mpsc;
@@ -194,6 +194,33 @@ pub async fn catchup_accumulator(
     };
 
     Ok(())
+}
+
+/// Worker id encoded in a header's `difficulty` (low 16 bits of `batch_index << 16 | worker_id`).
+pub(crate) fn worker_id_from_header(header: &SealedHeader) -> WorkerId {
+    (header.difficulty.into_limbs()[0] & 0xffff) as u16
+}
+
+/// Return the most recent on-chain `base_fee_per_gas` for each worker that produced a block in
+/// `headers`.
+///
+/// `headers` are the executed reth blocks for the current epoch (epoch-start height..=tip), in
+/// ascending block-number order, so the last header seen for a worker is its latest block. The
+/// worker id is read from each header's `difficulty` field (lower 16 bits, matching how
+/// [`GasAccumulator::inc_block`] callers encode it). Workers that produced no block in the range
+/// are absent from the returned map.
+///
+/// Used to seed per-worker base fees from the chain on sync and restart, preserving the
+/// base-fee-from-chain invariant (see the [`tn_types::gas_accumulator`] module docs).
+pub(crate) fn latest_base_fee_per_worker(headers: &[SealedHeader]) -> HashMap<WorkerId, u64> {
+    let mut fees = HashMap::new();
+    for header in headers {
+        let worker_id = worker_id_from_header(header);
+        if let Some(base_fee) = header.base_fee_per_gas {
+            fees.insert(worker_id, base_fee);
+        }
+    }
+    fees
 }
 
 /// Open the process-lifetime consensus DB, creating its directory if absent.

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -144,7 +144,7 @@ where
 
         // Base-fee-from-chain seeding: if the canonical tip is already in the epoch we are
         // entering, adopt each worker's latest on-chain base fee rather than recomputing. This
-        // covers syncing and restarting nodes -- they execute the fee already baked into the chain.
+        // covers syncing and restarting nodes: they execute the fee already baked into the chain.
         // A live producer crossing N->N+1 still has its tip in N here, so seeding is skipped and
         // the value adjust_base_fees computed at the boundary is kept. (See gas_accumulator docs.)
         {
@@ -588,12 +588,14 @@ where
         // Only the live producer (Some(shutdown)) holds a complete accumulator for the epoch it
         // just closed and may compute the next fee forward. Restart/leftover paths (None) defer to
         // epoch-start chain seeding so a catching-up node never diverges from the chain.
-        let live_boundary = shutdown_consensus.is_some();
+        let mut live_boundary = false;
         // begin consensus shutdown while engine executes
         if let Some(s) = shutdown_consensus {
-            s.notify()
+            s.notify();
+            live_boundary = true;
         }
         self.consensus_bus.wait_for_consensus_execution(target_hash).await?;
+        // adjust basefees after final execution
         if live_boundary {
             adjust_base_fees(gas_accumulator);
         }
@@ -637,6 +639,7 @@ fn seed_base_fees_from_chain(
     gas_accumulator: &GasAccumulator,
 ) {
     if tip_epoch != entered_epoch {
+        // new epoch - calculate fees from accumulated epoch gas
         return;
     }
     for worker_id in 0..gas_accumulator.num_workers() as u16 {

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -17,15 +17,19 @@
 //! [`ReplayResult`] types that thread control flow through the loop.
 
 use crate::{engine::ExecutionNode, manager::EpochManager, worker::worker_task_manager_name};
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tn_config::{NetworkConfig, TelcoinDirs};
 use tn_executor::subscriber::spawn_subscriber;
 use tn_primary::ConsensusBus;
+use tn_reth::RethEnv;
 use tn_storage::{certificate_pack::CertificatePack, tables::OurNodeBatchesCache};
 use tn_types::{
     gas_accumulator::{compute_next_base_fee_eip1559, GasAccumulator},
-    BlsPublicKey, Committee, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase,
-    EpochRecord, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
+    BlsPublicKey, Committee, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase, Epoch,
+    EpochRecord, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver, WorkerId,
 };
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -137,6 +141,38 @@ where
         self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
         self.metrics.current.set(committee.epoch() as f64);
         self.metrics.boundary_timestamp_seconds.set(self.epoch_boundary as f64);
+
+        // Base-fee-from-chain seeding: if the canonical tip is already in the epoch we are
+        // entering, adopt each worker's latest on-chain base fee rather than recomputing. This
+        // covers syncing and restarting nodes -- they execute the fee already baked into the chain.
+        // A live producer crossing N->N+1 still has its tip in N here, so seeding is skipped and
+        // the value adjust_base_fees computed at the boundary is kept. (See gas_accumulator docs.)
+        {
+            let reth_env = engine.get_reth_env().await;
+            if let Some(tip) = reth_env.finalized_header()? {
+                let tip_epoch = RethEnv::extract_epoch_from_header(&tip);
+                let chain_fees = if tip_epoch == committee.epoch() {
+                    // The range END (`tip.number`) comes from `finalized_header()` above, while the
+                    // range START (`epoch_info.blockHeight`) comes from the canonical-tip epoch
+                    // state. These reference the same block under this node's instant BFT finality
+                    // (the payload builder finalizes the header it just made canonical), so the
+                    // range is well-formed. If finality ever lags the canonical tip, pin both ends
+                    // to one header (the same dual-reference pattern lives in catchup_accumulator).
+                    let epoch_state = reth_env.epoch_state_from_canonical_tip()?;
+                    let blocks = reth_env
+                        .blocks_for_range(epoch_state.epoch_info.blockHeight..=tip.number)?;
+                    super::latest_base_fee_per_worker(&blocks)
+                } else {
+                    HashMap::new()
+                };
+                seed_base_fees_from_chain(
+                    committee.epoch(),
+                    tip_epoch,
+                    &chain_fees,
+                    &gas_accumulator,
+                );
+            }
+        }
         // Produce a "dummy" epoch 0 EpochRecord if missing.
         // This will let us use simple code to find any epoch including 0 at startup.
         if !self.consensus_chain.epochs().contains_epoch(0).await {
@@ -538,22 +574,29 @@ where
     ///
     /// Begins shutting consensus down (when a [`Notifier`] is supplied) so it winds down in
     /// parallel while the engine finishes executing up to `target_hash`, then blocks until that
-    /// execution is confirmed. Afterward it runs the (currently no-op) base fee adjustment and
-    /// clears the [`GasAccumulator`] so the next epoch starts from zero. Called both on the
-    /// normal boundary path and on the restart replay-and-close path, which passes `None`
-    /// because there is no live consensus to stop.
+    /// execution is confirmed. On the live boundary path it then recomputes each worker's
+    /// next-epoch base fee ([`adjust_base_fees`]); the restart replay-and-close and leftover-drain
+    /// paths (which pass `None`) skip that forward computation and instead adopt the chain's fee
+    /// via epoch-start seeding, preserving the base-fee-from-chain invariant. Finally it clears the
+    /// [`GasAccumulator`] so the next epoch starts from zero.
     async fn close_epoch(
         &self,
         shutdown_consensus: Option<Notifier>,
         gas_accumulator: &GasAccumulator,
         target_hash: ConsensusHeaderDigest,
     ) -> eyre::Result<()> {
+        // Only the live producer (Some(shutdown)) holds a complete accumulator for the epoch it
+        // just closed and may compute the next fee forward. Restart/leftover paths (None) defer to
+        // epoch-start chain seeding so a catching-up node never diverges from the chain.
+        let live_boundary = shutdown_consensus.is_some();
         // begin consensus shutdown while engine executes
         if let Some(s) = shutdown_consensus {
             s.notify()
         }
         self.consensus_bus.wait_for_consensus_execution(target_hash).await?;
-        adjust_base_fees(gas_accumulator);
+        if live_boundary {
+            adjust_base_fees(gas_accumulator);
+        }
         gas_accumulator.clear(); // Clear the accumlated values for next epoch.
         Ok(())
     }
@@ -576,6 +619,30 @@ fn adjust_base_fees(gas_accumulator: &GasAccumulator) {
         // u64::MAX target => inert: floors at MIN until governance targets are read.
         let next_base_fee = compute_next_base_fee_eip1559(base_fee.base_fee(), gas_used, u64::MAX);
         base_fee.set_base_fee(next_base_fee);
+    }
+}
+
+/// Seed per-worker base fees from the chain at epoch entry (the base-fee-from-chain invariant).
+///
+/// When `tip_epoch == entered_epoch` the canonical tip is already in the epoch being entered, so
+/// the node is syncing/restarting and adopts each worker's latest on-chain base fee from
+/// `chain_fees`. When the epochs differ the node is the live producer that just crossed the
+/// boundary (its tip is still in the previous epoch), so the value [`adjust_base_fees`] computed
+/// is kept untouched. Workers absent from `chain_fees` (no block produced this epoch) are left
+/// as-is.
+fn seed_base_fees_from_chain(
+    entered_epoch: Epoch,
+    tip_epoch: Epoch,
+    chain_fees: &HashMap<WorkerId, u64>,
+    gas_accumulator: &GasAccumulator,
+) {
+    if tip_epoch != entered_epoch {
+        return;
+    }
+    for worker_id in 0..gas_accumulator.num_workers() as u16 {
+        if let Some(&fee) = chain_fees.get(&worker_id) {
+            gas_accumulator.base_fee(worker_id).set_base_fee(fee);
+        }
     }
 }
 
@@ -625,5 +692,49 @@ mod tests {
             prev = now;
         }
         assert!(reached_min, "fee should ratchet all the way down to MIN");
+    }
+
+    #[test]
+    fn seed_base_fees_adopts_chain_fee_when_tip_in_entered_epoch() {
+        // Syncing/restarting node: the tip is already in the epoch being entered, so each worker
+        // adopts its latest on-chain base fee, overwriting any locally-held value.
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(1000);
+        acc.base_fee(1).set_base_fee(2000);
+        let chain_fees = HashMap::from([(0u16, 111u64), (1u16, 222u64)]);
+
+        seed_base_fees_from_chain(5, 5, &chain_fees, &acc);
+
+        assert_eq!(acc.base_fee(0).base_fee(), 111);
+        assert_eq!(acc.base_fee(1).base_fee(), 222);
+    }
+
+    #[test]
+    fn seed_base_fees_keeps_computed_value_for_live_producer() {
+        // Live producer crossing into a new epoch: the tip is still in the previous epoch, so the
+        // value adjust_base_fees computed at the boundary is kept and the chain is NOT consulted.
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(1000);
+        acc.base_fee(1).set_base_fee(2000);
+        let chain_fees = HashMap::from([(0u16, 111u64), (1u16, 222u64)]);
+
+        seed_base_fees_from_chain(5, 4, &chain_fees, &acc);
+
+        assert_eq!(acc.base_fee(0).base_fee(), 1000);
+        assert_eq!(acc.base_fee(1).base_fee(), 2000);
+    }
+
+    #[test]
+    fn seed_base_fees_leaves_workers_without_chain_blocks_untouched() {
+        // A worker that produced no block this epoch is absent from chain_fees and keeps its value.
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(1000);
+        acc.base_fee(1).set_base_fee(2000);
+        let chain_fees = HashMap::from([(0u16, 111u64)]); // only worker 0 produced a block
+
+        seed_base_fees_from_chain(7, 7, &chain_fees, &acc);
+
+        assert_eq!(acc.base_fee(0).base_fee(), 111); // seeded from chain
+        assert_eq!(acc.base_fee(1).base_fee(), 2000); // untouched
     }
 }

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -573,7 +573,7 @@ fn adjust_base_fees(gas_accumulator: &GasAccumulator) {
         let worker_id = worker_id as u16;
         let (_blocks, gas_used, _gas_limit) = gas_accumulator.get_values(worker_id);
         let base_fee = gas_accumulator.base_fee(worker_id);
-        // u64::MAX target => inert: floors at MIN until governance targets are read (PR6).
+        // u64::MAX target => inert: floors at MIN until governance targets are read.
         let next_base_fee = compute_next_base_fee_eip1559(base_fee.base_fee(), gas_used, u64::MAX);
         base_fee.set_base_fee(next_base_fee);
     }
@@ -588,8 +588,7 @@ mod tests {
     fn adjust_base_fees_keeps_workers_at_min() {
         // Production starting point: every worker's base fee defaults to MIN. With the u64::MAX
         // target the fee can only ratchet down and is floored at MIN, so a worker that starts at
-        // MIN stays at MIN regardless of how much gas it used. This is the inert guarantee that
-        // keeps PR1-PR5 behavior-preserving.
+        // MIN stays at MIN regardless of how much gas it used.
         let acc = GasAccumulator::new(2);
         assert_eq!(acc.base_fee(0).base_fee(), MIN_PROTOCOL_BASE_FEE);
         assert_eq!(acc.base_fee(1).base_fee(), MIN_PROTOCOL_BASE_FEE);

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -23,6 +23,15 @@
 //! 3. **`EpochManager::run_epoch`** — on `Initial` and `NewEpoch` modes, invokes
 //!    `replay_missed_consensus` before starting the live consensus loop, ensuring no rounds are
 //!    skipped or double-counted. State is updated through the normal path (payload_builder).
+//!
+//! ## Base fee on sync and restart (the base-fee-from-chain invariant)
+//!
+//! Base fee is consensus-affecting, so a node that is merely catching up must never recompute it
+//! and risk diverging from the value already baked into the chain. At epoch entry, if the
+//! canonical tip is already in the epoch being entered, each worker's [`BaseFeeContainer`] is
+//! seeded from its most recent on-chain block (`latest_base_fee_per_worker`); otherwise the
+//! container keeps the value the live producer just computed at the boundary. Only the live
+//! producer crossing the boundary computes the next fee forward; everyone else reads the chain.
 
 use crate::{AuthorityIdentifier, Committee, WorkerId};
 


### PR DESCRIPTION
- At epoch entry, compare the canonical tip's epoch to the epoch being entered. If they match, the node is catching up (sync/restart) and adopts each worker's latest on-chain `base_fee_per_gas` instead of recomputing; if they differ, it's the live producer crossing the boundary and keeps the value `adjust_base_fees` already computed.
- Added `worker_id_from_header`/`latest_base_fee_per_worker` in `crates/node/src/manager/node.rs` to recover per-worker base fee from executed headers (worker id is read from the low 16 bits of `difficulty`, matching `GasAccumulator::inc_block` encoding).
- `close_epoch` now only calls `adjust_base_fees` on the live boundary path (`shutdown_consensus.is_some()`); restart/leftover-drain paths (`None`) skip it and rely on the new epoch-start seeding instead.
- Documented the base-fee-from-chain invariant in `crates/types/src/gas_accumulator.rs` module docs.
- New unit tests cover: seed-adopts-chain-fee when tip is in the entered epoch, keep-computed-value for the live producer, and untouched-for-workers-with-no-blocks-this-epoch.

closes #839