### PR TITLE
build: forward `adiri` feature to `tn-types/adiri` in storage, engine, executor

### DIFF
--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -38,4 +38,4 @@ workspace = true
 
 [features]
 default = []
-adiri = []
+adiri = ["tn-types/adiri"]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -39,7 +39,7 @@ assert_matches = { workspace = true }
 [features]
 default = []
 test-utils = ["dep:eyre"]
-adiri = []
+adiri = ["tn-types/adiri"]
 
 [lints]
 workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -47,7 +47,7 @@ redb = []
 reth-libmdbx = ["dep:reth-libmdbx", "dep:page_size"]
 default = ["reth-libmdbx"]
 test-utils = []
-adiri = []
+adiri = ["tn-types/adiri"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

The `adiri` cargo feature was declared as `adiri = []` in `tn-storage`,
`tn-engine`, and `tn-executor`, but each crate gates code on it that reads
`tn_types::forks::ADIRI_DUP_BATCH_EPOCH` (itself `#[cfg(feature = "adiri")]` in
`crates/types/src/forks.rs`). An empty feature never enables `tn-types/adiri`,
so building any of these crates with the feature on fails to compile:

```
error[E0425]: cannot find value `ADIRI_DUP_BATCH_EPOCH` in module `tn_types::forks`
```

`make clippy` (`--workspace --all-features`) masks this because a
workspace-wide all-features build enables `tn-types/adiri` directly.  Anyone
iterating on one of these crates alone (`cargo clippy -p tn-storage
--all-features`, a common flow) hits the error.

## Changes

- [x] `crates/storage/Cargo.toml`: `adiri = ["tn-types/adiri"]`
- [x] `crates/engine/Cargo.toml`: `adiri = ["tn-types/adiri"]`
- [x] `crates/consensus/executor/Cargo.toml`: `adiri = ["tn-types/adiri"]`

## Audit of the other `cfg(feature = "adiri")` crates

The issue asked for a quick audit of the other crates for the same missing
forward.  I checked every crate that declares or uses the `adiri` feature:

| Crate | State | Action |
| --- | --- | --- |
| `tn-storage` | references `ADIRI_DUP_BATCH_EPOCH` under `cfg(adiri)`, `adiri = []` | fixed |
| `tn-engine` | references `ADIRI_DUP_BATCH_EPOCH` under `cfg(adiri)`, `adiri = []` | fixed |
| `tn-executor` | references `ADIRI_DUP_BATCH_EPOCH` under `cfg(adiri)`, `adiri = []` | fixed |
| `tn-types` | defines `ADIRI_DUP_BATCH_EPOCH` (origin crate) | none (a self-forward would be circular) |
| `telcoin-network-cli` | `adiri` gate only reads `chain_id`, no gated dep item | none (compiles regardless) |
| `tn-reth` | `adiri = ["faucet"]`, no `cfg(adiri)` code | none (unrelated) |

`ADIRI_DUP_BATCH_EPOCH` is the only `adiri`-gated symbol in the workspace, and
storage/engine/executor are the only crates that reference it, so the three
forwards above are the complete fix.  No other feature (`faucet`, `test-utils`,
`redb`, `reth-libmdbx`) shows the same missing-forward pattern.

## Verification

Before (each crate fails independently under `--all-features`):

```
cargo check -p tn-storage  --all-features    # E0425
cargo check -p tn-engine   --all-features    # E0425
cargo check -p tn-executor --all-features    # E0425
```

After:

```
cargo check  -p tn-storage -p tn-engine -p tn-executor --all-features                  # Finished
cargo clippy -p tn-storage -p tn-engine -p tn-executor --all-features --all-targets    # 0 errors, 0 warnings
```

Closes #853.
