### PR TITLE
test: fix faucet e2e ABI + precompile drift via generated bindings (#863)

### DIFF
--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -51,7 +51,7 @@ secp256k1 = { workspace = true, features = [
 
 [features]
 default = []
-faucet = ["dep:futures"]
+faucet = ["dep:futures", "tn-reth/faucet"]
 
 [lints]
 workspace = true

--- a/crates/e2e-tests/tests/it/faucet.rs
+++ b/crates/e2e-tests/tests/it/faucet.rs
@@ -1,6 +1,6 @@
 //! Integration test for faucet drip functionality.
 //!
-//! Tests calling the StablecoinManager's permissionless `drip()` function directly
+//! Tests calling the StablecoinManager's permissionless `dripTo()` function directly
 //! via `eth_sendRawTransaction`. The contract mints TEL via the precompile at 0x7e1
 //! and stablecoins via ERC20 mint. Rate limiting is handled by the contract's `_checkDrip()`.
 
@@ -10,7 +10,10 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use std::{str::FromStr, sync::Arc, time::Duration};
 use tn_config::{fetch_file_content_relative_to_manifest, Config, ConfigFmt, ConfigTrait};
-use tn_reth::{test_utils::TransactionFactory, RethChainSpec, RethEnv};
+use tn_reth::{
+    faucet_mint_role_slot, test_utils::TransactionFactory, RethChainSpec, RethEnv,
+    TELCOIN_PRECOMPILE_ADDRESS,
+};
 use tn_types::{
     adiri_genesis, hex, sol, Address, Encodable2718 as _, Genesis, GenesisAccount, SolValue,
     TaskManager, B256, U256,
@@ -21,6 +24,10 @@ use tracing::{debug, info};
 #[tokio::test]
 async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     // faucet interface
+    //
+    // mirrors `tn-contracts/artifacts/StablecoinManager.json`; every call below is encoded
+    // through these generated call types so a selector can never drift from its params
+    // again (see #863)
     sol!(
         #[allow(clippy::too_many_arguments)]
         #[sol(rpc)]
@@ -33,10 +40,18 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
                 uint256 initMinLimit;
                 uint256 dripAmount_;
                 uint256 nativeDripAmount_;
+                uint256 baseDripCooldown_;
             }
 
             function initialize(StablecoinManagerInitParams calldata initParams) external;
-            function drip(address token, address recipient) external;
+            function UpdateXYZ(
+                address token,
+                bool validity,
+                uint256 maxLimit,
+                uint256 minLimit,
+                uint256 baseDripAmount
+            ) external;
+            function dripTo(address recipient, address token, uint256 amount) external;
         }
     );
 
@@ -51,6 +66,7 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
             ) external;
             function decimals() external view returns (uint8);
             function balanceOf(address account) external view returns (uint256);
+            function grantRole(bytes32 role, address account) external;
         }
     );
 
@@ -103,7 +119,6 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     );
 
     // get data for faucet proxy deployment w/ initdata
-    let faucet_init_selector = [22, 173, 166, 177];
     let deployed_token_bytes = vec![];
     let init_max_limit = U256::MAX;
     let init_min_limit = U256::from(1_000);
@@ -111,20 +126,27 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let tel_amount =
         U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256"); // 1 $TEL
 
-    // encode initialization struct
-    let init_params = StablecoinManager::StablecoinManagerInitParams {
-        admin_: factory_address,
-        maintainer_: factory_address,
-        tokens_: deployed_token_bytes,
-        initMaxLimit: init_max_limit,
-        initMinLimit: init_min_limit,
-        dripAmount_: xyz_amount,
-        nativeDripAmount_: tel_amount,
+    // 1 day; must be nonzero (`_setBaselineDripCooldown` rejects writing the value already
+    // stored, and the fresh slot is zero). The value never gates this test: every drip
+    // below targets a fresh recipient, whose cooldown clock starts at zero.
+    let base_drip_cooldown = U256::from(60 * 60 * 24);
+
+    // encode initialization call (selector + params struct) via the generated binding
+    let init_call = StablecoinManager::initializeCall {
+        initParams: StablecoinManager::StablecoinManagerInitParams {
+            admin_: factory_address,
+            maintainer_: factory_address,
+            tokens_: deployed_token_bytes,
+            initMaxLimit: init_max_limit,
+            initMinLimit: init_min_limit,
+            dripAmount_: xyz_amount,
+            nativeDripAmount_: tel_amount,
+            baseDripCooldown_: base_drip_cooldown,
+        },
     }
     .abi_encode();
 
     // construct create data for faucet proxy address
-    let init_call = [&faucet_init_selector, &init_params[..]].concat();
     let constructor_params = (faucet_impl_address, init_call.clone()).abi_encode_params();
     let proxy_json =
         fetch_file_content_relative_to_manifest("../../tn-contracts/artifacts/ERC1967Proxy.json");
@@ -140,9 +162,12 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let faucet_create_data = [proxy_initcode.clone().as_slice(), &constructor_params[..]].concat();
 
     // construct create data for stablecoin proxy
-    let stablecoin_init_selector = [22, 36, 246, 198];
-    let stablecoin_init_params = ("name", "symbol", 6).abi_encode_params();
-    let stablecoin_init_call = [&stablecoin_init_selector, &stablecoin_init_params[..]].concat();
+    let stablecoin_init_call = Stablecoin::initializeCall {
+        name_: "name".to_string(),
+        symbol_: "symbol".to_string(),
+        decimals_: 6,
+    }
+    .abi_encode();
     let stablecoin_constructor_params =
         (stablecoin_impl_address, stablecoin_init_call.clone()).abi_encode_params();
     let stablecoin_create_data =
@@ -152,19 +177,27 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let faucet_proxy_address = factory_address.create(0);
     let stablecoin_address = factory_address.create(1);
 
-    // construct `updateXYZ()` data
-    let updatexyz_selector = [233, 174, 163, 150];
-    let updatexyz_params = (stablecoin_address, true, U256::MAX, U256::ZERO).abi_encode_params();
-    let updatexyz_call = [&updatexyz_selector, &updatexyz_params[..]].concat().into();
+    // construct `UpdateXYZ()` data enabling the stablecoin for drips; the inherited 4-arg
+    // overload reverts with `UpdateXYZRequiresBaseDripAmount`, so the token's baseline
+    // drip amount is seeded here via StablecoinManager's 5-arg overload
+    let updatexyz_call = StablecoinManager::UpdateXYZCall {
+        token: stablecoin_address,
+        validity: true,
+        maxLimit: U256::MAX,
+        minLimit: U256::ZERO,
+        baseDripAmount: xyz_amount,
+    }
+    .abi_encode()
+    .into();
 
     // construct `grantRole(minter_role)` on stablecoin to faucet proxy
-    let grant_role_selector = [47, 47, 241, 93];
-    let minter_role_params = (
-        B256::from_str("0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6")?,
-        faucet_proxy_address,
-    )
-        .abi_encode_params();
-    let minter_role_call = [&grant_role_selector, &minter_role_params[..]].concat().into();
+    let minter_role_call = Stablecoin::grantRoleCall {
+        // keccak256("MINTER_ROLE")
+        role: B256::from_str("0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6")?,
+        account: faucet_proxy_address,
+    }
+    .abi_encode()
+    .into();
 
     // assemble eip1559 transactions using constructed datas
     let pre_genesis_chain: Arc<RethChainSpec> = Arc::new(tmp_genesis.into());
@@ -217,18 +250,51 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     )?;
     // fetch state to be set on the faucet proxy address
     let execution_bundle = tmp_reth_env
-        .execution_outcome_for_tests(raw_txs, &pre_genesis_chain.sealed_genesis_header());
+        .execution_outcome_for_tests(raw_txs, &pre_genesis_chain.sealed_genesis_header())?;
     let execution_storage_faucet = &execution_bundle
         .state
         .get(&faucet_proxy_address)
-        .expect("faucet address missing from bundle state")
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "faucet proxy missing from bundle state: its CREATE landed at a different \
+                 address than the one predicted from the deployer's nonce 0"
+            )
+        })?
         .storage;
     // fetch state to be set on the stablecoin address
     let execution_storage_stablecoin = &execution_bundle
         .state
         .get(&stablecoin_address)
-        .expect("stablecoin address missing from bundle state")
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "stablecoin proxy missing from bundle state: its CREATE landed at a different \
+                 address than the one predicted from the deployer's nonce 1"
+            )
+        })?
         .storage;
+
+    // extend (never replace) the canonical TEL precompile genesis account with the faucet
+    // proxy's mint role: its nonzero code (`0xfe`) is what exempts the account from
+    // EIP-158 state clearing, which would otherwise delete it at the end of the first
+    // block that touches the precompile, silently wiping the mint-role and total-supply
+    // slots and reverting every subsequent drip
+    let tel_precompile_genesis_account = genesis
+        .alloc
+        .get(&TELCOIN_PRECOMPILE_ADDRESS)
+        .cloned()
+        .ok_or_else(|| eyre::eyre!("TEL precompile account missing from genesis template"))?;
+    let tel_precompile_storage = tel_precompile_genesis_account
+        .storage
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .chain(std::iter::once((
+            faucet_mint_role_slot(faucet_proxy_address).into(),
+            B256::with_last_byte(1),
+        )))
+        .collect();
+    let tel_precompile_genesis_account =
+        tel_precompile_genesis_account.with_storage(Some(tel_precompile_storage));
 
     // real genesis: configure genesis accounts for proxy deployment
     let genesis_accounts = vec![
@@ -265,6 +331,10 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
                         .collect(),
                 )),
         ),
+        // authorize the faucet proxy to call the TEL precompile's `mint(address,uint256)`:
+        // seed its mint-role slot in genesis, mirroring what a runtime `grantMintRole`
+        // from the governance safe writes
+        (TELCOIN_PRECOMPILE_ADDRESS, tel_precompile_genesis_account),
     ];
 
     // create and launch validator nodes on local network
@@ -299,9 +369,17 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     debug!(target: "faucet-test", "starting balance: {starting_tel_balance:?}");
     assert_eq!(U256::from_str(&starting_tel_balance)?, U256::ZERO);
 
-    // call drip(address(0), recipient) for TEL via the contract directly
-    let drip_calldata =
-        StablecoinManager::dripCall { token: Address::ZERO, recipient }.abi_encode();
+    // native TEL is keyed by the conventional eth pseudo-address (`NATIVE_TOKEN_POINTER`
+    // in tn-contracts' TNFaucet.sol), not `address(0)`
+    let native_token_pointer = Address::from_str("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE")?;
+    let encode_drip = |recipient: Address, token: Address, amount: U256| {
+        StablecoinManager::dripToCall { recipient, token, amount }.abi_encode()
+    };
+
+    // call dripTo(recipient, native, 1 TEL) for TEL via the contract directly; the amount
+    // is the baseline max seeded at initialization, and `_checkDrip` floors requests at
+    // one tenth of that max
+    let drip_calldata = encode_drip(recipient, native_token_pointer, tel_amount);
     let drip_tx = caller.create_eip1559(
         chain.clone(),
         None,
@@ -327,11 +405,9 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     .await?
     .expect("expected TEL balance timeout");
 
-    // call drip(stablecoin, new_recipient) for XYZ
+    // call dripTo(new_recipient, stablecoin, 1 XYZ) for XYZ
     let new_recipient = Address::random();
-    let xyz_drip_calldata =
-        StablecoinManager::dripCall { token: stablecoin_address, recipient: new_recipient }
-            .abi_encode();
+    let xyz_drip_calldata = encode_drip(new_recipient, stablecoin_address, xyz_amount);
     let xyz_drip_tx = caller.create_eip1559(
         chain.clone(),
         None,
@@ -385,9 +461,7 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let drip_txs: Vec<_> = random_addresses
         .iter()
         .map(|&address| {
-            let drip_calldata =
-                StablecoinManager::dripCall { token: Address::ZERO, recipient: address }
-                    .abi_encode();
+            let drip_calldata = encode_drip(address, native_token_pointer, tel_amount);
             let tx = caller.create_eip1559(
                 chain.clone(),
                 None,

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -33,6 +33,8 @@ pub use bls_precompile::{add_bls_precompile, BLS_G1_PRECOMPILE_ADDRESS};
 pub(crate) use config::*;
 pub(crate) use context::*;
 pub(crate) use factory::*;
+#[cfg(feature = "faucet")]
+pub use tel_precompile::faucet_mint_role_slot;
 #[cfg(not(feature = "faucet"))]
 pub use tel_precompile::TIMELOCK_DURATION;
 pub use tel_precompile::{

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -84,6 +84,21 @@ pub use faucet::mintCall;
 pub const TELCOIN_PRECOMPILE_ADDRESS: Address =
     address!("00000000000000000000000000000000000007e1");
 
+/// Storage slot under [`TELCOIN_PRECOMPILE_ADDRESS`] holding `addr`'s faucet mint role.
+///
+/// Seeding this slot to `1` in genesis authorizes `addr` to call the faucet
+/// `mint(address, uint256)`, mirroring what a runtime [`grantMintRoleCall`] from the
+/// governance safe writes.
+///
+/// When seeding, extend the canonical precompile genesis account rather than replacing
+/// it: its nonzero code (`0xfe`) exempts the account from EIP-158 state clearing. A
+/// storage-only (empty) account is deleted at the end of the first block that touches
+/// the precompile, silently wiping this slot and the total supply.
+#[cfg(feature = "faucet")]
+pub fn faucet_mint_role_slot(addr: Address) -> U256 {
+    faucet::mint_role_slot(addr)
+}
+
 /// Fixed storage slot (100) that holds the total circulating supply of TEL.
 ///
 /// Incremented on [`handle_claim`] and decremented on [`handle_burn`].

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -172,6 +172,8 @@ mod evm;
 pub mod rpc_server_args;
 pub mod system_calls;
 pub mod worker;
+#[cfg(feature = "faucet")]
+pub use evm::faucet_mint_role_slot;
 #[cfg(not(feature = "faucet"))]
 pub use evm::TIMELOCK_DURATION;
 pub use evm::{

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -113,7 +113,7 @@ impl RethEnv {
         &self,
         txs: Vec<Vec<u8>>,
         parent: &SealedHeader,
-    ) -> BundleState {
+    ) -> eyre::Result<BundleState> {
         // create "empty" header with default values
         let mut header = ExecHeader {
             parent_hash: parent.hash(),
@@ -139,16 +139,21 @@ impl RethEnv {
             requests_hash: None,
         };
 
-        // decode transactions
-        let mut decoded_txs = Vec::with_capacity(txs.len());
-        let mut signers = Vec::with_capacity(txs.len());
-        for tx_bytes in &txs {
-            let tx = recover_raw_transaction(tx_bytes)
-                .expect("raw transaction recovered for test")
-                .into_inner();
-            signers.push(tx.recover_signer().expect("recover signer for test tx"));
-            decoded_txs.push(tx);
-        }
+        // decode transactions and recover their signers
+        let (decoded_txs, signers): (Vec<_>, Vec<_>) = txs
+            .iter()
+            .map(|tx_bytes| {
+                let tx = recover_raw_transaction(tx_bytes)
+                    .map_err(|e| eyre::eyre!("recover raw test transaction: {e:?}"))?
+                    .into_inner();
+                let signer = tx
+                    .recover_signer()
+                    .map_err(|e| eyre::eyre!("recover signer for test tx: {e:?}"))?;
+                Ok::<_, eyre::Report>((tx, signer))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?
+            .into_iter()
+            .unzip();
 
         // update header's transactions root
         header.transactions_root = if txs.is_empty() {
@@ -169,14 +174,22 @@ impl RethEnv {
 
         // create execution db
         let mut db = StateProviderDatabase::new(
-            self.latest().expect("provider retrieves latest during test batch execution"),
+            self.latest()
+                .map_err(|e| eyre::eyre!("provider retrieves latest for test batch: {e:?}"))?,
         );
         let executor = self.inner.evm_config.executor(&mut db);
         let res = executor
             .execute(&RecoveredBlock::new_unhashed(block, signers))
-            .expect("execute one block");
+            .map_err(|e| eyre::eyre!("execute one block for test: {e:?}"))?;
 
-        res.state
+        // a reverted tx still commits (with a failed receipt), silently yielding bundle
+        // state that is missing the tx's intended effects; fail loudly with the receipts
+        // so the offending tx is identifiable instead of surfacing later as missing
+        // genesis state (see #863)
+        let all_succeeded = res.result.receipts.iter().all(|receipt| receipt.success);
+        all_succeeded.then_some(res.state).ok_or_else(|| {
+            eyre::eyre!("setup tx reverted during simulated execution: {:?}", res.result.receipts)
+        })
     }
 
     /// Retrieve validator rewards.


### PR DESCRIPTION
Fixes #863.

`test_faucet_drip_tel_and_xyz_e2e` failed deterministically at setup (before any node spawned): the test hand-encoded the `StablecoinManager` initialize call from a hardcoded selector `0x16ada6b1` that is three ABI revisions stale, so the `ERC1967Proxy` init delegatecall matched no function, the proxy CREATE reverted, and the `expect("faucet address missing from bundle state")` panicked.  The issue has the full history. Fixing that surfaced four more drift legs stacked behind it, the last two node-side rather than ABI-side.

High-level changes:

- [ ] Bring the inline `sol!` interfaces in `crates/e2e-tests/tests/it/faucet.rs` up to the current `tn-contracts` artifacts:
  - `StablecoinManagerInitParams` gains the 8th field `baseDripCooldown_` (set to 1 day; must be nonzero because `_setBaselineDripCooldown` rejects rewriting the stored value, and it never gates the test since every drip targets a fresh recipient).
  - `drip(address,address)` is gone; drips now go through `dripTo(recipient, token, amount)` with native TEL keyed by `NATIVE_TOKEN_POINTER` (`0xEeee...EEeE`) instead of `address(0)`.  Amounts drip the exact baseline max seeded at init (`_checkDrip` bounds requests to `[max/10, max]`).
  - The inherited 4-arg `UpdateXYZ` now reverts by design (`UpdateXYZRequiresBaseDripAmount`);  the stablecoin is enabled via the 5-arg overload, seeding its baseline drip amount.
- [ ] Encode every setup and drip call through the bindings' generated call types (`initializeCall`, `UpdateXYZCall`, `dripToCall`, `grantRoleCall`) instead of concatenating hardcoded selector byte arrays with separately encoded params.  This is what let the test rot invisibly: the struct kept compiling while the selector literal aged.  With generated call types the selector and the params struct are a single value and cannot diverge.
- [ ] Wire up the TEL precompile's faucet mode, which the test predates: the contract's `TEL_MINT.mint(recipient, amount)` only exists behind `tn-reth/faucet` (production builds dispatch the timelocked `mint(uint256)` instead, so the selector was rejected), and it is role-gated.  The `e2e-tests/faucet` feature now forwards `tn-reth/faucet`, and the test grants the faucet proxy the mint role in genesis via a new `tn_reth::faucet_mint_role_slot` helper (exported behind the `faucet` feature; mirrors what a runtime `grantMintRole` from the governance safe writes).
- [ ] Seed that mint role by extending the canonical `0x7e1` genesis account instead of replacing it.  This one is subtle enough to be worth spelling out: a storage-only `GenesisAccount` at the precompile address is EIP-158-empty (no code, zero balance, zero nonce), so the first block that touches the precompile state-clears the account, silently wiping the mint-role and total-supply slots.  Concretely: the first drip succeeded and every drip in a later block reverted with `LowLevelCallFailure("")`.  The canonical genesis ships `code: "0xfe"` at `0x7e1` precisely to keep the account non-empty;  the test now clones that account and merges the mint-role slot into its storage, and the helper's docs call out the requirement.
- [ ] `RethEnv::execution_outcome_for_tests` now asserts every simulated setup tx succeeded and dumps the receipts on failure.  Previously a reverted setup tx was silently committed (with a failed receipt), producing genesis state that was missing the tx's effects and surfacing much later as an opaque "address missing from bundle state" panic.  This test is the helper's only caller.
- [ ] The two bare bundle-state `expect`s become `eyre` errors naming the one failure cause left after the revert guard (proxy CREATE landing at a different address than the deployer-nonce prediction).

Verification:

- [ ] `cargo nextest run -p e2e-tests --features faucet -E 'test(test_faucet_drip_tel_and_xyz_e2e)'`: previously failed in ~0.4s at setup;  now passes end to end twice in a row (spawns the local testnet, drips TEL + XYZ, runs the 10-recipient concurrent leg).
- [ ] Nightly fmt clean; nightly clippy clean on the touched crates.

Deliberately not in this PR (issue's third checklist item): wiring the `faucet` feature into CI. Now that the test passes it spawns a full local testnet, so whether it belongs in the PR gate or a nightly job is a maintainer call;  I'm happy to follow up either way.

