### PR TITLE
Harden known peers restore

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -434,9 +434,22 @@ where
             stream_protocols,
         );
 
-        // Promote the surviving records into the local peer cache.
+        // Promote the surviving records into the local peer cache. The store's contents are
+        // peer-fillable (arbitrary signature-valid third-party records held as DHT storage
+        // duty), so entries are restored UNPINNED and stay prunable at the first committee
+        // rotation. Our own record is skipped: both primary and worker key their record by
+        // the primary BLS key, and there is no point caching ourselves as a known peer.
+        let own_key = key_config.primary_public_key();
+        let mut restored: usize = 0;
         for (key, info) in known {
-            behavior.peer_manager.add_known_peer(key, info);
+            if key == own_key {
+                continue;
+            }
+            behavior.peer_manager.add_restored_peer(key, info);
+            restored += 1;
+        }
+        if restored > 0 {
+            info!(target: "network-kad", restored, "restored persisted kad records into the local peer cache");
         }
 
         let network_pubkey = keypair.public().into();
@@ -737,20 +750,20 @@ where
                 let _ = reply.send(Ok(()));
             }
             NetworkCommand::AddBootstrapPeers { peers, reply } => {
-                // update peer manager
+                // update peer manager: always pin bootstrap peers (even when a record already
+                // exists, e.g. restored unpinned from persistence), but never overwrite an
+                // existing record with the config-derived stub
                 let peer = &mut self.swarm.behaviour_mut().peer_manager;
                 for (bls, info) in peers {
-                    if peer.auth_to_peer(bls).is_none() {
-                        peer.add_known_peer(
-                            bls,
-                            NetworkInfo {
-                                pubkey: info.network_key,
-                                multiaddrs: vec![info.network_address],
-                                timestamp: now(),
-                                rpc: None,
-                            },
-                        );
-                    }
+                    peer.add_bootstrap_peer(
+                        bls,
+                        NetworkInfo {
+                            pubkey: info.network_key,
+                            multiaddrs: vec![info.network_address],
+                            timestamp: now(),
+                            rpc: None,
+                        },
+                    );
                 }
                 let _ = reply.send(Ok(()));
             }

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -2025,6 +2025,16 @@ where
     }
 
     /// Cleanup kad record queries (called on last step).
+    ///
+    /// The winning record is promoted ONLY into the peer manager's `known_peers` cache (via
+    /// `add_discovered_peer`) and deliberately NOT written to the kad store: `known_peers` is
+    /// the read model of discovery, and the node needs the resolution, not the record.
+    /// Persisting merely-queried third-party records would enlist libp2p's `PutRecordJob` to
+    /// republish them on every replication run (hourly by libp2p default), making this node an
+    /// hourly replicator of records it never needed to serve, and would erode the store's
+    /// max-records cap — the node's DHT storage-duty budget — with query traffic. Nothing is
+    /// lost: peers push their own records on first connect (an inbound kad put handled by
+    /// [`Self::process_kad_put_request`]), which is the path that legitimately feeds the store.
     fn close_kad_query(&mut self, query_id: &QueryId) {
         if let Some(query) = self.kad_record_queries.remove(query_id) {
             if let Some(node_record) = query.result {

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -54,11 +54,14 @@ pub(crate) struct PeerManager {
     known_peers: HashMap<BlsPublicKey, NetworkInfo>,
     /// BLS keys whose `known_peers` entry is pinned and never evicted by committee rotation.
     ///
-    /// Populated by the locally provisioned insertion paths — trusted/bootstrap/explicit peers and
-    /// records restored from persistence at startup — whose count is bounded by node
-    /// configuration. Every other `known_peers` entry is a kad-discovered committee record kept
-    /// only while its key sits in a tracked committee slot, so [`Self::prune_known_peers`] can
-    /// drop rotated-out members without touching operator-provisioned peers.
+    /// Populated only by the operator-provisioned insertion paths — trusted/bootstrap/explicit
+    /// peers — whose count is bounded by node configuration. Records restored from persistence
+    /// at startup are NOT pinned: the persisted kad store holds peer-fillable third-party records
+    /// (stored as the node's DHT storage duty), so restored entries stay subject to
+    /// committee-rotation pruning. Every other `known_peers` entry is a kad-discovered committee
+    /// record kept only while its key sits in a tracked committee slot, so
+    /// [`Self::prune_known_peers`] can drop rotated-out members without touching
+    /// operator-provisioned peers.
     pinned_peers: HashSet<BlsPublicKey>,
     /// A queue of events that the `PeerManager` is waiting to produce.
     events: VecDeque<PeerEvent>,
@@ -763,14 +766,45 @@ impl PeerManager {
 
     /// Add a locally provisioned known peer and pin it against eviction.
     ///
-    /// Used for operator-driven entries — bootstrap and explicit peers, and records restored from
-    /// local persistence at startup — whose count is bounded by node configuration. Pinned entries
-    /// survive committee rotation (see [`Self::prune_known_peers`]). The attacker-reachable kad
-    /// discovery path must instead use [`Self::add_discovered_peer`], which is bounded to committee
+    /// Used for operator-driven entries only — trusted/explicit peers (bootstrap peers go through
+    /// [`Self::add_bootstrap_peer`]) — whose count is bounded by node configuration. Pinned
+    /// entries survive committee rotation (see [`Self::prune_known_peers`]). Records restored
+    /// from local persistence at startup do NOT use this method precisely because they must not
+    /// pin — they go through [`Self::add_restored_peer`]. The attacker-reachable kad discovery
+    /// path must instead use [`Self::add_discovered_peer`], which is bounded to committee
     /// membership.
     pub(crate) fn add_known_peer(&mut self, bls_key: BlsPublicKey, info: NetworkInfo) {
         self.pinned_peers.insert(bls_key);
         self.cache_known_peer(bls_key, info);
+    }
+
+    /// Add a peer record restored from the persisted kad store at startup, WITHOUT pinning it.
+    ///
+    /// Restored records are kad-discovered cache, not operator-provisioned peers: the persisted
+    /// store's contents are peer-fillable because the node stores arbitrary signature-valid
+    /// third-party records as its DHT storage duty. Pinning them would let a restart convert
+    /// attacker-fillable store entries into permanently pinned `known_peers` entries, so restored
+    /// entries are deliberately NOT pinned — they survive only until the first
+    /// [`Self::update_committees`] prunes non-members, restoring the issue #827 committee bound.
+    pub(crate) fn add_restored_peer(&mut self, bls_key: BlsPublicKey, info: NetworkInfo) {
+        self.cache_known_peer(bls_key, info);
+    }
+
+    /// Add an operator-configured bootstrap peer: always pin it, but never overwrite an existing
+    /// `known_peers` record.
+    ///
+    /// Bootstrap peers are operator-provisioned and bounded by node configuration, so they must
+    /// always be pinned — under unpinned restore, skipping keys that already resolve (the old
+    /// handler pattern) would leave a bootstrap peer with a restored record unpinned, and it
+    /// would be pruned at the first committee rotation. An existing `known_peers` entry (e.g. a
+    /// richer record restored from persistence, which may carry fresher multiaddrs/rpc info) is
+    /// not overwritten by the config-derived stub, preserving the don't-overwrite contract of
+    /// the [`AddBootstrapPeers`](crate::types::NetworkCommand) command.
+    pub(crate) fn add_bootstrap_peer(&mut self, bls_key: BlsPublicKey, info: NetworkInfo) {
+        self.pinned_peers.insert(bls_key);
+        if !self.known_peers.contains_key(&bls_key) {
+            self.cache_known_peer(bls_key, info);
+        }
     }
 
     /// Add a peer learned from the kad discovery DHT, but only if it is a tracked committee member.
@@ -846,8 +880,8 @@ impl PeerManager {
     /// Validate the advertised endpoint, register the peer's network identity, cache its info, and
     /// close the committee trust window if it belongs to a tracked slot.
     ///
-    /// Shared body of [`Self::add_known_peer`] and [`Self::add_discovered_peer`]; the caller
-    /// decides whether the entry is pinned or admitted at all.
+    /// Shared body of the known-peer insertion paths; the caller decides whether the entry is
+    /// pinned or admitted at all.
     fn cache_known_peer(&mut self, bls_key: BlsPublicKey, mut info: NetworkInfo) {
         // signature verification proves authenticity but not scheme correctness; drop a
         // malformed advertised endpoint so only well-formed RPC info is ever cached in

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -827,6 +827,14 @@ impl PeerManager {
             );
             return;
         }
+        if self.kad_record_is_stale(&bls_key, &info) {
+            trace!(
+                target: "peer-manager",
+                ?bls_key,
+                "dropping stale discovered peer record"
+            );
+            return;
+        }
         self.cache_known_peer(bls_key, info);
     }
 
@@ -852,6 +860,15 @@ impl PeerManager {
     ) {
         let advertised: PeerId = info.pubkey.clone().into();
         if self.peers.is_committee_member(&bls_key) {
+            if self.kad_record_is_stale(&bls_key, &info) {
+                trace!(
+                    target: "peer-manager",
+                    ?bls_key,
+                    ?source,
+                    "dropping stale self-advertised record for committee member"
+                );
+                return;
+            }
             self.cache_known_peer(bls_key, info);
         } else if source == advertised {
             trace!(
@@ -875,6 +892,31 @@ impl PeerManager {
     #[cfg(test)]
     pub(crate) fn peer_multiaddr_count(&self, peer_id: &PeerId) -> Option<usize> {
         self.peers.get_peer(peer_id).map(|peer| peer.multiaddr_count())
+    }
+
+    /// Check whether a kad-sourced record's timestamp fails to advance the cached entry.
+    ///
+    /// Mirrors the store-side `is_newer_record` monotonicity check (consensus.rs) so kad-sourced
+    /// updates can never regress a fresher `known_peers` entry — `get_record` query results reach
+    /// the cache without passing through the store, so the store-side check alone cannot protect
+    /// it. EQUAL timestamps keep the existing entry (benign replay churn — the same rule as the
+    /// store side). Operator-provisioned paths bypass this guard structurally: they all stamp
+    /// `timestamp: now()` when building the [`NetworkInfo`] (the `AddTrustedPeerAndDial` /
+    /// `AddExplicitPeer` / `AddBootstrapPeers` handlers in consensus.rs), and
+    /// [`Self::add_bootstrap_peer`] never overwrites an existing entry at all.
+    ///
+    /// Pinned (operator-provisioned) entries are exempt from the comparison in the other
+    /// direction too: their timestamp is a local provisioning stamp, not a peer-signed record
+    /// timestamp, and node records are signed once at peer startup — so an operator stub stamped
+    /// after the peer started would otherwise block the peer's real record (fresh multiaddrs,
+    /// advertised rpc) forever. A signed record may therefore always refresh a pinned entry,
+    /// which is the pre-existing upgrade flow for trusted/explicit peers.
+    fn kad_record_is_stale(&self, bls_key: &BlsPublicKey, info: &NetworkInfo) -> bool {
+        !self.pinned_peers.contains(bls_key)
+            && self
+                .known_peers
+                .get(bls_key)
+                .is_some_and(|existing| existing.timestamp >= info.timestamp)
     }
 
     /// Validate the advertised endpoint, register the peer's network identity, cache its info, and

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -47,10 +47,29 @@ pub(crate) struct PeerManager {
     heartbeat: tokio::time::Interval,
     /// All peers for the manager.
     peers: AllPeers,
-    /// The collection of bls public keys to known peers.
-    /// This should incude the current and next couple of committee members network info.
-    /// This is used for bootstrapping and to make sure we know the network settings of committee
-    /// members.
+    /// The validated read-model of kad discovery: resolves a committee member's
+    /// [`BlsPublicKey`] to its [`NetworkInfo`] on the hot send path. [`Self::auth_to_peer`] is
+    /// a synchronous map probe on the swarm loop for every outbound BLS-addressed request;
+    /// resolving through the kad store instead would cost a key hash, a db get, and a decode
+    /// per call.
+    ///
+    /// The kad store is NOT a superset of this map: `get_record` query results are promoted
+    /// straight into this cache (`close_kad_query` in consensus.rs) and are deliberately never
+    /// written back to the store, so replacing this map with store reads would lose data.
+    ///
+    /// The lifecycles also differ. Store records lazily expire (the configured kad record TTL)
+    /// and can be evicted (max-records cap, ban-triggered removal); entries here have NO TTL by
+    /// design, because a committee member must stay resolvable for its whole committee window —
+    /// an expiry-driven resolution failure would be a consensus liveness bug.
+    ///
+    /// Values are post-validation — BLS signature verified and publisher-checked
+    /// (`peer_record_valid` in consensus.rs), committee-gated per issue #827, malformed
+    /// advertised RPC info stripped in [`Self::cache_known_peer`] — while the store holds raw
+    /// signed record bytes.
+    ///
+    /// Bounded to pinned operator peers plus the tracked committee slots
+    /// ([`Self::prune_known_peers`]); kad-sourced updates are timestamp-monotonic
+    /// ([`Self::kad_record_is_stale`]), mirroring the store-side `is_newer_record` rule.
     known_peers: HashMap<BlsPublicKey, NetworkInfo>,
     /// BLS keys whose `known_peers` entry is pinned and never evicted by committee rotation.
     ///

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2982,6 +2982,181 @@ async fn test_startup_tolerates_legacy_and_corrupt_kad_records() -> eyre::Result
     Ok(())
 }
 
+/// Records restored from the persisted kad store at startup are UNPINNED: the store legitimately
+/// holds arbitrary signature-valid third-party records (DHT storage duty), so a restart must not
+/// convert them into permanently pinned `known_peers` entries. Restored records resolve until the
+/// first committee rotation, which prunes every key outside a tracked slot — restoring the issue
+/// #827 bound.
+#[tokio::test]
+async fn test_restored_records_survive_only_committee_rotation() -> eyre::Result<()> {
+    use libp2p::kad;
+    use tn_types::Signer as _;
+
+    let all_nodes = CommitteeFixture::builder(MemDatabase::default)
+        .with_network_config(NetworkConfig::default())
+        .build();
+    let mut authorities = all_nodes.authorities();
+    let authority_1 = authorities.next().expect("first authority");
+    let authority_2 = authorities.next().expect("second authority");
+    let config_1 = authority_1.consensus_config();
+    let config_2 = authority_2.consensus_config();
+    let task_manager = TaskManager::default();
+
+    let authority_bls = config_2.key_config().primary_public_key();
+
+    // a third party whose signature-valid record the node stored as its DHT storage duty
+    let outsider_keypair = BlsKeypair::generate(&mut StdRng::from_seed([5; 32]));
+    let outsider_bls = *outsider_keypair.public();
+
+    let db = MemDatabase::default();
+
+    // seed the DB before the network starts with two VALID records: one for a committee
+    // authority and one for the non-committee outsider
+    {
+        let mut kad_store = KadStore::new(db.clone(), config_1.key_config(), NetworkType::Primary);
+
+        let key_config_2 = config_2.key_config();
+        let authority_record = NodeRecord::build(
+            key_config_2.primary_network_public_key(),
+            config_2.primary_address(),
+            None,
+            |data| key_config_2.request_signature_direct(data),
+        );
+        kad_store.put(kad::Record {
+            key: kad::RecordKey::new(&authority_bls),
+            value: encode(&authority_record),
+            publisher: None,
+            expires: None,
+        })?;
+
+        let outsider_netkey: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+        let outsider_record =
+            NodeRecord::build(outsider_netkey, create_multiaddr(None), None, |data| {
+                outsider_keypair.sign(data)
+            });
+        kad_store.put(kad::Record {
+            key: kad::RecordKey::new(&outsider_bls),
+            value: encode(&outsider_record),
+            publisher: None,
+            expires: None,
+        })?;
+    }
+
+    // construct the network over the seeded DB — the startup restore path
+    let (tx, _network_events) = mpsc::channel(10);
+    let network_key = config_1.key_config().primary_network_keypair().clone();
+    let mut network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_1.network_config(),
+        tx,
+        config_1.key_config().clone(),
+        network_key,
+        db,
+        task_manager.get_spawner(),
+        NetworkType::Primary,
+        config_1.primary_address(),
+        None,
+    )?;
+
+    // both restored records resolve after startup
+    assert!(
+        network.swarm.behaviour().peer_manager.auth_to_peer(authority_bls).is_some(),
+        "restored authority record resolvable at startup"
+    );
+    assert!(
+        network.swarm.behaviour().peer_manager.auth_to_peer(outsider_bls).is_some(),
+        "restored outsider record resolvable at startup"
+    );
+
+    // the first committee rotation tracks only the authority; production applies committee
+    // membership from epoch state the same way
+    network.swarm.behaviour_mut().peer_manager.update_committees(
+        Default::default(),
+        std::iter::once(authority_bls).collect(),
+        Default::default(),
+    );
+
+    assert!(
+        network.swarm.behaviour().peer_manager.auth_to_peer(authority_bls).is_some(),
+        "restored committee authority must survive rotation"
+    );
+    assert!(
+        network.swarm.behaviour().peer_manager.auth_to_peer(outsider_bls).is_none(),
+        "restored non-committee record must be pruned at the first rotation"
+    );
+
+    Ok(())
+}
+
+/// Startup restore skips the node's own persisted kad record: both primary and worker key their
+/// record by the primary BLS key, and there is no point caching ourselves as a known peer.
+#[tokio::test]
+async fn test_restore_skips_own_record() -> eyre::Result<()> {
+    use libp2p::kad;
+
+    let all_nodes = CommitteeFixture::builder(MemDatabase::default)
+        .with_network_config(NetworkConfig::default())
+        .build();
+    let mut authorities = all_nodes.authorities();
+    let authority_1 = authorities.next().expect("first authority");
+    let config_1 = authority_1.consensus_config();
+    let task_manager = TaskManager::default();
+
+    let own_bls = config_1.key_config().primary_public_key();
+    let db = MemDatabase::default();
+
+    // seed the DB with a valid record for the node's OWN primary BLS key, built the same way
+    // the node builds its own record
+    {
+        let mut kad_store = KadStore::new(db.clone(), config_1.key_config(), NetworkType::Primary);
+        let key_config = config_1.key_config();
+        let own_record = NodeRecord::build(
+            key_config.primary_network_public_key(),
+            config_1.primary_address(),
+            None,
+            |data| key_config.request_signature_direct(data),
+        );
+        kad_store.put(kad::Record {
+            key: kad::RecordKey::new(&own_bls),
+            value: encode(&own_record),
+            publisher: None,
+            expires: None,
+        })?;
+    }
+
+    // construct the network over the seeded DB — the startup restore path
+    let (tx, _network_events) = mpsc::channel(10);
+    let network_key = config_1.key_config().primary_network_keypair().clone();
+    let network = ConsensusNetwork::<
+        TestWorkerRequest,
+        TestWorkerResponse,
+        MemDatabase,
+        mpsc::Sender<NetworkEvent<TestWorkerRequest, TestWorkerResponse>>,
+    >::new(
+        config_1.network_config(),
+        tx,
+        config_1.key_config().clone(),
+        network_key,
+        db,
+        task_manager.get_spawner(),
+        NetworkType::Primary,
+        config_1.primary_address(),
+        None,
+    )?;
+
+    // the restore loop skipped our own record
+    assert!(
+        network.swarm.behaviour().peer_manager.auth_to_peer(own_bls).is_none(),
+        "own record must be skipped by the startup restore"
+    );
+
+    Ok(())
+}
+
 /// Regression for issue #743: a response from a peer whose BLS identity is not
 /// yet resolved must surface as the transient `PeerUnresolved`, never the
 /// misleading `PeerMissing`, because the response payload itself is genuine.

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -923,6 +923,65 @@ async fn test_known_peers_pruned_on_rotation_but_pinned_survive() {
     );
 }
 
+#[tokio::test]
+async fn test_restored_records_not_pinned_and_pruned_at_rotation() {
+    // Records restored from the persisted kad store at startup are peer-fillable third-party
+    // records (DHT storage duty), so they must NOT be pinned: the first committee rotation prunes
+    // every restored key that does not sit in a tracked slot, restoring the issue #827 bound that
+    // a pinning restore would bypass.
+    let mut peer_manager = create_test_peer_manager(None);
+    let mut rng = StdRng::from_seed([17; 32]);
+
+    let restored_a = *BlsKeypair::generate(&mut rng).public();
+    let restored_b = *BlsKeypair::generate(&mut rng).public();
+    peer_manager.add_restored_peer(restored_a, random_network_info());
+    peer_manager.add_restored_peer(restored_b, random_network_info());
+    assert!(peer_manager.auth_to_peer(restored_a).is_some(), "restored record a resolvable");
+    assert!(peer_manager.auth_to_peer(restored_b).is_some(), "restored record b resolvable");
+
+    // first rotation: only `restored_b` occupies a tracked committee slot
+    peer_manager.update_committees(HashSet::new(), HashSet::from([restored_b]), HashSet::new());
+
+    assert!(
+        peer_manager.auth_to_peer(restored_a).is_none(),
+        "restored non-member must be pruned at the first rotation"
+    );
+    assert!(
+        peer_manager.auth_to_peer(restored_b).is_some(),
+        "restored committee member must be retained"
+    );
+}
+
+#[tokio::test]
+async fn test_bootstrap_peer_pins_existing_entry_without_overwrite() {
+    // A bootstrap peer whose record was already restored (unpinned) from persistence must still
+    // be pinned — otherwise the first rotation would prune it — while the existing, possibly
+    // richer record is not overwritten by the config-derived stub.
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([23; 32])).public();
+
+    // restored (unpinned) record with distinctive multiaddrs
+    let restored_info = random_network_info();
+    let restored_addrs = restored_info.multiaddrs.clone();
+    peer_manager.add_restored_peer(bls, restored_info);
+
+    // the operator's bootstrap config carries a different (stub) address for the same key
+    let bootstrap_info = random_network_info();
+    assert_ne!(restored_addrs, bootstrap_info.multiaddrs, "addresses must differ for this test");
+    peer_manager.add_bootstrap_peer(bls, bootstrap_info);
+
+    // the restored record won: no overwrite
+    let (_, multiaddrs) = peer_manager.auth_to_peer(bls).expect("bootstrap peer resolvable");
+    assert_eq!(multiaddrs, restored_addrs, "existing record must not be overwritten");
+
+    // rotate to a committee that does NOT include the bootstrap peer: it survives, pinned
+    let new_member = *BlsKeypair::generate(&mut StdRng::from_seed([99; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([new_member]), HashSet::new());
+    let (_, multiaddrs) =
+        peer_manager.auth_to_peer(bls).expect("bootstrap peer must survive rotation");
+    assert_eq!(multiaddrs, restored_addrs, "pinned entry keeps the restored record");
+}
+
 /// Build a [`NetworkInfo`] like [`random_network_info`], but advertising a valid [`RpcInfo`].
 fn random_network_info_with_rpc() -> (NetworkInfo, RpcInfo) {
     let rpc = RpcInfo {

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -982,6 +982,151 @@ async fn test_bootstrap_peer_pins_existing_entry_without_overwrite() {
     assert_eq!(multiaddrs, restored_addrs, "pinned entry keeps the restored record");
 }
 
+#[tokio::test]
+async fn test_discovered_peer_stale_record_ignored() {
+    // Timestamp monotonicity (defect D2): `get_record` query results bypass the store-side
+    // `is_newer_record` check entirely (close_kad_query -> add_discovered_peer), so without a
+    // cache-side guard a stale-but-valid record served as the only query response would regress
+    // a fresher `known_peers` entry.
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([31; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+
+    // cache the committee member's record at timestamp T
+    let mut fresh = random_network_info();
+    fresh.timestamp = 1_000;
+    let fresh_addrs = fresh.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, fresh);
+
+    // an older record arriving via the same discovery path is dropped
+    let mut stale = random_network_info();
+    stale.timestamp = 999;
+    assert_ne!(stale.multiaddrs, fresh_addrs, "addresses must differ for this test");
+    peer_manager.add_discovered_peer(bls, stale);
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(cached.multiaddrs, fresh_addrs, "stale record must not regress the cached entry");
+    assert_eq!(cached.timestamp, 1_000, "cached timestamp unchanged");
+
+    // a strictly newer record applies
+    let mut newer = random_network_info();
+    newer.timestamp = 1_001;
+    let newer_addrs = newer.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, newer);
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(cached.multiaddrs, newer_addrs, "newer record must replace the cached entry");
+    assert_eq!(cached.timestamp, 1_001, "cached timestamp advanced");
+}
+
+#[tokio::test]
+async fn test_discovered_peer_equal_timestamp_keeps_existing() {
+    // EQUAL timestamps keep the existing entry (benign replay churn) — the same rule as the
+    // store-side `is_newer_record` check.
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([37; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+
+    let mut original = random_network_info();
+    original.timestamp = 1_000;
+    let original_addrs = original.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, original);
+
+    // a same-timestamp record with different addresses must not displace the cached entry
+    let mut replay = random_network_info();
+    replay.timestamp = 1_000;
+    assert_ne!(replay.multiaddrs, original_addrs, "addresses must differ for this test");
+    peer_manager.add_discovered_peer(bls, replay);
+
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(
+        cached.multiaddrs, original_addrs,
+        "equal-timestamp record must keep the existing entry"
+    );
+}
+
+#[tokio::test]
+async fn test_self_advertised_stale_record_ignored() {
+    // A pushed record can pass the store-side `is_newer_record` check yet still be older than the
+    // cached entry (the cache learned a fresher record via a query result the store never saw).
+    // The committee branch of `add_self_advertised_peer` must not regress the cache.
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([41; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+
+    // cache the committee member's record at timestamp T via kad discovery
+    let mut fresh = random_network_info();
+    fresh.timestamp = 1_000;
+    let fresh_addrs = fresh.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, fresh);
+
+    // a stale record pushed over the peer's own authenticated connection (source == advertised)
+    let mut stale = random_network_info();
+    stale.timestamp = 999;
+    let source: PeerId = stale.pubkey.clone().into();
+    assert_ne!(stale.multiaddrs, fresh_addrs, "addresses must differ for this test");
+    peer_manager.add_self_advertised_peer(source, bls, stale);
+
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(
+        cached.multiaddrs, fresh_addrs,
+        "stale self-advertised record must not regress the cache"
+    );
+    assert_eq!(cached.timestamp, 1_000, "cached timestamp unchanged");
+}
+
+#[tokio::test]
+async fn test_operator_add_overwrites_newer_kad_record() {
+    // Operator-provisioned paths deliberately bypass the staleness guard: `add_known_peer`
+    // (the AddExplicitPeer handler) inserts unconditionally, so an operator can always repair a
+    // bad cached record regardless of its timestamp. In production these handlers stamp now().
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([43; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+
+    // a kad-discovered record with a high timestamp
+    let mut discovered = random_network_info();
+    discovered.timestamp = 10_000;
+    let discovered_addrs = discovered.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, discovered);
+
+    // the operator provisions the peer with a LOWER timestamp and different addresses: it wins
+    let mut operator = random_network_info();
+    operator.timestamp = 5_000;
+    let operator_addrs = operator.multiaddrs.clone();
+    assert_ne!(operator_addrs, discovered_addrs, "addresses must differ for this test");
+    peer_manager.add_known_peer(bls, operator);
+
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(cached.multiaddrs, operator_addrs, "operator record must overwrite the kad record");
+    assert_eq!(cached.timestamp, 5_000, "operator record timestamp wins");
+}
+
+#[tokio::test]
+async fn test_pinned_peer_kad_record_bypasses_staleness_guard() {
+    // An operator-provisioned (pinned) entry's timestamp is a local now() provisioning stamp,
+    // not a peer-signed record timestamp, and node records are signed once at peer startup. The
+    // staleness guard must therefore not apply to pinned entries: the peer's real signed record
+    // (older stamp, but carrying rpc info and real multiaddrs) must still replace the operator
+    // stub — the flow exercised end-to-end by `test_advertise_rpc_via_kad`.
+    let mut peer_manager = create_test_peer_manager(None);
+    let bls = *BlsKeypair::generate(&mut StdRng::from_seed([47; 32])).public();
+    peer_manager.update_committees(HashSet::new(), HashSet::from([bls]), HashSet::new());
+
+    // the operator stub: pinned, rpc-less, stamped AFTER the peer signed its own record
+    let mut stub = random_network_info();
+    stub.timestamp = 10_000;
+    peer_manager.add_known_peer(bls, stub);
+
+    // the peer's real record arrives via kad with its startup-signed (older) timestamp
+    let (mut real, rpc) = random_network_info_with_rpc();
+    real.timestamp = 5_000;
+    let real_addrs = real.multiaddrs.clone();
+    peer_manager.add_discovered_peer(bls, real);
+
+    let cached = peer_manager.known_peers.get(&bls).expect("member record cached");
+    assert_eq!(cached.multiaddrs, real_addrs, "signed record must refresh the pinned stub");
+    assert_eq!(cached.rpc, Some(rpc), "advertised rpc must reach the cache despite older stamp");
+}
+
 /// Build a [`NetworkInfo`] like [`random_network_info`], but advertising a valid [`RpcInfo`].
 fn random_network_info_with_rpc() -> (NetworkInfo, RpcInfo) {
     let rpc = RpcInfo {


### PR DESCRIPTION
- Restore persisted kad records via a new cache-only `add_restored_peer` instead of `add_known_peer`, so restart no longer pins up to `MaxRecords` attacker-fillable records past the #827 committee bound. The node's own record is skipped during restore.
- Add a new `add_bootstrap_peer` for bootstrap peers specifically — always pins, never overwrites an existing richer record.
- Add a `kad_record_is_stale` guard mirroring the store's `is_newer_record` check, applied to `add_discovered_peer` and the committee branch of `add_self_advertised_peer`, so a stale record served as a query response can't regress a fresher cached entry. Pinned entries are exempt since their timestamp is a local provisioning stamp, not peer-signed.
- Document `known_peers` as the validated read-model of kad — why it's not redundant with the store (different lifecycles, post-validation values, sync hot-path lookup) and why `close_kad_query` deliberately never writes query results back to the store.

closes #905 