### PR TITLE
test(e2e): cut runtime of the four ignored e2e tests (#897)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,10 +14,13 @@ retries = 2
 fail-fast = true
 test-threads = "num-cpus"
 
-# E2E tests use dynamic ports and can run in parallel.
-# Limit concurrency since each test spawns 4-6 node processes.
+# E2E tests each spawn 4-6 node processes, and the heavy (ignored) ones run for minutes.
+# Running two at once puts 12+ node processes on the box and inflated wall time ~3.5-4x,
+# so cap the whole e2e group at one test at a time (was max-threads = 2). Using a single
+# group rather than a name-matched "heavy" subset also covers heavy tests added later
+# (basefee, metrics, ...) without enumerating them, and avoids two groups overlapping.
 [test-groups.e2e]
-max-threads = 2
+max-threads = 1
 
 [[profile.default.overrides]]
 filter = "package(e2e-tests)"

--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,22 @@ test-cargo:
 test-faucet:
 	cargo nextest run --package telcoin-network --features faucet --test it ;
 
+# Build the node binary once so e2e test processes reuse it via TN_BIN_PATH instead of
+# rebuilding it through escargot (~3-10s of cargo overhead per test process).
+.PHONY: build-e2e-bin
+build-e2e-bin:
+	cargo build --bin telcoin-network --features tn-storage/test-utils --target-dir $(CURDIR)/target ;
+
+# Location of the binary built by build-e2e-bin, passed to the e2e tests via TN_BIN_PATH.
+E2E_BIN := $(CURDIR)/target/debug/telcoin-network
+
 # run restart integration tests
-test-restarts:
-	cargo nextest run --run-ignored all test_restarts ;
+test-restarts: build-e2e-bin
+	TN_BIN_PATH=$(E2E_BIN) cargo nextest run --run-ignored all test_restarts ;
 
 # run e2e tests
-test-e2e:
-	cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
+test-e2e: build-e2e-bin
+	TN_BIN_PATH=$(E2E_BIN) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
 
 # run tests with coverage (using llvm-cov + nextest)
 coverage:
@@ -181,10 +190,10 @@ revert-submodule:
 	cd tn-contracts && git checkout $(COMMIT_SHA)
 
 # workspace tests that don't require faucet credentials
-public-tests:
-	cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
-	cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
-	cargo nextest run --run-ignored all test_restarts ;
+public-tests: build-e2e-bin
+	TN_BIN_PATH=$(E2E_BIN) cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
+	TN_BIN_PATH=$(E2E_BIN) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH=$(E2E_BIN) cargo nextest run --run-ignored all test_restarts ;
 
 # local checks to ensure PR is ready
 pr:

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -18,8 +18,32 @@ use tn_types::{test_utils::CommandParser, Address, Genesis, GenesisAccount};
 use tracing::{error, info};
 // unused deps warnings
 
-/// Only compile main bin once for all tests.
-pub static TELCOIN_BINARY: OnceLock<CargoRun> = OnceLock::new();
+/// A telcoin-network binary for the e2e tests.
+///
+/// Building the node binary via escargot costs ~3-10s of cargo overhead per test process.
+/// Setting `TN_BIN_PATH` to a prebuilt binary (see `make build-e2e-bin`) skips that
+/// entirely; when it is unset we fall back to an escargot build so `cargo nextest` and
+/// `cargo test` still work with no extra setup.
+#[derive(Debug)]
+pub enum TestBinary {
+    /// Prebuilt binary located via the `TN_BIN_PATH` environment variable.
+    Prebuilt(PathBuf),
+    /// Binary built on demand by escargot.
+    Cargo(CargoRun),
+}
+
+impl TestBinary {
+    /// Build a [`std::process::Command`] that runs this binary.
+    pub fn command(&self) -> std::process::Command {
+        match self {
+            TestBinary::Prebuilt(path) => std::process::Command::new(path),
+            TestBinary::Cargo(run) => run.command(),
+        }
+    }
+}
+
+/// Resolve the main bin once for all tests.
+pub static TELCOIN_BINARY: OnceLock<TestBinary> = OnceLock::new();
 
 /// RPC endpoints for a single node across all transports.
 #[derive(Debug)]
@@ -352,23 +376,35 @@ pub fn setup_log_dir(
     test_dir
 }
 
-/// Helper to retrieve and build the main project binary.
-pub fn get_telcoin_network_binary() -> &'static CargoRun {
-    info!("building main binary for e2e tests");
+/// Retrieve the main project binary, resolving it once for the whole test process.
+///
+/// Honors `TN_BIN_PATH`: when set, the prebuilt binary at that path is used and no
+/// per-process cargo build runs. Otherwise the binary is built once via escargot.
+pub fn get_telcoin_network_binary() -> &'static TestBinary {
     TELCOIN_BINARY.get_or_init(|| {
+        if let Ok(prebuilt) = std::env::var("TN_BIN_PATH") {
+            let path = PathBuf::from(&prebuilt);
+            assert!(path.is_file(), "TN_BIN_PATH is set to {prebuilt:?} but no file exists there");
+            info!("using prebuilt telcoin-network binary from TN_BIN_PATH: {prebuilt}");
+            return TestBinary::Prebuilt(path);
+        }
+
+        info!("building main binary for e2e tests");
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
         let path = PathBuf::from(manifest_dir);
         let workspace_root =
             path.parent().and_then(|p| p.parent()).expect("Cannot find workspace root");
 
-        CargoBuild::new()
-            .bin("telcoin-network")
-            .features("tn-storage/test-utils")
-            .manifest_path(workspace_root.join("Cargo.toml"))
-            .target_dir(workspace_root.join("target"))
-            .current_target()
-            .run()
-            .expect("Failed to build telcoin-network binary")
+        TestBinary::Cargo(
+            CargoBuild::new()
+                .bin("telcoin-network")
+                .features("tn-storage/test-utils")
+                .manifest_path(workspace_root.join("Cargo.toml"))
+                .target_dir(workspace_root.join("target"))
+                .current_target()
+                .run()
+                .expect("Failed to build telcoin-network binary"),
+        )
     })
 }
 

--- a/crates/e2e-tests/tests/it/basefee.rs
+++ b/crates/e2e-tests/tests/it/basefee.rs
@@ -46,8 +46,9 @@ use crate::common::{
     network_advancing, send_tel, start_validator, ProcessGuard,
 };
 
-/// Epoch duration (seconds) for base-fee tests. Mirrors `epochs.rs::EPOCH_DURATION` so boundaries
-/// occur on the same cadence under the `test-utils` feature.
+/// Epoch duration (seconds) for base-fee tests. Held at 10s independently of
+/// `epochs.rs::EPOCH_DURATION` (which #897 cut to 5s): these base-fee tests are outside that
+/// four-test scope, and 10s keeps ample margin for their epoch-boundary assertions.
 const EPOCH_DURATION: u64 = 10;
 
 /// Static fee used by the deterministic tests. A clearly non-`MIN` value so any block produced

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -2,8 +2,7 @@
 //!
 //! Process management, cleanup guards, and helpers used across all test modules.
 
-use e2e_tests::setup_log_dir;
-use escargot::CargoRun;
+use e2e_tests::{setup_log_dir, TestBinary};
 use ethereum_tx_sign::{LegacyTransaction, Transaction};
 use eyre::Report;
 use jsonrpsee::{
@@ -244,7 +243,9 @@ where
     let mut resp = client.request(command, params.clone()).await;
     let mut i = 0;
     while i < retries && resp.is_err() {
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Short backoff: these retries mask brief RPC unavailability (e.g. a node
+        // mid-restart), so poll ~4x/sec instead of once a second.
+        tokio::time::sleep(Duration::from_millis(250)).await;
         let client = HttpClientBuilder::default()
             .request_timeout(Duration::from_secs(10))
             .build(node)
@@ -318,7 +319,7 @@ pub(crate) fn network_advancing(client_urls: &[String; 4]) -> eyre::Result<()> {
 /// Start a process running a validator node.
 pub(crate) fn start_validator(
     instance: usize,
-    bin: &'static CargoRun,
+    bin: &'static TestBinary,
     base_dir: &Path,
     rpc_port: u16,
     test: &str,
@@ -330,7 +331,7 @@ pub(crate) fn start_validator(
 /// Start a validator node process with additional CLI arguments (e.g. `--metrics`).
 pub(crate) fn start_validator_with_args(
     instance: usize,
-    bin: &'static CargoRun,
+    bin: &'static TestBinary,
     base_dir: &Path,
     rpc_port: u16,
     test: &str,
@@ -369,7 +370,7 @@ pub(crate) fn start_validator_with_args(
 /// Start a process running an observer node.
 pub(crate) fn start_observer(
     instance: usize,
-    bin: &'static CargoRun,
+    bin: &'static TestBinary,
     base_dir: &Path,
     rpc_port: u16,
     test: &str,

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -32,8 +32,12 @@ const INITIAL_STAKE_AMOUNT: &str = "1_000_000";
 const MIN_EPOCHS_TO_TEST: usize = 6;
 // Epoch init creates HDX index files per epoch (open_epoch_pack → new_epoch →
 // ConsensusPack::open_append). With test-utils, these are ~1.3MB each (vs ~130MB in prod).
-// 10s provides margin for parallel test execution and CI load variance.
-const EPOCH_DURATION: u64 = 10;
+// 5s is the consensus minimum epoch duration; halving it from 10s roughly halves the
+// wall time of each epoch test. The two `tn_epochRecord` certificate-availability polls
+// below are floored to an absolute minimum (`.max(..)`) rather than scaling with this
+// constant, because certificate production is a fixed async quorum-voting cost that does
+// not shrink with the epoch cadence.
+const EPOCH_DURATION: u64 = 5;
 
 async fn test_epoch_boundary_inner(
     genesis: Genesis,
@@ -147,7 +151,9 @@ async fn test_epoch_boundary_inner(
         for ep in endpoints {
             let provider = ProviderBuilder::new().connect_http(ep.http_url.parse()?);
             for epoch in 0..=latest_epoch {
-                let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 3);
+                // Certificate availability is a fixed async quorum-voting cost, so floor
+                // this deadline at 30s instead of letting it shrink with EPOCH_DURATION.
+                let deadline = Instant::now() + Duration::from_secs((EPOCH_DURATION * 3).max(30));
                 let (epoch_rec, cert) = loop {
                     match provider
                         .raw_request::<_, (EpochRecord, EpochCertificate)>(
@@ -406,11 +412,12 @@ async fn test_epoch_sync_inner(
                 .join("data");
             let pack_file_exists = std::fs::exists(file_test).unwrap_or_default();
             assert!(pack_file_exists, "Missing an epoch pack file for {val_name} on epoch {epoch}");
-            // Use 6× epoch duration: when a new validator joins the committee mid-test,
-            // its epoch vote quorum collection can time out (25 × 2.5s = ~62s) before the
-            // failed-quorum P2P fallback runs. The spawn_epoch_record_collector retries
-            // every 5s independently, so 60s gives enough time for it to succeed.
-            let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 6);
+            // When a new validator joins the committee mid-test, its epoch vote quorum
+            // collection can time out (25 × 2.5s = ~62s) before the failed-quorum P2P
+            // fallback runs. The spawn_epoch_record_collector retries every 5s
+            // independently, so 60s gives enough time for it to succeed. This is a fixed
+            // cost, so floor the deadline at 60s rather than scaling it with EPOCH_DURATION.
+            let deadline = Instant::now() + Duration::from_secs((EPOCH_DURATION * 6).max(60));
             let (epoch_rec, cert) = loop {
                 match provider
                     .raw_request::<_, (EpochRecord, EpochCertificate)>(

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -6,14 +6,17 @@ use crate::common::{
     get_key, get_latest_consensus_header_number, get_node_info, get_positive_balance_with_retry,
     network_advancing, send_and_confirm, send_tel, start_observer, start_validator, WEI_PER_TEL,
 };
-use e2e_tests::config_local_testnet;
-use escargot::CargoRun;
+use e2e_tests::{config_local_testnet, TestBinary};
 use eyre::Report;
 use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
-use std::{path::Path, process::Child, time::Duration};
+use std::{
+    path::Path,
+    process::Child,
+    time::{Duration, Instant},
+};
 use tn_types::get_available_tcp_port;
 use tracing::{error, info};
 
@@ -21,7 +24,7 @@ use tracing::{error, info};
 fn run_restart_tests1(
     client_urls: &[String; 4],
     child2: &mut Child,
-    bin: &'static CargoRun,
+    bin: &'static TestBinary,
     temp_path: &Path,
     rpc_port2: u16,
     delay_secs: u64,
@@ -70,11 +73,11 @@ fn run_restart_tests1(
 
     info!(target: "restart-test", "killing child2...");
     kill_child(child2);
-    info!(target: "restart-test", "child2 dead :D sleeping...");
-    std::thread::sleep(Duration::from_secs(delay_secs));
+    info!(target: "restart-test", "child2 dead :D waiting out downtime...");
+    wait_for_downtime(client_urls, delay_secs)?;
 
     // This validator should be down now, confirm.
-    if get_balance(&client_urls[2], &to_account.to_string(), 5).is_ok() {
+    if get_balance(&client_urls[2], &to_account.to_string(), 0).is_ok() {
         error!(target: "restart-test", "tests1: get_balancer worked for shutdown validator - returning error!");
         return Err(Report::msg("Validator not down!".to_string()));
     }
@@ -113,7 +116,7 @@ fn run_restart_tests1(
 fn run_restart_tests_lagged1(
     client_urls: &[String; 4],
     child2: &mut Child,
-    bin: &'static CargoRun,
+    bin: &'static TestBinary,
     temp_path: &Path,
     rpc_port2: u16,
     delay_secs: u64,
@@ -138,11 +141,11 @@ fn run_restart_tests_lagged1(
 
     info!(target: "restart-test", "killing child2...");
     kill_child(child2);
-    info!(target: "restart-test", "child2 dead :D sleeping...");
-    std::thread::sleep(Duration::from_secs(delay_secs));
+    info!(target: "restart-test", "child2 dead :D waiting out downtime...");
+    wait_for_downtime(client_urls, delay_secs)?;
 
     // This validator should be down now, confirm.
-    if get_balance(&client_urls[2], &to_account.to_string(), 5).is_ok() {
+    if get_balance(&client_urls[2], &to_account.to_string(), 0).is_ok() {
         error!(target: "restart-test", "tests1: get_balancer worked for shutdown validator - returning error!");
         return Err(Report::msg("Validator not down!".to_string()));
     }
@@ -151,7 +154,10 @@ fn run_restart_tests_lagged1(
     let amount = 10 * WEI_PER_TEL; // 10 TEL
     let expected = current + amount;
     send_tel(&client_urls[0], &key, to_account, amount, 250, 21000, 1)?;
-    std::thread::sleep(Duration::from_millis(5000));
+    // Wait for the transfer to settle on the live network before restarting the lagged
+    // node, so it must catch the balance up via sync. Event-driven (polls a live peer
+    // until the balance lands) instead of a fixed 5s sleep.
+    get_balance_above_with_retry(&client_urls[0], &to_account.to_string(), expected - 1)?;
 
     info!(target: "restart-test", "restarting child2...");
     // Restart
@@ -225,6 +231,48 @@ fn run_restart_tests2(client_urls: &[String; 4]) -> eyre::Result<()> {
     Ok(())
 }
 
+/// Wait out a restarted node's downtime, then proceed only once the live validators are
+/// still advancing the consensus chain.
+///
+/// A validator that misses more than `parameters.gc_depth - 10` (50 - 10 = 40) consensus
+/// rounds while offline is pushed outside the GC window (see the primary network handler's
+/// `outside_gc_window` check) and must rejoin via the follow/catch-up path rather than
+/// live consensus. The `min_secs` floor is the real guarantee: `max_header_delay = 1s`
+/// bounds a round to ~1s and the heavy restart tests run serially (nextest `e2e` group,
+/// max-threads = 1) so nothing else steals cores, so 60s reliably clears the ~40-round /
+/// ~40s threshold with margin while still cutting ~10s per test vs the old fixed 70s
+/// sleep. The peer-advancement check is only a stall-guard against the network wedging
+/// (which would make the downtime meaningless), not a substitute for the floor. Node
+/// index 2 is the killed one; 0/1/3 stay live.
+fn wait_for_downtime(client_urls: &[String; 4], min_secs: u64) -> eyre::Result<()> {
+    // Nodes 0/1/3 stay live (index 2 is the killed one).
+    let peer_height = || {
+        [&client_urls[0], &client_urls[1], &client_urls[3]]
+            .into_iter()
+            .filter_map(|url| get_latest_consensus_header_number(url).ok())
+            .max()
+    };
+
+    let start_height = peer_height();
+    let start = Instant::now();
+    let floor = Duration::from_secs(min_secs);
+    // Fail-safe cap so a genuinely stalled network surfaces downstream instead of hanging here.
+    let cap = Duration::from_secs(min_secs * 2 + 30);
+
+    loop {
+        let elapsed = start.elapsed();
+        let advanced = start_height.zip(peer_height()).is_some_and(|(s, now)| now > s);
+        if elapsed >= floor && advanced {
+            return Ok(());
+        }
+        if elapsed >= cap {
+            info!(target: "restart-test", ?elapsed, "wait_for_downtime hit fail-safe cap; proceeding");
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
 fn do_restarts(delay: u64, lagged: bool, test: &str) -> eyre::Result<()> {
     info!(target: "restart-test", "do_restarts, delay: {delay}");
     let tmp_guard = tempfile::TempDir::new().expect("tempdir is okay");
@@ -286,10 +334,12 @@ fn do_restarts(delay: u64, lagged: bool, test: &str) -> eyre::Result<()> {
     // Make sure we shutdown nodes even if an error in first testing.
     assert!(is_ok, "Phase 1 failed: {assert_str}. Check logs in test_logs/{test}/");
     let to_account = address_from_word("testing");
-    assert!(get_balance(&client_urls[0], &to_account.to_string(), 5).is_err());
-    assert!(get_balance(&client_urls[1], &to_account.to_string(), 5).is_err());
-    assert!(get_balance(&client_urls[2], &to_account.to_string(), 5).is_err());
-    assert!(get_balance(&client_urls[3], &to_account.to_string(), 5).is_err());
+    // These nodes are all shut down, so a dead connection is expected: use retries = 0 so a
+    // known-down node fails immediately instead of burning ~5s of retries per check.
+    assert!(get_balance(&client_urls[0], &to_account.to_string(), 0).is_err());
+    assert!(get_balance(&client_urls[1], &to_account.to_string(), 0).is_err());
+    assert!(get_balance(&client_urls[2], &to_account.to_string(), 0).is_err());
+    assert!(get_balance(&client_urls[3], &to_account.to_string(), 0).is_err());
 
     info!(target: "restart-test", "all nodes shutdown...restarting network");
     // Restart network
@@ -403,7 +453,7 @@ fn test_restarts_observer() -> eyre::Result<()> {
 #[ignore = "should not run with a default cargo test, run restart tests as seperate step"]
 fn test_restarts_delayed() -> eyre::Result<()> {
     let _permit = super::common::acquire_test_permit();
-    do_restarts(70, false, "restarts_delayed")
+    do_restarts(60, false, "restarts_delayed")
 }
 
 /// Test a restart case with a long delay, the stopped node should not rejoin consensus but follow
@@ -412,7 +462,7 @@ fn test_restarts_delayed() -> eyre::Result<()> {
 #[ignore = "should not run with a default cargo test, run restart tests as seperate step"]
 fn test_restarts_lagged_delayed() -> eyre::Result<()> {
     let _permit = super::common::acquire_test_permit();
-    do_restarts(70, true, "restarts_lagged_delayed")
+    do_restarts(60, true, "restarts_lagged_delayed")
 }
 
 fn test_blocks_same(client_urls: &[String; 4]) -> eyre::Result<()> {

--- a/crates/e2e-tests/tests/it/sync.rs
+++ b/crates/e2e-tests/tests/it/sync.rs
@@ -13,9 +13,10 @@ use crate::common::{
     send_and_confirm, start_observer, start_validator, ProcessGuard,
 };
 
-/// Epoch duration (in seconds) used by the pack-import test. Mirrors the value used by
-/// `epochs.rs::EPOCH_DURATION` so that epoch boundaries occur on the same cadence under
-/// test-utils.
+/// Epoch duration (in seconds) used by the pack-import test. Held at 10s independently of
+/// `epochs.rs::EPOCH_DURATION` (which #897 cut to 5s): this pack-import regression test is
+/// outside that four-test scope, and 10s keeps ample margin for the epoch-0
+/// close + certify + observer pack-import path.
 const PACK_IMPORT_EPOCH_DURATION: u64 = 10;
 
 /// Regression test: an observer joining after epoch 0 has been closed and certified must


### PR DESCRIPTION
## Summary

Closes #897.  Test-only optimization of the four ignored e2e integration tests
(`test_epoch_boundary`, `test_epoch_sync`, `test_restarts_delayed`,
`test_restarts_lagged_delayed`) that cuts their wall time by removing
non-essential overhead.  **No test assertions, epoch counts, or iteration counts
are changed, and restart follow-path coverage is preserved.**  The shared-infra
changes (nextest de-contention, prebuilt binary, RPC backoff) also speed up the
other ignored restart/observer/sync e2e tests for free.

## Changes

**Finding 1 — CPU de-contention (`.config/nextest.toml`)**
- Every e2e test spawns 4-6 node processes, and the heavy `#[ignore]`d ones
  (restart, epoch, observer, basefee, metrics, sync) run for minutes.  Under
  `max-threads = 2` two of them co-scheduled, putting 12+ node processes on the
  box and inflating wall time ~3.5-4x.
- Capped the whole `e2e` test-group at `max-threads = 1` (both `default` and
  `ci` profiles), so no two e2e tests ever run concurrently.  A single group is
  deliberately chosen over a name-matched "heavy" subset: it also covers heavy
  tests added later (there are already `basefee`/`metrics` ones that a
  restart/epoch/observer name filter would miss) and, being one group, cannot
  overlap itself.  The 720s slow-timeout and ci `retries = 0` overrides are
  preserved.  `cargo nextest show-config test-groups` confirms `e2e (max threads = 1)`
  applies to every e2e test.

**Finding 2 — event-driven restart downtime (`restarts.rs`)**
- Replaced the fixed 70s post-kill sleep in `run_restart_tests1` /
  `run_restart_tests_lagged1` with `wait_for_downtime`, which polls the live
  validators' consensus chain and returns once a floor has elapsed **and** the
  peers have actually advanced.
- The delayed tests now pass `60` instead of `70`.  Demotion to the
  follow/catch-up path happens once a node falls outside the GC window
  (`crates/consensus/primary/src/network/handler.rs`:
  `effective_exec_round + (gc_depth - 10) < round`, i.e. > 40 rounds behind with
  the default `gc_depth = 50`).  At the tests' `--max-header-delay-ms 1000`
  cadence (~1 round/s) the 60s floor clears that ~40-round / ~40s threshold with
  margin, so the restarted node still exercises the follow path.  The floor is the
  actual guarantee (valid because `max_header_delay` bounds the round period and
  Finding 1 now runs the e2e group serially, so nothing else steals cores);  the
  peer-advancement check is a stall-guard so the wait can't end while the network
  is wedged, and a fail-safe cap prevents hangs.  (An earlier draft used a 50s
  floor; review flagged it as too tight under load, so it was raised to 60 —
  still 10s/test faster than the old 70s sleep.)

**Finding 3 — no retries on dead-node checks (`restarts.rs`)**
- The six balance checks that assert a *known-shut-down* node is unreachable
  used `retries = 5` (~5s of 1s-spaced retries each).  A dead node cannot recover,
  so these now use `retries = 0` and fail immediately.  `kill_child`/`kill_all`
  wait for process exit before the checks run, so the connection is already
  refused.

**Finding 4 — shorter epoch, floored deadlines (`epochs.rs`)**
- `EPOCH_DURATION` 10s -> 5s (the consensus minimum).  It feeds genesis via
  `--epoch-duration-in-secs`, so `assert_eq!(epochInfo.epochDuration, EPOCH_DURATION)`
  still holds and epoch counts are unchanged.
- The two `tn_epochRecord` certificate-availability polls are floored at 30s and
  60s absolute (`(EPOCH_DURATION * 3).max(30)`, `(EPOCH_DURATION * 6).max(60)`).
  Certificate production is a fixed async quorum-voting cost (~62s worst case
  when a new validator joins mid-test), so those deadlines must not shrink with
  the epoch cadence.  All other epoch-scaled deadlines (epoch-change polls,
  first-epoch offset, tx-confirm timeout) legitimately track the cadence and
  still hold at 5s.
- The separate `EPOCH_DURATION`/`PACK_IMPORT_EPOCH_DURATION` constants in
  `sync.rs` and `basefee.rs` are intentionally left at 10s (those tests are
  outside the four-test scope);  their comments are updated to note the
  deliberate divergence from `epochs.rs` rather than silently going stale.

**Finding 5 — build the node binary once (`lib.rs`, `Makefile`)**
- `get_telcoin_network_binary` now honors `TN_BIN_PATH`: when set it uses the
  prebuilt binary and runs no per-process cargo build (escargot otherwise costs
  ~3-10s of overhead per test process).  When unset it falls back to the existing
  escargot build, so `cargo nextest`/`cargo test` still work with no setup.
- Added a `build-e2e-bin` make target
  (`cargo build --bin telcoin-network --features tn-storage/test-utils`) and
  threaded `TN_BIN_PATH=$(E2E_BIN)` through `test-restarts`, `test-e2e`, and
  `public-tests`.

**Finding 6 — tighter polling (`common.rs`, `restarts.rs`)**
- RPC retry backoff in `call_rpc_inner` 1s -> 250ms (these retries only mask
  brief unavailability such as a node mid-restart).
- The lagged-restart transaction settle is now event-driven: poll a live peer
  until the transfer lands (`get_balance_above_with_retry`) instead of a blind
  5s sleep before restarting the lagged node.

## Acceptance criteria

- [x] All four tests keep identical assertions — only timing constants and the
      wait mechanism changed.
- [x] No epoch-count or iteration-count reductions (the `0..25` / `loop_epochs`
      counts are untouched; only `EPOCH_DURATION` changed).
- [x] Restart follow-path coverage preserved — the 60s downtime floor still
      exceeds the ~40-round GC-window demotion threshold at the test cadence.
- [ ] **≥25% aggregate speedup** — expected from the de-contention (heavy tests
      no longer contend), the epoch-duration halving (~38-48% per epoch test),
      the 70->60s and 5s->event-driven restart waits, and the build-once binary.
      Please confirm the aggregate number from a CI run / a full
      `make public-tests` on the reference machine — see the note below.

## Verification

- `cargo +nightly-2026-03-20 fmt --check` clean.
- `cargo check -p e2e-tests --tests` compiles clean (0 warnings; the whole `it`
  test binary, including `basefee`/`metrics`, builds against the `TestBinary`
  refactor).
- `cargo +nightly-2026-03-20 clippy -p e2e-tests --all-features -- -D warnings`
  passes (0 warnings) — this matches CI's `cargo clippy --all --all-features --
  -D warnings`, which gates the lib; `TestBinary` derives `Debug` so it does not
  trip the workspace `missing_debug_implementations` lint under `-D warnings`.
- `cargo build --bin telcoin-network --features tn-storage/test-utils` (the
  `build-e2e-bin` invocation) builds successfully → the prebuilt binary path is
  valid.
- `cargo nextest show-config test-groups` reports `e2e (max threads = 1)` applied
  to every e2e test;  `make -n test-restarts` / `test-e2e` confirm `build-e2e-bin`
  runs first and `TN_BIN_PATH` is threaded correctly.
- Reviewed with a multi-agent adversarial pass; its findings led to three
  hardening changes already folded in here: the nextest de-contention was made a
  single `max-threads = 1` group (the earlier name-matched filter missed the
  `basefee`/`metrics` heavy tests), `TestBinary` got `#[derive(Debug)]`, and
  `build-e2e-bin` pins `--target-dir` (so a set `CARGO_TARGET_DIR` can't make
  `TN_BIN_PATH` point at a missing file).
- The heavy e2e suite was not run end-to-end locally (multi-process, resource
  heavy);  the **≥25% aggregate-speedup** AC should be validated in CI or on the
  maintainer's machine via `make public-tests`.
