### PR TITLE
perf(primary): resolve remaining #822 review findings (missing-certs sync)

### DIFF
--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -443,6 +443,15 @@ async fn fetch_and_process_certificates<DB: Database, F: MissingCertFetcher>(
 /// Try to fetch certificates from multiple peers with staggered requests.
 /// Sends requests to peers one at a time with ~5 second intervals between each.
 /// Returns as soon as one peer provides a non-empty response.
+///
+/// Memory envelope: fetches are cancelled only on the first success, so slow, empty, or
+/// invalid responders keep buffering until their per-fetch timeout elapses. Each in-flight
+/// fetch accepts up to the per-exchange cap (`MAX_SYNC_MISSING_CERTS_ACCEPT_BYTES`, ~64.5 MiB),
+/// and up to `min(peers.len(), ceil(per_fetch_timeout / fallback_delay))` run concurrently, so
+/// the requester-side peak is that many times the per-fetch cap (a few hundred MiB with the
+/// defaults, scaling with committee size up to the overlap bound). There is no joint byte
+/// budget shared across in-flight fetches: capping the concurrent fan-out or threading a shared
+/// budget is left as a design decision (issue #822, finding 2).
 async fn fetch_from_peers<F: MissingCertFetcher>(
     network: F,
     peers: Vec<BlsPublicKey>,

--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -23,7 +23,7 @@ use futures::{
 use std::time::Duration;
 use tn_network_libp2p::{read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame};
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{encode, try_decode, BlsPublicKey, Certificate, Epoch};
+use tn_types::{encode, encoded_size, try_decode, BlsPublicKey, Certificate, Epoch};
 use tokio::io::AsyncRead as TokioAsyncRead;
 use tracing::debug;
 
@@ -74,6 +74,11 @@ const MAX_SYNC_MISSING_CERTS_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 /// responder cap so the batch that carries an honest responder past
 /// [`MAX_SYNC_MISSING_CERTS_RESPONSE_BYTES`] is still accepted, while a responder
 /// that ignores `End` and streams unboundedly is cut off.
+///
+/// This bounds a *single* exchange. The requester (`fetch_from_peers`) staggers several
+/// fetches and cancels only on the first success, so a catch-up round can hold multiple
+/// exchanges open at once; the process-wide requester peak is that concurrency times this
+/// cap. See `fetch_from_peers` for the aggregate envelope (issue #822, finding 2).
 const MAX_SYNC_MISSING_CERTS_ACCEPT_BYTES: usize =
     MAX_SYNC_MISSING_CERTS_RESPONSE_BYTES + MAX_SYNC_CERT_FRAME_SIZE;
 
@@ -324,7 +329,9 @@ where
     // A storage error yielded by `certs` short-circuits the fold and propagates so the
     // caller signals `SyncFrame::Err`.
     futures::stream::iter(certs)
-        .map(|cert| cert.map(|cert| (encode(&cert).len(), cert)))
+        .map(|cert| {
+            cert.and_then(|cert| encoded_size(&cert).map(|size| (size, cert)).map_err(Into::into))
+        })
         .scan(0usize, |sent, sized| {
             let within_cap = *sent < MAX_SYNC_MISSING_CERTS_RESPONSE_BYTES;
             futures::future::ready(within_cap.then(|| sized.inspect(|(size, _)| *sent += *size)))

--- a/crates/consensus/primary/src/state_sync/cert_collector.rs
+++ b/crates/consensus/primary/src/state_sync/cert_collector.rs
@@ -58,8 +58,18 @@ where
         config: ConsensusConfig<DB>,
     ) -> PrimaryNetworkResult<Self> {
         let start_time = Instant::now();
-        let request =
-            MissingCertificatesRequest { exclusive_lower_bound, skip_rounds, max_response_size: 0 };
+        // `max_response_size` is unused on the sync fetch path: the reply is streamed and ended
+        // explicitly, so the legacy request-response size cap no longer applies. The field is kept
+        // only for BCS wire compatibility of the retained `/0.0.1`
+        // `PrimaryRequest::MissingCertificates` variant (removed at the coordinated `/0.0.2` bump,
+        // item 9 of #739); this local rebuild exists solely to reuse `get_bounds()`, which ignores
+        // it, so a fixed dummy is correct.
+        const SYNC_PATH_UNUSED_RESPONSE_CAP: usize = 0;
+        let request = MissingCertificatesRequest {
+            exclusive_lower_bound,
+            skip_rounds,
+            max_response_size: SYNC_PATH_UNUSED_RESPONSE_CAP,
+        };
         let (lower_bound, skip_rounds) = request.get_bounds()?;
 
         // initialize the fetch queue with the first round for each authority

--- a/crates/types/src/codec.rs
+++ b/crates/types/src/codec.rs
@@ -70,6 +70,16 @@ pub fn encode<T: Serialize>(obj: &T) -> Vec<u8> {
     bcs::to_bytes(obj).unwrap_or_else(|_| panic!("Serialization should not fail"))
 }
 
+/// Return the BCS-encoded byte length of `obj` without allocating the bytes.
+///
+/// Runs the same serializer as [`encode`] over a byte counter, so `encoded_size(x)`
+/// equals `encode(x).len()` for any value that serializes, and surfaces the serializer
+/// error instead of panicking. Use it where only the size is needed (e.g. streaming
+/// byte-cap accounting) to avoid the throwaway allocation of encoding just to read `.len()`.
+pub fn encoded_size<T: ?Sized + Serialize>(obj: &T) -> bcs::Result<usize> {
+    bcs::serialized_size(obj)
+}
+
 /// Encode into a provided buffer.
 pub fn encode_into_buffer<W, T>(write: &mut W, value: &T) -> bcs::Result<()>
 where


### PR DESCRIPTION
## Summary

Follow-up to the #822 review, addressing the remaining findings that PR #826 deliberately deferred.  PR #826 (merged) fixed the High out-of-bounds panic (finding 1), the `get_bounds` overflow (finding 4), and added the regression test (finding 6).  This PR closes out the three remaining findings — **2 (memory envelope)**, **3 (double BCS encode)**, and **5 (vestigial `max_response_size`)** — each kept minimal and wire-safe.

Fixes are scoped to be provably behavior-preserving where the finding is efficiency/cleanup, and to respect the deliberately-retained legacy wire shape.

## Finding 2 (Medium) — document the requester-side aggregate memory envelope

Each per-peer fetch accepts up to `MAX_SYNC_MISSING_CERTS_ACCEPT_BYTES` (~64.5 MiB), and `fetch_from_peers` staggers fetches while cancelling only on the first success, so several exchanges can buffer concurrently with no joint byte budget.  The reviewer flagged this as a design decision to confirm with the author.

This PR takes the documentation route (the reviewer's option 1): the worst-case envelope — `min(peers, ceil(per_fetch_timeout / fallback_delay))` concurrent exchanges × the per-fetch cap — is now spelled out on both `fetch_from_peers` and the accept-cap doc-comment, so the per-exchange cap can no longer be mistaken for the process-wide bound.

I did **not** change the fan-out behavior.  A concurrent-fetch cap (option 2) was rejected because it changes observable fan-out that two existing behavior tests assert — it deadlocks `test_timeout_scenario` (which drops every reply, so a live-task cap never releases a slot and stalls below `num_peers`) and alters `test_network_failure_keeps_trying`.  A shared byte budget across in-flight fetches (option 3) is the only bound that caps peak memory independent of committee size without breaking the all-peers-requested test premise, but it is a real design change (threading a shared budget into every `spawn_peer_fetch` and enforcing it in the streaming reader) — left to the maintainers' call.  I'd be happy to follow up with option 3 if wanted.

## Finding 3 (Low) — drop the throwaway per-certificate encode on the responder hot path

`send_sync_certificates_over_stream` computed each certificate's byte size with `encode(&cert).len()`, allocating and discarding a full `Vec<u8>` per certificate purely to read its length;  the batch is then encoded again whole in `write_cert_batch_frame`.

- Added `tn_types::encoded_size`, which returns the BCS-encoded byte count via `bcs::serialized_size` **without** allocating the encoding — the same value `encode(obj).len()` produces.
- Replaced `encode(&cert).len()` with `encoded_size(&cert)`, threading its (unreachable, for locally-read certs) error through the existing `PrimaryNetworkResult` rather than panicking.

The per-certificate `size` still drives the `MAX_SYNC_MISSING_CERTS_RESPONSE_BYTES` cap accounting (`scan`) and the `SYNC_CERT_BATCH_TARGET_SIZE` flush threshold (`CertBatch::push`) with byte-for-byte identical values, so frame boundaries and the streamed bytes are unchanged.  The existing `sync_codec` round-trip test passing unchanged proves the equivalence.

## Finding 5 (Informational) — clarify the vestigial `max_response_size` dummy

`max_response_size` is unused on the sync fetch path (the reply is streamed and ended explicitly).  `CertificateCollector::new` rebuilds a `MissingCertificatesRequest` locally with a dummy `max_response_size: 0` solely to reuse `get_bounds()`.

The field is **not** removed: `MissingCertificatesRequest` is embedded whole in `PrimaryRequest::MissingCertificates`, the `/0.0.1` request-response variant that is deliberately retained for wire compatibility until the coordinated `/0.0.2` bump (item 9 of #739).  Removing the field would change that variant's BCS encoding and desynchronize decoding against `/0.0.1` peers.

Instead, the bare literal `0` is replaced with a named constant and a comment explaining it is a wire-compat dummy the sync path ignores — no wire-byte or behavior change.

## Testing

- `cargo clippy -p tn-types -p tn-primary --all-targets` — 0 errors.
- `cargo test -p tn-primary --lib sync_codec certificate_fetcher` — 18 passed, 0 failed.  The
  `sync_codec` round-trip tests derive their frame boundaries from `encode(&cert).len()`, so
  passing unchanged proves finding 3's `encoded_size` is byte-for-byte equivalent.
- `cargo +nightly-2026-03-20 fmt` — clean.

No wire-format change, no behavior change: `encoded_size` produces the same byte count as
`encode(..).len()`, and findings 2 and 5 are documentation / a named-constant rename.
