### PR TITLE
test: use an injectable clock for BannedPeerCache expiry tests

### DIFF
--- a/crates/network-libp2p/src/peers/cache.rs
+++ b/crates/network-libp2p/src/peers/cache.rs
@@ -9,6 +9,56 @@ use std::{
 #[path = "../tests/cache_peers.rs"]
 mod cache_peers;
 
+/// Source of the current [`Instant`] used to timestamp insertions and evaluate expiry.
+///
+/// Production uses [`SystemClock`], which reads the real monotonic clock. Tests inject a manually
+/// advanced clock so expiry is deterministic and does not depend on wall-clock sleeps.
+pub(super) trait Clock {
+    /// Return the current instant.
+    fn now(&self) -> Instant;
+}
+
+/// The real monotonic clock backed by [`Instant::now`].
+#[derive(Debug)]
+pub(super) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// A manually advanced [`Clock`] for deterministic expiry tests.
+///
+/// The instant only moves forward when [`ManualClock::advance`] is called, so tests control expiry
+/// precisely without `std::thread::sleep`. The handle is cheaply cloneable and shares its
+/// underlying instant, letting a test advance the same clock the cache reads.
+#[cfg(test)]
+#[derive(Debug, Clone)]
+struct ManualClock {
+    now: std::rc::Rc<std::cell::Cell<Instant>>,
+}
+
+#[cfg(test)]
+impl ManualClock {
+    /// Create a clock anchored at the current instant.
+    fn new() -> Self {
+        ManualClock { now: std::rc::Rc::new(std::cell::Cell::new(Instant::now())) }
+    }
+
+    /// Advance the clock by `duration`.
+    fn advance(&self, duration: Duration) {
+        self.now.set(self.now.get() + duration);
+    }
+}
+
+#[cfg(test)]
+impl Clock for ManualClock {
+    fn now(&self) -> Instant {
+        self.now.get()
+    }
+}
+
 /// The element representing a temporarily banend peer
 #[derive(Debug)]
 struct Element<Key> {
@@ -23,22 +73,41 @@ struct Element<Key> {
 /// This implementation requires manually managing the cache.
 /// The cache is intended to only be updated during the peer manager's heartbeat interval.
 #[derive(Debug)]
-pub(super) struct BannedPeerCache<Key> {
+pub(super) struct BannedPeerCache<Key, C = SystemClock> {
     /// The duplicate cache.
     map: HashSet<Key>,
     /// A list of keys sorted by the time they were inserted.
     list: VecDeque<Element<Key>>,
     /// The duration an element remains in the cache.
     duration: Duration,
+    /// The clock used to timestamp insertions and evaluate expiry.
+    clock: C,
 }
 
-impl<Key> BannedPeerCache<Key>
+impl<Key> BannedPeerCache<Key, SystemClock>
 where
     Key: Eq + std::hash::Hash + Clone,
 {
-    /// Create a new instance of `Self`.
+    /// Create a new instance of `Self` backed by the real system clock.
     pub(super) fn new(duration: Duration) -> Self {
-        BannedPeerCache { map: HashSet::default(), list: VecDeque::new(), duration }
+        BannedPeerCache {
+            map: HashSet::default(),
+            list: VecDeque::new(),
+            duration,
+            clock: SystemClock,
+        }
+    }
+}
+
+impl<Key, C> BannedPeerCache<Key, C>
+where
+    Key: Eq + std::hash::Hash + Clone,
+    C: Clock,
+{
+    /// Create a new instance of `Self` backed by the provided clock.
+    #[cfg(test)]
+    pub(super) fn with_clock(duration: Duration, clock: C) -> Self {
+        BannedPeerCache { map: HashSet::default(), list: VecDeque::new(), duration, clock }
     }
 
     /// Insert a key and return true if the key does not already exist.
@@ -50,11 +119,11 @@ where
 
         // add the new key to the list, if it doesn't already exist.
         if is_new {
-            self.list.push_back(Element { key, inserted: Instant::now() });
+            self.list.push_back(Element { key, inserted: self.clock.now() });
         } else {
             let position = self.list.iter().position(|e| e.key == key).expect("Key is not new");
             let mut element = self.list.remove(position).expect("Position is not occupied");
-            element.inserted = Instant::now();
+            element.inserted = self.clock.now();
             self.list.push_back(element);
         }
 
@@ -86,7 +155,7 @@ where
             return Vec::new();
         }
 
-        let now = Instant::now();
+        let now = self.clock.now();
         let mut removed_elements = Vec::new();
         // remove any expired results
         while let Some(element) = self.list.pop_front() {

--- a/crates/network-libp2p/src/tests/cache_peers.rs
+++ b/crates/network-libp2p/src/tests/cache_peers.rs
@@ -27,7 +27,8 @@ fn test_cache_entries_exist() {
 
 #[test]
 fn test_remove_expired() {
-    let mut cache = BannedPeerCache::new(Duration::from_millis(100));
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
@@ -36,10 +37,10 @@ fn test_remove_expired() {
     assert!(cache.insert(peer1), "Peer1 should be newly inserted");
     assert!(cache.insert(peer2), "Peer2 should be newly inserted");
 
-    // wait for a short time, but not enough to expire
-    std::thread::sleep(Duration::from_millis(25));
+    // advance the clock, but not enough to expire anything
+    clock.advance(Duration::from_millis(25));
 
-    // insert third peer after a delay
+    // insert third peer after the delay
     assert!(cache.insert(peer3), "Peer3 should be newly inserted");
 
     // assert no peers expired yet
@@ -49,12 +50,12 @@ fn test_remove_expired() {
     // explicitly remove peer2
     assert!(cache.remove(&peer2), "Peer2 should be successfully removed");
 
-    // wait long enough for peer1 and peer2 to expire, but not peer3
-    std::thread::sleep(Duration::from_millis(76));
+    // advance past peer1's 100ms expiry, but not peer3's (inserted 25ms later)
+    clock.advance(Duration::from_millis(76));
 
-    // peer1 should be expired (inserted ~101ms ago)
+    // peer1 was inserted 101ms ago -> expired
     // peer2 already removed
-    // peer3 should still be valid (inserted ~76ms ago)
+    // peer3 was inserted 76ms ago -> still valid
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Peer1 should be expired");
 
@@ -64,8 +65,8 @@ fn test_remove_expired() {
     assert!(!expired.contains(&peer2), "Peer2 already removed");
     assert!(!expired.contains(&peer3), "Peer3 is not expired yet");
 
-    // wait for peer3 to expire
-    std::thread::sleep(Duration::from_millis(25));
+    // advance until peer3 expires (now 126ms after its insertion)
+    clock.advance(Duration::from_millis(25));
 
     // Now peer3 should be expired as well
     let expired = cache.heartbeat();
@@ -80,7 +81,8 @@ fn test_remove_expired() {
 #[test]
 fn test_remove_expired_with_reinsertions() {
     // create a cache with a short expiration time
-    let mut cache = BannedPeerCache::new(Duration::from_millis(100));
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
 
@@ -88,14 +90,14 @@ fn test_remove_expired_with_reinsertions() {
     cache.insert(peer1);
     cache.insert(peer2);
 
-    // wait some time
-    std::thread::sleep(Duration::from_millis(60));
+    // advance some time
+    clock.advance(Duration::from_millis(60));
 
     // reinsert peer1 - this should reset the expiration timer
     assert!(!cache.insert(peer1), "Peer1 already inserted, but returned true");
 
-    // wait another period that would expire peer2 but not the reinstated peer1
-    std::thread::sleep(Duration::from_millis(50));
+    // advance another period that would expire peer2 but not the reinstated peer1
+    clock.advance(Duration::from_millis(50));
 
     // assert only peer2 expired
     let expired = cache.heartbeat();
@@ -103,8 +105,8 @@ fn test_remove_expired_with_reinsertions() {
     assert!(expired.contains(&peer2), "Peer2 should be expired");
     assert!(!expired.contains(&peer1), "Peer1 should not be expired due to reinsertion");
 
-    // wait for peer1 to expire
-    std::thread::sleep(Duration::from_millis(60));
+    // advance until the reinserted peer1 expires
+    clock.advance(Duration::from_millis(60));
 
     // assert peer1 expired
     let expired = cache.heartbeat();
@@ -124,35 +126,35 @@ fn test_remove_expired_empty_cache() {
 
 #[test]
 fn test_remove_expired_ordering() {
-    // Use a larger timeout to reduce flakiness
-    let mut cache = BannedPeerCache::new(Duration::from_millis(500));
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(500), clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
     let peer4 = PeerId::random();
 
-    // Insert with larger gaps between insertions
+    // insert with gaps between insertions
     cache.insert(peer1);
-    std::thread::sleep(Duration::from_millis(100));
+    clock.advance(Duration::from_millis(100));
     cache.insert(peer2);
-    std::thread::sleep(Duration::from_millis(100));
+    clock.advance(Duration::from_millis(100));
     cache.insert(peer3);
-    std::thread::sleep(Duration::from_millis(100));
+    clock.advance(Duration::from_millis(100));
     cache.insert(peer4);
 
-    // Wait with more buffer time
-    std::thread::sleep(Duration::from_millis(210)); // Wait for peer1 to expire
+    // advance until peer1 (inserted 510ms ago) passes its 500ms expiry
+    clock.advance(Duration::from_millis(210));
 
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Only Peer1 should be expired");
     assert_eq!(expired[0], peer1, "Peer1 should be expired");
 
-    std::thread::sleep(Duration::from_millis(100)); // Wait for peer2 to expire
+    clock.advance(Duration::from_millis(100)); // advance until peer2 expires
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 1, "Only peer2 should be expired");
     assert_eq!(expired[0], peer2, "Peer2 should be expired");
 
-    std::thread::sleep(Duration::from_millis(200)); // Wait for peer3 and peer4 to expire
+    clock.advance(Duration::from_millis(200)); // advance until peer3 and peer4 expire
     let expired = cache.heartbeat();
     assert_eq!(expired.len(), 2, "Peer3 and Peer4 should be expired");
     assert_eq!(expired[0], peer3, "The first expired element should be peer3");


### PR DESCRIPTION
## Summary

Fixes the flaky `BannedPeerCache` expiry tests reported in #834 by removing their dependence on wall-clock `std::thread::sleep`.

The tests measured a 100ms TTL with real sleeps, so a scheduling stall on a single sleep could push a peer past its expiry boundary a heartbeat early and fail an exact `expired.len()` assertion.  Because `sleep` only ever overshoots, a ~24ms overshoot concentrated on one sleep was enough to flip `test_remove_expired`.

## Changes

- Add a `Clock` trait (`now() -> Instant`) that timestamps insertions and drives expiry in `BannedPeerCache`.
- Wire production through a defaulted type parameter `BannedPeerCache<Key, C = SystemClock>`, where `SystemClock` returns `Instant::now()`. `manager.rs` (`BannedPeerCache<PeerId>` / `BannedPeerCache::new`) needs no changes and production behavior is identical.
- Add a `#[cfg(test)]` `ManualClock` (a cheaply cloneable `Rc<Cell<Instant>>`) and a `#[cfg(test)] with_clock` constructor, so the test clock adds zero production API surface.
- Rewrite `test_remove_expired`, `test_remove_expired_with_reinsertions`, and `test_remove_expired_ordering` to advance the fake clock deterministically and drop every `std::thread::sleep`. The tests now run instantly and no longer depend on scheduler timing.

## Verification

- `cargo nextest run -p tn-network-libp2p` cache tests: 5 passed, 0 failed
- `cargo clippy -p tn-network-libp2p --all-targets --all-features` (stable + nightly-2026-03-20): 0 warnings
- `cargo +nightly-2026-03-20 fmt`: no changes
