### PR TITLE
feat(tn-reth): expand RethEnv read API for ExEx consumers

### DIFF
--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -9,7 +9,7 @@ use jsonrpsee::proc_macros::rpc;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tn_reth::{
-    error::{RegistryReadError, RegistryReadResult},
+    error::{EvmReadError, EvmReadResult},
     system_calls::ConsensusRegistry,
     RethEnv,
 };
@@ -444,7 +444,7 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
     async fn spawn_registry_read<R, F>(&self, read: F) -> TelcoinNetworkRpcResult<R>
     where
         R: Send + 'static,
-        F: FnOnce(RethEnv) -> RegistryReadResult<R> + Send + 'static,
+        F: FnOnce(RethEnv) -> EvmReadResult<R> + Send + 'static,
     {
         // bound concurrent blocking reads; queues (does not reject) at capacity, mirroring
         // reth's eth_call guard. acquire only fails if the semaphore is closed, which never
@@ -471,10 +471,10 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
                 TNRpcError::Internal
             })?
             .map_err(|err| match &err {
-                RegistryReadError::Revert { output, .. } => {
+                EvmReadError::Revert { output, .. } => {
                     TNRpcError::Revert { message: err.to_string(), output: output.clone() }
                 }
-                RegistryReadError::Internal(_) => {
+                EvmReadError::Internal(_) => {
                     tracing::debug!(
                         target: "tn::rpc",
                         error = ?err,

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -74,6 +74,16 @@ impl TnExExContext {
     ///   empty `BundleState`); this is what [`replay_from`](Self::replay_from) uses.
     /// - `latest()` — a state provider for account/storage queries against the latest committed
     ///   state.
+    /// - `transaction_by_hash_with_meta(hash)` — a transaction with its recovered sender and block
+    ///   metadata (block number/hash, index, timestamp).
+    /// - `receipt_by_hash(hash)` / `receipts_by_block(..)` — transaction receipts.
+    /// - `total_transactions()` + `transactions_by_tx_range_with_meta(range)` — the chain-wide
+    ///   sequential transaction feed (serve "latest N transactions" pages without visiting empty
+    ///   blocks).
+    /// - `retrieve_account(&addr)` / `account_code(&addr)` — account nonce/balance/code-hash and
+    ///   deployed bytecode at the latest state.
+    /// - `read_contract(contract, calldata)` — an `eth_call`-style read-only contract call at the
+    ///   canonical tip (`read_contract_at_block` pins it to a block hash).
     pub fn reth_env(&self) -> &RethEnv {
         &self.reth_env
     }

--- a/crates/tn-reth/src/error.rs
+++ b/crates/tn-reth/src/error.rs
@@ -48,6 +48,9 @@ pub enum TnRethError {
     /// it is treated as an error instead.
     #[error("receipts not found for existing block {0} during replay")]
     ReplayReceiptsMissing(u64),
+    /// Failed to recover a transaction's signer from its signature.
+    #[error(transparent)]
+    SignerRecovery(#[from] alloy::consensus::crypto::RecoveryError),
 }
 
 impl From<TnRethError> for EthApiError {
@@ -66,12 +69,12 @@ impl<T> From<std::sync::mpsc::SendError<T>> for TnRethError {
     }
 }
 
-/// Failure reading the on-chain `ConsensusRegistry`.
+/// Failure executing a read-only on-chain EVM call.
 ///
 /// Distinguishes a user-triggerable on-chain revert (revert bytes surfaced to RPC
 /// clients eth_call-style) from internal node failures (never leaked to clients).
 #[derive(Debug, thiserror::Error)]
-pub enum RegistryReadError {
+pub enum EvmReadError {
     /// The EVM call reverted on-chain.
     #[error("execution reverted{}", .reason.as_ref().map(|r| format!(": {r}")).unwrap_or_default())]
     Revert {
@@ -85,9 +88,9 @@ pub enum RegistryReadError {
     Internal(String),
 }
 
-/// Result of an on-chain `ConsensusRegistry` read.
+/// Result of a read-only on-chain EVM call.
 ///
-/// The error is always a [`RegistryReadError`], so consumers (e.g. the RPC layer) can match
+/// The error is always an [`EvmReadError`], so consumers (e.g. the RPC layer) can match
 /// revert-vs-internal directly instead of recovering it via a runtime downcast. Every non-revert
-/// failure — state provider/EVM setup, `Halt`, ABI decode — is a [`RegistryReadError::Internal`].
-pub type RegistryReadResult<T> = Result<T, RegistryReadError>;
+/// failure — state provider/EVM setup, `Halt`, ABI decode — is an [`EvmReadError::Internal`].
+pub type EvmReadResult<T> = Result<T, EvmReadError>;

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -37,7 +37,7 @@ use alloy::{
 use alloy_evm::Evm;
 use clap::Parser;
 use dirs::path_to_datadir;
-use error::{RegistryReadError, RegistryReadResult, TnRethError, TnRethResult};
+use error::{EvmReadError, EvmReadResult, TnRethError, TnRethResult};
 use evm::TnEvmConfig;
 use eyre::OptionExt;
 use jsonrpsee::Methods;
@@ -80,12 +80,14 @@ use reth_node_builder::{
     DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES, DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
 };
 use reth_node_core::node_config::DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB;
+use reth_primitives_traits::SignerRecoverable as _;
 use reth_provider::{
-    providers::BlockchainProvider, BlockIdReader as _, BlockNumReader, BlockReader,
-    CanonChainTracker, CanonStateSubscriptions as _, Chain, ChainStateBlockReader,
-    ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ExecutionOutcome,
-    HeaderProvider as _, ProviderFactory, ReceiptProvider as _, StateProviderBox,
-    StateProviderFactory, TransactionVariant,
+    providers::BlockchainProvider, AccountReader as _, BlockBodyIndicesProvider as _,
+    BlockIdReader as _, BlockNumReader, BlockReader, CanonChainTracker,
+    CanonStateSubscriptions as _, Chain, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
+    DatabaseProviderFactory, ExecutionOutcome, HeaderProvider as _, ProviderFactory,
+    ReceiptProvider as _, StateProvider as _, StateProviderBox, StateProviderFactory,
+    TransactionVariant, TransactionsProvider as _,
 };
 use reth_revm::{
     cached::CachedReads,
@@ -119,10 +121,10 @@ use tn_config::{
 use tn_types::{
     deconstruct_nonce,
     gas_accumulator::{RewardsCounter, WorkerFeeConfig},
-    Address, BlockBody, BlockHashOrNumber, BlockNumHash, BlockNumber, ConsensusNumHash,
-    EngineUpdate, Epoch, ExecHeader, Genesis, GenesisAccount, RecoveredBlock, Round, SealedBlock,
-    SealedHeader, TaskManager, TaskSpawner, TransactionSigned, B256, ETHEREUM_BLOCK_GAS_LIMIT_30M,
-    U256,
+    Account, Address, BlockBody, BlockHashOrNumber, BlockNumHash, BlockNumber, ConsensusNumHash,
+    EngineUpdate, Epoch, ExecHeader, Genesis, GenesisAccount, Receipt, Recovered, RecoveredBlock,
+    Round, SealedBlock, SealedHeader, TaskManager, TaskSpawner, TransactionMeta, TransactionSigned,
+    TxHash, TxNumber, B256, ETHEREUM_BLOCK_GAS_LIMIT_30M, U256,
 };
 use tracing::{debug, error, info, warn};
 use traits::{TNPrimitives, TelcoinNode};
@@ -227,6 +229,27 @@ pub type ToTree = std::sync::mpsc::Sender<
 ///
 /// This type is a SealedBlock with a list of senders that match the transactions in the block.
 pub type BlockWithSenders = RecoveredBlock<reth_ethereum_primitives::Block>;
+
+/// One transaction in the chain-wide sequential transaction feed.
+///
+/// Storage assigns every mined transaction a sequential [`TxNumber`]; this entry pairs the
+/// recovered transaction with that number and the containing block's context so consumers can
+/// serve "latest N transactions" style queries without touching block bodies of empty blocks.
+#[derive(Clone, Debug)]
+pub struct TxFeedEntry {
+    /// Sequential, chain-wide transaction number (position in the global feed).
+    pub tx_number: TxNumber,
+    /// The signed transaction with its sender attached.
+    pub transaction: Recovered<TransactionSigned>,
+    /// Number of the block containing this transaction.
+    pub block_number: BlockNumber,
+    /// Hash of the block containing this transaction.
+    pub block_hash: B256,
+    /// Timestamp of the containing block.
+    pub timestamp: u64,
+    /// Zero-based index of the transaction within its block.
+    pub index: u64,
+}
 
 /// Reth specific command line args.
 #[derive(Debug, Parser, Clone)]
@@ -1121,6 +1144,190 @@ impl RethEnv {
         Ok(self.inner.blockchain_provider.latest()?)
     }
 
+    /// Look up a transaction by hash, returning it with its sender and block metadata
+    /// (block number/hash, index in block, base fee, block timestamp).
+    pub fn transaction_by_hash_with_meta(
+        &self,
+        hash: TxHash,
+    ) -> TnRethResult<Option<(Recovered<TransactionSigned>, TransactionMeta)>> {
+        let Some((tx, meta)) =
+            self.inner.blockchain_provider.transaction_by_hash_with_meta(hash)?
+        else {
+            return Ok(None);
+        };
+
+        // prefer the sender persisted at execution time (two point reads, no ecrecover)
+        let sender = match self.inner.blockchain_provider.transaction_id(hash)? {
+            Some(id) => self.inner.blockchain_provider.transaction_sender(id)?,
+            None => None,
+        };
+        let sender = match sender {
+            Some(sender) => sender,
+            None => tx.recover_signer()?,
+        };
+
+        Ok(Some((Recovered::new_unchecked(tx, sender), meta)))
+    }
+
+    /// Return the receipt for a transaction hash, if the transaction has been mined.
+    ///
+    /// `Receipt::cumulative_gas_used` is cumulative within the block; use
+    /// [`Self::receipt_by_hash_with_gas_used`] for this transaction's own gas.
+    pub fn receipt_by_hash(&self, hash: TxHash) -> TnRethResult<Option<Receipt>> {
+        Ok(self.inner.blockchain_provider.receipt_by_hash(hash)?)
+    }
+
+    /// Return the receipt for a transaction hash together with the gas used by that
+    /// transaction alone (the delta of cumulative gas vs. the previous receipt in the block).
+    pub fn receipt_by_hash_with_gas_used(
+        &self,
+        hash: TxHash,
+    ) -> TnRethResult<Option<(Receipt, u64)>> {
+        let Some(id) = self.inner.blockchain_provider.transaction_id(hash)? else {
+            return Ok(None);
+        };
+        let Some(receipt) = self.inner.blockchain_provider.receipt(id)? else {
+            return Ok(None);
+        };
+        let block = self
+            .inner
+            .blockchain_provider
+            .block_by_transaction_id(id)?
+            .ok_or(ProviderError::TransactionNotFound(id.into()))?;
+        let indices = self
+            .inner
+            .blockchain_provider
+            .block_body_indices(block)?
+            .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
+
+        let gas_used = if id == indices.first_tx_num() {
+            receipt.cumulative_gas_used
+        } else {
+            let prev = self
+                .inner
+                .blockchain_provider
+                .receipt(id - 1)?
+                .ok_or(ProviderError::ReceiptNotFound((id - 1).into()))?;
+            receipt.cumulative_gas_used.saturating_sub(prev.cumulative_gas_used)
+        };
+
+        Ok(Some((receipt, gas_used)))
+    }
+
+    /// Return all receipts for a block by hash or number.
+    ///
+    /// `Ok(None)` means the block is unknown; an empty vec means the block has no transactions.
+    pub fn receipts_by_block(
+        &self,
+        block: BlockHashOrNumber,
+    ) -> TnRethResult<Option<Vec<Receipt>>> {
+        Ok(self.inner.blockchain_provider.receipts_by_block(block)?)
+    }
+
+    /// Total number of transactions ever mined on the canonical chain.
+    ///
+    /// The latest transaction's [`TxNumber`] is `total - 1`; serve "latest N, newest-first"
+    /// pages by reading descending [`TxNumber`] ranges via
+    /// [`Self::transactions_by_tx_range_with_meta`].
+    pub fn total_transactions(&self) -> TnRethResult<u64> {
+        let tip = self.last_block_number()?;
+        Ok(self
+            .inner
+            .blockchain_provider
+            .block_body_indices(tip)?
+            .map(|indices| indices.next_tx_num())
+            .unwrap_or(0))
+    }
+
+    /// Return the transactions in a chain-wide [`TxNumber`] range (inclusive), each with its
+    /// sender and containing-block metadata.
+    ///
+    /// Cost scales with the number of transactions returned, not the number of blocks the
+    /// range spans: empty blocks are never visited. Ranges extending past the newest
+    /// transaction are clamped to what exists.
+    pub fn transactions_by_tx_range_with_meta(
+        &self,
+        range: RangeInclusive<TxNumber>,
+    ) -> TnRethResult<Vec<TxFeedEntry>> {
+        if range.is_empty() {
+            return Ok(Vec::new());
+        }
+        let start = *range.start();
+        let txs = self.inner.blockchain_provider.transactions_by_tx_range(range.clone())?;
+        if txs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut senders = self.inner.blockchain_provider.senders_by_tx_range(range)?;
+        if senders.len() != txs.len() {
+            // defensive: persistence always writes senders alongside transactions, so a
+            // misaligned read should be impossible — recover in parallel if it happens
+            senders = txs
+                .par_iter()
+                .map(|tx| tx.recover_signer().map_err(TnRethError::from))
+                .collect::<TnRethResult<Vec<_>>>()?;
+        }
+
+        let mut entries = Vec::with_capacity(txs.len());
+        // cached (block_number, first_tx_num, next_tx_num, block_hash, timestamp) for the block
+        // containing the previous transaction; refreshed only when the cursor crosses into the
+        // next non-empty block, so each non-empty block costs three point reads and empty
+        // blocks are never visited (the `TransactionBlocks` seek skips them by construction).
+        let mut block_ctx: Option<(BlockNumber, TxNumber, TxNumber, B256, u64)> = None;
+        for (offset, (tx, sender)) in txs.into_iter().zip(senders).enumerate() {
+            let tx_number = start + offset as u64;
+            let (block_number, first_tx_num, _, block_hash, timestamp) = match block_ctx {
+                Some(ctx) if tx_number < ctx.2 => ctx,
+                _ => {
+                    let block = self
+                        .inner
+                        .blockchain_provider
+                        .block_by_transaction_id(tx_number)?
+                        .ok_or(ProviderError::TransactionNotFound(tx_number.into()))?;
+                    let indices = self
+                        .inner
+                        .blockchain_provider
+                        .block_body_indices(block)?
+                        .ok_or(ProviderError::BlockBodyIndicesNotFound(block))?;
+                    let header = self
+                        .inner
+                        .blockchain_provider
+                        .sealed_header(block)?
+                        .ok_or(ProviderError::HeaderNotFound(block.into()))?;
+                    let ctx = (
+                        block,
+                        indices.first_tx_num(),
+                        indices.next_tx_num(),
+                        header.hash(),
+                        header.timestamp,
+                    );
+                    block_ctx = Some(ctx);
+                    ctx
+                }
+            };
+            entries.push(TxFeedEntry {
+                tx_number,
+                transaction: Recovered::new_unchecked(tx, sender),
+                block_number,
+                block_hash,
+                timestamp,
+                index: tx_number.saturating_sub(first_tx_num),
+            });
+        }
+
+        Ok(entries)
+    }
+
+    /// Return balance, nonce, and code hash for an account at the latest canonical state.
+    pub fn retrieve_account(&self, address: &Address) -> TnRethResult<Option<Account>> {
+        Ok(self.inner.blockchain_provider.basic_account(address)?)
+    }
+
+    /// Return the contract bytecode deployed at `address` at the latest canonical state
+    /// (`eth_getCode` equivalent). `None` for EOAs and unknown accounts.
+    pub fn account_code(&self, address: &Address) -> TnRethResult<Option<Bytes>> {
+        Ok(self.latest()?.account_code(address)?.map(|code| code.original_bytes()))
+    }
+
     /// Create a new temp RethEnv using a specified chain spec.
     pub fn new_for_temp_chain<P: AsRef<Path>>(
         chain: Arc<RethChainSpec>,
@@ -1434,7 +1641,7 @@ impl RethEnv {
     ///
     /// Convenience wrapper over [`Self::read_consensus_registry_batch`] for the common
     /// single-read case (one pinned EVM, one call).
-    pub fn read_consensus_registry<T>(&self, calldata: Bytes) -> RegistryReadResult<T>
+    pub fn read_consensus_registry<T>(&self, calldata: Bytes) -> EvmReadResult<T>
     where
         T: alloy::sol_types::SolValue,
         T: From<
@@ -1442,7 +1649,7 @@ impl RethEnv {
         >,
     {
         self.read_consensus_registry_batch(vec![calldata])?.pop().ok_or_else(|| {
-            RegistryReadError::Internal("consensus registry batch read returned no result".into())
+            EvmReadError::Internal("consensus registry batch read returned no result".into())
         })
     }
 
@@ -1457,10 +1664,7 @@ impl RethEnv {
     /// validator that changes status between reads. Each call still runs under its own fresh 30M
     /// gas budget (`transact_system_call`), so splitting a large query across calls keeps gas
     /// bounded per call.
-    pub fn read_consensus_registry_batch<T>(
-        &self,
-        calldatas: Vec<Bytes>,
-    ) -> RegistryReadResult<Vec<T>>
+    pub fn read_consensus_registry_batch<T>(&self, calldatas: Vec<Bytes>) -> EvmReadResult<Vec<T>>
     where
         T: alloy::sol_types::SolValue,
         T: From<
@@ -1474,14 +1678,14 @@ impl RethEnv {
             .inner
             .blockchain_provider
             .state_by_block_hash(canonical_tip.hash())
-            .map_err(|e| RegistryReadError::Internal(e.to_string()))?;
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder().with_database(state).with_bundle_update().build();
         let evm_env = self
             .inner
             .evm_config
             .evm_env(&canonical_tip)
-            .map_err(|e| RegistryReadError::Internal(e.to_string()))?;
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         // reuse the one pinned EVM for every read; `call_consensus_registry` is non-committing,
@@ -1492,6 +1696,75 @@ impl RethEnv {
             .collect()
     }
 
+    /// Execute a read-only contract call at the canonical tip and return the raw ABI-encoded
+    /// output bytes.
+    ///
+    /// `eth_call`-like semantics: caller is the zero address, value 0, gas price 0, nonce and
+    /// base fee checks disabled, 30M gas; no state is committed. Callers decode the returned
+    /// bytes themselves (e.g. with `SolCall::abi_decode_returns`).
+    pub fn read_contract(&self, contract: Address, calldata: Bytes) -> EvmReadResult<Bytes> {
+        self.read_contract_inner(&self.canonical_tip(), Address::ZERO, contract, calldata)
+    }
+
+    /// Same as [`Self::read_contract`], but pinned to the state of the block identified by
+    /// `block_hash`.
+    pub fn read_contract_at_block(
+        &self,
+        block_hash: B256,
+        contract: Address,
+        calldata: Bytes,
+    ) -> EvmReadResult<Bytes> {
+        let header = self
+            .sealed_header_by_hash(block_hash)
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?
+            .ok_or_else(|| {
+                EvmReadError::Internal(format!(
+                    "sealed header not found for block hash {block_hash:?}"
+                ))
+            })?;
+        self.read_contract_inner(&header, Address::ZERO, contract, calldata)
+    }
+
+    /// Build an EVM against `header`'s state and execute one read-only call, returning raw
+    /// output bytes on success and mapping Revert/Halt like the registry read path.
+    fn read_contract_inner(
+        &self,
+        header: &SealedHeader,
+        caller: Address,
+        contract: Address,
+        calldata: Bytes,
+    ) -> EvmReadResult<Bytes> {
+        let state_provider = self
+            .inner
+            .blockchain_provider
+            .state_by_block_hash(header.hash())
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
+        let state = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder().with_database(state).with_bundle_update().build();
+        let evm_env = self
+            .inner
+            .evm_config
+            .evm_env(header)
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
+        let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
+
+        let result = self
+            .read_state_on_chain(&mut tn_evm, caller, contract, calldata)
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
+
+        // surface user-triggerable reverts distinctly from internal node faults
+        match result.result {
+            ExecutionResult::Success { output, .. } => Ok(output.into_data()),
+            ExecutionResult::Revert { output, .. } => Err(EvmReadError::Revert {
+                reason: alloy::sol_types::decode_revert_reason(&output),
+                output,
+            }),
+            ExecutionResult::Halt { reason, gas_used } => Err(EvmReadError::Internal(format!(
+                "contract call halted: {reason:?} (gas {gas_used})"
+            ))),
+        }
+    }
+
     /// Extract the epoch number from a header's nonce.
     pub fn extract_epoch_from_header(header: &ExecHeader) -> Epoch {
         let nonce: u64 = header.nonce.into();
@@ -1499,7 +1772,7 @@ impl RethEnv {
     }
 
     /// Read the curret epoch number from the [ConsensusRegistry] on-chain.
-    fn get_current_epoch_number<DB>(&self, evm: &mut TNEvm<DB>) -> RegistryReadResult<u32>
+    fn get_current_epoch_number<DB>(&self, evm: &mut TNEvm<DB>) -> EvmReadResult<u32>
     where
         DB: alloy_evm::Database,
     {
@@ -1511,7 +1784,7 @@ impl RethEnv {
     fn get_current_epoch_info<DB>(
         &self,
         evm: &mut TNEvm<DB>,
-    ) -> RegistryReadResult<ConsensusRegistry::EpochInfo>
+    ) -> EvmReadResult<ConsensusRegistry::EpochInfo>
     where
         DB: alloy_evm::Database,
     {
@@ -1524,7 +1797,7 @@ impl RethEnv {
         &self,
         epoch: Epoch,
         evm: &mut TNEvm<DB>,
-    ) -> RegistryReadResult<Vec<ConsensusRegistry::ValidatorInfo>>
+    ) -> EvmReadResult<Vec<ConsensusRegistry::ValidatorInfo>>
     where
         DB: alloy_evm::Database,
     {
@@ -1537,7 +1810,7 @@ impl RethEnv {
         &self,
         epoch: Epoch,
         evm: &mut TNEvm<DB>,
-    ) -> RegistryReadResult<Vec<alloy::primitives::Bytes>>
+    ) -> EvmReadResult<Vec<alloy::primitives::Bytes>>
     where
         DB: alloy_evm::Database,
     {
@@ -1656,7 +1929,7 @@ impl RethEnv {
         &self,
         evm: &mut TNEvm<DB>,
         calldata: Bytes,
-    ) -> RegistryReadResult<T>
+    ) -> EvmReadResult<T>
     where
         DB: alloy_evm::Database,
         T: alloy::sol_types::SolValue,
@@ -1666,7 +1939,7 @@ impl RethEnv {
     {
         let state = self
             .read_state_on_chain(evm, SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)
-            .map_err(|e| RegistryReadError::Internal(e.to_string()))?;
+            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
 
         // retrieve data from state, distinguishing user-triggerable reverts from node faults
         match state.result {
@@ -1674,16 +1947,16 @@ impl RethEnv {
                 let data = output.into_data();
                 // use SolValue to decode the result
                 alloy::sol_types::SolValue::abi_decode(&data).map_err(|e| {
-                    RegistryReadError::Internal(format!("registry return decode failed: {e}"))
+                    EvmReadError::Internal(format!("registry return decode failed: {e}"))
                 })
             }
-            ExecutionResult::Revert { output, .. } => Err(RegistryReadError::Revert {
+            ExecutionResult::Revert { output, .. } => Err(EvmReadError::Revert {
                 reason: alloy::sol_types::decode_revert_reason(&output),
                 output,
             }),
-            ExecutionResult::Halt { reason, gas_used } => Err(RegistryReadError::Internal(
-                format!("registry call halted: {reason:?} (gas {gas_used})"),
-            )),
+            ExecutionResult::Halt { reason, gas_used } => Err(EvmReadError::Internal(format!(
+                "registry call halted: {reason:?} (gas {gas_used})"
+            ))),
         }
     }
 
@@ -1724,9 +1997,9 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng as _};
     use tempfile::TempDir;
     use tn_types::{
-        generate_proof_of_possession_bls_for_test, BlsKeypair, BlsSignature, Certificate,
-        CommittedSubDag, ConsensusHeader, ConsensusOutput, NodeP2pInfo, ReputationScores,
-        SignatureVerificationState,
+        generate_proof_of_possession_bls_for_test, keccak256, test_genesis, BlsKeypair,
+        BlsSignature, Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput,
+        Encodable2718 as _, NodeP2pInfo, ReputationScores, SignatureVerificationState,
     };
 
     /// Helper function for creating a consensus output for tests.
@@ -1782,6 +2055,227 @@ mod tests {
         reth_env.finish_executing_output(vec![block.clone()], None)?;
         reth_env.finalize_block(canonical_header.clone())?;
         Ok(block)
+    }
+
+    /// Exercise the tx/receipt/feed read API against a persisted three-block chain:
+    /// block 1 holds two transfers, block 2 is empty, block 3 holds one transfer.
+    #[tokio::test]
+    async fn test_read_api_tx_receipts_and_feed() -> eyre::Result<()> {
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Test Task Manager");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        let mut factory = TransactionFactory::new();
+        let recipient = Address::from_slice(&[0xcc; 20]);
+        let value = U256::from(1_000_000);
+        let tx1 =
+            factory.create_eip1559(chain.clone(), None, 100, Some(recipient), value, Bytes::new());
+        let tx2 =
+            factory.create_eip1559(chain.clone(), None, 100, Some(recipient), value, Bytes::new());
+        let tx3 =
+            factory.create_eip1559(chain.clone(), None, 100, Some(recipient), value, Bytes::new());
+
+        // block 1: two transfers
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(
+            &reth_env,
+            payload,
+            vec![tx1.encoded_2718(), tx2.encoded_2718()],
+        )?;
+        let block1_header = block1.recovered_block.clone_sealed_header();
+
+        // block 2: empty
+        let consensus_output = consensus_output_for_tests(2, 0, 2, false);
+        let payload = TNPayload::new_for_test(block1_header.clone(), &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let block2_header = block2.recovered_block.clone_sealed_header();
+
+        // block 3: one transfer
+        let consensus_output = consensus_output_for_tests(2, 0, 3, false);
+        let payload = TNPayload::new_for_test(block2_header, &consensus_output);
+        let block3 = execute_payload_and_update_canonical_chain(
+            &reth_env,
+            payload,
+            vec![tx3.encoded_2718()],
+        )?;
+        let block3_header = block3.recovered_block.clone_sealed_header();
+
+        // tx-by-hash roundtrip for the second transaction in block 1
+        let tx2_hash = *tx2.hash();
+        let (recovered, meta) = reth_env
+            .transaction_by_hash_with_meta(tx2_hash)?
+            .expect("mined transaction found by hash");
+        assert_eq!(recovered.signer(), factory.address());
+        assert_eq!(*recovered.hash(), tx2_hash);
+        assert_eq!(meta.block_number, 1);
+        assert_eq!(meta.index, 1);
+        assert_eq!(meta.block_hash, block1_header.hash());
+        assert_eq!(meta.timestamp, block1_header.timestamp);
+        // unknown hash is Ok(None), not an error
+        assert!(reth_env.transaction_by_hash_with_meta(TxHash::random())?.is_none());
+
+        // receipts by hash: cumulative gas is block-wide, per-tx gas is the delta
+        let receipt = reth_env.receipt_by_hash(tx2_hash)?.expect("receipt for mined tx");
+        assert!(receipt.success);
+        let (receipt, gas_used) = reth_env
+            .receipt_by_hash_with_gas_used(tx2_hash)?
+            .expect("receipt with gas for mined tx");
+        assert_eq!(gas_used, 21_000);
+        assert_eq!(receipt.cumulative_gas_used, 42_000);
+        // first-in-block transaction: per-tx gas equals its cumulative gas
+        let (receipt, gas_used) = reth_env
+            .receipt_by_hash_with_gas_used(*tx3.hash())?
+            .expect("receipt with gas for mined tx");
+        assert_eq!(gas_used, 21_000);
+        assert_eq!(receipt.cumulative_gas_used, 21_000);
+
+        // receipts by block: number- and hash-based reads agree
+        let by_number =
+            reth_env.receipts_by_block(BlockHashOrNumber::Number(1))?.expect("block 1 receipts");
+        let by_hash = reth_env
+            .receipts_by_block(BlockHashOrNumber::Hash(block1_header.hash()))?
+            .expect("block 1 receipts by hash");
+        assert_eq!(by_number.len(), 2);
+        assert_eq!(by_number, by_hash);
+        // known-but-empty block returns Some(empty); unknown block returns None
+        assert_eq!(reth_env.receipts_by_block(BlockHashOrNumber::Number(2))?, Some(vec![]));
+        assert!(reth_env.receipts_by_block(BlockHashOrNumber::Number(99))?.is_none());
+
+        // chain-wide feed: three transactions total
+        assert_eq!(reth_env.total_transactions()?, 3);
+        let feed = reth_env.transactions_by_tx_range_with_meta(0..=2)?;
+        assert_eq!(feed.len(), 3);
+        let tx_numbers: Vec<_> = feed.iter().map(|entry| entry.tx_number).collect();
+        assert_eq!(tx_numbers, vec![0, 1, 2]);
+        for (entry, tx) in feed.iter().zip([&tx1, &tx2, &tx3]) {
+            assert_eq!(*entry.transaction.hash(), *tx.hash());
+            assert_eq!(entry.transaction.signer(), factory.address());
+        }
+        // entries 0-1 come from block 1
+        assert_eq!(feed[0].block_number, 1);
+        assert_eq!(feed[0].index, 0);
+        assert_eq!(feed[0].block_hash, block1_header.hash());
+        assert_eq!(feed[1].block_number, 1);
+        assert_eq!(feed[1].index, 1);
+        // entry 2 comes from block 3 — the empty block 2 is skipped entirely
+        assert_eq!(feed[2].block_number, 3);
+        assert_eq!(feed[2].index, 0);
+        assert_eq!(feed[2].block_hash, block3_header.hash());
+        assert_eq!(feed[2].timestamp, block3_header.timestamp);
+
+        // ranges past the newest transaction clamp to what exists
+        assert_eq!(reth_env.transactions_by_tx_range_with_meta(0..=99)?.len(), 3);
+        // empty range yields an empty vec
+        assert!(reth_env.transactions_by_tx_range_with_meta(RangeInclusive::new(1, 0))?.is_empty());
+
+        // newest-first page of two: read a descending window and reverse it
+        let total = reth_env.total_transactions()?;
+        let mut page = reth_env.transactions_by_tx_range_with_meta(total - 2..=total - 1)?;
+        page.reverse();
+        let hashes: Vec<_> = page.iter().map(|entry| *entry.transaction.hash()).collect();
+        assert_eq!(hashes, vec![*tx3.hash(), *tx2.hash()]);
+
+        Ok(())
+    }
+
+    /// Minimal runtime bytecode: `PUSH1 42, PUSH1 0, MSTORE, PUSH1 32, PUSH1 0, RETURN` —
+    /// returns `uint256(42)` for any calldata.
+    const RETURN_42: &[u8] = &[0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+    /// Minimal runtime bytecode: `PUSH1 0, PUSH1 0, REVERT` — reverts with empty output.
+    const ALWAYS_REVERT: &[u8] = &[0x60, 0x00, 0x60, 0x00, 0xfd];
+
+    /// Exercise account/code reads and the generic read-only contract call against two
+    /// bytecode fixtures deployed in genesis.
+    #[tokio::test]
+    async fn test_read_api_account_code_and_contract_read() -> eyre::Result<()> {
+        let return_42_addr = Address::from_slice(&[0xaa; 20]);
+        let always_revert_addr = Address::from_slice(&[0xbb; 20]);
+        let genesis = test_genesis().extend_accounts([
+            (
+                return_42_addr,
+                GenesisAccount::default().with_code(Some(Bytes::from_static(RETURN_42))),
+            ),
+            (
+                always_revert_addr,
+                GenesisAccount::default().with_code(Some(Bytes::from_static(ALWAYS_REVERT))),
+            ),
+        ]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Test Task Manager");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+        let genesis_hash = chain.sealed_genesis_header().hash();
+
+        let mut factory = TransactionFactory::new();
+        let genesis_balance = reth_env
+            .retrieve_account(&factory.address())?
+            .expect("factory funded in genesis")
+            .balance;
+
+        // execute one transfer so the factory's nonce and balance move
+        let recipient = Address::from_slice(&[0xcc; 20]);
+        let transfer = factory.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(recipient),
+            U256::from(1_000_000),
+            Bytes::new(),
+        );
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![transfer])?;
+
+        // account state reflects the executed transfer
+        let factory_account =
+            reth_env.retrieve_account(&factory.address())?.expect("factory account exists");
+        assert_eq!(factory_account.nonce, 1);
+        assert!(factory_account.balance < genesis_balance);
+
+        // genesis contract account carries the bytecode hash; unknown account is None
+        let contract_account =
+            reth_env.retrieve_account(&return_42_addr)?.expect("genesis contract account exists");
+        assert_eq!(contract_account.bytecode_hash, Some(keccak256(RETURN_42)));
+        assert!(reth_env.retrieve_account(&Address::from_slice(&[0xdd; 20]))?.is_none());
+
+        // eth_getCode semantics: byte-exact for contracts, None for EOAs and unknowns
+        assert_eq!(reth_env.account_code(&return_42_addr)?, Some(Bytes::from_static(RETURN_42)));
+        assert!(reth_env.account_code(&factory.address())?.is_none());
+        assert!(reth_env.account_code(&Address::from_slice(&[0xdd; 20]))?.is_none());
+
+        // read-only contract call at the canonical tip
+        let output = reth_env
+            .read_contract(return_42_addr, Bytes::default())
+            .expect("read-only call succeeds");
+        assert_eq!(output.len(), 32);
+        assert_eq!(U256::from_be_slice(&output), U256::from(42));
+
+        // on-chain revert surfaces as EvmReadError::Revert with the raw output bytes
+        let err = reth_env
+            .read_contract(always_revert_addr, Bytes::default())
+            .expect_err("reverting call must error");
+        match err {
+            EvmReadError::Revert { output, reason } => {
+                assert!(output.is_empty());
+                // alloy's `decode_revert_reason` treats any valid-UTF-8 output as a raw-string
+                // reason (Vyper convention), so empty revert data yields `Some("")` rather than
+                // `None`; assert there is no *meaningful* reason either way
+                assert!(reason.as_deref().unwrap_or_default().is_empty());
+            }
+            other => panic!("expected revert error, got: {other:?}"),
+        }
+
+        // historical pinning: the same read against the genesis block's state
+        let output = reth_env
+            .read_contract_at_block(genesis_hash, return_42_addr, Bytes::default())
+            .expect("read-only call at genesis succeeds");
+        assert_eq!(U256::from_be_slice(&output), U256::from(42));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -20,12 +20,10 @@ use alloy::{
 };
 use reth_chainspec::{ChainSpec as RethChainSpec, EthChainSpec};
 use reth_evm::{execute::Executor as _, ConfigureEvm, EvmFactory as _};
-use reth_primitives::{sign_message, Account};
+use reth_primitives::sign_message;
 use reth_primitives_traits::SignerRecoverable;
-use reth_provider::{AccountReader as _, StateProvider, StateProviderBox, StateProviderFactory};
-use reth_revm::{
-    context::result::ResultAndState, database::StateProviderDatabase, db::BundleState, State,
-};
+use reth_provider::{StateProvider, StateProviderBox, StateProviderFactory};
+use reth_revm::{database::StateProviderDatabase, db::BundleState, State};
 use reth_transaction_pool::{EthPoolTransaction, EthPooledTransaction, PoolTransaction};
 use secp256k1::{
     rand::{rngs::StdRng, Rng, SeedableRng as _},
@@ -69,11 +67,6 @@ impl RethEnv {
         Ok(self.inner.blockchain_provider.state_by_block_hash(hash)?)
     }
 
-    /// Retrieve the account balance.
-    pub fn retrieve_account(&self, address: &Address) -> TnRethResult<Option<Account>> {
-        Ok(self.inner.blockchain_provider.basic_account(address)?)
-    }
-
     /// Create an EVM-environment from state provider.
     pub fn tn_evm(&self, hash: BlockHash) -> eyre::Result<TNEvmTestType> {
         let header = self.header(hash)?.expect("provided hash in header table");
@@ -87,21 +80,6 @@ impl RethEnv {
             .evm_config
             .evm_factory()
             .create_evm(db, self.inner.evm_config.evm_env(&header)?))
-    }
-
-    /// Execute a read-only system call against a contract and return the result.
-    ///
-    /// Useful for integration tests that need to read precompile state after
-    /// block execution without importing the `Evm` trait.
-    pub fn read_contract_state(
-        &self,
-        block_hash: BlockHash,
-        contract: Address,
-        calldata: Bytes,
-    ) -> eyre::Result<ResultAndState> {
-        use reth_evm::Evm;
-        let mut evm = self.tn_evm(block_hash)?;
-        Ok(evm.transact_system_call(crate::system_calls::SYSTEM_ADDRESS, contract, calldata)?)
     }
 
     /// Test utility to execute batch and return execution outcome.

--- a/crates/tn-reth/tests/it/pipeline_helpers.rs
+++ b/crates/tn-reth/tests/it/pipeline_helpers.rs
@@ -5,7 +5,6 @@
 //! signature recovery, block building, state persistence, and finalization.
 
 use alloy::sol_types::SolCall;
-use reth_revm::context::result::{ExecutionResult, Output};
 use secp256k1::rand::{rngs::StdRng, SeedableRng as _};
 use std::{
     collections::VecDeque,
@@ -332,23 +331,15 @@ impl PipelineTestEnv {
         self.read_precompile_u256(calldata)
     }
 
-    /// Execute a read-only system call to the precompile and decode a U256 result.
+    /// Execute a read-only contract call to the precompile and decode a U256 result.
     fn read_precompile_u256(&self, calldata: Vec<u8>) -> U256 {
         let hash = self.canonical_header.hash();
-        let result = self
+        let bytes = self
             .reth_env
-            .read_contract_state(hash, TELCOIN_PRECOMPILE_ADDRESS, Bytes::from(calldata))
-            .expect("read_contract_state");
-        match result.result {
-            ExecutionResult::Success { output, .. } => match output {
-                Output::Call(bytes) => {
-                    assert!(bytes.len() >= 32, "output too short for U256");
-                    U256::from_be_slice(&bytes[..32])
-                }
-                _ => panic!("unexpected output type"),
-            },
-            other => panic!("expected Success, got {other:?}"),
-        }
+            .read_contract_at_block(hash, TELCOIN_PRECOMPILE_ADDRESS, Bytes::from(calldata))
+            .expect("read contract");
+        assert!(bytes.len() >= 32, "output too short for U256");
+        U256::from_be_slice(&bytes[..32])
     }
 
     /// Check if a transaction in the most recent block succeeded.

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -48,6 +48,7 @@ pub use alloy::{
     consensus::{
         constants::{EMPTY_OMMER_ROOT_HASH, EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, EMPTY_WITHDRAWALS},
         proofs::calculate_transaction_root,
+        transaction::TransactionMeta,
         BlockHeader, Header as ExecHeader, SignableTransaction, Transaction as TransactionTrait,
         TxEip1559,
     },
@@ -60,8 +61,8 @@ pub use alloy::{
     genesis::{Genesis, GenesisAccount},
     hex::{self, FromHex},
     primitives::{
-        address, hex_literal, keccak256, Address, BlockHash, BlockNumber, Bloom, Bytes, Sealable,
-        TxHash, TxKind, B256, U160, U256,
+        address, hex_literal, keccak256, Address, BlockHash, BlockNumber, Bloom, Bytes, Log,
+        LogData, Sealable, TxHash, TxKind, TxNumber, B256, U160, U256,
     },
     rpc::types::{AccessList, Withdrawals},
     signers::Signature as EthSignature,
@@ -70,6 +71,6 @@ pub use alloy::{
 };
 pub use libp2p::{multiaddr::Protocol, Multiaddr};
 pub use reth_primitives::{
-    Block, BlockBody, EthPrimitives, NodePrimitives, PooledTransaction, Receipt, Recovered,
-    RecoveredBlock, SealedBlock, SealedHeader, Transaction, TransactionSigned,
+    Account, Block, BlockBody, EthPrimitives, NodePrimitives, PooledTransaction, Receipt,
+    Recovered, RecoveredBlock, SealedBlock, SealedHeader, Transaction, TransactionSigned,
 };


### PR DESCRIPTION
- Add the reads an out-of-process ExEx (e.g. an explorer indexer) needs to serve queries without JSON-RPC: `transaction_by_hash_with_meta`, `receipt_by_hash` (plus a per-transaction gas variant), `receipts_by_block`, `total_transactions`, `account_code`, and `read_contract` / `read_contract_at_block`.
- `transactions_by_tx_range_with_meta` is a chain-wide `TxNumber` feed that skips empty blocks rather than visiting them.
- Read-only calls use `eth_call` semantics: zero-address caller, no state commit, inherent 30M system-call gas cap.
- Rename `RegistryReadError` / `RegistryReadResult` to `EvmReadError` / `EvmReadResult` now that the revert-vs-internal split covers arbitrary contract reads; add `TnRethError::SignerRecovery` for the sender-recovery fallback.
- `retrieve_account` moves verbatim from test-utils into the production API; `read_contract_state` is superseded by `read_contract_at_block` (its one caller rewired).
- `tn_types` re-exports `TxNumber`, `Log`, `LogData`, `TransactionMeta`, and `Account` so external crates can name the new signatures without depending on reth directly.

closes #849 