### PR TITLE
test: cut targeted suite runtime by memoizing fixtures and sharing crypto contexts

### DIFF
--- a/crates/consensus/primary/src/tests/certificate_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_tests.rs
@@ -1,7 +1,7 @@
 //! Certificate tests
 
 use rand::{rngs::StdRng, SeedableRng};
-use std::num::NonZeroUsize;
+use std::{cell::RefCell, collections::HashMap, num::NonZeroUsize, rc::Rc};
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{AuthorityIdentifier, BlsKeypair, Certificate, SignatureVerificationState, Vote};
@@ -113,14 +113,29 @@ fn test_unknown_signature_in_certificate() {
     assert!(Certificate::new_unverified(&committee, header, signatures).is_err());
 }
 
+// Proptest runs every case for this test on the single libtest thread (no fork is
+// configured), so a thread_local cache is sound. Memoizing one CommitteeFixture per
+// committee size avoids regenerating BLS keypairs for every case; reusing the same keys
+// across cases changes neither the generated input range nor any assertion.
+thread_local! {
+    static FIXTURE_CACHE: RefCell<HashMap<usize, Rc<CommitteeFixture<MemDatabase>>>> =
+        RefCell::new(HashMap::new());
+}
+
 proptest::proptest! {
     #[test]
     fn test_certificate_verification(
         committee_size in 4..35_usize
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(NonZeroUsize::new(committee_size).unwrap())
-            .build();
+        let fixture = FIXTURE_CACHE.with(|cache| {
+            Rc::clone(cache.borrow_mut().entry(committee_size).or_insert_with(|| {
+                Rc::new(
+                    CommitteeFixture::builder(MemDatabase::default)
+                        .committee_size(NonZeroUsize::new(committee_size).unwrap())
+                        .build(),
+                )
+            }))
+        });
         let committee = fixture.committee();
         let header = fixture.header_from_last_authority();
 

--- a/crates/consensus/primary/src/tests/certifier_tests.rs
+++ b/crates/consensus/primary/src/tests/certifier_tests.rs
@@ -88,7 +88,7 @@ async fn propose_header_to_form_certificate() {
     ));
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn propose_header_failure() {
     let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
     let committee = fixture.committee();
@@ -144,7 +144,7 @@ async fn propose_header_failure() {
     }
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn propose_header_scenario_with_bad_sigs() {
     // expect cert if less than 2 byzantines, otherwise no cert
     run_vote_aggregator_with_param(6, 0, true).await;

--- a/crates/consensus/primary/tests/it/consensus_props.rs
+++ b/crates/consensus/primary/tests/it/consensus_props.rs
@@ -7,11 +7,39 @@
 //! - Committee membership invariants
 
 use proptest::prelude::*;
-use std::collections::HashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{LazyLock, Mutex},
+};
 use tn_primary::consensus::{LeaderSchedule, LeaderSwapTable};
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
-use tn_types::{AuthorityIdentifier, ReputationScores};
+use tn_types::{AuthorityIdentifier, Committee, ReputationScores};
+
+/// Committees memoized by committee size.
+///
+/// Building a [CommitteeFixture] generates fresh BLS keypairs for every authority, which
+/// dominates the runtime of these property tests. The properties under test depend only on
+/// the committee for a given size, so each size is built once per test process.
+static COMMITTEE_CACHE: LazyLock<Mutex<HashMap<usize, (Committee, Vec<AuthorityIdentifier>)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Return the memoized [Committee] and authority ids for a committee of `size`.
+fn committee_for_size(size: usize) -> (Committee, Vec<AuthorityIdentifier>) {
+    COMMITTEE_CACHE
+        .lock()
+        .unwrap()
+        .entry(size)
+        .or_insert_with(|| {
+            let fixture = CommitteeFixture::builder(MemDatabase::default)
+                .committee_size(std::num::NonZeroUsize::new(size).unwrap())
+                .build();
+            let authority_ids: Vec<AuthorityIdentifier> =
+                fixture.authorities().map(|a| a.id()).collect();
+            (fixture.committee(), authority_ids)
+        })
+        .clone()
+}
 
 proptest! {
     /// Leader selection must be deterministic: same round always produces same leader.
@@ -20,10 +48,7 @@ proptest! {
         committee_size in 4usize..15,
         round in (1u32..100).prop_map(|r| r * 2) // Even rounds only
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
+        let (committee, _) = committee_for_size(committee_size);
 
         let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
@@ -47,10 +72,7 @@ proptest! {
     fn prop_round_robin_covers_all(
         committee_size in 4usize..15
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
+        let (committee, _) = committee_for_size(committee_size);
 
         let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
@@ -77,10 +99,7 @@ proptest! {
         committee_size in 4usize..15,
         start_round in 1u32..50
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
+        let (committee, _) = committee_for_size(committee_size);
 
         let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
@@ -104,10 +123,7 @@ proptest! {
         committee_size in 4usize..15,
         round in (1u32..100).prop_map(|r| r * 2)
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
+        let (committee, _) = committee_for_size(committee_size);
 
         let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
         let leader = schedule.leader(round);
@@ -124,12 +140,7 @@ proptest! {
         committee_size in 4usize..15,
         round in (1u32..100).prop_map(|r| r * 2)
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
-        let authority_ids: Vec<AuthorityIdentifier> =
-            fixture.authorities().map(|a| a.id()).collect();
+        let (committee, authority_ids) = committee_for_size(committee_size);
 
         // Create scores where authority 0 is bad
         let mut scores = ReputationScores::new(&committee);
@@ -161,10 +172,7 @@ proptest! {
         committee_size in 4usize..15,
         num_cycles in 2usize..5
     ) {
-        let fixture = CommitteeFixture::builder(MemDatabase::default)
-            .committee_size(std::num::NonZeroUsize::new(committee_size).unwrap())
-            .build();
-        let committee = fixture.committee();
+        let (committee, _) = committee_for_size(committee_size);
 
         let schedule = LeaderSchedule::new(committee, LeaderSwapTable::default());
 
@@ -194,11 +202,7 @@ proptest! {
 /// Test that bad nodes with low scores get swapped.
 #[test]
 fn test_bad_node_gets_swapped() {
-    let fixture = CommitteeFixture::builder(MemDatabase::default)
-        .committee_size(std::num::NonZeroUsize::new(7).unwrap())
-        .build();
-    let committee = fixture.committee();
-    let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
+    let (committee, authority_ids) = committee_for_size(7);
 
     // No swap schedule
     let no_swap_schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1819,6 +1819,18 @@ pub(crate) mod test {
         }
     }
 
+    /// Poll `condition` every 25ms until it holds, panicking with a clear message if it
+    /// does not become true within 10s. Bounded, event-driven replacement for fixed sleeps.
+    async fn wait_for(mut condition: impl AsyncFnMut() -> bool, msg: &str) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !condition().await {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out after 10s waiting for {msg}"));
+    }
+
     #[tokio::test]
     async fn test_pack_save_wrong_epoch_rejected() {
         let temp_dir = TempDir::with_prefix("test_pack_wrong_epoch").expect("temp dir");
@@ -1949,7 +1961,14 @@ pub(crate) mod test {
             )
             .await
             .expect("open pack");
-            tokio::time::sleep(Duration::from_secs(2)).await;
+            // stream_import fully drains the stream before returning, so the data already
+            // lives in the pack thread; wait (bounded) for the last output to be readable
+            // instead of sleeping a fixed 2s.
+            wait_for(
+                async || pack.get_consensus_output(num_outputs as u64 * 2).await.is_ok(),
+                "last stream-imported consensus output to be readable",
+            )
+            .await;
             for i in 0..num_outputs {
                 let output_db = pack.get_consensus_output(i as u64 + 1).await.unwrap();
                 let output = outputs.get(i as usize).unwrap();

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -27,7 +27,7 @@ use reth_revm::{database::StateProviderDatabase, db::BundleState, State};
 use reth_transaction_pool::{EthPoolTransaction, EthPooledTransaction, PoolTransaction};
 use secp256k1::{
     rand::{rngs::StdRng, Rng, SeedableRng as _},
-    Secp256k1,
+    SECP256K1,
 };
 use std::{collections::HashMap, path::Path, str::FromStr, sync::Arc};
 use tn_config::NodeInfo;
@@ -219,25 +219,22 @@ impl TransactionFactory {
     /// Secret: 9bf49a6a0755f953811fce125f2683d50429c3bb49e074147e0089a52eae155f
     pub fn new() -> Self {
         let mut rng = StdRng::from_seed([0; 32]);
-        let secp = Secp256k1::new();
-        let (secret_key, _public_key) = secp.generate_keypair(&mut rng);
-        let keypair = ExecutionKeypair::from_secret_key(&secp, &secret_key);
+        let (secret_key, _public_key) = SECP256K1.generate_keypair(&mut rng);
+        let keypair = ExecutionKeypair::from_secret_key(SECP256K1, &secret_key);
         Self { keypair, nonce: 0 }
     }
 
     /// create a new instance of self from a provided seed.
     pub fn new_random_from_seed<R: Rng + ?Sized>(rand: &mut R) -> Self {
-        let secp = Secp256k1::new();
-        let (secret_key, _public_key) = secp.generate_keypair(rand);
-        let keypair = ExecutionKeypair::from_secret_key(&secp, &secret_key);
+        let (secret_key, _public_key) = SECP256K1.generate_keypair(rand);
+        let keypair = ExecutionKeypair::from_secret_key(SECP256K1, &secret_key);
         Self { keypair, nonce: 0 }
     }
 
     /// create a new instance of self from a random seed.
     pub fn new_random() -> Self {
-        let secp = Secp256k1::new();
-        let (secret_key, _public_key) = secp.generate_keypair(&mut StdRng::from_os_rng());
-        let keypair = ExecutionKeypair::from_secret_key(&secp, &secret_key);
+        let (secret_key, _public_key) = SECP256K1.generate_keypair(&mut StdRng::from_os_rng());
+        let keypair = ExecutionKeypair::from_secret_key(SECP256K1, &secret_key);
         Self { keypair, nonce: 0 }
     }
 

--- a/crates/types/src/task_manager.rs
+++ b/crates/types/src/task_manager.rs
@@ -768,7 +768,26 @@ mod test {
 
         drop(task_manager);
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Dropping the manager notifies local_shutdown; each killed task drops its
+        // Ping on exit, closing the ping channel. Poll for that instead of a fixed
+        // 1s sleep, bounded so a shutdown regression still fails loudly.
+        let killed = [
+            &pong_crit.ping_tx,
+            &pong_norm.ping_tx,
+            &spong_crit.ping_tx,
+            &spong_norm.ping_tx,
+            &rspong_crit.ping_tx,
+            &rspong_norm.ping_tx,
+            &rspong_block.ping_tx,
+            &rspong_crit_block.ping_tx,
+        ];
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while killed.iter().any(|tx| !tx.is_closed()) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("spawned tasks still alive 5s after TaskManager drop");
         assert!(pong_crit.ping(2).await.is_err());
         assert!(pong_norm.ping(2).await.is_err());
 

--- a/crates/types/tests/it/committee_props.rs
+++ b/crates/types/tests/it/committee_props.rs
@@ -8,23 +8,39 @@
 
 use proptest::prelude::*;
 use rand::{rngs::StdRng, SeedableRng};
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{LazyLock, Mutex},
+};
 use tn_types::{Address, Authority, BlsKeypair, BlsPublicKey, Committee};
 
 /// Create a test committee with the given number of authorities, all with voting power 1.
+///
+/// Committees are memoized by size: BLS key generation dominates test runtime and the
+/// generated keys are never asserted on, so reusing one committee per size is equivalent.
 fn create_test_committee(seed: u64, size: usize) -> Committee {
-    let mut rng = StdRng::seed_from_u64(seed);
+    static CACHE: LazyLock<Mutex<HashMap<usize, Committee>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    let authorities: BTreeMap<BlsPublicKey, Authority> = (0..size)
-        .map(|_| {
-            let keypair = BlsKeypair::generate(&mut rng);
-            let authority =
-                Authority::new_for_test(*keypair.public(), Address::random_with(&mut rng));
-            (*keypair.public(), authority)
+    CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entry(size)
+        .or_insert_with(|| {
+            let mut rng = StdRng::seed_from_u64(seed);
+
+            let authorities: BTreeMap<BlsPublicKey, Authority> = (0..size)
+                .map(|_| {
+                    let keypair = BlsKeypair::generate(&mut rng);
+                    let authority =
+                        Authority::new_for_test(*keypair.public(), Address::random_with(&mut rng));
+                    (*keypair.public(), authority)
+                })
+                .collect();
+
+            Committee::new_for_test(authorities, 0, BTreeMap::new())
         })
-        .collect();
-
-    Committee::new_for_test(authorities, 0, BTreeMap::new())
+        .clone()
 }
 
 proptest! {


### PR DESCRIPTION
## Summary

Implements the Tier B test-suite speedup proposed in #894.  A batch of targeted
unit and property tests spent most of their wall time rebuilding
input-invariant fixtures inside hot loops.  This memoizes or hoists those
fixtures and replaces a few fixed wall-clock sleeps with event-driven waits,
cutting the targeted suite without changing what any test asserts and without
lowering any proptest case count or benchmark iteration count.

All changes are test-only; there is no production-code behavior change.

## Changes

**Memoize `CommitteeFixture` by committee size.** Building a `CommitteeFixture`
generates one BLS keypair per authority, which dominated these tests.  Each was
rebuilding the fixture inside every proptest case:

- `consensus/primary/tests/it/consensus_props.rs`: 6 `prop_*` fns at proptest's
  default 256 cases each rebuilt a fixture per case.  A file-local
  `committee_for_size` now caches `(Committee, Vec<AuthorityIdentifier>)` by size
  in a `LazyLock<Mutex<HashMap<..>>>`, so each of the ~11 distinct sizes builds
  once per test process.
- `types/tests/it/committee_props.rs`: `create_test_committee` now memoizes the
  `Committee` by size behind a `LazyLock<Mutex<HashMap<..>>>`;  the signature is
  unchanged so callers are untouched.
- `consensus/primary/src/tests/certificate_tests.rs`:
  `test_certificate_verification` (sizes 4..35) now memoizes the full
  `CommitteeFixture` per size in a `thread_local` cache (proptest runs every case
  on the single libtest thread here, so a `thread_local` is sound), since
  certificate signing needs the authority keypairs, not just the committee.

The generated-input range and case count of every property test are unchanged.
The only behavioral difference is that key material is reused across cases for a
given size; no test asserts on per-case key identity, so this preserves coverage.

**Share one secp256k1 context in `TransactionFactory`**
(`tn-reth/src/test_utils.rs`).  The three factory constructors each built a fresh
`Secp256k1::new()`, which precomputes the EC multiplication tables.  They now use
the crate's global `SECP256K1` context (the `global-context` feature is already
enabled on the workspace dependency), which is built once lazily and yields
byte-identical keys and signatures.  The seeded constructor still produces the
same documented address.

**Replace fixed sleeps with event-driven waits.**

- `storage/src/consensus_pack.rs`: the fixed 2s sleep after `stream_import` is
  replaced with a bounded `wait_for` helper that polls until the last imported
  output is readable (the exact condition the following assertion checks),
  capped at 10s so a regression still fails loudly.
- `types/src/task_manager.rs`: the fixed 1s post-drop sleep is replaced with a
  bounded poll (capped 5s) on the killed tasks' ping channels closing.
- `consensus/primary/src/tests/certifier_tests.rs`: `propose_header_failure` and
  `propose_header_scenario_with_bad_sigs` gain `start_paused = true` on their
  `#[tokio::test]` attribute.  These tests' 5s negative-path timeouts are pure
  dead waits proving no certificate arrives over in-memory channels;  under paused
  time tokio auto-advances the clock once the runtime is idle, so the windows
  elapse instantly with identical semantics.  Two same-crate tests already use
  this pattern.

## Not done (documented dead ends from #894)

`pipeline_tel_precompile_props` (the largest bucket) and `test_archive_hdx_index`
have no lever that preserves coverage;  both only shrink by cutting case/element
volume, which is out of scope here.  See #894 for the full analysis.

## Verification

All targeted tests pass, and the same tests were timed on the same machine
before and after the change (`cargo nextest run`, warm cache, same
`-E` filter, run as an isolated subset).  Per-test durations below.

`tn-primary` (fixture memoization + `start_paused`):

| Test | Before | After |
|---|---|---|
| `certifier_tests::propose_header_failure` | 5.039s | 0.031s |
| `certifier_tests::propose_header_scenario_with_bad_sigs` | 10.137s | 0.208s |
| `certificate_tests::test_certificate_verification` | 10.457s | 2.659s |
| `consensus_props::prop_leader_deterministic` | 5.241s | 0.243s |
| `consensus_props::prop_round_robin_covers_all` | 4.503s | 0.206s |
| `consensus_props::prop_no_consecutive_leaders` | 4.496s | 0.265s |
| `consensus_props::prop_leader_schedule_cycles` | 4.107s | 0.190s |
| `consensus_props::prop_leader_is_committee_member` | 3.987s | 0.118s |
| `consensus_props::prop_swap_deterministic` | 3.349s | 0.143s |
| `consensus_props::test_bad_node_gets_swapped` | 0.026s | 0.028s |
| **wall time (2 binaries)** | **27.01s** | **2.67s** |

`tn-types` / `tn-storage` (committee memoization + shared secp + sleep removal):

| Test | Before | After |
|---|---|---|
| `consensus_pack::test_consensus_pack` | 7.922s | 5.307s |
| `task_manager::test_task_manager` | 1.021s | 0.031s |
| `committee_props::prop_two_quorums_intersect` | 1.840s | 0.271s |
| `committee_props::prop_validity_threshold_greater_than_one_third` | 1.687s | 0.270s |
| `committee_props::prop_quorum_threshold_greater_than_two_thirds` | 1.669s | 0.265s |
| `committee_props::prop_quorum_greater_than_validity` | 1.484s | 0.270s |
| `committee_props::prop_byzantine_fault_tolerance` | 1.303s | 0.254s |
| `consensus_pack::test_pack_save_wrong_epoch_rejected` | 0.163s | 0.151s |

Across both groups the affected-test wall time drops from ~37.1s to ~8.0s
(~78%) on this machine.

Note on the absolute numbers: these per-test times are lower than the
full-suite figures in #894 because that baseline ran the whole ~56-test set in
parallel, where CPU contention inflates each test roughly 3x.  Running the
affected tests as an isolated subset here understates the absolute time removed
but cleanly isolates each change's effect;  on the contended full suite the
wall-clock gain is larger.

- `cargo nextest run` of all affected tests: 23 passed, 0 failed (both groups).
- `cargo clippy -p tn-primary -p tn-types -p tn-storage -p tn-reth --all-targets`:
  0 errors, and 0 new warnings (the pre-existing workspace warnings are all at
  untouched lines).
- `cargo +nightly fmt`: no changes.
