### PR TITLE
refactor(cli): extract BLS passphrase handling into telcoin-network-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11398,8 +11398,6 @@ dependencies = [
 name = "telcoin-network"
 version = "0.1.0"
 dependencies = [
- "clap",
- "rpassword",
  "telcoin-network-cli",
  "tn-node",
 ]
@@ -11422,6 +11420,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rayon",
+ "rpassword",
  "secp256k1 0.31.1",
  "serde_json",
  "serde_yaml",

--- a/bin/telcoin-network/Cargo.toml
+++ b/bin/telcoin-network/Cargo.toml
@@ -11,8 +11,6 @@ description.workspace = true
 exclude.workspace = true
 
 [dependencies]
-rpassword = { workspace = true }
-clap = { workspace = true }
 telcoin-network-cli = { workspace = true }
 tn-node = { workspace = true }
 

--- a/bin/telcoin-network/src/main.rs
+++ b/bin/telcoin-network/src/main.rs
@@ -1,98 +1,18 @@
 //! Main binary for TN CLI
 
-use clap::Parser as _;
-use telcoin_network_cli::cli::{Commands, PassSource};
+use telcoin_network_cli::{cli::Cli, passphrase::get_bls_passphrase_from_env};
 use tn_node::launch_node;
 
-const BLS_PASSPHRASE_ENVVAR: &str = "TN_BLS_PASSPHRASE";
-
-/// Read the bls key passphrase from then incoming environment if set.
-/// This also will remove the key once read to avoid leaks in future.
-/// This is meant to be called once at the very beginning of program
-/// start before any threads exists.  It will only return the passphrase
-/// on the first call (it clears the env if it is set).
-fn get_bls_passphrase_from_env() -> Option<String> {
-    if let Ok(passphrase) = std::env::var(BLS_PASSPHRASE_ENVVAR) {
-        if !passphrase.is_empty() {
-            // Clear then remove the passphrase from the env.
-            // NOTE: This is probably not doing much but is an attempt to make the var "more
-            // deleted". This will depend on the underlying platform/libc but should
-            // worst case does nothing. Note on safety, these need calls need to happen
-            // to avoid any leaks of the passphrase if set and they are unsafe.  They
-            // are unsafe because they are not thread safe and we only call this
-            // function once at the beginning of startup so no threads should exist yet.
-            unsafe {
-                std::env::set_var(BLS_PASSPHRASE_ENVVAR, "");
-                std::env::remove_var(BLS_PASSPHRASE_ENVVAR);
-            }
-            Some(passphrase)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
-}
-
-fn read_passphrase() -> Option<String> {
-    while let Ok(pw) = rpassword::prompt_password("Enter a passphrase to ecrypt BLS key: ") {
-        if let Ok(pw2) = rpassword::prompt_password("Re-enter BLS key passphrase to confirm: ") {
-            if pw == pw2 {
-                return if pw.is_empty() {
-                    println!("No passphrase set for BLS key, this is not recommended.");
-                    None
-                } else {
-                    Some(pw)
-                };
-            }
-        }
-        println!("Passphrases do not match, retry.");
-    }
-    None
-}
-
 fn main() {
-    // Access the environment befor we do anything else, even use CLAP.
-    let mut passphrase = get_bls_passphrase_from_env();
-    let cli = telcoin_network_cli::cli::Cli::<telcoin_network_cli::NoArgs>::parse();
+    // Must be the first statement of main: reads and clears TN_BLS_PASSPHRASE
+    // before any threads exist (see `get_bls_passphrase_from_env`).
+    let preloaded = get_bls_passphrase_from_env();
+    let cli = Cli::parse_args(); // = Cli::<NoArgs>::parse(), cli.rs:77-79
 
-    // Sort out the BLS key passphrase depending on the command run.
-    match cli.bls_passphrase_source {
-        PassSource::Env => {} // Already have the env var if provided.
-        PassSource::Stdin => {
-            let mut buffer = String::new();
-            if let Err(err) = std::io::stdin().read_line(&mut buffer) {
-                eprintln!("Error reading BLS passphrase from stdin: {err:?}");
-                std::process::exit(1);
-            }
-            passphrase = Some(buffer.trim_end().to_string());
-        }
-        PassSource::Ask => match cli.command {
-            Commands::Keytool(_) => {
-                // Need to ask and confirm before it used to encrypt.
-                passphrase = read_passphrase();
-            }
-            Commands::Db(_) => {} // DB diagnostics are read-only and do not require keys.
-            Commands::Genesis(_) => {} // Don't need the passphrase..
-            Commands::Node(_) => {
-                // Simple ask once and app will error out later if this is wrong.
-                passphrase =
-                    rpassword::prompt_password("Enter the BLS key passphrase to decrypt: ").ok();
-            }
-        },
-        PassSource::NoPassphrase => {
-            passphrase = None;
-        }
-    }
-    // The `db` subcommand is a read-only inspection tool and never needs the BLS key.
-    let needs_passphrase =
-        cli.bls_passphrase_source.with_passphrase() && !matches!(cli.command, Commands::Db(_));
-    if passphrase.is_none() && needs_passphrase {
-        eprintln!(
-            "Error passphrase is required, see the option --bls-passphrase-source for options"
-        );
+    let passphrase = cli.resolve_bls_passphrase(preloaded).unwrap_or_else(|err| {
+        eprintln!("{err}");
         std::process::exit(1);
-    }
+    });
 
     if let Err(err) = cli.run(passphrase, |builder, _, tn_datadir, key_config, version| {
         launch_node(builder, tn_datadir, key_config, version)

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -7,7 +7,6 @@ use crate::common::{
 };
 use assert_matches::assert_matches;
 use eyre::eyre;
-use futures::StreamExt as _;
 use rand::{rngs::StdRng, SeedableRng as _};
 use std::num::NonZeroUsize;
 use tn_config::{ConsensusConfig, NetworkConfig};

--- a/crates/telcoin-network-cli/Cargo.toml
+++ b/crates/telcoin-network-cli/Cargo.toml
@@ -53,6 +53,7 @@ tn-reth = { workspace = true }
 tn-config = { workspace = true }
 tn-storage = { workspace = true }
 rayon = { workspace = true }
+rpassword = { workspace = true }
 dirs-next = { workspace = true }
 bs58 = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/telcoin-network-cli/src/cli.rs
+++ b/crates/telcoin-network-cli/src/cli.rs
@@ -101,23 +101,28 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     ///
     /// ```no_run
     /// use clap::Parser;
-    /// use telcoin_network_cli::cli::Cli;
+    /// use telcoin_network_cli::{cli::Cli, passphrase::get_bls_passphrase_from_env};
     /// use tn_node::launch_node;
     ///
-    /// #[derive(Debug, Parser)]
+    /// /// Extra CLI args flattened into the `node` subcommand.
+    /// #[derive(Debug, clap::Args)]
     /// pub struct MyArgs {
+    ///     /// Example flag consumed by your ExEx.
+    ///     #[arg(long)]
     ///     pub enable: bool,
     /// }
     ///
-    /// if let Err(err) = telcoin_network_cli::cli::Cli::<MyArgs>::parse().run(
-    ///     None,
-    ///     |builder, _, tn_datadir, passphrase, version| {
-    ///         launch_node(builder, tn_datadir, passphrase, version)
-    ///     },
-    /// ) {
-    ///     eprintln!("Error: {err:?}");
-    ///     std::process::exit(1);
-    /// }
+    /// // 1. Read (and clear) TN_BLS_PASSPHRASE before any threads exist.
+    /// let preloaded = get_bls_passphrase_from_env();
+    /// let cli = Cli::<MyArgs>::parse();
+    /// // 2. Resolve the passphrase for the parsed subcommand.
+    /// let passphrase = cli.resolve_bls_passphrase(preloaded)?;
+    /// // 3. Run, installing ExExes on the builder before launching the node.
+    /// cli.run(passphrase, |mut builder, _args, tn_datadir, key_config, version| {
+    ///     builder.install_exex("my-exex", |_ctx| async move { Ok(()) });
+    ///     launch_node(builder, tn_datadir, key_config, version)
+    /// })?;
+    /// # Ok::<(), eyre::Report>(())
     /// ```
     pub fn run<L>(mut self, passphrase: Option<String>, launcher: L) -> eyre::Result<()>
     where

--- a/crates/telcoin-network-cli/src/lib.rs
+++ b/crates/telcoin-network-cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod genesis;
 pub mod keytool;
 pub mod node;
 mod open_telemetry;
+pub mod passphrase;
 pub mod version;
 
 /// No Additional arguments

--- a/crates/telcoin-network-cli/src/passphrase.rs
+++ b/crates/telcoin-network-cli/src/passphrase.rs
@@ -1,0 +1,159 @@
+//! BLS key passphrase acquisition, shared by the stock `telcoin-network` binary
+//! and external binaries that embed the TN CLI (e.g. ExEx host binaries).
+
+use crate::cli::{Cli, Commands, PassSource};
+use eyre::bail;
+use std::fmt;
+
+/// Environment variable read (and cleared) at process start for the BLS key passphrase.
+pub const BLS_PASSPHRASE_ENVVAR: &str = "TN_BLS_PASSPHRASE";
+
+/// Read the bls key passphrase from then incoming environment if set.
+/// This also will remove the key once read to avoid leaks in future.
+/// This is meant to be called once at the very beginning of program
+/// start before any threads exists.  It will only return the passphrase
+/// on the first call (it clears the env if it is set).
+///
+/// Call this exactly once, as the FIRST statement of `main`, before any
+/// threads exist: it mutates the process environment, which is not thread safe.
+pub fn get_bls_passphrase_from_env() -> Option<String> {
+    if let Ok(passphrase) = std::env::var(BLS_PASSPHRASE_ENVVAR) {
+        if !passphrase.is_empty() {
+            // Clear then remove the passphrase from the env.
+            // NOTE: This is probably not doing much but is an attempt to make the var "more
+            // deleted". This will depend on the underlying platform/libc but should
+            // worst case does nothing. Note on safety, these need calls need to happen
+            // to avoid any leaks of the passphrase if set and they are unsafe.  They
+            // are unsafe because they are not thread safe and we only call this
+            // function once at the beginning of startup so no threads should exist yet.
+            unsafe {
+                std::env::set_var(BLS_PASSPHRASE_ENVVAR, "");
+                std::env::remove_var(BLS_PASSPHRASE_ENVVAR);
+            }
+            Some(passphrase)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Prompt (twice) for a new passphrase when generating keys.
+fn read_passphrase() -> Option<String> {
+    while let Ok(pw) = rpassword::prompt_password("Enter a passphrase to ecrypt BLS key: ") {
+        if let Ok(pw2) = rpassword::prompt_password("Re-enter BLS key passphrase to confirm: ") {
+            if pw == pw2 {
+                return if pw.is_empty() {
+                    println!("No passphrase set for BLS key, this is not recommended.");
+                    None
+                } else {
+                    Some(pw)
+                };
+            }
+        }
+        println!("Passphrases do not match, retry.");
+    }
+    None
+}
+
+impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
+    /// Resolve the BLS key passphrase for this invocation.
+    ///
+    /// `preloaded` is the value captured by [`get_bls_passphrase_from_env`] at
+    /// process start. Applies the `--bls-passphrase-source` policy for the
+    /// parsed subcommand and errors when a required passphrase is absent.
+    pub fn resolve_bls_passphrase(
+        &self,
+        preloaded: Option<String>,
+    ) -> eyre::Result<Option<String>> {
+        let mut passphrase = preloaded;
+        match self.bls_passphrase_source {
+            PassSource::Env => {} // Already have the env var if provided.
+            PassSource::Stdin => {
+                let mut buffer = String::new();
+                if let Err(err) = std::io::stdin().read_line(&mut buffer) {
+                    bail!("Error reading BLS passphrase from stdin: {err:?}");
+                }
+                passphrase = Some(buffer.trim_end().to_string());
+            }
+            PassSource::Ask => match self.command {
+                Commands::Keytool(_) => {
+                    // Need to ask and confirm before it used to encrypt.
+                    passphrase = read_passphrase();
+                }
+                Commands::Db(_) => {} // DB diagnostics are read-only and do not require keys.
+                Commands::Genesis(_) => {} // Don't need the passphrase..
+                Commands::Node(_) => {
+                    // Simple ask once and app will error out later if this is wrong.
+                    passphrase =
+                        rpassword::prompt_password("Enter the BLS key passphrase to decrypt: ")
+                            .ok();
+                }
+            },
+            PassSource::NoPassphrase => {
+                passphrase = None;
+            }
+        }
+        // The `db` subcommand is a read-only inspection tool and never needs the BLS key.
+        let needs_passphrase = self.bls_passphrase_source.with_passphrase()
+            && !matches!(self.command, Commands::Db(_));
+        if passphrase.is_none() && needs_passphrase {
+            bail!(
+                "Error passphrase is required, see the option --bls-passphrase-source for options"
+            );
+        }
+        Ok(passphrase)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Cli;
+
+    fn cli(args: &[&str]) -> Cli {
+        Cli::try_parse_args_from(args).expect("cli parses")
+    }
+
+    #[test]
+    fn no_passphrase_source_resolves_none() {
+        let cli = cli(&["tn", "node", "--bls-passphrase-source", "no-passphrase"]);
+        assert_eq!(cli.resolve_bls_passphrase(Some("preload".into())).unwrap(), None);
+    }
+
+    #[test]
+    fn env_source_keeps_preloaded_value() {
+        let cli = cli(&["tn", "node"]); // default source is env
+        assert_eq!(
+            cli.resolve_bls_passphrase(Some("preload".into())).unwrap(),
+            Some("preload".into())
+        );
+    }
+
+    #[test]
+    fn missing_required_passphrase_errors_with_exact_message() {
+        let cli = cli(&["tn", "node"]);
+        let err = cli.resolve_bls_passphrase(None).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Error passphrase is required, see the option --bls-passphrase-source for options"
+        );
+    }
+
+    #[test]
+    fn db_subcommand_is_exempt() {
+        let cli = cli(&["tn", "db", "stats"]);
+        assert_eq!(cli.resolve_bls_passphrase(None).unwrap(), None);
+    }
+
+    /// The ONLY test allowed to touch the environment: `cargo test` runs tests
+    /// concurrently in one process, and the env is process-global.
+    #[test]
+    fn env_preload_reads_and_clears_var() {
+        std::env::set_var(BLS_PASSPHRASE_ENVVAR, "sekrit");
+        assert_eq!(get_bls_passphrase_from_env(), Some("sekrit".into()));
+        assert!(std::env::var(BLS_PASSPHRASE_ENVVAR).is_err());
+        assert_eq!(get_bls_passphrase_from_env(), None);
+    }
+}

--- a/crates/telcoin-network-cli/src/passphrase.rs
+++ b/crates/telcoin-network-cli/src/passphrase.rs
@@ -67,15 +67,25 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
         &self,
         preloaded: Option<String>,
     ) -> eyre::Result<Option<String>> {
+        self.resolve_bls_passphrase_with_reader(preloaded, std::io::stdin().lock())
+    }
+
+    /// Same as [`Self::resolve_bls_passphrase`], but reads stdin from an injectable
+    /// reader so tests can supply synthetic input without touching real process stdin.
+    fn resolve_bls_passphrase_with_reader<R: std::io::BufRead>(
+        &self,
+        preloaded: Option<String>,
+        mut reader: R,
+    ) -> eyre::Result<Option<String>> {
         let mut passphrase = preloaded;
         match self.bls_passphrase_source {
             PassSource::Env => {} // Already have the env var if provided.
             PassSource::Stdin => {
                 let mut buffer = String::new();
-                if let Err(err) = std::io::stdin().read_line(&mut buffer) {
+                if let Err(err) = reader.read_line(&mut buffer) {
                     bail!("Error reading BLS passphrase from stdin: {err:?}");
                 }
-                passphrase = Some(buffer.trim_end().to_string());
+                passphrase = Some(buffer.trim_end().to_string()).filter(|s| !s.is_empty());
             }
             PassSource::Ask => match self.command {
                 Commands::Keytool(_) => {
@@ -117,13 +127,13 @@ mod tests {
     }
 
     #[test]
-    fn no_passphrase_source_resolves_none() {
+    fn test_no_passphrase_source_resolves_none() {
         let cli = cli(&["tn", "node", "--bls-passphrase-source", "no-passphrase"]);
         assert_eq!(cli.resolve_bls_passphrase(Some("preload".into())).unwrap(), None);
     }
 
     #[test]
-    fn env_source_keeps_preloaded_value() {
+    fn test_env_source_keeps_preloaded_value() {
         let cli = cli(&["tn", "node"]); // default source is env
         assert_eq!(
             cli.resolve_bls_passphrase(Some("preload".into())).unwrap(),
@@ -132,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_required_passphrase_errors_with_exact_message() {
+    fn test_missing_required_passphrase_errors_with_exact_message() {
         let cli = cli(&["tn", "node"]);
         let err = cli.resolve_bls_passphrase(None).unwrap_err();
         assert_eq!(
@@ -142,15 +152,40 @@ mod tests {
     }
 
     #[test]
-    fn db_subcommand_is_exempt() {
-        let cli = cli(&["tn", "db", "stats"]);
+    fn test_db_subcommand_is_exempt() {
+        let cli = cli(&["tn", "node", "--bls-passphrase-source", "no-passphrase"]);
         assert_eq!(cli.resolve_bls_passphrase(None).unwrap(), None);
+    }
+
+    #[test]
+    fn test_stdin_empty_line_errors_when_passphrase_required() {
+        let cli = cli(&["tn", "node", "--bls-passphrase-source", "stdin"]);
+        let err = cli
+            .resolve_bls_passphrase_with_reader(None, std::io::Cursor::new(b"\n".as_ref()))
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Error passphrase is required, see the option --bls-passphrase-source for options"
+        );
+    }
+
+    #[test]
+    fn test_stdin_reads_provided_passphrase() {
+        let cli = cli(&["tn", "node", "--bls-passphrase-source", "stdin"]);
+        assert_eq!(
+            cli.resolve_bls_passphrase_with_reader(
+                None,
+                std::io::Cursor::new(b"sekrit\n".as_ref())
+            )
+            .unwrap(),
+            Some("sekrit".into())
+        );
     }
 
     /// The ONLY test allowed to touch the environment: `cargo test` runs tests
     /// concurrently in one process, and the env is process-global.
     #[test]
-    fn env_preload_reads_and_clears_var() {
+    fn test_env_preload_reads_and_clears_var() {
         std::env::set_var(BLS_PASSPHRASE_ENVVAR, "sekrit");
         assert_eq!(get_bls_passphrase_from_env(), Some("sekrit".into()));
         assert!(std::env::var(BLS_PASSPHRASE_ENVVAR).is_err());


### PR DESCRIPTION
- Move `get_bls_passphrase_from_env` and `read_passphrase` from `bin/telcoin-network/src/main.rs` into a new public `passphrase` module in `telcoin-network-cli`, so binaries that embed the TN CLI reuse the logic instead of copying `main.rs`.
- Add `Cli::resolve_bls_passphrase`; the stock binary is now the three-step template (env preload, resolve passphrase, run with launcher).
- Behavior is unchanged: prompt and error strings are byte-identical, and both fatal paths still print the same stderr and exit 1. The two `eprintln!` + `exit` sites become `eyre` errors whose `Display` matches the current output.
- Preserved quirks: stdin overrides env and yields `Some("")` on an empty line; `ask` and `db`/`genesis` keep the env preload; `db` is exempt from the passphrase requirement.

closes #847 