### PR TITLE
fix(engine): bound the consensus-output execution backlog

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -28,6 +28,15 @@ use tracing::{debug, error, info, warn};
 /// `SealedHeader`.
 type PendingExecutionTask = oneshot::Receiver<EngineResult<SealedHeader>>;
 
+/// Maximum number of consensus outputs buffered for execution.
+///
+/// Each queued output holds a full `CommittedSubDag` plus batches, so an unbounded queue lets a
+/// lagging engine consume all memory while consensus keeps committing. Once the queue is full
+/// the engine stops polling the consensus stream, pushing backpressure into the `to_engine`
+/// channel (and ultimately the EpochManager forwarder) instead of buffering here. The
+/// `tn_engine_queued_outputs` gauge tracks occupancy.
+pub const MAX_QUEUED_OUTPUTS: usize = 8;
+
 /// The TN consensus engine is responsible executing state that has reached consensus.
 ///
 /// The engine makes no attempt to track consensus. It's only purpose is to receive output from
@@ -229,7 +238,11 @@ impl ExecutorEngine {
                 _ = &self.rx_shutdown, if !self.rx_shutdown.noticed() => {}
 
                 // check if output is available from consensus to keep broadcast stream from "lagging"
-                output = self.consensus_output_stream.next(), if !consensus_closed => {
+                //
+                // gated on the queue bound: while the backlog is full there is always a
+                // pending execution task to wake the loop, and each completion re-opens the
+                // gate, so consensus backpressures instead of growing the queue unbounded
+                output = self.consensus_output_stream.next(), if !consensus_closed && self.queued.len() < MAX_QUEUED_OUTPUTS => {
                     output
                         .map(|output| {
                             // queue the output for local execution

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -13,7 +13,7 @@ use std::{
 use tempfile::TempDir;
 use tn_batch_builder::test_utils::execute_test_batch;
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_engine::{ExecutorEngine, TnEngineError};
+use tn_engine::{ExecutorEngine, TnEngineError, MAX_QUEUED_OUTPUTS};
 use tn_reth::{
     calculate_gas_penalty, recover_signed_transaction,
     system_calls::EpochState,
@@ -211,6 +211,117 @@ async fn test_empty_output_skips_execution() -> eyre::Result<()> {
     assert_eq!(last_block_num, 0);
     // canonical tip is still genesis
     assert_eq!(canonical_tip.hash(), genesis_header.hash());
+
+    Ok(())
+}
+
+/// The engine must stop draining the consensus stream once its execution backlog reaches
+/// [`MAX_QUEUED_OUTPUTS`], then drain to completion (executing every output exactly once, in
+/// order) as completed executions re-open the gate.
+#[tokio::test]
+async fn test_queued_outputs_bounded_with_backpressure() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+    let tmp_dir = TempDir::new().expect("temp dir");
+    // execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.rewards_counter()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus
+    //
+    // build a chain of empty outputs. Pre-fill one more than the bound: the loop immediately
+    // pops one output into the in-flight execution slot, so MAX_QUEUED_OUTPUTS + 1 leaves the
+    // queue exactly at the bound (gate closed) when the stream is first polled.
+    const STREAMED: usize = 2;
+    let prefill = MAX_QUEUED_OUTPUTS + 1;
+    let total = prefill + STREAMED;
+    let timestamp = now();
+    let mut outputs = Vec::with_capacity(total);
+    let mut parent_hash = ConsensusHeaderDigest::default();
+    let mut previous_sub_dag: Option<CommittedSubDag> = None;
+    for i in 0..total {
+        let round = i as u32 + 1;
+        let mut leader = Certificate::default();
+        leader.update_header_round_for_test(round);
+        leader.update_header_created_at_for_test(timestamp);
+        leader.update_header_author_for_test(leader_id.clone());
+        let sub_dag = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader,
+            round as u64,
+            ReputationScores::default(),
+            previous_sub_dag.clone(),
+        );
+        let output = ConsensusOutput::new_with_subdag(sub_dag.clone(), parent_hash, i as u64 + 1);
+        parent_hash = output.consensus_header_hash();
+        previous_sub_dag = Some(sub_dag);
+        outputs.push(output);
+    }
+
+    //=== Execution
+
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(STREAMED);
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(total + 1);
+    let mut engine = ExecutorEngine::new(
+        reth_env.clone(),
+        None,
+        from_consensus,
+        genesis_header.clone(),
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        gas_accumulator,
+        engine_update_tx,
+    );
+
+    // pre-fill the queue past the bound and fill the channel behind it
+    let mut outputs_iter = outputs.iter();
+    for output in outputs_iter.by_ref().take(prefill) {
+        engine.push_back_queued_for_test(output.clone());
+    }
+    for output in outputs_iter {
+        to_engine.send(output.clone()).await?;
+    }
+    assert_eq!(to_engine.capacity(), 0, "test setup: channel must start full");
+
+    // first poll: the queue is at the bound, so the engine must leave the stream untouched
+    // (an unbounded engine drains the whole channel on this poll)
+    let mut engine_fut = Box::pin(engine.run());
+    assert!(futures::poll!(&mut engine_fut).is_pending());
+    assert_eq!(
+        to_engine.capacity(),
+        0,
+        "engine drained the consensus stream past MAX_QUEUED_OUTPUTS"
+    );
+
+    // as executions complete the gate re-opens: everything drains and the engine shuts
+    // down once the (dropped) stream is exhausted
+    drop(to_engine);
+    let res = timeout(Duration::from_secs(30), engine_fut).await?;
+    assert_matches!(res, Err(TnEngineError::ConsensusOutputStreamClosed));
+
+    // every output was executed exactly once, in order
+    for (i, output) in outputs.iter().enumerate() {
+        let (leader_round, consensus_num_hash, _tip) =
+            engine_update_rx.try_recv().unwrap_or_else(|e| {
+                panic!("missing engine update for output {}: {e}", i + 1);
+            });
+        assert_eq!(leader_round, i as u32 + 1, "output executed out of order");
+        assert_eq!(consensus_num_hash, output.num_hash());
+    }
+    assert!(engine_update_rx.try_recv().is_err(), "extra engine update: output executed twice");
 
     Ok(())
 }

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -57,6 +57,16 @@ pub(crate) const WORKER_TASK_BASE: &str = "Worker Task";
 /// a small bound is enough and keeps a buggy ExEx from growing it without limit.
 const EXEX_EVENT_CAPACITY: usize = 16;
 
+/// Capacity of the manager → engine `to_engine` channel.
+///
+/// Each item is a full [`ConsensusOutput`] (subdag + batches), and the engine additionally
+/// bounds its own backlog at [`tn_engine::MAX_QUEUED_OUTPUTS`], so total in-flight memory is
+/// capped at roughly `TO_ENGINE_CAPACITY + MAX_QUEUED_OUTPUTS` outputs. A deep channel here
+/// would defeat the engine's bound by buffering the backlog one hop upstream; 64 absorbs
+/// bursts (e.g. restart replay) while a persistently full channel backpressures the epoch
+/// manager's forwarder instead of consuming memory.
+const TO_ENGINE_CAPACITY: usize = 64;
+
 /// The long-running owner that oversees epoch transitions.
 ///
 /// One instance exists for the lifetime of the process. It holds the resources that must survive
@@ -807,12 +817,18 @@ where
         // Prime the last forwarded consensus number at startup.
         // Normally this is not needed but is a layer of safety in case
         // run_epoch() does not process any output for some reason.
-        self.last_forwarded_consensus_number = self.consensus_chain.latest_consensus_number();
+        // Use the same anchor the subscriber numbers new output from (pack ground truth,
+        // falling back over the executed tip) rather than the slot-file hint: the hint can be
+        // stale after a hard crash, and a low prime would make `wait_for_epoch_boundary`'s
+        // continuity check report a spurious gap on the first live output (and the leftover
+        // drain re-forward already-executed output).
+        self.last_forwarded_consensus_number =
+            state_sync::last_consensus_parent(&self.consensus_bus, &self.consensus_chain).await.1;
 
         info!(target: "epoch-manager", "starting node and launching first epoch");
 
         // create channels for engine that survive the lifetime of the node
-        let (to_engine, for_engine) = mpsc::channel(1000);
+        let (to_engine, for_engine) = mpsc::channel(TO_ENGINE_CAPACITY);
 
         // Create the epoch gas accumulator with a single worker slot. The on-chain WorkerConfigs
         // contract is the absolute source of truth for the worker count: catchup_accumulator

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -565,6 +565,32 @@ where
     ) -> eyre::Result<ConsensusHeaderDigest> {
         // receive output from consensus and forward to engine
         while let Some(mut output) = consensus_output.recv().await {
+            // The engine executes exactly the sequence forwarded here, so enforce continuity
+            // against the last number that actually reached it. A stale output (already
+            // forwarded, e.g. replayed from the DB) would double-execute; a gap (e.g. the
+            // broadcast lagged this receiver) would silently diverge execution from
+            // consensus. Every output is saved to the consensus DB before it is broadcast,
+            // so erroring here lets the restart path replay the gap from the DB.
+            match check_output_continuity(self.last_forwarded_consensus_number, output.number()) {
+                OutputContinuity::Stale => {
+                    warn!(
+                        target: "epoch-manager",
+                        number=output.number(),
+                        last_forwarded=self.last_forwarded_consensus_number,
+                        "skipping already-forwarded consensus output",
+                    );
+                    continue;
+                }
+                OutputContinuity::Gap => {
+                    return Err(eyre::eyre!(
+                        "consensus output gap: expected {} but received {} - restarting to \
+                        replay missed consensus from the DB",
+                        self.last_forwarded_consensus_number + 1,
+                        output.number(),
+                    ));
+                }
+                OutputContinuity::Next => {}
+            }
             // observe epoch boundary to initiate epoch transition
             if output.committed_at() >= self.epoch_boundary {
                 info!(
@@ -837,6 +863,33 @@ pub(crate) fn next_base_fee_for_config(
     }
 }
 
+/// How the next consensus output's number relates to the last one forwarded to the engine.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum OutputContinuity {
+    /// Already forwarded (`number <= last_forwarded`): skip as a duplicate.
+    Stale,
+    /// The expected next output (`last_forwarded + 1`): forward it.
+    Next,
+    /// At least one output was missed (`number > last_forwarded + 1`): forwarding would leave
+    /// a silent execution gap.
+    Gap,
+}
+
+/// Classify `number` against the last consensus number actually forwarded to the engine.
+///
+/// Used only on the live-forwarding path ([`EpochManager::wait_for_epoch_boundary`]); the
+/// replay and leftover-drain paths legitimately re-forward numbers at or below
+/// `last_forwarded` and must not be checked.
+fn check_output_continuity(last_forwarded: u64, number: u64) -> OutputContinuity {
+    if number <= last_forwarded {
+        OutputContinuity::Stale
+    } else if number == last_forwarded + 1 {
+        OutputContinuity::Next
+    } else {
+        OutputContinuity::Gap
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1060,5 +1113,22 @@ mod tests {
         assert_eq!(acc.get_values(0), (1, 1_000_000, 30_000_000), "worker 0 gas unchanged");
 
         Ok(())
+    }
+
+    #[test]
+    fn test_check_output_continuity() {
+        // stale: anything at or below the last forwarded number
+        assert_eq!(check_output_continuity(5, 0), OutputContinuity::Stale);
+        assert_eq!(check_output_continuity(5, 4), OutputContinuity::Stale);
+        assert_eq!(check_output_continuity(5, 5), OutputContinuity::Stale);
+        // next: exactly one past
+        assert_eq!(check_output_continuity(5, 6), OutputContinuity::Next);
+        // genesis: nothing forwarded yet, first output is number 1
+        assert_eq!(check_output_continuity(0, 1), OutputContinuity::Next);
+        // gap: anything further ahead
+        assert_eq!(check_output_continuity(5, 7), OutputContinuity::Gap);
+        assert_eq!(check_output_continuity(5, u64::MAX), OutputContinuity::Gap);
+        // overflow safety at the top of the range
+        assert_eq!(check_output_continuity(u64::MAX, u64::MAX), OutputContinuity::Stale);
     }
 }


### PR DESCRIPTION
The engine drained its consensus stream into queued: VecDeque unconditionally while executing one output at a time, so whenever execution lags consensus the backlog grows without bound - each entry a full CommittedSubDag plus batches. Combined with the 1000-slot to_engine channel this let a lagging engine buffer over a thousand outputs.

- engine: stop polling the stream while queued holds MAX_QUEUED_OUTPUTS (8). A pending execution task always exists while gated, and each completion re-opens the gate, so backpressure propagates to the to_engine channel instead of memory. tn_engine_queued_outputs already tracks occupancy.
- node: shrink to_engine 1000 -> 64 (TO_ENGINE_CAPACITY); a deep channel would just buffer the backlog one hop upstream.

Backpressure changes lag behavior: beyond the 100-slot consensus_output broadcast, a blocked epoch-manager forwarder gets Lagged -> warn-and-skip, which was previously a silent execution gap. It now ships with detection:

- wait_for_epoch_boundary classifies each output number against the last number actually forwarded to the engine (check_output_continuity): stale outputs (already forwarded, e.g. replayed from the DB) are skipped instead of double-executed, and a gap is a hard error so the restart path replays the missed output from the consensus DB (every output is saved before it is broadcast) instead of diverging silently. The replay and leftover-drain paths legitimately re-forward and are not checked.
- prime last_forwarded_consensus_number from last_consensus_parent (pack ground truth, the same anchor the subscriber numbers new output from) instead of the slot-file hint, which can be stale after a hard crash and would trip the continuity check with a spurious gap on the first live output.

Tests: engine backpressure IT (gate holds at the bound on first poll - fails with 'drained 2' without the gate - then drains to completion with every output executed exactly once, in order) and unit coverage for check_output_continuity including the genesis and u64::MAX edges.

closes #879 