### PR TITLE
fix(network-libp2p): bound known_peers against unbounded peer injection (#827)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -1593,7 +1593,14 @@ where
                     .put(record)
                     .map_err(|e| NetworkError::StoreKademliaRecord(e.to_string()))?;
                 trace!(target: "network-kad", "Got record {key} {value:?}");
-                self.swarm.behaviour_mut().peer_manager.add_discovered_peer(key, value.info);
+                // a peer pushing its own record over its own connection (source == the record's
+                // network identity) also confirms its identity so a live non-committee connection
+                // (e.g. an nvv in the gossip mesh) is retained; relayed and non-self records stay
+                // committee-gated (issue #827).
+                self.swarm
+                    .behaviour_mut()
+                    .peer_manager
+                    .add_self_advertised_peer(source, key, value.info);
             } else {
                 // A peer republishing a slightly stale (but signature-valid) record is
                 // expected after restarts and benign — the local store keeps the newer

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -1593,7 +1593,7 @@ where
                     .put(record)
                     .map_err(|e| NetworkError::StoreKademliaRecord(e.to_string()))?;
                 trace!(target: "network-kad", "Got record {key} {value:?}");
-                self.swarm.behaviour_mut().peer_manager.add_known_peer(key, value.info);
+                self.swarm.behaviour_mut().peer_manager.add_discovered_peer(key, value.info);
             } else {
                 // A peer republishing a slightly stale (but signature-valid) record is
                 // expected after restarts and benign — the local store keeps the newer
@@ -1683,7 +1683,7 @@ where
                 self.swarm
                     .behaviour_mut()
                     .peer_manager
-                    .add_known_peer(query.request, node_record.info);
+                    .add_discovered_peer(query.request, node_record.info);
             }
         }
     }

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -1136,6 +1136,19 @@ impl AllPeers {
         self.apply_committee_membership(committee)
     }
 
+    /// Whether `bls_key` sits in any tracked committee slot (previous, current, or next).
+    ///
+    /// Committee membership is set every epoch from authoritative consensus state, so this is the
+    /// authority on whether a peer record is worth retaining: a key in no slot is neither a
+    /// current, outgoing, nor incoming validator. Used to bound the peer manager's `known_peers`
+    /// cache against records for arbitrary keys (see
+    /// [`super::manager::PeerManager::add_discovered_peer`]).
+    pub(super) fn is_committee_member(&self, bls_key: &BlsPublicKey) -> bool {
+        self.previous_committee.contains(bls_key)
+            || self.current_committee.contains(bls_key)
+            || self.next_committee.contains(bls_key)
+    }
+
     /// Lazily apply committee membership to a single member the moment its network identity is
     /// learned.
     ///
@@ -1149,10 +1162,7 @@ impl AllPeers {
         &mut self,
         bls_key: BlsPublicKey,
     ) -> Vec<(PeerId, PeerAction)> {
-        if self.previous_committee.contains(&bls_key)
-            || self.current_committee.contains(&bls_key)
-            || self.next_committee.contains(&bls_key)
-        {
+        if self.is_committee_member(&bls_key) {
             self.apply_committee_membership(std::iter::once(bls_key))
         } else {
             Vec::new()

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -52,6 +52,14 @@ pub(crate) struct PeerManager {
     /// This is used for bootstrapping and to make sure we know the network settings of committee
     /// members.
     known_peers: HashMap<BlsPublicKey, NetworkInfo>,
+    /// BLS keys whose `known_peers` entry is pinned and never evicted by committee rotation.
+    ///
+    /// Populated by the locally provisioned insertion paths — trusted/bootstrap/explicit peers and
+    /// records restored from persistence at startup — whose count is bounded by node
+    /// configuration. Every other `known_peers` entry is a kad-discovered committee record kept
+    /// only while its key sits in a tracked committee slot, so [`Self::prune_known_peers`] can
+    /// drop rotated-out members without touching operator-provisioned peers.
+    pinned_peers: HashSet<BlsPublicKey>,
     /// A queue of events that the `PeerManager` is waiting to produce.
     events: VecDeque<PeerEvent>,
     /// A queue of peers to dial.
@@ -110,6 +118,7 @@ impl PeerManager {
             heartbeat,
             peers,
             known_peers: Default::default(),
+            pinned_peers: Default::default(),
             events: Default::default(),
             dial_requests: Default::default(),
             temporarily_banned,
@@ -136,6 +145,8 @@ impl PeerManager {
         if self.temporarily_banned.remove(&peer_id) {
             warn!(target: "peer-manager", ?peer_id, "removed trusted peer from temporarily banned list");
         }
+        // trusted peers are operator-provisioned; pin so committee rotation never evicts them
+        self.pinned_peers.insert(bls_key);
         self.known_peers.insert(bls_key, info);
 
         self.dial_peer(peer_id, multiaddr, Some(reply));
@@ -685,6 +696,10 @@ impl PeerManager {
         self.forgive_temporarily_banned(&next);
         let unban_actions = self.peers.update_committees(previous, current, next);
         self.apply_unban_actions(unban_actions);
+        // bound `known_peers`: with the new committee slots in place, drop every entry that is
+        // neither pinned nor a current committee member so rotated-out members and stale discovered
+        // records cannot accumulate across epochs (issue #827).
+        self.prune_known_peers();
     }
 
     /// Pre-dial recovery: forgive bans for a committee so a subsequent dial loop can connect,
@@ -696,6 +711,21 @@ impl PeerManager {
         self.forgive_temporarily_banned(&committee);
         let unban_actions = self.peers.mark_committee_for_dial(committee);
         self.apply_unban_actions(unban_actions);
+    }
+
+    /// Drop cached network info for peers no longer worth tracking, bounding `known_peers`.
+    ///
+    /// Run after every committee rotation. An entry survives only if it is pinned (an
+    /// operator-provisioned trusted/bootstrap/explicit peer) or its key still sits in a tracked
+    /// committee slot, so members that rotated out — and any stale kad-discovered records — cannot
+    /// accumulate across epochs. `known_peers` is thereby bounded by the operator-configured set
+    /// plus the three committee slots. Evicting a still-relevant peer only forces a fresh kad
+    /// lookup if it becomes a committee member again, which is the intended discovery flow.
+    fn prune_known_peers(&mut self) {
+        let pinned = &self.pinned_peers;
+        let peers = &self.peers;
+        self.known_peers
+            .retain(|bls_key, _| pinned.contains(bls_key) || peers.is_committee_member(bls_key));
     }
 
     /// Lift any already-known committee members out of the manager's temporary-ban cache.
@@ -731,9 +761,47 @@ impl PeerManager {
         }
     }
 
-    /// Add a known peer to the known list.
-    /// Used for bootstrap servers or possibly committee members.
-    pub(crate) fn add_known_peer(&mut self, bls_key: BlsPublicKey, mut info: NetworkInfo) {
+    /// Add a locally provisioned known peer and pin it against eviction.
+    ///
+    /// Used for operator-driven entries — bootstrap and explicit peers, and records restored from
+    /// local persistence at startup — whose count is bounded by node configuration. Pinned entries
+    /// survive committee rotation (see [`Self::prune_known_peers`]). The attacker-reachable kad
+    /// discovery path must instead use [`Self::add_discovered_peer`], which is bounded to committee
+    /// membership.
+    pub(crate) fn add_known_peer(&mut self, bls_key: BlsPublicKey, info: NetworkInfo) {
+        self.pinned_peers.insert(bls_key);
+        self.cache_known_peer(bls_key, info);
+    }
+
+    /// Add a peer learned from the kad discovery DHT, but only if it is a tracked committee member.
+    ///
+    /// Unlike [`Self::add_known_peer`], this path is reachable by any remote peer: a
+    /// signature-valid kad record only proves the publisher owns the network key it advertises,
+    /// not that the advertised [`BlsPublicKey`] belongs to any committee. Caching every such
+    /// record would let a peer grow `known_peers` without bound by publishing records for endless
+    /// fresh keys (issue #827). `known_peers` exists solely to resolve committee members' network
+    /// info, so a record whose key is in no tracked committee slot is dropped: it is either stale
+    /// (a member that already rotated out) or forged, and is never read. Legitimate discovery is
+    /// unaffected because kad lookups are only ever triggered for current/next committee members
+    /// whose info is missing (see [`Self::trigger_missing_authorities`]).
+    pub(crate) fn add_discovered_peer(&mut self, bls_key: BlsPublicKey, info: NetworkInfo) {
+        if !self.peers.is_committee_member(&bls_key) {
+            trace!(
+                target: "peer-manager",
+                ?bls_key,
+                "dropping discovered peer record for non-committee key"
+            );
+            return;
+        }
+        self.cache_known_peer(bls_key, info);
+    }
+
+    /// Validate the advertised endpoint, register the peer's network identity, cache its info, and
+    /// close the committee trust window if it belongs to a tracked slot.
+    ///
+    /// Shared body of [`Self::add_known_peer`] and [`Self::add_discovered_peer`]; the caller
+    /// decides whether the entry is pinned or admitted at all.
+    fn cache_known_peer(&mut self, bls_key: BlsPublicKey, mut info: NetworkInfo) {
         // signature verification proves authenticity but not scheme correctness; drop a
         // malformed advertised endpoint so only well-formed RPC info is ever cached in
         // `known_peers`. the rest of the (signed, authentic) record is still usable.

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -796,6 +796,47 @@ impl PeerManager {
         self.cache_known_peer(bls_key, info);
     }
 
+    /// Admit a peer record pushed to us over the peer's own authenticated connection (a kad PUT
+    /// whose `source` is the sending peer).
+    ///
+    /// A committee member is cached in `known_peers` exactly as via [`Self::add_discovered_peer`].
+    /// A non-committee peer that advertises its OWN record - the authenticated kad-put `source`
+    /// equals the record's advertised network identity, so libp2p has already proven the sender
+    /// owns that transport key - has only its `bls_key <-> peer_id` identity confirmed in the peer
+    /// store, so a live connection (for example an nvv joining the gossip mesh) is retained. It is
+    /// deliberately NOT inserted into the committee-only `known_peers` cache. Because
+    /// [`AllPeers::upsert_peer`] re-keys by peer id, a peer can only ever hold ONE confirmed
+    /// identity for its own connection, so this is bounded by the live connection count and keeps
+    /// the issue #827 bound against unbounded record injection intact. A relayed record (`source`
+    /// != the advertised identity) cannot confirm an identity the sender does not control and is
+    /// dropped, so this never lets a peer displace another peer's identity.
+    pub(crate) fn add_self_advertised_peer(
+        &mut self,
+        source: PeerId,
+        bls_key: BlsPublicKey,
+        info: NetworkInfo,
+    ) {
+        let advertised: PeerId = info.pubkey.clone().into();
+        if self.peers.is_committee_member(&bls_key) {
+            self.cache_known_peer(bls_key, info);
+        } else if source == advertised {
+            trace!(
+                target: "peer-manager",
+                ?bls_key,
+                ?source,
+                "confirming self-advertised connected peer identity"
+            );
+            self.peers.upsert_peer(bls_key, info.pubkey, info.multiaddrs);
+        } else {
+            trace!(
+                target: "peer-manager",
+                ?bls_key,
+                ?source,
+                "dropping non-committee relayed peer record"
+            );
+        }
+    }
+
     /// Validate the advertised endpoint, register the peer's network identity, cache its info, and
     /// close the committee trust window if it belongs to a tracked slot.
     ///

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1338,6 +1338,14 @@ async fn test_banned_peer_reconnection_attempt() -> eyre::Result<()> {
 
     let malicious_addr = config_2.primary_address();
 
+    // honest must resolve malicious_bls -> peer id to penalize it. the committee gate added in
+    // #827 drops kad-discovered records for non-committee keys, so register the malicious peer
+    // explicitly (an operator-provisioned, pinned path) instead. unlike committee membership this
+    // does not make honest re-dial the peer, so the Fatal ban disconnects and stays disconnected.
+    honest_peer
+        .add_explicit_peer(malicious_bls, config_2.primary_networkkey(), malicious_addr.clone())
+        .await?;
+
     // Connect malicious to honest
     malicious_peer
         .add_explicit_peer(
@@ -2397,6 +2405,14 @@ async fn test_advertise_rpc_via_kad() -> eyre::Result<()> {
         network.run().await.expect("nvv network run failed!");
     });
     nvv.start_listening(nvv_config.primary_address()).await?;
+    // seed the nvv's committee (target + the rest) BEFORE it connects so target's rpc-bearing
+    // record is retained the moment it arrives via kad; the committee gate added in #827 drops
+    // records for non-committee keys, and a late seed misses the record's first delivery. an nvv
+    // following the chain learns the committee from epoch state.
+    let committee_keys = std::iter::once(target_peer_bls)
+        .chain(committee.iter().map(|p| p.config.key_config().primary_public_key()))
+        .collect();
+    nvv.update_committees(Default::default(), committee_keys, Default::default()).await?;
     nvv.add_trusted_peer_and_dial(
         target_peer_bls,
         target_peer_net.clone(),
@@ -2485,6 +2501,14 @@ async fn test_pre_upgrade_record_accepted_with_default_rpc() -> eyre::Result<()>
     assert!(node_record.info.rpc.is_none());
     assert_eq!(node_record.info.multiaddrs, vec![peer2.config.primary_address()]);
 
+    // owner is a committee member so the gated discovery path (#827) retains its record;
+    // production applies committee membership from epoch state before processing records.
+    network.swarm.behaviour_mut().peer_manager.update_committees(
+        Default::default(),
+        std::iter::once(owner_bls).collect(),
+        Default::default(),
+    );
+
     // an inbound put request stores the record and promotes it into `known_peers`
     network.process_kad_put_request(owner_peer_id, kad_record.clone())?;
     assert!(network.swarm.behaviour_mut().kademlia.store_mut().get(&kad_record.key).is_some());
@@ -2537,6 +2561,14 @@ async fn test_malformed_rpc_scheme_stripped_on_promotion() -> eyre::Result<()> {
         publisher: Some(owner_peer_id),
         expires: None,
     };
+
+    // owner is a committee member so the gated discovery path (#827) retains its record;
+    // production applies committee membership from epoch state before processing records.
+    network.swarm.behaviour_mut().peer_manager.update_committees(
+        Default::default(),
+        std::iter::once(owner_bls).collect(),
+        Default::default(),
+    );
 
     network.process_kad_put_request(owner_peer_id, kad_record.clone())?;
 

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -733,6 +733,86 @@ async fn test_add_known_peer_closes_validator_gap_on_discovery() {
     );
 }
 
+/// Build a well-formed [`NetworkInfo`] with a fresh, random network identity.
+fn random_network_info() -> NetworkInfo {
+    let netkey: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    NetworkInfo {
+        pubkey: netkey,
+        multiaddrs: vec![create_multiaddr(None)],
+        timestamp: now(),
+        rpc: None,
+    }
+}
+
+#[tokio::test]
+async fn test_discovered_peers_bounded_to_committee_membership() {
+    // Regression (issue #827): a flood of signature-valid kad records for fresh, non-committee keys
+    // must not grow `known_peers`. Only records whose key is a tracked committee member are cached.
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // a single legitimate current-committee member, tracked by bls before its identity is known
+    let mut rng = StdRng::from_seed([11; 32]);
+    let committee_bls = *BlsKeypair::generate(&mut rng).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([committee_bls]), HashSet::new());
+    assert!(peer_manager.known_peers.is_empty(), "no records cached before discovery");
+
+    // an attacker publishes many valid records for endless fresh keys it controls; none are
+    // committee members, so every one is dropped and `known_peers` never grows
+    let mut attacker_rng = StdRng::from_seed([42; 32]);
+    for _ in 0..1_000 {
+        let attacker_bls = *BlsKeypair::generate(&mut attacker_rng).public();
+        peer_manager.add_discovered_peer(attacker_bls, random_network_info());
+    }
+    assert!(
+        peer_manager.known_peers.is_empty(),
+        "non-committee discovered records must all be dropped"
+    );
+
+    // the legitimate committee member's record, arriving via the same discovery path, IS cached
+    peer_manager.add_discovered_peer(committee_bls, random_network_info());
+    assert!(
+        peer_manager.known_peers.contains_key(&committee_bls),
+        "a committee member discovered via kad must be cached"
+    );
+    assert!(peer_manager.known_peers.len() == 1, "only the committee member is cached");
+}
+
+#[tokio::test]
+async fn test_known_peers_pruned_on_rotation_but_pinned_survive() {
+    // Regression (issue #827): committee members discovered in one epoch must not accumulate across
+    // rotations, while operator-provisioned (pinned) peers must never be evicted.
+    let mut peer_manager = create_test_peer_manager(None);
+    let mut rng = StdRng::from_seed([13; 32]);
+
+    // an operator/bootstrap peer added via `add_known_peer` is pinned even though it is never a
+    // committee member
+    let pinned_bls = *BlsKeypair::generate(&mut rng).public();
+    peer_manager.add_known_peer(pinned_bls, random_network_info());
+
+    // a committee member discovered this epoch via the kad path
+    let member_bls = *BlsKeypair::generate(&mut rng).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([member_bls]), HashSet::new());
+    peer_manager.add_discovered_peer(member_bls, random_network_info());
+    assert!(peer_manager.known_peers.contains_key(&member_bls), "member cached while in committee");
+    assert!(peer_manager.known_peers.contains_key(&pinned_bls), "pinned peer cached");
+
+    // next epoch: `member_bls` falls out of every slot (a member still in `previous` would be kept
+    // one more epoch); a fresh committee replaces it
+    let mut next_rng = StdRng::from_seed([99; 32]);
+    let new_member = *BlsKeypair::generate(&mut next_rng).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([new_member]), HashSet::new());
+
+    // the rotated-out member is pruned; the pinned operator peer survives
+    assert!(
+        !peer_manager.known_peers.contains_key(&member_bls),
+        "rotated-out member must be pruned"
+    );
+    assert!(
+        peer_manager.known_peers.contains_key(&pinned_bls),
+        "pinned operator peer must survive rotation"
+    );
+}
+
 #[tokio::test]
 async fn test_register_outgoing_connection() {
     let mut peer_manager = create_test_peer_manager(None);

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -778,6 +778,81 @@ async fn test_discovered_peers_bounded_to_committee_membership() {
 }
 
 #[tokio::test]
+async fn test_self_advertised_connected_peer_confirmed_not_cached_and_bounded() {
+    // Issue #827 gate refinement: a non-committee peer that pushes its OWN record over its own
+    // authenticated connection (kad-put `source` == the record's advertised network identity) has
+    // its bls<->peer-id identity confirmed so a live connection (e.g. an nvv in the gossip mesh) is
+    // retained, but it is NOT added to the committee-only `known_peers` cache. A relayed record
+    // (source != identity) confirms nothing, and a flood of fresh keys over one connection stays
+    // bounded because the peer store re-keys by peer id.
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // a non-committee peer self-advertises its own record: source == the advertised network id
+    let netkey: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let self_peer_id: PeerId = netkey.clone().into();
+    let info = NetworkInfo {
+        pubkey: netkey,
+        multiaddrs: vec![create_multiaddr(None)],
+        timestamp: now(),
+        rpc: None,
+    };
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([7; 32])).public();
+    peer_manager.add_self_advertised_peer(self_peer_id, bls, info);
+
+    // identity confirmed in the peer store (resolvable by peer id) ...
+    assert_eq!(
+        peer_manager.peer_to_bls(&self_peer_id),
+        Some(bls),
+        "self-advertised connected peer must have its identity confirmed"
+    );
+    // ... but NOT cached in the committee-only known_peers
+    assert!(
+        peer_manager.known_peers.is_empty(),
+        "self-advertised non-committee peer must not enter the committee-only known_peers cache"
+    );
+
+    // a relayed record (source is not the advertised identity) confirms nothing and is not cached,
+    // so a peer can never displace an identity it does not control
+    let relayed = random_network_info();
+    let relayed_bls = *BlsKeypair::generate(&mut StdRng::from_seed([8; 32])).public();
+    let unrelated_source = PeerId::random();
+    peer_manager.add_self_advertised_peer(unrelated_source, relayed_bls, relayed);
+    assert_eq!(
+        peer_manager.peer_to_bls(&unrelated_source),
+        None,
+        "a relayed record must not confirm an identity the sender does not control"
+    );
+    assert!(peer_manager.known_peers.is_empty(), "relayed record must not be cached");
+
+    // a flood of fresh bls keys all self-advertised over ONE connection stays bounded: the peer
+    // store re-keys by peer id (one confirmed identity per connection) so only the latest survives,
+    // and known_peers never grows
+    let flood_netkey: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    let flood_peer_id: PeerId = flood_netkey.clone().into();
+    let mut attacker_rng = StdRng::from_seed([42; 32]);
+    let last_bls = (0..1_000).fold(bls, |_, _| {
+        let next_bls = *BlsKeypair::generate(&mut attacker_rng).public();
+        let info = NetworkInfo {
+            pubkey: flood_netkey.clone(),
+            multiaddrs: vec![create_multiaddr(None)],
+            timestamp: now(),
+            rpc: None,
+        };
+        peer_manager.add_self_advertised_peer(flood_peer_id, next_bls, info);
+        next_bls
+    });
+    assert!(
+        peer_manager.known_peers.is_empty(),
+        "a self-advertised flood must never grow the committee-only known_peers cache"
+    );
+    assert_eq!(
+        peer_manager.peer_to_bls(&flood_peer_id),
+        Some(last_bls),
+        "the flooded connection retains exactly one (the latest) confirmed identity, not 1000"
+    );
+}
+
+#[tokio::test]
 async fn test_known_peers_pruned_on_rotation_but_pinned_survive() {
     // Regression (issue #827): committee members discovered in one epoch must not accumulate across
     // rotations, while operator-provisioned (pinned) peers must never be evicted.


### PR DESCRIPTION
Fixes #827.

## Summary

`PeerManager.known_peers` was insert-only and unbounded.  Any remote peer could grow it without limit by publishing signature-valid kad records for endless fresh `BlsPublicKey`s, and rotated-out committee members were never removed.  On a RAM-capped node this is an eventual OOM-kill plus restart loop.

This bounds the map with a hard structural invariant:

> `known_peers` ⊆ operator-pinned keys ∪ (previous ∪ current ∪ next committee)

Both sets are bounded (node config and committee size), so the map can no longer grow without bound: no soft LRU/TTL cap needed.

## How

The single `add_known_peer` served two very different callers, and the fix separates them by trust:

- **Operator/local path** (`add_known_peer`, unchanged callers: startup restore, `AddExplicitPeer`, `AddBootstrapPeers`, and the trusted-peer dial).  These are config-bounded and not attacker-reachable, so they stay uncapped but are now **pinned** . . . recorded in a new `pinned_peers` set so rotation never evicts them.
- **Kad discovery path** (new `add_discovered_peer`, wired to the two kad sites in `consensus.rs`: the inbound `PutRecord` handler and the query-result handler).  This is the attacker-reachable path.  A record is cached **only if its key is a tracked committee member**.  `known_peers` exists solely to resolve committee members' network info, so a record for a key in no committee slot is either stale or forged and is never read: dropping it costs nothing.  Legitimate discovery is unaffected because kad lookups are only ever triggered for current/next committee members whose info is missing (`trigger_missing_authorities`).

To also close the slower leak (members that legitimately rotate out), `prune_known_peers` runs at the end of `update_committees` and retains only pinned or currently-committee keys.  A member still in the `previous` slot is kept one more epoch by design (late gossip), then dropped.

Supporting change: `AllPeers::is_committee_member` centralizes the previous∨current∨next slot check (also now used by `apply_membership_if_committee`).

## Why this is safe

Committee membership is set every epoch from authoritative consensus state, never from a network record, so an attacker cannot make `is_committee_member` return true for a key they invented. Evicting a non-committee entry only forces a fresh kad lookup if that peer later becomes committee-relevant — which is the intended discovery flow (see the issue's "Fix risk: low").  All readers of `known_peers` (`get_rpc`, `all_rpcs`, `auth_to_peer`, `find_authorities`, `trigger_missing_authorities`) query by authority/committee key, so non-committee entries were never usefully read.

## Tests

- `test_discovered_peers_bounded_to_committee_membership`: floods 1,000 signature-valid records for fresh non-committee keys via the discovery path and asserts `known_peers` stays empty, while a genuine committee member's record on the same path is cached.
- `test_known_peers_pruned_on_rotation_but_pinned_survive`: a discovered committee member is pruned once it rotates out of every slot, while an operator-pinned peer survives rotation.

## Checklist

- [x] Prune `known_peers` on committee rotation (keep current/next/previous committee + pinned)
- [x] Bound the discovery-inserted subset (reject non-committee kad records — tighter than the LRU/TTL the issue suggested; gives an exact structural bound)
- [x] Resident-size regression test: flood signed records for fresh keys, assert `known_peers` stays bounded