### PR TITLE
feat(network): cut the primary partial epoch-pack path over to the typed sync protocol with legacy fallback (739)

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -1180,9 +1180,10 @@ where
         peer: BlsPublicKey,
         mut stream: Stream,
         epoch: Epoch,
+        stop_number: Option<u64>,
         consensus_chain: &ConsensusChain,
     ) -> PrimaryNetworkResult<()> {
-        debug!(target: "primary::network", %peer, epoch, "serving inbound sync epoch pack stream");
+        debug!(target: "primary::network", %peer, epoch, ?stop_number, "serving inbound sync epoch pack stream");
         let max_frame = crate::network::sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
 
         // bound the whole serve; flatten the timeout's outer Result into the send's
@@ -1192,6 +1193,7 @@ where
                 &mut stream,
                 consensus_chain,
                 epoch,
+                stop_number,
                 SEND_STREAM_BUFFER_TIMEOUT,
                 peer,
             ),

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -12,7 +12,9 @@ use std::{
 use crate::{
     proposer::OurDigestMessage, state_sync::StateSynchronizer, ConsensusBus, ConsensusBusApp,
 };
-use futures::{AsyncReadExt as _, AsyncWriteExt as _, StreamExt as _};
+use futures::{
+    AsyncReadExt as _, AsyncWriteExt as _, FutureExt as _, StreamExt as _, TryFutureExt as _,
+};
 use handler::RequestHandler;
 pub use message::{MissingCertificatesRequest, PrimaryRequest, PrimaryResponse};
 use message::{PrimaryGossip, PrimaryRPCError};
@@ -690,7 +692,9 @@ impl PrimaryNetworkHandle {
     /// Full-pack fetch is typed-only (no legacy fallback): this returns `Err`, and
     /// the caller retries, when no connected peer successfully serves a pack over
     /// the sync protocol (no peers, all unsupported, or all failed to import). See
-    /// [`Self::request_epoch_pack_sync`] for the per-peer probe behavior.
+    /// [`Self::request_epoch_pack_sync`] for the per-peer probe behavior. The partial
+    /// prefix ([`Self::request_partial_epoch_pack`]) reuses the same probe over the
+    /// sync protocol but keeps a legacy fallback.
     pub async fn request_epoch_pack(
         &self,
         epoch_record: &EpochRecord,
@@ -736,8 +740,9 @@ impl PrimaryNetworkHandle {
     /// Shared implementation for full ([`Self::request_epoch_pack`]) and partial
     /// ([`Self::request_partial_epoch_pack`]) epoch pack streaming. A full pack
     /// (`last_consensus_number` is `None`) is fetched over the typed sync protocol
-    /// only; a partial prefix (`Some`) still negotiates over the legacy stream path,
-    /// which has no typed sync request variant yet.
+    /// only; a partial prefix (`Some`) is fetched over the sync protocol first and
+    /// falls back to the legacy stream path for peers that do not yet serve the
+    /// `EpochPackPartial` sync variant.
     async fn request_epoch_pack_inner(
         &self,
         epoch_record: &EpochRecord,
@@ -752,12 +757,12 @@ impl PrimaryNetworkHandle {
         // fallback was removed so that a full-pack fetch hard-fails (and the caller
         // retries) when no connected peer serves the `/tn-primary-sync` protocol,
         // rather than silently syncing over the legacy stream path. This forces
-        // peers to upgrade. The partial-prefix transfer has no typed sync request
-        // variant yet, so it still negotiates over the legacy path below.
+        // peers to upgrade.
         let Some(last_consensus_number) = last_consensus_number else {
             return self
                 .request_epoch_pack_sync(
                     epoch,
+                    None,
                     epoch_record,
                     previous_epoch,
                     consensus_chain,
@@ -766,7 +771,26 @@ impl PrimaryNetworkHandle {
                 .await;
         };
 
-        // Partial prefix: negotiate the stream over the legacy path. Try up to three
+        // Partial prefix (#739, step 9): try the typed sync protocol first (the same
+        // per-peer probe as the full pack), then fall back to the legacy stream path
+        // below for peers that do not yet serve the `EpochPackPartial` sync variant.
+        // The sync probe is penalty-exempt; `is_ok` avoids matching the `Result`.
+        if self
+            .request_epoch_pack_sync(
+                epoch,
+                Some(last_consensus_number),
+                epoch_record,
+                previous_epoch,
+                consensus_chain,
+                record_timeout,
+            )
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+
+        // Legacy fallback: negotiate the stream over the legacy path. Try up to three
         // times (from three peers) to get consensus. This could be a lot more
         // complicated but this KISS method should work fine.
         let (request, kind) = (
@@ -880,6 +904,7 @@ impl PrimaryNetworkHandle {
     async fn request_epoch_pack_sync(
         &self,
         epoch: Epoch,
+        last_consensus_number: Option<u64>,
         epoch_record: &EpochRecord,
         previous_epoch: &EpochRecord,
         consensus_chain: &ConsensusChain,
@@ -903,6 +928,7 @@ impl PrimaryNetworkHandle {
                     .sync_epoch_pack_from_peer(
                         peer,
                         epoch,
+                        last_consensus_number,
                         epoch_record,
                         previous_epoch,
                         consensus_chain,
@@ -921,11 +947,21 @@ impl PrimaryNetworkHandle {
                         true
                     }
                     EpochPackAttempt::Unsupported => {
-                        self.sync_capability.lock().insert(peer, false);
+                        // Only a FULL-pack `Unsupported` authoritatively proves the peer
+                        // does not speak `/tn-primary-sync`. A PARTIAL `Unsupported` is
+                        // ambiguous: the peer may be on an earlier item that serves full
+                        // packs but cannot decode the newer `EpochPackPartial` variant, so
+                        // it must not cache `false` and hide that peer from full-pack sync.
+                        // (Partial still honors a `false` a full probe wrote and caches
+                        // `true` on success, so it dedups without poisoning.)
+                        if last_consensus_number.is_none() {
+                            self.sync_capability.lock().insert(peer, false);
+                        }
                         debug!(
                             target: "primary::network",
                             %peer,
-                            "peer did not answer epoch pack sync; caching unsyncable this epoch"
+                            partial = last_consensus_number.is_some(),
+                            "peer did not answer epoch pack sync; skipping this probe"
                         );
                         false
                     }
@@ -960,6 +996,7 @@ impl PrimaryNetworkHandle {
         &self,
         peer: BlsPublicKey,
         epoch: Epoch,
+        last_consensus_number: Option<u64>,
         epoch_record: &EpochRecord,
         previous_epoch: &EpochRecord,
         consensus_chain: &ConsensusChain,
@@ -968,6 +1005,7 @@ impl PrimaryNetworkHandle {
         self.try_sync_epoch_pack_exchange(
             peer,
             epoch,
+            last_consensus_number,
             epoch_record,
             previous_epoch,
             consensus_chain,
@@ -977,9 +1015,12 @@ impl PrimaryNetworkHandle {
         .map_or_else(|attempt| attempt, |()| EpochPackAttempt::Imported)
     }
 
-    /// Open a `/tn-primary-sync` stream, write the [`PrimarySyncRequest::EpochPack`]
-    /// request in the opening frame, and stream the pack through
-    /// [`ConsensusChain::stream_import`].
+    /// Open a `/tn-primary-sync` stream, write the epoch-pack request in the opening
+    /// frame, and stream the pack into the consensus chain. `last_consensus_number`
+    /// selects the transfer: `None` requests the full pack ([`PrimarySyncRequest::EpochPack`])
+    /// and imports it in place via [`ConsensusChain::stream_import`]; `Some(number)`
+    /// requests a verifiable prefix ([`PrimarySyncRequest::EpochPackPartial`]) and imports
+    /// it into a side staging dir via [`ConsensusChain::import_partial_to_staging`].
     ///
     /// `Err(EpochPackAttempt::Unsupported)` means the peer did not answer the
     /// protocol (negotiation failed, or it negotiated but never `Ack`ed), so it is
@@ -993,6 +1034,7 @@ impl PrimaryNetworkHandle {
         &self,
         peer: BlsPublicKey,
         epoch: Epoch,
+        last_consensus_number: Option<u64>,
         epoch_record: &EpochRecord,
         previous_epoch: &EpochRecord,
         consensus_chain: &ConsensusChain,
@@ -1017,7 +1059,13 @@ impl PrimaryNetworkHandle {
         // write the request in the opening frame. Negotiation already succeeded, so
         // the peer is sync-capable; a write failure is transient -> try next.
         let max_frame = sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
-        let request = SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch });
+        // full pack vs a verifiable partial prefix: select the request variant through
+        // the `Option`'s combinator (no Some/None branch).
+        let request = SyncFrame::Req(
+            last_consensus_number.map_or(PrimarySyncRequest::EpochPack { epoch }, |number| {
+                PrimarySyncRequest::EpochPackPartial { epoch, last_consensus_number: number }
+            }),
+        );
         let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
         write_frame(&mut stream, &request, &mut encode_buffer, &mut compressed_buffer, max_frame)
             .await
@@ -1063,22 +1111,43 @@ impl PrimaryNetworkHandle {
 
         match first {
             // accepted: reassemble the `Data`/`End` frames into a contiguous reader
-            // and import it. A bad pack is the peer's fault on the legacy path, but
-            // the sync path is metrics-only during rollout: classify it `Failed`
-            // (try next peer) without a penalty.
-            SyncFrame::Ack => consensus_chain
-                .stream_import(
-                    sync_codec::sync_pack_reader(stream),
-                    epoch_record,
-                    previous_epoch,
-                    record_timeout,
-                )
-                .await
-                .map_err(|e| {
-                    EpochPackAttempt::Failed(NetworkError::RPCError(format!(
-                        "failed to import epoch pack over sync stream: {e}"
-                    )))
-                }),
+            // and import it. A full pack imports in place; a partial prefix imports to
+            // a side staging dir so it cannot race the in-order build of the current
+            // epoch's main pack (matching the legacy responder split). A bad pack is
+            // the peer's fault on the legacy path, but the sync path is metrics-only
+            // during rollout: classify it `Failed` (try next peer) without a penalty.
+            SyncFrame::Ack => {
+                let reader = sync_codec::sync_pack_reader(stream);
+                // pick the import target on `last_consensus_number.is_some()` (a bool,
+                // not an `Option` pattern-match); each branch normalizes to
+                // `Result<(), EpochPackAttempt>` then boxes so the `if` unifies their
+                // distinct future types.
+                let import = if last_consensus_number.is_some() {
+                    consensus_chain
+                        .import_partial_to_staging(
+                            reader,
+                            epoch_record,
+                            previous_epoch,
+                            record_timeout,
+                        )
+                        .map_err(|e| {
+                            EpochPackAttempt::Failed(NetworkError::RPCError(format!(
+                                "failed to import partial epoch pack over sync stream: {e}"
+                            )))
+                        })
+                        .boxed()
+                } else {
+                    consensus_chain
+                        .stream_import(reader, epoch_record, previous_epoch, record_timeout)
+                        .map_err(|e| {
+                            EpochPackAttempt::Failed(NetworkError::RPCError(format!(
+                                "failed to import epoch pack over sync stream: {e}"
+                            )))
+                        })
+                        .boxed()
+                };
+                import.await
+            }
             // sync-capable, but shedding load or lacking the pack: try next peer
             SyncFrame::Deny(reason) => Err(EpochPackAttempt::Failed(NetworkError::RPCRetryable(
                 format!("peer denied epoch pack sync request: {reason:?}"),
@@ -1691,7 +1760,25 @@ where
             match request {
                 SyncFrame::Req(PrimarySyncRequest::EpochPack { epoch }) => {
                     request_handler
-                        .process_sync_epoch_pack_stream(peer, stream, epoch, &consensus_chain)
+                        .process_sync_epoch_pack_stream(peer, stream, epoch, None, &consensus_chain)
+                        .await?;
+                }
+                // `EpochPackPartial` over sync (item 9): serve the verifiable prefix of
+                // an in-progress epoch, replacing the legacy `StreamEpochPartial`
+                // ack-plus-digest path. Same serve as the full pack, bounded to the
+                // prefix length by `Some(last_consensus_number)`.
+                SyncFrame::Req(PrimarySyncRequest::EpochPackPartial {
+                    epoch,
+                    last_consensus_number,
+                }) => {
+                    request_handler
+                        .process_sync_epoch_pack_stream(
+                            peer,
+                            stream,
+                            epoch,
+                            Some(last_consensus_number),
+                            &consensus_chain,
+                        )
                         .await?;
                 }
                 // `MissingCertificates` over sync (item 7): serve the matching

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -238,6 +238,27 @@ enum EpochPackAttempt {
     Failed(NetworkError),
 }
 
+/// One epoch-pack fetch over the typed sync protocol, as threaded unchanged
+/// through every per-peer probe (`request_epoch_pack_sync` down to the stream
+/// exchange). Bundles what the exchange needs so each probe hop takes the peer
+/// plus this instead of six loose parameters.
+#[derive(Clone, Copy)]
+struct EpochPackSyncRequest<'a> {
+    /// The epoch whose pack is requested.
+    epoch: Epoch,
+    /// `None` requests the full pack; `Some(n)` requests a verifiable prefix
+    /// stopping after consensus number `n`.
+    last_consensus_number: Option<u64>,
+    /// Record of the epoch being fetched; the streamed pack verifies against it.
+    epoch_record: &'a EpochRecord,
+    /// The preceding epoch's record, anchoring verification.
+    previous_epoch: &'a EpochRecord,
+    /// Destination chain the served pack imports into.
+    consensus_chain: &'a ConsensusChain,
+    /// Timeout applied when importing the streamed records.
+    record_timeout: Duration,
+}
+
 /// RAII guard for an admitted inbound sync epoch-pack stream.
 ///
 /// Holds a global concurrency permit and counts toward the peer's per-peer
@@ -772,14 +793,14 @@ impl PrimaryNetworkHandle {
         // peers to upgrade.
         let Some(last_consensus_number) = last_consensus_number else {
             return self
-                .request_epoch_pack_sync(
+                .request_epoch_pack_sync(EpochPackSyncRequest {
                     epoch,
-                    None,
+                    last_consensus_number: None,
                     epoch_record,
                     previous_epoch,
                     consensus_chain,
                     record_timeout,
-                )
+                })
                 .await;
         };
 
@@ -788,14 +809,14 @@ impl PrimaryNetworkHandle {
         // below for peers that do not yet serve the `EpochPackPartial` sync variant.
         // The sync probe is penalty-exempt; `is_ok` avoids matching the `Result`.
         if self
-            .request_epoch_pack_sync(
+            .request_epoch_pack_sync(EpochPackSyncRequest {
                 epoch,
-                Some(last_consensus_number),
+                last_consensus_number: Some(last_consensus_number),
                 epoch_record,
                 previous_epoch,
                 consensus_chain,
                 record_timeout,
-            )
+            })
             .await
             .is_ok()
         {
@@ -913,15 +934,8 @@ impl PrimaryNetworkHandle {
     /// that imports; otherwise `Err` (full-pack fetch has no legacy fallback, so the
     /// caller retries). A peer that does not answer is cached unsyncable (skipping
     /// its probe next time); the probe is penalty-exempt either way.
-    async fn request_epoch_pack_sync(
-        &self,
-        epoch: Epoch,
-        last_consensus_number: Option<u64>,
-        epoch_record: &EpochRecord,
-        previous_epoch: &EpochRecord,
-        consensus_chain: &ConsensusChain,
-        record_timeout: Duration,
-    ) -> NetworkResult<()> {
+    async fn request_epoch_pack_sync(&self, sync: EpochPackSyncRequest<'_>) -> NetworkResult<()> {
+        let EpochPackSyncRequest { epoch, last_consensus_number, .. } = sync;
         let peers = self.handle.connected_peers().await?;
 
         // Probe candidate peers one at a time (the async analog of a short-circuiting
@@ -936,18 +950,7 @@ impl PrimaryNetworkHandle {
             })
             .take(MAX_EPOCH_SYNC_PROBES)
             .then(move |peer| async move {
-                match self
-                    .sync_epoch_pack_from_peer(
-                        peer,
-                        epoch,
-                        last_consensus_number,
-                        epoch_record,
-                        previous_epoch,
-                        consensus_chain,
-                        record_timeout,
-                    )
-                    .await
-                {
+                match self.sync_epoch_pack_from_peer(peer, sync).await {
                     EpochPackAttempt::Imported => {
                         self.sync_capability.lock().insert(peer, true);
                         info!(
@@ -1007,24 +1010,11 @@ impl PrimaryNetworkHandle {
     async fn sync_epoch_pack_from_peer(
         &self,
         peer: BlsPublicKey,
-        epoch: Epoch,
-        last_consensus_number: Option<u64>,
-        epoch_record: &EpochRecord,
-        previous_epoch: &EpochRecord,
-        consensus_chain: &ConsensusChain,
-        record_timeout: Duration,
+        sync: EpochPackSyncRequest<'_>,
     ) -> EpochPackAttempt {
-        self.try_sync_epoch_pack_exchange(
-            peer,
-            epoch,
-            last_consensus_number,
-            epoch_record,
-            previous_epoch,
-            consensus_chain,
-            record_timeout,
-        )
-        .await
-        .map_or_else(|attempt| attempt, |()| EpochPackAttempt::Imported)
+        self.try_sync_epoch_pack_exchange(peer, sync)
+            .await
+            .map_or_else(|attempt| attempt, |()| EpochPackAttempt::Imported)
     }
 
     /// Open a `/tn-primary-sync` stream, write the epoch-pack request in the opening
@@ -1045,13 +1035,16 @@ impl PrimaryNetworkHandle {
     async fn try_sync_epoch_pack_exchange(
         &self,
         peer: BlsPublicKey,
-        epoch: Epoch,
-        last_consensus_number: Option<u64>,
-        epoch_record: &EpochRecord,
-        previous_epoch: &EpochRecord,
-        consensus_chain: &ConsensusChain,
-        record_timeout: Duration,
+        sync: EpochPackSyncRequest<'_>,
     ) -> Result<(), EpochPackAttempt> {
+        let EpochPackSyncRequest {
+            epoch,
+            last_consensus_number,
+            epoch_record,
+            previous_epoch,
+            consensus_chain,
+            record_timeout,
+        } = sync;
         // open the sync stream, flattening the command-channel and stream-open
         // results. Only a genuine negotiation failure (`UpgradeFailed`) is a
         // pre-cutover peer that does not advertise the protocol -> Unsupported

--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -18,13 +18,13 @@
 use crate::error::PrimaryNetworkResult;
 use futures::{
     io::{AsyncRead as FuturesAsyncRead, AsyncWrite as FuturesAsyncWrite},
-    AsyncWriteExt as _, StreamExt as _, TryStreamExt as _,
+    AsyncWriteExt as _, FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
 };
 use std::time::Duration;
 use tn_network_libp2p::{read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{encode, try_decode, BlsPublicKey, Certificate, Epoch};
-use tokio::io::AsyncRead as TokioAsyncRead;
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncReadExt as _};
 use tracing::debug;
 
 /// The raw pack bytes carried by a single [`SyncFrame::Data`] frame.
@@ -84,18 +84,24 @@ const MISSING_CERTS_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Serve an accepted epoch-pack sync exchange over `stream`.
 ///
-/// A full epoch pack is all-or-nothing: if the complete, verifiable pack is not
-/// held, the responder sheds with [`SyncFrame::Deny`]`(`[`DenyReason::Unavailable`]`)`
-/// so the requester retries another peer immediately instead of waiting out its
-/// ack timeout. Otherwise it writes [`SyncFrame::Ack`], streams the pack as
-/// [`SyncFrame::Data`] frames, and ends with [`SyncFrame::End`]. Each frame write
-/// is bounded by `buffer_timeout` so a peer that stops reading cannot stall the
+/// `stop_number` selects the transfer: `None` serves the complete epoch pack,
+/// `Some(last_consensus_number)` serves the verifiable PREFIX up to that consensus
+/// output (the partial in-progress epoch, [`ConsensusChain::get_partial_epoch_stream`]).
+/// Either way the transfer is all-or-nothing: if the requested pack (or its prefix)
+/// is not held, the responder sheds with
+/// [`SyncFrame::Deny`]`(`[`DenyReason::Unavailable`]`)` so the requester retries
+/// another peer immediately instead of waiting out its ack timeout. Otherwise it
+/// writes [`SyncFrame::Ack`], streams the pack as [`SyncFrame::Data`] frames, and
+/// ends with [`SyncFrame::End`]. A partial transfer bounds the source reader to the
+/// prefix length so it never streams past the verifiable point. Each frame write is
+/// bounded by `buffer_timeout` so a peer that stops reading cannot stall the
 /// responder task on an unbounded write. The caller has already admitted the
 /// exchange against the concurrency caps and read the opening request frame.
 pub(crate) async fn send_sync_epoch_pack_over_stream<S>(
     stream: &mut S,
     consensus_chain: &ConsensusChain,
     epoch: Epoch,
+    stop_number: Option<u64>,
     buffer_timeout: Duration,
     peer: BlsPublicKey,
 ) -> PrimaryNetworkResult<()>
@@ -104,9 +110,26 @@ where
 {
     let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
 
-    // the complete pack is not held: shed cleanly so the requester retries elsewhere
-    let Ok(mut epoch_stream) = consensus_chain.get_epoch_stream(epoch).await else {
-        debug!(target: "primary::network", %peer, epoch, "epoch pack unavailable; denying sync request");
+    // resolve the source reader and its byte cap through the `Option`'s combinator
+    // rather than a Some/None branch: a full pack streams to EOF (`u64::MAX` never
+    // bounds the `take` below), a partial prefix is capped at its `[0, end)`
+    // verifiable length. Both arms normalize to one boxed future so `map_or_else`
+    // can pick either; a missing pack (or an out-of-range partial stop point) sheds
+    // cleanly so the requester retries elsewhere.
+    let source = stop_number
+        .map_or_else(
+            || {
+                consensus_chain
+                    .get_epoch_stream(epoch)
+                    .map_ok(|reader| (reader, u64::MAX))
+                    .map_err(drop)
+                    .boxed()
+            },
+            |number| consensus_chain.get_partial_epoch_stream(epoch, number).map_err(drop).boxed(),
+        )
+        .await;
+    let Ok((epoch_stream, cap)) = source else {
+        debug!(target: "primary::network", %peer, epoch, ?stop_number, "epoch pack unavailable; denying sync request");
         write_one_frame(
             stream,
             &SyncFrame::Deny(DenyReason::Unavailable),
@@ -131,7 +154,10 @@ where
     )
     .await?;
 
-    write_pack_data_frames(&mut epoch_stream, stream, buffer_timeout).await?;
+    // a partial transfer caps the reader at the prefix length; a full transfer
+    // resolved `cap` to `u64::MAX`, which never bounds the read, so this streams to
+    // EOF.
+    write_pack_data_frames(&mut epoch_stream.take(cap), stream, buffer_timeout).await?;
     Ok(())
 }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -1094,6 +1094,96 @@ async fn test_send_partial_epoch_over_stream() {
     assert_eq!(&sent_more[..sent.len()], &sent[..], "smaller prefix must prefix the larger one");
 }
 
+/// Serving a partial prefix over the sync protocol (`EpochPackPartial`, item 9)
+/// writes `Ack` then streams exactly the verifiable prefix bytes as `Data` frames:
+/// the bytes reassembled from the frames must equal the data file truncated at
+/// `output_end(k)`, and a later cutoff must stream strictly more (with the smaller
+/// prefix a true prefix of it): the sync mirror of `test_send_partial_epoch_over_stream`.
+#[tokio::test]
+async fn test_sync_partial_epoch_pack_over_stream() {
+    use tokio::io::AsyncReadExt as _;
+
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+    let committee_obj = committee.committee();
+    let peer = *committee.first_authority().authority().protocol_key();
+
+    // Populate the in-progress (never finalized) epoch-0 pack with some outputs.
+    let num_outputs = 15u64;
+    for number in 1..=num_outputs {
+        let cert = Certificate::default();
+        let sub_dag = CommittedSubDag::new(
+            vec![cert.clone()],
+            cert,
+            number,
+            ReputationScores::new(&committee_obj),
+            None,
+        );
+        handler.consensus_chain().write_subdag_for_test(number, sub_dag).await;
+    }
+
+    // Reassemble the pack bytes streamed by the sync serve for a stop point `k`: read
+    // the leading `Ack`, then feed the remaining `Data`/`End` frames through
+    // `sync_pack_reader` (the reader the real requester uses).
+    async fn reassemble_partial(
+        consensus_chain: &tn_storage::consensus::ConsensusChain,
+        stop_number: u64,
+        peer: BlsPublicKey,
+    ) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        crate::network::sync_codec::send_sync_epoch_pack_over_stream(
+            &mut out,
+            consensus_chain,
+            0,
+            Some(stop_number),
+            Duration::from_secs(10),
+            peer,
+        )
+        .await
+        .expect("serve partial epoch pack over sync");
+
+        let mut cursor = futures::io::Cursor::new(out);
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        let ack = tn_network_libp2p::read_frame::<_, tn_network_libp2p::PrimarySyncRequest>(
+            &mut cursor,
+            &mut dec,
+            &mut comp,
+            crate::network::sync_codec::MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("read ack frame");
+        assert_matches!(ack, tn_network_libp2p::SyncFrame::Ack);
+
+        let mut reassembled = Vec::new();
+        crate::network::sync_codec::sync_pack_reader(cursor)
+            .read_to_end(&mut reassembled)
+            .await
+            .expect("reassemble partial pack data frames");
+        reassembled
+    }
+
+    // The reassembled bytes must equal the verifiable prefix the chain exposes, i.e.
+    // the data file truncated at `output_end(k)`.
+    let k = 9u64;
+    let reassembled = reassemble_partial(handler.consensus_chain(), k, peer).await;
+    let (stream, len) =
+        handler.consensus_chain().get_partial_epoch_stream(0, k).await.expect("partial stream");
+    let mut expected = Vec::new();
+    stream.take(len).read_to_end(&mut expected).await.unwrap();
+    assert_eq!(reassembled.len() as u64, len, "streamed byte count must equal the partial cutoff");
+    assert_eq!(reassembled, expected, "reassembled bytes must equal the verifiable prefix");
+
+    // A later cutoff streams strictly more, and the smaller prefix is a true prefix of it.
+    let reassembled_more = reassemble_partial(handler.consensus_chain(), num_outputs, peer).await;
+    assert!(reassembled_more.len() > reassembled.len(), "a later cutoff must stream more bytes");
+    assert_eq!(
+        &reassembled_more[..reassembled.len()],
+        &reassembled[..],
+        "smaller prefix must prefix the larger one"
+    );
+}
+
 /// A full epoch pack the responder does not hold is shed with
 /// `Deny(Unavailable)`, so a sync requester retries another peer immediately
 /// instead of waiting out its ack timeout. (The `Ack`+`Data`+`End` happy path is
@@ -1112,6 +1202,7 @@ async fn test_sync_epoch_pack_unavailable_denies() {
         &mut out,
         handler.consensus_chain(),
         0,
+        None,
         Duration::from_secs(5),
         peer,
     )

--- a/crates/network-libp2p/src/sync/request.rs
+++ b/crates/network-libp2p/src/sync/request.rs
@@ -56,6 +56,20 @@ pub enum PrimarySyncRequest {
         /// Per-authority rounds to skip, each serialized as a RoaringBitmap.
         skip_rounds: Vec<(AuthorityIdentifier, Vec<u8>)>,
     },
+    /// Request a verifiable PREFIX of an epoch's consensus pack file, stopping
+    /// after the consensus output with `last_consensus_number`.
+    ///
+    /// Folds the legacy `StreamEpochPartial` ack-plus-digest handshake into a
+    /// single open. Unlike [`Self::EpochPack`] (a complete epoch), this streams
+    /// the in-progress current epoch up to an already-committed, verifiable
+    /// point; `last_consensus_number` is a chain consensus number, not a
+    /// pack-relative index.
+    EpochPackPartial {
+        /// The epoch whose consensus data is requested.
+        epoch: Epoch,
+        /// The final (inclusive) consensus header number to stream up to.
+        last_consensus_number: u64,
+    },
 }
 
 #[cfg(test)]
@@ -96,6 +110,12 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn primary_partial_epoch_pack_request_round_trips() {
+        let request = PrimarySyncRequest::EpochPackPartial { epoch: 7, last_consensus_number: 41 };
+        assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
+    }
+
+    #[tokio::test]
     async fn primary_missing_certificates_request_round_trips() {
         let request = PrimarySyncRequest::MissingCertificates {
             exclusive_lower_bound: 12,
@@ -128,5 +148,12 @@ mod tests {
         })
         .expect("encode missing certificates");
         assert_eq!(missing.first(), Some(&1));
+
+        let partial = bcs::to_bytes(&PrimarySyncRequest::EpochPackPartial {
+            epoch: 0,
+            last_consensus_number: 0,
+        })
+        .expect("encode partial epoch pack");
+        assert_eq!(partial.first(), Some(&2));
     }
 }


### PR DESCRIPTION
## Summary

Cuts the primary **partial epoch-pack** stream path (`StreamEpochPartial`) over to the typed `/tn-primary-sync` protocol, with a legacy fallback for peers that do not yet serve the new sync variant.  This is the direct partial-prefix sibling of the full-pack cutover (#797) and its fallback removal (#810), and it removes one of the two remaining users of the raw `/tn-stream` behaviour (the other, single-consensus-output streaming, is a follow-up).  It is part of finishing the #739 migration before the final legacy freeze.

Additive and wire-compatible: no request/response or `PrimarySyncRequest` variant is reordered or removed; the legacy `StreamEpochPartial` request-response + `/tn-stream` responder stay in place as the fallback and are removed in the coordinated `/0.0.2` bump (item 9).

## What changes

**New typed request variant.** `PrimarySyncRequest::EpochPackPartial { epoch, last_consensus_number }` is appended (BCS discriminant 2); `request_tags_are_stable` pins it and a round-trip test covers it.  It folds the legacy `StreamEpochPartial` ack-plus-digest handshake into the opening `SyncFrame::Req`, exactly as `EpochPack` did for the full pack.

**Requester (dual-stack, sync-first).** `request_partial_epoch_pack` now tries the sync protocol first over the same per-peer probe as the full pack (`request_epoch_pack_sync`, reused with a `last_consensus_number: Option<u64>` selector), then falls back to the existing legacy `/tn-stream` loop when no connected peer serves the partial variant over sync.  The sync probe is penalty-exempt.  On `Ack` the reassembled `Data`/`End` stream is imported via `ConsensusChain::import_partial_to_staging` (a side staging dir), preserving the legacy split that keeps the partial prefix from racing the in-order build of the current epoch's main pack.  Bad-pack import errors on the sync path are metrics-only (no penalty) during rollout, matching the full-pack sync path.

**Capability-cache isolation.** The shared `sync_capability` probe-dedup cache is not poisoned by a partial `Unsupported`: only a *full*-pack `Unsupported` authoritatively proves a peer does not speak `/tn-primary-sync`.  A partial `Unsupported` is ambiguous: the peer may be on an earlier item that serves full packs but cannot decode the newer `EpochPackPartial` variant, so it must not cache `false` and hide that peer from full-pack sync.  Partial still honors a `false` a full probe wrote and caches `true` on success, so it dedups without cross-contamination.

**Responder.** `process_inbound_sync_stream` gains an `EpochPackPartial` arm; `send_sync_epoch_pack_over_stream` is generalized with `stop_number: Option<u64>` and bounds the source reader to the verifiable `[0, output_end(k))` prefix (`get_partial_epoch_stream` + `AsyncReadExt::take`), reusing the same `Ack` + chunked `Data` + `End` framing, admission caps, and bounded writes as the full pack.

## Conventions

No two-branch pattern-match on `Option`: the request variant is selected with `Option::map_or`, the source reader/cap with `Option::map_or_else` over boxed futures, and the import target with `last_consensus_number.is_some()` + a boxed `if` (never a `match`/`if let` on the `Option`).

## Tests

- `primary_partial_epoch_pack_request_round_trips` + extended `request_tags_are_stable` (pins discriminant 2).
- `test_sync_partial_epoch_pack_over_stream`: the sync serve writes `Ack` then streams exactly the verifiable prefix bytes; the reassembled `Data` frames equal the data file truncated at `output_end(k)`, and a later cutoff streams strictly more with the smaller prefix a true prefix of it (the sync mirror of `test_send_partial_epoch_over_stream`).

The requester-side import-target choice (`import_partial_to_staging` for partial vs `stream_import` for full) is not unit-tested because the exchange runs over a real `libp2p::Stream`, which is unmockable, so the epoch-pack requester has no trait seam (same limitation as the already-merged full-pack requester;  the streamed happy path is covered by the ignored observer-pack-import e2e test).  The choice mirrors the tested legacy `StreamEpochPartial` requester, which also stages, and the in-code comment documents why partial must not import in place.

## Gates

`-j 2` throughout (OOM-safe).  fmt (nightly-2026-03-20);  clippy `-p tn-network-libp2p --all-features --all-targets` and `-p tn-primary` clean;  `tn-network-libp2p` + `tn-primary` tests pass;  `cargo doc -D warnings`.

## Rollout / follow-ups

Dual-stack per the #739 rollout rules (`Severe` suppressed for the new-protocol negotiation failure while the fallback exists).  Remaining before the epic closes:
- Single consensus-output stream (`StreamConsensusOutput`) cutover: the last legacy `/tn-stream` user.
- Then the legacy freeze: make the worker-batch and these paths sync-only (mirroring #810), answer the deprecated request-response variants with a typed error, and delete the raw `/tn-stream` open path, digest pending maps, and prune tasks.
- Finally the coordinated `/0.0.2` bump (telemetry + epoch-boundary gated): delete the deprecated BCS variants and drop the `From<PeerExchangeMap>` / `peer_exchange_msg()` bounds from `TNMessage`.
