### PR TITLE
fix(network-libp2p): prune zero-count `banned_peers_by_ip` keys (#829)

### DIFF
--- a/crates/network-libp2p/src/peers/banned.rs
+++ b/crates/network-libp2p/src/peers/banned.rs
@@ -44,15 +44,22 @@ impl BannedPeers {
 
         ip_addresses
             .filter(|ip| {
-                match self.banned_peers_by_ip.get_mut(ip) {
-                    Some(count) => {
+                self.banned_peers_by_ip
+                    .get_mut(ip)
+                    .map(|count| {
                         // reduce count
                         *count = count.saturating_sub(1);
+                        *count
+                    })
+                    .is_some_and(|count| {
+                        // drop keys that no longer track a banned peer so the map
+                        // cannot grow without bound as distinct IPs churn
+                        if count == 0 {
+                            self.banned_peers_by_ip.remove(ip);
+                        }
                         // return ip if no longer associated with a banned peer
-                        !self.ip_banned(ip)
-                    }
-                    None => false,
-                }
+                        count <= BANNED_PEERS_PER_IP_THRESHOLD
+                    })
             })
             .collect()
     }

--- a/crates/network-libp2p/src/tests/banned_peers.rs
+++ b/crates/network-libp2p/src/tests/banned_peers.rs
@@ -314,3 +314,50 @@ fn test_remove_validator_ip_for_never_banned_member_preserves_total() {
         "clearing a never-banned validator IP must not change the banned total"
     );
 }
+
+#[test]
+fn test_remove_banned_peer_prunes_zero_count_keys() {
+    let mut banned_peers = BannedPeers::default();
+
+    // ban a single peer on each of many distinct IPs
+    let ips: Vec<IpAddr> = (0..64).map(|_| random_ip_addr()).collect();
+    for ip in &ips {
+        banned_peers.add_banned_peer(&create_peer_with_ips(vec![*ip]));
+    }
+
+    // every distinct IP now holds an entry
+    assert_eq!(banned_peers.banned_peers_by_ip.len(), ips.len());
+
+    // unban every peer again
+    for ip in &ips {
+        assert_eq!(banned_peers.remove_banned_peer(std::iter::once(*ip)), vec![*ip]);
+    }
+
+    // the map must shrink back to empty rather than leaking a permanent
+    // zero-count entry per distinct banned IP
+    assert!(
+        banned_peers.banned_peers_by_ip.is_empty(),
+        "zero-count keys should be pruned, found {} lingering entries",
+        banned_peers.banned_peers_by_ip.len()
+    );
+}
+
+#[test]
+fn test_remove_banned_peer_keeps_entry_until_zero() {
+    let mut banned_peers = BannedPeers::default();
+    let ip = random_ip_addr();
+
+    // two banned peers share the same IP
+    for _ in 0..2 {
+        banned_peers.add_banned_peer(&create_peer_with_ips(vec![ip]));
+    }
+    assert_eq!(banned_peers.banned_peers_by_ip.get(&ip), Some(&2));
+
+    // first removal decrements but must keep the entry (count still above zero)
+    banned_peers.remove_banned_peer(std::iter::once(ip));
+    assert_eq!(banned_peers.banned_peers_by_ip.get(&ip), Some(&1));
+
+    // second removal drives the count to zero and must prune the entry
+    banned_peers.remove_banned_peer(std::iter::once(ip));
+    assert!(!banned_peers.banned_peers_by_ip.contains_key(&ip));
+}


### PR DESCRIPTION
fix(network-libp2p): prune zero-count `banned_peers_by_ip` keys (#829)

## Summary

`BannedPeers::remove_banned_peer` decrements `banned_peers_by_ip[ip]` but never deletes the key when the count returns to zero, so the map grows monotonically with the cumulative set of distinct IPs that have ever hosted a banned peer.  On a RAM-capped node this is an unbounded leak: an attacker rotating source IPs (cheap under IPv6), or ordinary long-run churn, leaves a permanent `IpAddr -> 0` entry per distinct IP, ending in an eventual OOM-kill / restart loop.  Fixes #829.

This is distinct from #809 / #818, which corrected the `total` over-decrement;  that fix left the per-IP zero-count entries in place.

## Change

In `remove_banned_peer`, delete the entry once its decremented count reaches 0, preserving the existing "return the IP to the sender iff it is no longer banned" semantics.  The two-arm `match` on `Option` is replaced with `get_mut().map(...).is_some_and(...)` combinators, and the return decision is computed from the decremented count as `count <= BANNED_PEERS_PER_IP_THRESHOLD` (exactly the old `!self.ip_banned(ip)`), so no second map lookup is needed.

- The returned `Vec<IpAddr>` is unchanged for every reachable count transition (3->2, 2->1, 1->0, absent key).
- Entries at count >= 1 are retained; only count-0 entries (which carry no information — `ip_banned` is already false for them) are dropped.

## Testing

- `test_remove_banned_peer_prunes_zero_count_keys`: ban one peer on each of 64 distinct IPs, unban all, assert `banned_peers_by_ip` shrinks back to empty (fails against the pre-fix code, which leaves 64 lingering zero-count keys).
- `test_remove_banned_peer_keeps_entry_until_zero`: two peers share an IP;  assert the entry is retained after the first removal (count 1) and pruned only when the second removal drives it to 0.
- All existing `banned_peers` tests still pass (`cargo nextest run -p tn-network-libp2p banned_peers`: 13 passed).

## Checklist
- [x] Delete zero-count keys in `remove_banned_peer`
- [x] Regression test: ban then unban across many distinct IPs, assert the map shrinks back
- [x] Regression test: entry retained above zero, pruned only at zero
- [x] `make fmt` + nightly clippy clean
