### PR TITLE
Save consensus in pack files with the header then the batches instead of batches then the header.

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1127,6 +1127,7 @@ impl PrimaryNetworkHandle {
                 | PackError::InvalidConsensusNumber(_, _)
                 | PackError::ConsensusNumberAlreadyAdded
                 | PackError::ConsensusNumberTooLow
+                | PackError::InvalidVersion(_, _)
                 | PackError::ConsensusNumberTooHigh => None,
             },
             ConsensusChainError::EpochMismatch

--- a/crates/storage/src/archive/digest_index/index.rs
+++ b/crates/storage/src/archive/digest_index/index.rs
@@ -807,7 +807,7 @@ mod tests {
     fn test_archive_hdx_index() {
         let tmp_dir = TempDir::with_prefix("test_archive_hdx_index").expect("temp dir");
         let tmp_path = tmp_dir.path();
-        let data_header = DataHeader::new(0, crate::archive::pack::PackCompression::ZStd);
+        let data_header = DataHeader::new(0, crate::archive::pack::PackCompression::ZStd, 0);
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut idx: HdxIndex =
             HdxIndex::open_hdx_file(tmp_path.join("index.hdx"), &data_header, builder, false)
@@ -869,7 +869,7 @@ mod tests {
     fn test_archive_hdx_index_geometry_mismatch() {
         let tmp_dir = TempDir::with_prefix("test_archive_hdx_geometry").expect("temp dir");
         let tmp_path = tmp_dir.path();
-        let data_header = DataHeader::new(0, crate::archive::pack::PackCompression::ZStd);
+        let data_header = DataHeader::new(0, crate::archive::pack::PackCompression::ZStd, 0);
 
         // Create an index with the default 32-byte keys.
         {

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -19,7 +19,7 @@ use std::{
     fmt::Debug,
     fs::{self, File},
     hash::Hasher as _,
-    io::{self, ErrorKind, Read, Seek, SeekFrom, Write},
+    io::{self, Read, Seek, SeekFrom, Write},
     marker::PhantomData,
     path::Path,
 };
@@ -448,8 +448,7 @@ where
     W: ?Sized + std::io::Write,
 {
     value_buffer.clear();
-    encode_into_buffer(value_buffer, value)
-        .map_err(|e| std::io::Error::new(ErrorKind::Other, e.to_string()))?;
+    encode_into_buffer(value_buffer, value).map_err(|e| std::io::Error::other(e.to_string()))?;
     let buffer = match compression {
         PackCompression::None => value_buffer,
         PackCompression::ZStd => {

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -19,7 +19,7 @@ use std::{
     fmt::Debug,
     fs::{self, File},
     hash::Hasher as _,
-    io::{self, Read, Seek, SeekFrom, Write},
+    io::{self, ErrorKind, Read, Seek, SeekFrom, Write},
     marker::PhantomData,
     path::Path,
 };
@@ -44,8 +44,9 @@ where
         uid_idx: u64,
         read_only: bool,
         compression: PackCompression,
+        version: u16,
     ) -> Result<Self, OpenError> {
-        Ok(Self { inner: PackInner::open(path, uid_idx, read_only, compression)? })
+        Ok(Self { inner: PackInner::open(path, uid_idx, read_only, compression, version)? })
     }
 
     /// Length of the Pack file.
@@ -188,9 +189,11 @@ where
         uid_idx: u64,
         read_only: bool,
         compression: PackCompression,
+        version: u16,
     ) -> Result<Self, OpenError> {
-        let (data_file, header) = Self::open_data_file(path, uid_idx, read_only, compression)
-            .map_err(OpenError::DataFileOpen)?;
+        let (data_file, header) =
+            Self::open_data_file(path, uid_idx, read_only, compression, version)
+                .map_err(OpenError::DataFileOpen)?;
         Ok(Self {
             header,
             data_file,
@@ -233,33 +236,14 @@ where
     /// Do the actual insert so the public function can rollback easily on an error.
     fn append_inner(&mut self, value: &V) -> Result<u64, AppendError> {
         let record_pos = self.data_file.len();
-        self.value_buffer.clear();
-        encode_into_buffer(&mut self.value_buffer, value)
-            .map_err(|e| AppendError::SerializeValue(e.to_string()))?;
-        let buffer = match self.header.compression {
-            PackCompression::None => &self.value_buffer,
-            PackCompression::ZStd => {
-                self.compression_buffer.clear();
-                let mut compressor =
-                    zstd::stream::write::Encoder::new(&mut self.compression_buffer, 0)?;
-                compressor.write_all(&self.value_buffer)?;
-                compressor.finish()?;
-                &self.compression_buffer
-            }
-        };
 
-        let mut crc32_hasher = crc32fast::Hasher::new();
-        // Once we have written to write_buffer, it needs to be rolled back before returning an
-        // error. Space for the value length.
-        let value_size = (buffer.len() as u32).to_le_bytes();
-        self.data_file.write_all(&value_size)?;
-        crc32_hasher.update(&value_size);
-
-        self.data_file.write_all(buffer)?;
-        crc32_hasher.update(buffer);
-        let crc32 = crc32_hasher.finalize();
-        self.data_file.write_all(&crc32.to_le_bytes())?;
-
+        write_value(
+            value,
+            &mut self.data_file,
+            &mut self.value_buffer,
+            &mut self.compression_buffer,
+            self.header.compression,
+        )?;
         Ok(record_pos)
     }
 
@@ -332,17 +316,19 @@ where
         uid_idx: u64,
         ro: bool,
         compression: PackCompression,
+        version: u16,
     ) -> Result<(DataFile, DataHeader), LoadHeaderError> {
         let mut data_file = DataFile::open(path, ro)?;
         let file_end = data_file.data_file_end();
 
         let header = if file_end == 0 {
-            let header = DataHeader::new(uid_idx, compression);
+            let header = DataHeader::new(uid_idx, compression, version);
             header.write_header(&mut data_file)?;
             header
         } else {
             let header = DataHeader::load_header(&mut data_file, uid_idx)?;
-            if header.version() != 0 {
+            if header.version() > version {
+                // Do not allow a newer version than we request but allow an older.
                 return Err(LoadHeaderError::InvalidVersion);
             }
             if header.appnum() != 1 {
@@ -449,6 +435,49 @@ where
     }
 }
 
+/// Do the actual insert so the public function can rollback easily on an error.
+pub fn write_value<V, W>(
+    value: &V,
+    writer: &mut W,
+    value_buffer: &mut Vec<u8>,
+    mut compression_buffer: &mut Vec<u8>,
+    compression: PackCompression,
+) -> Result<(), std::io::Error>
+where
+    V: Debug + Serialize,
+    W: ?Sized + std::io::Write,
+{
+    value_buffer.clear();
+    encode_into_buffer(value_buffer, value)
+        .map_err(|e| std::io::Error::new(ErrorKind::Other, e.to_string()))?;
+    let buffer = match compression {
+        PackCompression::None => value_buffer,
+        PackCompression::ZStd => {
+            compression_buffer.clear();
+            {
+                let mut compressor = zstd::stream::write::Encoder::new(&mut compression_buffer, 0)?;
+                compressor.write_all(value_buffer)?;
+                compressor.finish()?;
+            }
+            compression_buffer
+        }
+    };
+
+    let mut crc32_hasher = crc32fast::Hasher::new();
+    // Once we have written to write_buffer, it needs to be rolled back before returning an
+    // error. Space for the value length.
+    let value_size = (buffer.len() as u32).to_le_bytes();
+    writer.write_all(&value_size)?;
+    crc32_hasher.update(&value_size);
+
+    writer.write_all(buffer)?;
+    crc32_hasher.update(buffer);
+    let crc32 = crc32_hasher.finalize();
+    writer.write_all(&crc32.to_le_bytes())?;
+
+    Ok(())
+}
+
 /// Size of the data file header.
 pub const DATA_HEADER_BYTES: usize = 28;
 
@@ -471,9 +500,9 @@ pub struct DataHeader {
 }
 
 impl DataHeader {
-    pub(crate) fn new(uid_idx: u64, compression: PackCompression) -> Self {
+    pub(crate) fn new(uid_idx: u64, compression: PackCompression, version: u16) -> Self {
         let uid = Self::gen_uid(uid_idx);
-        Self { type_id: *b"telnet", version: 0, uid, appnum: 1, compression }
+        Self { type_id: *b"telnet", version, uid, appnum: 1, compression }
     }
 
     /// Load a DataHeader from source.
@@ -640,7 +669,7 @@ mod tests {
     fn archive_pack_(compression: PackCompression) {
         let tmp_path = TempDir::with_prefix("test_archive_pack_one").expect("temp dir");
         let mut db: TestPack =
-            Pack::open(tmp_path.path().join("pack_test_one"), 0, false, compression)
+            Pack::open(tmp_path.path().join("pack_test_one"), 0, false, compression, 0)
                 .expect("open pack");
         let pos_1 = db.append(&TestRec { idx: 1, name: "Value One".to_string() }).expect("append");
         let pos_2 = db.append(&TestRec { idx: 2, name: "Value Two".to_string() }).expect("append");
@@ -688,7 +717,7 @@ mod tests {
         drop(db);
 
         let mut db: TestPack =
-            Pack::open(tmp_path.path().join("pack_test_one"), 0, false, compression)
+            Pack::open(tmp_path.path().join("pack_test_one"), 0, false, compression, 0)
                 .expect("open pack");
         let pos_1_2 =
             db.append(&TestRec { idx: 6, name: "Value One2".to_string() }).expect("append");
@@ -709,7 +738,7 @@ mod tests {
         drop(db);
 
         let mut db: TestPack =
-            Pack::open(tmp_path.path().join("pack_test_one"), 0, true, compression)
+            Pack::open(tmp_path.path().join("pack_test_one"), 0, true, compression, 0)
                 .expect("open pack");
         let v = db.fetch(pos_1_2).unwrap();
         assert_eq!(v.idx, 6);
@@ -755,8 +784,9 @@ mod tests {
         assert_eq!(v.name, "Value Three2");
         assert!(iter.next().is_none());
 
-        let db: TestPack = Pack::open(tmp_path.path().join("pack_test_one"), 0, true, compression)
-            .expect("open pack");
+        let db: TestPack =
+            Pack::open(tmp_path.path().join("pack_test_one"), 0, true, compression, 0)
+                .expect("open pack");
         let mut iter = db.raw_iter().unwrap().map(|r| r.unwrap());
         let v: TestRec = iter.next().unwrap();
         assert_eq!(v.idx, 1);
@@ -809,7 +839,7 @@ mod tests {
         let path = tmp_path.path().join("pack_bomb");
         {
             let _pack: TestPack =
-                Pack::open(&path, 0, false, PackCompression::ZStd).expect("open pack");
+                Pack::open(&path, 0, false, PackCompression::ZStd, 0).expect("open pack");
         }
         let pos = fs::metadata(&path).expect("metadata").len();
 
@@ -849,7 +879,7 @@ mod tests {
         let path = tmp_path.path().join("pack_corrupt");
         let pos = {
             let mut pack: TestPack =
-                Pack::open(&path, 0, false, PackCompression::ZStd).expect("open pack");
+                Pack::open(&path, 0, false, PackCompression::ZStd, 0).expect("open pack");
             pack.append(&TestRec { idx: 1, name: "f4 fixture".to_string() }).expect("append")
         };
 
@@ -897,7 +927,7 @@ mod tests {
         let (tmp_dir, pos) = build_pack_with_decompression_bomb();
         let path = tmp_dir.path().join("pack_bomb");
         let mut pack: TestPack =
-            Pack::open(&path, 0, true, PackCompression::ZStd).expect("open pack");
+            Pack::open(&path, 0, true, PackCompression::ZStd, 0).expect("open pack");
         match pack.fetch(pos) {
             Err(FetchError::RequestedDecompressSizeTooLarge(max)) => {
                 assert_eq!(max, MAX_RECORD_SIZE);
@@ -946,7 +976,7 @@ mod tests {
         let (tmp_dir, pos) = build_pack_with_corrupt_zstd_frame();
         let path = tmp_dir.path().join("pack_corrupt");
         let mut pack: TestPack =
-            Pack::open(&path, 0, true, PackCompression::ZStd).expect("open pack");
+            Pack::open(&path, 0, true, PackCompression::ZStd, 0).expect("open pack");
         match pack.fetch(pos) {
             Err(FetchError::IO(_)) | Err(FetchError::DeserializeValue(_)) => {}
             other => panic!("expected IO or DeserializeValue error, got {other:?}"),
@@ -987,16 +1017,16 @@ mod tests {
         let path = tmp_path.path().join("pack_badver");
         {
             let mut pack: TestPack =
-                Pack::open(&path, 0, false, PackCompression::ZStd).expect("open pack");
+                Pack::open(&path, 0, false, PackCompression::ZStd, 0).expect("open pack");
             pack.append(&TestRec { idx: 1, name: "v".to_string() }).expect("append");
             pack.commit().expect("commit");
         }
-        // Patch version (bytes 6..8) to 1 and re-stamp the header CRC over bytes [0, 24).
+        // Patch version (bytes 6..8) to 100 and re-stamp the header CRC over bytes [0, 24).
         let mut header = [0_u8; DATA_HEADER_BYTES];
         {
             let mut file = OpenOptions::new().read(true).write(true).open(&path).expect("open rw");
             file.read_exact(&mut header).expect("read header");
-            header[6..8].copy_from_slice(&1_u16.to_le_bytes());
+            header[6..8].copy_from_slice(&100_u16.to_le_bytes());
             add_crc32(&mut header);
             file.seek(SeekFrom::Start(0)).expect("seek");
             file.write_all(&header).expect("write header");
@@ -1032,7 +1062,7 @@ mod tests {
         let tmp_path = TempDir::with_prefix("test_read_bytes_oob").expect("temp dir");
         let path = tmp_path.path().join("pack_oob");
         let mut pack: TestPack =
-            Pack::open(&path, 0, false, PackCompression::None).expect("open pack");
+            Pack::open(&path, 0, false, PackCompression::None, 0).expect("open pack");
         pack.append(&TestRec { idx: 1, name: "x".to_string() }).expect("append");
         pack.commit().expect("commit");
 

--- a/crates/storage/src/archive/pack_iter.rs
+++ b/crates/storage/src/archive/pack_iter.rs
@@ -11,9 +11,12 @@ use serde::{de::DeserializeOwned, Serialize};
 use tn_types::try_decode;
 use tokio::io::{AsyncRead, AsyncReadExt as _};
 
-use crate::archive::{
-    error::{fetch::FetchError, load_header::LoadHeaderError},
-    pack::{DataHeader, PackCompression},
+use crate::{
+    archive::{
+        error::{fetch::FetchError, load_header::LoadHeaderError},
+        pack::{DataHeader, PackCompression},
+    },
+    consensus_pack::PACK_VERSION,
 };
 
 /// Provide an upper bound on a record size.
@@ -46,7 +49,7 @@ where
     /// are returned in insert order.
     pub fn open(mut reader: R, uid_idx: u64) -> Result<Self, LoadHeaderError> {
         let header = DataHeader::load_header(&mut reader, uid_idx)?;
-        if header.version() != 0 {
+        if header.version() > PACK_VERSION {
             return Err(LoadHeaderError::InvalidVersion);
         }
         if header.appnum() != 1 {
@@ -161,6 +164,7 @@ where
     buffer: Vec<u8>,
     decompress_buffer: Vec<u8>,
     compression: PackCompression,
+    version: u16,
 }
 
 impl<V, R> AsyncPackIter<V, R>
@@ -176,7 +180,7 @@ where
         // Mirror PackIter::open / PackInner::open_data_file: reject unexpected version/appnum
         // so the (peer-facing) async path rejects future/foreign formats instead of parsing
         // them with current-format logic.
-        if header.version() != 0 {
+        if header.version() > PACK_VERSION {
             return Err(LoadHeaderError::InvalidVersion);
         }
         if header.appnum() != 1 {
@@ -188,6 +192,7 @@ where
             buffer: Vec::new(),
             decompress_buffer: Vec::new(),
             compression: header.compression(),
+            version: header.version(),
         })
     }
 
@@ -199,6 +204,7 @@ where
     pub async fn open_partial(
         reader: R,
         compression: PackCompression,
+        version: u16,
     ) -> Result<Self, LoadHeaderError> {
         Ok(AsyncPackIter {
             _val: PhantomData,
@@ -206,7 +212,13 @@ where
             buffer: Vec::new(),
             decompress_buffer: Vec::new(),
             compression,
+            version,
         })
+    }
+
+    /// Return the version of the underlying data.
+    pub fn version(&self) -> u16 {
+        self.version
     }
 
     /// Read the next record or return an error if an overflow bucket.
@@ -277,5 +289,10 @@ where
                 _ => Some(Err(err)),
             },
         }
+    }
+
+    /// Consume the iter and return the underlying reader.
+    pub fn into_reader(self) -> R {
+        self.reader
     }
 }

--- a/crates/storage/src/archive/position_index/index.rs
+++ b/crates/storage/src/archive/position_index/index.rs
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn test_archive_pdx_index_single() {
         let tmp_path = TempDir::with_prefix("test_archive_pdx_index").expect("temp dir");
-        let data_header = DataHeader::new(0, PackCompression::ZStd);
+        let data_header = DataHeader::new(0, PackCompression::ZStd, 0);
         let mut idx: PositionIndex<u64> = PositionIndex::open_pdx_file(
             tmp_path.path().join("index.pdx"),
             &data_header,
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn test_archive_pdx_index_double() {
         let tmp_path = TempDir::with_prefix("test_archive_pdx_index_double").expect("temp dir");
-        let data_header = DataHeader::new(0, PackCompression::ZStd);
+        let data_header = DataHeader::new(0, PackCompression::ZStd, 0);
         let mut idx: PositionIndex<(u64, u64)> =
             PositionIndex::open_pdx_file(tmp_path.path(), &data_header, "index2.pdx", false)
                 .expect("pdx file");
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn test_archive_pdx_torn_tail_heals() {
         let tmp_path = TempDir::with_prefix("test_archive_pdx_torn").expect("temp dir");
-        let data_header = DataHeader::new(0, PackCompression::ZStd);
+        let data_header = DataHeader::new(0, PackCompression::ZStd, 0);
         let file = tmp_path.path().join("torn.pdx");
 
         {
@@ -586,7 +586,7 @@ mod tests {
     #[test]
     fn test_archive_pdx_geometry_mismatch() {
         let tmp_path = TempDir::with_prefix("test_archive_pdx_geometry").expect("temp dir");
-        let data_header = DataHeader::new(0, PackCompression::ZStd);
+        let data_header = DataHeader::new(0, PackCompression::ZStd, 0);
 
         {
             let mut idx: PositionIndex<u64> =

--- a/crates/storage/src/certificate_pack.rs
+++ b/crates/storage/src/certificate_pack.rs
@@ -13,12 +13,15 @@ use tokio::sync::{
 };
 use tracing::{error, info};
 
-use crate::archive::{
-    digest_index::index::HdxIndex,
-    error::{fetch::FetchError, open::OpenError},
-    fxhasher::FxHasher,
-    index::Index as _,
-    pack::{Pack, PackCompression, DATA_HEADER_BYTES},
+use crate::{
+    archive::{
+        digest_index::index::HdxIndex,
+        error::{fetch::FetchError, open::OpenError},
+        fxhasher::FxHasher,
+        index::Index as _,
+        pack::{Pack, PackCompression, DATA_HEADER_BYTES},
+    },
+    consensus_pack::PACK_VERSION,
 };
 
 enum PackMessage {
@@ -238,8 +241,13 @@ impl Inner {
         if !read_only {
             let _ = std::fs::create_dir_all(base_dir);
         }
-        let mut data: Pack<Certificate> =
-            Pack::open(base_dir.join(Self::DATA_NAME), 0, read_only, PackCompression::ZStd)?;
+        let mut data: Pack<Certificate> = Pack::open(
+            base_dir.join(Self::DATA_NAME),
+            0,
+            read_only,
+            PackCompression::ZStd,
+            PACK_VERSION,
+        )?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut digest_idx = HdxIndex::open_hdx_file(
             base_dir.join(Self::HASH_NAME),

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -685,6 +685,10 @@ impl Inner {
                 }
                 idx -= 1;
             }
+            // Only ever shrink: `truncate` is `set_len`, so a `new_pack_len` above the current
+            // length (an index entry claiming an `output_end` past the data we actually have)
+            // would zero-extend the pack.  Clamp defensively.
+            let new_pack_len = new_pack_len.min(pack_len);
             if new_pack_len != pack_len {
                 data.truncate(new_pack_len)?;
             }
@@ -1427,10 +1431,22 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
         }
     }
     let expected_digest_count = expected_batch_digests.len();
+    // Bound how many batch records we will read for one output before the terminating
+    // condition.  The header is read first, so a hostile stream cannot flood batches ahead of
+    // it, but the header's sub-dag (attacker-controlled, bounded only by MAX_RECORD_SIZE) can
+    // still declare a huge number of payload digests.  Reject early — before reading/buffering
+    // any batches — like the legacy path does.  A legitimate ConsensusOutput references far
+    // fewer batches than this.
+    if expected_digest_count > MAX_BATCHES_PER_OUTPUT {
+        return Err(PackError::TooManyBatches(MAX_BATCHES_PER_OUTPUT));
+    }
     let mut expected_batch_digests = expected_batch_digests.into_iter();
 
     let mut available_batches = HashMap::new();
-    // Load and verify batches.
+    // Load and verify batches.  Batches are matched positionally against `expected_batch_digests`
+    // (sorted digest order): producers write them in `BTreeMap`/`BTreeSet` digest order (see
+    // `collect_batches` / `save_consensus_batches`), so the stream MUST arrive in that same order.
+    // Out-of-order input is rejected below rather than silently reordered.
     let mut digest_count = 0;
     while let Some(record) = next_output_record(stream_iter, timeout).await? {
         match record {
@@ -2093,7 +2109,7 @@ pub(crate) mod test {
             let output_db = pack
                 .get_consensus_output(i as u64 + 1)
                 .await
-                .expect(&format!("failed output on {i}"));
+                .unwrap_or_else(|e| panic!("failed output on {i}: {e}"));
             let output = outputs.get(i as usize).unwrap();
             compare_outputs(&output_db, output);
         }
@@ -2335,6 +2351,79 @@ pub(crate) mod test {
         .await;
         // New format will fail by starting with a batch.  This would be TooManyBatches with v0.
         assert!(matches!(res, Err(PackError::BatchLoad(_))), "expected BatchLoad");
+    }
+
+    /// CP1b: in the v1 (header-first) format a hostile header whose sub-dag declares more than
+    /// `MAX_BATCHES_PER_OUTPUT` payload digests must be rejected up front — before any batch is
+    /// read — rather than allocating/reading a batch per declared digest.
+    #[tokio::test]
+    async fn test_iter_to_output_caps_expected_batches() {
+        use crate::{
+            archive::pack::{Pack, DATA_HEADER_BYTES},
+            consensus_pack::{bytes_to_output, PackError, PackRecord, MAX_BATCHES_PER_OUTPUT},
+        };
+        use std::io::Cursor;
+
+        let temp_dir = TempDir::with_prefix("test_cp_expected_cap").expect("temp dir");
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+
+        // Craft a single consensus header whose leader references more distinct batch digests
+        // than the cap.
+        let batches = tn_reth::test_utils::batches(chain, MAX_BATCHES_PER_OUTPUT + 5);
+        let authority = committee.authorities().first().expect("authority").id();
+        let mut leader = Certificate::default();
+        leader.update_header_author_for_test(authority);
+        for batch in &batches {
+            let mut builder = HeaderBuilder::from_header(leader.header());
+            builder = builder.with_payload_batch(batch, 0_u16);
+            leader.update_header_for_test(builder.build());
+        }
+        leader.update_header_round_for_test(1);
+        leader.update_header_epoch_for_test(committee.epoch());
+        let sub_dag = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader,
+            1,
+            ReputationScores::default(),
+            None,
+        );
+        let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+        let output = ConsensusOutput::new(
+            sub_dag,
+            ConsensusHeader::default().digest(),
+            1,
+            false,
+            batch_digests,
+            vec![],
+        );
+        assert!(
+            output.sub_dag().num_primary_batches() > MAX_BATCHES_PER_OUTPUT,
+            "test must exceed the cap"
+        );
+
+        // Write just the header record (v1: header first) with no batch records to follow.
+        let path = temp_dir.path().join("header_only");
+        {
+            let mut pack: Pack<PackRecord> =
+                Pack::open(&path, 0, false, PackCompression::ZStd, PACK_VERSION)
+                    .expect("open pack");
+            pack.append(&PackRecord::Consensus(Box::new(output.consensus_header())))
+                .expect("append header");
+            pack.commit().expect("commit");
+        }
+        let file_bytes = std::fs::read(&path).expect("read file");
+        let records = file_bytes[DATA_HEADER_BYTES..].to_vec();
+
+        let res = bytes_to_output(
+            Cursor::new(records),
+            PackCompression::ZStd,
+            Duration::from_secs(5),
+            &committee,
+        )
+        .await;
+        assert!(matches!(res, Err(PackError::TooManyBatches(_))), "expected TooManyBatches");
     }
 
     /// CP2: get_consensus_output with a number below start_consensus_number must error rather

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -216,11 +216,33 @@ impl ConsensusPack {
         previous_epoch: EpochRecord,
         committee: Committee,
     ) -> Result<ConsensusPack, PackError> {
+        Self::open_append_inner(path, previous_epoch, committee, PACK_VERSION)
+    }
+
+    /// Test-only: open an append pack forcing a specific on-disk data version so tests can
+    /// construct genuine v0 (legacy, batches-first) pack files.
+    #[cfg(test)]
+    pub(crate) fn open_append_version<P: Into<PathBuf>>(
+        path: P,
+        previous_epoch: EpochRecord,
+        committee: Committee,
+        version: u16,
+    ) -> Result<ConsensusPack, PackError> {
+        Self::open_append_inner(path, previous_epoch, committee, version)
+    }
+
+    /// Shared body for [`Self::open_append`] stamping the given on-disk data `version`.
+    fn open_append_inner<P: Into<PathBuf>>(
+        path: P,
+        previous_epoch: EpochRecord,
+        committee: Committee,
+        version: u16,
+    ) -> Result<ConsensusPack, PackError> {
         let (tx, rx) = mpsc::channel(1000);
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let epoch = committee.epoch();
-        let inner = Inner::open_append(path.clone(), &previous_epoch, committee.clone())?;
+        let inner = Inner::open_append(path.clone(), &previous_epoch, committee.clone(), version)?;
         let version = inner.version();
         let compression = inner.data.header().compression();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
@@ -415,8 +437,11 @@ impl ConsensusPack {
                 bytes.clear();
                 let mut value_buffer = Vec::new();
                 let mut compress_buffer = Vec::new();
+                // Re-encode as PackRecord-wrapped records (header first) to match the on-disk v1
+                // format the consumer decodes; the raw v1 serve path (below) returns these same
+                // PackRecord records straight from the pack file.
                 write_value(
-                    &header,
+                    &PackRecord::Consensus(Box::new(header)),
                     &mut bytes,
                     &mut value_buffer,
                     &mut compress_buffer,
@@ -424,7 +449,7 @@ impl ConsensusPack {
                 )?;
                 for (_, batch) in batches.into_iter() {
                     write_value(
-                        &batch,
+                        &PackRecord::Batch(batch),
                         &mut bytes,
                         &mut value_buffer,
                         &mut compress_buffer,
@@ -726,6 +751,7 @@ impl Inner {
         path: P,
         previous_epoch: &EpochRecord,
         committee: Committee,
+        version: u16,
     ) -> Result<Self, PackError> {
         let epoch = committee.epoch();
         let base_dir = path.as_ref().join(format!("epoch-{epoch}"));
@@ -733,7 +759,7 @@ impl Inner {
         let pack_file = base_dir.join(Self::DATA_NAME);
         let have_pack = std::fs::exists(&pack_file).unwrap_or_default();
         let mut data: Pack<PackRecord> =
-            Pack::open(&pack_file, epoch as u64, false, PackCompression::ZStd, PACK_VERSION)?;
+            Pack::open(&pack_file, epoch as u64, false, PackCompression::ZStd, version)?;
         let start_consensus_number =
             if epoch == 0 { 1 } else { previous_epoch.final_consensus.number + 1 };
         let epoch_meta = EpochMeta {
@@ -2424,6 +2450,92 @@ pub(crate) mod test {
         )
         .await;
         assert!(matches!(res, Err(PackError::TooManyBatches(_))), "expected TooManyBatches");
+    }
+
+    /// A v0 (legacy, batches-first) pack must serve its outputs as v1 (header-first) bytes via
+    /// `get_consensus_output_bytes`, so all peer-facing bytes are v1 regardless of on-disk format.
+    #[tokio::test]
+    async fn test_v0_output_served_as_v1_bytes() {
+        use crate::{
+            archive::pack_iter::AsyncPackIter,
+            consensus_pack::{bytes_to_output, bytes_to_output_legacy, PackRecord},
+        };
+        use std::io::Cursor;
+        use tokio::io::BufReader;
+
+        let temp_dir = TempDir::with_prefix("test_v0_served_v1").expect("temp dir");
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let previous_epoch = test_previous_epoch(&committee);
+
+        // Force a genuine v0 pack file (header stamped version 0 -> batches-first on disk).
+        let pack = ConsensusPack::open_append_version(
+            temp_dir.path(),
+            previous_epoch,
+            committee.clone(),
+            0,
+        )
+        .expect("open v0 pack");
+        assert_eq!(pack.version, 0, "constructor must produce a v0 pack file");
+
+        let num_outputs = 5;
+        let mut outputs = Vec::new();
+        let mut parent = ConsensusHeader::default().digest();
+        for i in 0..num_outputs {
+            let output = make_test_output(&committee, i % 4, chain.clone(), (i as u64) + 1, parent);
+            parent = output.digest();
+            outputs.push(output.clone());
+            pack.save_consensus_output(output).await.unwrap();
+        }
+        pack.persist().await.expect("persist");
+
+        for (i, original) in outputs.iter().enumerate() {
+            let number = i as u64 + 1;
+            let bytes = pack.get_consensus_output_bytes(number).await.expect("bytes");
+
+            // 1. Header-first: the first record must be a Consensus header (v1 ordering). A v0 file
+            //    would have yielded a Batch first.
+            let mut iter = AsyncPackIter::<PackRecord, _>::open_partial(
+                BufReader::new(Cursor::new(bytes.clone())),
+                PackCompression::ZStd,
+                PACK_VERSION,
+            )
+            .await
+            .expect("open partial");
+            match iter.next().await {
+                Some(Ok(PackRecord::Consensus(_))) => {}
+                other => panic!("expected first record to be a Consensus header, got {other:?}"),
+            }
+
+            // 2. Decodes with the v1 decoder and matches the original output.
+            let decoded = bytes_to_output(
+                BufReader::new(Cursor::new(bytes.clone())),
+                PackCompression::ZStd,
+                Duration::from_secs(5),
+                &committee,
+            )
+            .await
+            .expect("v1 decode");
+            compare_outputs(&decoded, original);
+
+            // 3. The bytes are truly re-ordered: the legacy (batches-first) decoder rejects them.
+            let legacy = bytes_to_output_legacy(
+                BufReader::new(Cursor::new(bytes)),
+                PackCompression::ZStd,
+                Duration::from_secs(5),
+                &committee,
+            )
+            .await;
+            assert!(legacy.is_err(), "legacy decode of v1 bytes must fail, got {legacy:?}");
+
+            // The local read path still honors the on-disk v0 format (legacy decode).
+            compare_outputs(
+                &pack.get_consensus_output(number).await.expect("local read"),
+                original,
+            );
+        }
+        drop(pack);
     }
 
     /// CP2: get_consensus_output with a number below start_consensus_number must error rather

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -29,18 +29,21 @@ use tokio::{
         oneshot, watch,
     },
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::archive::{
-    data_file::{create_dir_synced, fsync_directory},
+    data_file::create_dir_synced,
     digest_index::index::HdxIndex,
     error::{fetch::FetchError, open::OpenError},
     fxhasher::FxHasher,
     index::Index as _,
-    pack::{DataHeader, Pack, PackCompression, DATA_HEADER_BYTES},
+    pack::{write_value, DataHeader, Pack, PackCompression, DATA_HEADER_BYTES},
     pack_iter::AsyncPackIter,
     position_index::index::{PosIndexValue, PositionIndex},
 };
+
+/// Current version for new pack files.
+pub const PACK_VERSION: u16 = 1;
 
 /// Metadata for an Epoch.  Should always be the first record in a consensus pack.
 #[derive(PartialEq, Serialize, Deserialize, Clone, Debug, Default)]
@@ -123,6 +126,7 @@ pub struct ConsensusPack {
     committee: Committee,
     compression: PackCompression,
     is_static: bool,
+    version: u16, // Version of the underlying data pack file.
 }
 
 fn run_pack_loop(
@@ -217,6 +221,7 @@ impl ConsensusPack {
         let (tx_error, error) = watch::channel(None);
         let epoch = committee.epoch();
         let inner = Inner::open_append(path.clone(), &previous_epoch, committee.clone())?;
+        let version = inner.version();
         let compression = inner.data.header().compression();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
         Ok(Self {
@@ -227,6 +232,7 @@ impl ConsensusPack {
             committee,
             compression,
             is_static: false,
+            version,
         })
     }
 
@@ -236,6 +242,7 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let inner = Inner::open_append_exists(path.clone(), epoch)?;
+        let version = inner.version();
         let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
@@ -247,6 +254,7 @@ impl ConsensusPack {
             committee,
             compression,
             is_static: false,
+            version,
         })
     }
 
@@ -258,6 +266,7 @@ impl ConsensusPack {
         let path: PathBuf = path.into();
         let (tx_error, error) = watch::channel(None);
         let inner = Inner::open_static(path.clone(), epoch)?;
+        let version = inner.version();
         let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || run_pack_loop(inner, rx, tx_error));
@@ -269,6 +278,7 @@ impl ConsensusPack {
             committee,
             compression,
             is_static: true,
+            version,
         })
     }
 
@@ -293,6 +303,7 @@ impl ConsensusPack {
             timeout,
         )
         .await?;
+        let version = inner.version();
         let compression = inner.data.header().compression();
         let committee = inner.epoch_meta.committee.clone();
         let handle = std::thread::spawn(move || {
@@ -306,6 +317,7 @@ impl ConsensusPack {
             committee,
             compression,
             is_static: true,
+            version,
         })
     }
 
@@ -350,7 +362,22 @@ impl ConsensusPack {
         };
         let cursor = Cursor::new(bytes);
         let reader = BufReader::new(cursor);
-        bytes_to_output(reader, self.compression, Duration::from_secs(5), &self.committee).await
+        match self.version {
+            0 => {
+                bytes_to_output_legacy(
+                    reader,
+                    self.compression,
+                    Duration::from_secs(5),
+                    &self.committee,
+                )
+                .await
+            }
+            1 => {
+                bytes_to_output(reader, self.compression, Duration::from_secs(5), &self.committee)
+                    .await
+            }
+            _ => Err(PackError::InvalidVersion(PACK_VERSION, self.version)),
+        }
     }
 
     /// Decode pack-file `bytes` (as produced by [`Self::get_consensus_output_bytes`] / streamed via
@@ -367,10 +394,47 @@ impl ConsensusPack {
     pub async fn get_consensus_output_bytes(&self, number: u64) -> Result<Vec<u8>, PackError> {
         self.get_error()?;
         let (tx, rx) = oneshot::channel();
-        if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
+        let mut bytes = if self.tx.send(PackMessage::BytesForConsensus(number, tx)).await.is_ok() {
             rx.await.map_err(|_| PackError::ReceiveFailed)?
         } else {
             Err(PackError::SendFailed)
+        }?;
+        match self.version {
+            0 => {
+                let cursor = Cursor::new(bytes.clone());
+                let reader = BufReader::new(cursor);
+                let out = bytes_to_output_legacy(
+                    reader,
+                    self.compression,
+                    Duration::from_secs(5),
+                    &self.committee,
+                )
+                .await?;
+                let batches = collect_batches(&out);
+                let header: ConsensusHeader = out.into();
+                bytes.clear();
+                let mut value_buffer = Vec::new();
+                let mut compress_buffer = Vec::new();
+                write_value(
+                    &header,
+                    &mut bytes,
+                    &mut value_buffer,
+                    &mut compress_buffer,
+                    PackCompression::ZStd,
+                )?;
+                for (_, batch) in batches.into_iter() {
+                    write_value(
+                        &batch,
+                        &mut bytes,
+                        &mut value_buffer,
+                        &mut compress_buffer,
+                        PackCompression::ZStd,
+                    )?;
+                }
+                Ok(bytes)
+            }
+            1 => Ok(bytes),
+            _ => Err(PackError::InvalidVersion(PACK_VERSION, self.version)),
         }
     }
 
@@ -562,20 +626,14 @@ impl Inner {
             return false;
         }
         if !consensus_pos_idx.is_empty() {
-            let last_record = match consensus_pos_idx.load(consensus_pos_idx.len() as u64 - 1) {
-                Ok(p) => p.consensus_header,
+            let last_record_end = match consensus_pos_idx.load(consensus_pos_idx.len() as u64 - 1) {
+                Ok(p) => p.output_end,
                 Err(_) => return false,
             };
-            let mut iter = match data.raw_iter() {
-                Ok(i) => i,
-                Err(_) => return false,
-            };
-            if iter.set_position(last_record).is_err() {
-                return false;
-            }
-            match (iter.next(), iter.next()) {
-                (Some(_), None) => iter.position().unwrap_or_default() == pack_len,
-                _ => false,
+            if pack_len == last_record_end {
+                true
+            } else {
+                false
             }
         } else {
             true
@@ -613,16 +671,13 @@ impl Inner {
             let mut idx = start_idx;
             loop {
                 if let Ok(last_record) = consensus_pos_idx.load(idx) {
-                    let record_size_res = data.record_size(last_record.consensus_header);
-                    let record_valid = record_size_res.is_ok();
-                    if record_valid {
-                        if idx != start_idx {
-                            // Keep the bytes index in sync with the consensus index so the two
-                            // never diverge in length after healing a damaged pack.
-                            consensus_pos_idx.truncate_to_index(idx)?;
-                        }
-                        new_pack_len = last_record.consensus_header
-                            + record_size_res.unwrap_or_default() as u64;
+                    if idx != start_idx {
+                        // Keep the bytes index in sync with the consensus index so the two
+                        // never diverge in length after healing a damaged pack.
+                        consensus_pos_idx.truncate_to_index(idx)?;
+                    }
+                    new_pack_len = last_record.output_end;
+                    if new_pack_len <= pack_len {
                         break;
                     }
                 }
@@ -647,6 +702,11 @@ impl Inner {
         Ok(())
     }
 
+    /// Return the version of the underlying data pack file.
+    fn version(&self) -> u16 {
+        self.data.version()
+    }
+
     /// Open a PDX index file and return the open index.
     fn open_pdx_file<P: AsRef<Path>, T: PosIndexValue>(
         dir: P,
@@ -656,59 +716,6 @@ impl Inner {
         let base_dir = dir.as_ref().join(Self::CONSENSUS_POS_NAME);
         let consensus_pos_idx =
             PositionIndex::open_pdx_file(&base_dir, data_header, "index_pos.pdx", read_only)
-                .map_err(OpenError::IndexFileOpen)?;
-        Ok(consensus_pos_idx)
-    }
-
-    /// Open a PDX index file and return the open index.
-    /// This will handle an update of the index on older testnet epochs.
-    fn open_pdx_file_with_update<P: AsRef<Path>, T: PosIndexValue>(
-        dir: P,
-        read_only: bool,
-        data: &mut Pack<PackRecord>,
-    ) -> Result<PositionIndex<T>, PackError> {
-        let base_dir = dir.as_ref().join(Self::CONSENSUS_POS_NAME);
-        if PositionIndex::<T>::pdx_file_exists(&base_dir, "index.pdx")
-            && !PositionIndex::<T>::pdx_file_exists(&base_dir, "index_pos.pdx")
-        {
-            warn!(target: "consensus_pack", "Found old but not new position index, updating");
-            // We have an old index but, need to create a new one and build it.
-            // This code should only effect OG testnet nodes and should not need
-            // to be maintained forever.
-            let mut old_idx: PositionIndex<u64> =
-                PositionIndex::open_pdx_file(&base_dir, data.header(), "index.pdx", false)
-                    .map_err(OpenError::IndexFileOpen)?;
-            let _ = std::fs::remove_file(base_dir.join("index_pos.pdx.tmp"));
-            let mut new_idx: PositionIndex<IndexPositions> =
-                PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx.tmp", false)
-                    .map_err(OpenError::IndexFileOpen)?;
-            let mut end = 0;
-            for i in 0..old_idx.len() {
-                let idx = i as u64;
-                let start = if idx > 0 {
-                    end
-                } else {
-                    DATA_HEADER_BYTES as u64 + data.record_size(DATA_HEADER_BYTES as u64)? as u64
-                };
-                let Ok(pos) = old_idx.load(idx) else {
-                    break;
-                };
-                let Ok(record_size) = data.record_size(pos) else {
-                    break;
-                };
-                end = pos + record_size as u64;
-                new_idx
-                    .save(idx, IndexPositions::new(pos, start, end))
-                    .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
-            }
-            drop(new_idx);
-            drop(old_idx);
-            std::fs::rename(base_dir.join("index_pos.pdx.tmp"), base_dir.join("index_pos.pdx"))?;
-            fsync_directory(&base_dir)?;
-            let _ = std::fs::remove_file(base_dir.join("index.pdx"));
-        }
-        let consensus_pos_idx =
-            PositionIndex::open_pdx_file(&base_dir, data.header(), "index_pos.pdx", read_only)
                 .map_err(OpenError::IndexFileOpen)?;
         Ok(consensus_pos_idx)
     }
@@ -726,7 +733,7 @@ impl Inner {
         let pack_file = base_dir.join(Self::DATA_NAME);
         let have_pack = std::fs::exists(&pack_file).unwrap_or_default();
         let mut data: Pack<PackRecord> =
-            Pack::open(&pack_file, epoch as u64, false, PackCompression::ZStd)?;
+            Pack::open(&pack_file, epoch as u64, false, PackCompression::ZStd, PACK_VERSION)?;
         let start_consensus_number =
             if epoch == 0 { 1 } else { previous_epoch.final_consensus.number + 1 };
         let epoch_meta = EpochMeta {
@@ -749,7 +756,7 @@ impl Inner {
             data.append(&PackRecord::EpochMeta(epoch_meta.clone()))
                 .map_err(|e| PackError::Append(e.to_string()))?;
         }
-        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, false, &mut data)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -791,12 +798,13 @@ impl Inner {
             epoch as u64,
             false,
             PackCompression::ZStd,
+            PACK_VERSION,
         )?;
         let epoch_meta = data
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, false, &mut data)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), false)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let mut consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -833,12 +841,13 @@ impl Inner {
             epoch as u64,
             true,
             PackCompression::ZStd,
+            PACK_VERSION,
         )?;
         let epoch_meta = data
             .fetch(DATA_HEADER_BYTES as u64)
             .map_err(|e| PackError::EpochLoad(e.to_string()))?
             .into_epoch()?;
-        let mut consensus_pos_idx = Self::open_pdx_file_with_update(&base_dir, true, &mut data)?;
+        let mut consensus_pos_idx = Self::open_pdx_file(&base_dir, data.header(), true)?;
         let builder = BuildHasherDefault::<FxHasher>::default();
         let consensus_digests = HdxIndex::open_hdx_file(
             base_dir.join(Self::CONSENSUS_HASH_NAME),
@@ -877,27 +886,19 @@ impl Inner {
         final_consensus_number: u64,
         timeout: Duration,
     ) -> Result<Self, PackError> {
-        /// Private helper to read the next record from a pack iterator or timeout if it takes
-        /// longer than timeout.
-        async fn next<R: AsyncRead + Unpin>(
-            iter: &mut AsyncPackIter<PackRecord, R>,
-            timeout: Duration,
-        ) -> Result<Option<PackRecord>, PackError> {
-            match tokio::time::timeout(timeout, iter.next()).await {
-                Ok(Some(Ok(rec))) => Ok(Some(rec)),
-                Ok(Some(Err(e))) => Err(PackError::ReadError(e.to_string())),
-                Ok(None) => Ok(None),
-                Err(_) => Err(PackError::ReadError("timeout".to_string())),
-            }
-        }
         let base_dir = path.as_ref().join(format!("epoch-{epoch}"));
         let _ = create_dir_synced(&base_dir);
         let mut stream_iter = AsyncPackIter::<PackRecord, R>::open(stream, epoch as u64)
             .await
             .map_err(|e| PackError::ReadError(e.to_string()))?;
-        let mut data =
-            Pack::open(base_dir.join(Self::DATA_NAME), epoch as u64, false, PackCompression::ZStd)?;
-        let epoch_meta = if let Some(meta) = next(&mut stream_iter, timeout).await? {
+        let mut data = Pack::open(
+            base_dir.join(Self::DATA_NAME),
+            epoch as u64,
+            false,
+            PackCompression::ZStd,
+            PACK_VERSION,
+        )?;
+        let epoch_meta = if let Some(meta) = next_output_record(&mut stream_iter, timeout).await? {
             meta.into_epoch()?
         } else {
             return Err(PackError::NotEpoch);
@@ -930,12 +931,21 @@ impl Inner {
         let mut pack =
             Self { data, consensus_pos_idx, consensus_digests, batch_digests, epoch_meta };
         loop {
-            let output =
+            let output = if stream_iter.version() == 0 {
+                match iter_to_output_legacy(&mut stream_iter, timeout, &pack.epoch_meta.committee)
+                    .await
+                {
+                    Ok(output) => output,
+                    Err(PackError::NotConsensus) => break,
+                    Err(e) => return Err(e),
+                }
+            } else {
                 match iter_to_output(&mut stream_iter, timeout, &pack.epoch_meta.committee).await {
                     Ok(output) => output,
                     Err(PackError::NotConsensus) => break,
                     Err(e) => return Err(e),
-                };
+                }
+            };
             if output.parent_hash() != parent_digest {
                 return Err(PackError::InvalidConsensusChain);
             }
@@ -950,6 +960,32 @@ impl Inner {
             pack.save_consensus_output(&output)?;
         }
         Ok(pack)
+    }
+
+    /// Write the batches for consensus to the pack file.
+    fn save_consensus_batches(
+        &mut self,
+        consensus: &ConsensusOutput,
+    ) -> Result<Option<u64>, PackError> {
+        let batches = collect_batches(&consensus);
+        let mut first_batch_pos = None;
+        // Save all the required batches into the pack file.
+        for (batch_digest, batch) in batches.into_iter() {
+            let position = self
+                .data
+                .append(&PackRecord::Batch(batch))
+                .map_err(|e| PackError::Append(e.to_string()))?;
+            if first_batch_pos.is_none() {
+                first_batch_pos = Some(position);
+            }
+            self.batch_digests
+                .save(batch_digest, position)
+                .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
+            let len = self.data.file_len();
+            self.consensus_digests.set_data_file_length(len);
+            self.batch_digests.set_data_file_length(len);
+        }
+        Ok(first_batch_pos)
     }
 
     /// Save all the batches and consensus header from the ConsensusOutput the pack file.
@@ -979,41 +1015,17 @@ impl Inner {
                 consensus_number,
             ));
         }
-        let mut batches = BTreeMap::new();
-        // We want to make sure batches are saved to the pack in a deterministic order, so
-        // collect them in a BTreeMap.  We probably don't actually need this but this
-        // means we do not impose any extra restrictions on consensus output.
-        for cert_batch in consensus.batches() {
-            for batch in &cert_batch.batches {
-                let digest = batch.digest();
-                // Should not have duplicate batches across output.
-                // Will work if we do but will save batches more than once in a pack.
-                batches.insert(digest, batch.clone());
-            }
-        }
-        let mut first_batch_pos = None;
-        // Save all the required batcdhes into the pack file.
-        for (batch_digest, batch) in batches.into_iter() {
-            let position = self
-                .data
-                .append(&PackRecord::Batch(batch))
-                .map_err(|e| PackError::Append(e.to_string()))?;
-            if first_batch_pos.is_none() {
-                first_batch_pos = Some(position);
-            }
-            self.batch_digests
-                .save(batch_digest, position)
-                .map_err(|e| PackError::IndexAppend(format!("batch {e}")))?;
-            let len = self.data.file_len();
-            self.consensus_digests.set_data_file_length(len);
-            self.batch_digests.set_data_file_length(len);
-        }
+        let first_batch_pos =
+            if self.version() == 0 { self.save_consensus_batches(consensus)? } else { None };
         // Now save the consensus header.
         let consensus_digest = consensus.consensus_header_hash();
         let position = self
             .data
             .append(&PackRecord::Consensus(Box::new(consensus.consensus_header())))
             .map_err(|e| PackError::Append(e.to_string()))?;
+        if self.version() > 0 {
+            self.save_consensus_batches(consensus)?;
+        };
         let batch_pos = if let Some(batch_pos) = first_batch_pos { batch_pos } else { position };
         self.consensus_digests
             .save(consensus_digest.into(), position)
@@ -1256,6 +1268,22 @@ impl Inner {
     }
 }
 
+/// Gathers all the batches from consensus into an ordered Map by digest.
+fn collect_batches<'a>(consensus: &ConsensusOutput) -> BTreeMap<BlockHash, Batch> {
+    let mut batches = BTreeMap::new();
+    // We want to make sure batches are saved to the pack in a deterministic order, so
+    // collect them in a BTreeMap.
+    for cert_batch in consensus.batches() {
+        for batch in &cert_batch.batches {
+            let digest = batch.digest();
+            // Should not have duplicate batches across output.
+            // They will be de-duped in the pack file by the BTreeMap if they do exist.
+            batches.insert(digest, batch.clone());
+        }
+    }
+    batches
+}
+
 /// Verify a streamed [`EpochMeta`] record links correctly to the previous epoch's record.
 ///
 /// Extracted from [`Inner::stream_import`] as a free function (it is stateless) so the offline pack
@@ -1329,10 +1357,39 @@ pub async fn bytes_to_output<R: AsyncRead + Unpin>(
     timeout: Duration,
     committee: &Committee,
 ) -> Result<ConsensusOutput, PackError> {
-    let mut stream_iter = AsyncPackIter::<PackRecord, R>::open_partial(stream, compression)
+    let mut stream_iter =
+        AsyncPackIter::<PackRecord, R>::open_partial(stream, compression, PACK_VERSION)
+            .await
+            .map_err(|e| PackError::ReadError(e.to_string()))?;
+    iter_to_output(&mut stream_iter, timeout, committee).await
+}
+
+/// Take an async stream of bytes that in pack file representation of ConsensusOutput and return the
+/// ConsensusOutput.
+pub async fn bytes_to_output_legacy<R: AsyncRead + Unpin>(
+    stream: R,
+    compression: PackCompression,
+    timeout: Duration,
+    committee: &Committee,
+) -> Result<ConsensusOutput, PackError> {
+    let mut stream_iter = AsyncPackIter::<PackRecord, R>::open_partial(stream, compression, 0)
         .await
         .map_err(|e| PackError::ReadError(e.to_string()))?;
-    iter_to_output(&mut stream_iter, timeout, committee).await
+    iter_to_output_legacy(&mut stream_iter, timeout, committee).await
+}
+
+/// Private helper to read the next record from a pack iterator or timeout if it takes
+/// longer than timeout.
+async fn next_output_record<R: AsyncRead + Unpin>(
+    iter: &mut AsyncPackIter<PackRecord, R>,
+    timeout: Duration,
+) -> Result<Option<PackRecord>, PackError> {
+    match tokio::time::timeout(timeout, iter.next()).await {
+        Ok(Some(Ok(rec))) => Ok(Some(rec)),
+        Ok(Some(Err(e))) => Err(PackError::ReadError(e.to_string())),
+        Ok(None) => Ok(None),
+        Err(_) => Err(PackError::ReadError("timeout".to_string())),
+    }
 }
 
 /// Take an iter over PackRecords that represent a ConsensusOutput and return the ConsensusOutput.
@@ -1341,24 +1398,144 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
     timeout: Duration,
     committee: &Committee,
 ) -> Result<ConsensusOutput, PackError> {
-    /// Private helper to read the next record from a pack iterator or timeout if it takes
-    /// longer than timeout.
-    async fn next<R: AsyncRead + Unpin>(
-        iter: &mut AsyncPackIter<PackRecord, R>,
-        timeout: Duration,
-    ) -> Result<Option<PackRecord>, PackError> {
-        match tokio::time::timeout(timeout, iter.next()).await {
-            Ok(Some(Ok(rec))) => Ok(Some(rec)),
-            Ok(Some(Err(e))) => Err(PackError::ReadError(e.to_string())),
-            Ok(None) => Ok(None),
-            Err(_) => Err(PackError::ReadError("timeout".to_string())),
+    let mut referenced_batches = HashSet::new();
+    let consensus_header = if let Some(record) = next_output_record(stream_iter, timeout).await? {
+        match record {
+            PackRecord::EpochMeta(_epoch_meta) => {
+                return Err(PackError::EpochLoad("unexpected epoch meta data found".to_string()))
+            }
+            PackRecord::Batch(_batch) => {
+                return Err(PackError::BatchLoad("unexpected batch found".to_string()))
+            }
+            PackRecord::Consensus(consensus_header) => consensus_header,
+        }
+    } else {
+        return Err(PackError::NotConsensus);
+    };
+    let parent_hash = consensus_header.parent_hash;
+    let deliver = consensus_header.sub_dag;
+    let num_blocks = deliver.num_primary_batches();
+    let num_certs = deliver.len();
+
+    let sub_dag = deliver;
+    if num_blocks == 0 {
+        return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, consensus_header.number));
+    }
+
+    let mut expected_batch_digests = BTreeSet::new();
+    let mut batch_digests = VecDeque::with_capacity(num_certs);
+    for header in sub_dag.headers() {
+        for (digest, _) in header.payload().iter() {
+            expected_batch_digests.insert(*digest);
+            batch_digests.push_back(*digest);
         }
     }
+    let expected_digest_count = expected_batch_digests.len();
+    let mut expected_batch_digests = expected_batch_digests.into_iter();
+
+    let mut available_batches = HashMap::new();
+    // Load and verify batches.
+    let mut digest_count = 0;
+    while let Some(record) = next_output_record(stream_iter, timeout).await? {
+        match record {
+            PackRecord::EpochMeta(_epoch_meta) => {
+                return Err(PackError::EpochLoad("unexpected epoch meta data found".to_string()))
+            }
+            PackRecord::Batch(batch) => {
+                let Some(expected_digest) = expected_batch_digests.next() else {
+                    return Err(PackError::EpochLoad("unexpected batch found".to_string()));
+                };
+                let digest = batch.digest();
+                if expected_digest != digest {
+                    return Err(PackError::EpochLoad(format!(
+                        "unexpected batch found, expected {expected_digest}, got {}",
+                        digest
+                    )));
+                }
+                referenced_batches.insert(digest);
+                available_batches.insert(digest, batch);
+                digest_count += 1;
+                if digest_count == expected_digest_count {
+                    // We loaded all the batches, so we are done.
+                    break;
+                }
+            }
+            PackRecord::Consensus(_consensus_header) => {
+                return Err(PackError::EpochLoad("unexpected consensusheader found".to_string()))
+            }
+        }
+    }
+
+    // map all fetched batches to their respective certificates for applying block rewards
+    let mut batches = Vec::with_capacity(num_certs);
+    for header in sub_dag.headers() {
+        // create collection of batches to execute for this certificate
+        let mut cert_batches = Vec::with_capacity(header.payload().len());
+
+        // retrieve fetched batch by digest
+        for digest in header.payload().keys() {
+            if let Some(batch) = available_batches.remove(digest) {
+                cert_batches.push(batch);
+            } else if referenced_batches.contains(digest) {
+                // Handle the case with dup batches.  This should be rare to non-existant so not
+                // worried about the poor efficiency here.  This allows us
+                // to remove in the common case to avoid a batch clone.
+                if let Some(batch) = batches
+                    .iter()
+                    .flat_map(|cb: &CertifiedBatch| cb.batches.iter())
+                    .chain(cert_batches.iter())
+                    .find(|b| b.digest() == *digest)
+                {
+                    #[cfg(not(feature = "adiri"))]
+                    cert_batches.push(batch.clone());
+
+                    #[cfg(feature = "adiri")]
+                    if sub_dag.leader_epoch() > tn_types::forks::ADIRI_DUP_BATCH_EPOCH {
+                        // ADIRI BUG
+                        // Epoch 74 and possibly other early epochs of adiri testnet had a bug
+                        // with duplicate batches. We have to
+                        // recreate it in order to sync testnet so we skip this push
+                        // on adiri with early epochs.
+                        cert_batches.push(batch.clone());
+                    }
+                } else {
+                    return Err(PackError::MissingBatch);
+                }
+            } else {
+                return Err(PackError::MissingBatch);
+            }
+        }
+
+        let address = committee.authority(header.author()).map(|a| a.execution_address());
+        if let Some(address) = address {
+            // main collection for execution
+            batches.push(CertifiedBatch { address, batches: cert_batches });
+        } else {
+            return Err(PackError::MissingAuthority);
+        }
+    }
+    Ok(ConsensusOutput::new(
+        sub_dag,
+        parent_hash,
+        consensus_header.number,
+        false,
+        batch_digests,
+        batches,
+    ))
+}
+
+/// Take an iter over PackRecords that represent a ConsensusOutput and return the ConsensusOutput.
+/// Legacy version, expects Batches then the ConsensusHeader.
+async fn iter_to_output_legacy<R: AsyncRead + Unpin>(
+    stream_iter: &mut AsyncPackIter<PackRecord, R>,
+    timeout: Duration,
+    committee: &Committee,
+) -> Result<ConsensusOutput, PackError> {
     let mut header = None;
     let mut available_batches = HashMap::new();
     let mut referenced_batches = HashSet::new();
     let mut batch_records = 0_usize;
-    while let Some(record) = next(stream_iter, timeout).await? {
+    while let Some(record) = next_output_record(stream_iter, timeout).await? {
         match record {
             PackRecord::EpochMeta(_epoch_meta) => {
                 return Err(PackError::EpochLoad("unexpected epoch meta data found".to_string()))
@@ -1482,6 +1659,8 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
 }
 
 /// Values stored in the position index.
+/// Note for v1 format consensus_header and output_start will be the same value.
+/// Once v0 is gone we can remove or repurpose on of these fields.
 #[derive(Debug, Copy, Clone)]
 struct IndexPositions {
     /// The first byte of the ConsensusHeader record for position.
@@ -1573,6 +1752,8 @@ pub enum PackError {
     ConsensusNumberTooLow,
     ConsensusNumberTooHigh,
     TooManyBatches(usize),
+    /// Data pack file version is too new.
+    InvalidVersion(u16, u16),
 }
 
 impl Error for PackError {}
@@ -1619,6 +1800,9 @@ impl Display for PackError {
             PackError::TooManyBatches(max) => {
                 write!(f, "Too many batches buffered for one consensus output (max {max})")
             }
+            PackError::InvalidVersion(expected, got) => {
+                write!(f, "Pack file version too new: got {got}, expected {expected}")
+            }
         }
     }
 }
@@ -1647,7 +1831,6 @@ pub(crate) mod test {
         collections::VecDeque,
         fs::{File, OpenOptions},
         io::{Seek as _, SeekFrom},
-        path::Path,
         sync::Arc,
         time::Duration,
     };
@@ -1662,12 +1845,8 @@ pub(crate) mod test {
     };
 
     use crate::{
-        archive::{
-            index::Index as _,
-            pack::{DataHeader, PackCompression},
-            position_index::index::PositionIndex,
-        },
-        consensus_pack::{ConsensusPack, IndexPositions, Inner},
+        archive::pack::PackCompression,
+        consensus_pack::{ConsensusPack, Inner, PACK_VERSION},
         mem_db::MemDatabase,
     };
 
@@ -1915,7 +2094,10 @@ pub(crate) mod test {
             pack.save_consensus_output(consensus_output).await.unwrap();
         }
         for i in 0..(num_outputs * 2) {
-            let output_db = pack.get_consensus_output(i as u64 + 1).await.unwrap();
+            let output_db = pack
+                .get_consensus_output(i as u64 + 1)
+                .await
+                .expect(&format!("failed output on {i}"));
             let output = outputs.get(i as usize).unwrap();
             compare_outputs(&output_db, output);
         }
@@ -2108,141 +2290,6 @@ pub(crate) mod test {
         drop(pack);
     }
 
-    /// Convert a pack directory's position index into the legacy format written by older
-    /// nodes: an "index.pdx" of u64 consensus header positions and no "index_pos.pdx".
-    /// The pack data file is identical between the two formats so this faithfully
-    /// recreates an old pack directory for migration testing.
-    fn make_legacy_index(epoch_dir: &Path) {
-        let idx_dir = epoch_dir.join("idx");
-        let header = DataHeader::new(0, PackCompression::ZStd);
-        let mut new_idx: PositionIndex<IndexPositions> =
-            PositionIndex::open_pdx_file(&idx_dir, &header, "index_pos.pdx", true)
-                .expect("open new index");
-        let mut old_idx: PositionIndex<u64> =
-            PositionIndex::open_pdx_file(&idx_dir, &header, "index.pdx", false)
-                .expect("open legacy index");
-        assert!(old_idx.is_empty(), "legacy index must start empty");
-        for i in 0..new_idx.len() as u64 {
-            let positions = new_idx.load(i).expect("new index entry");
-            old_idx.save(i, positions.consensus_header).expect("save legacy entry");
-        }
-        old_idx.sync().expect("sync legacy index");
-        drop(old_idx);
-        drop(new_idx);
-        std::fs::remove_file(idx_dir.join("index_pos.pdx")).expect("remove new index");
-    }
-
-    /// Test the one time migration of a legacy position index (consensus header positions
-    /// only) to the new index containing consensus output byte ranges.  Covers the append
-    /// path, the read only static path and recovery from a stale tmp file left by a crash
-    /// between the tmp write and the rename.
-    #[tokio::test]
-    async fn test_consensus_pack_index_migration() {
-        let temp_dir = TempDir::with_prefix("test_consensus_pack_migration").expect("temp dir");
-        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
-        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
-        let committee = fixture.committee();
-        let previous_epoch = EpochRecord {
-            epoch: 0,
-            committee: committee.bls_keys().iter().copied().collect(),
-            next_committee: committee.bls_keys().iter().copied().collect(),
-            ..Default::default()
-        };
-        let epoch_dir = temp_dir.path().join("epoch-0");
-        let idx_dir = epoch_dir.join("idx");
-
-        // Build a pack with the current format.
-        let pack =
-            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
-                .expect("open pack");
-        let num_outputs = 10;
-        let mut outputs = Vec::new();
-        let mut parent = ConsensusHeader::default().digest();
-        for i in 0..num_outputs {
-            let output = make_test_output(&committee, i % 4, chain.clone(), i as u64 + 1, parent);
-            parent = output.digest().into();
-            outputs.push(output.clone());
-            pack.save_consensus_output(output).await.unwrap();
-        }
-        pack.persist().await.expect("persist");
-        drop(pack);
-
-        // Migrate on the append path.  Reading the first output verifies the migrated
-        // byte range starts after the EpochMeta record.
-        make_legacy_index(&epoch_dir);
-        assert!(PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index.pdx"));
-        assert!(!PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx"));
-        let pack =
-            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
-                .expect("open legacy pack for append");
-        assert!(
-            PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx"),
-            "migration creates the new index"
-        );
-        assert!(
-            !PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index.pdx"),
-            "migration removes the old index"
-        );
-        for (i, output) in outputs.iter().enumerate() {
-            let output_db = pack
-                .get_consensus_output(i as u64 + 1)
-                .await
-                .expect(&format!("output {} after append migration", i + 1));
-            compare_outputs(&output_db, output);
-        }
-        // The pack keeps working for new appends after migration.
-        let output = make_test_output(&committee, 0, chain.clone(), num_outputs as u64 + 1, parent);
-        outputs.push(output.clone());
-        pack.save_consensus_output(output).await.unwrap();
-        let output_db = pack
-            .get_consensus_output(num_outputs as u64 + 1)
-            .await
-            .expect("appended output after migration");
-        compare_outputs(&output_db, outputs.last().unwrap());
-        pack.persist().await.expect("persist");
-        drop(pack);
-
-        // Migrate on the read only static path.
-        make_legacy_index(&epoch_dir);
-        let pack = ConsensusPack::open_static(temp_dir.path(), 0).expect("open legacy pack static");
-        for (i, output) in outputs.iter().enumerate() {
-            let output_db = pack
-                .get_consensus_output(i as u64 + 1)
-                .await
-                .expect(&format!("output {} after static migration", i + 1));
-            compare_outputs(&output_db, output);
-        }
-        drop(pack);
-
-        // Migrate with a stale partial tmp file left by a "crash" between the tmp write
-        // and the rename.  The migration must discard it and rebuild.
-        make_legacy_index(&epoch_dir);
-        {
-            let header = DataHeader::new(0, PackCompression::ZStd);
-            let mut stale: PositionIndex<IndexPositions> =
-                PositionIndex::open_pdx_file(&idx_dir, &header, "index_pos.pdx.tmp", false)
-                    .expect("open stale tmp");
-            stale.save(0, IndexPositions::new(1, 1, 1)).expect("save stale entry");
-            stale.sync().expect("sync stale tmp");
-        }
-        assert!(PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx.tmp"));
-        let pack =
-            ConsensusPack::open_append(temp_dir.path(), previous_epoch.clone(), committee.clone())
-                .expect("open legacy pack with stale tmp");
-        assert!(
-            !PositionIndex::<u64>::pdx_file_exists(&idx_dir, "index_pos.pdx.tmp"),
-            "stale tmp removed by migration"
-        );
-        for (i, output) in outputs.iter().enumerate() {
-            let output_db = pack
-                .get_consensus_output(i as u64 + 1)
-                .await
-                .expect(&format!("output {} after stale tmp migration", i + 1));
-            compare_outputs(&output_db, output);
-        }
-        drop(pack);
-    }
-
     fn test_previous_epoch(committee: &Committee) -> EpochRecord {
         EpochRecord {
             epoch: 0,
@@ -2271,7 +2318,8 @@ pub(crate) mod test {
         let path = temp_dir.path().join("batch_only");
         {
             let mut pack: Pack<PackRecord> =
-                Pack::open(&path, 0, false, PackCompression::ZStd).expect("open pack");
+                Pack::open(&path, 0, false, PackCompression::ZStd, PACK_VERSION)
+                    .expect("open pack");
             let batch = tn_reth::test_utils::batches(chain.clone(), 1).pop().expect("one batch");
             for _ in 0..(MAX_BATCHES_PER_OUTPUT + 5) {
                 pack.append(&PackRecord::Batch(batch.clone())).expect("append batch");
@@ -2289,7 +2337,8 @@ pub(crate) mod test {
             &committee,
         )
         .await;
-        assert!(matches!(res, Err(PackError::TooManyBatches(_))), "expected TooManyBatches");
+        // New format will fail by starting with a batch.  This would be TooManyBatches with v0.
+        assert!(matches!(res, Err(PackError::BatchLoad(_))), "expected BatchLoad");
     }
 
     /// CP2: get_consensus_output with a number below start_consensus_number must error rather

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -630,11 +630,7 @@ impl Inner {
                 Ok(p) => p.output_end,
                 Err(_) => return false,
             };
-            if pack_len == last_record_end {
-                true
-            } else {
-                false
-            }
+            pack_len == last_record_end
         } else {
             true
         }
@@ -967,7 +963,7 @@ impl Inner {
         &mut self,
         consensus: &ConsensusOutput,
     ) -> Result<Option<u64>, PackError> {
-        let batches = collect_batches(&consensus);
+        let batches = collect_batches(consensus);
         let mut first_batch_pos = None;
         // Save all the required batches into the pack file.
         for (batch_digest, batch) in batches.into_iter() {
@@ -1269,7 +1265,7 @@ impl Inner {
 }
 
 /// Gathers all the batches from consensus into an ordered Map by digest.
-fn collect_batches<'a>(consensus: &ConsensusOutput) -> BTreeMap<BlockHash, Batch> {
+fn collect_batches(consensus: &ConsensusOutput) -> BTreeMap<BlockHash, Batch> {
     let mut batches = BTreeMap::new();
     // We want to make sure batches are saved to the pack in a deterministic order, so
     // collect them in a BTreeMap.

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -34,6 +34,9 @@ use crate::archive::{
     position_index::index::PositionIndex,
 };
 
+/// Current version of the epoch pack file.
+const EPOCH_PACK_VERSION: u16 = 0;
+
 enum EpochDbMessage {
     /// Save a "dummy" epoch 0 [`EpochRecord`] without a certificate.
     SaveDummy0Record(EpochRecord),
@@ -488,12 +491,14 @@ impl Inner {
             Self::PACK_EPOCH,
             false,
             PackCompression::ZStd,
+            EPOCH_PACK_VERSION,
         )?;
         let mut certs = Pack::<EpochCertificate>::open(
             base_dir.join(Self::CERTS_NAME),
             Self::CERT_PACK_EPOCH,
             false,
             PackCompression::ZStd,
+            EPOCH_PACK_VERSION,
         )?;
 
         let mut epoch_idx: PositionIndex<u64> = PositionIndex::open_pdx_file(

--- a/crates/storage/src/pack_validate.rs
+++ b/crates/storage/src/pack_validate.rs
@@ -835,9 +835,9 @@ mod test {
         assert_eq!(report.missing_batch_count(BatchClass::Absent), 0);
     }
 
-    /// v1: same corruption in the header-first layout. To land the moved batch in group 5, splice it
-    /// just *after* consensus header 5 (a v1 group's batches follow its header). Present-but-wrong-
-    /// group → Misordered at 3; orphan in group 5 → ExtraBatch at 5.
+    /// v1: same corruption in the header-first layout. To land the moved batch in group 5, splice
+    /// it just *after* consensus header 5 (a v1 group's batches follow its header).
+    /// Present-but-wrong- group → Misordered at 3; orphan in group 5 → ExtraBatch at 5.
     #[test]
     fn test_validate_misordered_batch_v1() {
         let (temp_dir, committee, chain) = setup();
@@ -880,8 +880,8 @@ mod test {
         let outputs = make_outputs(&committee, chain, 5);
         let (mut records, _) = build_records(epoch0_meta(&committee), &outputs, 1);
 
-        // Swap the first two Batch records that follow consensus header 3 (its group has 4 batches),
-        // breaking the ascending-digest order without changing the set.
+        // Swap the first two Batch records that follow consensus header 3 (its group has 4
+        // batches), breaking the ascending-digest order without changing the set.
         let header3 = records
             .iter()
             .position(|r| matches!(r, PackRecord::Consensus(h) if h.number == 3))
@@ -952,8 +952,9 @@ mod test {
                 "v{version}: expected NonSequentialConsensusNumber(expected 5, found 99); issues: {:?}",
                 report.issues
             );
-            // The chain check alone misses this: the final header has no successor whose parent_hash
-            // would mismatch, so no ChainBreak fires — the sequential check is what catches it.
+            // The chain check alone misses this: the final header has no successor whose
+            // parent_hash would mismatch, so no ChainBreak fires — the sequential check
+            // is what catches it.
             let chain_breaks =
                 report.issues.iter().filter(|i| matches!(i, PackIssue::ChainBreak { .. })).count();
             assert_eq!(

--- a/crates/storage/src/pack_validate.rs
+++ b/crates/storage/src/pack_validate.rs
@@ -28,7 +28,7 @@
 //! Absent-vs-Misordered distinction this validator surfaces.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeSet, HashSet},
     fmt::{self, Display},
     path::Path,
 };
@@ -36,7 +36,10 @@ use std::{
 use tn_types::{BlockHash, ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochRecord};
 
 use crate::{
-    archive::pack::{Pack, PackCompression},
+    archive::{
+        error::fetch::FetchError,
+        pack::{Pack, PackCompression},
+    },
     consensus_pack::{verify_epoch_meta, PackError, PackRecord, PACK_VERSION},
 };
 
@@ -86,6 +89,15 @@ pub enum PackIssue {
         number: u64,
         /// The unreferenced batch digest.
         digest: BlockHash,
+    },
+    /// A v1 group's `Batch` records are present and correct as a set, but not in the ascending
+    /// digest order the v1 importer ([`iter_to_output`](crate::consensus_pack)) requires. Only
+    /// emitted when the group has no missing/extra batch, so it isolates a pure ordering defect —
+    /// distinct from [`BatchClass::Misordered`], which means a batch in the *wrong group*. (v1
+    /// only; v0 does not constrain intra-group batch order.)
+    UnsortedBatches {
+        /// Consensus number of the group whose batches are out of order.
+        number: u64,
     },
     /// A consensus header's `number` is not the next sequential value.
     ///
@@ -180,10 +192,6 @@ pub fn validate_pack_file(
 
     // ---- Single pass: mirror `Inner::stream_import`, but collect every issue instead of bailing.
     let mut issues = Vec::new();
-    let mut batch_count: u64 = 0;
-    let mut consensus_count: u64 = 0;
-    let mut first_consensus_number: Option<u64> = None;
-    let mut last_consensus_number: Option<u64> = None;
 
     let mut iter = pack.raw_iter().map_err(|e| PackError::ReadError(e.to_string()))?;
 
@@ -216,12 +224,30 @@ pub fn validate_pack_file(
 
     // Expected `parent_hash` of the *next* consensus header. `None` = "no anchor, skip the check":
     // a bare file with no previous record cannot verify its first header's parent.
-    let mut expected_parent: Option<ConsensusHeaderDigest> = if epoch == 0 {
+    let expected_parent: Option<ConsensusHeaderDigest> = if epoch == 0 {
         Some(ConsensusHeader::default().digest())
     } else {
         previous.map(|p| p.final_consensus.hash)
     };
 
+    if pack.version() == 0 {
+        verify_v0_data(&mut iter, epoch, expected_parent, start_consensus_number, issues)
+    } else {
+        verify_v1_data(&mut iter, epoch, expected_parent, start_consensus_number, issues)
+    }
+}
+
+fn verify_v0_data(
+    iter: &mut impl Iterator<Item = Result<PackRecord, FetchError>>,
+    epoch: Epoch,
+    mut expected_parent: Option<ConsensusHeaderDigest>,
+    start_consensus_number: u64,
+    mut issues: Vec<PackIssue>,
+) -> Result<PackValidationReport, PackError> {
+    let mut batch_count: u64 = 0;
+    let mut consensus_count: u64 = 0;
+    let mut first_consensus_number: Option<u64> = None;
+    let mut last_consensus_number: Option<u64> = None;
     // Per-group sets, cleared after every consensus header exactly like `stream_import`.
     let mut batches: HashSet<BlockHash> = HashSet::new();
     let mut referenced_batches: HashSet<BlockHash> = HashSet::new();
@@ -312,10 +338,184 @@ pub fn validate_pack_file(
         }
     }
 
-    // The global set is now complete. Resolve every deferred `MissingBatch` class in place: a
-    // digest present anywhere in the file is `Misordered`, otherwise it is a genuine `Absent` gap.
-    // This is a cheap pass over `issues` (bounded by the number of missing references), not another
-    // file traversal.
+    Ok(finalize_report(
+        epoch,
+        start_consensus_number,
+        batch_count,
+        consensus_count,
+        first_consensus_number,
+        last_consensus_number,
+        issues,
+        &all_batch_digests,
+    ))
+}
+
+/// Validate the `data` record stream of a **v1** pack (header-first layout).
+///
+/// v1 writes each `Consensus` header *before* the `Batch` records it references (the reverse of
+/// v0), and those batches arrive in ascending digest order (`collect_batches` uses a `BTreeMap`;
+/// [`iter_to_output`](crate::consensus_pack) rejects any out-of-order batch). So a group's batches
+/// are exactly the `Batch` records between a header and the next header. We hold the open header
+/// and the batches seen since it, resolving the group when the next header (or EOF) closes it.
+///
+/// The per-header sequential-number and chain-continuity checks are identical to
+/// [`verify_v0_data`]; only the batch grouping differs, plus the v1-only intra-group ordering check
+/// performed in [`close_v1_group`].
+fn verify_v1_data(
+    iter: &mut impl Iterator<Item = Result<PackRecord, FetchError>>,
+    epoch: Epoch,
+    mut expected_parent: Option<ConsensusHeaderDigest>,
+    start_consensus_number: u64,
+    mut issues: Vec<PackIssue>,
+) -> Result<PackValidationReport, PackError> {
+    let mut batch_count: u64 = 0;
+    let mut consensus_count: u64 = 0;
+    let mut first_consensus_number: Option<u64> = None;
+    let mut last_consensus_number: Option<u64> = None;
+
+    // Persistent, never-cleared set of every batch digest seen anywhere in the file — same role as
+    // in `verify_v0_data`: it lets the deferred `MissingBatch` classification tell an *absent*
+    // digest (a real gap) apart from a *misordered* one (present, wrong group).
+    let mut all_batch_digests: HashSet<BlockHash> = HashSet::new();
+
+    // The currently open consensus header and the batch digests seen since it, in arrival order
+    // (a `Vec`, not a set, because the v1 ordering check needs the sequence). A batch that appears
+    // before the first header — a malformed pack the real writer never produces and the importer
+    // rejects outright — is attributed to the first group; an acceptable diagnostic.
+    let mut open_header: Option<Box<ConsensusHeader>> = None;
+    let mut collected: Vec<BlockHash> = Vec::new();
+
+    for record in iter {
+        match record? {
+            PackRecord::EpochMeta(_) => {
+                // A second EpochMeta is the same failure `stream_import` rejects.
+                issues.push(PackIssue::EpochMetaMismatch {
+                    detail: "epoch meta data found more than once".to_string(),
+                });
+            }
+            PackRecord::Batch(batch) => {
+                batch_count += 1;
+                let digest = batch.digest();
+                collected.push(digest);
+                all_batch_digests.insert(digest);
+            }
+            PackRecord::Consensus(consensus_header) => {
+                // A new header means the previous group's batches have all arrived — close it.
+                if let Some(prev) = open_header.take() {
+                    close_v1_group(&prev, &collected, &mut issues);
+                    collected.clear();
+                }
+
+                consensus_count += 1;
+                let number = consensus_header.number;
+                first_consensus_number.get_or_insert(number);
+                last_consensus_number = Some(number);
+
+                // Sequential numbering and chain continuity, identical to `verify_v0_data`. See the
+                // comments there for why `expected` is position-based and why the trailing header
+                // needs the explicit sequential check.
+                let expected_number = start_consensus_number + (consensus_count - 1);
+                if number != expected_number {
+                    issues.push(PackIssue::NonSequentialConsensusNumber {
+                        expected: expected_number,
+                        found: number,
+                    });
+                }
+                if let Some(parent) = expected_parent {
+                    if consensus_header.parent_hash != parent {
+                        issues.push(PackIssue::ChainBreak {
+                            number,
+                            expected_parent: parent,
+                            found_parent: consensus_header.parent_hash,
+                        });
+                    }
+                }
+                expected_parent = Some(consensus_header.digest());
+                open_header = Some(consensus_header);
+            }
+        }
+    }
+    // Close the final group at EOF.
+    if let Some(prev) = open_header.take() {
+        close_v1_group(&prev, &collected, &mut issues);
+    }
+
+    Ok(finalize_report(
+        epoch,
+        start_consensus_number,
+        batch_count,
+        consensus_count,
+        first_consensus_number,
+        last_consensus_number,
+        issues,
+        &all_batch_digests,
+    ))
+}
+
+/// Resolve a closed v1 group: append the batch-presence, extra-batch and ordering issues for the
+/// header whose group just ended. `collected` is the group's batch digests in arrival (file) order.
+///
+/// Mirrors the per-header batch checks `verify_v0_data` performs inline, plus the v1-only ordering
+/// check. `MissingBatch` is recorded with a placeholder [`BatchClass::Absent`]; the final class is
+/// resolved in [`finalize_report`] once every digest in the file is known.
+fn close_v1_group(header: &ConsensusHeader, collected: &[BlockHash], issues: &mut Vec<PackIssue>) {
+    let number = header.number;
+    let collected_set: HashSet<BlockHash> = collected.iter().copied().collect();
+
+    // Every referenced batch must be present in this header's group.
+    let mut referenced: BTreeSet<BlockHash> = BTreeSet::new();
+    let mut missing = false;
+    for sub_header in header.sub_dag.headers() {
+        for (digest, _) in sub_header.payload().iter() {
+            referenced.insert(*digest);
+            if !collected_set.contains(digest) {
+                missing = true;
+                issues.push(PackIssue::MissingBatch {
+                    number,
+                    digest: *digest,
+                    class: BatchClass::Absent,
+                });
+            }
+        }
+    }
+
+    // Any collected batch the header does not reference is an extra.
+    let mut extra = false;
+    for digest in &collected_set {
+        if !referenced.contains(digest) {
+            extra = true;
+            issues.push(PackIssue::ExtraBatch { number, digest: *digest });
+        }
+    }
+
+    // Ordering is only meaningful when the set is otherwise correct: with a missing or extra batch
+    // already reported, an order complaint would be redundant noise. The v1 writer emits batches in
+    // ascending digest order (the same order the importer's `BTreeSet` yields), so the expected
+    // sequence is the referenced digests sorted.
+    if !missing && !extra {
+        let expected: Vec<BlockHash> = referenced.into_iter().collect();
+        if collected != expected.as_slice() {
+            issues.push(PackIssue::UnsortedBatches { number });
+        }
+    }
+}
+
+/// Resolve every deferred [`PackIssue::MissingBatch`] class against the now-complete
+/// `all_batch_digests` set — a digest present anywhere in the file is [`BatchClass::Misordered`],
+/// otherwise it is a genuine [`BatchClass::Absent`] gap — then build the final report. This is a
+/// cheap pass over `issues` (bounded by the number of missing references), not another file
+/// traversal. Shared by [`verify_v0_data`] and [`verify_v1_data`].
+#[allow(clippy::too_many_arguments)]
+fn finalize_report(
+    epoch: Epoch,
+    start_consensus_number: u64,
+    batch_count: u64,
+    consensus_count: u64,
+    first_consensus_number: Option<u64>,
+    last_consensus_number: Option<u64>,
+    mut issues: Vec<PackIssue>,
+    all_batch_digests: &HashSet<BlockHash>,
+) -> PackValidationReport {
     for issue in issues.iter_mut() {
         if let PackIssue::MissingBatch { digest, class, .. } = issue {
             *class = if all_batch_digests.contains(digest) {
@@ -327,7 +527,7 @@ pub fn validate_pack_file(
     }
 
     let verdict = if issues.is_empty() { Verdict::Valid } else { Verdict::Invalid };
-    Ok(PackValidationReport {
+    PackValidationReport {
         epoch,
         start_consensus_number,
         batch_count,
@@ -336,7 +536,7 @@ pub fn validate_pack_file(
         last_consensus_number,
         issues,
         verdict,
-    })
+    }
 }
 
 impl Display for PackValidationReport {
@@ -349,6 +549,7 @@ impl Display for PackValidationReport {
         let mut missing_absent = 0usize;
         let mut missing_misordered = 0usize;
         let mut extra = 0usize;
+        let mut unsorted = 0usize;
         let mut non_sequential = 0usize;
         let mut meta = 0usize;
         for issue in &self.issues {
@@ -359,6 +560,7 @@ impl Display for PackValidationReport {
                     missing_misordered += 1
                 }
                 PackIssue::ExtraBatch { .. } => extra += 1,
+                PackIssue::UnsortedBatches { .. } => unsorted += 1,
                 PackIssue::NonSequentialConsensusNumber { .. } => non_sequential += 1,
                 PackIssue::EpochMetaMismatch { .. } => meta += 1,
             }
@@ -384,6 +586,7 @@ impl Display for PackValidationReport {
             missing_absent + missing_misordered
         )?;
         writeln!(f, "  extra batches:          {extra}")?;
+        writeln!(f, "  unsorted batch groups:  {unsorted}")?;
         writeln!(f, "  non-sequential numbers: {non_sequential}")?;
         writeln!(f, "  epoch meta mismatches:  {meta}")?;
 
@@ -405,6 +608,9 @@ impl Display for PackValidationReport {
                 }
                 PackIssue::ExtraBatch { number, digest } => {
                     writeln!(f, "  consensus {number}  EXTRA BATCH    {digest}")?
+                }
+                PackIssue::UnsortedBatches { number } => {
+                    writeln!(f, "  consensus {number}  UNSORTED BATCHES")?
                 }
                 PackIssue::NonSequentialConsensusNumber { expected, found } => {
                     writeln!(f, "  consensus {found}  NON-SEQUENTIAL  (expected {expected})")?
@@ -431,7 +637,7 @@ mod test {
     use super::{validate_pack_file, BatchClass, PackIssue, Verdict};
     use crate::{
         archive::pack::{Pack, PackCompression},
-        consensus_pack::{test::make_test_output, EpochMeta, PackRecord, PACK_VERSION},
+        consensus_pack::{test::make_test_output, EpochMeta, PackRecord},
         mem_db::MemDatabase,
     };
 
@@ -464,33 +670,48 @@ mod test {
         }
     }
 
-    /// Build the `data` record stream (EpochMeta, then each output's batches followed by its
-    /// consensus header). Also returns the batch digests per group, in order.
+    /// Build the `data` record stream for the given on-disk `version` (EpochMeta first, then one
+    /// group per output). The two layouts differ only in intra-group record order:
+    ///
+    /// - **v0:** each output's batches, then its consensus header.
+    /// - **v1:** the consensus header, then its batches in ascending digest order (matching the
+    ///   real writer, so a clean v1 pack has no `UnsortedBatches`).
+    ///
+    /// Also returns the batch digests per group. The returned digests are in the same file order
+    /// as the emitted `Batch` records, so v1 groups come back sorted.
     fn build_records(
         meta: EpochMeta,
         outputs: &[ConsensusOutput],
+        version: u16,
     ) -> (Vec<PackRecord>, Vec<Vec<BlockHash>>) {
         let mut records = vec![PackRecord::EpochMeta(meta)];
         let mut group_batches = Vec::new();
         for output in outputs {
-            let mut digests = Vec::new();
-            for cert_batch in output.batches() {
-                for batch in &cert_batch.batches {
-                    digests.push(batch.digest());
-                    records.push(PackRecord::Batch(batch.clone()));
-                }
+            let mut batches: Vec<_> =
+                output.batches().iter().flat_map(|cb| cb.batches.iter().cloned()).collect();
+            if version > 0 {
+                // v1 writes batches in ascending digest order (see `collect_batches`).
+                batches.sort_by_key(|b| b.digest());
             }
-            records.push(PackRecord::Consensus(Box::new(output.consensus_header())));
+            let digests = batches.iter().map(|b| b.digest()).collect();
+            let header = PackRecord::Consensus(Box::new(output.consensus_header()));
+            let batch_records = batches.into_iter().map(PackRecord::Batch);
+            if version == 0 {
+                records.extend(batch_records);
+                records.push(header);
+            } else {
+                records.push(header);
+                records.extend(batch_records);
+            }
             group_batches.push(digests);
         }
         (records, group_batches)
     }
 
-    /// Write a record stream to a bare epoch-0 `data` pack file.
-    fn write_records(path: &Path, records: &[PackRecord]) {
-        let mut pack =
-            Pack::<PackRecord>::open(path, 0, false, PackCompression::ZStd, PACK_VERSION)
-                .expect("open pack");
+    /// Write a record stream to a bare epoch-0 `data` pack file, stamped with `version`.
+    fn write_records(path: &Path, records: &[PackRecord], version: u16) {
+        let mut pack = Pack::<PackRecord>::open(path, 0, false, PackCompression::ZStd, version)
+            .expect("open pack");
         for record in records {
             pack.append(record).expect("append record");
         }
@@ -513,61 +734,74 @@ mod test {
         (temp_dir, committee, chain)
     }
 
-    /// A well-formed pack validates clean.
+    /// A well-formed pack validates clean, in both the v0 (batches-first) and v1 (header-first)
+    /// layouts.
     #[test]
     fn test_validate_clean_pack() {
-        let (temp_dir, committee, chain) = setup();
-        let outputs = make_outputs(&committee, chain, 5);
-        let (records, _) = build_records(epoch0_meta(&committee), &outputs);
-        let path = temp_dir.path().join("data");
-        write_records(&path, &records);
+        for version in [0u16, 1] {
+            let (temp_dir, committee, chain) = setup();
+            let outputs = make_outputs(&committee, chain, 5);
+            let (records, _) = build_records(epoch0_meta(&committee), &outputs, version);
+            let path = temp_dir.path().join("data");
+            write_records(&path, &records, version);
 
-        let report = validate_pack_file(&path, 0, None).expect("validate");
-        assert_eq!(report.verdict, Verdict::Valid, "unexpected issues: {:?}", report.issues);
-        assert!(report.issues.is_empty());
-        assert_eq!(report.consensus_count, 5);
-        assert_eq!(report.first_consensus_number, Some(1));
-        assert_eq!(report.last_consensus_number, Some(5));
+            let report = validate_pack_file(&path, 0, None).expect("validate");
+            assert_eq!(
+                report.verdict,
+                Verdict::Valid,
+                "v{version}: unexpected issues: {:?}",
+                report.issues
+            );
+            assert!(report.issues.is_empty(), "v{version}");
+            assert_eq!(report.consensus_count, 5, "v{version}");
+            assert_eq!(report.first_consensus_number, Some(1), "v{version}");
+            assert_eq!(report.last_consensus_number, Some(5), "v{version}");
+        }
     }
 
-    /// Dropping a batch record that no other group carries → reported Absent for the exact digest.
+    /// Dropping a batch record that no other group carries → reported Absent for the exact digest,
+    /// in both layouts.
     #[test]
     fn test_validate_absent_batch() {
-        let (temp_dir, committee, chain) = setup();
-        let outputs = make_outputs(&committee, chain, 5);
-        let (mut records, group_batches) = build_records(epoch0_meta(&committee), &outputs);
+        for version in [0u16, 1] {
+            let (temp_dir, committee, chain) = setup();
+            let outputs = make_outputs(&committee, chain, 5);
+            let (mut records, group_batches) =
+                build_records(epoch0_meta(&committee), &outputs, version);
 
-        // Target the first batch of group index 2 → referenced by consensus header number 3.
-        let target = group_batches[2][0];
-        let pos = find_batch(&records, target);
-        records.remove(pos);
+            // Target the first batch of group index 2 → referenced by consensus header number 3.
+            let target = group_batches[2][0];
+            let pos = find_batch(&records, target);
+            records.remove(pos);
 
-        let path = temp_dir.path().join("data");
-        write_records(&path, &records);
+            let path = temp_dir.path().join("data");
+            write_records(&path, &records, version);
 
-        let report = validate_pack_file(&path, 0, None).expect("validate");
-        assert_eq!(report.verdict, Verdict::Invalid);
-        let absent = report.issues.iter().any(|i| {
-            matches!(i,
-                PackIssue::MissingBatch { digest, class: BatchClass::Absent, number }
-                if *digest == target && *number == 3)
-        });
-        assert!(
-            absent,
-            "expected Absent missing batch at consensus 3; issues: {:?}",
-            report.issues
-        );
-        // Must not be misclassified as misordered.
-        assert_eq!(report.missing_batch_count(BatchClass::Misordered), 0);
+            let report = validate_pack_file(&path, 0, None).expect("validate");
+            assert_eq!(report.verdict, Verdict::Invalid, "v{version}");
+            let absent = report.issues.iter().any(|i| {
+                matches!(i,
+                    PackIssue::MissingBatch { digest, class: BatchClass::Absent, number }
+                    if *digest == target && *number == 3)
+            });
+            assert!(
+                absent,
+                "v{version}: expected Absent missing batch at consensus 3; issues: {:?}",
+                report.issues
+            );
+            // Must not be misclassified as misordered.
+            assert_eq!(report.missing_batch_count(BatchClass::Misordered), 0, "v{version}");
+        }
     }
 
-    /// Moving a batch into a later group → reported Misordered where it belongs, and ExtraBatch
-    /// where it now (wrongly) sits.
+    /// v0: moving a batch into a later group → reported Misordered where it belongs, and ExtraBatch
+    /// where it now (wrongly) sits. In the v0 (batches-first) layout the batch lands in group 5 by
+    /// being spliced just *before* consensus header 5.
     #[test]
     fn test_validate_misordered_batch() {
         let (temp_dir, committee, chain) = setup();
         let outputs = make_outputs(&committee, chain, 6);
-        let (mut records, group_batches) = build_records(epoch0_meta(&committee), &outputs);
+        let (mut records, group_batches) = build_records(epoch0_meta(&committee), &outputs, 0);
 
         // Take the first batch of group 2 (consensus number 3) and splice it into group 4's records
         // (just before consensus header number 5).
@@ -581,7 +815,7 @@ mod test {
         records.insert(insert_at, moved);
 
         let path = temp_dir.path().join("data");
-        write_records(&path, &records);
+        write_records(&path, &records, 0);
 
         let report = validate_pack_file(&path, 0, None).expect("validate");
         assert_eq!(report.verdict, Verdict::Invalid);
@@ -601,6 +835,87 @@ mod test {
         assert_eq!(report.missing_batch_count(BatchClass::Absent), 0);
     }
 
+    /// v1: same corruption in the header-first layout. To land the moved batch in group 5, splice it
+    /// just *after* consensus header 5 (a v1 group's batches follow its header). Present-but-wrong-
+    /// group → Misordered at 3; orphan in group 5 → ExtraBatch at 5.
+    #[test]
+    fn test_validate_misordered_batch_v1() {
+        let (temp_dir, committee, chain) = setup();
+        let outputs = make_outputs(&committee, chain, 6);
+        let (mut records, group_batches) = build_records(epoch0_meta(&committee), &outputs, 1);
+
+        let target = group_batches[2][0];
+        let from = find_batch(&records, target);
+        let moved = records.remove(from);
+        let header5 = records
+            .iter()
+            .position(|r| matches!(r, PackRecord::Consensus(h) if h.number == 5))
+            .expect("consensus header 5 present");
+        records.insert(header5 + 1, moved);
+
+        let path = temp_dir.path().join("data");
+        write_records(&path, &records, 1);
+
+        let report = validate_pack_file(&path, 0, None).expect("validate");
+        assert_eq!(report.verdict, Verdict::Invalid);
+        let misordered = report.issues.iter().any(|i| {
+            matches!(i,
+                PackIssue::MissingBatch { digest, class: BatchClass::Misordered, number }
+                if *digest == target && *number == 3)
+        });
+        assert!(misordered, "expected Misordered at consensus 3; issues: {:?}", report.issues);
+        let extra = report.issues.iter().any(|i| {
+            matches!(i, PackIssue::ExtraBatch { digest, number } if *digest == target && *number == 5)
+        });
+        assert!(extra, "expected ExtraBatch at consensus 5; issues: {:?}", report.issues);
+        assert_eq!(report.missing_batch_count(BatchClass::Absent), 0);
+    }
+
+    /// v1-only: a group whose batches are all present and correct as a set, but written out of the
+    /// ascending digest order v1 requires, is flagged `UnsortedBatches` for that group — with no
+    /// spurious MissingBatch/ExtraBatch (the set is intact).
+    #[test]
+    fn test_validate_unsorted_batches_v1() {
+        let (temp_dir, committee, chain) = setup();
+        let outputs = make_outputs(&committee, chain, 5);
+        let (mut records, _) = build_records(epoch0_meta(&committee), &outputs, 1);
+
+        // Swap the first two Batch records that follow consensus header 3 (its group has 4 batches),
+        // breaking the ascending-digest order without changing the set.
+        let header3 = records
+            .iter()
+            .position(|r| matches!(r, PackRecord::Consensus(h) if h.number == 3))
+            .expect("consensus header 3 present");
+        assert!(
+            matches!(records[header3 + 1], PackRecord::Batch(_))
+                && matches!(records[header3 + 2], PackRecord::Batch(_)),
+            "expected header 3 to be followed by at least two batch records"
+        );
+        records.swap(header3 + 1, header3 + 2);
+
+        let path = temp_dir.path().join("data");
+        write_records(&path, &records, 1);
+
+        let report = validate_pack_file(&path, 0, None).expect("validate");
+        assert_eq!(report.verdict, Verdict::Invalid, "issues: {:?}", report.issues);
+        let unsorted: Vec<_> = report
+            .issues
+            .iter()
+            .filter(|i| matches!(i, PackIssue::UnsortedBatches { .. }))
+            .collect();
+        assert_eq!(unsorted.len(), 1, "expected one UnsortedBatches; issues: {:?}", report.issues);
+        assert!(matches!(unsorted[0], PackIssue::UnsortedBatches { number: 3 }));
+        // The set is intact, so no missing or extra batch should be reported.
+        assert!(
+            !report.issues.iter().any(|i| matches!(
+                i,
+                PackIssue::MissingBatch { .. } | PackIssue::ExtraBatch { .. }
+            )),
+            "unexpected missing/extra batch issues: {:?}",
+            report.issues
+        );
+    }
+
     /// Overwrite the `number` field of the consensus header that currently carries `current`.
     fn set_consensus_number(records: &mut [PackRecord], current: u64, new: u64) {
         let rec = records
@@ -616,31 +931,36 @@ mod test {
     /// check, so only the explicit sequential-number check (mirroring the importer) catches it.
     #[test]
     fn test_validate_non_sequential_trailing_header() {
-        let (temp_dir, committee, chain) = setup();
-        let outputs = make_outputs(&committee, chain, 5);
-        let (mut records, _) = build_records(epoch0_meta(&committee), &outputs);
+        for version in [0u16, 1] {
+            let (temp_dir, committee, chain) = setup();
+            let outputs = make_outputs(&committee, chain, 5);
+            let (mut records, _) = build_records(epoch0_meta(&committee), &outputs, version);
 
-        // The 5th (last) header should carry number 5; corrupt it to 99.
-        set_consensus_number(&mut records, 5, 99);
+            // The 5th (last) header should carry number 5; corrupt it to 99.
+            set_consensus_number(&mut records, 5, 99);
 
-        let path = temp_dir.path().join("data");
-        write_records(&path, &records);
+            let path = temp_dir.path().join("data");
+            write_records(&path, &records, version);
 
-        let report = validate_pack_file(&path, 0, None).expect("validate");
-        assert_eq!(report.verdict, Verdict::Invalid);
-        let non_seq = report.issues.iter().any(|i| {
-            matches!(i, PackIssue::NonSequentialConsensusNumber { expected: 5, found: 99 })
-        });
-        assert!(
-            non_seq,
-            "expected NonSequentialConsensusNumber(expected 5, found 99); issues: {:?}",
-            report.issues
-        );
-        // The chain check alone misses this: the final header has no successor whose parent_hash
-        // would mismatch, so no ChainBreak fires — the sequential check is what catches it.
-        let chain_breaks =
-            report.issues.iter().filter(|i| matches!(i, PackIssue::ChainBreak { .. })).count();
-        assert_eq!(chain_breaks, 0, "trailing-number corruption should not trip ChainBreak");
+            let report = validate_pack_file(&path, 0, None).expect("validate");
+            assert_eq!(report.verdict, Verdict::Invalid, "v{version}");
+            let non_seq = report.issues.iter().any(|i| {
+                matches!(i, PackIssue::NonSequentialConsensusNumber { expected: 5, found: 99 })
+            });
+            assert!(
+                non_seq,
+                "v{version}: expected NonSequentialConsensusNumber(expected 5, found 99); issues: {:?}",
+                report.issues
+            );
+            // The chain check alone misses this: the final header has no successor whose parent_hash
+            // would mismatch, so no ChainBreak fires — the sequential check is what catches it.
+            let chain_breaks =
+                report.issues.iter().filter(|i| matches!(i, PackIssue::ChainBreak { .. })).count();
+            assert_eq!(
+                chain_breaks, 0,
+                "v{version}: trailing-number corruption should not trip ChainBreak"
+            );
+        }
     }
 
     /// A corrupted middle header number fires exactly one sequential-number issue: `expected` is
@@ -648,32 +968,34 @@ mod test {
     /// header.
     #[test]
     fn test_validate_non_sequential_middle_header() {
-        let (temp_dir, committee, chain) = setup();
-        let outputs = make_outputs(&committee, chain, 5);
-        let (mut records, _) = build_records(epoch0_meta(&committee), &outputs);
+        for version in [0u16, 1] {
+            let (temp_dir, committee, chain) = setup();
+            let outputs = make_outputs(&committee, chain, 5);
+            let (mut records, _) = build_records(epoch0_meta(&committee), &outputs, version);
 
-        // The header at position 3 should carry number 3; corrupt it to 7.
-        set_consensus_number(&mut records, 3, 7);
+            // The header at position 3 should carry number 3; corrupt it to 7.
+            set_consensus_number(&mut records, 3, 7);
 
-        let path = temp_dir.path().join("data");
-        write_records(&path, &records);
+            let path = temp_dir.path().join("data");
+            write_records(&path, &records, version);
 
-        let report = validate_pack_file(&path, 0, None).expect("validate");
-        assert_eq!(report.verdict, Verdict::Invalid);
-        let non_seq: Vec<_> = report
-            .issues
-            .iter()
-            .filter(|i| matches!(i, PackIssue::NonSequentialConsensusNumber { .. }))
-            .collect();
-        assert_eq!(
-            non_seq.len(),
-            1,
-            "expected exactly one non-sequential issue (no cascade); issues: {:?}",
-            report.issues
-        );
-        assert!(matches!(
-            non_seq[0],
-            PackIssue::NonSequentialConsensusNumber { expected: 3, found: 7 }
-        ));
+            let report = validate_pack_file(&path, 0, None).expect("validate");
+            assert_eq!(report.verdict, Verdict::Invalid, "v{version}");
+            let non_seq: Vec<_> = report
+                .issues
+                .iter()
+                .filter(|i| matches!(i, PackIssue::NonSequentialConsensusNumber { .. }))
+                .collect();
+            assert_eq!(
+                non_seq.len(),
+                1,
+                "v{version}: expected exactly one non-sequential issue (no cascade); issues: {:?}",
+                report.issues
+            );
+            assert!(matches!(
+                non_seq[0],
+                PackIssue::NonSequentialConsensusNumber { expected: 3, found: 7 }
+            ));
+        }
     }
 }

--- a/crates/storage/src/pack_validate.rs
+++ b/crates/storage/src/pack_validate.rs
@@ -37,7 +37,7 @@ use tn_types::{BlockHash, ConsensusHeader, ConsensusHeaderDigest, Epoch, EpochRe
 
 use crate::{
     archive::pack::{Pack, PackCompression},
-    consensus_pack::{verify_epoch_meta, PackError, PackRecord},
+    consensus_pack::{verify_epoch_meta, PackError, PackRecord, PACK_VERSION},
 };
 
 /// Classification of a referenced-but-missing batch digest.
@@ -175,7 +175,8 @@ pub fn validate_pack_file(
 ) -> Result<PackValidationReport, PackError> {
     // Read-only open of just the data file — `Pack::open` loads/cross-checks the header (the wrong
     // epoch fails here with an open error) and needs no sidecar index files.
-    let pack = Pack::<PackRecord>::open(path, epoch as u64, true, PackCompression::ZStd)?;
+    let pack =
+        Pack::<PackRecord>::open(path, epoch as u64, true, PackCompression::ZStd, PACK_VERSION)?;
 
     // ---- Single pass: mirror `Inner::stream_import`, but collect every issue instead of bailing.
     let mut issues = Vec::new();
@@ -430,7 +431,7 @@ mod test {
     use super::{validate_pack_file, BatchClass, PackIssue, Verdict};
     use crate::{
         archive::pack::{Pack, PackCompression},
-        consensus_pack::{test::make_test_output, EpochMeta, PackRecord},
+        consensus_pack::{test::make_test_output, EpochMeta, PackRecord, PACK_VERSION},
         mem_db::MemDatabase,
     };
 
@@ -488,7 +489,8 @@ mod test {
     /// Write a record stream to a bare epoch-0 `data` pack file.
     fn write_records(path: &Path, records: &[PackRecord]) {
         let mut pack =
-            Pack::<PackRecord>::open(path, 0, false, PackCompression::ZStd).expect("open pack");
+            Pack::<PackRecord>::open(path, 0, false, PackCompression::ZStd, PACK_VERSION)
+                .expect("open pack");
         for record in records {
             pack.append(record).expect("append record");
         }


### PR DESCRIPTION
This will make validating while downloading easier and will help close some potential dos attacks based on bogus consensus output data.