### PR TITLE
test(network-libp2p): replace fixed real-time sleeps in network_tests  with condition polling

### DIFF
--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -228,6 +228,35 @@ async fn wait_for_peer_discovery<Req: TNMessage, Res: TNMessage>(
     }
 }
 
+/// Poll an async `condition` until it returns `true`, or fail once `timeout_duration` elapses.
+///
+/// A bounded, self-synchronizing replacement for a fixed `sleep` that only guesses
+/// at how long an asynchronous swarm event (gossip mesh grafting, subscription
+/// propagation, connection teardown plus pending-request cleanup) takes. It waits
+/// for the real observable condition and fails with a clear message on timeout
+/// rather than asserting against not-yet-settled state. Mirrors the poll shape of
+/// [`wait_for_peer_discovery`] but is generic over the polled condition.
+async fn wait_until<F, Fut>(
+    timeout_duration: Duration,
+    description: &str,
+    mut condition: F,
+) -> eyre::Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = eyre::Result<bool>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    loop {
+        if condition().await? {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(eyre!("timed out waiting for condition: {description}"));
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 #[tokio::test]
 async fn test_valid_req_restt() -> eyre::Result<()> {
     // start honest peer1 network
@@ -359,8 +388,15 @@ async fn test_valid_req_res_connection_closed_cleanup() -> eyre::Result<()> {
     peer2_network_task.abort();
     assert!(peer2_network_task.await.unwrap_err().is_cancelled());
 
-    // allow peer1 to process disconnect
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // wait for peer1 to observe the disconnect and drain its pending request,
+    // instead of guessing at how long the teardown plus outbound-failure delivery takes
+    let handle = &peer1;
+    wait_until(
+        Duration::from_secs(5),
+        "peer1 clears its pending request after peer2 disconnects",
+        move || async move { Ok(handle.get_pending_request_count().await? == 0) },
+    )
+    .await?;
 
     // peer1 removes pending requests
     let count = peer1.get_pending_request_count().await?;
@@ -921,8 +957,21 @@ async fn test_publish_to_one_peer() -> eyre::Result<()> {
     let sealed_block = random_block.seal_slow();
     let expected_result = Vec::from(&sealed_block);
 
-    // sleep for gossip connection time lapse
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // wait until the publisher has observed a TEST_TOPIC subscriber before publishing.
+    // cvv is not subscribed itself, so `publish` fans out only to peers whose
+    // subscription has already propagated here; poll for that instead of guessing.
+    let topic_hash = TopicHash::from_raw(TEST_TOPIC);
+    let topic_ref = &topic_hash;
+    let handle = &cvv;
+    wait_until(
+        Duration::from_secs(5),
+        "publisher observes a TEST_TOPIC subscriber",
+        move || async move {
+            let peers = handle.all_peers().await?;
+            Ok(peers.values().any(|topics| topics.contains(topic_ref)))
+        },
+    )
+    .await?;
 
     // publish on wrong topic - no peers
     let expected_failure = cvv.publish("WRONG_TOPIC".into(), expected_result.clone()).await;
@@ -984,8 +1033,21 @@ async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<
     let sealed_block = random_block.seal_slow();
     let expected_result = Vec::from(&sealed_block);
 
-    // sleep for gossip connection time lapse
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // wait until the publisher has observed a TEST_TOPIC subscriber before publishing.
+    // cvv is not subscribed itself, so `publish` fans out only to peers whose
+    // subscription has already propagated here; poll for that instead of guessing.
+    let topic_hash = TopicHash::from_raw(TEST_TOPIC);
+    let topic_ref = &topic_hash;
+    let handle = &cvv;
+    wait_until(
+        Duration::from_secs(5),
+        "publisher observes a TEST_TOPIC subscriber",
+        move || async move {
+            let peers = handle.all_peers().await?;
+            Ok(peers.values().any(|topics| topics.contains(topic_ref)))
+        },
+    )
+    .await?;
 
     // publish correct message and wait to receive
     let _message_id = cvv.publish(TEST_TOPIC.into(), expected_result.clone()).await?;
@@ -1512,8 +1574,14 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
             .await?;
     }
 
-    // Wait for connections to stabilize
-    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL * 2)).await;
+    // Wait for every peer to connect to the target, instead of assuming a fixed
+    // number of heartbeats is enough
+    let handle = &target_peer.network_handle;
+    let expected = other_peers.len();
+    wait_until(Duration::from_secs(10), "all peers connected to target", move || async move {
+        Ok(handle.connected_peer_ids().await?.len() == expected)
+    })
+    .await?;
 
     // Verify all peers are connected to target
     let connected_peers = target_peer.network_handle.connected_peer_ids().await?;

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -7,6 +7,7 @@ use crate::common::{
 };
 use assert_matches::assert_matches;
 use eyre::eyre;
+use futures::StreamExt as _;
 use rand::{rngs::StdRng, SeedableRng as _};
 use std::num::NonZeroUsize;
 use tn_config::{ConsensusConfig, NetworkConfig};
@@ -232,29 +233,38 @@ async fn wait_for_peer_discovery<Req: TNMessage, Res: TNMessage>(
 ///
 /// A bounded, self-synchronizing replacement for a fixed `sleep` that only guesses
 /// at how long an asynchronous swarm event (gossip mesh grafting, subscription
-/// propagation, connection teardown plus pending-request cleanup) takes. It waits
-/// for the real observable condition and fails with a clear message on timeout
-/// rather than asserting against not-yet-settled state. Mirrors the poll shape of
+/// propagation, connection teardown plus pending-request cleanup) takes. It folds
+/// over a bounded sequence of ~10ms poll attempts, carrying the first resolved
+/// verdict forward: `Some(Ok(()))` once the condition holds, `Some(Err(_))` if a
+/// poll itself errors, and `None` while still waiting. An exhausted fold (still
+/// `None`) means the deadline passed. Mirrors the poll shape of
 /// [`wait_for_peer_discovery`] but is generic over the polled condition.
 async fn wait_until<F, Fut>(
     timeout_duration: Duration,
     description: &str,
-    mut condition: F,
+    condition: F,
 ) -> eyre::Result<()>
 where
-    F: FnMut() -> Fut,
+    F: Fn() -> Fut,
     Fut: std::future::Future<Output = eyre::Result<bool>>,
 {
-    let deadline = tokio::time::Instant::now() + timeout_duration;
-    loop {
-        if condition().await? {
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(eyre!("timed out waiting for condition: {description}"));
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    const POLL_INTERVAL: Duration = Duration::from_millis(10);
+    let attempts = (timeout_duration.as_millis() / POLL_INTERVAL.as_millis()).max(1);
+    let condition = &condition;
+
+    futures::stream::iter(0..attempts)
+        .fold(None, move |resolved: Option<eyre::Result<()>>, attempt| async move {
+            if resolved.is_some() {
+                resolved
+            } else {
+                if attempt > 0 {
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                condition().await.map(|met| met.then_some(())).transpose()
+            }
+        })
+        .await
+        .unwrap_or_else(|| Err(eyre!("timed out waiting for condition: {description}")))
 }
 
 #[tokio::test]


### PR DESCRIPTION
  ## What
  Replaces the four fixed `tokio::time::sleep(...)` "wait for convergence" calls in
  `crates/network-libp2p/src/tests/network_tests.rs` with bounded condition polls.

  ## Why
  Each sleep is a stand-in for an async swarm event and just bets the event lands
  before the timer fires. Under CI CPU starvation the ordering can invert and the
  following assertion runs against not-yet-settled state, producing rare
  intermittent failures. Polling the real condition removes the race while keeping
  an upper bound on runtime.

  ## Changes
  - New `wait_until(timeout, description, condition)` helper alongside the existing
    `wait_for_peer_discovery` precedent: polls every 10ms until the condition holds
    or the deadline elapses, failing with a descriptive message.
  - `test_valid_req_res_connection_closed_cleanup`: poll
  `get_pending_request_count()`
    to 0 instead of `sleep(500ms)`.
  `test_msg_verification_ignores_unauthorized_publisher`:
    poll `all_peers()` until the publisher has observed a `TEST_TOPIC` subscriber
    before publishing. The publisher is not subscribed to the topic, so its
    `mesh_peers` set is empty; `all_peers()` is the correct fanout precondition.
  - `test_multi_peer_mesh_formation`: poll `connected_peer_ids()` until it reaches
    `other_peers.len()` before the exact-count `assert_eq!`, instead of
    `sleep(2 * heartbeat)`.

  Test-only; no production code changed. Other sleeps in the file belong to tests
  outside this issue's scope and are untouched.

  Closes #835