### PR TITLE
fix(consensus): make the consensus-output batch-count bound symmetric across writer and reader

### DIFF
--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -130,6 +130,11 @@ where
         network_config: NetworkConfig,
         next_committee_keys: Vec<BlsPublicKey>,
     ) -> eyre::Result<Self> {
+        // Reject a configuration whose consensus parameters exceed the protocol ceilings the
+        // consensus-pack reader relies on, so a node can never commit an output it cannot later
+        // reconstruct.
+        config.parameters.validate()?;
+
         let local_network = LocalNetwork::new(key_config.primary_public_key());
 
         let primary_public_key = key_config.primary_public_key();

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -288,7 +288,7 @@ impl Parameters {
     }
 
     fn default_max_header_num_of_batches() -> usize {
-        10
+        tn_types::MAX_HEADER_NUM_OF_BATCHES
     }
 
     fn default_max_header_delay() -> Duration {
@@ -301,7 +301,7 @@ impl Parameters {
 
     /// The default gc depth for consensus.
     pub fn default_gc_depth() -> u32 {
-        50
+        tn_types::MAX_GC_DEPTH
     }
 
     fn default_sync_retry_delay() -> Duration {
@@ -371,6 +371,32 @@ impl Default for Parameters {
 }
 
 impl Parameters {
+    /// Validate protocol-critical parameters against the ceilings the rest of the protocol depends
+    /// on.
+    ///
+    /// `gc_depth` and `max_header_num_of_batches` together bound how many unique batches a single
+    /// committed [`ConsensusOutput`](tn_types::ConsensusOutput) can reference. The consensus-pack
+    /// reader derives its reconstruction bound from [`tn_types::MAX_GC_DEPTH`] and
+    /// [`tn_types::MAX_HEADER_NUM_OF_BATCHES`], so a node configured above those ceilings could
+    /// commit an output that no node (including itself, on restart) can later reconstruct.
+    /// Rejecting such a configuration at startup keeps the producing and reconstructing halves
+    /// in agreement.
+    pub fn validate(&self) -> eyre::Result<()> {
+        eyre::ensure!(
+            self.gc_depth <= tn_types::MAX_GC_DEPTH,
+            "gc_depth {} exceeds the protocol maximum {}",
+            self.gc_depth,
+            tn_types::MAX_GC_DEPTH,
+        );
+        eyre::ensure!(
+            self.max_header_num_of_batches <= tn_types::MAX_HEADER_NUM_OF_BATCHES,
+            "max_header_num_of_batches {} exceeds the protocol maximum {}",
+            self.max_header_num_of_batches,
+            tn_types::MAX_HEADER_NUM_OF_BATCHES,
+        );
+        Ok(())
+    }
+
     /// Tracing::info! for [Self].
     pub fn tracing(&self) {
         info!("Header number of batches threshold set to {}", self.header_num_of_batches_threshold);
@@ -382,5 +408,33 @@ impl Parameters {
         info!("Sync retry nodes set to {} nodes", self.sync_retry_nodes);
         info!("Max batch delay set to {} ms", self.max_batch_delay.as_millis());
         info!("Max concurrent requests set to {}", self.max_concurrent_requests);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Parameters;
+
+    #[test]
+    fn default_parameters_are_within_protocol_ceilings() {
+        Parameters::default().validate().expect("default parameters must validate");
+    }
+
+    #[test]
+    fn parameters_reject_gc_depth_over_ceiling() {
+        let params = Parameters { gc_depth: tn_types::MAX_GC_DEPTH + 1, ..Default::default() };
+        assert!(params.validate().is_err(), "gc_depth over the protocol ceiling must be rejected");
+    }
+
+    #[test]
+    fn parameters_reject_max_header_num_of_batches_over_ceiling() {
+        let params = Parameters {
+            max_header_num_of_batches: tn_types::MAX_HEADER_NUM_OF_BATCHES + 1,
+            ..Default::default()
+        };
+        assert!(
+            params.validate().is_err(),
+            "max_header_num_of_batches over the protocol ceiling must be rejected"
+        );
     }
 }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -463,8 +463,11 @@ impl<DB: Database> Subscriber<DB> {
             }
         }
 
-        // SAFETY: 10-node committees * 6-round commit max * 5 batch max = 300 max batch digests
-        // possible 32bytes * 300 = 9.6 kb => well within 1MB max message size
+        // A committed sub-DAG spans at most `MAX_GC_DEPTH` rounds, with at most one certificate per
+        // authority per round and at most `MAX_HEADER_NUM_OF_BATCHES` batches per header, so
+        // `batch_set` holds at most `committee.size() * MAX_GC_DEPTH * MAX_HEADER_NUM_OF_BATCHES`
+        // unique digests.  The consensus-pack reader (`max_batches_per_output`) uses that same
+        // bound, so every output built here can later be reconstructed from pack storage.
         let mut fetched_batches = self.fetch_batches_from_peers(batch_set).await?;
 
         let mut batches = Vec::with_capacity(num_certs);

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -463,11 +463,16 @@ impl<DB: Database> Subscriber<DB> {
             }
         }
 
-        // A committed sub-DAG spans at most `MAX_GC_DEPTH` rounds, with at most one certificate per
-        // authority per round and at most `MAX_HEADER_NUM_OF_BATCHES` batches per header, so
-        // `batch_set` holds at most `committee.size() * MAX_GC_DEPTH * MAX_HEADER_NUM_OF_BATCHES`
-        // unique digests.  The consensus-pack reader (`max_batches_per_output`) uses that same
-        // bound, so every output built here can later be reconstructed from pack storage.
+        // `MAX_GC_DEPTH` is the garbage-collection horizon, not the depth a commit reaches: a
+        // sub-DAG is usually only a few rounds deep (`order_dag` descends only to `gc_round + 1`
+        // and skips already-committed rounds), but because no certificate at or below
+        // `gc_round` is ever committed, a committed sub-DAG spans at most `MAX_GC_DEPTH`
+        // distinct rounds as a safe over-estimate.  With at most one certificate per
+        // authority per round and at most `MAX_HEADER_NUM_OF_BATCHES` batches per header,
+        // `batch_set` holds at most `committee.size() * MAX_GC_DEPTH *
+        // MAX_HEADER_NUM_OF_BATCHES` unique digests.  The consensus-pack reader
+        // (`max_batches_per_output`) uses that same bound, so every output built here can
+        // later be reconstructed from pack storage.
         let mut fetched_batches = self.fetch_batches_from_peers(batch_set).await?;
 
         let mut batches = Vec::with_capacity(num_certs);

--- a/crates/consensus/primary/src/error/network.rs
+++ b/crates/consensus/primary/src/error/network.rs
@@ -201,6 +201,7 @@ fn penalty_from_header_error(error: &HeaderError) -> Option<Penalty> {
         | HeaderError::AlreadyVoted(_, _)
         | HeaderError::DuplicateParents
         | HeaderError::TooManyParents(_, _)
+        | HeaderError::TooManyBatches(_, _)
         | HeaderError::UnknownNetworkKey(_)
         | HeaderError::PeerNotAuthor
         | HeaderError::InvalidGenesisParent(_)

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use std::collections::BTreeSet;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
-use tn_types::{now, HeaderBuilder, B256};
+use tn_types::{error::HeaderError, now, HeaderBuilder, B256, MAX_HEADER_NUM_OF_BATCHES};
 
 #[tokio::test]
 async fn test_empty_proposal() {
@@ -34,6 +34,31 @@ async fn test_empty_proposal() {
     assert!(header.validate(&committee).is_ok());
 
     // TODO: assert header el state present
+}
+
+/// A header at the protocol batch ceiling validates, but one batch over is rejected.  This keeps
+/// the per-header batch count a genuine consensus invariant (not just a proposer convention), which
+/// is what lets the consensus-pack reader bound the batches per output and always reconstruct a
+/// committed sub-DAG (#896).
+#[tokio::test]
+async fn test_header_rejects_too_many_batches() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+
+    // Random, distinct batch digests keyed to worker 0; only the payload length differs.
+    let at_ceiling: IndexMap<B256, u16> =
+        (0..MAX_HEADER_NUM_OF_BATCHES).map(|_| (B256::random(), 0)).collect();
+    let ok = primary.header_builder(&committee).payload(at_ceiling).build();
+    assert!(ok.validate(&committee).is_ok(), "header at the ceiling must validate");
+
+    let over_ceiling: IndexMap<B256, u16> =
+        (0..MAX_HEADER_NUM_OF_BATCHES + 1).map(|_| (B256::random(), 0)).collect();
+    let too_many = primary.header_builder(&committee).payload(over_ceiling).build();
+    assert!(
+        matches!(too_many.validate(&committee), Err(HeaderError::TooManyBatches(_, _))),
+        "header over the ceiling must be rejected"
+    );
 }
 
 #[tokio::test]

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -198,6 +198,7 @@ Source: `crates/consensus/primary/src/error/network.rs:137-171`.
 | `AlreadyVoted(_, _)`               | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
 | `DuplicateParents`                 | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
 | `TooManyParents(_, _)`             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
+| `TooManyBatches(_, _)`             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
 | `UnknownNetworkKey(_)`             | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
 | `PeerNotAuthor`                    | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |
 | `InvalidGenesisParent(_)`          | `Fatal`  | `crates/consensus/primary/src/error/network.rs:153-164` |

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -20,7 +20,7 @@ use tn_types::{
     gas_accumulator::RewardsCounter, AuthorityIdentifier, Batch, BlockHash, BlockNumHash,
     BlsPublicKey, CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader,
     ConsensusHeaderDigest, ConsensusNumHash, ConsensusOutput, Epoch, EpochRecord, Hash as _, Round,
-    B256,
+    B256, MAX_GC_DEPTH, MAX_HEADER_NUM_OF_BATCHES,
 };
 use tokio::{
     io::{AsyncRead, BufReader},
@@ -1311,15 +1311,21 @@ pub(crate) fn verify_epoch_meta(
     Ok(())
 }
 
-/// Upper bound on how many `Batch` records `iter_to_output` will buffer before the
-/// terminating `Consensus` record.  This caps memory use when reading a (possibly hostile)
-/// peer stream; a legitimate ConsensusOutput references far fewer batches than this.
-#[cfg(not(test))]
-const MAX_BATCHES_PER_OUTPUT: usize = 1_000;
-/// Lowered in tests so the cap can be exercised cheaply; legitimate test outputs use only a
-/// handful of batches, well under this.
-#[cfg(test)]
-const MAX_BATCHES_PER_OUTPUT: usize = 50;
+/// Upper bound on how many `Batch` records `iter_to_output` will buffer before the terminating
+/// `Consensus` record, derived from the committee that produced the output.
+///
+/// A single `CommittedSubDag` spans at most [`MAX_GC_DEPTH`] rounds (`order_dag` descends only to
+/// `gc_round + 1`), with at most one certificate per authority per round and at most
+/// [`MAX_HEADER_NUM_OF_BATCHES`] batches per header (the proposer self-limits and
+/// `Header::validate` rejects oversized inbound headers).  So a legitimately committed output
+/// references at most `committee.size() * MAX_GC_DEPTH * MAX_HEADER_NUM_OF_BATCHES` unique batches.
+/// Bounding the reader at exactly that maximum keeps the writer and reader in agreement by
+/// construction — every executed output can be reconstructed — while still capping an
+/// unauthenticated peer flood of `Batch` records (the sub-DAG is only authenticated *after* decode,
+/// and the per-record size cap does not bound their count).
+fn max_batches_per_output(committee: &Committee) -> usize {
+    committee.size().saturating_mul(MAX_GC_DEPTH as usize).saturating_mul(MAX_HEADER_NUM_OF_BATCHES)
+}
 
 /// Take an async stream of bytes that in pack file representation of ConsensusOutput and return the
 /// ConsensusOutput.
@@ -1358,6 +1364,7 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
     let mut available_batches = HashMap::new();
     let mut referenced_batches = HashSet::new();
     let mut batch_records = 0_usize;
+    let max_batches = max_batches_per_output(committee);
     while let Some(record) = next(stream_iter, timeout).await? {
         match record {
             PackRecord::EpochMeta(_epoch_meta) => {
@@ -1367,11 +1374,13 @@ async fn iter_to_output<R: AsyncRead + Unpin>(
                 // Bound how many batch records a (possibly hostile) stream can deliver before the
                 // terminating Consensus record arrives.  Without this an `EpochMeta`/`Consensus`
                 // -less flood of Batch records would grow `available_batches` until OOM; the
-                // per-record size cap (MAX_RECORD_SIZE) only bounds individual records.  A
-                // legitimate ConsensusOutput references far fewer batches than this.
+                // per-record size cap (MAX_RECORD_SIZE) only bounds individual records.  The bound
+                // is the maximum a legitimately committed output for this committee
+                // can reference (see `max_batches_per_output`), so an honest deep
+                // sub-DAG is never rejected.
                 batch_records += 1;
-                if batch_records > MAX_BATCHES_PER_OUTPUT {
-                    return Err(PackError::TooManyBatches(MAX_BATCHES_PER_OUTPUT));
+                if batch_records > max_batches {
+                    return Err(PackError::TooManyBatches(max_batches));
                 }
                 let batch_digest = batch.digest();
                 available_batches.insert(batch_digest, batch);
@@ -1656,9 +1665,9 @@ pub(crate) mod test {
     use tn_reth::RethChainSpec;
     use tn_test_utils::CommitteeFixture;
     use tn_types::{
-        test_genesis, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
-        ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, EpochRecord, Hash, HeaderBuilder,
-        ReputationScores,
+        test_genesis, Batch, BlockHash, Certificate, CertifiedBatch, CommittedSubDag, Committee,
+        ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput, EpochRecord, ExecHeader, Hash,
+        HeaderBuilder, ReputationScores,
     };
 
     use crate::{
@@ -1667,9 +1676,63 @@ pub(crate) mod test {
             pack::{DataHeader, PackCompression},
             position_index::index::PositionIndex,
         },
-        consensus_pack::{ConsensusPack, IndexPositions, Inner},
+        consensus_pack::{max_batches_per_output, ConsensusPack, IndexPositions, Inner},
         mem_db::MemDatabase,
     };
+
+    /// Build a [`ConsensusOutput`] whose single leader header references `num_batches` unique
+    /// batches, standing in for a deep sub-DAG that exceeds the old fixed reconstruction cap
+    /// but stays within the committee-derived bound.
+    fn make_wide_test_output(
+        committee: &Committee,
+        chain: Arc<RethChainSpec>,
+        number: u64,
+        parent: ConsensusHeaderDigest,
+        num_batches: usize,
+    ) -> ConsensusOutput {
+        // Reuse one transaction across many cheaply-distinct batches (each batch differs only by
+        // its `epoch` field, which is enough to give it a unique digest) so a wide output
+        // does not generate O(n^2) transactions.
+        let txs =
+            tn_reth::test_utils::batches(chain, 1).pop().expect("one batch").transactions().clone();
+        let batches: Vec<Batch> = (0..num_batches as u32)
+            .map(|epoch| Batch::new_for_test(txs.clone(), ExecHeader::default(), 0, epoch))
+            .collect();
+        let authorities = committee.authorities();
+        let authority = authorities.first().expect("committee has authorities");
+        let author_id = authority.id();
+        let producer = authority.execution_address();
+
+        let mut leader = Certificate::default();
+        leader.update_header_author_for_test(author_id);
+        // Accumulate the whole payload on a single builder so the header is only hashed once.
+        let header = batches
+            .iter()
+            .fold(HeaderBuilder::from_header(leader.header()), |builder, batch| {
+                builder.with_payload_batch(batch, 0_u16)
+            })
+            .build();
+        leader.update_header_for_test(header);
+        leader.update_header_round_for_test(1);
+        leader.update_header_epoch_for_test(committee.epoch());
+
+        let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+        let sub_dag = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader,
+            1,
+            ReputationScores::default(),
+            None,
+        );
+        ConsensusOutput::new(
+            sub_dag,
+            parent,
+            number,
+            false,
+            batch_digests,
+            vec![CertifiedBatch { address: producer, batches }],
+        )
+    }
 
     pub(crate) fn make_test_output(
         committee: &Committee,
@@ -2258,7 +2321,7 @@ pub(crate) mod test {
     async fn test_iter_to_output_caps_buffered_batches() {
         use crate::{
             archive::pack::{Pack, DATA_HEADER_BYTES},
-            consensus_pack::{bytes_to_output, PackError, PackRecord, MAX_BATCHES_PER_OUTPUT},
+            consensus_pack::{bytes_to_output, max_batches_per_output, PackError, PackRecord},
         };
         use std::io::Cursor;
 
@@ -2266,6 +2329,9 @@ pub(crate) mod test {
         let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
         let fixture = CommitteeFixture::builder(MemDatabase::default).build();
         let committee = fixture.committee();
+        // The reader bound is derived from this committee, so an unauthenticated flood past it must
+        // still be rejected to guard against OOM.
+        let max_batches = max_batches_per_output(&committee);
 
         // Build a record stream of more batch records than the cap with no Consensus record.
         let path = temp_dir.path().join("batch_only");
@@ -2273,7 +2339,7 @@ pub(crate) mod test {
             let mut pack: Pack<PackRecord> =
                 Pack::open(&path, 0, false, PackCompression::ZStd).expect("open pack");
             let batch = tn_reth::test_utils::batches(chain.clone(), 1).pop().expect("one batch");
-            for _ in 0..(MAX_BATCHES_PER_OUTPUT + 5) {
+            for _ in 0..(max_batches + 5) {
                 pack.append(&PackRecord::Batch(batch.clone())).expect("append batch");
             }
             pack.commit().expect("commit");
@@ -2290,6 +2356,34 @@ pub(crate) mod test {
         )
         .await;
         assert!(matches!(res, Err(PackError::TooManyBatches(_))), "expected TooManyBatches");
+    }
+
+    /// A `ConsensusOutput` that references more than the old fixed 1000-batch cap but stays within
+    /// the committee-derived bound must round-trip through the pack: it is executed live on
+    /// every node, so it must always be reconstructable.  Regression test for the writer/reader
+    /// batch-count asymmetry (#896) — before the fix the write succeeded but the read failed
+    /// with `TooManyBatches`, wedging restart replay and observer sync.
+    #[tokio::test]
+    async fn test_deep_output_round_trips() {
+        let temp_dir = TempDir::with_prefix("test_cp_deep_output").expect("temp dir");
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+
+        let max_batches = max_batches_per_output(&committee);
+        assert!(max_batches > 1_000, "derived bound must exceed the old fixed 1000 cap");
+        // Exceeds the old fixed cap yet stays within the committee-derived bound.
+        let num_batches = 1_100;
+        assert!(num_batches < max_batches, "test output must fit within the derived bound");
+
+        let previous_epoch = test_previous_epoch(&committee);
+        let pack = ConsensusPack::open_append(temp_dir.path(), previous_epoch, committee.clone())
+            .expect("open pack");
+        let parent = ConsensusHeader::default().digest();
+        let output = make_wide_test_output(&committee, chain.clone(), 1, parent, num_batches);
+        pack.save_consensus_output(output.clone()).await.expect("save deep output");
+        let read_back = pack.get_consensus_output(1).await.expect("read back deep output");
+        compare_outputs(&output, &read_back);
     }
 
     /// CP2: get_consensus_output with a number below start_consensus_number must error rather

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1314,15 +1314,20 @@ pub(crate) fn verify_epoch_meta(
 /// Upper bound on how many `Batch` records `iter_to_output` will buffer before the terminating
 /// `Consensus` record, derived from the committee that produced the output.
 ///
-/// A single `CommittedSubDag` spans at most [`MAX_GC_DEPTH`] rounds (`order_dag` descends only to
-/// `gc_round + 1`), with at most one certificate per authority per round and at most
+/// [`MAX_GC_DEPTH`] is the garbage-collection horizon, not the depth a commit actually reaches.
+/// `order_dag` descends only to `gc_round + 1` and additionally skips any round already committed
+/// per authority, so in practice a sub-DAG is only a handful of rounds deep (a leader commits every
+/// couple of rounds).  It serves purely as a safe ceiling: because no certificate at or below
+/// `gc_round` can ever be linked into a commit, a single `CommittedSubDag` references certificates
+/// from at most [`MAX_GC_DEPTH`] distinct rounds, a deliberately loose over-estimate that holds
+/// regardless of commit cadence.  With at most one certificate per authority per round and at most
 /// [`MAX_HEADER_NUM_OF_BATCHES`] batches per header (the proposer self-limits and
-/// `Header::validate` rejects oversized inbound headers).  So a legitimately committed output
+/// `Header::validate` rejects oversized inbound headers), a legitimately committed output therefore
 /// references at most `committee.size() * MAX_GC_DEPTH * MAX_HEADER_NUM_OF_BATCHES` unique batches.
 /// Bounding the reader at exactly that maximum keeps the writer and reader in agreement by
-/// construction — every executed output can be reconstructed — while still capping an
-/// unauthenticated peer flood of `Batch` records (the sub-DAG is only authenticated *after* decode,
-/// and the per-record size cap does not bound their count).
+/// construction (every executed output can be reconstructed) while still capping an unauthenticated
+/// peer flood of `Batch` records (the sub-DAG is only authenticated *after* decode, and the
+/// per-record size cap does not bound their count).
 fn max_batches_per_output(committee: &Committee) -> usize {
     committee.size().saturating_mul(MAX_GC_DEPTH as usize).saturating_mul(MAX_HEADER_NUM_OF_BATCHES)
 }

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -217,6 +217,9 @@ pub enum HeaderError {
     /// Vote request includes too many parents.
     #[error("Too many parents in vote request: {0} > {1}")]
     TooManyParents(usize, usize),
+    /// Header references more batch digests than the protocol permits.
+    #[error("Header references too many batches: {0} > {1}")]
+    TooManyBatches(usize, usize),
     /// Vote request includes parent(s) that were not requested.
     #[error("Got parents we did not request")]
     InvalidParents,

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -2,7 +2,7 @@ use crate::{
     crypto, encode,
     error::{HeaderError, HeaderResult},
     now, AuthorityIdentifier, Batch, BlockHash, BlockNumHash, Committee, Digest, Epoch, Hash,
-    Round, TimestampSec, VoteDigest, WorkerId,
+    Round, TimestampSec, VoteDigest, WorkerId, MAX_HEADER_NUM_OF_BATCHES,
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -109,6 +109,20 @@ impl Header {
         // Ensure we don't have too many parents.
         if self.inner.parents.len() > committee.size() {
             return Err(HeaderError::TooManyParents(self.inner.parents.len(), committee.size()));
+        }
+
+        // Ensure the header does not reference more batches than the protocol permits.  The
+        // proposer already caps its own headers at the configured
+        // `max_header_num_of_batches` (validated to be <= MAX_HEADER_NUM_OF_BATCHES by
+        // `Parameters::validate`); rejecting oversized inbound headers keeps the per-header
+        // batch count a genuine consensus invariant, which bounds how many unique batches a
+        // committed sub-DAG can reference and so keeps every committed output reconstructable
+        // from pack storage.
+        if self.inner.payload.len() > MAX_HEADER_NUM_OF_BATCHES {
+            return Err(HeaderError::TooManyBatches(
+                self.inner.payload.len(),
+                MAX_HEADER_NUM_OF_BATCHES,
+            ));
         }
 
         // Note that self.digest() MUST be set correctly so no need to check.  We could add a panic

--- a/crates/types/src/primary/mod.rs
+++ b/crates/types/src/primary/mod.rs
@@ -31,6 +31,25 @@ pub const DEFAULT_PRIMARY_PORT: u16 = 44894;
 /// same list (good or bad) not unfairly be punished while another node is rewarded.
 pub const DEFAULT_BAD_NODES_STAKE_THRESHOLD: u64 = 33;
 
+/// Maximum garbage-collection depth, in consensus rounds, that the protocol supports.
+///
+/// A single `CommittedSubDag` is the causal history of one leader certificate down to
+/// `gc_round + 1`, so it spans at most this many rounds (see `order_dag`). A node's configured
+/// `gc_depth` is validated against this ceiling by `Parameters::validate`, and the consensus-pack
+/// reconstruction bound (`max_batches_per_output`) is derived from it, so raising this value
+/// requires re-deriving that bound.
+pub const MAX_GC_DEPTH: Round = 50;
+
+/// Maximum number of batch digests a single primary `Header` may reference.
+///
+/// The proposer caps its own headers at the configured `max_header_num_of_batches`, and
+/// `Header::validate` rejects any inbound header that exceeds this protocol ceiling, so the
+/// per-header batch count is a genuine consensus invariant rather than a proposer-only convention.
+/// Together with [`MAX_GC_DEPTH`] and the committee size it bounds the number of unique batches a
+/// committed `ConsensusOutput` can contain, which the consensus-pack reader relies on to
+/// reconstruct every executed output.
+pub const MAX_HEADER_NUM_OF_BATCHES: usize = 10;
+
 /// The round number.
 /// Becomes the lower 32 bits of a nonce (with epoch the high bits).
 pub type Round = u32;

--- a/crates/types/src/primary/mod.rs
+++ b/crates/types/src/primary/mod.rs
@@ -33,11 +33,15 @@ pub const DEFAULT_BAD_NODES_STAKE_THRESHOLD: u64 = 33;
 
 /// Maximum garbage-collection depth, in consensus rounds, that the protocol supports.
 ///
-/// A single `CommittedSubDag` is the causal history of one leader certificate down to
-/// `gc_round + 1`, so it spans at most this many rounds (see `order_dag`). A node's configured
+/// This is the garbage-collection horizon, not the depth a commit actually reaches: `order_dag`
+/// descends only to `gc_round + 1` and additionally skips any round already committed per
+/// authority, so a `CommittedSubDag` is usually only a handful of rounds deep (a leader commits
+/// every couple of rounds).  It serves purely as a safe ceiling: because no certificate at or below
+/// `gc_round` can ever be linked into a commit, no sub-DAG can span more than this many rounds, a
+/// deliberately loose over-estimate that holds regardless of commit cadence.  A node's configured
 /// `gc_depth` is validated against this ceiling by `Parameters::validate`, and the consensus-pack
-/// reconstruction bound (`max_batches_per_output`) is derived from it, so raising this value
-/// requires re-deriving that bound.
+/// reconstruction bound (`max_batches_per_output`) is derived from it as a conservative
+/// over-estimate, so raising this value requires re-deriving that bound.
 pub const MAX_GC_DEPTH: Round = 50;
 
 /// Maximum number of batch digests a single primary `Header` may reference.


### PR DESCRIPTION
## Summary

Fixes #896.  A `ConsensusOutput` was produced, executed, and written to the pack with no bound on how many batches it may contain, but the pack reader capped it at a fixed `MAX_BATCHES_PER_OUTPUT = 1000` and returned `PackError::TooManyBatches` past that.  The producing and reconstructing halves disagreed, and nothing at consensus-commit time kept a sub-DAG under the reader's limit.

Under real mainnet parameters (`gc_depth = 50`, `max_header_num_of_batches = 10`, committee = 5) a single committed sub-DAG can reference ~2500 batches during an ordinary leader stall, which every node executes live but no node can reconstruct.  The consequences (no attacker required):

- **Restart crash-loop.** `replay_missed_consensus` re-reads the node's own oversized block through the capped decoder, propagates `TooManyBatches` with `?`, and shuts the node down.  The block stays in the pack, so every boot re-hits it.
- **Observer / rejoining-CVV wedge.** Sync decodes the fetched output, gets `TooManyBatches`, and returns `Retry` forever — the catch-up loop has no permanent-failure exit, so the node never advances past that height.
- **Honest peers penalized.** A peer serving the legitimate bytes is scored `Penalty::Severe`.

## Root cause

`MAX_BATCHES_PER_OUTPUT` was a reader-only guard whose comment assumed "a legitimate ConsensusOutput references far fewer batches than this," but no invariant at commit time enforced that.  A cap that is not symmetric across producing and reconstructing is a divergence source, not a safety bound.

## Fix

Make the batch-count bound a shared consensus invariant that the producer and the reader agree on by construction.

- **Reader bound is derived, not guessed.** `iter_to_output` now bounds buffered batches at `committee.size() * MAX_GC_DEPTH * MAX_HEADER_NUM_OF_BATCHES`, using the committee it already holds.  That is exactly the maximum a legitimately committed output can reference (a sub-DAG spans at most `gc_depth` rounds, one certificate per authority per round, at most `max_header_num_of_batches` batches per header), so an honest deep sub-DAG is never rejected — while an unauthenticated peer flood is still bounded (the sub-DAG is only authenticated *after* decode, so the cap remains load-bearing against OOM).
- **Producer side is enforced against the same maximum.** New `MAX_GC_DEPTH` / `MAX_HEADER_NUM_OF_BATCHES` protocol constants in `tn-types`;  `Parameters::validate` rejects a node configured above them (called from `ConsensusConfig::new_with_committee`, so every startup and epoch transition is checked); and `Header::validate` rejects any inbound header referencing more than `MAX_HEADER_NUM_OF_BATCHES` batches, so a certified header can never push a committed sub-DAG past the reader bound.
- **Stale comments corrected** in `subscriber.rs` (the "10-node committees * 6-round commit max * 5 batch max = 300" note) and `consensus_pack.rs` (the "far fewer batches than this" claim).

## Changes

- `crates/types/src/primary/mod.rs` — add `MAX_GC_DEPTH` and `MAX_HEADER_NUM_OF_BATCHES` protocol constants.
- `crates/types/src/error.rs` — add `HeaderError::TooManyBatches`.
- `crates/types/src/primary/header.rs` — `Header::validate` rejects an over-ceiling payload.
- `crates/config/src/node.rs` — `gc_depth` / `max_header_num_of_batches` defaults reference the constants; add `Parameters::validate`; tests.
- `crates/config/src/consensus.rs` — validate parameters in `new_with_committee`.
- `crates/storage/src/consensus_pack.rs` — derive the reader bound (`max_batches_per_output`); correct the comment; update the cap test; add a >1000-batch round-trip regression test.
- `crates/consensus/executor/src/subscriber.rs` — correct the stale batch-count comment on the active build path.
- `crates/consensus/primary/src/error/network.rs` — map `HeaderError::TooManyBatches` to `Penalty::Fatal` (malformed header, like `TooManyParents`).
- `crates/consensus/primary/src/tests/proposer_tests.rs` — `Header::validate` ceiling test.

## Tests

- `tn-storage`: a `ConsensusOutput` referencing 1100 batches (over the old fixed cap, within the derived bound) now round-trips through `save_consensus_output` -> pack decode; an unauthenticated flood past the derived bound is still rejected with `TooManyBatches`.
- `tn-primary`: a header at the batch ceiling validates;  one batch over is rejected with `TooManyBatches`.
- `tn-config`: default parameters validate; `gc_depth` / `max_header_num_of_batches` over the ceiling are rejected.

## Notes on the design choices

- **Why not reject at commit/write time?** Rejecting an already-executed output at write time converts the liveness bug into a different one (a node that cannot persist a block it already executed still halts). The bound is enforced *before* commit, at header validation and config load, so an oversized output is never produced in the first place.
- **Why constants rather than persisting the values in the pack?** The reader already carries the committee;  deriving the bound from two protocol constants avoids any pack-format/serialization change while keeping writer and reader in agreement. `gc_depth` and `max_header_num_of_batches` are network-wide protocol parameters (nodes must agree on them or they would compute different sub-DAGs), so treating their ceilings as shared constants is sound; raising a ceiling is a deliberate, coordinated change (the doc comments call this out).

## Deployment note

The new `Header::validate` batch-count check is a consensus-rule tightening, so it should be rolled out the way any consensus change is — at an epoch/version boundary rather than piecemeal within a live epoch.  Concretely: `Header::validate` now rejects (as `Penalty::Fatal`) any header referencing more than `MAX_HEADER_NUM_OF_BATCHES` (10) batches.  Both `mainnet` and `testnet` already run `max_header_num_of_batches: 10`, so no header any honest node produces today exceeds the ceiling and there is no behavioural change for the current networks.  The only exposure is an operator who had raised `max_header_num_of_batches` above 10 (previously unvalidated): during a mixed-version window an upgraded node would reject in-GC-window headers that a non-upgraded peer still accepts.  Such a node also now fails `Parameters::validate` at startup, so the intended migration is to lower the parameter to `<= 10` before upgrading.  If preferred, the `Header::validate` enforcement can be split into a follow-up gated on a version/epoch boundary while landing the storage-side reader bound and config validation first.
