### PR TITLE
feat(worker-gateway): edge protections — rate limits, size limit, tx screening (#712)

### DIFF
--- a/bin/worker-gateway/README.md
+++ b/bin/worker-gateway/README.md
@@ -9,10 +9,11 @@ request method, JSON-RPC body, and content type; the header contract is
 deliberately minimal (see Scope).
 
 Because every instance is stateless and identical, the gateway can be scaled
-horizontally: any replica can serve any request. This is PR2 of the epic
-(issue #712) and implements the crate skeleton plus the proxy core. Edge
-protections (rate/size limits, `eth_sendRawTransaction` sanity checks) and
-observability/deployment (Prometheus, Dockerfile, k8s/HPA) land in PR3 and PR4.
+horizontally: any replica can serve any request. This is PR3 of the epic
+(issue #712): it adds the edge protections (per-IP and global rate limits, a
+configurable request-size limit, and shallow `eth_sendRawTransaction` screening)
+on top of the PR2 proxy core. Observability and deployment (Prometheus,
+Dockerfile, k8s/HPA) land in PR4.
 
 ## Scope (v1)
 
@@ -102,6 +103,11 @@ Every flag has an environment-variable fallback.
 | `--upstream-request-timeout` | `WORKER_GATEWAY_UPSTREAM_REQUEST_TIMEOUT` | `30s` | Upstream per-request deadline. |
 | `--header-read-timeout` | `WORKER_GATEWAY_HEADER_READ_TIMEOUT` | `10s` | Inbound header read deadline (slow-loris guard). |
 | `--max-connections` | `WORKER_GATEWAY_MAX_CONNECTIONS` | `500` | Concurrent inbound connection cap. |
+| `--max-request-bytes` | `WORKER_GATEWAY_MAX_REQUEST_BYTES` | `26214400` | Max request body size, in bytes. |
+| `--rate-limit-per-ip` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP` | `100` | Per-IP requests/second (`0` disables). |
+| `--rate-limit-per-ip-burst` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP_BURST` | `0` | Per-IP burst (`0` derives 2×rate). |
+| `--rate-limit-global` | `WORKER_GATEWAY_RATE_LIMIT_GLOBAL` | `3000` | Gateway-wide requests/second (`0` disables). |
+| `--rate-limit-global-burst` | `WORKER_GATEWAY_RATE_LIMIT_GLOBAL_BURST` | `0` | Global burst (`0` derives 2×rate). |
 | `--graceful-shutdown-timeout` | `WORKER_GATEWAY_GRACEFUL_SHUTDOWN_TIMEOUT` | `30s` | Drain deadline on SIGTERM. |
 | `--log-filter` | `RUST_LOG` | `info` | Tracing filter directive. |
 
@@ -126,6 +132,55 @@ request that already carries it is rejected (HTTP `508`), so a misconfigured
 upstream or VIP that points back at a gateway breaks the loop at the first
 revisit instead of exhausting file descriptors.
 
+## Edge protections
+
+### Rate limiting
+
+Two token-bucket limiters shed load before a request is buffered or forwarded:
+
+- A **per-client-IP** limiter (`--rate-limit-per-ip`, requests/second, with
+  `--rate-limit-per-ip-burst`) stops any single source monopolizing the workers.
+- A **global** limiter (`--rate-limit-global` / `--rate-limit-global-burst`)
+  caps aggregate throughput to roughly what the upstream workers can absorb.
+
+Either limiter is disabled by setting its rate to `0`; a `0` burst derives twice
+the sustained rate. An over-limit request receives a JSON-RPC `429` (see below),
+never a bare reset.
+
+The client identity is the immediate TCP peer. Run the gateway **edge-facing**:
+behind an untrusted L7 proxy the peer is that proxy, so per-IP limiting would
+meter the proxy, not the real client. Terminate client identity at that proxy,
+or put the per-IP limit there.
+
+> The default rates (`100`/s per IP, `3000`/s global) are conservative starting
+> points, not tuned figures. Set them to your workers' measured capacity before
+> relying on them; they can also be disabled entirely (`0`) if you rate-limit at
+> the ingress.
+
+The gateway's own `GET /health` and `GET /ready` probes are **exempt** from rate
+limiting, so an orchestrator's liveness/readiness checks keep succeeding under a
+flood (rate-limiting them would make the orchestrator kill or depool the pod at
+the worst possible moment).
+
+Per-IP state is bounded: idle buckets are swept periodically and the number of
+tracked IPs is capped, so a wide spread of source IPs cannot grow memory without
+limit.
+
+### Request size
+
+`--max-request-bytes` (default 25 MiB) caps the buffered request body; a larger
+body is rejected with a JSON-RPC "request too large" error before forwarding.
+
+### Transaction screening
+
+A single `eth_sendRawTransaction` call is decoded far enough to reject, at the
+edge, the two cases the worker would also reject — an undecodable payload and an
+EIP-4844 blob transaction (the network does not accept blobs) — saving a wasted
+upstream round-trip. The decode uses the same pooled wire format the worker's
+RPC accepts and never recovers the signer, so it cannot reject a transaction the
+worker would accept. Batches (JSON arrays) and every other method are forwarded
+unchanged and validated by the worker.
+
 ## Gateway endpoints
 
 - `GET /health`: liveness, always `200 OK` while the process runs.
@@ -147,6 +202,9 @@ echoed when it can be recovered.
 | Request body too large | `413` | `-32003` |
 | Proxy loop detected | `508` | `-32004` |
 | Request deadline exceeded | `408` | `-32005` |
+| Rate limit exceeded | `429` | `-32006` |
+| Raw transaction undecodable | `400` | `-32007` |
+| Unsupported transaction type (EIP-4844 blob) | `400` | `-32008` |
 | Request body unreadable (client aborted) | `400` | `-32600` |
 
 The gateway's own codes sit in the JSON-RPC server-error range

--- a/bin/worker-gateway/src/app.rs
+++ b/bin/worker-gateway/src/app.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use crate::{
     cli::Settings,
+    ratelimit::{run_gc, RateLimiters, DEFAULT_MAX_PER_IP_ENTRIES},
     readiness::{run_poller, GatewayReadiness},
     server::{serve, AppState, ServerLimits},
 };
@@ -28,6 +29,9 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         upstream_request_timeout,
         header_read_timeout,
         max_connections,
+        max_request_bytes,
+        rate_limit_per_ip,
+        rate_limit_global,
         graceful_shutdown_timeout,
     } = settings;
 
@@ -39,6 +43,17 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
     );
 
     let readiness = Arc::new(GatewayReadiness::new(&upstreams));
+
+    // Edge rate limiters (per-IP and/or global), or `None` when both are
+    // disabled; in that case no rate-limit layer or sweep task is installed.
+    let rate_limiters =
+        RateLimiters::new(rate_limit_per_ip, rate_limit_global, DEFAULT_MAX_PER_IP_ENTRIES);
+    info!(
+        target: "gateway",
+        rate_limiting = rate_limiters.is_some(),
+        max_request_bytes,
+        "edge protections configured"
+    );
 
     // Dedicated clients: the proxy enforces connect + per-request deadlines; the
     // poller bounds each probe with its own tokio timeout.
@@ -79,11 +94,28 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         // cannot hold a request slot indefinitely.
         request_deadline: upstream_request_timeout.saturating_add(header_read_timeout),
         max_connections,
+        max_request_bytes,
     };
+
+    // Sweep idle per-IP buckets while the gateway runs (only when a limiter is
+    // active).
+    if let Some(limiters) = &rate_limiters {
+        spawner.spawn_critical_task(
+            "rate-limit-gc",
+            run_gc(Arc::clone(limiters), shutdown.subscribe()),
+        );
+    }
 
     spawner.spawn_critical_task(
         "gateway-server",
-        serve(listen_addr, state, limits, graceful_shutdown_timeout, shutdown.subscribe()),
+        serve(
+            listen_addr,
+            state,
+            limits,
+            rate_limiters,
+            graceful_shutdown_timeout,
+            shutdown.subscribe(),
+        ),
     );
 
     task_manager.join_until_exit(shutdown).await?;

--- a/bin/worker-gateway/src/cli.rs
+++ b/bin/worker-gateway/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroUsize,
+    num::{NonZeroU32, NonZeroUsize},
     path::PathBuf,
     time::Duration,
 };
@@ -10,7 +10,10 @@ use std::{
 use clap::Parser;
 use url::Url;
 
-use crate::config::{GatewayConfig, UpstreamWorker};
+use crate::{
+    config::{GatewayConfig, UpstreamWorker},
+    ratelimit::RateLimit,
+};
 
 /// Stateless reverse proxy in front of Telcoin Network worker JSON-RPC.
 #[derive(Debug, Parser)]
@@ -96,6 +99,38 @@ pub(crate) struct Cli {
     #[arg(long, env = "WORKER_GATEWAY_MAX_CONNECTIONS", default_value = "500")]
     pub(crate) max_connections: NonZeroUsize,
 
+    /// Maximum request body the gateway will accept, in bytes. Requests whose
+    /// body exceeds this are rejected with a JSON-RPC "request too large" error
+    /// before being forwarded.
+    #[arg(
+        long,
+        env = "WORKER_GATEWAY_MAX_REQUEST_BYTES",
+        default_value_t = crate::proxy::MAX_REQUEST_BYTES
+    )]
+    pub(crate) max_request_bytes: usize,
+
+    /// Sustained per-client-IP request rate, in requests per second (`0`
+    /// disables per-IP rate limiting). The client IP is the immediate TCP peer;
+    /// run the gateway directly edge-facing, not behind an untrusted proxy that
+    /// hides it (see the README).
+    #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_PER_IP", default_value_t = 100)]
+    pub(crate) rate_limit_per_ip: u32,
+
+    /// Burst allowance for the per-IP rate limit, in requests (`0` derives twice
+    /// the sustained rate). Ignored when per-IP rate limiting is disabled.
+    #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_PER_IP_BURST", default_value_t = 0)]
+    pub(crate) rate_limit_per_ip_burst: u32,
+
+    /// Sustained gateway-wide request rate across all clients, in requests per
+    /// second (`0` disables the global rate limit).
+    #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_GLOBAL", default_value_t = 3_000)]
+    pub(crate) rate_limit_global: u32,
+
+    /// Burst allowance for the global rate limit, in requests (`0` derives twice
+    /// the sustained rate). Ignored when the global rate limit is disabled.
+    #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_GLOBAL_BURST", default_value_t = 0)]
+    pub(crate) rate_limit_global_burst: u32,
+
     /// How long to drain in-flight requests on SIGTERM before forcing close.
     #[arg(
         long,
@@ -129,6 +164,12 @@ pub(crate) struct Settings {
     pub(crate) header_read_timeout: Duration,
     /// Maximum concurrently-open inbound connections.
     pub(crate) max_connections: NonZeroUsize,
+    /// Maximum accepted request body size, in bytes.
+    pub(crate) max_request_bytes: usize,
+    /// Per-client-IP rate limit, or `None` when disabled.
+    pub(crate) rate_limit_per_ip: Option<RateLimit>,
+    /// Gateway-wide rate limit, or `None` when disabled.
+    pub(crate) rate_limit_global: Option<RateLimit>,
     /// Graceful-shutdown drain deadline.
     pub(crate) graceful_shutdown_timeout: Duration,
 }
@@ -154,6 +195,15 @@ impl Cli {
             upstream_request_timeout: self.upstream_request_timeout,
             header_read_timeout: self.header_read_timeout,
             max_connections: self.max_connections,
+            max_request_bytes: self.max_request_bytes,
+            rate_limit_per_ip: resolve_rate_limit(
+                self.rate_limit_per_ip,
+                self.rate_limit_per_ip_burst,
+            ),
+            rate_limit_global: resolve_rate_limit(
+                self.rate_limit_global,
+                self.rate_limit_global_burst,
+            ),
             graceful_shutdown_timeout: self.graceful_shutdown_timeout,
         })
     }
@@ -181,6 +231,18 @@ impl Cli {
             }
         }
     }
+}
+
+/// Turn a `(rate, burst)` flag pair into a [`RateLimit`], or `None` when the
+/// rate is `0` (limiter disabled). A `0` burst derives twice the sustained rate
+/// so a modest headroom is the default without a second flag.
+fn resolve_rate_limit(rate: u32, burst: u32) -> Option<RateLimit> {
+    NonZeroU32::new(rate).map(|rate| {
+        let burst = if burst == 0 { rate.get().saturating_mul(2) } else { burst };
+        // `burst` is now >= `rate.get()` >= 1, so it is non-zero; fall back to
+        // the (non-zero) rate rather than panic if that ever fails to hold.
+        RateLimit::new(rate, NonZeroU32::new(burst).unwrap_or(rate))
+    })
 }
 
 /// Reject non-`http` upstream URLs at startup. The gateway is HTTP-only (the
@@ -311,5 +373,57 @@ mod tests {
         )
         .into_settings();
         assert!(result.is_err());
+    }
+
+    /// An inline-upstream CLI on another host (so the self-pointing guard does
+    /// not trip) plus whatever extra flags a test needs.
+    fn cli_with_flags(extra: &[&str]) -> Cli {
+        let mut argv = vec![
+            "worker-gateway".to_string(),
+            "--upstream-rpc-url=http://10.0.0.7:8545".to_string(),
+            "--upstream-readiness-url=http://10.0.0.7:8551/health/workers".to_string(),
+        ];
+        argv.extend(extra.iter().map(|flag| (*flag).to_string()));
+        Cli::parse_from(argv)
+    }
+
+    #[test]
+    fn edge_protection_defaults() -> eyre::Result<()> {
+        let settings = cli_with_flags(&[]).into_settings()?;
+        assert_eq!(settings.max_request_bytes, 26_214_400);
+        let per_ip = settings.rate_limit_per_ip.expect("per-ip limit on by default");
+        assert_eq!(per_ip.rate().get(), 100);
+        // A zero burst flag derives twice the sustained rate.
+        assert_eq!(per_ip.burst().get(), 200);
+        let global = settings.rate_limit_global.expect("global limit on by default");
+        assert_eq!(global.rate().get(), 3_000);
+        assert_eq!(global.burst().get(), 6_000);
+        Ok(())
+    }
+
+    #[test]
+    fn zero_rate_disables_the_limiter() -> eyre::Result<()> {
+        let settings =
+            cli_with_flags(&["--rate-limit-per-ip=0", "--rate-limit-global=0"]).into_settings()?;
+        assert!(settings.rate_limit_per_ip.is_none());
+        assert!(settings.rate_limit_global.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_burst_is_honored() -> eyre::Result<()> {
+        let settings = cli_with_flags(&["--rate-limit-per-ip=40", "--rate-limit-per-ip-burst=50"])
+            .into_settings()?;
+        let per_ip = settings.rate_limit_per_ip.expect("per-ip limit on");
+        assert_eq!(per_ip.rate().get(), 40);
+        assert_eq!(per_ip.burst().get(), 50);
+        Ok(())
+    }
+
+    #[test]
+    fn max_request_bytes_is_configurable() -> eyre::Result<()> {
+        let settings = cli_with_flags(&["--max-request-bytes=1024"]).into_settings()?;
+        assert_eq!(settings.max_request_bytes, 1_024);
+        Ok(())
     }
 }

--- a/bin/worker-gateway/src/error.rs
+++ b/bin/worker-gateway/src/error.rs
@@ -32,6 +32,13 @@ mod code {
     pub(super) const LOOP_DETECTED: i32 = -32004;
     /// The request did not complete within the gateway's request deadline.
     pub(super) const REQUEST_TIMEOUT: i32 = -32005;
+    /// The client exceeded the gateway's rate limit.
+    pub(super) const RATE_LIMITED: i32 = -32006;
+    /// An `eth_sendRawTransaction` payload could not be decoded as a transaction.
+    pub(super) const INVALID_TRANSACTION: i32 = -32007;
+    /// An `eth_sendRawTransaction` payload decoded to a transaction type the
+    /// network does not accept (an EIP-4844 blob transaction).
+    pub(super) const UNSUPPORTED_TRANSACTION_TYPE: i32 = -32008;
     /// The request body could not be read. This is the spec-defined
     /// "Invalid Request" code, not a gateway-range code.
     pub(super) const INVALID_REQUEST: i32 = -32600;
@@ -52,6 +59,14 @@ pub(crate) enum GatewayError {
     LoopDetected,
     /// The request did not complete within the gateway's request deadline.
     RequestTimeout,
+    /// The client exceeded the gateway's per-IP or global rate limit.
+    RateLimited,
+    /// An `eth_sendRawTransaction` payload could not be decoded as a
+    /// transaction (malformed hex or RLP).
+    InvalidTransaction,
+    /// An `eth_sendRawTransaction` payload decoded to a transaction type the
+    /// network does not accept (an EIP-4844 blob transaction).
+    UnsupportedTransactionType,
     /// The request body could not be read (e.g. the client aborted mid-body).
     UnreadableBody,
 }
@@ -66,6 +81,8 @@ impl GatewayError {
             Self::RequestTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             Self::LoopDetected => StatusCode::LOOP_DETECTED,
             Self::RequestTimeout => StatusCode::REQUEST_TIMEOUT,
+            Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
+            Self::InvalidTransaction | Self::UnsupportedTransactionType => StatusCode::BAD_REQUEST,
             Self::UnreadableBody => StatusCode::BAD_REQUEST,
         }
     }
@@ -79,6 +96,9 @@ impl GatewayError {
             Self::RequestTooLarge => code::REQUEST_TOO_LARGE,
             Self::LoopDetected => code::LOOP_DETECTED,
             Self::RequestTimeout => code::REQUEST_TIMEOUT,
+            Self::RateLimited => code::RATE_LIMITED,
+            Self::InvalidTransaction => code::INVALID_TRANSACTION,
+            Self::UnsupportedTransactionType => code::UNSUPPORTED_TRANSACTION_TYPE,
             Self::UnreadableBody => code::INVALID_REQUEST,
         }
     }
@@ -94,6 +114,11 @@ impl GatewayError {
                 "proxy loop detected: request already passed through a worker gateway"
             }
             Self::RequestTimeout => "request did not complete within the gateway's deadline",
+            Self::RateLimited => "rate limit exceeded; slow down and retry",
+            Self::InvalidTransaction => "raw transaction could not be decoded",
+            Self::UnsupportedTransactionType => {
+                "unsupported transaction type: EIP-4844 blob transactions are not accepted"
+            }
             Self::UnreadableBody => "request body could not be read",
         }
     }
@@ -187,5 +212,26 @@ mod tests {
             error_response(&GatewayError::UnreadableBody, b"{}").status(),
             StatusCode::BAD_REQUEST
         );
+        assert_eq!(
+            error_response(&GatewayError::RateLimited, b"{}").status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(
+            error_response(&GatewayError::InvalidTransaction, b"{}").status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            error_response(&GatewayError::UnsupportedTransactionType, b"{}").status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn new_edge_protection_codes_are_stable() {
+        // The codes are part of the client contract; pin them so a reorder or
+        // renumber is caught.
+        assert_eq!(GatewayError::RateLimited.code(), -32006);
+        assert_eq!(GatewayError::InvalidTransaction.code(), -32007);
+        assert_eq!(GatewayError::UnsupportedTransactionType.code(), -32008);
     }
 }

--- a/bin/worker-gateway/src/main.rs
+++ b/bin/worker-gateway/src/main.rs
@@ -12,6 +12,7 @@ mod cli;
 mod config;
 mod error;
 mod proxy;
+mod ratelimit;
 mod readiness;
 mod server;
 

--- a/bin/worker-gateway/src/proxy.rs
+++ b/bin/worker-gateway/src/proxy.rs
@@ -23,6 +23,8 @@ use axum::{
     response::Response,
 };
 use reqwest::Client;
+use serde_json::Value;
+use tn_types::{Decodable2718, PooledTransaction};
 use tracing::{debug, warn};
 use url::Url;
 
@@ -31,11 +33,15 @@ use crate::{
     server::AppState,
 };
 
-/// Maximum request body the gateway will buffer before forwarding.
+/// Default maximum request body the gateway will buffer before forwarding.
 ///
-/// A coarse guard against unbounded memory use; PR3 (edge protections) replaces
-/// this with a configurable, metric-backed request-size limit.
+/// A guard against unbounded memory use; the effective limit is configurable
+/// via `--max-request-bytes` (this value is that flag's default).
 pub(crate) const MAX_REQUEST_BYTES: usize = 25 * 1024 * 1024;
+
+/// The one JSON-RPC method whose payload the gateway inspects before
+/// forwarding (a raw-transaction submission).
+const SEND_RAW_TRANSACTION: &str = "eth_sendRawTransaction";
 
 /// Marker header stamped on every forwarded request. An inbound request that
 /// already carries it has looped back through a gateway (an upstream URL or
@@ -75,6 +81,14 @@ pub(crate) async fn proxy(
              check that upstream URLs point at workers, not gateways"
         );
         return error_response(&GatewayError::LoopDetected, body.as_ref());
+    }
+
+    // Shallow pre-flight for raw-transaction submissions: reject a payload the
+    // worker would also reject (undecodable, or an EIP-4844 blob) before paying
+    // for an upstream round-trip.
+    if let Some(err) = screen_raw_transaction(body.as_ref()) {
+        warn!(target: "gateway::proxy", ?err, "rejecting eth_sendRawTransaction before forwarding");
+        return error_response(&err, body.as_ref());
     }
 
     let Some(rpc_url) = state.readiness.first_ready_rpc_url() else {
@@ -170,5 +184,132 @@ fn classify_error(err: reqwest::Error) -> GatewayError {
         GatewayError::UpstreamTimeout
     } else {
         GatewayError::UpstreamUnreachable
+    }
+}
+
+/// Shallow pre-flight for `eth_sendRawTransaction`.
+///
+/// Returns `Some(error)` only when `body` is a single `eth_sendRawTransaction`
+/// call whose raw transaction cannot be decoded, or decodes to an EIP-4844 blob
+/// transaction (which the network does not accept). Every other request —
+/// including batches, other methods, and any structurally-off submission —
+/// returns `None` and is forwarded unchanged.
+///
+/// The decode uses the same pooled wire format the worker's RPC accepts and
+/// never recovers the signer, so it cannot reject a transaction the worker
+/// would have accepted (no false rejections); it only front-runs a rejection
+/// the worker would issue anyway.
+fn screen_raw_transaction(body: &[u8]) -> Option<GatewayError> {
+    // Fast path: skip JSON parsing entirely unless the method name is present.
+    if !mentions_send_raw_transaction(body) {
+        return None;
+    }
+    let request: Value = serde_json::from_slice(body).ok()?;
+    // Single-call objects only; a batch (a JSON array) is forwarded and left to
+    // the worker to validate per element.
+    if request.get("method").and_then(Value::as_str) != Some(SEND_RAW_TRANSACTION) {
+        return None;
+    }
+    // A submission whose params are structurally off (missing / not a string)
+    // is forwarded so the worker returns its own canonical parameter error.
+    let raw_hex = request.get("params").and_then(|params| params.get(0)).and_then(Value::as_str)?;
+
+    // From here the payload is unambiguously a raw transaction, so a decode
+    // failure is a real rejection rather than a reason to forward.
+    let Some(raw) = decode_hex(raw_hex) else {
+        return Some(GatewayError::InvalidTransaction);
+    };
+    let mut buf = raw.as_slice();
+    match PooledTransaction::decode_2718(&mut buf) {
+        Err(_) => Some(GatewayError::InvalidTransaction),
+        Ok(tx) if tx.is_eip4844() => Some(GatewayError::UnsupportedTransactionType),
+        Ok(_) => None,
+    }
+}
+
+/// Whether `body` is valid UTF-8 mentioning the raw-transaction method. JSON is
+/// UTF-8 by definition, so a non-UTF-8 body is not a JSON-RPC call we inspect.
+fn mentions_send_raw_transaction(body: &[u8]) -> bool {
+    std::str::from_utf8(body).is_ok_and(|text| text.contains(SEND_RAW_TRANSACTION))
+}
+
+/// Decode a `0x`-prefixed (or bare) hex string into bytes, or `None` if it is
+/// not valid hex.
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    let trimmed = value.strip_prefix("0x").or_else(|| value.strip_prefix("0X")).unwrap_or(value);
+    tn_types::hex::decode(trimmed).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canonical EIP-155 example transaction (a signed legacy transfer): a
+    /// well-formed, non-blob raw transaction that must be forwarded untouched.
+    const EIP155_LEGACY_TX: &str = "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83";
+
+    fn send_raw(params: &str) -> Vec<u8> {
+        format!(r#"{{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":{params},"id":1}}"#)
+            .into_bytes()
+    }
+
+    #[test]
+    fn valid_legacy_transaction_is_forwarded() {
+        assert!(screen_raw_transaction(&send_raw(&format!("[\"{EIP155_LEGACY_TX}\"]"))).is_none());
+    }
+
+    #[test]
+    fn undecodable_transaction_is_rejected() {
+        // Valid hex, but not a decodable transaction envelope.
+        let err = screen_raw_transaction(&send_raw(r#"["0xdeadbeef"]"#));
+        assert!(matches!(err, Some(GatewayError::InvalidTransaction)));
+    }
+
+    #[test]
+    fn blob_typed_payload_is_not_forwarded() {
+        // A type-`0x03` (EIP-4844) prefix with a truncated body cannot decode as
+        // a pooled transaction, so it is rejected rather than forwarded. Real
+        // blob submissions decode and hit the `is_eip4844` reject; either way a
+        // blob-typed payload never reaches an upstream.
+        let err = screen_raw_transaction(&send_raw(r#"["0x03c0"]"#));
+        assert!(err.is_some());
+    }
+
+    #[test]
+    fn non_hex_param_is_rejected() {
+        let err = screen_raw_transaction(&send_raw(r#"["not-hex"]"#));
+        assert!(matches!(err, Some(GatewayError::InvalidTransaction)));
+    }
+
+    #[test]
+    fn other_methods_are_forwarded() {
+        let body = br#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}"#;
+        assert!(screen_raw_transaction(body).is_none());
+    }
+
+    #[test]
+    fn batched_send_raw_is_forwarded() {
+        // A batch is a JSON array with no top-level "method"; it is forwarded and
+        // validated per element by the worker.
+        let body = format!(
+            r#"[{{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["{EIP155_LEGACY_TX}"],"id":1}}]"#
+        );
+        assert!(screen_raw_transaction(body.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn missing_params_are_forwarded() {
+        assert!(screen_raw_transaction(&send_raw("[]")).is_none());
+    }
+
+    #[test]
+    fn non_json_body_is_forwarded() {
+        // Mentions the method name but is not JSON: nothing to inspect, forward.
+        assert!(screen_raw_transaction(b"garbage eth_sendRawTransaction garbage").is_none());
+    }
+
+    #[test]
+    fn unrelated_body_skips_parsing() {
+        assert!(screen_raw_transaction(br#"{"method":"net_version","id":1}"#).is_none());
     }
 }

--- a/bin/worker-gateway/src/ratelimit.rs
+++ b/bin/worker-gateway/src/ratelimit.rs
@@ -1,0 +1,452 @@
+//! Per-IP and global request rate limiting.
+//!
+//! Two token-bucket limiters shed load before a request reaches the proxy or
+//! has its body buffered: a gateway-wide bucket caps aggregate throughput to
+//! roughly what the upstream workers can absorb, and a per-client-IP bucket
+//! stops any single source monopolizing that budget. An over-limit request
+//! receives the gateway's JSON-RPC "rate limit exceeded" envelope (HTTP `429`),
+//! never a bare connection reset.
+//!
+//! The client identity is the immediate TCP peer address (`ConnectInfo`,
+//! injected per connection by the accept loop). The gateway is meant to run
+//! edge-facing; behind an untrusted L7 proxy the peer is that proxy, so the
+//! per-IP bucket would meter the proxy rather than the real client. Terminate
+//! such a proxy's client identity upstream, or run the gateway at the edge (see
+//! the crate README).
+
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    num::NonZeroU32,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+    time::{Duration, Instant},
+};
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use tn_types::{Noticer, TaskError};
+use tokio::time::MissedTickBehavior;
+
+use crate::{
+    error::{error_response, GatewayError},
+    server::{HEALTH_PATH, READY_PATH},
+};
+
+/// How often the background sweep reclaims idle per-IP buckets.
+pub(crate) const GC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Default ceiling on tracked per-IP buckets. Bounds the per-IP map so a wide
+/// spread of source IPs cannot grow it without limit; ~10 MB at the cap, and
+/// idle buckets are reclaimed between sweeps by [`RateLimiters::gc`].
+pub(crate) const DEFAULT_MAX_PER_IP_ENTRIES: usize = 100_000;
+
+/// A source of monotonic time, injectable so the limiters can be driven
+/// deterministically in tests.
+pub(crate) trait Clock: Send + Sync + 'static {
+    fn now(&self) -> Instant;
+}
+
+/// The production clock: the process monotonic clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// A resolved rate limit: a sustained `rate` (requests per second) with a
+/// `burst` ceiling (the token-bucket capacity).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RateLimit {
+    rate: NonZeroU32,
+    burst: NonZeroU32,
+}
+
+impl RateLimit {
+    pub(crate) fn new(rate: NonZeroU32, burst: NonZeroU32) -> Self {
+        Self { rate, burst }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rate(&self) -> NonZeroU32 {
+        self.rate
+    }
+
+    #[cfg(test)]
+    pub(crate) fn burst(&self) -> NonZeroU32 {
+        self.burst
+    }
+
+    /// Sustained refill rate in tokens per second.
+    fn tokens_per_sec(&self) -> f64 {
+        f64::from(self.rate.get())
+    }
+
+    /// Bucket capacity in tokens.
+    fn capacity(&self) -> f64 {
+        f64::from(self.burst.get())
+    }
+}
+
+/// A refilling token bucket. It starts full and refills at `rate` tokens per
+/// second up to `capacity`; each admitted request spends one token.
+#[derive(Debug)]
+struct Bucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl Bucket {
+    fn full(now: Instant, capacity: f64) -> Self {
+        Self { tokens: capacity, last_refill: now }
+    }
+
+    /// The token count after refilling to `now`, clamped to `capacity`, without
+    /// mutating the bucket.
+    fn replenished(&self, now: Instant, rate: f64, capacity: f64) -> f64 {
+        let elapsed = now.saturating_duration_since(self.last_refill).as_secs_f64();
+        (self.tokens + elapsed * rate).min(capacity)
+    }
+
+    /// Refill for the elapsed time, then spend one token if one is available.
+    /// Returns whether the request is admitted.
+    fn try_admit(&mut self, now: Instant, rate: f64, capacity: f64) -> bool {
+        self.tokens = self.replenished(now, rate, capacity);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the bucket has refilled to capacity by `now`. An idle bucket
+    /// carries no state a freshly-created one would not, so the GC sweep can
+    /// drop it.
+    fn is_idle(&self, now: Instant, rate: f64, capacity: f64) -> bool {
+        self.replenished(now, rate, capacity) >= capacity
+    }
+}
+
+/// The single gateway-wide bucket.
+#[derive(Debug)]
+struct GlobalLimiter {
+    limit: RateLimit,
+    bucket: Mutex<Bucket>,
+}
+
+/// Per-client-IP buckets, bounded in cardinality; idle buckets are reclaimed by
+/// [`RateLimiters::gc`].
+#[derive(Debug)]
+struct PerIpLimiter {
+    limit: RateLimit,
+    max_entries: usize,
+    buckets: Mutex<HashMap<IpAddr, Bucket>>,
+}
+
+impl PerIpLimiter {
+    /// Admit or reject a request from `ip`, creating its bucket on first sight.
+    fn admit(&self, now: Instant, ip: IpAddr) -> bool {
+        let rate = self.limit.tokens_per_sec();
+        let capacity = self.limit.capacity();
+        let mut buckets = lock(&self.buckets);
+        // Bind the existing-bucket outcome first so its borrow of `buckets` ends
+        // before the new-IP path takes `&mut buckets`.
+        let existing = buckets.get_mut(&ip).map(|bucket| bucket.try_admit(now, rate, capacity));
+        existing.unwrap_or_else(|| {
+            admit_new_ip(&mut buckets, self.max_entries, now, ip, rate, capacity)
+        })
+    }
+}
+
+/// Admit a first-seen `ip`, tracking it unless the table is at capacity.
+///
+/// A new IP with the table already full is admitted *untracked* rather than
+/// evicting a live bucket or rejecting a fresh client: the global limit still
+/// bounds aggregate load, and the GC sweep keeps the table from staying full.
+/// Bounded memory is chosen over perfect per-IP fairness under a very wide
+/// source-IP spread.
+fn admit_new_ip(
+    buckets: &mut HashMap<IpAddr, Bucket>,
+    max_entries: usize,
+    now: Instant,
+    ip: IpAddr,
+    rate: f64,
+    capacity: f64,
+) -> bool {
+    if buckets.len() < max_entries {
+        let mut bucket = Bucket::full(now, capacity);
+        let admitted = bucket.try_admit(now, rate, capacity);
+        buckets.insert(ip, bucket);
+        admitted
+    } else {
+        // Table full: admit untracked (bounded memory over per-IP fairness).
+        true
+    }
+}
+
+/// The gateway's rate limiters. Either limiter may be disabled (`None`).
+pub(crate) struct RateLimiters<C: Clock = SystemClock> {
+    clock: C,
+    global: Option<GlobalLimiter>,
+    per_ip: Option<PerIpLimiter>,
+}
+
+impl RateLimiters<SystemClock> {
+    /// Build the limiters from resolved settings using the system clock, or
+    /// `None` when both limiters are disabled (so no layer need be installed).
+    pub(crate) fn new(
+        per_ip: Option<RateLimit>,
+        global: Option<RateLimit>,
+        max_per_ip_entries: usize,
+    ) -> Option<Arc<Self>> {
+        Self::with_clock(SystemClock, per_ip, global, max_per_ip_entries).map(Arc::new)
+    }
+}
+
+impl<C: Clock> RateLimiters<C> {
+    fn with_clock(
+        clock: C,
+        per_ip: Option<RateLimit>,
+        global: Option<RateLimit>,
+        max_per_ip_entries: usize,
+    ) -> Option<Self> {
+        if per_ip.is_none() && global.is_none() {
+            return None;
+        }
+        let now = clock.now();
+        let global = global.map(|limit| GlobalLimiter {
+            limit,
+            bucket: Mutex::new(Bucket::full(now, limit.capacity())),
+        });
+        let per_ip = per_ip.map(|limit| PerIpLimiter {
+            limit,
+            max_entries: max_per_ip_entries.max(1),
+            buckets: Mutex::new(HashMap::new()),
+        });
+        Some(Self { clock, global, per_ip })
+    }
+
+    /// Admit or reject a request from `peer`. A `None` peer skips the per-IP
+    /// bucket; the global bucket still applies.
+    ///
+    /// The global bucket is evaluated first and short-circuits (`&&`), so a
+    /// request rejected by the global limit does not spend a per-IP token. This
+    /// keeps the aggregate cap authoritative and can only reduce, never inflate,
+    /// admitted load.
+    pub(crate) fn check(&self, peer: Option<IpAddr>) -> Result<(), GatewayError> {
+        let now = self.clock.now();
+        let global_ok = self.global.as_ref().is_none_or(|global| {
+            lock(&global.bucket).try_admit(
+                now,
+                global.limit.tokens_per_sec(),
+                global.limit.capacity(),
+            )
+        });
+        let allowed = global_ok
+            && self.per_ip.as_ref().zip(peer).is_none_or(|(per_ip, ip)| per_ip.admit(now, ip));
+        allowed.then_some(()).ok_or(GatewayError::RateLimited)
+    }
+
+    /// Drop idle (fully-refilled) per-IP buckets to bound memory. Called
+    /// periodically from a background task.
+    pub(crate) fn gc(&self) {
+        if let Some(per_ip) = &self.per_ip {
+            let now = self.clock.now();
+            let rate = per_ip.limit.tokens_per_sec();
+            let capacity = per_ip.limit.capacity();
+            let mut buckets = lock(&per_ip.buckets);
+            buckets.retain(|_, bucket| !bucket.is_idle(now, rate, capacity));
+        }
+    }
+}
+
+/// Lock a mutex, recovering the guard if a previous holder panicked. The
+/// limiter state is a best-effort counter, so a poisoned lock is safe to reuse.
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Periodically reclaim idle per-IP buckets until `shutdown` fires. Runs as a
+/// managed task alongside the server; a missed interval is skipped rather than
+/// firing catch-up sweeps back to back.
+pub(crate) async fn run_gc(
+    limiters: Arc<RateLimiters>,
+    shutdown: Noticer,
+) -> Result<(), TaskError> {
+    let mut ticker = tokio::time::interval(GC_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // Consume the immediate first tick so the first real sweep is one interval
+    // out, not at startup against an empty map.
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            () = &shutdown => break,
+            _ = ticker.tick() => limiters.gc(),
+        }
+    }
+    Ok(())
+}
+
+/// Axum middleware: rate-limit by peer IP and globally, rejecting an over-limit
+/// request with the gateway's JSON-RPC `429` envelope before its body is read.
+pub(crate) async fn rate_limit(
+    State(limiters): State<Arc<RateLimiters>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // Orchestration probes are never rate-limited: a liveness/readiness check
+    // failing under load would take the gateway down (the orchestrator kills or
+    // depools the pod) exactly when it is meant to be absorbing a flood.
+    let path = request.uri().path();
+    let exempt = path == HEALTH_PATH || path == READY_PATH;
+    let peer = request.extensions().get::<ConnectInfo<SocketAddr>>().map(|info| info.0.ip());
+    let rejection = (!exempt).then(|| limiters.check(peer).err()).flatten();
+    // The final dispatch stays a `match`: one arm awaits `next`, which a
+    // combinator closure cannot do.
+    match rejection {
+        Some(err) => error_response(&err, b""),
+        None => next.run(request).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hand-advanced clock so token refills are deterministic without sleeps.
+    #[derive(Clone)]
+    struct ManualClock {
+        now: Arc<Mutex<Instant>>,
+    }
+
+    impl ManualClock {
+        fn new() -> Self {
+            Self { now: Arc::new(Mutex::new(Instant::now())) }
+        }
+
+        fn advance(&self, by: Duration) {
+            *lock(&self.now) += by;
+        }
+    }
+
+    impl Clock for ManualClock {
+        fn now(&self) -> Instant {
+            *lock(&self.now)
+        }
+    }
+
+    fn nz(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).expect("nonzero")
+    }
+
+    fn limit(rate: u32, burst: u32) -> RateLimit {
+        RateLimit::new(nz(rate), nz(burst))
+    }
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::from([10, 0, 0, last])
+    }
+
+    impl<C: Clock> RateLimiters<C> {
+        fn per_ip_len(&self) -> usize {
+            self.per_ip.as_ref().map(|per_ip| lock(&per_ip.buckets).len()).unwrap_or(0)
+        }
+    }
+
+    fn limiters<C: Clock>(
+        clock: C,
+        per_ip: Option<RateLimit>,
+        global: Option<RateLimit>,
+        max_entries: usize,
+    ) -> RateLimiters<C> {
+        RateLimiters::with_clock(clock, per_ip, global, max_entries).expect("some limiter enabled")
+    }
+
+    #[test]
+    fn global_bucket_admits_burst_then_rejects() {
+        let limiters = limiters(ManualClock::new(), None, Some(limit(1, 3)), 16);
+        // The burst of 3 is admitted; the 4th is rejected (no time advances, so
+        // nothing refills).
+        assert!(limiters.check(None).is_ok());
+        assert!(limiters.check(None).is_ok());
+        assert!(limiters.check(None).is_ok());
+        assert!(matches!(limiters.check(None), Err(GatewayError::RateLimited)));
+    }
+
+    #[test]
+    fn global_bucket_refills_over_time() {
+        let clock = ManualClock::new();
+        let limiters = limiters(clock.clone(), None, Some(limit(10, 1)), 16);
+        assert!(limiters.check(None).is_ok()); // spend the one token
+        assert!(limiters.check(None).is_err()); // empty
+        clock.advance(Duration::from_millis(100)); // 10/s => 1 token in 100ms
+        assert!(limiters.check(None).is_ok());
+    }
+
+    #[test]
+    fn per_ip_buckets_are_isolated() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 2)), None, 16);
+        // IP 1 exhausts its burst.
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert!(limiters.check(Some(ip(1))).is_err());
+        // IP 2 is unaffected.
+        assert!(limiters.check(Some(ip(2))).is_ok());
+    }
+
+    #[test]
+    fn missing_peer_skips_per_ip_but_global_still_applies() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 1)), Some(limit(1, 2)), 16);
+        // No peer => the per-IP bucket is skipped; the global burst of 2 caps it.
+        assert!(limiters.check(None).is_ok());
+        assert!(limiters.check(None).is_ok());
+        assert!(limiters.check(None).is_err());
+    }
+
+    #[test]
+    fn gc_reclaims_idle_buckets() {
+        let clock = ManualClock::new();
+        let limiters = limiters(clock.clone(), Some(limit(10, 2)), None, 16);
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert_eq!(limiters.per_ip_len(), 1);
+        // Advance well past a full refill, then sweep.
+        clock.advance(Duration::from_secs(1));
+        limiters.gc();
+        assert_eq!(limiters.per_ip_len(), 0);
+    }
+
+    #[test]
+    fn busy_bucket_survives_gc() {
+        let clock = ManualClock::new();
+        let limiters = limiters(clock.clone(), Some(limit(1, 5)), None, 16);
+        // Drain the bucket so it is not idle, then immediately sweep.
+        for _ in 0..5 {
+            assert!(limiters.check(Some(ip(1))).is_ok());
+        }
+        limiters.gc();
+        assert_eq!(limiters.per_ip_len(), 1, "a non-idle bucket must not be reclaimed");
+    }
+
+    #[test]
+    fn full_table_admits_untracked_new_ip() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 1)), None, 1);
+        // The first IP is tracked and exhausted.
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert!(limiters.check(Some(ip(1))).is_err());
+        // The table is full (cap 1): a new IP is admitted untracked, not rejected.
+        assert!(limiters.check(Some(ip(2))).is_ok());
+        assert_eq!(limiters.per_ip_len(), 1);
+    }
+
+    #[test]
+    fn both_disabled_yields_no_limiters() {
+        assert!(RateLimiters::with_clock(SystemClock, None, None, 16).is_none());
+    }
+}

--- a/bin/worker-gateway/src/server.rs
+++ b/bin/worker-gateway/src/server.rs
@@ -16,7 +16,7 @@ use std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration};
 use axum::{
     extract::{ConnectInfo, DefaultBodyLimit, State},
     http::StatusCode,
-    middleware::map_response,
+    middleware::{from_fn_with_state, map_response},
     response::{IntoResponse, Response},
     routing::get,
     Extension, Json, Router,
@@ -35,13 +35,20 @@ use tracing::{debug, info, warn};
 
 use crate::{
     error::{error_response, GatewayError},
-    proxy::{proxy, MAX_REQUEST_BYTES},
+    proxy::proxy,
+    ratelimit::{rate_limit, RateLimiters},
     readiness::GatewayReadiness,
 };
 
 /// Pause before re-polling `accept()` after it fails, so a persistent accept
 /// error (e.g. fd exhaustion) cannot spin the loop hot.
 const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// Liveness probe path. Exempt from rate limiting (see [`crate::ratelimit`]).
+pub(crate) const HEALTH_PATH: &str = "/health";
+
+/// Readiness probe path. Exempt from rate limiting (see [`crate::ratelimit`]).
+pub(crate) const READY_PATH: &str = "/ready";
 
 /// Shared state handed to every request handler.
 #[derive(Clone, Debug)]
@@ -65,6 +72,8 @@ pub(crate) struct ServerLimits {
     /// Maximum concurrently-open inbound connections; further connections wait
     /// in the OS accept backlog.
     pub(crate) max_connections: NonZeroUsize,
+    /// Maximum accepted request body size, in bytes.
+    pub(crate) max_request_bytes: usize,
 }
 
 /// JSON body of the gateway's `/ready` response.
@@ -76,20 +85,35 @@ struct ReadyBody {
 
 /// Build the gateway router: health/readiness routes plus the proxy fallback.
 ///
-/// `request_deadline` bounds each whole request (outermost layer); the bare
-/// `408` the timeout layer produces is rewritten into the gateway's JSON-RPC
-/// error envelope so the "always a well-formed JSON-RPC error" contract holds.
-/// Streamed *response* bodies are written after the handler returns and are
-/// bounded by the upstream client's own total timeout instead.
-pub(crate) fn router(state: AppState, request_deadline: Duration) -> Router {
-    Router::new()
-        .route("/health", get(liveness))
-        .route("/ready", get(readiness))
+/// `request_deadline` bounds each whole request; the bare `408` the timeout
+/// layer produces is rewritten into the gateway's JSON-RPC error envelope so
+/// the "always a well-formed JSON-RPC error" contract holds. Streamed
+/// *response* bodies are written after the handler returns and are bounded by
+/// the upstream client's own total timeout instead. `max_request_bytes` caps
+/// the buffered request body.
+///
+/// When `rate_limiters` is present it is installed as the outermost layer, so
+/// an over-limit request is shed with a JSON-RPC `429` before its body is
+/// buffered or forwarded.
+pub(crate) fn router(
+    state: AppState,
+    request_deadline: Duration,
+    max_request_bytes: usize,
+    rate_limiters: Option<Arc<RateLimiters>>,
+) -> Router {
+    let router = Router::new()
+        .route(HEALTH_PATH, get(liveness))
+        .route(READY_PATH, get(readiness))
         .fallback(proxy)
-        .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
+        .layer(DefaultBodyLimit::max(max_request_bytes))
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, request_deadline))
-        .layer(map_response(envelope_request_timeout))
-        .with_state(state)
+        .layer(map_response(envelope_request_timeout));
+    // Add the rate-limit layer last so it runs first, ahead of the body read.
+    let router = match rate_limiters {
+        Some(limiters) => router.layer(from_fn_with_state(limiters, rate_limit)),
+        None => router,
+    };
+    router.with_state(state)
 }
 
 /// Rewrite the timeout layer's bare `408` into the gateway's JSON-RPC error
@@ -123,6 +147,7 @@ pub(crate) async fn serve(
     listen_addr: SocketAddr,
     state: AppState,
     limits: ServerLimits,
+    rate_limiters: Option<Arc<RateLimiters>>,
     graceful_timeout: Duration,
     shutdown: Noticer,
 ) -> Result<(), TaskError> {
@@ -130,7 +155,7 @@ pub(crate) async fn serve(
     let local_addr = listener.local_addr()?;
     info!(target: "gateway::server", %local_addr, "worker gateway listening");
 
-    let app = router(state, limits.request_deadline);
+    let app = router(state, limits.request_deadline, limits.max_request_bytes, rate_limiters);
     accept_loop(listener, app, limits, graceful_timeout, shutdown).await
 }
 
@@ -219,8 +244,9 @@ async fn accept_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::UpstreamWorker;
+    use crate::{config::UpstreamWorker, proxy::MAX_REQUEST_BYTES, ratelimit::RateLimit};
     use axum::{http::HeaderMap, routing::post};
+    use std::num::NonZeroU32;
     use tn_types::Notifier;
     use tokio::{
         io::{AsyncReadExt as _, AsyncWriteExt as _},
@@ -234,6 +260,7 @@ mod tests {
             header_read_timeout: Duration::from_secs(5),
             request_deadline: Duration::from_secs(5),
             max_connections: NonZeroUsize::new(64).expect("nonzero"),
+            max_request_bytes: MAX_REQUEST_BYTES,
         }
     }
 
@@ -272,7 +299,11 @@ mod tests {
     }
 
     fn test_router(state: AppState) -> Router {
-        router(state, Duration::from_secs(5))
+        router(state, Duration::from_secs(5), MAX_REQUEST_BYTES, None)
+    }
+
+    fn nz(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).expect("nonzero")
     }
 
     #[tokio::test]
@@ -450,9 +481,9 @@ mod tests {
     #[tokio::test]
     async fn oversized_body_gets_jsonrpc_error() {
         let state = test_state(&[upstream("127.0.0.1:1".parse().expect("addr"))]);
-        // Tiny body limit so a small request trips the DefaultBodyLimit path.
-        let app = Router::new().fallback(proxy).layer(DefaultBodyLimit::max(8)).with_state(state);
-        let (addr, _shutdown) = spawn(app).await;
+        // A tiny configured body limit so a small request trips the size guard
+        // through the real router path (`--max-request-bytes` is configurable).
+        let (addr, _shutdown) = spawn(router(state, Duration::from_secs(5), 8, None)).await;
 
         let response = Client::new()
             .post(format!("http://{addr}/"))
@@ -464,6 +495,59 @@ mod tests {
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
         let body: serde_json::Value = response.json().await.expect("json");
         assert_eq!(body["error"]["code"], -32003);
+    }
+
+    #[tokio::test]
+    async fn over_limit_request_gets_jsonrpc_429() {
+        let mock = Router::new()
+            .route("/", post(|| async { r#"{"jsonrpc":"2.0","result":"0x1","id":1}"# }));
+        let (upstream_addr, _mock) = spawn(mock).await;
+
+        let state = test_state(&[upstream(upstream_addr)]);
+        state.readiness.set_ready(0, true);
+        // Global limit of one request with no burst headroom: the first request
+        // passes, the second (same instant, no refill) is rejected with 429.
+        let limiters =
+            RateLimiters::new(None, Some(RateLimit::new(nz(1), nz(1))), 16).expect("limiters");
+        let (addr, _shutdown) =
+            spawn(router(state, Duration::from_secs(5), MAX_REQUEST_BYTES, Some(limiters))).await;
+
+        let client = Client::new();
+        let first = client
+            .post(format!("http://{addr}/"))
+            .body(r#"{"jsonrpc":"2.0","method":"eth_chainId","id":1}"#)
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = client
+            .post(format!("http://{addr}/"))
+            .body(r#"{"jsonrpc":"2.0","method":"eth_chainId","id":2}"#)
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body: serde_json::Value = second.json().await.expect("json");
+        assert_eq!(body["error"]["code"], -32006);
+    }
+
+    #[tokio::test]
+    async fn health_probe_bypasses_rate_limit() {
+        let state = test_state(&[upstream("127.0.0.1:1".parse().expect("addr"))]);
+        // A maximally strict global limit (burst 1). If probes were rate-limited,
+        // the second `/health` hit would be 429; they must stay 200 so an
+        // orchestrator does not kill the pod under load.
+        let limiters =
+            RateLimiters::new(None, Some(RateLimit::new(nz(1), nz(1))), 16).expect("limiters");
+        let (addr, _shutdown) =
+            spawn(router(state, Duration::from_secs(5), MAX_REQUEST_BYTES, Some(limiters))).await;
+
+        let client = Client::new();
+        for _ in 0..5 {
+            let response = client.get(format!("http://{addr}/health")).send().await.expect("send");
+            assert_eq!(response.status(), StatusCode::OK);
+        }
     }
 
     #[tokio::test]
@@ -491,8 +575,11 @@ mod tests {
         state.readiness.set_ready(0, true);
         // Short whole-request deadline; generous header timeout so only the
         // body trickle trips.
-        let (addr, _shutdown) =
-            spawn_with_limits(router(state, Duration::from_millis(300)), test_limits()).await;
+        let (addr, _shutdown) = spawn_with_limits(
+            router(state, Duration::from_millis(300), MAX_REQUEST_BYTES, None),
+            test_limits(),
+        )
+        .await;
 
         // Complete headers, then stall mid-body below the size limit.
         let mut stream = TcpStream::connect(addr).await.expect("connect");

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -54,7 +54,7 @@ pub use alloy::{
     },
     eips::{
         eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
-        eip2718::Encodable2718,
+        eip2718::{Decodable2718, Encodable2718},
         eip4844::{env_settings::EnvKzgSettings, BlobAndProofV1, BlobTransactionSidecar},
         BlockHashOrNumber, BlockNumHash,
     },


### PR DESCRIPTION
> PR3 of the phased breakdown for #712.  Builds on the PR2 proxy core; adds the edge protections.  No compile dependency on any other PR . . . the gateway talks to workers over HTTP at runtime.

## What this adds

The three edge protections from the plan, all on the existing proxy path:

### 1. Rate limiting (per-IP + global)

Two token-bucket limiters shed load **before** a request is buffered or forwarded (the rate-limit layer is the outermost router layer, ahead of the body read):

- **Per-client-IP** (`--rate-limit-per-ip`, req/s, `--rate-limit-per-ip-burst`): stops any single source monopolizing the workers.
- **Global** (`--rate-limit-global` / `--rate-limit-global-burst`): caps aggregate throughput to roughly the workers' capacity.

Either is disabled with rate `0`;  a `0` burst derives 2×rate. An over-limit request gets a JSON-RPC `429` envelope (code `-32006`), never a bare reset.

Implementation is a small hand-rolled token bucket (std + tokio only: **no new dependency**), with an **injectable clock** so refill/GC behaviour is tested deterministically (mirrors the `BannedPeerCache` clock pattern in #834).  Per-IP state is bounded: idle buckets are reclaimed by a periodic sweep task (managed under the `TaskManager`, drains on SIGTERM) and the tracked-IP count is capped, so a wide source-IP spread cannot grow memory without limit.

The client identity is the **immediate TCP peer** (`ConnectInfo`, already injected per connection by PR2's accept loop). Documented caveat: run the gateway edge-facing; behind an untrusted L7 proxy the peer is that proxy, so trusting an inbound `X-Forwarded-For` would be a bypass . . . I did **not** trust it (see Q2).

### 2. Configurable request-size limit

`--max-request-bytes` (default 25 MiB, the previous hardcoded value) now feeds the `DefaultBodyLimit`;  oversized bodies still get the `-32003` "request too large" JSON-RPC error.

### 3. Shallow `eth_sendRawTransaction` screening

A single `eth_sendRawTransaction` call is decoded far enough to reject, at the edge, exactly what the worker would also reject, an **undecodable payload** (`-32007`) and an **EIP-4844 blob transaction** (`-32008`), front-running a wasted upstream round-trip. Key correctness property: the decode uses the same **pooled** wire format the worker's RPC accepts and **never recovers the signer**, so it is strictly more permissive than the worker and **cannot reject a transaction the worker would accept** (no false rejects).  A fast-path substring check means only bodies naming the method are parsed at all;  batches and every other method forward unchanged.

New JSON-RPC codes (gateway server-error range): `-32006` rate-limited (`429`), `-32007` invalid transaction (`400`), `-32008` unsupported transaction type (`400`).

## One-line cross-crate change

`crates/types/src/lib.rs` re-exports `alloy::eips::eip2718::Decodable2718` (alongside the already-exported `Encodable2718`) so the gateway decodes raw transactions version-aligned with reth's alloy, without a direct `alloy`/`tn-reth` dependency.

## Not in scope (deferred, per the plan)

- Prometheus metrics (incl. a rejections-by-reason counter and the in-flight HPA gauge), Dockerfile, k8s/HPA → **PR4**.
- TLS termination, auth/API keys, CORS, dynamic discovery: out of scope per the issue.

## Testing

**55 tests pass** (was 32 in PR2).  New coverage: rate-limiter unit tests (burst exhaustion, time-based refill, per-IP isolation, global cap, GC reclaims idle / spares busy buckets, full-table fail-open, both-disabled) driven by an injectable clock; an end-to-end `429`-envelope test through the real router;  transaction-screening tests (valid legacy tx forwarded, undecodable/non-hex/blob-typed rejected, other-method/batch/missing-params/non-JSON forwarded);  and CLI tests (defaults, `0`-disables, explicit burst, configurable size).

Gates: `cargo check`, `cargocho clippy --all-targets -D warnings` (0/0 on the gateway), `cargocho test` (56 pass), `cargo +nightly-2026-03-20 fmt --check` . . . all clean.  The binary's `--help` was smoke-tested (all new flags render with their defaults).

> Note: running clippy over `-p tn-types --all-targets` (which my one-line re-export touches) surfaces two **pre-existing** lints in `crates/types/src/{committee.rs, primary/epoch.rs}` . . . files this PR does not touch. They are on `origin/main` already, not introduced here.

Self-review: a 6-lens adversarial workflow (bounded ≤7 findings / ≤49 agents) over the diff surfaced only 3 low-severity items, all addressed . . . the rate-limit layer originally covered `/health` and `/ready` (now exempt, so an orchestrator's probes survive a flood; with a test), the limiter's control flow was moved onto combinators per the repo/style conventions, and this failure table gained the three new codes.  No correctness, security, or DoS finding survived verification.