### PR TITLE
test: add persistence barrier before iterating in db_simp_bench (#831)

### DIFF
--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -81,6 +81,13 @@ impl<DB: Database> DbTxMut for LayeredDbTxMut<DB> {
         Ok(())
     }
 
+    /// Queue the commit to the background writer thread and return.
+    ///
+    /// For a non-full-memory layer the commit is therefore asynchronous: when this
+    /// returns, the data may not be committed on-disk yet and may still be in the mem
+    /// layer, so an immediate `iter()` can observe a key in both layers.  Callers that
+    /// need a read-your-writes guarantee for iteration must call
+    /// [`Database::sync_persist`] (or await [`Database::persist`]) after committing.
     fn commit(self) -> eyre::Result<()> {
         self.tx.send(DBMessage::CommitTxn).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
         Ok(())

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -251,6 +251,15 @@ mod test {
             start.elapsed().as_secs_f64()
         );
 
+        // `commit()` on a non-full-memory layered DB only queues the commit to the
+        // background writer, so wait for that write path to drain before iterating.
+        // Without this barrier the chained disk+mem iterator below can briefly observe
+        // a key in both layers and fail the ordering assertions.  A single barrier
+        // covers all the reads below since no writes occur until the clear_table.
+        // Deliberately untimed: the commit number above measures the (async) commit
+        // call itself, not durability.
+        db.sync_persist();
+
         let start = std::time::Instant::now();
         let mut i = 0;
         #[allow(clippy::explicit_counter_loop)]


### PR DESCRIPTION
## Summary

`db_simp_bench` (`crates/storage/src/lib.rs`) writes 50k rows, commits, and iterates back to
back.  On a non-full-memory `LayeredDatabase`, `commit()` only queues `DBMessage::CommitTxn` to
the background writer thread and returns.  The handler commits the on-disk txn and only then
drains the mem layer, so there is a brief window (the length of the 50k-entry drain loop) in
which a key is present in both layers.  `iter()` on a non-full-memory layer chains the on-disk
and mem iterators, so an iterator consumed inside that window re-yields keys and the
`assert_eq!(k, i)` ordering assertion fails.  `test_compositedb_dbsimpbench` hits this because
`TestTable::HINT` is `TableHint::Cache`, which routes to the composite cache layer opened with
`full_memory = false`.  Rare, timing-dependent flake; full trace in #831.

## Fix

- Call `db.sync_persist()` in `db_simp_bench` after the first commit and before iterating.
  `CaughtUp` is FIFO-ordered behind `CommitTxn` on the same channel, so when it returns the
  on-disk commit has landed and the mem layer is drained.
- A single barrier covers the forward iterate, `reverse_iter`, and the read loops that follow,
  because no further writes occur until the `clear_table`.  This also closes the `reverse_iter`
  under-iteration case noted in the issue (on a non-full-memory layer it reads only the on-disk
  layer, which the barrier guarantees is committed).
- The barrier sits outside the printed timings on purpose: the commit number keeps measuring
  the (async) `commit()` call itself.  `sync_persist()` is a default no-op on the `Database`
  trait, so the raw MDBX / ReDB / MemDatabase callers of the shared helper are unaffected.
- Document on `LayeredDbTxMut::commit` that the commit is asynchronous for a non-full-memory
  layer and that callers needing a read-your-writes guarantee for iteration must
  `sync_persist()` (or await `persist()`) after committing.

Not changed here: `test_layereddb_dbsimpbench` still runs only the full-memory configuration
("Otherwise iterators, while correct, may not work the test").  With the barrier now in the
shared helper it could also cover the non-full-memory path; happy to extend it in this PR or a
follow-up if wanted.

## Tests

- `cargo test -p tn-storage dbsimpbench`: 5 passed (mdbx, memdb, layered, composite).
- `cargo test -p tn-storage --features redb dbsimpbench`: 5 passed.
- The pre-fix failure is timing-dependent (the commit-done, drain-pending window), so there is
  no deterministic fail-before repro; the barrier removes the window by construction.

## Checklist

- [x] `db.sync_persist()` barrier after commit, before the first `iter()` (issue box 1)
- [x] the same happens-before edge covers `reverse_iter` and the read-txn loops (issue box 2)
- [x] `commit()` async semantics documented on the layered impl (issue box 3)
- [x] `cargo +nightly-2026-03-20 fmt` clean
- [x] `cargo +nightly-2026-03-20 clippy -p tn-storage --features redb,test-utils --all-targets`
  clean (note: `-p tn-storage --all-features` fails to compile on current main because the
  crate's `adiri = []` feature does not forward to `tn-types/adiri`; unrelated to this diff)
- [x] `tn-storage` dbsimpbench tests pass (default and `redb`)

Closes #831.
