### PR TITLE
Fork consensus registry bls precompile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,9 @@ docker-login:
 	gcloud auth configure-docker us-docker.pkg.dev ;
 
 # build and push latest adiri image for amd64 and arm64
+# CARGO_FEATURES=adiri compiles in the testnet fork logic (ConsensusRegistry fork, ADIRI_DUP_BATCH_EPOCH).
 docker-adiri:
-	docker buildx build -f ./etc/Dockerfile --platform linux/amd64,linux/arm64 --no-cache -t us-docker.pkg.dev/telcoin-network/tn-public/adiri:$(TAG) . --push ;
+	docker buildx build -f ./etc/Dockerfile --build-arg CARGO_FEATURES=adiri --platform linux/amd64,linux/arm64 --no-cache -t us-docker.pkg.dev/telcoin-network/tn-public/adiri:$(TAG) . --push ;
 
 # push local adiri:latest to the gcloud artifact registry
 docker-push:

--- a/bin/telcoin-network/Cargo.toml
+++ b/bin/telcoin-network/Cargo.toml
@@ -14,5 +14,12 @@ exclude.workspace = true
 telcoin-network-cli = { workspace = true }
 tn-node = { workspace = true }
 
+[features]
+# Adiri-testnet build. Propagates the `adiri` feature through the whole node graph so the
+# testnet-only fork logic (`tn_types::forks`, the ConsensusRegistry fork, `ADIRI_DUP_BATCH_EPOCH`)
+# is actually compiled into the binary. Enabled for the `docker-adiri` image via a Docker build arg;
+# default/mainnet builds omit it. See `tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH`.
+adiri = ["telcoin-network-cli/adiri", "tn-node/adiri"]
+
 [lints]
 workspace = true

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -38,4 +38,5 @@ workspace = true
 
 [features]
 default = []
+# Adiri testnet fork logic gated on `tn_types::forks` — pull in the constants.
 adiri = ["tn-types/adiri"]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -39,6 +39,7 @@ assert_matches = { workspace = true }
 [features]
 default = []
 test-utils = ["dep:eyre"]
+# Adiri testnet fork logic gated on `tn_types::forks` — pull in the constants.
 adiri = ["tn-types/adiri"]
 
 [lints]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -40,6 +40,17 @@ reth-metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[features]
+# Propagate the adiri-testnet feature to every downstream crate that has adiri-gated fork logic, so
+# a `--features adiri` node build actually compiles it in. tn-node has no adiri code of its own.
+adiri = [
+    "tn-engine/adiri",
+    "tn-executor/adiri",
+    "tn-reth/adiri",
+    "tn-storage/adiri",
+    "tn-types/adiri",
+]
+
 [dev-dependencies]
 metrics-util = { workspace = true }
 rand = { workspace = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -47,6 +47,7 @@ redb = []
 reth-libmdbx = ["dep:reth-libmdbx", "dep:page_size"]
 default = ["reth-libmdbx"]
 test-utils = []
+# Adiri testnet fork logic gated on `tn_types::forks` — pull in the constants.
 adiri = ["tn-types/adiri"]
 
 [lints]

--- a/crates/telcoin-network-cli/Cargo.toml
+++ b/crates/telcoin-network-cli/Cargo.toml
@@ -73,7 +73,8 @@ vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl"] }
 workspace = true
 
 [features]
-adiri = []
 # Enables the insecure key-generation twins (weak PBKDF2 rounds) for tests.
 # Purely additive: it must never change how the secure paths behave.
 test-utils = ["tn-config/test-utils"]
+# Adiri testnet: propagate to the node graph + this crate's directly-gated fork logic.
+adiri = ["tn-node/adiri", "tn-reth/adiri", "tn-storage/adiri", "tn-types/adiri"]

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -76,7 +76,7 @@ tn-reth = { workspace = true, features = ["test-utils"] }
 default = []
 faucet = []
 test-utils = ["dep:secp256k1"]
-adiri = ["faucet"]
+adiri = ["faucet", "tn-types/adiri"]
 
 [lints]
 workspace = true

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -297,12 +297,27 @@ where
             .map_err(|e| TnRethError::EVMCustom(format!("registry account read failed: {e}")))?
             .unwrap_or_default();
 
-        // Log the pre-swap code hash so operators can audit at the boundary that the swap ran over
-        // the expected (pre-fork) deployment. The registry is non-upgradeable, so on the live chain
-        // this is the fixed genesis code hash. NOTE: before setting a real
-        // `CONSENSUS_REGISTRY_FORK_EPOCH`, consider gating the swap on a confirmed
-        // expected-old-hash allowlist so an unexpected deployment fails closed rather than
-        // migrating over an incompatible layout.
+        // Fail closed on an unexpected pre-fork deployment. The swap + `migrateValidatorSets()`
+        // assume the exact storage layout of the pinned pre-fork registry code (the registry is
+        // non-upgradeable, so on the live chain this is the fixed genesis code hash); migrating
+        // over anything else risks silent state corruption. Abort the block instead — the check is
+        // a pure function of committed state, so every fork-capable node fails uniformly rather
+        // than diverging.
+        if current.code_hash != tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH {
+            error!(
+                target: "engine",
+                pre_swap_code_hash = %current.code_hash,
+                expected = %tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH,
+                "consensus registry fork failing closed: unexpected pre-fork registry code",
+            );
+            return Err(TnRethError::EVMCustom(format!(
+                "consensus registry fork failing closed: pre-swap code hash {} does not match \
+                 the pinned pre-fork deployment {}",
+                current.code_hash,
+                tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH,
+            )));
+        }
+
         debug!(
             target: "engine",
             pre_swap_code_hash = %current.code_hash,

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -371,10 +371,14 @@ where
         // Read back the rebuilt eligible count for an operational confirmation log. Best-effort and
         // deliberately non-fatal: the migration is already committed above, so a hiccup on this
         // cosmetic read must not abort the block (which would discard a valid, deterministic
-        // migration). Pure read — state is not committed.
+        // migration) — and must not alarm at `error!` either, hence the `try_` variant + `debug!`.
+        // Pure read — state is not committed.
         let calldata = ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into();
         let eligible = self
-            .read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)
+            .try_read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)
+            .inspect_err(|e| {
+                debug!(target: "engine", "non-fatal eligible-count readback after migration failed: {e}");
+            })
             .ok()
             .and_then(|data| <U256 as alloy::sol_types::SolValue>::abi_decode(&data).ok());
 
@@ -579,34 +583,44 @@ where
         Ok(validators)
     }
 
-    /// Read state on-chain.
+    /// Read state on-chain, logging any failure at `error!` level.
+    ///
+    /// Thin wrapper over [`Self::try_read_state_on_chain`] for consensus-critical reads, where a
+    /// failure aborts the block and warrants an operator-facing error log.
     fn read_state_on_chain(
         &mut self,
         caller: Address,
         contract: Address,
         calldata: Bytes,
     ) -> TnRethResult<Bytes> {
+        self.try_read_state_on_chain(caller, contract, calldata).inspect_err(|e| {
+            error!(target: "engine", ?caller, ?contract, "failed to read state on chain: {e}");
+        })
+    }
+
+    /// Read state on-chain without logging failures.
+    ///
+    /// The two failure cases (the system call itself erroring vs an unsuccessful execution
+    /// result) stay distinguishable through the error strings. Callers pick the log level their
+    /// context warrants: consensus-critical reads go through [`Self::read_state_on_chain`]
+    /// (`error!`), best-effort reads log at `debug!`.
+    fn try_read_state_on_chain(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        calldata: Bytes,
+    ) -> TnRethResult<Bytes> {
         // read from state
-        let res = match self.evm.transact_system_call(caller, contract, calldata) {
-            Ok(res) => res,
-            Err(e) => {
-                // fatal error
-                error!(target: "engine", ?caller, ?contract, "failed to read state on chain: {}", e);
-                return Err(TnRethError::EVMCustom(format!("failed to read state on chain: {e}")));
-            }
-        };
+        let res = self
+            .evm
+            .transact_system_call(caller, contract, calldata)
+            .map_err(|e| TnRethError::EVMCustom(format!("failed to read state on chain: {e}")))?;
 
         // retrieve data from execution result
-        let data = match res.result {
-            ExecutionResult::Success { output, .. } => output.into_data(),
-            e => {
-                // fatal error
-                error!(target: "engine", "error reading state on chain: {:?}", e);
-                return Err(TnRethError::EVMCustom(format!("error reading state on chain: {e:?}")));
-            }
-        };
-
-        Ok(data)
+        match res.result {
+            ExecutionResult::Success { output, .. } => Ok(output.into_data()),
+            e => Err(TnRethError::EVMCustom(format!("error reading state on chain: {e:?}"))),
+        }
     }
 
     /// Return the next committee size.

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -800,13 +800,15 @@ where
             // the remainder of this very block.
             //
             // This MUST run BEFORE the rewards/conclude calls below. `shuffle_new_committee`
-            // (inside `apply_closing_epoch_contract_call`) reads the committee-eligible
-            // pool via `getValidatorsInfo` — the post-refactor ABI absent from the
-            // pre-fork testnet code — and the new `concludeEpoch` guards the committee
-            // size against the cached `eligibleValidatorCount`. Both only work once the
-            // code is swapped and `migrateValidatorSets` has populated the sets, so the
-            // fork leads. Reward math and the epoch transition then run on the new code
-            // over the byte-identical preserved storage.
+            // (inside `apply_closing_epoch_contract_call`) routes its committee-pool read
+            // by the registry's code hash (`read_committee_eligible_pool`): swapping first
+            // flips that gate to the post-fork `getValidatorsInfo` union for the remainder
+            // of this very block, and the new `concludeEpoch` guards the committee size
+            // against the cached `eligibleValidatorCount` that only `migrateValidatorSets`
+            // populates — so the fork leads. Reward math and the epoch transition then run
+            // on the new code over the byte-identical preserved storage. (Every epoch close
+            // BEFORE this boundary sees the pre-fork code hash and takes the gate's legacy
+            // branch instead, keeping pre-fork history re-executable on this same binary.)
             //
             // Both the production and replay paths reach this with an identical `ctx`, so the
             // resulting `state_root` is byte-identical across the fleet.

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -227,6 +227,146 @@ where
         Ok(())
     }
 
+    /// The upgraded `ConsensusRegistry` runtime bytecode and its code hash, sourced from the same
+    /// embedded artifact genesis deploys (`CONSENSUS_REGISTRY_JSON` `deployedBytecode.object`).
+    ///
+    /// Materialized once. The embedded artifact is a compile-time `include_str!` constant (the same
+    /// bytes genesis generation decodes, and exercised by the fork unit test), so a decode failure
+    /// here is a corrupt build — uniform across the fleet — not a live-node runtime condition;
+    /// hence `expect` rather than a fallible return.
+    #[cfg(feature = "adiri")]
+    fn consensus_registry_runtime_code() -> &'static (reth_revm::bytecode::Bytecode, B256) {
+        use reth_revm::bytecode::Bytecode;
+        use std::sync::LazyLock;
+
+        static CODE: LazyLock<(Bytecode, B256)> = LazyLock::new(|| {
+            let value = crate::RethEnv::fetch_value_from_json_str(
+                crate::CONSENSUS_REGISTRY_JSON,
+                Some("deployedBytecode.object"),
+            )
+            .expect("embedded consensus registry artifact json is valid");
+            let hex_str = value.as_str().expect("registry deployedBytecode.object is a string");
+            let raw =
+                alloy::hex::decode(hex_str).expect("registry deployedBytecode.object is valid hex");
+            let bytecode = Bytecode::new_raw(raw.into());
+            let code_hash = bytecode.hash_slow();
+            (bytecode, code_hash)
+        });
+
+        &CODE
+    }
+
+    /// Apply the in-protocol `ConsensusRegistry` fork.
+    ///
+    /// Swaps the deployed registry runtime bytecode to the upgraded version — preserving the
+    /// account's balance, nonce, and **all** existing storage (the new state is a clean append, so
+    /// the swap rewrites only the account-code leaf) — then runs the one-time
+    /// `migrateValidatorSets()` that back-fills the appended per-status `validatorSets` and cached
+    /// `eligibleValidatorCount` from the preserved `currentStatus` source of truth.
+    ///
+    /// Fires exactly once, from the epoch-closing block that concludes
+    /// `CONSENSUS_REGISTRY_FORK_EPOCH - 1`, as the FIRST step of that block's close-epoch handling
+    /// — before `applyIncentives`/`concludeEpoch`, which then run on the swapped-in code with
+    /// the migrated sets (the new committee read and eligible-count guard require them). From
+    /// this block onward every node runs on the new code with populated sets.
+    ///
+    /// Determinism: the production path (`context_for_next_block`) and the replay path
+    /// (`context_for_block`) build an identical `ctx.nonce`/`ctx.close_epoch` from the same
+    /// `ConsensusOutput`, and this routine is a pure function of the committed state plus the
+    /// embedded artifact, so every node re-derives a byte-identical `state_root`.
+    ///
+    /// Fatal on failure — a partial or failed migration diverges state across the fleet.
+    #[cfg(feature = "adiri")]
+    fn apply_consensus_registry_fork(&mut self) -> TnRethResult<()> {
+        // revm `Database` trait provides `basic`; imported anonymously to avoid clashing with the
+        // `alloy_evm::Database` already in module scope.
+        use reth_revm::{
+            state::{Account, AccountInfo, AccountStatus, EvmState},
+            Database as _,
+        };
+
+        let (code, code_hash) = Self::consensus_registry_runtime_code().clone();
+
+        // Preserve the registry account's balance + nonce; only the code changes. Reading via
+        // `basic` also loads the account into the `State` cache so the code-only commit below takes
+        // the `change` path (info updated, storage left intact) rather than creating a new account.
+        let current = self
+            .evm
+            .db_mut()
+            .basic(CONSENSUS_REGISTRY_ADDRESS)
+            .map_err(|e| TnRethError::EVMCustom(format!("registry account read failed: {e}")))?
+            .unwrap_or_default();
+
+        // Log the pre-swap code hash so operators can audit at the boundary that the swap ran over
+        // the expected (pre-fork) deployment. The registry is non-upgradeable, so on the live chain
+        // this is the fixed genesis code hash. NOTE: before setting a real
+        // `CONSENSUS_REGISTRY_FORK_EPOCH`, consider gating the swap on a confirmed
+        // expected-old-hash allowlist so an unexpected deployment fails closed rather than
+        // migrating over an incompatible layout.
+        debug!(
+            target: "engine",
+            pre_swap_code_hash = %current.code_hash,
+            new_code_hash = %code_hash,
+            "applying consensus registry fork",
+        );
+
+        // Commit a code-only override: an empty storage map and a plain `Touched` status (never
+        // `Created`/`SelfDestructed`) so no storage slot enters the bundle and the existing storage
+        // root is preserved — only the single account-code leaf changes. The new bytecode is
+        // carried inline on the account info, so it is registered in the bundle's contracts
+        // (for post-restart `code_by_hash`) and is immediately loadable by the migration
+        // call below.
+        let account = Account {
+            info: AccountInfo {
+                balance: current.balance,
+                nonce: current.nonce,
+                code_hash,
+                code: Some(code),
+                ..Default::default()
+            },
+            status: AccountStatus::Touched,
+            ..Default::default()
+        };
+        self.evm.db_mut().commit(EvmState::from_iter([(CONSENSUS_REGISTRY_ADDRESS, account)]));
+
+        // Run the one-time migration. Dispatches to the just-swapped new code.
+        let calldata = ConsensusRegistry::migrateValidatorSetsCall {}.abi_encode().into();
+        let mut res = match self.evm.transact_system_call(
+            SYSTEM_ADDRESS,
+            CONSENSUS_REGISTRY_ADDRESS,
+            calldata,
+        ) {
+            Ok(res) => res,
+            Err(e) => {
+                error!(target: "engine", "error executing consensus registry migration: {:?}", e);
+                return Err(TnRethError::EVMCustom(format!(
+                    "consensus registry migration failed: {e}"
+                )));
+            }
+        };
+        if !res.result.is_success() {
+            error!(target: "engine", "failed consensus registry migration: {:?}", res.result);
+            return Err(TnRethError::EVMCustom("failed consensus registry migration".to_string()));
+        }
+
+        // clean up SYSTEM_ADDRESS — only touched as the system caller, not a real state change
+        res.state.remove(&SYSTEM_ADDRESS);
+        self.evm.db_mut().commit(res.state);
+
+        // Read back the rebuilt eligible count for an operational confirmation log. Best-effort and
+        // deliberately non-fatal: the migration is already committed above, so a hiccup on this
+        // cosmetic read must not abort the block (which would discard a valid, deterministic
+        // migration). Pure read — state is not committed.
+        let calldata = ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into();
+        let eligible = self
+            .read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)
+            .ok()
+            .and_then(|data| <U256 as alloy::sol_types::SolValue>::abi_decode(&data).ok());
+
+        tracing::info!(target: "engine", ?eligible, %code_hash, "consensus registry fork applied");
+        Ok(())
+    }
+
     /// Generate calldata for updating the ConsensusRegistry to conclude the epoch.
     fn generate_conclude_epoch_calldata(&mut self, randomness: B256) -> TnRethResult<Bytes> {
         // shuffle all validators for new committee
@@ -545,6 +685,32 @@ where
         // potentially close epoch boundary
         if let Some(randomness) = self.ctx.close_epoch {
             debug!(target: "engine", ?randomness, "ctx indicates close epoch");
+
+            // In-protocol ConsensusRegistry fork boundary. `deconstruct_nonce(nonce).0` is the
+            // epoch being concluded by this block; firing when `concluding_epoch + 1 ==
+            // FORK_EPOCH` makes the swapped code + migrated per-status sets live for
+            // the remainder of this very block.
+            //
+            // This MUST run BEFORE the rewards/conclude calls below. `shuffle_new_committee`
+            // (inside `apply_closing_epoch_contract_call`) reads the committee-eligible
+            // pool via `getValidatorsInfo` — the post-refactor ABI absent from the
+            // pre-fork testnet code — and the new `concludeEpoch` guards the committee
+            // size against the cached `eligibleValidatorCount`. Both only work once the
+            // code is swapped and `migrateValidatorSets` has populated the sets, so the
+            // fork leads. Reward math and the epoch transition then run on the new code
+            // over the byte-identical preserved storage.
+            //
+            // Both the production and replay paths reach this with an identical `ctx`, so the
+            // resulting `state_root` is byte-identical across the fleet.
+            #[cfg(feature = "adiri")]
+            if tn_types::deconstruct_nonce(self.ctx.nonce).0.checked_add(1)
+                == Some(tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH)
+            {
+                self.apply_consensus_registry_fork().map_err(|e| {
+                    BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+                })?;
+            }
+
             self.apply_consensus_block_rewards(self.ctx.rewards_counter.get_address_counts())
                 .map_err(|e| {
                     BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -411,29 +411,7 @@ where
     fn shuffle_new_committee(&mut self, randomness: B256) -> TnRethResult<Vec<Address>> {
         let new_committee_size = self.next_committee_size()?;
 
-        // Read the committee-eligible validator pool from the consensus registry. The registry's
-        // per-status `getValidators`/`getValidatorsInfo` return ONLY the exact status set; the
-        // committee-eligible pool is the union of `{ Active, PendingActivation, PendingExit }` (the
-        // statuses for which `_eligibleForCommitteeNextEpoch` is true). The registry computes the
-        // O(1) eligible *count* on-chain and expects the protocol to assemble the eligible *pool*
-        // by unioning these queries off-chain. We use `getValidatorsInfo` (full structs)
-        // because the pending-exit validators are separated out below by `currentStatus`.
-        let mut all_active_validators: Vec<ConsensusRegistry::ValidatorInfo> = Vec::new();
-        for status in [
-            ValidatorStatus::Active,
-            ValidatorStatus::PendingActivation,
-            ValidatorStatus::PendingExit,
-        ] {
-            let calldata = ConsensusRegistry::getValidatorsInfoCall { status: status.into() }
-                .abi_encode()
-                .into();
-            let state =
-                self.read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
-            trace!(target: "engine", ?status, "get validators call:\n{:?}", state);
-            let validators: Vec<ConsensusRegistry::ValidatorInfo> =
-                alloy::sol_types::SolValue::abi_decode(&state)?;
-            all_active_validators.extend(validators);
-        }
+        let all_active_validators = self.read_committee_eligible_pool()?;
 
         debug!(target: "engine",  "validators pre-shuffle {:?}", all_active_validators);
 
@@ -483,6 +461,107 @@ where
         trace!(target: "engine",  ?new_committee_size, ?new_committee, "truncated shuffle for new committee");
 
         Ok(new_committee)
+    }
+
+    /// Read the committee-eligible validator pool from the consensus registry.
+    ///
+    /// The registry's per-status `getValidators`/`getValidatorsInfo` return ONLY the exact status
+    /// set; the committee-eligible pool is the union of `{ Active, PendingActivation, PendingExit
+    /// }` (the statuses for which `_eligibleForCommitteeNextEpoch` is true). The registry computes
+    /// the O(1) eligible *count* on-chain and expects the protocol to assemble the eligible *pool*
+    /// by unioning these queries off-chain. We use `getValidatorsInfo` (full structs) because the
+    /// pending-exit validators are separated out by `currentStatus` in `shuffle_new_committee`.
+    fn read_committee_eligible_pool(
+        &mut self,
+    ) -> TnRethResult<Vec<ConsensusRegistry::ValidatorInfo>> {
+        // While the deployed registry still carries the pre-fork adiri code, `getValidatorsInfo`
+        // does not exist on-chain — speak the legacy ABI instead. This keeps every pre-fork epoch
+        // close (fresh-node onboarding, full resync, a fork-capable build deployed before
+        // `CONSENSUS_REGISTRY_FORK_EPOCH`) executing byte-identically to the historical chain. At
+        // the fork boundary `apply_consensus_registry_fork` swaps the code first, so this gate
+        // already sees the upgraded hash and takes the post-fork read below.
+        #[cfg(feature = "adiri")]
+        if self.registry_code_is_pre_fork()? {
+            return self.read_committee_eligible_pool_legacy();
+        }
+
+        let mut all_active_validators: Vec<ConsensusRegistry::ValidatorInfo> = Vec::new();
+        for status in [
+            ValidatorStatus::Active,
+            ValidatorStatus::PendingActivation,
+            ValidatorStatus::PendingExit,
+        ] {
+            let calldata = ConsensusRegistry::getValidatorsInfoCall { status: status.into() }
+                .abi_encode()
+                .into();
+            let state =
+                self.read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
+            trace!(target: "engine", ?status, "get validators call:\n{:?}", state);
+            let validators: Vec<ConsensusRegistry::ValidatorInfo> =
+                alloy::sol_types::SolValue::abi_decode(&state)?;
+            all_active_validators.extend(validators);
+        }
+
+        Ok(all_active_validators)
+    }
+
+    /// Whether the deployed `ConsensusRegistry` still carries the pre-fork adiri runtime code.
+    ///
+    /// Compares the registry account's code hash against the pinned
+    /// [`tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]. A pure `basic()` read: the
+    /// account is neither touched nor committed, so the gate never enters the bundle/state root —
+    /// it is a deterministic function of committed state, identical on the production and replay
+    /// paths.
+    ///
+    /// A DB error propagates as an error; only a genuinely absent account (impossible on any real
+    /// TN chain) falls through to the default (non-pre-fork) hash. An infra failure must never be
+    /// silently read as "not V1".
+    #[cfg(feature = "adiri")]
+    fn registry_code_is_pre_fork(&mut self) -> TnRethResult<bool> {
+        // revm `Database` trait provides `basic`; imported anonymously to avoid clashing with the
+        // `alloy_evm::Database` already in module scope.
+        use reth_revm::Database as _;
+
+        let code_hash = self
+            .evm
+            .db_mut()
+            .basic(CONSENSUS_REGISTRY_ADDRESS)
+            .map_err(|e| TnRethError::EVMCustom(format!("registry account read failed: {e}")))?
+            .unwrap_or_default()
+            .code_hash;
+
+        Ok(code_hash == tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH)
+    }
+
+    /// Read the committee-eligible pool via the PRE-fork registry ABI.
+    ///
+    /// Byte-exact replay of the protocol read every pre-fork epoch close was produced with: the
+    /// pre-fork contract's `getValidators(uint8)` folds the whole committee-eligible union into
+    /// the `Active` query and returns full `ValidatorInfo` structs. One call, one decode — the
+    /// single-call return order feeds the Fisher-Yates shuffle exactly as the historical chain
+    /// computed it, so re-executed pre-fork blocks derive byte-identical committees and state
+    /// roots.
+    ///
+    /// The `getValidators(uint8)` selector is identical pre/post fork (only the declared return
+    /// type changed), so encoding through the current `getValidatorsCall` binding produces the
+    /// same calldata bytes the pre-fork node sent; the pre-fork `ValidatorInfo[]` return payload
+    /// is decoded directly via `SolValue` (the struct layout is byte-identical across the fork),
+    /// bypassing the binding's post-fork `address[]` return type.
+    #[cfg(feature = "adiri")]
+    fn read_committee_eligible_pool_legacy(
+        &mut self,
+    ) -> TnRethResult<Vec<ConsensusRegistry::ValidatorInfo>> {
+        let calldata =
+            ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
+                .abi_encode()
+                .into();
+        let state =
+            self.read_state_on_chain(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
+        trace!(target: "engine", "legacy get validators call:\n{:?}", state);
+        let validators: Vec<ConsensusRegistry::ValidatorInfo> =
+            alloy::sol_types::SolValue::abi_decode(&state)?;
+
+        Ok(validators)
     }
 
     /// Read state on-chain.

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -14,7 +14,7 @@ use reth_revm::{
 };
 use std::sync::Arc;
 use tn_types::{
-    gas_accumulator::RewardsCounter, BlockHeader as _, Bytes, SealedBlock, SealedHeader, B256, U256,
+    gas_accumulator::RewardsCounter, BlockHeader as _, SealedBlock, SealedHeader, B256, U256,
 };
 
 /// TN-related EVM configuration.
@@ -151,11 +151,19 @@ impl ConfigureEvm for TnEvmConfig {
         &self,
         block: &'a SealedBlock<BlockTy<Self::Primitives>>,
     ) -> Result<ExecutionCtxFor<'a, Self>, Self::Error> {
-        // extra data is default otherwise it contains the hashed bls signature
-        let close_epoch = if block.extra_data == Bytes::default() {
-            None
-        } else {
-            Some(B256::from_slice(block.extra_data.as_ref()))
+        // `extra_data` is empty for a normal block; an epoch-closing block carries the 32-byte
+        // keccak of the leader's aggregate BLS signature (see `TNBlockAssembler::assemble_block`).
+        // Any other length is a malformed header — error instead of panicking in `from_slice`.
+        let close_epoch = match block.extra_data.len() {
+            0 => None,
+            32 => Some(B256::from_slice(block.extra_data.as_ref())),
+            len => {
+                return Err(TnRethError::EVMCustom(format!(
+                    "invalid extra_data length {len} in block {}: expected empty or a 32-byte \
+                     closing-epoch digest",
+                    block.hash(),
+                )))
+            }
         };
 
         Ok(TNBlockExecutionCtx {
@@ -183,5 +191,40 @@ impl ConfigureEvm for TnEvmConfig {
             difficulty: U256::from(payload.batch_index << 16 | payload.worker_id as usize),
             rewards_counter: self.rewards_counter.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tn_types::{Block, Bytes, ExecHeader};
+
+    /// Replay-path `extra_data` decode: empty → no epoch close, 32 bytes → the closing-epoch
+    /// digest, anything else → an error rather than a `B256::from_slice` panic.
+    #[test]
+    fn test_context_for_block_extra_data_lengths() {
+        let chain: ChainSpec = tn_types::test_genesis().into();
+        let config = TnEvmConfig::new(Arc::new(chain), RewardsCounter::default());
+        let block_with_extra = |extra_data: Bytes| {
+            SealedBlock::seal_slow(Block {
+                header: ExecHeader { extra_data, ..Default::default() },
+                body: Default::default(),
+            })
+        };
+
+        // normal block: empty extra_data
+        let block = block_with_extra(Bytes::default());
+        let ctx = config.context_for_block(&block).expect("empty extra_data is valid");
+        assert!(ctx.close_epoch.is_none());
+
+        // epoch-closing block: 32-byte digest
+        let digest = B256::repeat_byte(7);
+        let block = block_with_extra(digest.to_vec().into());
+        let ctx = config.context_for_block(&block).expect("32-byte extra_data is valid");
+        assert_eq!(ctx.close_epoch, Some(digest));
+
+        // malformed header: any other length errors instead of panicking
+        let block = block_with_extra(Bytes::from_static(b"bad"));
+        assert!(config.context_for_block(&block).is_err());
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -2559,6 +2559,13 @@ mod tests {
     /// pubkey survives the swap as 96-byte compressed; and the fork block's `state_root` is
     /// identical across two independent executions (determinism — every node re-derives the
     /// same root).
+    ///
+    /// NOTE: the fixture is the LIVE pre-fork deployment, pinned by
+    /// `tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH` and its tn-types pin test. If
+    /// `chain-configs/testnet/genesis.yaml` is ever regenerated from the current (post-fork)
+    /// artifact, the `pre.is_err()` probe below fails first — that means the fixture no longer
+    /// mirrors the chain this fork targets; reassess the fork plan rather than updating the
+    /// probes.
     #[cfg(feature = "adiri")]
     #[tokio::test]
     async fn test_consensus_registry_fork_swaps_code_and_migrates() -> eyre::Result<()> {

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -2545,6 +2545,126 @@ mod tests {
         Ok(())
     }
 
+    /// In-protocol `ConsensusRegistry` fork over the PRE-fork testnet registry.
+    ///
+    /// `test_genesis()` embeds the committed testnet `genesis.yaml`, whose `ConsensusRegistry`
+    /// account carries the pre-fork runtime code and validator storage with NO per-status sets —
+    /// the exact on-chain shape the fork upgrades in place. The epoch-closing block that
+    /// concludes `FORK_EPOCH - 1` swaps in the new runtime and runs `migrateValidatorSets()`
+    /// FIRST, then the rewards + conclude calls run on the new code over the byte-identical
+    /// preserved storage.
+    ///
+    /// Asserts: the pre-fork code does not answer the new-ABI eligible-count call; post-fork the
+    /// new code is live and the migration populated a non-empty eligible set; a preserved BLS
+    /// pubkey survives the swap as 96-byte compressed; and the fork block's `state_root` is
+    /// identical across two independent executions (determinism — every node re-derives the
+    /// same root).
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_consensus_registry_fork_swaps_code_and_migrates() -> eyre::Result<()> {
+        // pre-fork fixture: old registry code + validator storage, no per-status sets
+        let chain: Arc<RethChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let genesis_header = chain.sealed_genesis_header();
+
+        // fork fires when the concluding epoch + 1 == FORK_EPOCH
+        let concluding_epoch = tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH - 1;
+
+        // one payload, cloned across both executions, so the determinism check compares
+        // byte-identical inputs (`new_for_test` otherwise randomizes
+        // beneficiary/mix_hash/digest per call)
+        let output = consensus_output_for_tests(2, concluding_epoch, 1, true);
+        let payload = TNPayload::new_for_test(genesis_header.clone(), &output);
+
+        // --- env 1: pre-fork state must NOT answer the new-ABI eligible-count call (old code) ---
+        let tmp1 = TempDir::new().unwrap();
+        let tm1 = TaskManager::new("fork test env1");
+        let env1 = RethEnv::new_for_temp_chain(chain.clone(), tmp1.path(), &tm1, None).unwrap();
+        {
+            let state = StateProviderDatabase::new(env1.latest()?);
+            let mut cached = CachedReads::default();
+            let mut db = State::builder()
+                .with_database(cached.as_db_mut(state))
+                .with_bundle_update()
+                .build();
+            let mut evm = env1
+                .inner
+                .evm_config
+                .evm_factory()
+                .create_evm(&mut db, env1.inner.evm_config.evm_env(genesis_header.header())?);
+            let pre = env1.call_consensus_registry::<_, U256>(
+                &mut evm,
+                ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into(),
+            );
+            assert!(
+                pre.is_err(),
+                "pre-fork registry (old code) must not expose getEligibleValidatorCount"
+            );
+        }
+
+        // --- produce the fork boundary block on the production path ---
+        let block = execute_payload_and_update_canonical_chain(&env1, payload.clone(), vec![])?;
+        let header = block.recovered_block.clone_sealed_header();
+        let produced_state_root = header.state_root;
+
+        // --- post-fork: new code is live and the sets are migrated ---
+        {
+            let state = StateProviderDatabase::new(env1.latest()?);
+            let mut cached = CachedReads::default();
+            let mut db = State::builder()
+                .with_database(cached.as_db_mut(state))
+                .with_bundle_update()
+                .build();
+            let mut evm = env1
+                .inner
+                .evm_config
+                .evm_factory()
+                .create_evm(&mut db, env1.inner.evm_config.evm_env(header.header())?);
+
+            let eligible = env1
+                .call_consensus_registry::<_, U256>(
+                    &mut evm,
+                    ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into(),
+                )
+                .expect("post-fork getEligibleValidatorCount must succeed on the swapped-in code");
+            assert!(eligible > U256::ZERO, "migration must populate a non-zero eligible count");
+
+            // getValidators(Active) now returns address[] (new ABI) from the migrated set
+            let active = env1
+                .call_consensus_registry::<_, Vec<Address>>(
+                    &mut evm,
+                    ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
+                        .abi_encode()
+                        .into(),
+                )
+                .expect("getValidators(Active) must succeed on new code");
+            assert!(!active.is_empty(), "migrated Active set must be non-empty");
+
+            // stored BLS pubkey survives the code swap untouched: still 96-byte compressed
+            let bls = env1
+                .call_consensus_registry::<_, Bytes>(
+                    &mut evm,
+                    ConsensusRegistry::getBlsPubkeyCall { validatorAddress: active[0] }
+                        .abi_encode()
+                        .into(),
+                )
+                .expect("getBlsPubkey must succeed");
+            assert_eq!(bls.len(), 96, "preserved BLS pubkey must remain 96-byte compressed");
+        }
+
+        // --- determinism: an independent execution of the identical block yields the same root ---
+        let tmp2 = TempDir::new().unwrap();
+        let tm2 = TaskManager::new("fork test env2");
+        let env2 = RethEnv::new_for_temp_chain(chain.clone(), tmp2.path(), &tm2, None).unwrap();
+        let block2 = execute_payload_and_update_canonical_chain(&env2, payload, vec![])?;
+        assert_eq!(
+            block2.recovered_block.clone_sealed_header().state_root,
+            produced_state_root,
+            "fork block state_root must be identical across independent executions"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_close_epochs() -> eyre::Result<()> {
         let validator_1 = Address::from_slice(&[0x11; 20]);

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -2665,6 +2665,129 @@ mod tests {
         Ok(())
     }
 
+    /// Pre-fork epoch conclusion over the LIVE adiri registry code must speak the legacy ABI.
+    ///
+    /// `test_genesis()` embeds the committed testnet `genesis.yaml` — the registry account
+    /// carries the pre-fork runtime code (pinned by `CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`)
+    /// whose `getValidators(uint8)` returns `ValidatorInfo[]` and which has no
+    /// `getValidatorsInfo`. Concluding a NORMAL (non-fork-boundary) epoch on this state
+    /// exercises the code-hash gate in `read_committee_eligible_pool`: without the gate the
+    /// close reverts fatally (the post-fork ABI is absent on-chain) — the exact path a fresh
+    /// node onboarding to adiri or a full resync executes for every pre-fork epoch boundary.
+    ///
+    /// Asserts: the closing block executes; the registry code hash is untouched (no swap —
+    /// epoch 3 is far from the fork boundary); the post-fork-only eligible-count call still
+    /// fails; and the block's `state_root` is identical across two independent executions.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_pre_fork_epoch_close_uses_legacy_registry_read() -> eyre::Result<()> {
+        // pre-fork fixture: the committed adiri genesis (old registry code + validator storage)
+        let chain: Arc<RethChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let genesis_header = chain.sealed_genesis_header();
+
+        // a normal epoch close, far from the fork boundary (`u32::MAX - 1`), so no swap can fire
+        let concluding_epoch = 3;
+        let output = consensus_output_for_tests(2, concluding_epoch, 1, true);
+        let payload = TNPayload::new_for_test(genesis_header.clone(), &output);
+
+        let tmp1 = TempDir::new().unwrap();
+        let tm1 = TaskManager::new("legacy read test env1");
+        let env1 = RethEnv::new_for_temp_chain(chain.clone(), tmp1.path(), &tm1, None).unwrap();
+
+        // --- pre-probes: readable failures if the committed genesis fixture is regenerated ---
+        {
+            let state = StateProviderDatabase::new(env1.latest()?);
+            let mut cached = CachedReads::default();
+            let mut db = State::builder()
+                .with_database(cached.as_db_mut(state))
+                .with_bundle_update()
+                .build();
+            let mut evm = env1
+                .inner
+                .evm_config
+                .evm_factory()
+                .create_evm(&mut db, env1.inner.evm_config.evm_env(genesis_header.header())?);
+
+            // legacy ABI: getValidators(Active) folds the committee-eligible pool into one
+            // ValidatorInfo[] response
+            let pool = env1
+                .call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
+                    &mut evm,
+                    ConsensusRegistry::getValidatorsCall { status: ValidatorStatus::Active.into() }
+                        .abi_encode()
+                        .into(),
+                )
+                .expect("pre-fork registry must answer the legacy getValidators(Active) read");
+            assert!(!pool.is_empty(), "legacy eligible pool must be non-empty");
+
+            let committee_size = env1
+                .call_consensus_registry::<_, u16>(
+                    &mut evm,
+                    ConsensusRegistry::getNextCommitteeSizeCall {}.abi_encode().into(),
+                )
+                .expect("pre-fork registry must answer getNextCommitteeSize");
+            assert!(
+                committee_size as usize <= pool.len(),
+                "genesis fixture must hold enough eligible validators ({}) for the next \
+                 committee ({committee_size}) — was chain-configs/testnet/genesis.yaml \
+                 regenerated?",
+                pool.len(),
+            );
+        }
+
+        // --- the epoch-closing block executes via the legacy read (without the gate: fatal) ---
+        let block = execute_payload_and_update_canonical_chain(&env1, payload.clone(), vec![])?;
+        let header = block.recovered_block.clone_sealed_header();
+        let produced_state_root = header.state_root;
+
+        // --- post: still the pre-fork code — no swap fired, post-fork ABI still absent ---
+        {
+            use reth_provider::StateProvider as _;
+            let code = env1
+                .latest()?
+                .account_code(&CONSENSUS_REGISTRY_ADDRESS)?
+                .expect("registry account must have code");
+            assert_eq!(
+                code.0.hash_slow(),
+                tn_types::forks::CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH,
+                "a normal pre-fork epoch close must not swap the registry code"
+            );
+
+            let state = StateProviderDatabase::new(env1.latest()?);
+            let mut cached = CachedReads::default();
+            let mut db = State::builder()
+                .with_database(cached.as_db_mut(state))
+                .with_bundle_update()
+                .build();
+            let mut evm = env1
+                .inner
+                .evm_config
+                .evm_factory()
+                .create_evm(&mut db, env1.inner.evm_config.evm_env(header.header())?);
+            let eligible = env1.call_consensus_registry::<_, U256>(
+                &mut evm,
+                ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into(),
+            );
+            assert!(
+                eligible.is_err(),
+                "post-fork-only getEligibleValidatorCount must still fail on the pre-fork code"
+            );
+        }
+
+        // --- determinism: an independent execution of the identical block yields the same root ---
+        let tmp2 = TempDir::new().unwrap();
+        let tm2 = TaskManager::new("legacy read test env2");
+        let env2 = RethEnv::new_for_temp_chain(chain.clone(), tmp2.path(), &tm2, None).unwrap();
+        let block2 = execute_payload_and_update_canonical_chain(&env2, payload, vec![])?;
+        assert_eq!(
+            block2.recovered_block.clone_sealed_header().state_root,
+            produced_state_root,
+            "pre-fork epoch-close state_root must be identical across independent executions"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_close_epochs() -> eyre::Result<()> {
         let validator_1 = Address::from_slice(&[0x11; 20]);

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -2788,6 +2788,53 @@ mod tests {
         Ok(())
     }
 
+    /// The `ConsensusRegistry` fork must fail closed over an unexpected pre-fork deployment.
+    ///
+    /// The swap + `migrateValidatorSets()` assume the exact storage layout of the pinned
+    /// pre-fork registry code. Here the genesis fixture's registry account is overwritten with
+    /// the post-fork artifact bytes (any hash other than
+    /// `CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH` — a stand-in for an unknown deployment), and the
+    /// fork-boundary block must abort with the fail-closed gate error instead of silently
+    /// migrating over an unverified layout. (Without the gate this block would execute: the
+    /// migration is idempotent on the new code, making this test the discriminating check.)
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_consensus_registry_fork_fails_closed_on_unexpected_code() -> eyre::Result<()> {
+        // overwrite the registry's code (keeping balance + storage) with the post-fork artifact
+        let mut genesis = tn_types::test_genesis();
+        let v2_value = RethEnv::fetch_value_from_json_str(
+            CONSENSUS_REGISTRY_JSON,
+            Some("deployedBytecode.object"),
+        )?;
+        let v2_code: Bytes =
+            hex::decode(v2_value.as_str().expect("deployedBytecode.object is a string"))?.into();
+        genesis
+            .alloc
+            .get_mut(&CONSENSUS_REGISTRY_ADDRESS)
+            .expect("testnet genesis must allocate the ConsensusRegistry account")
+            .code = Some(v2_code);
+
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let genesis_header = chain.sealed_genesis_header();
+
+        // drive the fork boundary: the concluding epoch + 1 == CONSENSUS_REGISTRY_FORK_EPOCH
+        let concluding_epoch = tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH - 1;
+        let output = consensus_output_for_tests(2, concluding_epoch, 1, true);
+        let payload = TNPayload::new_for_test(genesis_header.clone(), &output);
+
+        let tmp = TempDir::new().unwrap();
+        let tm = TaskManager::new("fail closed test");
+        let env = RethEnv::new_for_temp_chain(chain.clone(), tmp.path(), &tm, None).unwrap();
+        let err = execute_payload_and_update_canonical_chain(&env, payload, vec![])
+            .expect_err("fork over an unexpected registry deployment must abort the block");
+        assert!(
+            format!("{err:#}").contains("failing closed"),
+            "abort must come from the fail-closed code-hash gate, got: {err:#}"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_close_epochs() -> eyre::Result<()> {
         let validator_1 = Address::from_slice(&[0x11; 20]);

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -161,6 +161,13 @@ sol!(
         function applyIncentives(RewardInfo[] calldata rewardInfos) external;
         /// Apply negative incentives for the epoch. This must be called before `concludeEpoch`.
         function applySlashes(Slash[] calldata slashes) external;
+        /// One-time in-protocol fork migration: back-fills the appended per-status `validatorSets`
+        /// and the cached `eligibleValidatorCount` from the preserved `currentStatus` source of
+        /// truth after the registry bytecode is swapped in place. System-gated and idempotent.
+        function migrateValidatorSets() external;
+        /// Number of committee-eligible validators (union of `PendingActivation`, `Active`,
+        /// `PendingExit`). Single cached SLOAD; read back to confirm a successful migration.
+        function getEligibleValidatorCount() external view returns (uint256);
         /// Return the current epoch.
         function getCurrentEpoch() public view returns (uint32) ;
         /// Helper function to get the epoch info from the current epoch.
@@ -197,6 +204,13 @@ sol!(
         /// Returns the current stake config version.
         function getCurrentStakeVersion() external view returns (uint8);
         /// Returns true if the BLS pubkey belongs to a known validator.
+        ///
+        /// NOTE (post-`CONSENSUS_REGISTRY_FORK_EPOCH`): the upgraded contract keys its internal
+        /// dedup map by a masked-x `_blsKeyId` rather than `keccak(full key)`, and the fork's
+        /// `migrateValidatorSets()` does not re-key legacy entries. As an accepted, documented gap,
+        /// `isValidator(legacyKey)` returns `false` for validators that staked before the fork. This
+        /// is RPC-only and not consensus-critical (the protocol reads stored `blsPubkeys` via
+        /// `getCommitteeBlsPubkeys`, never this map). See `tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH`.
         function isValidator(bytes calldata blsPubkey) external view returns (bool);
         /// Returns true if the validator's stake originates from a delegator.
         function isDelegated(address validatorAddress) external view returns (bool);

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -50,14 +50,35 @@ pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
 ///
 /// PLACEHOLDER: `u32::MAX` practically never fires (the trigger would need epoch `u32::MAX - 1`,
 /// ~4.29e9 epochs away). Set to a concrete future epoch with ample lead time in a dedicated
-/// one-line PR before deploy (mirror the `ADIRI_DUP_BATCH_EPOCH` rollout). Pre-deploy checklist:
-/// - every node must run a **fork-capable build** (compiled with the `adiri` feature — verify the
-///   deploy image is built `--features adiri`) before this epoch, or it will reject the fork block
-///   and fork off the network;
+/// epoch-setting PR before deploy.
+///
+/// Rollout sequence (standard hard-fork rule): every validator must run a fork-capable build
+/// (compiled `--features adiri` — verify the deploy image — and including the epoch-setting PR)
+/// **before** the epoch-closing block of `CONSENSUS_REGISTRY_FORK_EPOCH - 1` executes. Nodes
+/// still on older builds never apply the swap at that boundary, reject the fork block, and
+/// diverge from the canonical chain.
+///
+/// Deploying the fork-capable build EARLY is safe for the registry-read path: the
+/// committee-pool read is gated on the deployed registry's code hash
+/// ([`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]), so every pre-fork epoch close speaks the legacy
+/// registry ABI and derives byte-identical committees (the legacy single-call pool order feeds
+/// the shuffle exactly as the historical chain computed it). The same gate keeps pre-fork
+/// history re-executable, so fresh-node onboarding and full resync from genesis work across the
+/// fork on one binary. Scope: this covers the registry reads only — full old-binary ↔
+/// fork-build live mixed-fleet compatibility depends on everything else shipped since and is
+/// confirmed by the operator dry-run below, not promised here.
+///
+/// Pre-deploy checklist for the epoch-setting PR:
+/// - pin the swapped-in (post-fork) runtime code hash the same way
+///   [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`] pins the pre-fork code, with a pin test against the
+///   embedded `ConsensusRegistry.json` artifact: after the fork runs live, a tn-contracts artifact
+///   bump would otherwise change the bytes re-execution swaps in and break historical state roots;
 /// - confirm the live validator/ConsensusNFT count leaves headroom under the 30M system-call gas
 ///   cap that bounds the one-shot `migrateValidatorSets()` walk;
-/// - the swap is gated on [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]: an unexpected on-chain
-///   deployment fails closed (fatal block error) rather than migrating over an incompatible layout.
+/// - operator dry-run: resync a fork-build node against a live adiri archive across the fork
+///   boundary and confirm matching state roots (also measures the live migration gas);
+/// - the swap fails closed on [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]: an unexpected on-chain
+///   deployment aborts the block (fatal error) rather than migrating over an incompatible layout.
 pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 
 #[cfg(test)]

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -56,8 +56,8 @@ pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
 ///   and fork off the network;
 /// - confirm the live validator/ConsensusNFT count leaves headroom under the 30M system-call gas
 ///   cap that bounds the one-shot `migrateValidatorSets()` walk;
-/// - consider gating the in-protocol swap on a confirmed expected pre-fork registry code hash so an
-///   unexpected on-chain deployment fails closed rather than migrating over an incompatible layout.
+/// - the swap is gated on [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]: an unexpected on-chain
+///   deployment fails closed (fatal block error) rather than migrating over an incompatible layout.
 pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 
 #[cfg(test)]

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -2,6 +2,26 @@
 
 #[cfg(feature = "adiri")]
 use crate::Epoch;
+use alloy::primitives::{b256, B256};
+
+/// Keccak-256 hash of the pre-fork `ConsensusRegistry` runtime bytecode deployed on the live
+/// adiri testnet (the registry account's `code` in the committed
+/// `chain-configs/testnet/genesis.yaml`).
+///
+/// This constant pins the code the [`CONSENSUS_REGISTRY_FORK_EPOCH`] upgrade expects to find
+/// on-chain, and is load-bearing in two places (both in `tn-reth::evm::block`):
+/// - **Legacy-read routing:** while the deployed registry still carries this code, the
+///   epoch-conclusion path reads the committee-eligible pool via the pre-fork `getValidators(uint8)
+///   -> ValidatorInfo[]` ABI instead of the post-fork `getValidatorsInfo` queries, so pre-fork
+///   epoch closes (fresh-node onboarding, full resync) execute byte-identically to the historical
+///   chain.
+/// - **Fail-closed swap gate:** the in-place code swap at the fork boundary refuses to run over any
+///   deployment whose code hash differs from this value, rather than migrating over an unknown
+///   storage layout.
+///
+/// Unconditional (not `adiri`-gated) so the pin test guarding it runs in default-feature CI.
+pub const CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH: B256 =
+    b256!("0x5318ebc5cd8123cfb0808fac0f3c0b95ed6f45f67c0853fea0766b52035fea53");
 
 #[cfg(feature = "adiri")]
 /// The epoch below which Adiri testnet may have had duplicate batches.
@@ -39,3 +59,34 @@ pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
 /// - consider gating the in-protocol swap on a confirmed expected pre-fork registry code hash so an
 ///   unexpected on-chain deployment fails closed rather than migrating over an incompatible layout.
 pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{address, keccak256};
+
+    /// Pin [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`] to the registry code committed in
+    /// `chain-configs/testnet/genesis.yaml`.
+    ///
+    /// Unconditional (not `adiri`-gated) so it runs in default-feature CI even though the fork
+    /// machinery consuming the constant is `adiri`-only.
+    #[test]
+    fn test_pre_fork_consensus_registry_code_hash_pinned() {
+        let genesis = crate::adiri_genesis();
+        // `tn-reth::system_calls::CONSENSUS_REGISTRY_ADDRESS`, hardcoded because tn-types cannot
+        // depend on tn-reth.
+        let registry = address!("0x07E17e17E17e17E17e17E17E17E17e17e17E17e1");
+        let code = genesis
+            .alloc
+            .get(&registry)
+            .and_then(|account| account.code.as_ref())
+            .expect("testnet genesis must allocate ConsensusRegistry runtime code");
+        assert_eq!(
+            keccak256(code),
+            CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH,
+            "CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH mirrors the LIVE adiri deployment — do not \
+             blindly update this constant to make the test pass; if genesis.yaml was regenerated, \
+             reassess the fork plan and `CONSENSUS_REGISTRY_FORK_EPOCH` first",
+        );
+    }
+}

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -6,3 +6,36 @@ use crate::Epoch;
 #[cfg(feature = "adiri")]
 /// The epoch below which Adiri testnet may have had duplicate batches.
 pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
+
+#[cfg(feature = "adiri")]
+/// First epoch that runs on the upgraded `ConsensusRegistry` bytecode.
+///
+/// The epoch-closing block of `CONSENSUS_REGISTRY_FORK_EPOCH - 1` swaps the deployed registry
+/// code to the upgraded version (preserving all existing storage) and runs the one-time
+/// `migrateValidatorSets()` that back-fills the appended per-status `validatorSets` and the cached
+/// `eligibleValidatorCount`. From the first block of `CONSENSUS_REGISTRY_FORK_EPOCH` onward the
+/// protocol runs on the new code with populated sets. See
+/// `tn-reth::evm::block::apply_consensus_registry_fork`.
+///
+/// Scope: an Adiri-testnet-only, in-place upgrade of an already-deployed registry (the whole
+/// mechanism is `#[cfg(feature = "adiri")]`, so non-adiri/mainnet builds exclude it) — not a
+/// general registry-upgrade path. The fork only exists in binaries compiled with the `adiri`
+/// feature, so the activation-epoch PR must ship alongside a confirmed fork-capable node build.
+///
+/// Accepted, documented behavior across the fork: the new contract keys its
+/// `blsPubkeyHashToValidator` dedup map by a masked-x `_blsKeyId` rather than `keccak(full key)`,
+/// and the migration does not re-key legacy entries. The only effects are `isValidator(legacyKey)`
+/// returning `false` (RPC-only, not consensus-critical) and a weakened cross-fork duplicate-key
+/// check (governance-gated NFT minting prevents abuse on the permissioned testnet).
+///
+/// PLACEHOLDER: `u32::MAX` practically never fires (the trigger would need epoch `u32::MAX - 1`,
+/// ~4.29e9 epochs away). Set to a concrete future epoch with ample lead time in a dedicated
+/// one-line PR before deploy (mirror the `ADIRI_DUP_BATCH_EPOCH` rollout). Pre-deploy checklist:
+/// - every node must run a **fork-capable build** (compiled with the `adiri` feature — verify the
+///   deploy image is built `--features adiri`) before this epoch, or it will reject the fork block
+///   and fork off the network;
+/// - confirm the live validator/ConsensusNFT count leaves headroom under the 30M system-call gas
+///   cap that bounds the one-shot `migrateValidatorSets()` walk;
+/// - consider gating the in-protocol swap on a confirmed expected pre-fork registry code hash so an
+///   unexpected on-chain deployment fails closed rather than migrating over an incompatible layout.
+pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -4,6 +4,10 @@ ENV RUSTUP_TOOLCHAIN=1.94
 
 WORKDIR /usr/src/telcoin-network
 
+# Cargo features for the node build. Empty by default (mainnet/default image); the `docker-adiri`
+# target passes `--build-arg CARGO_FEATURES=adiri` to compile in the Adiri-testnet fork logic.
+ARG CARGO_FEATURES=
+
 # install dependencies
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -27,7 +31,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=./target,sharing=locked \
     rm -rf /usr/local/cargo/registry/src \
-    && cargo build -p telcoin-network --bin telcoin-network --release \
+    && cargo build -p telcoin-network --bin telcoin-network --release ${CARGO_FEATURES:+--features ${CARGO_FEATURES}} \
     && mv ./target/release/telcoin-network /tmp/
 
 # production image


### PR DESCRIPTION
- Code-hash-gated dual-ABI committee read: `read_committee_eligible_pool` picks legacy or `getValidatorsInfo` based on the registry's code hash at each epoch close, so pre-fork closes stay byte-identical for historical resync.
- Fail-closed bytecode swap in `apply_consensus_registry_fork`: swaps the registry's code while preserving balance/nonce/storage, refusing to proceed if the pre-fork code hash doesn't match the pinned value.
- Swap runs `migrateValidatorSets()` as a system call immediately after, back-filling per-status validator sets and cached eligible count from the preserved `currentStatus` data.
- Sequencing: swap + migration happen first in the epoch-closing block that concludes `CONSENSUS_REGISTRY_FORK_EPOCH - 1`, before rewards/conclude, so downstream reads see migrated state in the same block.
- `extra_data` decode hardened in `config.rs`: distinguishes 0 bytes (normal) from 32 bytes (closing-epoch digest) and errors on anything else instead of panicking.
- Accepted gap: `isValidator` legacy-key lookups have a documented post-fork gap — RPC-only, not consensus-critical.
- `CONSENSUS_REGISTRY_FORK_EPOCH = u32::MAX` is a placeholder; setting the real target epoch is a deferred follow-up PR (`forks.rs` documents the pre-deploy checklist).
- `adiri` feature wiring added through Cargo.toml, Makefile, and Dockerfile so this only compiles for the testnet build.

closes #869 