### PR TITLE
feat(rpc): thread deadline through delegationDigest binding

### DIFF
--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -134,6 +134,7 @@ pub trait TelcoinNetworkRpcExtApi {
         bls_pubkey: Bytes,
         validator_address: Address,
         delegator: Address,
+        deadline: U256,
     ) -> TelcoinNetworkRpcResult<B256>;
     /// Return the BLS12-381 proof of possession message: `blsPubkey || validatorAddress`.
     ///
@@ -322,11 +323,13 @@ where
         bls_pubkey: Bytes,
         validator_address: Address,
         delegator: Address,
+        deadline: U256,
     ) -> TelcoinNetworkRpcResult<B256> {
         let calldata = ConsensusRegistry::delegationDigestCall {
             blsPubkey: bls_pubkey,
             validatorAddress: validator_address,
             delegator,
+            deadline,
         }
         .abi_encode()
         .into();

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -198,7 +198,7 @@ sol!(
         /// Returns the validator's (outstandingBalance, initialStake, rewards).
         function getBalanceBreakdown(address validatorAddress) external view returns (uint256, uint256, uint256);
         /// Returns the EIP-712 digest a validator signs to accept a delegation.
-        function delegationDigest(bytes memory blsPubkey, address validatorAddress, address delegator) external view returns (bytes32);
+        function delegationDigest(bytes memory blsPubkey, address validatorAddress, address delegator, uint256 deadline) external view returns (bytes32);
         /// Issuance not yet distributed to validators (public variable getter).
         function undistributedIssuance() external view returns (uint256);
         /// Sets the GSMA region identifier for a validator (0=unspecified, 1-255=assigned regions).
@@ -255,4 +255,20 @@ pub struct EpochState {
     /// This time plus the `EpochInfo::epochDuration` creates the timestamp for the next epoch
     /// boundary.
     pub epoch_start: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{primitives::keccak256, sol_types::SolCall};
+
+    /// The hand-written `delegationDigest` binding must track the on-chain 4-argument selector. If the
+    /// contract selector changes and this binding does not, `tn_delegationDigest` reverts at runtime
+    /// instead of failing to compile, so pin the selector here.
+    #[test]
+    fn delegation_digest_binding_selector_is_current() {
+        let expected: [u8; 4] =
+            keccak256("delegationDigest(bytes,address,address,uint256)")[..4].try_into().unwrap();
+        assert_eq!(ConsensusRegistry::delegationDigestCall::SELECTOR, expected);
+    }
 }

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -285,9 +285,9 @@ mod tests {
     use super::*;
     use alloy::{primitives::keccak256, sol_types::SolCall};
 
-    /// The hand-written `delegationDigest` binding must track the on-chain 4-argument selector. If the
-    /// contract selector changes and this binding does not, `tn_delegationDigest` reverts at runtime
-    /// instead of failing to compile, so pin the selector here.
+    /// The hand-written `delegationDigest` binding must track the on-chain 4-argument selector. If
+    /// the contract selector changes and this binding does not, `tn_delegationDigest` reverts
+    /// at runtime instead of failing to compile, so pin the selector here.
     #[test]
     fn delegation_digest_binding_selector_is_current() {
         let expected: [u8; 4] =


### PR DESCRIPTION
## Context

`ConsensusRegistry.delegationDigest` in tn-contracts gains a `uint256 deadline` argument (delegation signatures now carry an expiry; see tn-contracts #134). That changes the function selector, so the node's hand-written binding must match or `tn_delegationDigest` reverts at runtime.

## Change

- `system_calls.rs`: add `uint256 deadline` to the `delegationDigest` `sol!` binding.
- `rpc_ext.rs`: thread `deadline: U256` through the `tn_delegationDigest` trait method and its impl (`delegationDigestCall { ..., deadline }`). This adds a parameter to the public `tn_delegationDigest` JSON-RPC method.
- Add a unit test pinning the binding to the four-argument selector `delegationDigest(bytes,address,address,uint256)`. The RPC was previously untested, so a drifted binding would fail silently at runtime; this test fails at compile/test time instead.

## Verification

The binding and the selector test are self-contained (independent of the submodule artifact), so they compile and the unit test runs without a submodule bump - CI covers them here.

Not yet done, blocking full resolution:
- Bump the tn-contracts submodule to the merged commit from tn-contracts #134, so the deployed/genesis registry actually exposes the four-argument selector.
- Local build could not be run on Windows (pre-existing unrelated `ctrl_c` build failure in `tn-types`); relying on CI / WSL for confirmation.

Draft until tn-contracts #134 merges and the submodule is bumped.