### PR TITLE
test: drive test_all_possible_error_outcomes off the rebuild ordering instead of sleep(1s)

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -672,10 +672,9 @@ mod tests {
             // all 3 transactions present
             assert_eq!(sealed_batch.batch().transactions().len(), 3 + subdag_index);
 
-            // send non-fatal error
-            let _ = ack.send(Err(error));
-
-            // submit another tx to pool
+            // submit another tx to pool before acking so the builder's next rebuild
+            // (whenever it wakes) is guaranteed to see the new tx - the builder can't
+            // rebuild while it still awaits this ack
             tx_factory
                 .create_and_submit_eip1559_pool_tx(
                     chain.clone(),
@@ -697,8 +696,8 @@ mod tests {
             // update values for next loop
             parent = final_header;
 
-            // sleep to ensure canonical update received before ack
-            let _ = tokio::time::sleep(Duration::from_secs(1)).await;
+            // send non-fatal error
+            let _ = ack.send(Err(error));
         }
 
         // wait for next block


### PR DESCRIPTION
Closes #833.

`test_all_possible_error_outcomes` raced its own batch builder.   After acking a
non-fatal error the test submitted a new pending tx, and a fixed `sleep(1s)` was
the only thing between the builder's 1ms rebuild interval and that pool update.
Under CI load the builder could wake and snapshot the pool before the new tx
landed, producing a short batch that fails the zero-slack
`assert_eq!(len, 3 + subdag_index)`.

Changes (test-only, no production code touched):

- Submit the new pending tx and execute the canonical update *before* sending the
  non-fatal ack.  The builder cannot start another build while `pending_task` is
  still awaiting the ack, so the first possible rebuild happens only after the
  ack resolves - by which point the awaited (synchronous) pool submit guarantees
  the new tx is in the pending set.  Every rebuild now sees the new tx regardless
  of when the 1ms interval fires.  This mirrors the ordering
  `test_pool_updates_after_txs_mined` already uses.
- Remove the `sleep(Duration::from_secs(1))`;  with the reorder there is no timing
  window left for it to paper over, and the test no longer depends on wall-clock
  timing.

Asserted batch counts are unchanged (3, 4, 5, 6, then 7).  Verified with the fixed
test run 5x plus the full `tn-batch-builder` suite (7 passed);  nightly fmt clean.