### PR TITLE
fix: charge signed gossip content faults to the author, not the relayer

### DIFF
--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -302,4 +302,59 @@ mod tests {
         assert!(PrimaryNetworkError::UnknownConsensusHeaderCert(ConsensusHeaderDigest::default())
             .is_author_content_fault());
     }
+
+    /// Finding #871 attribution guard. `process_gossip` charges the accountable peer with
+    /// `if fault.is_author_content_fault() { author } else { relayer }.zip((&fault).into())`, so
+    /// for each fault this PR moved to the author arm the charged party is the authenticated
+    /// author and the penalty is the fault's own. Both halves are asserted here: a future edit
+    /// that re-routes a variant to the relayer, or drops its penalty (which `zip` would silently
+    /// swallow, charging no one), fails this test. The mirror of the selection is exercised by the
+    /// closing control case, and the honest relayer's protection is what the change exists for.
+    #[test]
+    fn moved_gossip_faults_charge_the_author_not_the_relayer() {
+        // the penalty the gossip handler charges the *author*, or `None` if the fault is not
+        // author-content (so the relayer would be charged instead) or carries no penalty
+        let author_penalty = |fault: &PrimaryNetworkError| {
+            fault.is_author_content_fault().then(|| Option::<Penalty>::from(fault)).flatten()
+        };
+
+        // certificate: unsigned / bad-signature -> Fatal, charged to the author
+        assert!(matches!(
+            author_penalty(&PrimaryNetworkError::Certificate(CertManagerError::Certificate(
+                CertificateError::Unsigned
+            ))),
+            Some(Penalty::Fatal)
+        ));
+        assert!(matches!(
+            author_penalty(&PrimaryNetworkError::Certificate(CertManagerError::Certificate(
+                CertificateError::InvalidSignature
+            ))),
+            Some(Penalty::Fatal)
+        ));
+        // epoch vote: bad signature (PeerNotAuthor) / non-committee key (UnknownAuthority) -> Fatal
+        assert!(matches!(
+            author_penalty(&PrimaryNetworkError::InvalidHeader(HeaderError::PeerNotAuthor)),
+            Some(Penalty::Fatal)
+        ));
+        assert!(matches!(
+            author_penalty(&PrimaryNetworkError::InvalidHeader(HeaderError::UnknownAuthority(
+                "key not in committee".to_string()
+            ))),
+            Some(Penalty::Fatal)
+        ));
+        // consensus result: bad signature -> Mild
+        assert!(matches!(
+            author_penalty(&PrimaryNetworkError::UnknownConsensusHeaderCert(
+                ConsensusHeaderDigest::default()
+            )),
+            Some(Penalty::Mild)
+        ));
+
+        // control: a non-content fault is not author-charged, so the relayer arm is taken and the
+        // author penalty is `None` even though the fault itself carries one
+        let relayer_fault = PrimaryNetworkError::InvalidEpochRequest;
+        assert!(!relayer_fault.is_author_content_fault());
+        assert!(author_penalty(&relayer_fault).is_none());
+        assert!(matches!(Option::<Penalty>::from(&relayer_fault), Some(Penalty::Medium)));
+    }
 }

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -71,36 +71,60 @@ pub(crate) enum PrimaryNetworkError {
 }
 
 impl PrimaryNetworkError {
-    /// Whether this fault is determined purely by the *content* of a gossip message — its BCS
-    /// encoding or its declared topic — and is therefore attributable to the message author
-    /// (`GossipMessage::source`) rather than the peer that relayed it.
+    /// Whether this gossip fault is determined by the *content* of the message and is therefore
+    /// charged to its authenticated publisher (the gossip source `GossipMessage::source`, resolved
+    /// to `author`), rather than to the peer that relayed it.
     ///
-    /// Mirrors `WorkerNetworkError::is_author_content_fault` (tn-worker) and is consulted only on
-    /// the gossip path (`PrimaryNetwork::process_gossip`): the network layer accepted and forwarded
-    /// the message after a shallow check, so an honest relayer could not have screened a
-    /// content-determined fault, and charging the relayer for it lets a Byzantine author ban honest
-    /// forwarders (see issues #801/#819). The request/response paths penalize the peer
-    /// unconditionally because there the peer *is* the originator.
+    /// Consulted only on the gossip path (`PrimaryNetwork::process_gossip`), whose deep validation
+    /// of a signed payload runs *after* gossipsub has already accepted and forwarded the message.
+    /// An honest relayer therefore cannot screen a content-determined fault before relaying it, and
+    /// charging the relayer for one lets a Byzantine author ban honest forwarders (#801/#785/#819).
+    /// The request/response paths never consult this classifier: there the peer *is* the originator
+    /// and is penalized unconditionally.
     ///
-    /// Restricted to the two `Fatal` faults authored by the gossip source and reachable from the
-    /// gossip handler: [`Self::Decode`] (`try_decode` of the payload) and [`Self::InvalidTopic`]
-    /// (the payload variant was published to the wrong topic). Every other variant is either
-    /// benign on the gossip path or concerns embedded certificate/consensus content whose signer
-    /// is carried inside the payload and is not necessarily the gossip source, so its existing
-    /// relayer/no-penalty attribution is left unchanged.
+    /// The publisher is the accountable party (not the relayer, and not a signer embedded in the
+    /// payload) for two reasons:
+    ///
+    /// 1. The source is authenticated. Gossipsub runs with `MessageAuthenticity::Signed` and
+    ///    `ValidationMode::Strict` (`crates/network-libp2p/src/consensus.rs`), so an accepted
+    ///    message carries a source signed by that peer's key; an attacker cannot publish under a
+    ///    victim's identity. Honest nodes only gossip content they produced and (for consensus
+    ///    results / epoch votes) self-signed (`publish_certificate` / `publish_consensus` /
+    ///    `publish_epoch_vote`), so a content-determined fault is the publisher's own.
+    ///
+    /// 2. Charging the *embedded* signer would be unsafe. A certificate is a multi-party aggregate,
+    ///    and the vote / consensus-result faults here are exactly signature-verification failures,
+    ///    so the key named in the payload is unauthenticated at the point of fault. An attacker
+    ///    could gossip a `ConsensusResult { validator: <victim>, .. }`, or an `EpochVote` naming
+    ///    any committee key, with a bad signature and have the innocent victim penalized: a framing
+    ///    vector the authenticated publisher carries no risk of.
+    ///
+    /// Parallels `WorkerNetworkError::is_author_content_fault` (tn-worker) at the mechanism level,
+    /// though the primary additionally covers the deep embedded-signature faults its signed
+    /// payloads carry, which the worker has no equivalent for.
+    ///
+    /// True for the envelope faults [`Self::Decode`] / [`Self::InvalidTopic`] and for the embedded
+    /// signed-payload content faults reachable from the gossip handler: [`Self::Certificate`] (a
+    /// malformed / unsigned / inquorate / bad-signature certificate), [`Self::InvalidHeader`] (an
+    /// `EpochVote` failing its signature or committee-membership check), and
+    /// [`Self::UnknownConsensusHeaderCert`] (a `ConsensusResult` with a bad signature). The
+    /// remaining arms are transport/local/benign and keep their relayer / no-penalty attribution;
+    /// [`Self::PeerNotInCommittee`] is content-determined but already maps to no penalty, so the
+    /// relayer was never charged for it.
     pub(crate) fn is_author_content_fault(&self) -> bool {
         //
         // explicitly match every variant so the classification is revisited with changes
         //
         match self {
-            PrimaryNetworkError::Decode(_) | PrimaryNetworkError::InvalidTopic => true,
-            PrimaryNetworkError::InvalidHeader(_)
+            PrimaryNetworkError::Decode(_)
+            | PrimaryNetworkError::InvalidTopic
+            | PrimaryNetworkError::InvalidHeader(_)
             | PrimaryNetworkError::Certificate(_)
-            | PrimaryNetworkError::StdIo(_)
+            | PrimaryNetworkError::UnknownConsensusHeaderCert(_) => true,
+            PrimaryNetworkError::StdIo(_)
             | PrimaryNetworkError::Storage(_)
             | PrimaryNetworkError::InvalidRequest(_)
             | PrimaryNetworkError::Internal(_)
-            | PrimaryNetworkError::UnknownConsensusHeaderCert(_)
             | PrimaryNetworkError::UnknownConsensusOutput(_)
             | PrimaryNetworkError::PeerNotInCommittee(_)
             | PrimaryNetworkError::UnavailableEpoch(_)
@@ -238,14 +262,44 @@ mod tests {
         assert!(PrimaryNetworkError::InvalidTopic.is_author_content_fault());
     }
 
-    /// Every other fault keeps its relayer / no-penalty attribution: transport and local faults
-    /// are not the author's, and embedded certificate/consensus content is signed by a party
-    /// carried inside the payload, not by the gossip source.
+    /// Transport and local faults keep their relayer / no-penalty attribution: they are not
+    /// determined by the gossip payload's content, so the authenticated publisher is not the
+    /// accountable party. (The embedded signed-payload content faults, by contrast, *are*
+    /// author-charged: see `embedded_signed_payload_faults_are_author_content`.)
     #[test]
-    fn non_envelope_faults_are_not_author_content() {
+    fn non_content_faults_are_not_author_charged() {
         assert!(!PrimaryNetworkError::InvalidEpochRequest.is_author_content_fault());
         assert!(!PrimaryNetworkError::UnknownConsensusOutput(0).is_author_content_fault());
         assert!(!PrimaryNetworkError::InvalidRequest("bad".to_string()).is_author_content_fault());
         assert!(!PrimaryNetworkError::Internal("boom".to_string()).is_author_content_fault());
+    }
+
+    /// Finding #871: the primary's signed gossip payloads carry content faults that deep validation
+    /// only surfaces after gossipsub has forwarded the message. Each is charged to the
+    /// authenticated author, not the honest relayer: a malformed certificate (`Certificate`),
+    /// an `EpochVote` that fails its signature (`PeerNotAuthor`) or committee-membership
+    /// (`UnknownAuthority`) check, and a `ConsensusResult` with a bad signature
+    /// (`UnknownConsensusHeaderCert`).
+    #[test]
+    fn embedded_signed_payload_faults_are_author_content() {
+        // gossiped Certificate faults (validate_received / process_peer_certificate)
+        assert!(PrimaryNetworkError::Certificate(CertManagerError::Certificate(
+            CertificateError::Unsigned
+        ))
+        .is_author_content_fault());
+        assert!(PrimaryNetworkError::Certificate(CertManagerError::Certificate(
+            CertificateError::InvalidSignature
+        ))
+        .is_author_content_fault());
+        // gossiped EpochVote: bad signature -> PeerNotAuthor; non-committee key -> UnknownAuthority
+        assert!(PrimaryNetworkError::InvalidHeader(HeaderError::PeerNotAuthor)
+            .is_author_content_fault());
+        assert!(PrimaryNetworkError::InvalidHeader(HeaderError::UnknownAuthority(
+            "key not in committee".to_string()
+        ))
+        .is_author_content_fault());
+        // gossiped ConsensusResult with a bad signature
+        assert!(PrimaryNetworkError::UnknownConsensusHeaderCert(ConsensusHeaderDigest::default())
+            .is_author_content_fault());
     }
 }


### PR DESCRIPTION
Closes #871.

## Problem

On the primary gossip path, `PrimaryNetworkError::is_author_content_fault` attributes a
fault to the message author for only `Decode` and `InvalidTopic`.  Every other
content-determined fault the gossip handler raises is classified `false` and charged to
the **relaying peer**.  Deep validation of a signed payload runs *after* gossipsub has
already accepted and forwarded the message, so an honest relayer cannot screen these
faults before relaying them.  That is the #801/#785/#819 failure mode, still open for the
primary's signed certificate, epoch-vote, and consensus-result payloads.

## Change

- [x] Move `InvalidHeader(_)`, `Certificate(_)`, and `UnknownConsensusHeaderCert(_)` to
      the author arm of `is_author_content_fault`, so these gossip content faults charge
      the authenticated gossip **author** (`GossipMessage::source`) instead of the honest
      relayer.
- [x] Rewrite the classifier doc comment: the author is the accountable **publisher**;
      explain why the embedded payload signer is deliberately *not* charged (framing
      risk, below).
- [x] Update the now-stale sibling test doc comment; add
      `embedded_signed_payload_faults_are_author_content` asserting the charged party for
      each reachable variant (cert `Unsigned`/`InvalidSignature`, `EpochVote`
      `PeerNotAuthor`/`UnknownAuthority`, `ConsensusResult` `UnknownConsensusHeaderCert`).

This is a gossip-path-only classifier;  the request/response and stream paths penalize the
peer through a separate, untouched mapping, so RPC/stream penalties are unchanged.

## Why the author, and not the payload-embedded signer

The issue proposed a third attribution path that charges the embedded signer (cert
aggregate signers / `vote.public_key` / `ConsensusResult.validator`).  Charging the
authenticated author is both simpler and strictly safer:

1. **The author is authenticated.** Gossipsub runs `MessageAuthenticity::Signed` +
   `ValidationMode::Strict`, so an accepted message's `source` is bound to the publisher's
   key and cannot be spoofed.  Honest nodes only gossip content they produced and
   self-signed (`publish_certificate` / `publish_consensus` / `publish_epoch_vote`), and
   gossipsub forwarding preserves the original `source`, so a content fault is the
   publisher's own.  `verify_cert` Fatal failures are logged, not propagated, and
   `process_peer_certificate` runs only after verification succeeds, so an honest author
   cannot trip the Fatal certificate arms.

2. **Charging the embedded signer would open a framing vector.** These faults are exactly
   signature-verification failures, so the key named inside the payload is unauthenticated
   at the point of fault.  An attacker could gossip
   `ConsensusResult { validator: <victim>, .. }` (or an `EpochVote` naming any committee
   key) with a bad signature and have the innocent victim penalized.  `HeaderError::
   UnknownAuthority` also carries only a formatted `String`, so the key is not even cleanly
   recoverable at the charge site.  The authenticated author carries no such risk.

## Acceptance criteria

- [x] Non-committee relayers (observers / NVVs) are no longer Fatal- or Mild-penalized for
      relaying content-determined faults they could not screen.
- [x] A malformed gossiped certificate, an `EpochVote` failing signature/committee checks,
      and a `ConsensusResult` with a bad signature are charged to the authenticated
      publisher rather than the relayer.
- [x] Test coverage exercises each reachable variant and asserts the charged party.

The remaining criteria ("attribute to the embedded certificate signer(s) / `vote.
public_key` / embedded validator") are intentionally satisfied by charging the
authenticated publisher instead of the embedded signer, for the framing reason above.  The
`is_author_content_fault` doc comment now states the residual exposure explicitly rather
than implying attribution is complete.

## Known bounded residual

`Certificate(_)` also covers `CertificateError::TooOld`, a **Mild** penalty judged against
the *receiver's* GC round. An honest node that re-publishes an old-but-valid certificate
(e.g. the startup re-publish of its last certificate) to a caught-up peer is now charged
that Mild penalty as the author, where previously it fell on the honest relayer.  This
replaces one honest-party Mild charge with another; it is self-limiting (a single ~-1.0
nick per distinct certificate, ~5-minute decay half-life, de-duplicated by storage and
gossipsub message-id, far below the ban threshold) and strictly better than charging an
arbitrary forwarder.  Splitting `TooOld` off to a no-penalty gossip outcome would require a
gossip-vs-RPC split in the shared penalty mapping and is left out of scope.

## Testing

- `cargo test -p tn-primary error::network` (classifier unit tests, incl. the new one).
- `cargo +<nightly> fmt` clean; `cargo clippy -p tn-primary` clean.
