### PR TITLE
cut the primary consensus-output path fully over to the typed sync protocol (739)

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -894,8 +894,9 @@ where
     ///
     /// Returns the full pack-file encoded output for `number` so a peer can reconstruct the
     /// [`tn_types::ConsensusOutput`] (batches + consensus header) without a separate batch fetch.
-    /// The bytes are streamed to the requesting peer (see `send_consensus_output_over_stream`),
-    /// because a single output can exceed the request/response message-size limit.
+    /// The bytes are streamed to the requesting peer over the typed sync protocol (see
+    /// `process_sync_consensus_output_stream`), because a single output can exceed the
+    /// request/response message-size limit.
     pub(super) async fn consensus_output_bytes(
         &self,
         number: u64,
@@ -1056,49 +1057,7 @@ where
         Ok(())
     }
 
-    /// Send a single consensus output's raw bytes over a stream.
-    ///
-    /// If the output is unavailable locally, the stream is simply closed with no bytes; the
-    /// requesting peer observes EOF and retries another peer.
-    pub(super) async fn send_consensus_output_over_stream<S>(
-        &self,
-        mut stream: S,
-        number: u64,
-        buffer_timeout: Duration,
-        peer: BlsPublicKey,
-    ) -> PrimaryNetworkResult<()>
-    where
-        S: AsyncWrite + Unpin + Send,
-    {
-        match self.consensus_output_bytes(number).await {
-            Ok(bytes) => {
-                // write in chunks so a single timeout bounds a slow reader
-                for chunk in bytes.chunks(16 * 1024) {
-                    timeout(buffer_timeout, stream.write_all(chunk)).await??;
-                }
-            }
-            Err(e) => {
-                // Benign miss (e.g. not-yet-served during catch-up): close with no bytes so the
-                // peer retries elsewhere. Closing below also handles the unavailable case.
-                debug!(
-                    target: "primary::network",
-                    %peer,
-                    ?number,
-                    ?e,
-                    "consensus output unavailable for stream; closing with no bytes"
-                );
-            }
-        }
-
-        // attempt to close the stream gracefully
-        if let Err(e) = stream.close().await {
-            tracing::warn!(target: "primary::network", %peer, ?number, ?e, "stream close failed");
-        }
-
-        Ok(())
-    }
-
-    /// Process request to open a stream for an epoch pack or a single consensus output.
+    /// Process request to open a stream for an epoch pack (full or partial prefix).
     pub(super) async fn process_request_epoch_stream(
         &self,
         peer: BlsPublicKey,
@@ -1165,27 +1124,6 @@ where
                 .await
                 .inspect_err(|e| {
                     warn!(target: "primary::network", %peer, ?e, "failed to send partial epoch over stream")
-                })
-            }
-            StreamRequestKind::ConsensusOutput(number) => {
-                debug!(
-                    target: "primary::network",
-                    %peer,
-                    ?request_digest,
-                    number,
-                    "processing inbound consensus output stream"
-                );
-
-                // set timeout to prevent slow-read attack
-                self.send_consensus_output_over_stream(
-                    stream,
-                    number,
-                    SEND_STREAM_BUFFER_TIMEOUT,
-                    peer,
-                )
-                .await
-                .inspect_err(|e| {
-                    warn!(target: "primary::network", %peer, ?e, "failed to send consensus output over stream")
                 })
             }
         }
@@ -1325,6 +1263,75 @@ where
             warn!(target: "primary::network", %peer, ?e, "failed to serve sync missing certificates stream");
             // bound the best-effort error write: a peer that read the `Ack` then
             // stopped reading would otherwise pin this responder task.
+            let _ = timeout(crate::network::SYNC_REQUEST_READ_TIMEOUT, async {
+                let _ = write_frame(
+                    &mut stream,
+                    &SyncFrame::<PrimarySyncRequest>::Err(SyncFrameError::Internal),
+                    &mut encode_buffer,
+                    &mut compressed_buffer,
+                    max_frame,
+                )
+                .await;
+            })
+            .await;
+        }
+
+        // attempt to close the stream gracefully, bounded so a peer that stops
+        // reading cannot pin this responder task on the FIN flush
+        let _ = timeout(crate::network::SYNC_REQUEST_READ_TIMEOUT, stream.close()).await;
+
+        Ok(())
+    }
+
+    /// Serve an inbound single-consensus-output sync exchange.
+    ///
+    /// The exchange has already been admitted against the concurrency caps and its
+    /// opening `Req(ConsensusOutput { number })` frame read by the caller. This
+    /// resolves the output bytes (with the same brief catch-up wait as before, via
+    /// [`Self::consensus_output_bytes`]) and streams them with
+    /// [`send_sync_consensus_output_over_stream`]: an available output is sent as
+    /// `Ack` + `Data`* + `End`; a benign miss (unknown number, or one not yet built
+    /// during catch-up) sheds with a [`SyncFrame::Deny`]`(Unavailable)` frame so the
+    /// requester retries elsewhere. A send failure is logged and best-effort signalled
+    /// with [`SyncFrame::Err`]; it is not a peer fault, so no penalty is returned
+    /// (metrics-only during the item-9b rollout, like the epoch-pack sync path).
+    ///
+    /// [`send_sync_consensus_output_over_stream`]: crate::network::sync_codec::send_sync_consensus_output_over_stream
+    pub(super) async fn process_sync_consensus_output_stream(
+        &self,
+        peer: BlsPublicKey,
+        mut stream: Stream,
+        number: u64,
+    ) -> PrimaryNetworkResult<()> {
+        debug!(target: "primary::network", %peer, number, "serving inbound sync consensus output stream");
+        let max_frame = crate::network::sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
+
+        // resolve the output bytes; a benign miss is shed with `Deny(Unavailable)`
+        // inside the serve helper (not a peer fault), so drop the error into `None`.
+        let bytes = self.consensus_output_bytes(number).await.ok();
+
+        // bound the whole serve; flatten the timeout's outer Result into the send's
+        let served = timeout(
+            SEND_SYNC_PACK_TIMEOUT,
+            crate::network::sync_codec::send_sync_consensus_output_over_stream(
+                &mut stream,
+                bytes,
+                SEND_STREAM_BUFFER_TIMEOUT,
+                peer,
+                number,
+            ),
+        )
+        .await
+        .map_err(PrimaryNetworkError::from)
+        .and_then(|served| served);
+
+        // a send failure or timeout is logged and best-effort signalled so the
+        // requester stops waiting; it is not a peer fault, so no penalty
+        if let Err(e) = served {
+            warn!(target: "primary::network", %peer, ?e, "failed to serve sync consensus output stream");
+            // bound the best-effort error write: a peer that read the `Ack` then
+            // stopped reading would otherwise pin this responder task.
+            let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
             let _ = timeout(crate::network::SYNC_REQUEST_READ_TIMEOUT, async {
                 let _ = write_frame(
                     &mut stream,

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -91,9 +91,6 @@ pub const MAX_PENDING_REQUESTS_PER_PEER: usize = 2;
 /// TODO- replace with a size from consensus.  See Issue 782.
 const MAX_CONSENSUS_OUTPUT_STREAM_BYTES: usize = 512 * 1024 * 1024;
 
-/// Per-read timeout while draining a consensus-output stream (slow-peer guard).
-const CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Timeout for the responder's first sync frame (`Ack`/`Deny`) after the epoch-pack
 /// request frame is written. A peer that negotiated the sync protocol but does not
 /// answer (a pre-cutover node that registered the protocol but reads the stream on
@@ -152,18 +149,15 @@ pub enum StreamRequestKind {
         /// The final (inclusive) consensus header number to stream up to.
         last_consensus_number: u64,
     },
-    /// Stream the raw bytes for a single consensus output (by consensus chain number).
-    ConsensusOutput(u64),
 }
 
-/// Correlation digest for a single consensus-output stream request.
+/// Correlation digest for an epoch-pack stream request.
 ///
 /// Each kind is domain-separated so distinct requests never collide in the pending map:
 /// - `EpochPack(epoch)` hashes only the epoch — byte-for-byte the original full-stream scheme, so
 ///   existing full-stream clients are unaffected.
 /// - `EpochPackPartial { epoch, n }` additionally mixes in the stop number, giving it a distinct
 ///   digest from the full-epoch request.
-/// - `ConsensusOutput(n)` is tagged so output `N` never collides with epoch `N`.
 fn stream_request_digest(kind: &StreamRequestKind) -> B256 {
     let mut hasher = tn_types::DefaultHashFunction::new();
     match kind {
@@ -175,10 +169,6 @@ fn stream_request_digest(kind: &StreamRequestKind) -> B256 {
             hasher.update(b"epoch-pack-partial");
             hasher.update(&epoch.to_le_bytes());
             hasher.update(&last_consensus_number.to_le_bytes());
-        }
-        StreamRequestKind::ConsensusOutput(number) => {
-            hasher.update(b"consensus-output");
-            hasher.update(&number.to_le_bytes());
         }
     }
     B256::from_slice(hasher.finalize().as_bytes())
@@ -231,6 +221,24 @@ enum EpochPackAttempt {
     Imported,
     /// The peer did not answer the sync exchange; cache it unsyncable this epoch
     /// and skip it on later probes (it must upgrade to be syncable again).
+    Unsupported,
+    /// The peer answered but the exchange failed; try the next peer.
+    Failed(NetworkError),
+}
+
+/// The outcome of a single-consensus-output fetch attempt over the typed sync
+/// protocol.
+///
+/// Mirrors [`EpochPackAttempt`] but carries the fetched bytes on success (an output
+/// is reassembled into a `Vec<u8>` for the caller to decode and verify, not imported
+/// into the chain).
+enum ConsensusOutputAttempt {
+    /// The peer served the output's bytes.
+    Fetched(Vec<u8>),
+    /// The peer did not answer the sync exchange. Unlike a full-pack `Unsupported`
+    /// this is NOT cached unsyncable, because a peer that speaks `/tn-primary-sync`
+    /// but cannot decode this newer `ConsensusOutput` variant still serves full epoch
+    /// packs and must not be hidden from the full-pack path.
     Unsupported,
     /// The peer answered but the exchange failed; try the next peer.
     Failed(NetworkError),
@@ -529,139 +537,209 @@ impl PrimaryNetworkHandle {
         }
     }
 
-    /// Request the raw (serialized) consensus output bytes for `number` from a specific peer.
+    /// Request the raw (serialized) consensus output bytes for `number` from any
+    /// connected peer over the typed `/tn-primary-sync` protocol.
     ///
-    /// Returns the pack-file encoded output (batches + consensus header). A single output can
-    /// exceed the request/response message-size limit, so the bytes are streamed: this negotiates
-    /// the stream via RPC, then opens a stream and reads the bytes. The caller is responsible for
-    /// deserializing the result (with the epoch's committee) and verifying it; the bytes cannot be
-    /// cheaply validated at the network layer.
-    pub async fn request_consensus_output_from_peer(
+    /// Item 9b (#739) cut this path fully over to sync: there is no legacy `/tn-stream`
+    /// fallback. Probes up to `MAX_EPOCH_SYNC_PROBES` connected peers that are not
+    /// cached unsyncable, opening a stream whose opening frame carries
+    /// [`PrimarySyncRequest::ConsensusOutput`]; returns the reassembled bytes from the
+    /// first peer that serves, otherwise `Err` (the caller retries). Returns the
+    /// pack-file encoded output (batches + consensus header); the caller deserializes it
+    /// with the epoch committee and verifies the decoded header digest. A peer that
+    /// serves proves it speaks the sync protocol (cached `true`); a peer that does not
+    /// answer is NOT cached (an ambiguous `Unsupported`; see `ConsensusOutputAttempt`).
+    /// The probe is penalty-exempt.
+    pub async fn request_consensus_output(&self, number: u64) -> NetworkResult<Vec<u8>> {
+        let peers = self.handle.connected_peers().await?;
+
+        // Probe candidate peers one at a time (the async analog of a short-circuiting
+        // fold): `filter` drops peers cached unsyncable for free, `take` bounds the
+        // network probes, `then` runs each exchange and records its verdict, and
+        // `filter_map` + `next` stop at the first peer that serves (so no peer past the
+        // first success is probed).
+        let probes = futures::stream::iter(peers)
+            .filter(move |peer| {
+                let known_unsyncable = self.sync_capability.lock().get(peer) == Some(&false);
+                futures::future::ready(!known_unsyncable)
+            })
+            .take(MAX_EPOCH_SYNC_PROBES)
+            .then(move |peer| async move {
+                match self.sync_consensus_output_from_peer(peer, number).await {
+                    ConsensusOutputAttempt::Fetched(bytes) => {
+                        self.sync_capability.lock().insert(peer, true);
+                        debug!(
+                            target: "primary::network",
+                            %peer,
+                            number,
+                            "fetched consensus output over sync protocol"
+                        );
+                        Some(bytes)
+                    }
+                    ConsensusOutputAttempt::Unsupported => {
+                        // Ambiguous: the peer may serve full epoch packs but not decode
+                        // this newer `ConsensusOutput` variant, so do NOT cache `false`
+                        // and hide it from the full-pack path.
+                        debug!(
+                            target: "primary::network",
+                            %peer,
+                            number,
+                            "peer did not answer consensus output sync; skipping this probe"
+                        );
+                        None
+                    }
+                    ConsensusOutputAttempt::Failed(e) => {
+                        // the peer speaks sync but this exchange failed; keep it
+                        // sync-capable and try the next peer
+                        self.sync_capability.lock().insert(peer, true);
+                        warn!(
+                            target: "primary::network",
+                            %peer,
+                            number,
+                            ?e,
+                            "consensus output sync exchange failed; trying next peer"
+                        );
+                        None
+                    }
+                }
+            })
+            .filter_map(futures::future::ready);
+
+        // `next` needs the stream `Unpin`, which the `then(async move { .. })`
+        // combinator is not, so pin the probe chain on the stack before pulling the
+        // first success.
+        let mut probes = std::pin::pin!(probes);
+        probes.next().await.ok_or_else(|| {
+            NetworkError::RPCError(
+                "no peer served the consensus output over the sync protocol".to_string(),
+            )
+        })
+    }
+
+    /// Run one consensus-output sync exchange against `peer`, flattening the classified
+    /// outcome into a single [`ConsensusOutputAttempt`].
+    async fn sync_consensus_output_from_peer(
         &self,
         peer: BlsPublicKey,
         number: u64,
-    ) -> NetworkResult<Vec<u8>> {
-        let request = PrimaryRequest::StreamConsensusOutput { number };
-        let request_digest = stream_request_digest(&StreamRequestKind::ConsensusOutput(number));
-        let resp = self.handle.send_request(request, peer).await?.await??;
-        let PrimaryResponse::StreamRequestAck { ack } = resp.result else {
-            return Err(NetworkError::RPCError(
-                "Got wrong response, not a stream ack!".to_string(),
-            ));
-        };
-        if !ack {
-            return Err(NetworkError::RPCError(
-                "peer declined consensus output stream request".to_string(),
-            ));
-        }
-        let bytes = self.stream_consensus_output(peer, request_digest).await?;
-        if bytes.is_empty() {
-            return Err(NetworkError::RPCError(
-                "peer streamed an empty consensus output".to_string(),
-            ));
-        }
-        Ok(bytes)
+    ) -> ConsensusOutputAttempt {
+        self.try_sync_consensus_output_exchange(peer, number)
+            .await
+            .map_or_else(|attempt| attempt, ConsensusOutputAttempt::Fetched)
     }
 
-    /// Request the raw (serialized) consensus output bytes for `number` from a random peer,
-    /// trying up to three times from three different peers.
+    /// Open a `/tn-primary-sync` stream, write the consensus-output request in the
+    /// opening frame, read the `Ack`, and reassemble the streamed output bytes.
     ///
-    /// Returns the pack-file encoded output (batches + consensus header). A single output can
-    /// exceed the request/response message-size limit, so the bytes are streamed (see
-    /// [`Self::request_consensus_output_from_peer`]). The caller is responsible for deserializing
-    /// the result (with the epoch's committee) and verifying it; the bytes cannot be cheaply
-    /// validated at the network layer.
-    pub async fn request_consensus_output(&self, number: u64) -> NetworkResult<Vec<u8>> {
-        const TIMEOUT: Duration = Duration::from_secs(10);
-        let request = PrimaryRequest::StreamConsensusOutput { number };
-        let request_digest = stream_request_digest(&StreamRequestKind::ConsensusOutput(number));
-        // Try up to three times (from three peers) to get the output.
-        // This could be a lot more complicated but this KISS method should work fine.
-        for _ in 0..3 {
-            let dispatch = match self.handle.send_request_any(request.clone()).await {
-                Ok(rx) => rx,
-                Err(e) => {
-                    warn!(target: "primary::network", ?e, ?number, "send_request_any failed; retrying");
-                    continue;
-                }
-            };
-            let resp = match tokio::time::timeout(TIMEOUT, dispatch).await {
-                Ok(Ok(Ok(r))) => r,
-                Ok(Ok(Err(e))) => {
-                    warn!(target: "primary::network", ?e, ?number, "peer responded with error; retrying");
-                    continue;
-                }
-                Ok(Err(e)) => {
-                    warn!(target: "primary::network", ?e, ?number, "peer dropped response channel; retrying");
-                    continue;
-                }
-                Err(_) => {
-                    warn!(target: "primary::network", ?number, "request_consensus_output timed out waiting for peer response");
-                    continue;
-                }
-            };
-            let PrimaryResponse::StreamRequestAck { ack } = resp.result else {
-                continue;
-            };
-            if !ack {
-                continue;
-            }
-            match self.stream_consensus_output(resp.peer, request_digest).await {
-                Ok(bytes) if !bytes.is_empty() => return Ok(bytes),
-                Ok(_) => {
-                    warn!(target: "primary::network", ?number, peer = %resp.peer, "peer streamed an empty consensus output; retrying");
-                }
-                Err(e) => {
-                    warn!(target: "primary::network", ?e, ?number, peer = %resp.peer, "failed to stream consensus output; retrying");
-                }
-            }
-        }
-        Err(NetworkError::RPCError("Could not get the consensus output!".to_string()))
-    }
-
-    /// Open a stream to `peer`, write the correlation digest, and read the streamed consensus
-    /// output bytes to EOF.
-    async fn stream_consensus_output(
+    /// `Err(ConsensusOutputAttempt::Unsupported)` means the peer did not answer the
+    /// protocol (negotiation failed, or it negotiated but never `Ack`ed - e.g. a peer
+    /// that speaks `/tn-primary-sync` but cannot decode the newer `ConsensusOutput`
+    /// variant and shut the stream). `Err(ConsensusOutputAttempt::Failed(_))` means a
+    /// transient or exchange-level error once the peer has proved sync-capable. A
+    /// transport I/O error during the open (`UpgradeIo`) is transient rather than a
+    /// protocol mismatch, so it maps to `Failed`.
+    async fn try_sync_consensus_output_exchange(
         &self,
         peer: BlsPublicKey,
-        request_digest: B256,
-    ) -> NetworkResult<Vec<u8>> {
-        let mut stream = self.handle.open_stream(peer, StreamKind::Legacy).await??;
-        stream
-            .write_all(request_digest.as_slice())
-            .await
-            .map_err(|e| NetworkError::RPCError(format!("failed to write request digest: {e}")))?;
-        stream
-            .flush()
-            .await
-            .map_err(|e| NetworkError::RPCError(format!("failed to flush request digest: {e}")))?;
-
-        let mut out = Vec::new();
-        let mut buf = vec![0u8; 16 * 1024];
-        loop {
-            let n = match tokio::time::timeout(
-                CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT,
-                stream.read(&mut buf[..]),
-            )
-            .await
-            {
-                Ok(Ok(n)) => n,
-                Ok(Err(e)) => {
-                    return Err(NetworkError::RPCError(format!("stream read failed: {e}")))
+        number: u64,
+    ) -> Result<Vec<u8>, ConsensusOutputAttempt> {
+        // open the sync stream, flattening the command-channel and stream-open results.
+        // Only a genuine negotiation failure (`UpgradeFailed`) is a peer that does not
+        // advertise the protocol -> Unsupported; a transient upgrade I/O error or any
+        // other open error is not proof the peer lacks sync -> try next.
+        let mut stream =
+            self.handle.open_stream(peer, StreamKind::Sync).await.and_then(|s| s).map_err(|e| {
+                match () {
+                    () if matches!(e, NetworkError::Stream(StreamError::UpgradeFailed)) => {
+                        ConsensusOutputAttempt::Unsupported
+                    }
+                    () => ConsensusOutputAttempt::Failed(e),
                 }
-                Err(_) => return Err(NetworkError::RPCError("stream read timed out".to_string())),
-            };
-            if n == 0 {
-                break;
+            })?;
+
+        // write the request in the opening frame. Negotiation already succeeded, so a
+        // write failure is transient -> try next.
+        let max_frame = sync_codec::MAX_SYNC_PACK_FRAME_SIZE;
+        let request = SyncFrame::Req(PrimarySyncRequest::ConsensusOutput { number });
+        let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        write_frame(&mut stream, &request, &mut encode_buffer, &mut compressed_buffer, max_frame)
+            .await
+            .and(stream.flush().await)
+            .map_err(|e| {
+                ConsensusOutputAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "failed to write consensus output sync request frame: {e}"
+                )))
+            })?;
+
+        // read the responder's first frame. A timeout (outer `Err`) means no `Ack` -> a
+        // peer that negotiated sync but does not serve this variant, so try the next
+        // peer. A clean close on the read (inner `Err`) is the same Unsupported signal;
+        // any other read error after negotiation is transient -> Failed.
+        let (mut decode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+        let first = tokio::time::timeout(
+            SYNC_ACK_TIMEOUT,
+            read_frame::<_, PrimarySyncRequest>(
+                &mut stream,
+                &mut decode_buffer,
+                &mut compressed_buffer,
+                max_frame,
+            ),
+        )
+        .await
+        .map_err(|_elapsed| ConsensusOutputAttempt::Unsupported)?
+        .map_err(|e| {
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::BrokenPipe
+            ) {
+                ConsensusOutputAttempt::Unsupported
+            } else {
+                ConsensusOutputAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "failed to read consensus output sync ack frame: {e}"
+                )))
             }
-            if out.len() + n > MAX_CONSENSUS_OUTPUT_STREAM_BYTES {
-                return Err(NetworkError::RPCError(
-                    "consensus output stream exceeded maximum size".to_string(),
-                ));
+        })?;
+
+        match first {
+            // accepted: reassemble the `Data`/`End` frames into the output bytes, bounded
+            // by the legacy size cap and the per-frame timeout inside the reader. An empty
+            // output is a miss (the responder `Ack`ed but holds nothing): try the next
+            // peer.
+            SyncFrame::Ack => {
+                let bytes = sync_codec::read_sync_consensus_output(
+                    stream,
+                    MAX_CONSENSUS_OUTPUT_STREAM_BYTES,
+                )
+                .await
+                .map_err(|e| {
+                    ConsensusOutputAttempt::Failed(NetworkError::RPCError(format!(
+                        "failed to read consensus output over sync stream: {e}"
+                    )))
+                })?;
+                (!bytes.is_empty()).then_some(bytes).ok_or_else(|| {
+                    ConsensusOutputAttempt::Failed(NetworkError::RPCError(
+                        "peer streamed an empty consensus output".to_string(),
+                    ))
+                })
             }
-            out.extend_from_slice(&buf[..n]);
+            // sync-capable, but shedding load or lacking the output: try next peer
+            SyncFrame::Deny(reason) => {
+                Err(ConsensusOutputAttempt::Failed(NetworkError::RPCRetryable(format!(
+                    "peer denied consensus output sync request: {reason:?}"
+                ))))
+            }
+            SyncFrame::Err(err) => Err(ConsensusOutputAttempt::Failed(NetworkError::RPCError(
+                format!("peer aborted consensus output sync exchange: {err:?}"),
+            ))),
+            // a well-behaved responder never opens with these
+            SyncFrame::Req(_) | SyncFrame::Data(_) | SyncFrame::End => {
+                Err(ConsensusOutputAttempt::Failed(NetworkError::ProtocolError(
+                    "unexpected opening sync frame from peer".to_string(),
+                )))
+            }
         }
-        Ok(out)
     }
 
     /// Request consensus header from a random peer up to three times from three different peers.
@@ -1531,18 +1609,34 @@ where
         self.send_stream_ack(ack, channel, cancel, format!("process-request-epoch-{peer}"));
     }
 
-    /// Process a request to stream a single consensus output's raw bytes.
+    /// Answer a legacy request-response `StreamConsensusOutput` request.
+    ///
+    /// Item 9b (#739) cut the consensus-output fetch fully over to the
+    /// `/tn-primary-sync` protocol, so this request-response path is no longer served:
+    /// peers fetch a single consensus output over sync. The request variant is retained
+    /// for wire compatibility (BCS variant indices stay until the coordinated `/0.0.2`
+    /// bump, item 9c); a legacy requester is answered with a typed error rather than
+    /// served.
     fn process_consensus_output_stream(
         &self,
         peer: BlsPublicKey,
-        number: u64,
+        _number: u64,
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {
-        let kind = StreamRequestKind::ConsensusOutput(number);
-        let request_digest = stream_request_digest(&kind);
-        let ack = self.accept_stream_request(peer, request_digest, kind);
-        self.send_stream_ack(ack, channel, cancel, format!("process-request-output-{peer}"));
+        let network_handle = self.network_handle.clone();
+        let task_name = format!("ConsensusOutputDeprecated-{peer}");
+        let response = PrimaryResponse::Error(PrimaryRPCError(
+            "consensus output is served over the sync protocol only".to_string(),
+        ));
+        self.task_spawner.spawn_task(task_name, async move {
+            tokio::select! {
+                _ = network_handle.handle.send_response(response, channel) => (),
+                // cancel notification from network layer
+                _ = cancel => (),
+            }
+            Ok(())
+        });
     }
 
     /// Process gossip from committee.
@@ -1720,6 +1814,14 @@ where
                             exclusive_lower_bound,
                             skip_rounds,
                         )
+                        .await?;
+                }
+                // `ConsensusOutput` over sync (item 9b): serve one output's raw bytes
+                // as a streamed `Ack` + `Data`* + `End`, replacing the legacy
+                // `StreamConsensusOutput` ack-plus-digest path.
+                SyncFrame::Req(PrimarySyncRequest::ConsensusOutput { number }) => {
+                    request_handler
+                        .process_sync_consensus_output_stream(peer, stream, number)
                         .await?;
                 }
                 // a well-behaved requester always opens with `Req`; anything else is

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1375,8 +1375,8 @@ where
                         channel,
                         cancel,
                     ),
-                PrimaryRequest::StreamConsensusOutput { number } => {
-                    self.process_consensus_output_stream(peer, number, channel, cancel)
+                PrimaryRequest::StreamConsensusOutput { .. } => {
+                    self.process_consensus_output_stream(peer, channel, cancel)
                 }
             },
             NetworkEvent::Gossip { message, relayer, author } => {
@@ -1620,7 +1620,6 @@ where
     fn process_consensus_output_stream(
         &self,
         peer: BlsPublicKey,
-        _number: u64,
         channel: ResponseChannel<PrimaryResponse>,
         cancel: oneshot::Receiver<()>,
     ) {

--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tn_network_libp2p::{read_frame, write_frame, DenyReason, PrimarySyncRequest, SyncFrame};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{encode, try_decode, BlsPublicKey, Certificate, Epoch};
-use tokio::io::AsyncRead as TokioAsyncRead;
+use tokio::io::{AsyncRead as TokioAsyncRead, AsyncReadExt as _};
 use tracing::debug;
 
 /// The raw pack bytes carried by a single [`SyncFrame::Data`] frame.
@@ -270,6 +270,93 @@ where
             "unexpected sync frame during epoch pack stream",
         )),
     }
+}
+
+/// Serve an accepted single-consensus-output sync exchange over `stream`.
+///
+/// `bytes` is the output's pack-file-encoded bytes when the responder holds it, or
+/// `None` when it is unavailable (an unknown number, or one not yet built during
+/// catch-up). An unavailable output sheds with
+/// [`SyncFrame::Deny`]`(`[`DenyReason::Unavailable`]`)` so the requester retries
+/// another peer immediately instead of waiting out its ack timeout. Otherwise it
+/// writes [`SyncFrame::Ack`], streams the bytes as [`SyncFrame::Data`] frames, and
+/// ends with [`SyncFrame::End`]. Reuses the epoch-pack chunk framing
+/// ([`write_pack_data_frames`]) and its [`MAX_SYNC_PACK_FRAME_SIZE`] bound, so the
+/// requester reassembles it with [`read_sync_consensus_output`]. Each frame write
+/// is bounded by `buffer_timeout` so a peer that stops reading cannot pin the
+/// responder task. The caller has already admitted the exchange against the
+/// concurrency caps and read the opening request frame.
+pub(crate) async fn send_sync_consensus_output_over_stream<S>(
+    stream: &mut S,
+    bytes: Option<Vec<u8>>,
+    buffer_timeout: Duration,
+    peer: BlsPublicKey,
+    number: u64,
+) -> PrimaryNetworkResult<()>
+where
+    S: FuturesAsyncWrite + Unpin + Send,
+{
+    let (mut encode_buffer, mut compressed_buffer) = (Vec::new(), Vec::new());
+
+    // an unavailable output sheds with `Deny(Unavailable)` so the requester retries
+    // elsewhere without waiting out its ack timeout, exactly as the epoch-pack serve
+    // does on a `get_epoch_stream` miss.
+    let Some(bytes) = bytes else {
+        debug!(target: "primary::network", %peer, number, "consensus output unavailable; denying sync request");
+        write_one_frame(
+            stream,
+            &SyncFrame::Deny(DenyReason::Unavailable),
+            &mut encode_buffer,
+            &mut compressed_buffer,
+            MAX_SYNC_PACK_FRAME_SIZE,
+            buffer_timeout,
+        )
+        .await?;
+        return Ok(());
+    };
+
+    // accept and flush immediately so the requester sees the `Ack` within its ack
+    // timeout, then stream the output bytes as fixed-size `Data` frames.
+    write_one_frame(
+        stream,
+        &SyncFrame::Ack,
+        &mut encode_buffer,
+        &mut compressed_buffer,
+        MAX_SYNC_PACK_FRAME_SIZE,
+        buffer_timeout,
+    )
+    .await?;
+    write_pack_data_frames(&mut std::io::Cursor::new(bytes), stream, buffer_timeout).await?;
+    Ok(())
+}
+
+/// Reassemble the `Data`/`End` frames of an accepted consensus-output sync
+/// exchange into a contiguous byte vector, bounded to `max_bytes`.
+///
+/// The caller has already read the opening [`SyncFrame::Ack`]; this reads the
+/// `Data`/`End` stream through [`sync_pack_reader`] (so an [`SyncFrame::Err`] or an
+/// out-of-place frame surfaces as a read error). Each frame is bounded by the
+/// per-frame [`EPOCH_PACK_FRAME_TIMEOUT`] inside the reader (the analog of the
+/// legacy per-read timeout), and a stream exceeding `max_bytes` is rejected with
+/// [`std::io::ErrorKind::InvalidData`] rather than silently truncated, matching the
+/// legacy size guard.
+pub(crate) async fn read_sync_consensus_output<S>(
+    stream: S,
+    max_bytes: usize,
+) -> std::io::Result<Vec<u8>>
+where
+    S: FuturesAsyncRead + Unpin + Send + 'static,
+{
+    let mut out = Vec::new();
+    // read one byte past the cap so an over-cap stream is detected here rather than
+    // silently truncated by `take`.
+    sync_pack_reader(stream).take(max_bytes as u64 + 1).read_to_end(&mut out).await?;
+    (out.len() <= max_bytes).then_some(out).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "consensus output stream exceeded maximum size",
+        )
+    })
 }
 
 /// Serve an accepted missing-certificates sync exchange over `stream`.
@@ -614,6 +701,136 @@ mod tests {
         assert!(
             read_back(framed).await.is_err(),
             "an unexpected control frame mid-stream must surface as a read error"
+        );
+    }
+
+    /// The consensus-output serve writes `Ack` then the exact output bytes as
+    /// `Data`+`End`, and `read_sync_consensus_output` reassembles them
+    /// byte-for-byte across chunk boundaries. This is the wire contract between an
+    /// item-9b responder and an item-9b requester.
+    #[tokio::test]
+    async fn sync_consensus_output_round_trip() {
+        // one full chunk plus a partial one, so the reader spans a frame boundary
+        let original: Vec<u8> =
+            (0..(SYNC_PACK_CHUNK_SIZE + 777)).map(|i| (i % 251) as u8).collect();
+        let mut wire = Vec::new();
+        send_sync_consensus_output_over_stream(
+            &mut wire,
+            Some(original.clone()),
+            Duration::from_secs(5),
+            BlsPublicKey::default(),
+            7,
+        )
+        .await
+        .expect("serve consensus output");
+
+        // consume the opening `Ack`, then reassemble the remaining `Data`/`End` frames
+        let mut cursor = futures::io::Cursor::new(wire);
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        let ack = read_frame::<_, PrimarySyncRequest>(
+            &mut cursor,
+            &mut dec,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("read ack");
+        assert!(matches!(ack, SyncFrame::Ack), "first frame must be Ack");
+        let received = read_sync_consensus_output(cursor, SYNC_PACK_CHUNK_SIZE * 8)
+            .await
+            .expect("reassemble output");
+        assert_eq!(received, original, "reassembled bytes must equal the served output");
+    }
+
+    /// An empty served output streams `Ack` then only `End`; the reader yields zero
+    /// bytes cleanly (distinct from the `None`/`Deny` unavailable case below).
+    #[tokio::test]
+    async fn sync_consensus_output_round_trip_empty() {
+        let mut wire = Vec::new();
+        send_sync_consensus_output_over_stream(
+            &mut wire,
+            Some(Vec::new()),
+            Duration::from_secs(5),
+            BlsPublicKey::default(),
+            7,
+        )
+        .await
+        .expect("serve empty consensus output");
+        let mut cursor = futures::io::Cursor::new(wire);
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        let ack = read_frame::<_, PrimarySyncRequest>(
+            &mut cursor,
+            &mut dec,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("read ack");
+        assert!(matches!(ack, SyncFrame::Ack), "first frame must be Ack");
+        let received = read_sync_consensus_output(cursor, SYNC_PACK_CHUNK_SIZE * 8)
+            .await
+            .expect("reassemble output");
+        assert!(received.is_empty(), "an empty served output reassembles to zero bytes");
+    }
+
+    /// An unavailable output (`None`) is shed with `Deny(Unavailable)` and no `Ack`,
+    /// so a sync requester retries another peer immediately.
+    #[tokio::test]
+    async fn sync_consensus_output_unavailable_denies() {
+        let mut wire = Vec::new();
+        send_sync_consensus_output_over_stream(
+            &mut wire,
+            None,
+            Duration::from_secs(5),
+            BlsPublicKey::default(),
+            7,
+        )
+        .await
+        .expect("serving an unavailable output sheds cleanly");
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        let frame = read_frame::<_, PrimarySyncRequest>(
+            &mut futures::io::Cursor::new(wire),
+            &mut dec,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("read deny");
+        assert!(
+            matches!(frame, SyncFrame::Deny(DenyReason::Unavailable)),
+            "an unavailable output must deny"
+        );
+    }
+
+    /// A served stream exceeding `max_bytes` is rejected rather than silently
+    /// truncated, mirroring the legacy size guard.
+    #[tokio::test]
+    async fn read_sync_consensus_output_rejects_oversize() {
+        let original: Vec<u8> = (0..(SYNC_PACK_CHUNK_SIZE + 10)).map(|i| (i % 251) as u8).collect();
+        let mut wire = Vec::new();
+        send_sync_consensus_output_over_stream(
+            &mut wire,
+            Some(original),
+            Duration::from_secs(5),
+            BlsPublicKey::default(),
+            7,
+        )
+        .await
+        .expect("serve consensus output");
+        let mut cursor = futures::io::Cursor::new(wire);
+        let (mut dec, mut comp) = (Vec::new(), Vec::new());
+        read_frame::<_, PrimarySyncRequest>(
+            &mut cursor,
+            &mut dec,
+            &mut comp,
+            MAX_SYNC_PACK_FRAME_SIZE,
+        )
+        .await
+        .expect("read ack");
+        // cap below the served size: reassembly must error, not truncate
+        assert!(
+            read_sync_consensus_output(cursor, SYNC_PACK_CHUNK_SIZE).await.is_err(),
+            "an over-cap stream must be rejected"
         );
     }
 

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -267,52 +267,6 @@ async fn test_retrieve_consensus_output() {
     assert!(penalty.is_none(), "an unknown consensus output must not penalize the peer");
 }
 
-/// The server-side stream send writes exactly the stored output bytes and closes the stream.
-/// An unknown number closes the stream with no bytes (the client observes EOF and retries).
-#[tokio::test]
-async fn test_send_consensus_output_over_stream() {
-    let temp_dir = TempDir::new().unwrap();
-    let TestTypes { committee, handler, task_manager: _task_manager, .. } =
-        create_test_types(temp_dir.path()).await;
-    let committee_obj = committee.committee();
-    let peer = BlsPublicKey::default();
-
-    for number in 1..=3u64 {
-        let cert = Certificate::default();
-        let sub_dag = CommittedSubDag::new(
-            vec![cert.clone()],
-            cert,
-            number,
-            ReputationScores::new(&committee_obj),
-            None,
-        );
-        handler.consensus_chain().write_subdag_for_test(number, sub_dag).await;
-    }
-
-    // streamed bytes for a stored output must match the bytes returned by the lookup
-    for number in 1..=3u64 {
-        let expected = handler
-            .consensus_output_bytes(number)
-            .await
-            .expect("stored consensus output should be served");
-        let mut streamed: Vec<u8> = Vec::new();
-        handler
-            .send_consensus_output_over_stream(&mut streamed, number, Duration::from_secs(5), peer)
-            .await
-            .expect("streaming a stored output should succeed");
-        assert_eq!(streamed, expected, "streamed bytes must match stored output {number}");
-        assert!(!streamed.is_empty(), "streamed output {number} must not be empty");
-    }
-
-    // an unknown number streams nothing (graceful EOF) rather than erroring the send
-    let mut streamed: Vec<u8> = Vec::new();
-    handler
-        .send_consensus_output_over_stream(&mut streamed, 999, Duration::from_secs(5), peer)
-        .await
-        .expect("streaming an unknown output closes gracefully");
-    assert!(streamed.is_empty(), "unknown output must stream zero bytes");
-}
-
 #[tokio::test]
 async fn test_vote_succeeds() -> eyre::Result<()> {
     // common types

--- a/crates/network-libp2p/src/sync/request.rs
+++ b/crates/network-libp2p/src/sync/request.rs
@@ -56,6 +56,17 @@ pub enum PrimarySyncRequest {
         /// Per-authority rounds to skip, each serialized as a RoaringBitmap.
         skip_rounds: Vec<(AuthorityIdentifier, Vec<u8>)>,
     },
+    /// Request the raw bytes of a single consensus output by chain consensus
+    /// number.
+    ///
+    /// Folds the legacy `StreamConsensusOutput` ack-plus-digest handshake into a
+    /// single open. This streams exactly one output's pack-file-encoded bytes; the
+    /// requester decodes them with the epoch committee and verifies the decoded
+    /// header digest before use.
+    ConsensusOutput {
+        /// The chain consensus number of the requested output.
+        number: u64,
+    },
 }
 
 #[cfg(test)]
@@ -107,6 +118,12 @@ mod tests {
         assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
     }
 
+    #[tokio::test]
+    async fn primary_consensus_output_request_round_trips() {
+        let request = PrimarySyncRequest::ConsensusOutput { number: 41 };
+        assert_eq!(roundtrip_req(request.clone()).await, SyncFrame::Req(request));
+    }
+
     /// The request enums' BCS discriminants ride on the wire (inside the `Req`
     /// frame), so pin them exactly as `frame_tags_are_stable` pins the frame
     /// tags. A reorder would keep the round-trip tests green while changing the
@@ -128,5 +145,9 @@ mod tests {
         })
         .expect("encode missing certificates");
         assert_eq!(missing.first(), Some(&1));
+
+        let consensus_output = bcs::to_bytes(&PrimarySyncRequest::ConsensusOutput { number: 0 })
+            .expect("encode consensus output");
+        assert_eq!(consensus_output.first(), Some(&2));
     }
 }


### PR DESCRIPTION
## What

Item 9b of #739.  Cuts the primary's single-consensus-output fetch (`PrimaryNetworkHandle::request_consensus_output`, the observer/state-sync catch-up path) **fully** over from the legacy `/tn-stream` digest-correlation transfer to the typed `/tn-primary-sync` protocol.  This is a hard cutover with **no legacy fallback**: the requester is sync-only, the responder answers the legacy request-response with a typed error, and the legacy consensus-output `/tn-stream` serve is removed.  Mirrors the item-7 MissingCertificates full cutover.

## Why

`StreamConsensusOutput` was the last primary `/tn-stream` opener that still carried a live requester.  It streams one output's opaque, pack-file-encoded bytes (returned as a `Vec<u8>` the caller decodes with the epoch committee and verifies against the already-known header digest).  A hard cutover removes the RPC-ack-plus-digest handshake, the correlation-digest machinery, and the legacy serve for this path in one step, rather than leaving a fallback to unwind later.

## How

**Base + discriminant.** Based directly on `origin/main`. `origin/main`'s `PrimarySyncRequest` is `{EpochPack(0), MissingCertificates(1)}`, so this appends `ConsensusOutput { number }` at BCS discriminant **2**. `request_tags_are_stable` pins it (`Some(&2)`) and a round-trip test covers the wire.  Append-only;  no existing variant is reordered or removed.

**Requester (sync-only).** `request_consensus_output` is rewritten to probe up to `MAX_EPOCH_SYNC_PROBES` connected peers over `/tn-primary-sync`, returning the reassembled bytes from the first peer that serves, otherwise `Err` (the caller, `get_consensus_output` in state-sync, already retries).  The structure mirrors the full-epoch-pack `request_epoch_pack_sync`: `filter` skips peers cached unsyncable, `then` classifies each exchange as `ConsensusOutputAttempt::{Fetched, Unsupported, Failed}`, and a pinned `filter_map(ready).next()` short-circuits on the first success.  `try_sync_consensus_output_exchange` opens the stream, writes `Req(ConsensusOutput { number })`, reads the `Ack`, and reassembles the `Data`/`End` frames into a `Vec<u8>` bounded by the `MAX_CONSENSUS_OUTPUT_STREAM_BYTES` (512 MiB) size cap and the per-frame `EPOCH_PACK_FRAME_TIMEOUT` inside the reader.

**Cache-poisoning guard.** A `ConsensusOutput` `Unsupported` (a peer that speaks `/tn-primary-sync` but cannot decode the newer discriminant-2 variant) does NOT write `false` to the shared per-peer `sync_capability` cache — unlike a full-pack `Unsupported`, which is authoritative — so a peer that still serves full epoch packs is not hidden from the full-pack path.

**Responder.** `process_inbound_sync_stream` gains a `ConsensusOutput` dispatch arm (the exhaustive `SyncFrame::Req(PrimarySyncRequest::…)` match forces it) routing to the new `RequestHandler::process_sync_consensus_output_stream`, which resolves the bytes via the existing `consensus_output_bytes` (with its brief catch-up wait) and serves them through the new `sync_codec::send_sync_consensus_output_over_stream`: `Ack` + `Data`* + `End`, or `Deny(Unavailable)` on a benign miss.  Reuses the epoch-pack chunk framing (`write_pack_data_frames`, `MAX_SYNC_PACK_FRAME_SIZE`) so the requester reassembles with the same `sync_pack_reader`.  Errors are metrics-only (no penalty), like the epoch-pack sync path.  Admission goes through the existing shared `try_admit_sync`.

**Legacy removal.** The request-response `PrimaryRequest::StreamConsensusOutput` is retained for wire compatibility (BCS request variant indices stay until the coordinated `/0.0.2` bump, item 9c) but is now answered with a typed `PrimaryResponse::Error` (mirroring `process_request_for_missing_certs`) instead of served.  Deleted: `request_consensus_output_from_peer`, `stream_consensus_output`, `send_consensus_output_over_stream`, the `StreamRequestKind::ConsensusOutput` variant and its `stream_request_digest`/`process_request_epoch_stream` arms, and the `CONSENSUS_OUTPUT_STREAM_READ_TIMEOUT` constant.

**Tests.** Request round-trip + tag-stability (`request.rs`);  `sync_codec` unit tests for the serve helper (round-trip, empty, `Deny(Unavailable)` on `None`, over-cap rejection).  The legacy `test_send_consensus_output_over_stream` (which drove the removed serve) is deleted;  `test_retrieve_consensus_output` (covering the retained `consensus_output_bytes`) stays.  As with the epoch-pack requester, `try_sync_consensus_output_exchange` and `process_sync_consensus_output_stream` run over an unmockable `libp2p::Stream`, so those are covered by the codec unit tests and the ignored observer e2e rather than a mocked-stream unit test.

## Compatibility / rollout

- Hard cutover (matches item 6 full-pack and item 7 missing-certs): a `request_consensus_output` that finds no peer serving the variant fails and the caller retries, forcing peers to upgrade.  There is no legacy fallback.
- A peer on an older binary that requests consensus output over the legacy request-response path receives a typed error and retries elsewhere.
- No wire-breaking change: the `ConsensusOutput` sync variant is append-only (disc 2);  the legacy `PrimaryRequest::StreamConsensusOutput` request variant is retained (answered-with-error) until the item-9c `/0.0.2` bump.  BCS encodes enum variant indices, so no deprecated variant is deleted before that coordinated bump.

## Gates

`-j2` throughout (OOM-safe). fmt (nightly-2026-03-20);  clippy `-p tn-network-libp2p -p tn-primary --all-features --all-targets` clean; `tn-network-libp2p` + `tn-primary` tests pass.  `cargo doc -D warnings` adds zero new warnings (pre-existing links only;  no cargo-doc CI gate).  Consumer crates compile with zero edits (`request_consensus_output` signature unchanged).