### PR TITLE
fix: reject round-0 headers on the vote path (header.round() - 1 underflow)

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -204,6 +204,7 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         | HeaderError::UnknownNetworkKey(_)
         | HeaderError::PeerNotAuthor
         | HeaderError::InvalidGenesisParent(_)
+        | HeaderError::InvalidRound(_)
         | HeaderError::ParentMissingSignature
         | HeaderError::InvalidParentTimestamp { .. }
         | HeaderError::UnkownWorkerId

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -529,6 +529,12 @@ where
 
         // validate header
         header.validate(committee)?;
+
+        // A proposed header is always at round >= 1; round 0 is reserved for genesis certificates
+        // and is never voted on. Reject a round-0 header here, before parent tracking, so
+        // `check_for_missing_parents` never evaluates `header.round() - 1` at round 0 (see #789).
+        ensure!(header.round() != 0, HeaderError::InvalidRound(header.digest()).into());
+
         let max_round =
             self.consensus_bus.committed_round() + self.consensus_config.parameters().gc_depth;
         // Make sure the header is not unreasonable in the future.
@@ -822,7 +828,9 @@ where
 
         // filter out parents that were already requested and new ones
         unknown_certs.retain(|digest| {
-            let key = (header.round() - 1, *digest);
+            // `saturating_sub` matches the style used for `limit` above and keeps this helper
+            // underflow-safe on its own; `vote_inner` already rejects round 0 (see #789).
+            let key = (header.round().saturating_sub(1), *digest);
             if let std::collections::btree_map::Entry::Vacant(e) = current_requests.entry(key) {
                 e.insert(header.author().clone());
                 true

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -92,6 +92,79 @@ async fn test_request_vote_too_new() {
     );
 }
 
+/// Regression for #789: a committee member can craft its own round-0 header (the Vote path is
+/// committee-gated). Before the fix, `check_for_missing_parents` evaluated `header.round() - 1`
+/// at round 0, wrapping to `u32::MAX` on the release binary and leaving a stale
+/// `(u32::MAX, digest)` requested-parent entry. The header is now rejected before parent tracking,
+/// so no underflow occurs and no stale state is left behind.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_request_vote_round_zero_rejected() {
+    const NUM_PARENTS: usize = 10;
+    let fixture = CommitteeFixture::builder(MemDatabase::default)
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(NUM_PARENTS).unwrap())
+        .build();
+    let target = fixture.authorities().next().unwrap();
+    let author = fixture.authorities().nth(2).unwrap();
+    let author_id = author.id();
+    let author_peer = *author.authority().protocol_key();
+
+    let cb = ConsensusBus::new();
+    let temp_dir = TempDir::new().unwrap();
+    let consensus_chain =
+        ConsensusChain::new_for_test(temp_dir.path().to_owned(), fixture.committee())
+            .await
+            .unwrap();
+    // Need a dummy parent so we can request a vote.
+    let dummy_parent = SealedHeader::seal_slow(ExecHeader::default());
+    cb.app().recent_blocks().send_modify(|blocks| {
+        blocks.push_latest(
+            0,
+            ConsensusNumHash::new(0, ConsensusHeaderDigest::default()),
+            Some(dummy_parent),
+        )
+    });
+    let task_manager = TaskManager::default();
+    let synchronizer =
+        StateSynchronizer::new(target.consensus_config(), cb.clone(), task_manager.get_spawner());
+    synchronizer.spawn(&task_manager);
+    let handler = RequestHandler::new(
+        target.consensus_config(),
+        cb.app().clone(),
+        synchronizer.clone(),
+        consensus_chain,
+    );
+
+    // Mock certificates to use as (bogus) parent digests on the crafted header.
+    let committee: Committee = fixture.committee();
+    let genesis =
+        Certificate::genesis(&committee).iter().map(|x| x.digest()).collect::<BTreeSet<_>>();
+    let ids: Vec<_> = fixture.authorities().map(|a| (a.id(), a.keypair().copy())).collect();
+    let (certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=3, &genesis, &committee, ids.as_slice());
+    let all_certificates = certificates.into_iter().collect::<Vec<_>>();
+    let round_2_certs = all_certificates[NUM_PARENTS..(NUM_PARENTS * 2)].to_vec();
+
+    // Craft a self-consistent round-0 header with non-empty parents, mirroring the attack shape.
+    let test_header = author
+        .header_builder(&fixture.committee())
+        .author(author_id)
+        .round(0)
+        .latest_execution_block(BlockNumHash::default())
+        .parents(round_2_certs.iter().map(|c| c.digest()).collect())
+        .with_payload_batch(&fixture_batch_with_transactions(10), 0)
+        .build();
+
+    // The round-0 header is rejected before parent tracking: no underflow, no stale entry.
+    let result =
+        timeout(Duration::from_secs(5), handler.vote(author_peer, test_header, Vec::new())).await;
+    let result = result.unwrap();
+    assert!(
+        matches!(result, Err(PrimaryNetworkError::InvalidHeader(HeaderError::InvalidRound(_)))),
+        "{result:?}"
+    );
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_request_vote_has_missing_execution_block() {
     const NUM_PARENTS: usize = 10;

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -247,6 +247,10 @@ pub enum HeaderError {
     /// The proposed header's round is too far ahead.
     #[error("Header {digest} for round {header_round} is too new for max round {max_round}")]
     TooNew { digest: HeaderDigest, header_round: Round, max_round: Round },
+    /// The proposed header's round is zero. Round 0 is reserved for genesis certificates and is
+    /// never voted on, so a header at round 0 is malformed.
+    #[error("Header {0} has an invalid round of 0; proposed headers must be at round >= 1")]
+    InvalidRound(HeaderDigest),
     /// The header contains a parent with an invalid aggregate BLS signature.
     #[error("Header's parent missing aggregate BLS signature")]
     ParentMissingSignature,


### PR DESCRIPTION
Closes #789.

## Problem

`check_for_missing_parents` (`crates/consensus/primary/src/network/handler.rs`) computes
`header.round() - 1` with no `saturating_sub` and no prior guarantee that `round >= 1`:

```rust
let key = (header.round() - 1, *digest);
```

The Vote path is committee-gated (`vote()` verifies the header author is a committee
authority and the peer id matches), so a **Byzantine committee member** can craft its own
self-consistent **round-0** header . . . no forgery needed.  With an empty `parents` vec,
`vote_inner` routes to `check_for_missing_parents`.  `Header::validate` does not reject round 0,
and the age guard `ensure!(limit <= header.round())` passes when `limit == 0` (true at
startup / early epoch), so the subtraction is reached at `round == 0`.

- **Release (mainnet):** `overflow-checks` default off — `0u32 - 1` wraps to `u32::MAX`,
  inserting a stale `(u32::MAX, digest)` requested-parent entry that the GC loop
  (`round < limit.saturating_sub(1)`) never reaches.  No crash/OOM/ban/consensus-safety
  impact (a round-0 header can never satisfy the parent-quorum checks), but a silent
  correctness/hygiene wart.
- **Debug/CI:** panics, but contained — the vote request runs in a non-critical task the
  task manager ignores.

## Changes

- [x] Add `HeaderError::InvalidRound(HeaderDigest)` (`crates/types/src/error.rs`).
- [x] Reject round-0 headers early in `vote_inner`, right after `Header::validate`, before
      parent tracking.  Proposed headers are always `round >= 1` (round 0 is reserved for
      genesis certificates and is never voted on), so this makes the implicit invariant
      explicit.
- [x] Classify `InvalidRound` as `Penalty::Fatal` in `penalty_from_header_error`, alongside
      the other structurally-malformed-header faults (`InvalidGenesisParent`, `UnkownWorkerId`,
      ...).  The exhaustive match forces this to be revisited on any future variant change.
- [x] Change the subtraction to `header.round().saturating_sub(1)` as defense-in-depth so the
      helper is underflow-safe independent of its caller, matching the `saturating_sub` style
      already used for `limit` two lines above.
- [x] Add `test_request_vote_round_zero_rejected` (`crates/consensus/primary/src/tests/primary_tests.rs`):
      a committee-authored round-0 header with empty parents is rejected with `InvalidRound`,
      so no underflow occurs and no stale requested-parent state is left behind.

## Acceptance criteria (from the issue)

- [x] A round-0 header on the Vote path does not produce a `u32::MAX` key or a stale
      requested-parent entry (the header is rejected before parent tracking runs).
- [x] Regression test for a committee-authored round-0 header with empty parents.

## Not included (deferred)

The issue also suggested enabling `overflow-checks = true` for the release profile so silent
wraps cannot mask logic errors elsewhere.  That is a repo-wide change with performance
implications and its own review surface, so it is intentionally left out of this targeted fix.
