### PR TITLE
feat(node): sync GasAccumulator worker count from on-chain `WorkerConfigs`

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -19,7 +19,7 @@ mod manager;
 mod metrics;
 pub mod primary;
 pub mod worker;
-pub use manager::catchup_accumulator;
+pub use manager::{catchup_accumulator, sync_num_workers_from_chain};
 
 #[cfg(test)]
 use tempfile as _;

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -194,6 +194,75 @@ pub async fn catchup_accumulator(
     Ok(())
 }
 
+/// Resize the [`GasAccumulator`] to the on-chain worker count for the epoch whose first block is
+/// `epoch_first_block`.
+///
+/// The `WorkerConfigs` contract is the absolute source of truth for the worker count, and the
+/// count for epoch E is its state at block `epoch_first_block - 1` - E's first block's parent,
+/// i.e. the previous epoch's closing block (`saturating_sub` makes epoch 0 read genesis state).
+/// That block is identical for a live producer at the boundary, a restarting node, and a
+/// mid-epoch syncing node, and it is immune to mid-epoch `setNumWorkers` writes, which by design
+/// only take effect at the next boundary.
+///
+/// FAIL-OPEN: any read failure (contract absent on older chains, state unavailable) logs a
+/// warning and keeps the accumulator's current size, so the node behaves exactly as it did
+/// before worker counts were chain-derived.
+///
+/// Callers must only invoke this while no consensus output is executing (startup before
+/// [`catchup_accumulator`], epoch entry before replay) - see
+/// [`GasAccumulator::set_num_workers`].
+pub fn sync_num_workers_from_chain(
+    reth_env: &RethEnv,
+    gas_accumulator: &GasAccumulator,
+    epoch_first_block: u64,
+) {
+    let read_block = epoch_first_block.saturating_sub(1);
+    let header = match reth_env.sealed_header_by_number(read_block) {
+        Ok(Some(header)) => header,
+        Ok(None) => {
+            warn!(
+                target: "epoch-manager",
+                read_block,
+                "no header at epoch start parent while syncing worker count - keeping current count"
+            );
+            return;
+        }
+        Err(e) => {
+            warn!(
+                target: "epoch-manager",
+                ?e,
+                read_block,
+                "failed to read header while syncing worker count - keeping current count"
+            );
+            return;
+        }
+    };
+
+    match reth_env.get_worker_fee_configs_at_block(header.hash()) {
+        Ok((num_workers, _configs)) => {
+            let current = gas_accumulator.num_workers();
+            if current != num_workers {
+                info!(
+                    target: "epoch-manager",
+                    current,
+                    on_chain = num_workers,
+                    read_block,
+                    "syncing GasAccumulator worker count to on-chain WorkerConfigs"
+                );
+            }
+            gas_accumulator.set_num_workers(num_workers);
+        }
+        Err(e) => {
+            warn!(
+                target: "epoch-manager",
+                ?e,
+                read_block,
+                "failed to read WorkerConfigs while syncing worker count - keeping current count"
+            );
+        }
+    }
+}
+
 /// Worker id encoded in a header's `difficulty` (low 16 bits of `batch_index << 16 | worker_id`).
 pub(crate) fn worker_id_from_header(header: &SealedHeader) -> WorkerId {
     (header.difficulty.into_limbs()[0] & 0xffff) as u16
@@ -346,8 +415,10 @@ where
         // create channels for engine that survive the lifetime of the node
         let (to_engine, for_engine) = mpsc::channel(1000);
 
-        // Create our epoch gas accumulator, we currently have one worker.
-        // All nodes have to agree on the worker count, do not change this for an existing chain.
+        // Create the epoch gas accumulator with a single worker slot. The on-chain WorkerConfigs
+        // contract is the absolute source of truth for the worker count:
+        // sync_num_workers_from_chain resizes the accumulator to match it below (before catchup)
+        // and again at every epoch entry, so all nodes converge on the governance-set count.
         let gas_accumulator = GasAccumulator::new(1);
         // create channel for engine updates to consensus
         let (engine_update_tx, engine_update_rx) = mpsc::channel(64);
@@ -364,14 +435,13 @@ where
             .await?;
 
         // retrieve epoch information from canonical tip on startup
-        let EpochState { epoch, .. } = engine.epoch_state_from_canonical_tip().await?;
+        let EpochState { epoch, epoch_info, .. } = engine.epoch_state_from_canonical_tip().await?;
         debug!(target: "epoch-manager", ?epoch, "retrieved epoch state from canonical tip");
-        catchup_accumulator(
-            engine.get_reth_env().await,
-            &gas_accumulator,
-            &mut self.consensus_chain,
-        )
-        .await?;
+        // Size the accumulator from on-chain state first so catchup's per-worker restore writes
+        // (keyed by each block header's worker id) land in a correctly sized accumulator.
+        let reth_env = engine.get_reth_env().await;
+        sync_num_workers_from_chain(&reth_env, &gas_accumulator, epoch_info.blockHeight);
+        catchup_accumulator(reth_env, &gas_accumulator, &mut self.consensus_chain).await?;
 
         // read the network config or use the default, then stamp the genesis chain id
         // onto it so every wire protocol and gossip topic is chain-namespaced (issue

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -142,12 +142,19 @@ where
         self.metrics.current.set(committee.epoch() as f64);
         self.metrics.boundary_timestamp_seconds.set(self.epoch_boundary as f64);
 
+        let reth_env = engine.get_reth_env().await;
+
+        // Size the accumulator to the on-chain worker count for the epoch being entered (read at
+        // the epoch's first block's parent - the previous epoch's closing block). Runs on every
+        // entry mode, before fee seeding (which loops 0..num_workers) and before replay drives
+        // inc_block, so both operate on a correctly sized accumulator.
+        super::sync_num_workers_from_chain(&reth_env, &gas_accumulator, epoch_info.blockHeight);
+
         // Base-fee-from-chain seeding: if the canonical tip is already in the epoch we are
         // entering, adopt each worker's latest on-chain base fee rather than recomputing. This
         // covers syncing and restarting nodes: they execute the fee already baked into the chain.
         // A live producer crossing N->N+1 still has its tip in N here, so seeding is skipped and
         // the value adjust_base_fees computed at the boundary is kept. (See gas_accumulator docs.)
-        let reth_env = engine.get_reth_env().await;
         {
             if let Some(tip) = reth_env.finalized_header()? {
                 let tip_epoch = RethEnv::extract_epoch_from_header(&tip);
@@ -619,23 +626,28 @@ where
 /// each worker's base-fee container. This is the deterministic seam every committee member runs
 /// identically at the boundary.
 ///
-/// Infallible: if the contract read fails, worker 0's fee is pinned to [`FALLBACK_BASE_FEE`]
-/// instead of aborting the epoch close (see the FAIL-OPEN note in the body).
+/// The read's config count is the on-chain `numWorkers()` at the closing block, i.e. the worker
+/// count for the NEXT epoch (a mid-epoch `setNumWorkers` only takes effect at the boundary by
+/// design). The accumulator is resized to it before the per-worker loop so workers governance
+/// just added get their configured fee (e.g. `Static`) computed here rather than defaulting to
+/// MIN; epoch-entry sync then confirms the same count from the same block.
+///
+/// Infallible: if the contract read fails, the current per-worker base fees and worker count are
+/// kept unchanged instead of aborting the epoch close (see the FAIL-OPEN note in the body).
 ///
 /// Inert on existing chains: the genesis fee strategy is `Eip1559 { target_gas: u64::MAX }`, which
 /// floors every worker at `MIN_PROTOCOL_BASE_FEE`. Fees only move once governance sets a real
 /// per-worker target.
 fn adjust_base_fees(reth_env: &RethEnv, gas_accumulator: &GasAccumulator) {
-    let num_workers = gas_accumulator.num_workers();
-    // num_workers is the count the GasAccumulator was sized to at startup; get_worker_fee_configs
-    // validates it against the on-chain numWorkers() and errors on drift.
-    //
-    // FAIL-OPEN: a contract-read revert or a numWorkers() drift must not abort the epoch close
-    // The fallback is deterministic (a fixed 1 GWEI for worker 0), so
-    // every committee member that hits the same on-chain condition lands on the same fee and
-    // consensus should not diverge.
-    match reth_env.get_worker_fee_configs(num_workers) {
+    // FAIL-OPEN: a contract-read failure must not abort the epoch close. Keep the current
+    // per-worker base fees and worker count untouched -- both are already consensus-consistent
+    // (seeded from the same chain at epoch entry, then held deterministic within the epoch), so
+    // every committee member that hits the same read failure lands on the same state. The count
+    // self-heals at the next epoch entry via `sync_num_workers_from_chain`, which fails open the
+    // same way.
+    match reth_env.get_worker_fee_configs() {
         Ok(configs) => {
+            gas_accumulator.set_num_workers(configs.len());
             for (worker_id, config) in configs.into_iter().enumerate() {
                 let worker_id = worker_id as u16;
                 let (_blocks, gas_used, _gas_limit) = gas_accumulator.get_values(worker_id);
@@ -648,16 +660,11 @@ fn adjust_base_fees(reth_env: &RethEnv, gas_accumulator: &GasAccumulator) {
             warn!(
                 target: "epoch-manager",
                 ?e,
-                "failed to read worker fee configs at epoch close - falling back to {FALLBACK_BASE_FEE} wei for worker 0"
+                "failed to read worker fee configs at epoch close - keeping current per-worker base fees and worker count"
             );
-            gas_accumulator.base_fee(0).set_base_fee(FALLBACK_BASE_FEE);
         }
     }
 }
-
-/// Deterministic base fee (1 GWEI) applied to worker 0 when the `WorkerConfigs` contract read
-/// fails at epoch close.
-const FALLBACK_BASE_FEE: u64 = 1_000_000_000;
 
 /// Apply a worker's [`WorkerFeeConfig`] to compute its next-epoch base fee.
 ///
@@ -788,13 +795,5 @@ mod tests {
 
         assert_eq!(acc.base_fee(0).base_fee(), 111); // seeded from chain
         assert_eq!(acc.base_fee(1).base_fee(), 2000); // untouched
-    }
-
-    #[test]
-    fn fallback_base_fee_is_one_gwei() {
-        // The fail-open fallback in adjust_base_fees must stay a fixed 1 GWEI: it is applied
-        // independently by every committee member, so determinism (and thus consensus) depends on
-        // this exact value.
-        assert_eq!(FALLBACK_BASE_FEE, 1_000_000_000);
     }
 }

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -10,18 +10,24 @@ use std::{
     time::Duration,
 };
 use tempfile::TempDir;
-use tn_config::ConsensusConfig;
+use tn_config::{ConsensusConfig, WORKER_CONFIGS_ADDRESS};
 use tn_engine::ExecutorEngine;
 use tn_executor::subscriber::spawn_subscriber;
 use tn_network_libp2p::types::{MessageId, NetworkCommand};
 use tn_network_types::MockPrimaryToWorkerClient;
-use tn_node::catchup_accumulator;
+use tn_node::{catchup_accumulator, sync_num_workers_from_chain};
 use tn_primary::{
     consensus::{Bullshark, Consensus, LeaderSchedule},
     network::PrimaryNetworkHandle,
     ConsensusBus,
 };
-use tn_reth::{test_utils::seeded_genesis_from_random_batches, RethChainSpec};
+use tn_reth::{
+    test_utils::{
+        seeded_genesis_from_random_batches, test_genesis_with_consensus_registry,
+        test_genesis_with_consensus_registry_and_workers,
+    },
+    RethChainSpec,
+};
 use tn_rpc::{EngineToPrimary, RpcNodeInfo};
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
 use tn_test_utils::{
@@ -542,6 +548,194 @@ async fn test_catchup_accumulator_partial_execution() -> eyre::Result<()> {
         .collect();
     assert_eq!(expected, recovered.rewards_counter().get_address_counts());
     assert_eq!(expected, gas_accumulator.rewards_counter().get_address_counts());
+
+    Ok(())
+}
+
+/// `sync_num_workers_from_chain` sizes the accumulator to the on-chain `WorkerConfigs` count,
+/// growing an undersized accumulator and shrinking an oversized one.
+#[tokio::test]
+async fn test_sync_num_workers_from_chain_adjusts_to_on_chain_count() -> eyre::Result<()> {
+    let temp_dir = TempDir::with_prefix("sync_num_workers")?;
+    // genesis deploys WorkerConfigs with 2 workers (worker 0 EIP-1559, worker 1 static)
+    let genesis = test_genesis_with_consensus_registry_and_workers(
+        4,
+        vec![(0u8, 30_000_000u64), (1u8, 500u64)],
+    );
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let execution_node =
+        default_test_execution_node(Some(chain), None, &temp_dir.path().join("reth"), None)?;
+    let reth_env = execution_node.get_reth_env().await;
+    let epoch_first_block = reth_env.epoch_state_from_canonical_tip()?.epoch_info.blockHeight;
+
+    // the startup default (1 worker) grows to the on-chain count
+    let gas_accumulator = GasAccumulator::new(1);
+    sync_num_workers_from_chain(&reth_env, &gas_accumulator, epoch_first_block);
+    assert_eq!(gas_accumulator.num_workers(), 2, "undersized accumulator grows to on-chain count");
+
+    // an oversized accumulator shrinks to the on-chain count
+    let gas_accumulator = GasAccumulator::new(3);
+    sync_num_workers_from_chain(&reth_env, &gas_accumulator, epoch_first_block);
+    assert_eq!(gas_accumulator.num_workers(), 2, "oversized accumulator shrinks to on-chain count");
+
+    Ok(())
+}
+
+/// FAIL-OPEN: on a chain without the `WorkerConfigs` contract (older networks), the worker-count
+/// sync must keep the accumulator's current size and return without error.
+#[tokio::test]
+async fn test_sync_num_workers_fail_open_when_contract_absent() -> eyre::Result<()> {
+    let temp_dir = TempDir::with_prefix("sync_num_workers_fail_open")?;
+    // strip the WorkerConfigs account from the alloc so the contract read is guaranteed to fail
+    let mut genesis = test_genesis_with_consensus_registry(4);
+    genesis.alloc.remove(&WORKER_CONFIGS_ADDRESS);
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let execution_node =
+        default_test_execution_node(Some(chain), None, &temp_dir.path().join("reth"), None)?;
+    let reth_env = execution_node.get_reth_env().await;
+    let epoch_first_block = reth_env.epoch_state_from_canonical_tip()?.epoch_info.blockHeight;
+
+    let gas_accumulator = GasAccumulator::new(1);
+    sync_num_workers_from_chain(&reth_env, &gas_accumulator, epoch_first_block);
+    assert_eq!(gas_accumulator.num_workers(), 1, "fail-open keeps the current worker count");
+
+    Ok(())
+}
+
+/// Mid-epoch recovery on a chain whose `WorkerConfigs` declares 2 workers, mirroring the startup
+/// order: `sync_num_workers_from_chain` sizes the accumulator first, then `catchup_accumulator`
+/// restores per-worker state into the correctly sized slots.
+///
+/// Consensus still only produces worker-0 blocks (worker spawning is a follow-up), so worker 0
+/// must match the live accumulator exactly while worker 1 carries an idle default slot.
+#[tokio::test]
+async fn test_sync_then_catchup_recovers_two_worker_accumulator() -> eyre::Result<()> {
+    let temp_dir = TempDir::with_prefix("sync_then_catchup").unwrap();
+    // create deterministic committee fixture and use first authority's components
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .with_rng(StdRng::seed_from_u64(8991))
+        .build();
+    let primary = fixture.authorities().next().unwrap();
+    let config = primary.consensus_config().clone();
+    let consensus_bus = ConsensusBus::new();
+    let committee = config.committee().clone();
+    let mut consensus_chain =
+        ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee).await.unwrap();
+
+    // make certificates with batches of txs (all worker 0)
+    let max_round = 21;
+    let (certificates, _next_parents, batches) =
+        create_signed_certificates_for_rounds(1..=max_round, &fixture, &[]);
+
+    // 2-worker WorkerConfigs at genesis; fund the batch senders so txs execute
+    let genesis = test_genesis_with_consensus_registry_and_workers(
+        4,
+        vec![(0u8, 30_000_000u64), (1u8, 500u64)],
+    );
+    let all_batches: Vec<_> = batches.values().cloned().collect();
+    let (genesis, _, _) = seeded_genesis_from_random_batches(genesis, all_batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // live accumulator sized 2, as the startup sync would have left it
+    let gas_accumulator = GasAccumulator::new(2);
+    gas_accumulator.rewards_counter().set_committee(fixture.committee());
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        &temp_dir.path().join("reth"),
+        Some(gas_accumulator.rewards_counter()),
+    )?;
+
+    // manually create engine
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(10);
+    let max = Some(max_round as u64 - 1); // consensus needs 1 extra round to commit
+    let parent = chain.sealed_genesis_header();
+
+    // start engine
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let reth_env = execution_node.get_reth_env().await;
+    let (engine_update_tx, _engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let engine = ExecutorEngine::new(
+        reth_env.clone(),
+        max,
+        from_consensus,
+        parent,
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        gas_accumulator.clone(),
+        engine_update_tx,
+    );
+    let (tx, mut rx) = oneshot::channel();
+    task_manager.spawn_task("test task eng", async move {
+        let res = engine.run().await;
+        debug!(target: "gas-test", ?res, "res:");
+        let _ = tx.send(res);
+        Ok(())
+    });
+
+    // subscribe to output early
+    let mut consensus_output = consensus_bus.app().subscribe_consensus_output();
+
+    // spawn consensus to send output to engine for full execution
+    spawn_consensus(
+        &fixture,
+        &consensus_bus,
+        batches,
+        config,
+        &task_manager,
+        consensus_chain.clone(),
+    )
+    .await;
+
+    // send certificates to trigger subdag commit
+    for certificate in certificates.iter() {
+        consensus_bus.new_certificates().send(certificate.clone()).await.unwrap();
+    }
+
+    // forward consensus output to engine until `max_round`
+    loop {
+        tokio::select! {
+            Some(output) = consensus_output.recv() => {
+                to_engine.send(output).await?;
+            }
+            engine_task = timeout(Duration::from_secs(30), &mut rx) => {
+                assert!(engine_task.is_ok());
+                break;
+            }
+        }
+    }
+
+    // simulate node recovery in the startup order: sync worker count first, then catchup
+    let recovered = GasAccumulator::new(1);
+    recovered.rewards_counter().set_committee(fixture.committee());
+    // poison worker 0's fee to prove the resize preserves the slot and catchup then restores it
+    let expected_base_fee = reth_env
+        .finalized_header()?
+        .expect("finalized header exists after producing blocks")
+        .base_fee_per_gas
+        .expect("executed blocks carry a base fee");
+    recovered.base_fee(0).set_base_fee(expected_base_fee + 999);
+
+    let epoch_first_block = reth_env.epoch_state_from_canonical_tip()?.epoch_info.blockHeight;
+    sync_num_workers_from_chain(&reth_env, &recovered, epoch_first_block);
+    assert_eq!(recovered.num_workers(), 2, "sync sizes the accumulator before catchup");
+
+    catchup_accumulator(reth_env.clone(), &recovered, &mut consensus_chain).await?;
+
+    // worker 0: totals and fee restored to match the live accumulator
+    let (blocks, gas_used, gas_limit) = recovered.get_values(0);
+    assert_eq!((blocks, gas_used, gas_limit), gas_accumulator.get_values(0));
+    assert!(gas_used > 0, "worker 0 accumulated gas this epoch");
+    assert_eq!(recovered.base_fee(0).base_fee(), expected_base_fee);
+    // worker 1: idle governance-declared slot stays at defaults
+    assert_eq!(recovered.get_values(1), (0, 0, 0));
+    assert_eq!(recovered.base_fee(1).base_fee(), MIN_PROTOCOL_BASE_FEE);
+    // rewards restored identically
+    assert_eq!(
+        gas_accumulator.rewards_counter().get_address_counts(),
+        recovered.rewards_counter().get_address_counts()
+    );
 
     Ok(())
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1635,19 +1635,13 @@ impl RethEnv {
 
     /// Read worker fee configs from the [`WorkerConfigs`] contract at the canonical tip.
     ///
-    /// `num_workers` is the caller's view of the on-chain worker count. It is compared against
-    /// the value returned by `numWorkers()` at canonical tip; a mismatch indicates governance
-    /// grew/shrank the worker set mid-node-lifetime and the in-memory `GasAccumulator` no longer
-    /// matches the contract. Caller must restart or re-resolve the worker count.
-    pub fn get_worker_fee_configs(&self, num_workers: usize) -> eyre::Result<Vec<WorkerFeeConfig>> {
+    /// The returned `Vec`'s length is the on-chain `numWorkers()` at the canonical tip (the
+    /// arity between the count and the per-worker arrays is validated in
+    /// [`Self::worker_fee_configs_inner`]). Callers size their in-memory worker state (e.g. the
+    /// `GasAccumulator`) to match, rather than asserting a preconceived count.
+    pub fn get_worker_fee_configs(&self) -> eyre::Result<Vec<WorkerFeeConfig>> {
         let canonical_tip = self.canonical_tip();
-        let (num_workers_on_chain, configs) = self.worker_fee_configs_inner(&canonical_tip)?;
-        if num_workers != num_workers_on_chain {
-            return Err(eyre::eyre!(
-                "worker count drift: caller={num_workers}, on-chain numWorkers()={num_workers_on_chain}; \
-                 GasAccumulator sized at startup no longer matches WorkerConfigs; node restart required"
-            ));
-        }
+        let (_num_workers, configs) = self.worker_fee_configs_inner(&canonical_tip)?;
         Ok(configs)
     }
 
@@ -2468,11 +2462,151 @@ mod tests {
             RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
                 .unwrap();
 
-        // read back worker configs from chain state
-        let configs = reth_env.get_worker_fee_configs(2)?;
+        // read back worker configs from chain state - the returned length IS the on-chain
+        // numWorkers()
+        let configs = reth_env.get_worker_fee_configs()?;
         assert_eq!(configs.len(), 2);
         assert_eq!(configs[0], WorkerFeeConfig::Eip1559 { target_gas: 30_000_000 });
         assert_eq!(configs[1], WorkerFeeConfig::Static { fee: 500 });
+
+        // the block-pinned read primitive reports the same count at genesis
+        let (num_workers, configs_at_block) =
+            reth_env.get_worker_fee_configs_at_block(chain.sealed_genesis_header().hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(configs_at_block, configs);
+
+        Ok(())
+    }
+
+    /// Pins the per-epoch worker-count read rule: the count for epoch E is the `WorkerConfigs`
+    /// state at E's first block's parent (= E-1's closing block). Governance submits
+    /// `setWorkerConfig` + `setNumWorkers` during epoch 0; the count read at epoch 1's
+    /// start-parent block reflects the change, while the count read at epoch 0's start-parent
+    /// (genesis) still reports the original single worker.
+    #[tokio::test]
+    async fn test_worker_count_read_at_epoch_start_parent() -> eyre::Result<()> {
+        // minimal validator set (5 validators)
+        let all_validators: Vec<Address> =
+            (1..=5).map(|i| Address::from_slice(&[i * 0x11; 20])).collect();
+
+        let validators: Vec<_> = all_validators
+            .iter()
+            .enumerate()
+            .map(|(i, addr)| {
+                let mut rng = StdRng::seed_from_u64(i as u64);
+                let bls = BlsKeypair::generate(&mut rng);
+                let bls_pubkey = bls.public();
+                let pop = generate_proof_of_possession_bls_for_test(&bls, addr)
+                    .expect("pop generation failed");
+                NodeInfo {
+                    name: format!("validator-{i}"),
+                    bls_public_key: *bls_pubkey,
+                    p2p_info: NodeP2pInfo::default(),
+                    execution_address: *addr,
+                    proof_of_possession: pop,
+                }
+            })
+            .collect();
+
+        let initial_stake_config = ConsensusRegistry::StakeConfig {
+            stakeAmount: U256::from(parse_ether("1_000_000").unwrap()),
+            minWithdrawAmount: U256::from(parse_ether("1_000").unwrap()),
+            epochIssuance: U256::from(parse_ether("20_000_000").unwrap())
+                .checked_div(U256::from(28))
+                .expect("u256 div checked"),
+            epochDuration: 28800,
+        };
+
+        // governance owns the WorkerConfigs contract and signs the config txs
+        let mut governance_multisig =
+            TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+        let governance = governance_multisig.address();
+        let tmp_genesis = tn_types::test_genesis().extend_accounts([(
+            governance,
+            GenesisAccount::default().with_balance(U256::from(parse_ether("50_000_000")?)),
+        )]);
+
+        // deploy with a single worker (the canonical existing-chain shape)
+        let genesis = RethEnv::create_consensus_registry_genesis_accounts(
+            validators.clone(),
+            tmp_genesis,
+            initial_stake_config.clone(),
+            governance,
+            vec![(0u8, 30_000_000u64)],
+        )?;
+
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Worker Count Epoch Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+                .unwrap();
+
+        // sanity: epoch 0 starts at blockHeight 0, so its start-parent (saturating) is genesis
+        let EpochState { epoch, epoch_info, .. } = reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 0);
+        let epoch_zero_read_block = epoch_info.blockHeight.saturating_sub(1);
+        assert_eq!(epoch_zero_read_block, 0);
+
+        // governance grows the worker set mid-epoch: config worker 1 (Static 500), then grow
+        // the count (setWorkerConfig must precede setNumWorkers per the contract)
+        let set_config_tx = governance_multisig.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(WORKER_CONFIGS_ADDRESS),
+            U256::ZERO,
+            WorkerConfigs::setWorkerConfigCall { workerId: 1, strategy: 1, value: 500, data: 0 }
+                .abi_encode()
+                .into(),
+        );
+        let set_num_workers_tx = governance_multisig.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(WORKER_CONFIGS_ADDRESS),
+            U256::ZERO,
+            WorkerConfigs::setNumWorkersCall { numWorkers_: 2 }.abi_encode().into(),
+        );
+
+        // block 1 (mid-epoch-0): the governance txs land
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(
+            &reth_env,
+            payload,
+            vec![set_config_tx, set_num_workers_tx],
+        )?;
+        let canonical_header = block1.recovered_block.clone_sealed_header();
+
+        // block 2 closes epoch 0 -> epoch 1's first block will be 3, start-parent = block 2
+        let consensus_output = consensus_output_for_tests(2, 1, 2, true);
+        let payload = TNPayload::new_for_test(canonical_header, &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let close_block_hash = block2.recovered_block.clone_sealed_header().hash();
+
+        // the new epoch's info points its start-parent at the closing block
+        let EpochState { epoch, epoch_info, .. } = reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 1);
+        let epoch_one_read_block = epoch_info.blockHeight.saturating_sub(1);
+        let epoch_one_read_header = reth_env
+            .sealed_header_by_number(epoch_one_read_block)?
+            .expect("epoch 1 start-parent header");
+        assert_eq!(epoch_one_read_header.hash(), close_block_hash);
+
+        // epoch 1's count (read at its start-parent) reflects the governance change...
+        let (num_workers, configs) =
+            reth_env.get_worker_fee_configs_at_block(epoch_one_read_header.hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(configs[1], WorkerFeeConfig::Static { fee: 500 });
+
+        // ...while epoch 0's count (read at genesis) still reports the original single worker
+        let genesis_hash = reth_env
+            .sealed_header_by_number(epoch_zero_read_block)?
+            .expect("genesis header")
+            .hash();
+        let (num_workers, _configs) = reth_env.get_worker_fee_configs_at_block(genesis_hash)?;
+        assert_eq!(num_workers, 1);
 
         Ok(())
     }

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -715,6 +715,19 @@ pub async fn create_committee_from_state(epoch_state: EpochState) -> eyre::Resul
 /// NOTE: this is sync but must be called from within a tokio runtime (e.g. a `#[tokio::test]`),
 /// because deploying the registry spins up a temporary `RethEnv`.
 pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
+    test_genesis_with_consensus_registry_and_workers(num_validators, vec![(0u8, 30_000_000u64)])
+}
+
+/// [`test_genesis_with_consensus_registry`] with explicit `WorkerConfigs` deployment parameters.
+///
+/// `worker_configs` is one `(strategy, value)` pair per worker (strategy 0 = EIP-1559 with
+/// `value` as the gas target, strategy 1 = static with `value` as the fee), so its length is the
+/// genesis `numWorkers()`. Use this for tests that need a multi-worker `WorkerConfigs` contract;
+/// the single-worker default above matches the canonical testnet genesis.
+pub fn test_genesis_with_consensus_registry_and_workers(
+    num_validators: usize,
+    worker_configs: Vec<(u8, u64)>,
+) -> Genesis {
     // deterministic committee-eligible validator addresses (0x11.., 0x22.., ...)
     let all_validators: Vec<Address> = (1..=num_validators)
         .map(|i| Address::from_slice(&[(i as u8).wrapping_mul(0x11); 20]))
@@ -768,7 +781,7 @@ pub fn test_genesis_with_consensus_registry(num_validators: usize) -> Genesis {
         base_genesis,
         initial_stake_config,
         governance,
-        vec![(0u8, 30_000_000u64)],
+        worker_configs,
     )
     .expect("create consensus registry genesis accounts")
 }

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -70,6 +70,7 @@ use std::{
         Arc,
     },
 };
+use tracing::warn;
 
 /// Tracks how many blocks each leader committed during an epoch for reward distribution.
 ///
@@ -334,7 +335,10 @@ impl GasAccumulator {
     /// catchup, epoch entry before replay, epoch close after final execution): a resize that
     /// races `inc_block` for a removed worker id panics there by design.
     pub fn set_num_workers(&self, num_workers: usize) {
-        // A chain always has at least worker 0.
+        // a chain always has at least worker 0.
+        if num_workers == 0 {
+            warn!(target: "epoch-manager", "attempt to set num workers to {num_workers}");
+        }
         let num_workers = num_workers.max(1);
         let mut inner = self.inner.write();
         if inner.len() == num_workers {

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -5,6 +5,15 @@
 //! block. At epoch boundaries these totals drive base-fee adjustments and validator reward
 //! withdrawals.
 //!
+//! ## Worker count
+//!
+//! The number of worker slots is not fixed at construction. The on-chain `WorkerConfigs`
+//! contract is the absolute source of truth: `sync_num_workers_from_chain` (in `node::manager`)
+//! reads the count for the entered epoch at the epoch's first block's parent and resizes the
+//! accumulator in place via [`GasAccumulator::set_num_workers`] - at startup (before catchup)
+//! and at every epoch entry - and `adjust_base_fees` resizes at epoch close to the count read
+//! from the closing block (the next epoch's count).
+//!
 //! ## Startup recovery
 //!
 //! Because the accumulator is purely in-memory, its state must be rebuilt whenever a node restarts
@@ -225,13 +234,21 @@ impl Default for Accumulated {
 /// [`EpochManager::adjust_base_fees`] reads the totals at the epoch boundary to update each
 /// worker's base fee for the next epoch.
 ///
+/// The worker count is not fixed at construction: the on-chain `WorkerConfigs` contract is the
+/// source of truth, and [`GasAccumulator::set_num_workers`] resizes the slot list in place to
+/// match it at each epoch boundary. Resizing in place (rather than replacing the accumulator)
+/// keeps the node-lifetime clones held by the engine and the [`RewardsCounter`] held by the EVM
+/// config live across epochs.
+///
 /// If the engine is moved to a separate process in the future, this shared-memory design will
 /// need to be replaced with an IPC mechanism (or something similar).
 #[derive(Clone, Debug)]
 pub struct GasAccumulator {
     /// One [`Accumulated`] entry per worker, indexed by worker id. Wrapped in `Arc` for
-    /// cheap cloning across the engine and consensus tasks.
-    inner: Arc<Vec<Accumulated>>,
+    /// cheap cloning across the engine and consensus tasks; the `RwLock` exists solely so
+    /// [`GasAccumulator::set_num_workers`] can resize the slot list in place - per-slot state
+    /// stays interior-mutable behind its own lock.
+    inner: Arc<RwLock<Vec<Accumulated>>>,
     /// Leader block counts used to compute validator rewards at epoch boundaries.
     rewards_counter: RewardsCounter,
 }
@@ -248,7 +265,7 @@ impl GasAccumulator {
         for _ in 0..workers {
             inner.push(Accumulated::default());
         }
-        Self { inner: Arc::new(inner), rewards_counter: rewards }
+        Self { inner: Arc::new(RwLock::new(inner)), rewards_counter: rewards }
     }
 
     /// Increment the block count, gas used, and gas limit for `worker_id`.
@@ -257,13 +274,16 @@ impl GasAccumulator {
     ///
     /// # Panics
     ///
-    /// Panics if `worker_id` is out of range. Any batch that reaches execution has a valid id.
+    /// Panics if `worker_id` is out of range. Any batch that reaches execution has a valid id;
+    /// an out-of-range id here means the accumulator disagrees with the chain on the worker
+    /// count, and halting beats silently diverging gas totals.
     pub fn inc_block(&self, worker_id: WorkerId, gas_used: u64, gas_limit: u64) {
         // Don't bother accumulating empty blocks- helps with restarts.
         if gas_used == 0 {
             return;
         }
-        let mut guard = self.inner.get(worker_id as usize).expect("valid worker id").gas.lock();
+        let inner = self.inner.read();
+        let mut guard = inner.get(worker_id as usize).expect("valid worker id").gas.lock();
         guard.blocks += 1;
         guard.gas_used += gas_used;
         guard.gas_limit += gas_limit;
@@ -271,7 +291,7 @@ impl GasAccumulator {
 
     /// Reset all gas totals and leader counts to zero. Called at epoch boundaries.
     pub fn clear(&self) {
-        for acc in self.inner.iter() {
+        for acc in self.inner.read().iter() {
             let mut guard = acc.gas.lock();
             guard.blocks = 0;
             guard.gas_used = 0;
@@ -286,20 +306,41 @@ impl GasAccumulator {
     ///
     /// Panics if `worker_id` is out of range.
     pub fn get_values(&self, worker_id: WorkerId) -> (u64, u64, u64) {
-        let guard = self.inner.get(worker_id as usize).expect("valid worker id").gas.lock();
+        let inner = self.inner.read();
+        let guard = inner.get(worker_id as usize).expect("valid worker id").gas.lock();
         (guard.blocks, guard.gas_used, guard.gas_limit)
     }
 
     /// Return the shared [`BaseFeeContainer`] for `worker_id`. Mutations are visible to all
     /// holders of the returned clone.
     pub fn base_fee(&self, worker_id: WorkerId) -> BaseFeeContainer {
-        self.inner.get(worker_id as usize).expect("valid worker id").base_fee.clone()
+        self.inner.read().get(worker_id as usize).expect("valid worker id").base_fee.clone()
     }
 
     /// Return the number of workers in the accumulator.
     /// Worker ids will be 0 to one less that this value.
     pub fn num_workers(&self) -> usize {
-        self.inner.len()
+        self.inner.read().len()
+    }
+
+    /// Resize the slot list in place to `num_workers` (clamped to at least 1).
+    ///
+    /// The change is visible to every clone of this accumulator, so node-lifetime handles (the
+    /// engine's, the EVM config's rewards counter) stay live. Growing appends default slots
+    /// (`MIN_PROTOCOL_BASE_FEE` fee, zero gas); shrinking truncates, discarding the removed
+    /// workers' totals and fees. Existing slots and the [`RewardsCounter`] are untouched.
+    ///
+    /// Callers must only invoke this while no consensus output is executing (startup before
+    /// catchup, epoch entry before replay, epoch close after final execution): a resize that
+    /// races `inc_block` for a removed worker id panics there by design.
+    pub fn set_num_workers(&self, num_workers: usize) {
+        // A chain always has at least worker 0.
+        let num_workers = num_workers.max(1);
+        let mut inner = self.inner.write();
+        if inner.len() == num_workers {
+            return;
+        }
+        inner.resize_with(num_workers, Accumulated::default);
     }
 
     /// Return a copy of the rewards counter object.
@@ -438,5 +479,90 @@ mod tests {
             compute_next_base_fee_eip1559(MIN_PROTOCOL_BASE_FEE, 200, 100),
             MIN_PROTOCOL_BASE_FEE + 1
         );
+    }
+
+    #[test]
+    fn set_num_workers_grow_preserves_existing_and_defaults_new_slots() {
+        let acc = GasAccumulator::new(1);
+        acc.inc_block(0, 100, 200);
+        acc.base_fee(0).set_base_fee(999);
+
+        acc.set_num_workers(3);
+
+        assert_eq!(acc.num_workers(), 3);
+        // existing slot keeps its gas totals and fee
+        assert_eq!(acc.get_values(0), (1, 100, 200));
+        assert_eq!(acc.base_fee(0).base_fee(), 999);
+        // new slots start at (MIN fee, zero gas)
+        for worker_id in 1..3u16 {
+            assert_eq!(acc.get_values(worker_id), (0, 0, 0));
+            assert_eq!(acc.base_fee(worker_id).base_fee(), MIN_PROTOCOL_BASE_FEE);
+        }
+    }
+
+    #[test]
+    fn set_num_workers_shrink_truncates_high_slots() {
+        let acc = GasAccumulator::new(3);
+        acc.inc_block(0, 100, 200);
+        acc.inc_block(2, 300, 400);
+        acc.base_fee(2).set_base_fee(777);
+
+        acc.set_num_workers(2);
+        assert_eq!(acc.num_workers(), 2);
+        assert_eq!(acc.get_values(0), (1, 100, 200));
+
+        // re-growing yields a fresh default slot, not the truncated one
+        acc.set_num_workers(3);
+        assert_eq!(acc.get_values(2), (0, 0, 0));
+        assert_eq!(acc.base_fee(2).base_fee(), MIN_PROTOCOL_BASE_FEE);
+    }
+
+    #[test]
+    fn set_num_workers_clamps_zero_to_one() {
+        let acc = GasAccumulator::new(2);
+        acc.set_num_workers(0);
+        assert_eq!(acc.num_workers(), 1);
+    }
+
+    #[test]
+    fn set_num_workers_same_size_is_noop() {
+        let acc = GasAccumulator::new(2);
+        acc.inc_block(1, 50, 60);
+        acc.base_fee(1).set_base_fee(123);
+
+        acc.set_num_workers(2);
+
+        assert_eq!(acc.num_workers(), 2);
+        assert_eq!(acc.get_values(1), (1, 50, 60));
+        assert_eq!(acc.base_fee(1).base_fee(), 123);
+    }
+
+    #[test]
+    fn clones_observe_resize() {
+        // The engine holds a node-lifetime clone taken before any resize; a resize through the
+        // manager's handle must be visible through it (the resize-in-place requirement).
+        let acc = GasAccumulator::new(1);
+        let engine_handle = acc.clone();
+
+        acc.set_num_workers(2);
+
+        assert_eq!(engine_handle.num_workers(), 2);
+        // writes through the pre-resize clone land in the new slot
+        engine_handle.inc_block(1, 10, 20);
+        assert_eq!(acc.get_values(1), (1, 10, 20));
+    }
+
+    #[test]
+    fn resize_preserves_rewards_counter_identity() {
+        // RethEnv/TnEvmConfig hold a RewardsCounter clone taken at startup; resizing the worker
+        // slots must not detach it.
+        let acc = GasAccumulator::new(1);
+        let evm_handle = acc.rewards_counter();
+
+        acc.set_num_workers(3);
+
+        let leader = AuthorityIdentifier::default();
+        evm_handle.inc_leader_count(&leader);
+        assert_eq!(acc.rewards_counter().leader_counts.lock().get(&leader), Some(&1));
     }
 }


### PR DESCRIPTION
- `GasAccumulator`'s slot list is now `Arc<RwLock<Vec<Accumulated>>>` instead of `Arc<Vec<_>>`, with a new `set_num_workers` that resizes in place (grow appends default slots, shrink truncates) so existing clones (engine, rewards counter) see the change without reconstruction
- Added `sync_num_workers_from_chain`, called at startup (before `catchup_accumulator`) and at every epoch entry (before fee seeding/replay), reading the `WorkerConfigs` count at the entering epoch's first block's parent
- `adjust_base_fees` now resizes the accumulator to the count returned by `get_worker_fee_configs()` directly instead of asserting a caller-supplied count against on-chain `numWorkers()` — new workers get their configured fee applied immediately at close rather than waiting for the next epoch-entry sync
- Removed `get_worker_fee_configs`'s `num_workers` drift-check parameter and the hardcoded 1 GWEI fallback for worker 0; both sync points now fail open by keeping current state on any read failure
- Added IT tests covering: accumulator grow/shrink to on-chain count, fail-open behavior when `WorkerConfigs` is absent, and worker-count reads landing on the correct epoch-boundary block

closes #845 