### PR TITLE
fix(network-libp2p): bound `published_to_peers` with an LRU (closes #828)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11699,6 +11699,7 @@ dependencies = [
  "eyre",
  "futures",
  "libp2p",
+ "lru",
  "metrics",
  "metrics-util",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ ouroboros = "0.17"
 proc-macro2 = "1.0.47"
 uint = "0.10"
 cfg-if = "1.0.0"
-lru = "0.10"
+lru = "0.16"
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 serde_yaml = "0.8.26"
 byteorder = "1.4.3"

--- a/crates/network-libp2p/Cargo.toml
+++ b/crates/network-libp2p/Cargo.toml
@@ -35,6 +35,7 @@ snap = { workspace = true }
 # peer manager
 rand = { workspace = true }
 serde_with = { workspace = true }
+lru = { workspace = true }
 
 # metrics
 metrics = { workspace = true }

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -31,9 +31,11 @@ use libp2p::{
     swarm::{NetworkBehaviour, SwarmEvent},
     Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
+use lru::LruCache;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     io::ErrorKind,
+    num::NonZeroUsize,
     time::Duration,
 };
 use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
@@ -50,6 +52,22 @@ use tracing::{debug, error, info, instrument, trace, warn};
 #[cfg(test)]
 #[path = "tests/network_tests.rs"]
 mod network_tests;
+
+/// Hard cap on the number of distinct peers retained in
+/// [`ConsensusNetwork::published_to_peers`], the de-dup set that records which peers we have
+/// already pushed our [`NodeRecord`] to.
+///
+/// Without a cap this set grows once per distinct `PeerId` ever connected and is never cleaned up
+/// (a `PeerId` is a peer-minted cryptographic identity, so a churn of fresh identities grows it
+/// without bound), which on a RAM-capped node is a slow but guaranteed OOM. Backing the set with a
+/// capacity-bounded LRU caps its resident size to this many entries (~64-80 B each, so well under
+/// 1 MB) while preserving the de-dup intent: an actively (re)connecting peer is promoted on every
+/// connect and so is never the eviction victim, and only a peer absent long enough to fall out of
+/// the LRU is re-pushed to on its eventual return - at worst once, which is self-limiting.
+///
+/// The value is a generous multiple of the live-peer target (`PeerConfig::max_peers()` defaults to
+/// ~33), so the LRU only ever evicts peers well outside the current working set. See issue #828.
+const MAX_PUBLISHED_TO_PEERS: NonZeroUsize = NonZeroUsize::new(10_000).expect("10_000 is nonzero");
 
 /// Custom network libp2p behaviour type for Telcoin Network.
 ///
@@ -178,9 +196,15 @@ where
     /// A peer connecting for the first time needs our record before it can resolve
     /// our BLS key, so we push it on `PeerConnected`. A peer that reconnects (or that
     /// flaps repeatedly, as observed with banned peers in adiri testnet) should already have
-    /// the record in their persistent kad store. This list is per-process-lifetime in case nodes
-    /// restart.
-    published_to_peers: HashSet<PeerId>,
+    /// the record in their persistent kad store, so we skip the push for peers already in here.
+    ///
+    /// A capacity-bounded LRU rather than an unbounded set: entries are never removed on
+    /// disconnect (removing them would re-enable the exact kad re-push amplification on flapping
+    /// peers that this de-dup gate exists to prevent), so an unbounded set would grow once per
+    /// distinct `PeerId` ever seen and eventually OOM a RAM-capped node. The LRU caps resident
+    /// size at [`MAX_PUBLISHED_TO_PEERS`] and promotes actively (re)connecting peers so they are
+    /// never evicted; see that constant for the full rationale.
+    published_to_peers: LruCache<PeerId, ()>,
     /// Prometheus metrics for swarm-level events (gossip, requests).
     metrics: SwarmMetrics,
 }
@@ -396,7 +420,7 @@ where
             key_config,
             task_spawner,
             node_record,
-            published_to_peers: HashSet::new(),
+            published_to_peers: LruCache::new(MAX_PUBLISHED_TO_PEERS),
             metrics: SwarmMetrics::new_for(&network_type),
         })
     }
@@ -490,6 +514,18 @@ where
             vec![peer].into_iter(),
             kad::Quorum::One,
         );
+    }
+
+    /// Record that we have pushed our [`NodeRecord`] to `peer_id`, returning `true` the first time
+    /// we see a peer (i.e. when a direct push is warranted) and `false` for a peer we have already
+    /// pushed to.
+    ///
+    /// Backed by the capacity-bounded [`Self::published_to_peers`] LRU so this de-dup gate cannot
+    /// grow without bound. A hit promotes the peer to most-recently-used, so an actively
+    /// (re)connecting peer is never evicted and never re-pushed to; only a peer absent long enough
+    /// to fall out of the LRU is pushed to again on its eventual return.
+    fn mark_published_to_peer(&mut self, peer_id: PeerId) -> bool {
+        self.published_to_peers.put(peer_id, ()).is_none()
     }
 
     /// Run the network loop to process incoming gossip.
@@ -1288,8 +1324,8 @@ where
 
                 // First-time connections need a direct record push so the peer can resolve
                 // our BLS key without waiting for the next kad publication interval. Skip
-                // on reconnects to avoid amplifying the local kad store on flapping peers
-                if self.published_to_peers.insert(peer_id) {
+                // on reconnects to avoid amplifying the local kad store on flapping peers.
+                if self.mark_published_to_peer(peer_id) {
                     self.publish_our_data_to_peer(peer_id);
                 }
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2727,3 +2727,74 @@ fn accepted_gossip_with_resolved_relayer_carries_identity() -> eyre::Result<()> 
     assert_matches!(event, NetworkEvent::Gossip(_, Some(got)) if got == bls);
     Ok(())
 }
+
+/// Regression test for issue #828: `published_to_peers` is a per-process-lifetime de-dup gate that
+/// is never cleaned on disconnect, so as an unbounded set it grew once per distinct `PeerId` ever
+/// seen and would eventually OOM a RAM-capped node. It is now a capacity-bounded LRU: a flood of
+/// fresh peer identities must pin it at [`MAX_PUBLISHED_TO_PEERS`] and never grow past it.
+#[tokio::test]
+async fn test_published_to_peers_is_bounded() {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    // The field is initialized at the intended cap and starts empty.
+    assert_eq!(network.published_to_peers.cap(), MAX_PUBLISHED_TO_PEERS);
+    assert_eq!(network.published_to_peers.len(), 0);
+
+    // Each fresh, never-before-seen peer is a first-time push (this is exactly what the
+    // `PeerEvent::PeerConnected` arm does when it sees a new `PeerId`). Overrun the cap and
+    // assert the set never grows past it.
+    let cap = MAX_PUBLISHED_TO_PEERS.get();
+    for _ in 0..(cap + 100) {
+        let peer_id = PeerId::random();
+        assert!(
+            network.mark_published_to_peer(peer_id),
+            "a never-before-seen peer must register as a first-time push"
+        );
+        assert!(
+            network.published_to_peers.len() <= cap,
+            "published_to_peers must never exceed its LRU capacity"
+        );
+    }
+
+    // The flood pinned the set at capacity rather than growing without bound.
+    assert_eq!(
+        network.published_to_peers.len(),
+        cap,
+        "a flood of distinct peers fills the LRU to exactly its capacity and stays there"
+    );
+}
+
+/// Regression test for issue #828: bounding `published_to_peers` must not reintroduce the kad
+/// re-push amplification the gate exists to prevent. An actively (re)connecting peer must stay
+/// resident in the LRU - so it keeps de-duping and is never re-pushed to - even while a flood of
+/// fresh peers churns the rest of the set.
+#[tokio::test]
+async fn test_published_to_peers_keeps_active_peer_resident() {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    // First sight of our sticky peer warrants a one-time push.
+    let sticky = PeerId::random();
+    assert!(
+        network.mark_published_to_peer(sticky),
+        "first sight of a peer must register as a first-time push"
+    );
+
+    // The sticky peer keeps reconnecting while enough fresh identities connect to overrun the
+    // cap. Because every reconnect promotes it to most-recently-used, it is never the eviction
+    // victim - unlike a plain insertion-order set, which would drop it after `cap` fresh inserts.
+    for _ in 0..(MAX_PUBLISHED_TO_PEERS.get() + 100) {
+        assert!(
+            !network.mark_published_to_peer(sticky),
+            "a reconnecting peer we have already pushed to must not be re-pushed"
+        );
+        network.mark_published_to_peer(PeerId::random());
+    }
+
+    // Despite the flood, the continually-active peer survived eviction and still de-dups.
+    assert!(
+        !network.mark_published_to_peer(sticky),
+        "an actively reconnecting peer must survive LRU eviction (no re-push storm)"
+    );
+}


### PR DESCRIPTION
## Problem

`published_to_peers` (`crates/network-libp2p/src/consensus.rs`) is a per-process-lifetime de-dup
gate recording every peer we have pushed our `NodeRecord` to.  It is inserted into once per distinct
`PeerId` ever connected (`PeerEvent::PeerConnected`) and **never removed** . . . the `PeerDisconnected`
handlers clean only `connected_peers`, not this set.  Because a `PeerId` is a peer-minted
cryptographic identity, a churn of fresh identities (or benign long-uptime peer churn) grows the set
without bound.  On a RAM-capped node this monotonic growth is a slow but guaranteed OOM-kill plus
restart loop.

Removing entries on disconnect is **not** a valid fix: it re-enables the exact kad re-push
amplification on flapping peers that this gate exists to prevent.

## Fix

Replace the unbounded `HashSet<PeerId>` with a capacity-bounded `lru::LruCache<PeerId, ()>`
(`MAX_PUBLISHED_TO_PEERS = 10_000`, a generous multiple of the ~33 live-peer target, ~64–80 B/entry
so well under 1 MB resident):

- The de-dup decision is factored into `mark_published_to_peer(peer_id) -> bool`, which returns
  `true` the first time a peer is seen (a push is warranted) and `false` otherwise.  It is backed by
  `LruCache::put(peer_id, ()).is_none()`, which is behaviourally identical to the old
  `HashSet::insert(peer_id)` for the de-dup decision.
- A hit **promotes** the peer to most-recently-used, so an actively (re)connecting peer is never the
  eviction victim and is never re-pushed to.  Only a peer absent long enough to fall out of the LRU
  is re-pushed on its eventual return . . . at worst once, which is self-limiting.  This preserves the
  de-dup intent while capping resident memory.

`lru` was already an (unused) workspace dependency pinned at a stale `0.10`;  bumped to `0.16` to
match the version already resolved transitively (`0.16.3`), so no new lockfile version is
introduced.

## Changes

- [x] Replace the unbounded `HashSet<PeerId>` with a capacity-bounded LRU (`MAX_PUBLISHED_TO_PEERS`)
- [x] Preserve the de-dup intent for actively churning peers via LRU promotion (no re-push storm)
- [x] Add resident-size regression test: a flood of distinct fresh peer ids keeps the set pinned at
      capacity (`test_published_to_peers_is_bounded`)
- [x] Add an anti-amplification regression test: an actively reconnecting peer survives eviction and
      keeps de-duping under a fresh-peer flood (`test_published_to_peers_keeps_active_peer_resident`)
- [x] `lru` workspace dependency `0.10` → `0.16`; add `lru = { workspace = true }` to
      `tn-network-libp2p`

Companion issues from the same unbounded-peer-map audit (separate PRs): `known_peers`
(`peers/manager.rs`), `banned_peers_by_ip` (`peers/banned.rs`), `consensus_certs`
(`consensus/primary`).

Closes #828 