### PR TITLE
fix: enforce the gossip size bound as a protocol constant on both paths (#872)

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -95,18 +95,28 @@ impl NetworkConfig {
     }
 }
 
+/// The maximum size, in bytes, of a gossip message payload (`GossipMessage::data`).
+///
+/// This is a protocol constant, not a per-node tunable, and is deliberately identical on every
+/// node. The gossip reject path Fatal-bans the *relaying* peer for delivering an oversized payload
+/// (`RejectReason::TooLarge` -> `RejectPenalty::FatalRelayer`), and that attribution is sound only
+/// if every honest node applies the identical bound: under gossipsub `Strict` validation a peer
+/// that deems a message `TooLarge` reports `Reject` and never forwards it, so a delivered oversized
+/// payload is genuine relayer misbehavior. The bound is enforced symmetrically on both the publish
+/// path (the network layer refuses to originate a larger message) and the receive path, so an
+/// honest node never emits one for its peers to reject. A per-node bound would instead let an
+/// honest relayer configured with a larger limit be Fatal-banned for forwarding a payload that is
+/// under its own limit but over ours, so the bound is fixed here network-wide rather than read from
+/// operator config. The largest legitimate gossip message is a `Certificate`; 12,000 bytes is sized
+/// to accommodate it.
+pub const MAX_GOSSIP_MESSAGE_SIZE: usize = 12_000;
+
 /// Configurations for libp2p library.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct LibP2pConfig {
     /// Maximum message size between request/response network messages in bytes.
     pub max_rpc_message_size: usize,
-    /// Maximum message size for gossipped network messages in bytes.
-    ///
-    /// The largest gossip message is likely a `Certificate`.
-    /// The default of 12,000 bytes should be enough for legit gossip.
-    /// Large messages should not be gossipped
-    pub max_gossip_message_size: usize,
     /// The maximum duration to keep an idle connection alive between peers.
     ///
     /// The strategy for TN is to rely on QUIC to send keep alive messages instead of adding
@@ -181,7 +191,6 @@ impl Default for LibP2pConfig {
     fn default() -> Self {
         Self {
             max_rpc_message_size: 1024 * 1024,                    // 1 MiB
-            max_gossip_message_size: 12_000,                      // 12kb
             max_idle_connection_timeout: Duration::from_secs(65), // same as quic handshake
             max_px_disconnects: 10,
             px_disconnect_timeout: Duration::from_secs(3),
@@ -503,7 +512,6 @@ mod tests {
         let yaml = r#"
 libp2p_config:
   max_rpc_message_size: 2097152
-  max_gossip_message_size: 12000
   max_idle_connection_timeout:
     secs: 65
     nanos: 0

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -19,8 +19,8 @@ use crate::{
 use futures::StreamExt as _;
 use libp2p::{
     gossipsub::{
-        self, Event as GossipEvent, IdentTopic, Message as GossipMessage, MessageAcceptance, Topic,
-        TopicHash,
+        self, Event as GossipEvent, IdentTopic, Message as GossipMessage, MessageAcceptance,
+        PublishError, Topic, TopicHash,
     },
     kad::{self, store::RecordStore, Mode, QueryId},
     request_response::{
@@ -36,7 +36,7 @@ use std::{
     io::ErrorKind,
     time::Duration,
 };
-use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig};
+use tn_config::{KeyConfig, LibP2pConfig, NetworkConfig, PeerConfig, MAX_GOSSIP_MESSAGE_SIZE};
 use tn_types::{
     encode, now, BlsPublicKey, BlsSigner, Database, NetworkKeypair, NetworkPublicKey, TaskSpawner,
     TnSender, WorkerId,
@@ -720,8 +720,18 @@ where
                 send_or_log_error!(reply, peer_id, "LocalPeerId");
             }
             NetworkCommand::Publish { topic, msg, reply } => {
-                let res =
-                    self.swarm.behaviour_mut().gossipsub.publish(TopicHash::from_raw(topic), msg);
+                // Enforce `MAX_GOSSIP_MESSAGE_SIZE` at origination, symmetrically with the
+                // receive-side check in `verify_gossip`. Honest peers reject an oversized payload
+                // as `RejectReason::TooLarge` and Fatal-attribute it to the
+                // relaying peer; on the first hop that relayer is the originator,
+                // so a node that published an oversized message would be banned by
+                // its own neighbours. Refuse locally with a clear error instead, so
+                // origination and forwarding apply the identical bound.
+                let res = if msg.len() > MAX_GOSSIP_MESSAGE_SIZE {
+                    Err(PublishError::MessageTooLarge)
+                } else {
+                    self.swarm.behaviour_mut().gossipsub.publish(TopicHash::from_raw(topic), msg)
+                };
                 if res.is_ok() {
                     self.metrics.record_gossip_published();
                 }
@@ -1419,8 +1429,10 @@ where
     ///
     /// Messages are only published by current committee nodes and must be within max size.
     fn verify_gossip(&self, gossip: &GossipMessage) -> GossipAcceptance {
-        // verify message size
-        if gossip.data.len() > self.config.max_gossip_message_size {
+        // verify message size against the network-wide protocol constant (not per-node config):
+        // the reject path attributes an oversized payload to the relaying peer, which is sound only
+        // if every honest node applies the identical bound. See `MAX_GOSSIP_MESSAGE_SIZE`.
+        if gossip.data.len() > MAX_GOSSIP_MESSAGE_SIZE {
             return GossipAcceptance::Reject(RejectReason::TooLarge);
         }
 
@@ -1956,10 +1968,12 @@ enum GossipAcceptance {
 /// of the reason; the distinction only governs peer scoring.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RejectReason {
-    /// The payload exceeds `max_gossip_message_size`. The bound is a shared constant, so under
-    /// gossipsub `Strict` validation an honest peer computes the same verdict and never forwards
-    /// the message: a peer that forwards an oversized payload is itself misbehaving, so the
-    /// relaying peer is accountable.
+    /// The payload exceeds [`MAX_GOSSIP_MESSAGE_SIZE`]. That bound is a compile-time protocol
+    /// constant, identical on every honest node, and enforced on both the publish path (the size
+    /// guard in the `NetworkCommand::Publish` handler) and the receive path here. An honest node
+    /// therefore never originates an oversized payload, and under gossipsub `Strict` validation
+    /// never forwards one either: a peer that delivers an oversized payload is itself misbehaving,
+    /// so the relaying peer is accountable.
     TooLarge,
     /// The message author is absent, has no resolved BLS identity, or is not an authorized
     /// publisher for the topic. The fault is the author's, not the forwarder's: an honest relayer
@@ -1986,9 +2000,11 @@ impl RejectReason {
     /// Decide the peer-scoring outcome for this reject, given whether the relaying peer's and the
     /// message author's BLS identities have resolved.
     ///
-    /// An oversized payload is charged to the relaying peer: the size bound is a shared constant,
-    /// so under gossipsub `Strict` validation an honest peer computes the same verdict and never
-    /// forwards one, making a forwarded oversized payload relayer misbehavior. An unauthorized
+    /// An oversized payload is charged to the relaying peer: the size bound is a compile-time
+    /// protocol constant ([`MAX_GOSSIP_MESSAGE_SIZE`]), identical on every honest node and enforced
+    /// on both the publish and receive paths, so an honest peer never originates one and (under
+    /// gossipsub `Strict` validation) never forwards one, making a delivered oversized payload
+    /// relayer misbehavior. An unauthorized
     /// author is charged to the *author*, never the forwarder — an honest relayer merely forwarded
     /// content the author is responsible for (the reject-path analogue of #801/#785), and an honest
     /// author authorized under a neighbouring committee view is spared downstream by the committee

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -38,8 +38,8 @@ All sites live in `crates/network-libp2p/src/consensus.rs`. `NetworkCommand::Rep
 
 | Location                                     | Trigger (immediate guard)                                                     | Severity |
 | -------------------------------------------- | ----------------------------------------------------------------------------- | -------- |
-| `crates/network-libp2p/src/consensus.rs:940` | `verify_gossip` rejected `TooLarge` (oversized payload) **and** the relaying peer's BLS has resolved (`RejectPenalty::FatalRelayer`) — the size bound is deterministic network-wide, so under `Strict` validation a peer that forwards an oversized payload is itself misbehaving | `Fatal`  |
-| `crates/network-libp2p/src/consensus.rs:942` | `verify_gossip` rejected `UnauthorizedAuthor` (author absent / unresolved / unauthorized), or `TooLarge` from an unresolved relayer (`RejectPenalty::Skip`) — author-attributable or unattributable, so the forwarder is not penalized (issues #801/#819) | `None`   |
+| `crates/network-libp2p/src/consensus.rs:1004` | `verify_gossip` rejected `TooLarge` (oversized payload) **and** the relaying peer's BLS has resolved (`RejectPenalty::FatalRelayer`) — the size bound is a compile-time protocol constant (`MAX_GOSSIP_MESSAGE_SIZE`) identical on every honest node, so under `Strict` validation a peer that forwards an oversized payload is itself misbehaving | `Fatal`  |
+| `crates/network-libp2p/src/consensus.rs:1030` | `verify_gossip` rejected `UnauthorizedAuthor` (author absent / unresolved / unauthorized), or `TooLarge` from an unresolved relayer (`RejectPenalty::Skip`) — author-attributable or unattributable, so the forwarder is not penalized (issues #801/#819) | `None`   |
 | `crates/network-libp2p/src/consensus.rs:839` | `GossipEvent::GossipsubNotSupported { peer_id }`                              | `Fatal`  |
 | `crates/network-libp2p/src/consensus.rs:843` | `GossipEvent::SlowPeer { peer_id, failed_messages }`                          | `Mild`   |
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2974,9 +2974,10 @@ fn author_attributable_reject_charges_the_author_never_the_relayer() {
     }
 }
 
-/// An oversized payload is the only relayer-attributable reject — the size bound is deterministic
-/// network-wide, so under `Strict` validation an honest peer never forwards one — and it is
-/// charged to the forwarder only once its BLS identity has resolved (the author's resolution is
+/// An oversized payload is the only relayer-attributable reject — the size bound is a compile-time
+/// protocol constant (`MAX_GOSSIP_MESSAGE_SIZE`), identical on every honest node and enforced on
+/// both the publish and receive paths, so an honest peer never originates or forwards one — and it
+/// is charged to the forwarder only once its BLS identity has resolved (the author's resolution is
 /// irrelevant), mirroring the Accept path's unresolved-relayer skip.
 #[test]
 fn oversized_reject_penalizes_only_a_resolved_relayer() {
@@ -2987,4 +2988,25 @@ fn oversized_reject_penalizes_only_a_resolved_relayer() {
         );
         assert_eq!(RejectReason::TooLarge.penalty(false, author_resolved), RejectPenalty::Skip);
     }
+}
+
+/// #872: a node must never originate a gossip payload larger than `MAX_GOSSIP_MESSAGE_SIZE`. Honest
+/// peers reject an oversized payload as `RejectReason::TooLarge` and Fatal-attribute it to the
+/// relaying peer, which on the first hop is the originator — so the publish path enforces the same
+/// bound as `verify_gossip`, refusing an oversized message locally with
+/// `PublishError::MessageTooLarge` instead of letting the originator be banned by its peers.
+#[tokio::test]
+async fn oversized_publish_is_refused_locally() -> eyre::Result<()> {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { network_handle: cvv, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    // one byte over the bound is refused at origination, before it can reach any peer
+    let too_big = vec![0u8; MAX_GOSSIP_MESSAGE_SIZE + 1];
+    let err = cvv.publish(TEST_TOPIC.into(), too_big).await.expect_err("oversized publish refused");
+    assert_matches!(err, NetworkError::Publish(PublishError::MessageTooLarge));
+
+    Ok(())
 }


### PR DESCRIPTION
Closes #872.

## Problem

On the gossip reject path, an oversized message (`RejectReason::TooLarge`)
whose relaying peer resolves is mapped to `RejectPenalty::FatalRelayer`, which
Fatal-bans the propagation source.  The doc comments justified this with the
claim that `max_gossip_message_size` is a "shared constant", so under gossipsub
`Strict` validation an honest peer computes the same verdict and never forwards
an oversized message.

That was overstated: `max_gossip_message_size` was a per-node
`#[serde(default)]` config field (default `12_000`), not an enforced protocol
constant.  Under heterogeneous operator config, an honest relayer whose own
configured limit is larger than ours could be Fatal-banned for forwarding a
payload that is under its own limit but over the local node's.

## Fix

Promote the bound to a genuine compile-time protocol constant,
`tn_config::MAX_GOSSIP_MESSAGE_SIZE` (`= 12_000`), and enforce it on **both**
gossip paths so the attribution is genuinely sound:

- **Receive path**: `verify_gossip` checks `MAX_GOSSIP_MESSAGE_SIZE` instead
  of `self.config.max_gossip_message_size`.  Because the bound is now identical
  on every honest node and gossipsub runs `Strict` with `validate_messages()`,
  a peer that deems a message `TooLarge` reports `Reject` and never forwards it,
  so a forwarded oversized payload is genuine relayer misbehavior.
- **Publish path**: the `NetworkCommand::Publish` handler refuses a message
  larger than `MAX_GOSSIP_MESSAGE_SIZE` locally, returning
  `PublishError::MessageTooLarge` to the caller.

### Why the publish-side guard is part of this fix

`Strict` validation only gates *forwarding* of received messages; it never runs
on a node's own originated message.  Without a publish-side check the enforcement
is asymmetric: gossipsub's own cap is the unset `65_536`-byte default, so a
non-committee node, which uses the non-CVV `publish_txn` path
(`worker/src/network/handle.rs`), and whose transactions reth's pool allows up
to 128 KiB — could originate a `12_001..65_535`-byte gossip message.  Its honest
first-hop neighbours would then reject it as `TooLarge` and Fatal-attribute it
to the propagation source, which on the first hop is the honest originator.  That
is the same class of honest-node-ban the issue is about, relocated from
heterogeneous config to a missing origination/forwarding symmetry.  Guarding the
publish path closes it: origination and forwarding now apply the identical
bound, so the "genuine relayer misbehavior" rationale in the docs is literally
true, and an honest node that tries to publish an oversized message gets a
clear local error instead of a silent network-wide drop plus a peer-applied ban.

This behaviour is strictly safer than before: a `> 12_000`-byte message was
already un-gossipable (every receiver rejects it) . . . the guard just surfaces that
locally and immediately instead of after a failed fan-out.

### Changes

- [x] Add `tn_config::MAX_GOSSIP_MESSAGE_SIZE` (`= 12_000`), documented as a
      protocol constant enforced on both paths.
- [x] `verify_gossip` and the `NetworkCommand::Publish` handler both enforce
      `MAX_GOSSIP_MESSAGE_SIZE`.
- [x] Remove the `max_gossip_message_size` field from `LibP2pConfig` (and its
      default);  drop the now-nonexistent key from the partial-yaml test fixture.
      Existing config files that still carry the key keep loading unchanged —
      `LibP2pConfig` does not deny unknown fields.
- [x] Correct the "shared constant" / "deterministic network-wide" language in
      `consensus.rs`, `peers/penalty.md`, and `network_tests.rs`.
- [x] Update the stale `consensus.rs:940/942` line references in
      `peers/penalty.md` §3.1 to the current application sites (`994` / `1020`).
- [x] `oversized_reject_penalizes_only_a_resolved_relayer` still passes (only
      its doc changed); add `oversized_publish_is_refused_locally` covering the
      publish guard.

## Why not set libp2p `max_transmit_size`?

The issue listed setting libp2p's `max_transmit_size` to the same bound as an
alternative transport-layer back-stop.  I did not take that path: `max_transmit_size`
caps the whole protobuf-encoded RPC frame, not a single message's `data` field,
so pinning it at `12_000` would refuse a legitimate `12_000`-byte message (which
`verify_gossip` accepts, since its check is `> MAX_GOSSIP_MESSAGE_SIZE`) once
protobuf framing and any piggybacked gossipsub control are added.  The frame and
per-message limits are at different granularities, so `max_transmit_size` cannot
cleanly enforce the `12_000`-byte payload bound.  The compile-time constant plus
symmetric application-layer enforcement makes the attribution sound without it.

## Notes / out of scope

- `peers/penalty.md` carries other `consensus.rs:<line>` references (in §3.2–§3.5)
  that also drifted after the #819 merge (same ~200-line offset).  This PR updates
  only the two rows the issue names (§3.1).  A full line-number refresh, or a
  switch to stable anchors (function / match-arm names) since raw line numbers
  drift chronically here, is a separate cleanup.

## Testing

- `cargo clippy -p tn-config -p tn-network-libp2p --all-targets` — clean.
- `cargo test -p tn-config` (network config round-trip / partial-yaml / defaults).
- `cargo test -p tn-network-libp2p` — `oversized_reject_penalizes_only_a_resolved_relayer`,
  `author_attributable_reject_charges_the_author_never_the_relayer`, and the new
  `oversized_publish_is_refused_locally`.
