### PR TITLE
fix(state-sync): request missing range from peers on observer catch-up stall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11223,6 +11223,7 @@ dependencies = [
  "eyre",
  "metrics",
  "metrics-util",
+ "parking_lot",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "reth-metrics",

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -32,6 +32,11 @@ impl NetworkConfig {
         &self.sync_config
     }
 
+    /// Return a mutable reference to the [SyncConfig].
+    pub fn sync_config_mut(&mut self) -> &mut SyncConfig {
+        &mut self.sync_config
+    }
+
     /// Return a reference to the [LibP2pConfig].
     pub fn libp2p_config(&self) -> &LibP2pConfig {
         &self.libp2p_config
@@ -248,6 +253,19 @@ pub struct SyncConfig {
     ///
     /// This value is used by `CertificateValidator::requires_direct_verification`
     pub certificate_verification_chunk_size: usize,
+    /// How long the observer's consensus-header catch-up loop waits between polls of local
+    /// storage while a missing range is being fetched.
+    ///
+    /// Used by `state_sync::spawn_stream_consensus_headers`. Only affects nodes that follow
+    /// consensus (CVV-inactive / observer), not active CVVs.
+    pub consensus_header_catch_up_poll_interval: Duration,
+    /// Number of consecutive no-progress catch-up polls the observer tolerates before it
+    /// re-drives a state-sync request for the missing consensus-header range.
+    ///
+    /// At the default poll interval this bounds a single passive wait to roughly
+    /// `consensus_header_catch_up_poll_interval * consensus_header_catch_up_max_no_progress`
+    /// before the observer actively re-requests the range instead of waiting for gossip.
+    pub consensus_header_catch_up_max_no_progress: u32,
 }
 
 impl Default for SyncConfig {
@@ -262,6 +280,9 @@ impl Default for SyncConfig {
             max_num_missing_certs_within_gc_round: 50,
             certificate_verification_round_interval: 50,
             certificate_verification_chunk_size: 50,
+            // 600 * 100ms = 60 seconds of passive polling before actively re-driving a request.
+            consensus_header_catch_up_poll_interval: Duration::from_millis(100),
+            consensus_header_catch_up_max_no_progress: 600,
         }
     }
 }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -190,6 +190,7 @@ impl<DB: Database> Subscriber<DB> {
             self.consensus_bus.clone(),
             tasks,
             self.inner.consensus_chain.clone(),
+            self.network_handle.clone(),
         );
         while let Some(output) = rx_sync_output.recv().await {
             let consensus_header_number = output.number();
@@ -224,6 +225,7 @@ impl<DB: Database> Subscriber<DB> {
             self.consensus_bus.clone(),
             tasks,
             self.inner.consensus_chain.clone(),
+            self.network_handle.clone(),
         );
         let mut processed_count: u64 = 0;
         while let Some(output) = rx_sync_output.recv().await {

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -190,7 +190,6 @@ impl<DB: Database> Subscriber<DB> {
             self.consensus_bus.clone(),
             tasks,
             self.inner.consensus_chain.clone(),
-            self.network_handle.clone(),
         );
         while let Some(output) = rx_sync_output.recv().await {
             let consensus_header_number = output.number();
@@ -225,7 +224,6 @@ impl<DB: Database> Subscriber<DB> {
             self.consensus_bus.clone(),
             tasks,
             self.inner.consensus_chain.clone(),
-            self.network_handle.clone(),
         );
         let mut processed_count: u64 = 0;
         while let Some(output) = rx_sync_output.recv().await {

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -216,6 +216,15 @@ pub struct ConsensusBusAppInner {
     tx_last_consensus_header: watch::Sender<Option<ConsensusHeader>>,
     /// Watch tracking the last gossipped consensus block number and hash.
     tx_last_published_consensus_num_hash: watch::Sender<(Epoch, u64, ConsensusHeaderDigest)>,
+    /// Watch requesting the fetch task backfill a bottom gap the gossip-driven walk cannot reach.
+    ///
+    /// Published by the observer's `state_sync::spawn_stream_consensus_headers` when its catch-up
+    /// loop stalls, carrying `(epoch, target_number, target_hash, floor)`: fill the consensus
+    /// range `floor..=target_number` (walking back from the verified gossip tip
+    /// `target_hash`). Consumed by `state_sync::spawn_fetch_recent_consensus`, which owns the
+    /// in-flight accounting. This is deliberately separate from the gossip watermark so a gap
+    /// below it can still be recovered.
+    tx_consensus_gap: watch::Sender<Option<(Epoch, u64, ConsensusHeaderDigest, u64)>>,
 
     /// Verified consensus OUTPUTs (header + batches) delivered to a following/catching-up
     /// subscriber for execution. Filled by the state-sync forward drain; used only by
@@ -290,6 +299,7 @@ impl ConsensusBusApp {
         let (tx_last_consensus_header, _) = watch::channel(None);
         let (tx_last_published_consensus_num_hash, _) =
             watch::channel((0, 0, ConsensusHeaderDigest::default()));
+        let (tx_consensus_gap, _) = watch::channel(None);
 
         let (tx_recent_blocks, _) = watch::channel(RecentBlocks::new(recent_blocks as usize));
         let (tx_sync_status, _) = watch::channel(NodeMode::default());
@@ -313,6 +323,7 @@ impl ConsensusBusApp {
                 tx_recent_blocks,
                 tx_last_consensus_header,
                 tx_last_published_consensus_num_hash,
+                tx_consensus_gap,
                 sync_output,
                 consensus_output,
                 exex_certificates,
@@ -336,6 +347,10 @@ impl ConsensusBusApp {
     pub fn reset_for_epoch(&self) {
         self.inner.tx_committed_round_updates.send_replace(Round::default());
         self.inner.tx_primary_round_updates.send_replace(0u32);
+        // Drop any pending gap request from the prior epoch so the fetch task never backfills a
+        // stale (epoch, number, hash) after we have moved on; the new epoch's stream task will
+        // re-signal if it stalls.
+        self.inner.tx_consensus_gap.send_replace(None);
     }
 
     /// Contains the highest committed round & corresponding gc_round for consensus.
@@ -421,6 +436,18 @@ impl ConsensusBusApp {
                 false
             }
         })
+    }
+
+    /// Watch used by the observer catch-up loop to ask the fetch task to backfill a bottom gap.
+    ///
+    /// Send `Some((epoch, target_number, target_hash, floor))` via `send_replace` to request the
+    /// consensus range `floor..=target_number`; subscribe to consume it in the fetch task. The
+    /// watch coalesces (only the latest request survives), which is intended: the requester
+    /// re-signals with a fresh floor if a request is superseded.
+    pub fn consensus_gap_request(
+        &self,
+    ) -> &watch::Sender<Option<(Epoch, u64, ConsensusHeaderDigest, u64)>> {
+        &self.inner.tx_consensus_gap
     }
 
     /// Track the latest published consensus header block number and hash seen on the gossip

--- a/crates/state-sync/Cargo.toml
+++ b/crates/state-sync/Cargo.toml
@@ -19,6 +19,7 @@ tn-config = { workspace = true }
 tn-primary = { workspace = true }
 metrics = { workspace = true }
 reth-metrics = { workspace = true }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 metrics-util = { workspace = true }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -365,7 +365,7 @@ pub async fn spawn_fetch_consensus(
 
 /// Retrieve a consensus headers from a peer.
 /// Start at number/hash and work backwards to end number.
-async fn get_consensus_header_range<DB: TNDatabase>(
+pub(crate) async fn get_consensus_header_range<DB: TNDatabase>(
     number: u64,
     hash: ConsensusHeaderDigest,
     db: &DB,

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -2,7 +2,7 @@
 
 use std::{
     sync::{
-        atomic::{AtomicI32, Ordering},
+        atomic::{AtomicBool, AtomicI32, Ordering},
         Arc,
     },
     time::Duration,
@@ -29,6 +29,31 @@ enum ConsensusHeaderResult {
     Done,
     Continue(u64, ConsensusHeaderDigest),
     Retry,
+}
+
+/// RAII accounting for a single in-flight gap-fill walk.
+///
+/// Constructing one marks the gap walk active (single-flight) and adds it to the shared `tasks`
+/// throttle so the gossip-driven backfill sees the load. `Drop` releases both, so the slot is
+/// freed even if the walk task panics or is cancelled — otherwise a lost walk would wedge gap
+/// recovery permanently.
+struct GapWalkGuard {
+    active: Arc<AtomicBool>,
+    tasks: Arc<AtomicI32>,
+}
+
+impl GapWalkGuard {
+    fn new(active: Arc<AtomicBool>, tasks: Arc<AtomicI32>) -> Self {
+        tasks.fetch_add(1, Ordering::Relaxed);
+        Self { active, tasks }
+    }
+}
+
+impl Drop for GapWalkGuard {
+    fn drop(&mut self) {
+        self.tasks.fetch_sub(1, Ordering::Relaxed);
+        self.active.store(false, Ordering::Relaxed);
+    }
 }
 
 /// Retrieve a verified consensus OUTPUT (header + batches) for `number` and cache it.
@@ -530,6 +555,10 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
     let mut first_gossipped_epoch = None; // Track the first epoch we see via gossip.
     let mut last_number = None;
     let tasks = Arc::new(AtomicI32::new(0));
+    // At most one gap-fill walk runs at a time (single-flight); further requests coalesce onto the
+    // watch until it clears. Independent of the gossip watermark, so it can reach a gap below it.
+    let gap_walk_active = Arc::new(AtomicBool::new(false));
+    let mut rx_consensus_gap = consensus_bus.consensus_gap_request().subscribe();
     // This loop will track current consensus as well as try to backfill from current.
     // This task backfills the current epoch records as well as requesting entire pack files
     // be downloaded for missing historic epochs.
@@ -552,6 +581,46 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
                     &mut last_number,
                     &mut current_fetch_epoch,
                 ).await;
+            }
+
+            // The observer catch-up loop stalled on a bottom gap the gossip-driven walk cannot
+            // reach (its floor only ever rises). Fill exactly that range here, in the task that
+            // owns the fetch accounting, walking back from the verified tip down to `floor`.
+            gap = rx_consensus_gap.changed() => {
+                if gap.is_err() {
+                    // Bus dropped: the node is shutting down and this critical task ends with it.
+                    return;
+                }
+                let request = *rx_consensus_gap.borrow_and_update();
+                if let Some((epoch, number, hash, floor)) = request {
+                    // Single-flight: skip if a gap walk is already in flight (it will re-signal).
+                    if number >= floor && !gap_walk_active.swap(true, Ordering::Relaxed) {
+                        let guard = GapWalkGuard::new(gap_walk_active.clone(), tasks.clone());
+                        let db = db.clone();
+                        let consensus_bus = consensus_bus.clone();
+                        let network = network.clone();
+                        let consensus_chain = consensus_chain.clone();
+                        task_spawner.spawn_task(
+                            format!("gap-fill epoch {epoch} consensus {floor}..={number}"),
+                            async move {
+                                // Held for the walk's lifetime; Drop frees the single-flight slot
+                                // and the task count even on panic/cancellation.
+                                let _guard = guard;
+                                get_consensus_header_range(
+                                    number,
+                                    hash,
+                                    &db,
+                                    &consensus_bus,
+                                    &network,
+                                    &consensus_chain,
+                                    floor,
+                                )
+                                .await;
+                                Ok(())
+                            },
+                        );
+                    }
+                }
             }
 
             _ = &rx_shutdown => {

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -27,6 +27,11 @@ enum ConsensusHeaderResult {
 }
 
 /// A single consensus-height range `[floor..=ceil]` currently being walked by a fetch task.
+///
+/// Ranges carry no epoch tag even though the tracker is app-scoped (a walk from one epoch can
+/// linger into the next). This is sound ONLY because consensus numbers are globally monotonic
+/// across epochs, so a `(floor, ceil)` pair names a unique height range regardless of epoch. If
+/// numbering ever became per-epoch, two epochs' ranges could alias and a walk could wrongly defer.
 struct WalkRange {
     id: u64,
     floor: u64,
@@ -68,20 +73,48 @@ impl WalkTracker {
         WalkGuard { tracker: self.clone(), id }
     }
 
-    /// Reserve `[floor..=ceil]` only if no in-flight walk already covers all of it. Returns `None`
-    /// when another walk already owns the range: the stall that prompted the request is that walk
-    /// still filling top-down (the execute loop drains bottom-up, so it sees no progress until the
-    /// walk reaches the bottom), not an unfilled gap, so we defer to it rather than duplicate the
-    /// download.
+    /// Reserve `[floor..=ceil]` only if the in-flight walks do not TOGETHER already cover it.
+    /// Returns `None` when they do: the stall that prompted the request is those walks still
+    /// filling top-down (the execute loop drains bottom-up, so it sees no progress until they
+    /// reach the bottom), not an unfilled gap, so we defer rather than duplicate the download.
+    /// Coverage is a UNION test, not a single-range one: during deep catch-up the gossip
+    /// backfills TILE the space (`[0..=n2], [n2+1..=n3], ...`), so no single walk covers a
+    /// full-tip gap request even though together they do, so we sort the overlapping ranges by
+    /// floor and sweep up from `floor`.
     ///
-    /// Deferring is safe even when the covering walk is stuck retrying a height rather than
+    /// Deferring is safe even when a covering walk is stuck retrying a height rather than
     /// progressing: `get_consensus_output` fetches via `request_consensus_output`, which re-samples
     /// peers on every attempt, so a fresh walk would retry the exact same way and gain nothing over
     /// the retries the covering walk is already making. A covering walk that instead panics or is
     /// cancelled releases its reservation on `Drop`, so the next stall re-drives with a fresh walk.
     fn reserve_if_uncovered(&self, floor: u64, ceil: u64) -> Option<WalkGuard> {
         let mut ledger = self.inner.lock();
-        ledger.ranges.iter().all(|r| !(r.floor <= floor && r.ceil >= ceil)).then(|| {
+        let mut ranges: Vec<(u64, u64)> = ledger
+            .ranges
+            .iter()
+            .filter(|r| r.ceil >= floor && r.floor <= ceil)
+            .map(|r| (r.floor, r.ceil))
+            .collect();
+        ranges.sort_unstable();
+        // Sweep upward from `floor`. `needed` is the lowest height still to cover; using `Err` as
+        // the short-circuit signal, a range starting above `needed` leaves a gap
+        // (`Err(false)`), a range reaching `ceil` completes coverage (`Err(true)`),
+        // otherwise advance past it. Running out of ranges without reaching `ceil` (`Ok`)
+        // also means uncovered.
+        let covered = ranges
+            .into_iter()
+            .try_fold(floor, |needed, (range_floor, range_ceil)| {
+                if range_floor > needed {
+                    Err(false)
+                } else if range_ceil >= ceil {
+                    Err(true)
+                } else {
+                    Ok(needed.max(range_ceil.saturating_add(1)))
+                }
+            })
+            .err()
+            .unwrap_or(false);
+        (!covered).then(|| {
             let id = ledger.push(floor, ceil);
             WalkGuard { tracker: self.clone(), id }
         })
@@ -229,6 +262,7 @@ async fn try_partial_pack_catch_up(
     consensus_bus: &ConsensusBusApp,
     network: &PrimaryNetworkHandle,
     consensus_chain: &ConsensusChain,
+    walk_tracker: &WalkTracker,
     epoch: Epoch,
     number: u64,
     hash: ConsensusHeaderDigest,
@@ -279,6 +313,11 @@ async fn try_partial_pack_catch_up(
         ..EpochRecord::default()
     };
     info!(target: "state-sync", epoch, number, our_latest, "bulk catching up current epoch via partial pack stream (staging)");
+    // Reserve exactly the range this stream fills into staging (`our_latest+1..=number`). Staging
+    // publishes atomically, so the observer drain sees nothing and stalls at `our_latest+1` for the
+    // whole stream; without this reservation a catch-up gap fill would race it over the same range.
+    // Held across the await; dropped when this returns (success or fall-back-to-header).
+    let _guard = walk_tracker.reserve(our_latest.saturating_add(1), number);
     match network
         .request_partial_epoch_pack(
             &epoch_record,
@@ -523,6 +562,7 @@ async fn manage_new_consensus<DB: TNDatabase>(
                 &consensus_bus,
                 &network,
                 &consensus_chain,
+                &walk_tracker,
                 epoch,
                 number,
                 hash,
@@ -534,9 +574,8 @@ async fn manage_new_consensus<DB: TNDatabase>(
                 // Note we do this no matter the tasks count "for free"
                 // This should be atypical and must happen and the task count is a loose metric
                 // to avoid tasks running amock anyway.
-                // Register only this backwards header walk (not the partial-pack fast path, which
-                // fills staging directly): the reservation then matches exactly the range this walk
-                // fills top-down, so a catch-up gap fill defers to it instead of racing it.
+                // Reserve this backwards header walk's range (the partial-pack path above reserves
+                // its own) so a catch-up gap fill defers to it instead of racing it.
                 let _guard = walk_tracker.reserve(end_number, number);
                 get_consensus_header_range(
                     number,
@@ -742,6 +781,36 @@ mod tests {
         let gap = tracker.reserve_if_uncovered(1, 100).expect("uncovered gap must fire");
         assert_eq!(tracker.active(), 1);
         drop(gap);
+        assert_eq!(tracker.active(), 0);
+    }
+
+    /// Coverage is a UNION test: during deep catch-up the gossip backfills tile the space, so a
+    /// full-tip gap request must defer when the tiles TOGETHER cover it even though no single tile
+    /// does, but still fire when the tiles leave a real gap.
+    #[test]
+    fn walk_tracker_defers_to_a_covering_union() {
+        let tracker = WalkTracker::default();
+        // Two tiles that together cover [0..=200] (the second floors at the first's ceil + 1).
+        let lo = tracker.reserve(0, 100);
+        let hi = tracker.reserve(101, 200);
+        assert_eq!(tracker.active(), 2);
+
+        // No single tile covers [50..=200], but their union does -> defer.
+        assert!(
+            tracker.reserve_if_uncovered(50, 200).is_none(),
+            "a gap the tiles jointly cover must defer"
+        );
+        assert_eq!(tracker.active(), 2, "a deferred union gap must not spawn a walk");
+
+        // A hole between the tiles means the union does NOT cover -> fire.
+        drop(hi);
+        let with_hole = tracker.reserve(150, 200); // now [0..=100] and [150..=200], gap 101..=149
+        let fill = tracker
+            .reserve_if_uncovered(50, 200)
+            .expect("a range with an uncovered sub-range must fire");
+        drop(fill);
+        drop(with_hole);
+        drop(lo);
         assert_eq!(tracker.active(), 0);
     }
 }

--- a/crates/state-sync/src/consensus.rs
+++ b/crates/state-sync/src/consensus.rs
@@ -1,13 +1,8 @@
 //! Tasks and helpers for collecting consensus headers and epoch pack files trustlessly.
 
-use std::{
-    sync::{
-        atomic::{AtomicBool, AtomicI32, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
+use parking_lot::Mutex;
 use tn_config::ConsensusConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusCache};
@@ -31,28 +26,86 @@ enum ConsensusHeaderResult {
     Retry,
 }
 
-/// RAII accounting for a single in-flight gap-fill walk.
-///
-/// Constructing one marks the gap walk active (single-flight) and adds it to the shared `tasks`
-/// throttle so the gossip-driven backfill sees the load. `Drop` releases both, so the slot is
-/// freed even if the walk task panics or is cancelled — otherwise a lost walk would wedge gap
-/// recovery permanently.
-struct GapWalkGuard {
-    active: Arc<AtomicBool>,
-    tasks: Arc<AtomicI32>,
+/// A single consensus-height range `[floor..=ceil]` currently being walked by a fetch task.
+struct WalkRange {
+    id: u64,
+    floor: u64,
+    ceil: u64,
 }
 
-impl GapWalkGuard {
-    fn new(active: Arc<AtomicBool>, tasks: Arc<AtomicI32>) -> Self {
-        tasks.fetch_add(1, Ordering::Relaxed);
-        Self { active, tasks }
+#[derive(Default)]
+struct WalkLedger {
+    next_id: u64,
+    ranges: Vec<WalkRange>,
+}
+
+/// Cloneable ledger of the consensus-height ranges fetch tasks are walking right now.
+///
+/// Every download walk registers its range here: the initial bulk backfill, each gossip-driven
+/// backfill, and the catch-up gap fill. A single ledger lets a new walk see whether another task
+/// already owns its range — so it can defer instead of racing a duplicate download — and bounds how
+/// many walks run at once (`active`). Because a reservation is released by its `WalkGuard`'s
+/// `Drop`, a walk that panics or is cancelled frees its claim, so a lost walk never wedges gap
+/// recovery.
+///
+/// The lock is held only for the small, synchronous ledger updates below (never across an
+/// `.await`), so it cannot deadlock the fetch loop or the walk tasks.
+#[derive(Clone, Default)]
+struct WalkTracker {
+    inner: Arc<Mutex<WalkLedger>>,
+}
+
+impl WalkTracker {
+    /// Number of walks in flight. A loose throttle metric: the value can race a walk finishing, but
+    /// (as with the previous counter) one walk more or less does not matter.
+    fn active(&self) -> usize {
+        self.inner.lock().ranges.len()
+    }
+
+    /// Reserve `[floor..=ceil]` unconditionally, returning a guard that releases it on `Drop`.
+    fn reserve(&self, floor: u64, ceil: u64) -> WalkGuard {
+        let id = self.inner.lock().push(floor, ceil);
+        WalkGuard { tracker: self.clone(), id }
+    }
+
+    /// Reserve `[floor..=ceil]` only if no in-flight walk already covers all of it. Returns `None`
+    /// when another walk already owns the range: the stall that prompted the request is that walk
+    /// still filling top-down (the execute loop drains bottom-up, so it sees no progress until the
+    /// walk reaches the bottom), not an unfilled gap, so we defer to it rather than duplicate the
+    /// download.
+    ///
+    /// Deferring is safe even when the covering walk is stuck retrying a height rather than
+    /// progressing: `get_consensus_output` fetches via `request_consensus_output`, which re-samples
+    /// peers on every attempt, so a fresh walk would retry the exact same way and gain nothing over
+    /// the retries the covering walk is already making. A covering walk that instead panics or is
+    /// cancelled releases its reservation on `Drop`, so the next stall re-drives with a fresh walk.
+    fn reserve_if_uncovered(&self, floor: u64, ceil: u64) -> Option<WalkGuard> {
+        let mut ledger = self.inner.lock();
+        ledger.ranges.iter().all(|r| !(r.floor <= floor && r.ceil >= ceil)).then(|| {
+            let id = ledger.push(floor, ceil);
+            WalkGuard { tracker: self.clone(), id }
+        })
     }
 }
 
-impl Drop for GapWalkGuard {
+impl WalkLedger {
+    fn push(&mut self, floor: u64, ceil: u64) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.ranges.push(WalkRange { id, floor, ceil });
+        id
+    }
+}
+
+/// Releases a [`WalkTracker`] reservation when the walk task ends (including on panic/cancel).
+struct WalkGuard {
+    tracker: WalkTracker,
+    id: u64,
+}
+
+impl Drop for WalkGuard {
     fn drop(&mut self) {
-        self.tasks.fetch_sub(1, Ordering::Relaxed);
-        self.active.store(false, Ordering::Relaxed);
+        self.tracker.inner.lock().ranges.retain(|r| r.id != self.id);
     }
 }
 
@@ -390,7 +443,7 @@ pub async fn spawn_fetch_consensus(
 
 /// Retrieve a consensus headers from a peer.
 /// Start at number/hash and work backwards to end number.
-pub(crate) async fn get_consensus_header_range<DB: TNDatabase>(
+async fn get_consensus_header_range<DB: TNDatabase>(
     number: u64,
     hash: ConsensusHeaderDigest,
     db: &DB,
@@ -443,7 +496,7 @@ async fn manage_new_consensus<DB: TNDatabase>(
     network: &PrimaryNetworkHandle,
     consensus_chain: &ConsensusChain,
     task_spawner: &TaskSpawner,
-    tasks: Arc<AtomicI32>,
+    walk_tracker: &WalkTracker,
     epoch: Epoch,
     number: u64,
     hash: ConsensusHeaderDigest,
@@ -462,6 +515,7 @@ async fn manage_new_consensus<DB: TNDatabase>(
         let consensus_bus = consensus_bus.clone();
         let network = network.clone();
         let consensus_chain = consensus_chain.clone();
+        let walk_tracker = walk_tracker.clone();
         task_spawner.spawn_task(format!("partial pack catchup epoch {epoch}"), async move {
             // Bulk fast-path: if we're far behind on the in-progress current epoch, stream a verified
             // partial pack into staging in one shot instead of only crawling headers.
@@ -480,6 +534,10 @@ async fn manage_new_consensus<DB: TNDatabase>(
                 // Note we do this no matter the tasks count "for free"
                 // This should be atypical and must happen and the task count is a loose metric
                 // to avoid tasks running amock anyway.
+                // Register only this backwards header walk (not the partial-pack fast path, which
+                // fills staging directly): the reservation then matches exactly the range this walk
+                // fills top-down, so a catch-up gap fill defers to it instead of racing it.
+                let _guard = walk_tracker.reserve(end_number, number);
                 get_consensus_header_range(
                     number,
                     hash,
@@ -494,19 +552,18 @@ async fn manage_new_consensus<DB: TNDatabase>(
             Ok(())
         });
     } else {
-        // Note that the way tasks is used is open to "races" but this is a simple throttle for not
-        // firing too many fetch tasks so not worth the overhead of using a full lock here.  I.e.
-        // one more or less task won't matter.
-        let task_num = tasks.load(Ordering::Relaxed);
+        // A loose throttle: the ledger read can race a walk finishing, but one walk more or less
+        // does not matter, and the reservation below still keeps this walk from racing another over
+        // the same range.
         // Skip for now, this number will be subsumed by gossip once enough tasks end.
-        if task_num < 6 {
+        if walk_tracker.active() < 6 {
             let end_number = last_number.unwrap_or_default();
             *last_number = Some(number + 1);
-            let tasks_clone = tasks.clone();
-            tasks.fetch_add(1, Ordering::Relaxed);
+            let guard = walk_tracker.reserve(end_number, number);
             task_spawner.spawn_task(
                 format!("backfilling epoch {epoch} consensus from {number}/{hash} to {end_number}"),
                 async move {
+                    let _guard = guard;
                     get_consensus_header_range(
                         number,
                         hash,
@@ -517,7 +574,6 @@ async fn manage_new_consensus<DB: TNDatabase>(
                         end_number,
                     )
                     .await;
-                    tasks_clone.fetch_sub(1, Ordering::Relaxed);
                     Ok(())
                 },
             );
@@ -554,10 +610,10 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
     let mut current_fetch_epoch = consensus_chain.latest_consensus_epoch();
     let mut first_gossipped_epoch = None; // Track the first epoch we see via gossip.
     let mut last_number = None;
-    let tasks = Arc::new(AtomicI32::new(0));
-    // At most one gap-fill walk runs at a time (single-flight); further requests coalesce onto the
-    // watch until it clears. Independent of the gossip watermark, so it can reach a gap below it.
-    let gap_walk_active = Arc::new(AtomicBool::new(false));
+    // One ledger for every fetch walk (bulk backfill, gossip backfill, gap fill): it throttles how
+    // many run at once and lets a gap fill defer to a walk already covering its range instead of
+    // racing a duplicate download.
+    let walk_tracker = WalkTracker::default();
     let mut rx_consensus_gap = consensus_bus.consensus_gap_request().subscribe();
     // This loop will track current consensus as well as try to backfill from current.
     // This task backfills the current epoch records as well as requesting entire pack files
@@ -575,7 +631,7 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
                     &network,
                     &consensus_chain,
                     &task_spawner,
-                    tasks.clone(),
+                    &walk_tracker,
                     epoch, number, hash,
                     &mut first_gossipped_epoch,
                     &mut last_number,
@@ -593,9 +649,14 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
                 }
                 let request = *rx_consensus_gap.borrow_and_update();
                 if let Some((epoch, number, hash, floor)) = request {
-                    // Single-flight: skip if a gap walk is already in flight (it will re-signal).
-                    if number >= floor && !gap_walk_active.swap(true, Ordering::Relaxed) {
-                        let guard = GapWalkGuard::new(gap_walk_active.clone(), tasks.clone());
+                    // Fill only a non-empty range that no walk already owns. `reserve_if_uncovered`
+                    // returns `None` when a bulk/gossip/earlier-gap walk already covers this range
+                    // (the stall is that walk still filling top-down, not an unfilled gap), which
+                    // also subsumes the old single-flight guard. It reserves the range so a second
+                    // stall coalesces, and the guard releases it on completion/panic/cancel.
+                    if let Some(guard) =
+                        (number >= floor).then(|| walk_tracker.reserve_if_uncovered(floor, number)).flatten()
+                    {
                         let db = db.clone();
                         let consensus_bus = consensus_bus.clone();
                         let network = network.clone();
@@ -603,8 +664,6 @@ pub async fn spawn_fetch_recent_consensus<DB: TNDatabase>(
                         task_spawner.spawn_task(
                             format!("gap-fill epoch {epoch} consensus {floor}..={number}"),
                             async move {
-                                // Held for the walk's lifetime; Drop frees the single-flight slot
-                                // and the task count even on panic/cancellation.
                                 let _guard = guard;
                                 get_consensus_header_range(
                                     number,
@@ -642,4 +701,47 @@ pub async fn request_missing_packs(
     // Get the epoch of our last executed consensus.
     let mut current_fetch_epoch = consensus_chain.latest_consensus_epoch();
     request_epochs(&mut current_fetch_epoch, consensus_chain, consensus_bus).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shared walk ledger is what keeps a catch-up gap fill from racing a walk that already
+    /// covers its range: it defers while such a walk is in flight, still fires for a range no walk
+    /// reaches, coalesces a repeated request, and — because a reservation is released on `Drop` —
+    /// re-drives once a covering walk ends (so a crashed walk cannot wedge recovery).
+    #[test]
+    fn walk_tracker_defers_only_to_a_covering_walk() {
+        let tracker = WalkTracker::default();
+        assert_eq!(tracker.active(), 0);
+
+        // A bulk backfill claims the whole catch-up range [0..=100].
+        let backfill = tracker.reserve(0, 100);
+        assert_eq!(tracker.active(), 1);
+
+        // A stall at [1..=100] while that backfill is still filling top-down is a false alarm:
+        // the range is fully covered, so the gap fill must defer (add no walk).
+        assert!(tracker.reserve_if_uncovered(1, 100).is_none());
+        assert_eq!(tracker.active(), 1, "a deferred gap fill must not spawn a walk");
+
+        // A range extending above the covering walk's ceiling is not fully covered, so it fires.
+        let above = tracker.reserve_if_uncovered(1, 150).expect("uncovered range must fire");
+        assert_eq!(tracker.active(), 2);
+        // A repeat of that request now coalesces onto the in-flight walk (old single-flight guard).
+        assert!(tracker.reserve_if_uncovered(1, 150).is_none());
+        assert_eq!(tracker.active(), 2);
+        drop(above);
+        assert_eq!(tracker.active(), 1);
+
+        // When the covering backfill ends its range is released...
+        drop(backfill);
+        assert_eq!(tracker.active(), 0);
+
+        // ...so the same gap now fires: a finished (or crashed) covering walk re-drives recovery.
+        let gap = tracker.reserve_if_uncovered(1, 100).expect("uncovered gap must fire");
+        assert_eq!(tracker.active(), 1);
+        drop(gap);
+        assert_eq!(tracker.active(), 0);
+    }
 }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -201,7 +201,9 @@ async fn spawn_stream_consensus_headers<DB: Database>(
     // out (both are `Copy`) so the borrow of `config` does not outlive this line.
     let sync_config = config.network_config().sync_config();
     let catch_up_poll_interval = sync_config.consensus_header_catch_up_poll_interval;
-    let max_no_progress = sync_config.consensus_header_catch_up_max_no_progress;
+    // Clamp to at least one poll: a misconfigured `= 0` would otherwise make `stall_recheck` zero
+    // and busy-spin the bottom select (and signal a gap before any poll elapses).
+    let max_no_progress = sync_config.consensus_header_catch_up_max_no_progress.max(1);
     // After a stall we hand the fill off to the fetch task and park on the bottom select. Because
     // that fill lands in the cache silently (it never advances the `last_consensus_header` watch
     // for heights at or below the target, so `changed()` does not fire), we also wake on this

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -10,9 +10,8 @@ use tn_test_utils as _;
 #[cfg(test)]
 use tn_test_utils_committee as _;
 
-use std::time::Duration;
 use tn_config::ConsensusConfig;
-use tn_primary::{ConsensusBusApp, NodeMode};
+use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusCache};
 use tn_types::{
     ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, Database, Epoch, TaskError,
@@ -25,7 +24,7 @@ pub use epoch::spawn_epoch_record_collector;
 mod consensus;
 mod metrics;
 use crate::metrics::STATE_SYNC_METRICS;
-use consensus::spawn_track_recent_consensus;
+use consensus::{get_consensus_header_range, spawn_track_recent_consensus};
 pub use consensus::{request_missing_packs, spawn_fetch_consensus, spawn_fetch_recent_consensus};
 
 /// Sets some bus defaults.
@@ -63,6 +62,7 @@ pub fn spawn_state_sync<DB: Database>(
     consensus_bus: ConsensusBusApp,
     task_spawner: TaskSpawner,
     consensus_chain: ConsensusChain,
+    network: PrimaryNetworkHandle,
 ) {
     let mode = *consensus_bus.node_mode().borrow();
     match mode {
@@ -86,7 +86,7 @@ pub fn spawn_state_sync<DB: Database>(
                 "state sync: stream consensus headers",
                 async move {
                     info!(target: "state-sync", "Starting state sync: stream consensus header from peers");
-                    if let Err(e) = spawn_stream_consensus_headers(config, consensus_bus, consensus_chain).await {
+                    if let Err(e) = spawn_stream_consensus_headers(config, consensus_bus, consensus_chain, network).await {
                         error!(target: "state-sync", "Error streaming consensus headers: {e}");
                         Err(TaskError::from_message(e))
                     } else {
@@ -188,6 +188,7 @@ async fn spawn_stream_consensus_headers<DB: Database>(
     config: ConsensusConfig<DB>,
     consensus_bus: ConsensusBusApp,
     consensus_chain: ConsensusChain,
+    network: PrimaryNetworkHandle,
 ) -> eyre::Result<()> {
     let rx_shutdown = config.shutdown().subscribe();
 
@@ -196,6 +197,17 @@ async fn spawn_stream_consensus_headers<DB: Database>(
         consensus_bus.last_consensus_block(&consensus_chain).await.unwrap_or_default();
     let mut last_consensus_height = last_consensus_header.number;
     let epoch = config.committee().epoch();
+
+    // Catch-up tuning (observer-only): how long to poll local storage between catch-up attempts
+    // and how many no-progress polls to tolerate before actively re-driving a request. Copied out
+    // (both are `Copy`) so the borrow of `config` does not outlive this line.
+    let sync_config = config.network_config().sync_config();
+    let catch_up_poll_interval = sync_config.consensus_header_catch_up_poll_interval;
+    let max_no_progress = sync_config.consensus_header_catch_up_max_no_progress;
+    // Cap a single inline re-drive fetch to roughly the passive budget it replaces, so a peer that
+    // never serves the missing range cannot wedge this loop. Partial fetches are cached and
+    // persisted, so the next re-drive resumes where this one left off. Saturates on overflow.
+    let redrive_fetch_budget = catch_up_poll_interval.saturating_mul(max_no_progress);
 
     // Read and consume the current watch value immediately. This handles a race where a pack
     // file was downloaded and last_consensus_header() was updated before this task subscribed
@@ -210,13 +222,12 @@ async fn spawn_stream_consensus_headers<DB: Database>(
         if pending_header.number > last_consensus_height {
             debug!(target: "state-sync", rx_last_consensus_header=?pending_header.number, ?last_consensus_height, "streaming consensus headers detected change");
             // Retry loop: the concurrent backward traversal in
-            // spawn_track_recent_consensus fills ConsensusHeaderCache asynchronously.
+            // spawn_track_recent_consensus fills the ConsensusCache asynchronously.
             // catch_up_consensus_from_to may return early on a cache miss before the
             // backward traversal has fetched an intermediate block. Retry with a short
             // delay to let the traversal finish rather than waiting for the next gossip
             // update (which may never come for an older epoch's blocks).
             let mut no_progress_count = 0u32;
-            const MAX_NO_PROGRESS: u32 = 600; // 600 * 100ms = 60 seconds max wait
             loop {
                 let prev_height = last_consensus_height;
                 last_consensus_header = catch_up_consensus_from_to(
@@ -243,13 +254,44 @@ async fn spawn_stream_consensus_headers<DB: Database>(
                     // No progress: the backward traversal hasn't yet cached this block.
                     no_progress_count += 1;
                     STATE_SYNC_METRICS.no_progress_total.increment(1);
-                    if no_progress_count >= MAX_NO_PROGRESS {
+                    if no_progress_count >= max_no_progress {
+                        // The gossip-driven backward traversal (spawn_track_recent_consensus ->
+                        // spawn_fetch_recent_consensus) only runs when a gossip update arrives, and
+                        // even then floors its walk at an internal watermark, so it cannot recover
+                        // a gap at the bottom of the catch-up range. Rather
+                        // than parking on the next gossip update (which may
+                        // never arrive for an older epoch's blocks or on an
+                        // independently running node), directly request the missing range from
+                        // peers: walk backward from the pending header down to
+                        // last_consensus_height
+                        // + 1, populating the ConsensusCache that the next catch-up poll consumes.
+                        // The fetch is bounded by redrive_fetch_budget (so a peer that never serves
+                        // the range cannot wedge this loop; partial fetches are cached and the next
+                        // re-drive resumes) and by rx_shutdown (so it never delays shutdown). The
+                        // counter is reset so we re-drive at most once per no-progress budget.
                         warn!(target: "state-sync", ?epoch, last_consensus_height, target=pending_header.number,
-                            "could not catch up to consensus target after retries, waiting for next gossip update");
-                        break;
+                            "catch-up stalled after retries, requesting the missing consensus range from peers");
+                        STATE_SYNC_METRICS.catch_up_redrives_total.increment(1);
+                        tokio::select! {
+                            _ = get_consensus_header_range(
+                                pending_header.number,
+                                pending_header.digest(),
+                                config.node_storage(),
+                                &consensus_bus,
+                                &network,
+                                &consensus_chain,
+                                last_consensus_height + 1,
+                            ) => {}
+                            _ = tokio::time::sleep(redrive_fetch_budget) => {
+                                debug!(target: "state-sync", ?epoch, last_consensus_height, target=pending_header.number,
+                                    "re-drive fetch exceeded budget, yielding; will resume next cycle");
+                            }
+                            _ = &rx_shutdown => return Ok(()),
+                        }
+                        no_progress_count = 0;
                     }
                     tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+                        _ = tokio::time::sleep(catch_up_poll_interval) => {}
                         _ = &rx_shutdown => return Ok(()),
                     }
                 } else {
@@ -275,8 +317,14 @@ async fn spawn_stream_consensus_headers<DB: Database>(
     }
 }
 
-/// Applies consensus output "from" (exclusive) to height "max_consensus_height" (inclusive).
-/// Queries peers for latest height and downloads and executes any missing consensus output.
+/// Applies consensus output "from" (exclusive) up to "max_consensus" (inclusive) by reading
+/// consensus outputs from local storage — first the `ConsensusCache`, then the `ConsensusChain`.
+///
+/// This function does not itself query peers: the backward traversal spawned by
+/// `spawn_track_recent_consensus` / `spawn_fetch_recent_consensus` is what fetches missing outputs
+/// into the cache. On a cache miss for an output that has not been fetched yet, it returns the last
+/// applied header early, leaving the caller (`spawn_stream_consensus_headers`) to re-drive a
+/// request for the missing range.
 /// Returns the last ConsensusHeader that was applied on success.
 async fn catch_up_consensus_from_to<DB: Database>(
     consensus_bus: &ConsensusBusApp,
@@ -380,4 +428,79 @@ async fn catch_up_consensus_from_to<DB: Database>(
         consensus_bus.sync_output().send(output).await?;
     }
     Ok(result_header)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use tn_config::NetworkConfig;
+    use tn_storage::mem_db::MemDatabase;
+    use tn_test_utils_committee::CommitteeFixture;
+    use tokio::sync::mpsc;
+
+    /// Issue #836: when the observer catch-up loop makes no progress within its budget, it must
+    /// directly request the missing consensus range from peers rather than parking on the next
+    /// gossip update. With an empty cache and chain, catch-up can never make progress, so the
+    /// stall branch must issue an outbound network request within the (tiny, test-tuned) budget.
+    #[tokio::test]
+    async fn redrives_state_sync_request_on_catch_up_timeout() -> eyre::Result<()> {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+
+        // Borrow one authority's base config/storage/keys, then build a config with a fast,
+        // deterministic catch-up budget (re-drive after a single no-progress poll).
+        let (base_config, node_storage, key_config) = {
+            let authority = fixture.authorities().next().expect("fixture yields an authority");
+            let cc = authority.consensus_config();
+            (cc.config().clone(), cc.node_storage().clone(), cc.key_config().clone())
+        };
+        let mut network_config = NetworkConfig::default();
+        let sync = network_config.sync_config_mut();
+        // Re-drive after a single no-progress poll. The poll interval also bounds a single re-drive
+        // fetch (interval * max_no_progress); keep it comfortably above the outbound-request
+        // latency so the fetch is not cancelled before it issues the request we assert on.
+        sync.consensus_header_catch_up_poll_interval = Duration::from_millis(100);
+        sync.consensus_header_catch_up_max_no_progress = 1;
+
+        let committee = fixture.committee();
+        let config = ConsensusConfig::new_with_committee_for_test(
+            base_config,
+            node_storage,
+            key_config,
+            committee.clone(),
+            network_config,
+        )?;
+        let consensus_bus = ConsensusBusApp::new();
+        let temp_dir = TempDir::new()?;
+        let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned(), committee)?;
+
+        // Capture outbound network commands so we can observe the direct peer request. This
+        // isolated loop performs no other network I/O, so any command proves the re-drive fired.
+        let (net_tx, mut net_rx) = mpsc::channel(16);
+        let network = PrimaryNetworkHandle::new_for_test(net_tx);
+
+        // Publish a pending header ahead of local height. The chain and cache are empty, so
+        // catch-up returns early on the first missing output and makes no progress, forcing the
+        // stall branch.
+        let target = ConsensusHeader { number: 5, ..Default::default() };
+        consensus_bus.last_consensus_header().send_replace(Some(target.clone()));
+
+        let handle = tokio::spawn(spawn_stream_consensus_headers(
+            config,
+            consensus_bus,
+            consensus_chain,
+            network,
+        ));
+
+        // The stall must actively request the missing range from peers instead of parking on the
+        // next gossip update; the outbound request appears on the mock network within the budget.
+        tokio::time::timeout(Duration::from_secs(5), net_rx.recv())
+            .await
+            .expect("catch-up stall did not request the missing range from peers in time")
+            .expect("network command channel closed unexpectedly");
+
+        handle.abort();
+        Ok(())
+    }
 }

--- a/crates/state-sync/src/lib.rs
+++ b/crates/state-sync/src/lib.rs
@@ -11,7 +11,7 @@ use tn_test_utils as _;
 use tn_test_utils_committee as _;
 
 use tn_config::ConsensusConfig;
-use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp, NodeMode};
+use tn_primary::{ConsensusBusApp, NodeMode};
 use tn_storage::{consensus::ConsensusChain, tables::ConsensusCache};
 use tn_types::{
     ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, Database, Epoch, TaskError,
@@ -24,7 +24,7 @@ pub use epoch::spawn_epoch_record_collector;
 mod consensus;
 mod metrics;
 use crate::metrics::STATE_SYNC_METRICS;
-use consensus::{get_consensus_header_range, spawn_track_recent_consensus};
+use consensus::spawn_track_recent_consensus;
 pub use consensus::{request_missing_packs, spawn_fetch_consensus, spawn_fetch_recent_consensus};
 
 /// Sets some bus defaults.
@@ -62,7 +62,6 @@ pub fn spawn_state_sync<DB: Database>(
     consensus_bus: ConsensusBusApp,
     task_spawner: TaskSpawner,
     consensus_chain: ConsensusChain,
-    network: PrimaryNetworkHandle,
 ) {
     let mode = *consensus_bus.node_mode().borrow();
     match mode {
@@ -86,7 +85,7 @@ pub fn spawn_state_sync<DB: Database>(
                 "state sync: stream consensus headers",
                 async move {
                     info!(target: "state-sync", "Starting state sync: stream consensus header from peers");
-                    if let Err(e) = spawn_stream_consensus_headers(config, consensus_bus, consensus_chain, network).await {
+                    if let Err(e) = spawn_stream_consensus_headers(config, consensus_bus, consensus_chain).await {
                         error!(target: "state-sync", "Error streaming consensus headers: {e}");
                         Err(TaskError::from_message(e))
                     } else {
@@ -188,7 +187,6 @@ async fn spawn_stream_consensus_headers<DB: Database>(
     config: ConsensusConfig<DB>,
     consensus_bus: ConsensusBusApp,
     consensus_chain: ConsensusChain,
-    network: PrimaryNetworkHandle,
 ) -> eyre::Result<()> {
     let rx_shutdown = config.shutdown().subscribe();
 
@@ -199,15 +197,17 @@ async fn spawn_stream_consensus_headers<DB: Database>(
     let epoch = config.committee().epoch();
 
     // Catch-up tuning (observer-only): how long to poll local storage between catch-up attempts
-    // and how many no-progress polls to tolerate before actively re-driving a request. Copied out
-    // (both are `Copy`) so the borrow of `config` does not outlive this line.
+    // and how many no-progress polls to tolerate before asking the fetch task to backfill. Copied
+    // out (both are `Copy`) so the borrow of `config` does not outlive this line.
     let sync_config = config.network_config().sync_config();
     let catch_up_poll_interval = sync_config.consensus_header_catch_up_poll_interval;
     let max_no_progress = sync_config.consensus_header_catch_up_max_no_progress;
-    // Cap a single inline re-drive fetch to roughly the passive budget it replaces, so a peer that
-    // never serves the missing range cannot wedge this loop. Partial fetches are cached and
-    // persisted, so the next re-drive resumes where this one left off. Saturates on overflow.
-    let redrive_fetch_budget = catch_up_poll_interval.saturating_mul(max_no_progress);
+    // After a stall we hand the fill off to the fetch task and park on the bottom select. Because
+    // that fill lands in the cache silently (it never advances the `last_consensus_header` watch
+    // for heights at or below the target, so `changed()` does not fire), we also wake on this
+    // interval to re-drain the cache. One stall budget: the same passive window the loop already
+    // tolerated. Saturates on overflow.
+    let stall_recheck = catch_up_poll_interval.saturating_mul(max_no_progress);
 
     // Read and consume the current watch value immediately. This handles a race where a pack
     // file was downloaded and last_consensus_header() was updated before this task subscribed
@@ -257,38 +257,25 @@ async fn spawn_stream_consensus_headers<DB: Database>(
                     if no_progress_count >= max_no_progress {
                         // The gossip-driven backward traversal (spawn_track_recent_consensus ->
                         // spawn_fetch_recent_consensus) only runs when a gossip update arrives, and
-                        // even then floors its walk at an internal watermark, so it cannot recover
-                        // a gap at the bottom of the catch-up range. Rather
-                        // than parking on the next gossip update (which may
-                        // never arrive for an older epoch's blocks or on an
-                        // independently running node), directly request the missing range from
-                        // peers: walk backward from the pending header down to
-                        // last_consensus_height
-                        // + 1, populating the ConsensusCache that the next catch-up poll consumes.
-                        // The fetch is bounded by redrive_fetch_budget (so a peer that never serves
-                        // the range cannot wedge this loop; partial fetches are cached and the next
-                        // re-drive resumes) and by rx_shutdown (so it never delays shutdown). The
-                        // counter is reset so we re-drive at most once per no-progress budget.
+                        // even then floors its walk at a watermark that only ever rises, so it
+                        // cannot recover a gap at the bottom of the catch-up range. Rather than
+                        // spinning here (or parking on the next gossip update, which may never
+                        // arrive for an older epoch's blocks or on an independently running node),
+                        // hand that exact range to the fetch task, which owns the in-flight
+                        // accounting, then break to the bottom select. That select re-drains the
+                        // cache on `stall_recheck` even though the fill lands silently (it never
+                        // advances last_consensus_header for heights <= the target), and reacts to
+                        // a fresh gossip target if one arrives.
                         warn!(target: "state-sync", ?epoch, last_consensus_height, target=pending_header.number,
-                            "catch-up stalled after retries, requesting the missing consensus range from peers");
+                            "catch-up stalled after retries, requesting the missing consensus range from the fetch task");
                         STATE_SYNC_METRICS.catch_up_redrives_total.increment(1);
-                        tokio::select! {
-                            _ = get_consensus_header_range(
-                                pending_header.number,
-                                pending_header.digest(),
-                                config.node_storage(),
-                                &consensus_bus,
-                                &network,
-                                &consensus_chain,
-                                last_consensus_height + 1,
-                            ) => {}
-                            _ = tokio::time::sleep(redrive_fetch_budget) => {
-                                debug!(target: "state-sync", ?epoch, last_consensus_height, target=pending_header.number,
-                                    "re-drive fetch exceeded budget, yielding; will resume next cycle");
-                            }
-                            _ = &rx_shutdown => return Ok(()),
-                        }
-                        no_progress_count = 0;
+                        consensus_bus.consensus_gap_request().send_replace(Some((
+                            epoch,
+                            pending_header.number,
+                            pending_header.digest(),
+                            last_consensus_height.saturating_add(1),
+                        )));
+                        break;
                     }
                     tokio::select! {
                         _ = tokio::time::sleep(catch_up_poll_interval) => {}
@@ -310,6 +297,11 @@ async fn spawn_stream_consensus_headers<DB: Database>(
                 // updates during the retry loop above will re-arm changed() correctly.
                 pending_header = rx_last_consensus_header.borrow_and_update().clone().unwrap_or_default();
             }
+            // Re-drain the cache after a stall: the fetch task fills the missing range silently
+            // (it never advances last_consensus_header for heights <= the target, so changed()
+            // above does not fire), so we re-enter the catch-up loop on this interval and drain
+            // whatever has landed. When already caught up this is a cheap periodic no-op.
+            _ = tokio::time::sleep(stall_recheck) => {}
             _ = &rx_shutdown => {
                 return Ok(())
             }
@@ -438,18 +430,18 @@ mod tests {
     use tn_config::NetworkConfig;
     use tn_storage::mem_db::MemDatabase;
     use tn_test_utils_committee::CommitteeFixture;
-    use tokio::sync::mpsc;
 
     /// Issue #836: when the observer catch-up loop makes no progress within its budget, it must
-    /// directly request the missing consensus range from peers rather than parking on the next
-    /// gossip update. With an empty cache and chain, catch-up can never make progress, so the
-    /// stall branch must issue an outbound network request within the (tiny, test-tuned) budget.
+    /// hand the missing range to the fetch task (rather than parking on the next gossip update)
+    /// by publishing a gap request on the bus. With an empty cache and chain, catch-up can never
+    /// make progress, so the stall branch must publish `Some((epoch, target, hash, floor))` within
+    /// the (tiny, test-tuned) budget.
     #[tokio::test]
-    async fn redrives_state_sync_request_on_catch_up_timeout() -> eyre::Result<()> {
+    async fn signals_gap_request_on_catch_up_timeout() -> eyre::Result<()> {
         let fixture = CommitteeFixture::builder(MemDatabase::default).build();
 
         // Borrow one authority's base config/storage/keys, then build a config with a fast,
-        // deterministic catch-up budget (re-drive after a single no-progress poll).
+        // deterministic catch-up budget (signal after a single no-progress poll).
         let (base_config, node_storage, key_config) = {
             let authority = fixture.authorities().next().expect("fixture yields an authority");
             let cc = authority.consensus_config();
@@ -457,10 +449,9 @@ mod tests {
         };
         let mut network_config = NetworkConfig::default();
         let sync = network_config.sync_config_mut();
-        // Re-drive after a single no-progress poll. The poll interval also bounds a single re-drive
-        // fetch (interval * max_no_progress); keep it comfortably above the outbound-request
-        // latency so the fetch is not cancelled before it issues the request we assert on.
-        sync.consensus_header_catch_up_poll_interval = Duration::from_millis(100);
+        // Signal after a single no-progress poll and keep the poll interval short so the test does
+        // not wait on the (interval * max_no_progress) recheck window.
+        sync.consensus_header_catch_up_poll_interval = Duration::from_millis(50);
         sync.consensus_header_catch_up_max_no_progress = 1;
 
         let committee = fixture.committee();
@@ -475,30 +466,29 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let consensus_chain = ConsensusChain::new(temp_dir.path().to_owned(), committee)?;
 
-        // Capture outbound network commands so we can observe the direct peer request. This
-        // isolated loop performs no other network I/O, so any command proves the re-drive fired.
-        let (net_tx, mut net_rx) = mpsc::channel(16);
-        let network = PrimaryNetworkHandle::new_for_test(net_tx);
-
         // Publish a pending header ahead of local height. The chain and cache are empty, so
         // catch-up returns early on the first missing output and makes no progress, forcing the
         // stall branch.
         let target = ConsensusHeader { number: 5, ..Default::default() };
         consensus_bus.last_consensus_header().send_replace(Some(target.clone()));
 
-        let handle = tokio::spawn(spawn_stream_consensus_headers(
-            config,
-            consensus_bus,
-            consensus_chain,
-            network,
-        ));
+        // Subscribe before spawning so we cannot miss the coalescing gap request.
+        let mut rx_gap = consensus_bus.consensus_gap_request().subscribe();
 
-        // The stall must actively request the missing range from peers instead of parking on the
-        // next gossip update; the outbound request appears on the mock network within the budget.
-        tokio::time::timeout(Duration::from_secs(5), net_rx.recv())
+        let handle =
+            tokio::spawn(spawn_stream_consensus_headers(config, consensus_bus, consensus_chain));
+
+        // The stall must publish a gap request for the missing range within the budget.
+        tokio::time::timeout(Duration::from_secs(5), rx_gap.changed())
             .await
-            .expect("catch-up stall did not request the missing range from peers in time")
-            .expect("network command channel closed unexpectedly");
+            .expect("catch-up stall did not signal a gap request in time")
+            .expect("gap request watch closed unexpectedly");
+
+        let request = *rx_gap.borrow_and_update();
+        let (_epoch, number, _hash, floor) =
+            request.expect("gap request should be Some after a stall");
+        assert_eq!(number, target.number, "gap target is the pending header number");
+        assert_eq!(floor, 1, "floor is last_consensus_height + 1 (0 + 1) for an empty chain");
 
         handle.abort();
         Ok(())

--- a/crates/state-sync/src/metrics.rs
+++ b/crates/state-sync/src/metrics.rs
@@ -21,6 +21,8 @@ pub(crate) struct StateSyncMetrics {
     pub(crate) headers_fetched_total: Counter,
     /// Epoch pack file fetches started.
     pub(crate) epoch_pack_fetches_total: Counter,
+    /// State-sync requests re-driven after a catch-up stall (issue #836).
+    pub(crate) catch_up_redrives_total: Counter,
 }
 
 #[cfg(test)]
@@ -38,6 +40,7 @@ mod tests {
             metrics.no_progress_total.increment(1);
             metrics.headers_fetched_total.increment(5);
             metrics.epoch_pack_fetches_total.increment(1);
+            metrics.catch_up_redrives_total.increment(1);
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
@@ -52,5 +55,6 @@ mod tests {
         assert!(matches!(value, DebugValue::Counter(5)));
         find("tn_state_sync.no_progress_total");
         find("tn_state_sync.epoch_pack_fetches_total");
+        find("tn_state_sync.catch_up_redrives_total");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #836.  The observer consensus-header catch-up loop
(`spawn_stream_consensus_headers`) polled the local `ConsensusCache` on a fixed
100ms interval, gave up after ~60s of no progress, then fell back to waiting for
the next `last_consensus_header` (gossip) update.  On a slow or independently
running node that update may never arrive, so the observer could stay parked
below the consensus target indefinitely.  On timeout it should actively request
the missing range from peers instead of blocking passively.

## Changes

- [x] On the catch-up no-progress timeout, directly request the missing range
  from peers: walk backward from the pending header down to
  `last_consensus_height + 1` (`get_consensus_header_range`), populating the
  `ConsensusCache` that the next catch-up poll consumes.  This does **not** rely
  on the gossip-driven backward traversal (`spawn_track_recent_consensus` ->
  `spawn_fetch_recent_consensus`), which only runs when a gossip update arrives
  and floors its walk at an internal `last_number` watermark, so it cannot
  recover a gap at the bottom of the catch-up range.  The request is bounded by a
  fetch budget (so a peer that never serves the range cannot wedge the loop;  
  partial fetches are cached and persisted, so the next re-drive resumes) and
  guarded by `rx_shutdown`, and the loop keeps polling instead of parking.  This
  threads the existing `PrimaryNetworkHandle` through `spawn_state_sync` ->
  `spawn_stream_consensus_headers` (issue item 2).
- [x] Make the catch-up poll interval and no-progress bound configurable via
  `SyncConfig` (`consensus_header_catch_up_poll_interval`,
  `consensus_header_catch_up_max_no_progress`), defaulting to the previous
  100ms / 600 (60s) behavior. Adds a `sync_config_mut` accessor on `NetworkConfig`.
- [x] Add a `tn_state_sync.catch_up_redrives_total` metric so re-drives are
  observable in production.
- [x] Correct the `catch_up_consensus_from_to` doc comment, which claimed it
  "queries peers";  it only reads local storage (`ConsensusCache`, then
  `ConsensusChain`), leaving the caller to request the missing range.

## Testing

- New unit test `state_sync::tests::redrives_state_sync_request_on_catch_up_timeout`:
  with an empty cache and chain (so catch-up can never progress) and a tiny tuned
  budget, it asserts the stall branch issues an outbound peer request on a mock
  `PrimaryNetworkHandle` within the budget (the loop performs no other network
  I/O, so any command proves the direct re-drive fired).
- Extended the `metrics` test to cover the new counter.
- `cargo clippy -p tn-config -p state-sync -p tn-executor --all-targets --all-features`
  clean; `cargo test -p state-sync` green; `make fmt` clean.

## Notes

- Happy-path behavior is unchanged: when the async backward traversal completes
  within the budget (the common case), the loop makes progress by polling and no
  peer request is issued.  The direct request is the safety net for the no-gossip
  / bottom-of-range-gap case, throttled to at most once per no-progress budget
  and shutdown-aware.
- The remaining #836 checklist item (default-CI coverage via a fast deterministic
  variant of `test_epoch_sync` / `test_epoch_boundary`) is deferred: those tests
  spin up multiple node processes and are `#[ignore]`d for independent runs.  The
  new unit test covers the re-drive decision deterministically without that
  harness.
