### PR TITLE
Use validator RPC from the current committee

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -935,7 +935,7 @@ where
                 send_or_log_error!(reply, rpc, "GetValidatorRpc");
             }
             NetworkCommand::GetAllValidatorRpcs { reply } => {
-                let rpcs = self.swarm.behaviour().peer_manager.all_rpcs();
+                let rpcs = self.swarm.behaviour_mut().peer_manager.current_committee_rpcs();
                 send_or_log_error!(reply, rpcs, "GetAllValidatorRpcs");
             }
             NetworkCommand::OpenStream { peer, kind, reply } => {

--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -1138,6 +1138,12 @@ impl AllPeers {
         self.apply_committee_membership(committee)
     }
 
+    /// The current committee slot, as set from authoritative epoch state by
+    /// [`Self::update_committees`].
+    pub(super) fn current_committee(&self) -> &HashSet<BlsPublicKey> {
+        &self.current_committee
+    }
+
     /// Whether `bls_key` sits in any tracked committee slot (previous, current, or next).
     ///
     /// Committee membership is set every epoch from authoritative consensus state, so this is the

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -897,11 +897,24 @@ impl PeerManager {
         self.known_peers.get(bls_key).and_then(|info| info.rpc.clone())
     }
 
-    /// Return a snapshot of every known authority that has advertised an [RpcInfo].
-    pub(crate) fn all_rpcs(&self) -> Vec<(BlsPublicKey, RpcInfo)> {
-        self.known_peers
+    /// Return the advertised [RpcInfo] for every current-committee validator, and
+    /// chase node records for current members that are still unknown.
+    ///
+    /// Scoped to the current committee: pinned operator peers and previous/next
+    /// committee members never appear, even if they advertised RPC info. For any
+    /// current member with no known record, kad discovery is (re)triggered via
+    /// [`PeerEvent::MissingAuthorities`] — the same path `update_committees` takes at
+    /// epoch start — so a polling caller converges as records arrive. Members whose
+    /// record is known but carries no RPC info did not advertise one and are skipped
+    /// without a re-fetch.
+    pub(crate) fn current_committee_rpcs(&mut self) -> Vec<(BlsPublicKey, RpcInfo)> {
+        let current = self.peers.current_committee().clone();
+        self.trigger_missing_authorities(&current);
+        current
             .iter()
-            .filter_map(|(bls, info)| info.rpc.clone().map(|rpc| (*bls, rpc)))
+            .filter_map(|bls| {
+                self.known_peers.get(bls).and_then(|info| info.rpc.clone()).map(|rpc| (*bls, rpc))
+            })
             .collect()
     }
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2748,7 +2748,7 @@ async fn test_pre_upgrade_record_accepted_with_default_rpc() -> eyre::Result<()>
 
     // no rpc was advertised so lookups return None
     assert!(network.swarm.behaviour().peer_manager.get_rpc(&owner_bls).is_none());
-    assert!(network.swarm.behaviour().peer_manager.all_rpcs().is_empty());
+    assert!(network.swarm.behaviour_mut().peer_manager.current_committee_rpcs().is_empty());
 
     // honest pre-upgrade sender is not penalized
     assert!(!network.swarm.behaviour().peer_manager.peer_banned(&owner_peer_id));
@@ -2864,7 +2864,7 @@ async fn test_malformed_rpc_scheme_stripped_on_promotion() -> eyre::Result<()> {
     assert_eq!(peer_id, owner_peer_id);
     assert_eq!(multiaddrs, vec![peer2.config.primary_address()]);
     assert!(network.swarm.behaviour().peer_manager.get_rpc(&owner_bls).is_none());
-    assert!(network.swarm.behaviour().peer_manager.all_rpcs().is_empty());
+    assert!(network.swarm.behaviour_mut().peer_manager.current_committee_rpcs().is_empty());
 
     // the sender was not penalized
     assert!(!network.swarm.behaviour().peer_manager.peer_banned(&owner_peer_id));

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -923,6 +923,125 @@ async fn test_known_peers_pruned_on_rotation_but_pinned_survive() {
     );
 }
 
+/// Build a [`NetworkInfo`] like [`random_network_info`], but advertising a valid [`RpcInfo`].
+fn random_network_info_with_rpc() -> (NetworkInfo, RpcInfo) {
+    let rpc = RpcInfo {
+        http: "https://validator.example.com:8545/".parse().expect("http url"),
+        ws: Some("wss://validator.example.com:8546/".parse().expect("ws url")),
+    };
+    let mut info = random_network_info();
+    info.rpc = Some(rpc.clone());
+    (info, rpc)
+}
+
+#[tokio::test]
+async fn test_current_committee_rpcs_scoped_to_current_committee() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // a pinned rpc-advertising peer; pinning keeps its record through committee rotation
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([21; 32])).public();
+    let (info, rpc) = random_network_info_with_rpc();
+    peer_manager.add_known_peer(bls, info);
+
+    // known and advertising, but not a current-committee member: excluded
+    assert!(
+        peer_manager.current_committee_rpcs().is_empty(),
+        "pinned non-committee peer must not appear in the snapshot"
+    );
+
+    // once the peer joins the current committee its advertised rpc is returned
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+    assert_eq!(
+        peer_manager.current_committee_rpcs(),
+        vec![(bls, rpc)],
+        "current-committee member's advertised rpc must be returned"
+    );
+}
+
+#[tokio::test]
+async fn test_current_committee_rpcs_excludes_previous_and_next_only_members() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let mut rng = StdRng::from_seed([22; 32]);
+
+    // rpc-advertising peers with known records, seeded only into previous and next
+    let previous_bls = *BlsKeypair::generate(&mut rng).public();
+    let next_bls = *BlsKeypair::generate(&mut rng).public();
+    let (previous_info, _) = random_network_info_with_rpc();
+    let (next_info, _) = random_network_info_with_rpc();
+    peer_manager.add_known_peer(previous_bls, previous_info);
+    peer_manager.add_known_peer(next_bls, next_info);
+    peer_manager.update_committees(
+        HashSet::from([previous_bls]),
+        HashSet::new(),
+        HashSet::from([next_bls]),
+    );
+    // isolate the call under test from anything update_committees emitted
+    collect_all_events(&mut peer_manager);
+
+    // neither the outgoing nor the incoming member appears in the snapshot
+    assert!(
+        peer_manager.current_committee_rpcs().is_empty(),
+        "previous/next-only members must not appear in the snapshot"
+    );
+    // and no discovery is triggered: the current committee has no missing records
+    let events = collect_all_events(&mut peer_manager);
+    let missing_events = extract_events(&events, |e| matches!(e, PeerEvent::MissingAuthorities(_)));
+    assert!(
+        missing_events.is_empty(),
+        "previous/next-only members must not trigger discovery from the snapshot call"
+    );
+}
+
+#[tokio::test]
+async fn test_current_committee_rpcs_ignores_members_without_advertised_rpc() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // a current-committee member with a known record that advertises no rpc
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([23; 32])).public();
+    peer_manager.add_known_peer(bls, random_network_info());
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+    // isolate the call under test from anything update_committees emitted
+    collect_all_events(&mut peer_manager);
+
+    // the member advertised nothing, so it is excluded from the snapshot ...
+    assert!(
+        peer_manager.current_committee_rpcs().is_empty(),
+        "member without advertised rpc must be excluded"
+    );
+    // ... and its record is known, so no futile re-discovery is triggered
+    let events = collect_all_events(&mut peer_manager);
+    let missing_events = extract_events(&events, |e| matches!(e, PeerEvent::MissingAuthorities(_)));
+    assert!(
+        missing_events.is_empty(),
+        "a known record without rpc must not trigger discovery from the snapshot call"
+    );
+}
+
+#[tokio::test]
+async fn test_current_committee_rpcs_triggers_discovery_for_missing_records() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // a current-committee member whose node record was never discovered
+    let unknown_bls = *BlsKeypair::generate(&mut StdRng::from_seed([24; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([unknown_bls]), HashSet::new());
+    // drain the MissingAuthorities that update_committees itself emitted so the assertions
+    // below observe only what the snapshot call emits
+    collect_all_events(&mut peer_manager);
+
+    // no record means no rpc entry, but the call re-triggers kad discovery for the member
+    assert!(
+        peer_manager.current_committee_rpcs().is_empty(),
+        "member without a record has no rpc to report"
+    );
+    let events = collect_all_events(&mut peer_manager);
+    let missing_events = extract_events(&events, |e| matches!(e, PeerEvent::MissingAuthorities(_)));
+    assert!(missing_events.len() == 1, "expect one fresh missing authorities event");
+    assert_matches!(
+        missing_events.first().unwrap(),
+        PeerEvent::MissingAuthorities(missing) if *missing == [unknown_bls]
+    );
+}
+
 #[tokio::test]
 async fn test_register_outgoing_connection() {
     let mut peer_manager = create_test_peer_manager(None);

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -514,7 +514,8 @@ where
         /// The reply to caller.
         reply: oneshot::Sender<Option<RpcInfo>>,
     },
-    /// Snapshot of all known authority RPCs.
+    /// Snapshot of the current committee's advertised RPCs; triggers kad discovery
+    /// for members with no known record.
     GetAllValidatorRpcs {
         /// The reply to caller.
         reply: oneshot::Sender<Vec<(BlsPublicKey, RpcInfo)>>,
@@ -820,11 +821,13 @@ where
         rx.await.map_err(Into::into)
     }
 
-    /// Snapshot of all known authority RPCs.
+    /// Snapshot of the current committee's advertised RPCs.
     ///
-    /// Returns the RPC info for every known authority that has advertised it.
-    /// Callers that need fresh data should call [`Self::find_authorities`] first
-    /// and wait for discovery to complete.
+    /// Returns the RPC info for every current-committee validator that has
+    /// advertised it. Pinned operator peers and previous/next committee members
+    /// never appear. The call itself (re)triggers kad discovery for current
+    /// members whose node records are still unknown, so a polling caller picks
+    /// up their entries on a later call once the records arrive.
     ///
     /// Only worker [`NodeRecord`]s carry RPC info, so this returns entries on a
     /// worker network handle and an empty list on a primary handle. This is the


### PR DESCRIPTION
# Scope validator RPC snapshot to the current committee

- Replaced `all_rpcs()` (all of `known_peers`) with `current_committee_rpcs()`, filtered through a new `AllPeers::current_committee()` accessor.
- The snapshot call re-triggers kad discovery for current-committee members with no known record, so later polls pick up their entries as discovery converges.
- Updated the doc comments on `NetworkHandle::get_all_validator_rpcs` and `NetworkCommand::GetAllValidatorRpcs` to describe the new scoping and discovery behavior.
- Added test coverage for committee scoping, exclusion of previous/next-only and non-committee members, and discovery triggering for missing current-committee records.

closes #903 
blocked by #820 