### PR TITLE
test: reserve test ports from per-nextest-slot windows (#830)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,7 +24,13 @@ filter = "package(e2e-tests)"
 test-group = "e2e"
 slow-timeout = { period = "720s", terminate-after = 3 }
 
+# The cross-process slot allocator (tn_types::helpers) closes the ephemeral-port race,
+# so e2e tests no longer need retries to mask it. Real regressions now surface instead of
+# being silently retried away. The allocator's degraded edges (window exhausted, slot
+# beyond the band's capacity) announce themselves on stderr, so a failure they cause is
+# attributable in the captured output. Other packages keep the profile-wide retries = 2.
 [[profile.ci.overrides]]
 filter = "package(e2e-tests)"
 test-group = "e2e"
+retries = 0
 slow-timeout = { period = "720s", terminate-after = 3 }

--- a/crates/types/src/helpers.rs
+++ b/crates/types/src/helpers.rs
@@ -2,12 +2,43 @@
 
 use parking_lot::Mutex;
 use secp256k1::PublicKey;
-use std::net::{TcpListener, UdpSocket};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    net::{TcpListener, UdpSocket},
+    sync::OnceLock,
+};
 
+/// Number of probe attempts before giving up on finding a free port.
 const MAX_RETRIES: u32 = 1000;
 
-/// Track any ports we have given out already to avoid TOCTOU issues with port generation.
+/// Ports this process has already handed out.
+///
+/// This guard is **per-process only**. `cargo nextest` runs each test in its own
+/// process, and each process starts with a fresh, empty `USED_PORTS`, so this set
+/// cannot stop two concurrent test processes from being handed the same freed port.
+/// Cross-process disjointness is provided separately by [`slot_window`], which carves
+/// a fixed port band into non-overlapping windows keyed on the nextest slot. Keep both:
+/// `USED_PORTS` dedups *within* a process, the slot window dedups *across* processes.
 static USED_PORTS: Mutex<Vec<u16>> = Mutex::new(Vec::new());
+
+/// Lowest port of the cross-process coordination band.
+///
+/// The band sits deliberately **below** the operating system's ephemeral range (Linux
+/// 32768-60999, macOS/IANA 49152-65535). The kernel never auto-assigns a port from this
+/// band to an unrelated process, so once a test process picks a port here nothing else
+/// on the host will race it into the close-then-rebind gap.
+const SLOT_BAND_START: u16 = 16384;
+
+/// One past the highest port of the coordination band (exclusive): `16384..32768`.
+const SLOT_BAND_END: u16 = 32768;
+
+/// Ports reserved per nextest slot. `256 * 64` slots exactly fills the band, and 256
+/// comfortably exceeds the few dozen ports a single e2e test allocates across its nodes.
+const SLOT_WINDOW: u16 = 256;
+
+/// Number of disjoint slot windows the band is divided into.
+const SLOT_COUNT: u16 = (SLOT_BAND_END - SLOT_BAND_START) / SLOT_WINDOW;
 
 /// Represents the type of socket to create
 #[derive(Debug, Clone, Copy)]
@@ -31,18 +62,15 @@ pub enum PortError {
     NoPortsAvailable,
 }
 
-/// Get an available port with the specified configuration
+/// Get an available port with the specified configuration.
+///
+/// When running under `cargo nextest` the port is drawn from this process's slot window
+/// (see [`slot_window`]) so concurrent test processes never collide. Otherwise the port
+/// is a kernel-assigned ephemeral one, preserving the historical behavior for plain
+/// `cargo test` and non-test callers.
 pub fn get_available_port(config: &PortConfig) -> Result<u16, PortError> {
-    for _ in 0..config.max_retries {
-        if let Ok(port) = get_ephemeral_port(&config.host, config.socket_type) {
-            let mut used_ports = USED_PORTS.lock();
-            if !used_ports.contains(&port) {
-                used_ports.push(port);
-                return Ok(port);
-            }
-        }
-    }
-    Err(PortError::NoPortsAvailable)
+    nextest_global_slot()
+        .map_or_else(|| reserve_ephemeral_port(config), |slot| reserve_windowed_port(config, slot))
 }
 
 impl From<std::io::Error> for PortError {
@@ -51,17 +79,173 @@ impl From<std::io::Error> for PortError {
     }
 }
 
-/// Get an ephemeral port for the specified socket type
-fn get_ephemeral_port(host: &str, socket_type: SocketType) -> std::io::Result<u16> {
+/// This process's nextest global slot, if it is running under `cargo nextest` and the
+/// slot fits the coordination band. Memoized, so a degraded edge below announces itself
+/// once per process rather than once per allocated port.
+///
+/// `NEXTEST_TEST_GLOBAL_SLOT` is unique among the test processes running *at the same
+/// time*, which is exactly the set that must not be handed overlapping ports. Returns
+/// `None` under a plain `cargo test` or any non-nextest invocation, and for slots beyond
+/// the band's capacity (see [`slot_fits_band`]). A value that is present but does not
+/// parse also returns `None`, announced on stderr: unlike the absent-var case it means
+/// the process *is* under nextest but degrades to ephemeral ports anyway, and that must
+/// stay attributable in captured output.
+///
+/// Child processes spawned by a test (the nodes the e2e tests launch) inherit the
+/// variable; a child that ever called this allocator would compute its parent's window
+/// and offset with a fresh claim set, a deterministic same-window race. No spawned-node
+/// code path calls it today; if one ever does, clear `NEXTEST_*` from the child's
+/// environment at the spawn site first.
+fn nextest_global_slot() -> Option<u16> {
+    static SLOT: OnceLock<Option<u16>> = OnceLock::new();
+    *SLOT.get_or_init(|| {
+        let raw = std::env::var("NEXTEST_TEST_GLOBAL_SLOT").ok()?;
+        raw.parse()
+            .ok()
+            .or_else(|| {
+                eprintln!(
+                    "tn_types::helpers: NEXTEST_TEST_GLOBAL_SLOT {raw:?} did not parse as \
+                     a slot number; using kernel-assigned ephemeral ports (cross-process \
+                     port race possible)"
+                );
+                None
+            })
+            .filter(slot_fits_band)
+    })
+}
+
+/// Whether `slot` fits the coordination band's capacity, announcing on stderr when it
+/// does not.
+///
+/// Wrapping an out-of-capacity slot onto an in-use window would have two concurrent
+/// processes probe the same ports deterministically, which is worse than the historical
+/// kernel-assigned behavior. So past [`SLOT_COUNT`] concurrently running port-allocating
+/// tests, the excess processes degrade to ephemeral ports (rarely-colliding) instead,
+/// and say so, keeping any resulting failure attributable.
+fn slot_fits_band(slot: &u16) -> bool {
+    let fits = *slot < SLOT_COUNT;
+    if !fits {
+        eprintln!(
+            "tn_types::helpers: nextest global slot {slot} exceeds the band's \
+             {SLOT_COUNT}-slot capacity; using a kernel-assigned ephemeral port \
+             (cross-process port race possible)"
+        );
+    }
+    fits
+}
+
+/// The half-open `[start, end)` port window reserved for nextest global `slot`.
+///
+/// Windows are disjoint for distinct `slot % SLOT_COUNT`, so two test processes with
+/// different global slots draw from non-overlapping ranges. [`nextest_global_slot`]
+/// rejects slots beyond the band's capacity before this is reached; the modulo only
+/// keeps the function total.
+fn slot_window(slot: u16) -> (u16, u16) {
+    let lane = slot % SLOT_COUNT;
+    let start = SLOT_BAND_START + lane * SLOT_WINDOW;
+    (start, start + SLOT_WINDOW)
+}
+
+/// Reserve a port from this process's slot window, probing each port in turn.
+///
+/// The probe is bounded by the window itself, not `config.max_retries`; that field
+/// governs only the ephemeral allocator.
+///
+/// Falls back to a kernel-assigned ephemeral port only if the whole window is saturated,
+/// so a heavily loaded host degrades to the old behavior instead of failing outright.
+/// The fallback reopens the cross-process race this allocator exists to close, so it is
+/// announced on stderr: with the e2e retries at 0 a resulting flake fails hard, and the
+/// message ties that failure back to the exhausted window instead of leaving a mystery.
+fn reserve_windowed_port(config: &PortConfig, slot: u16) -> Result<u16, PortError> {
+    let (start, end) = slot_window(slot);
+    let offset = run_offset();
+    (0..SLOT_WINDOW)
+        .map(|i| start + ((offset + i) % SLOT_WINDOW))
+        .find(|&port| {
+            is_unclaimed(port) && can_bind(&config.host, config.socket_type, port) && claim(port)
+        })
+        .map_or_else(
+            || {
+                eprintln!(
+                    "tn_types::helpers: slot window {start}..{end} exhausted; falling back to \
+                     a kernel-assigned ephemeral port (cross-process port race possible)"
+                );
+                reserve_ephemeral_port(config)
+            },
+            Ok,
+        )
+}
+
+/// Per-run starting offset inside a slot window.
+///
+/// Slot windows are disjoint within one nextest run, but a second nextest invocation
+/// running concurrently on the same host (say, e2e suites in two worktrees) reuses the
+/// same slot numbers and therefore the same windows. Probing every window from its base
+/// would have both runs race deterministically for the same first port, which is worse
+/// than the kernel-assigned behavior this allocator replaces. Starting the probe at an
+/// offset hashed from `NEXTEST_RUN_ID` (fixed within a run, different across runs) and
+/// wrapping cyclically through the window keeps concurrent runs on separate stretches;
+/// they can only collide after one run's allocations wrap into the other's stretch.
+fn run_offset() -> u16 {
+    std::env::var("NEXTEST_RUN_ID").ok().map_or(0, |id| {
+        let mut hasher = DefaultHasher::new();
+        id.hash(&mut hasher);
+        u16::try_from(hasher.finish() % u64::from(SLOT_WINDOW)).unwrap_or(0)
+    })
+}
+
+/// Reserve a kernel-assigned ephemeral port (bind `:0`, record it, hand back the number).
+///
+/// This is the historical allocator: it retains the close-then-rebind gap and is only
+/// reached off the nextest path or when a slot window is exhausted.
+fn reserve_ephemeral_port(config: &PortConfig) -> Result<u16, PortError> {
+    (0..config.max_retries)
+        .find_map(|_| {
+            bind_ephemeral(&config.host, config.socket_type).ok().filter(|&port| claim(port))
+        })
+        .ok_or(PortError::NoPortsAvailable)
+}
+
+/// Whether `port` is absent from the per-process guard, without inserting it.
+///
+/// The windowed probe walks the same deterministic sequence on every allocation, so
+/// without this pre-check each later allocation would bind-and-drop every port the
+/// process already handed out ([`claim`] rejects them only after the probe). That
+/// transient bind can land at the exact moment the port's consumer binds for real and
+/// fail it; checking the guard first skips owned ports without touching a socket. The
+/// gap between this check and [`claim`] is closed by `claim` re-checking under the lock.
+fn is_unclaimed(port: u16) -> bool {
+    !USED_PORTS.lock().contains(&port)
+}
+
+/// Record `port` in the per-process guard, returning `false` if it was already taken.
+fn claim(port: u16) -> bool {
+    let mut used_ports = USED_PORTS.lock();
+    if used_ports.contains(&port) {
+        false
+    } else {
+        used_ports.push(port);
+        true
+    }
+}
+
+/// Whether `port` can currently be bound on `host` for `socket_type`.
+///
+/// The listener is dropped immediately, so this only reports availability at the instant
+/// of the probe. Within the slot band that is safe: no concurrent test process shares the
+/// window and the kernel will not auto-assign the port to anything else.
+fn can_bind(host: &str, socket_type: SocketType, port: u16) -> bool {
     match socket_type {
-        SocketType::Tcp => {
-            let listener = TcpListener::bind((host, 0))?;
-            Ok(listener.local_addr()?.port())
-        }
-        SocketType::Udp => {
-            let socket = UdpSocket::bind((host, 0))?;
-            Ok(socket.local_addr()?.port())
-        }
+        SocketType::Tcp => TcpListener::bind((host, port)).is_ok(),
+        SocketType::Udp => UdpSocket::bind((host, port)).is_ok(),
+    }
+}
+
+/// Bind an ephemeral (`:0`) port and return the number the kernel assigned.
+fn bind_ephemeral(host: &str, socket_type: SocketType) -> std::io::Result<u16> {
+    match socket_type {
+        SocketType::Tcp => Ok(TcpListener::bind((host, 0))?.local_addr()?.port()),
+        SocketType::Udp => Ok(UdpSocket::bind((host, 0))?.local_addr()?.port()),
     }
 }
 
@@ -101,4 +285,85 @@ pub fn deconstruct_nonce(nonce: u64) -> (u32, u32) {
     let epoch = (nonce >> 32) as u32; // Extract the upper 32 bits
     let round = nonce as u32; // Extract the lower 32 bits (truncates upper bits)
     (epoch, round)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_windows_are_disjoint_across_slots() {
+        for a in 0..SLOT_COUNT {
+            for b in (a + 1)..SLOT_COUNT {
+                let (a0, a1) = slot_window(a);
+                let (b0, b1) = slot_window(b);
+                assert!(
+                    a1 <= b0 || b1 <= a0,
+                    "slot {a} window {a0}..{a1} overlaps slot {b} window {b0}..{b1}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn slot_windows_stay_within_band() {
+        for slot in 0..SLOT_COUNT {
+            let (start, end) = slot_window(slot);
+            assert!(start >= SLOT_BAND_START, "slot {slot} start {start} below band");
+            assert!(end <= SLOT_BAND_END, "slot {slot} end {end} above band");
+            assert_eq!(end - start, SLOT_WINDOW, "slot {slot} window mis-sized");
+        }
+    }
+
+    #[test]
+    fn slot_windows_wrap_beyond_capacity() {
+        assert_eq!(slot_window(0), slot_window(SLOT_COUNT));
+        assert_eq!(slot_window(1), slot_window(SLOT_COUNT + 1));
+    }
+
+    #[test]
+    fn out_of_capacity_slots_are_rejected() {
+        assert!(slot_fits_band(&(SLOT_COUNT - 1)), "last in-band slot should fit");
+        assert!(!slot_fits_band(&SLOT_COUNT), "first out-of-band slot should be rejected");
+    }
+
+    #[test]
+    fn windowed_port_comes_from_the_slot_band() {
+        let config = PortConfig {
+            host: "127.0.0.1".to_string(),
+            socket_type: SocketType::Tcp,
+            max_retries: MAX_RETRIES,
+        };
+        // Slot 3 is a real lane a concurrent test process may own; this reservation
+        // bind-probes exactly one free port there and drops it, a bounded, one-shot
+        // overlap accepted for exercising the real probe path.
+        let slot = 3;
+        let port = reserve_windowed_port(&config, slot).expect("a free port in the window");
+        let (start, end) = slot_window(slot);
+        assert!((start..end).contains(&port), "port {port} outside window {start}..{end}");
+    }
+
+    #[test]
+    fn saturated_window_falls_back_to_an_ephemeral_port() {
+        let config = PortConfig {
+            host: "127.0.0.1".to_string(),
+            socket_type: SocketType::Tcp,
+            max_retries: MAX_RETRIES,
+        };
+        // Claim every port in this slot's window up front, so the windowed probe finds
+        // nothing claimable and must fall back. Slot 7 keeps the claims disjoint from the
+        // windows other tests in this process draw from, and the claim pre-filter means
+        // the probe skips every claimed port without binding, so this test touches no
+        // real socket in the band even if a concurrent test process owns slot 7.
+        let slot = 7;
+        let (start, end) = slot_window(slot);
+        (start..end).for_each(|port| {
+            claim(port);
+        });
+        let port = reserve_windowed_port(&config, slot).expect("an ephemeral fallback port");
+        assert!(
+            !(start..end).contains(&port),
+            "port {port} should come from outside the exhausted window {start}..{end}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`get_available_port` (`crates/types/src/helpers.rs`) binds `:0`, records the kernel-assigned
port in the process-local `USED_PORTS` set, drops the listener, and returns the bare number.
The node binds that port later from a spawned thread, so nothing owns the port during the gap.
nextest runs each test in its own process, and each process starts with a fresh `USED_PORTS`,
so the guard cannot stop two concurrent e2e tests (`max-threads = 2`) from being handed the
same freed port inside the close-then-rebind window.  Both node threads then race to bind the
same port; one loses and the test errors or times out.  Full trace in #830.

## Fix

Cross-process coordination via the nextest slot (issue suggested-fix option 3):

- When `NEXTEST_TEST_GLOBAL_SLOT` is set (nextest exports it to every test process, unique
  among tests running at the same time), `get_available_port` draws from a 256-port window
  keyed on the slot: `slot_window(slot) = 16384 + (slot % 64) * 256`, half-open, inside the
  fixed band `16384..32768`.
- Windows are disjoint per slot, so two concurrent test processes can never probe the same
  port.  The band sits deliberately below every OS ephemeral range (Linux 32768..60999,
  macOS/IANA 49152..65535), so the kernel never auto-assigns a band port to an unrelated
  process; only an explicit bind could collide, and nothing else in the test run binds there.
- Ports in the window are probed in order: the per-process guard is checked first, so ports
  already handed out are skipped without touching a socket (a transient probe bind could
  otherwise collide with the earlier port's consumer binding for real), then `can_bind` +
  `claim`.  A fully saturated window falls back to the historical ephemeral allocator instead of failing,
  so a heavily loaded host degrades to the old behavior.  Because degrading reopens the
  cross-process race while `retries = 0` assumes it closed, every degraded edge (window
  exhausted, slot beyond band capacity, `NEXTEST_TEST_GLOBAL_SLOT` present but unparsable)
  is announced on stderr, once per process (the slot lookup is memoized): a failure one
  causes is attributable in the captured test output instead of surfacing as an unexplained
  flake.  Saturation needs a single test process to claim more than 256 ports (nextest runs
  one test per process), so in practice these messages should never appear.
- Slot windows are disjoint within one nextest run, but a second nextest invocation running
  concurrently on the same host reuses the same slot numbers.  So each run probes its window
  cyclically from a starting offset hashed from `NEXTEST_RUN_ID` (fixed within a run,
  different across runs): concurrent runs walk separate stretches of a shared window and can
  only collide after one run's allocations wrap into the other's stretch, instead of racing
  deterministically for the window's first port.
- No `NEXTEST_TEST_GLOBAL_SLOT` (plain `cargo test`, non-test callers): kernel-assigned
  ephemeral ports, exactly the historical behavior.
- `USED_PORTS` is kept as the intra-process dedup and documented as a per-process guard only
  (issue box 4).
- With the race closed, the ci-profile e2e `retries` drop from 2 to 0 (issue box 5) so real
  regressions surface instead of being silently retried away.

Band capacity: the band holds 64 windows, and nextest global slots are dense small integers
assigned from actual concurrency, so exceeding capacity requires 65 simultaneously running
port-allocating test processes (the e2e group, where the port-heavy tests live, caps at
`max-threads = 2`).  A slot past capacity is rejected up front and degrades loudly to the
ephemeral path rather than wrapping onto a window another process is using, where the two
would probe the same ports deterministically.  If CI ever runs that wide, `SLOT_WINDOW` can
shrink (128 ports x 128 slots fills the same band); 256 ports per window comfortably exceeds
the few dozen ports a single e2e test allocates across its nodes.

Not changed here: the issue's alternative fixes (holding the bound listener open through node
startup, or having the node bind `:0` and report back) would remove the gap entirely but
require plumbing listeners/addresses through node startup; the slot allocator closes the
cross-process race without touching node code.  One latent hazard is documented rather than
coded around: spawned node children inherit `NEXTEST_TEST_GLOBAL_SLOT`, so a child code path
that ever called this allocator would compute its parent's window; no such path exists today,
and the doc on `nextest_global_slot` says to clear `NEXTEST_*` at the spawn site if one is
added.

## Tests

- `cargo test -p tn-types`: 92 passed, including 6 new unit tests (window disjointness across
  all slot pairs, band containment, wrap totality, out-of-capacity slot rejection, windowed
  reservation lands in its slot's window regardless of run offset, saturated window falls
  back to an out-of-window port).
- `cargo nextest run -p e2e-tests -E 'test(test_genesis_with_consensus_registry_accounts)'`
  passes with the allocator active (nextest sets `NEXTEST_TEST_GLOBAL_SLOT`, so the e2e path
  draws from the slot band end to end).
- The two port-heaviest ignored tests pass when run concurrently, two processes with the
  allocator active on distinct slots: `cargo nextest run -p e2e-tests --run-ignored all -E
  'test(test_restartstt) or test(test_restarts_observer)'` (2 passed, ~7 min each side by
  side under `max-threads = 2`).
- The pre-fix failure needs two e2e processes to draw the same port in a millisecond window,
  so there is no deterministic fail-before repro; the disjoint windows remove the overlap by
  construction.

Found while verifying, unrelated to this diff: `test_faucet_drip_tel_and_xyz_e2e` (behind
`--features faucet`, not enabled by the CI `nextest run --workspace` invocation) currently
fails during pre-genesis setup at `faucet.rs:224` ("faucet address missing from bundle
state"), before `spawn_local_testnet` allocates any port.  Happy to file it separately.

## Checklist

- [x] cross-process-coordinated allocator keyed on the nextest slot (issue box 3)
- [x] `USED_PORTS` documented as per-process only (issue box 4)
- [x] e2e `retries` back to 0 (issue box 5)
- [x] `cargo +nightly fmt` clean
- [x] `cargo clippy -p tn-types --all-targets` clean (2 pre-existing warnings in
  `committee.rs` / `epoch.rs`, untouched by this diff)
- [x] `cargo test -p tn-types` 92 passed
- [x] concurrent e2e pair green (`test_restartstt` + `test_restarts_observer`, 2/2)

Closes #830.