### PR TITLE
Limit reth MDBX sizes for temp-chain tests

### DIFF
--- a/crates/consensus/primary/src/network/sync_codec.rs
+++ b/crates/consensus/primary/src/network/sync_codec.rs
@@ -554,7 +554,6 @@ where
 mod tests {
     use super::*;
     use tn_network_libp2p::SyncFrameError;
-    use tokio::io::AsyncReadExt as _;
 
     /// Frame `bytes` through [`write_pack_data_frames`] into an in-memory buffer.
     async fn frame_pack(bytes: &[u8]) -> Vec<u8> {

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1410,7 +1410,6 @@ impl RethEnv {
         /// concurrent 8 TB virtual reservations exhaust the address space and MDBX aborts
         /// env-open with ENOMEM ("Cannot allocate memory (12)"). A temp chain never holds a
         /// full node's history, so a small ceiling is safe and lets many envs coexist.
-        /// (`cargo nextest`, one process per test, never hit this — hence `make test` passed.)
         const TEMP_CHAIN_DB_MAX_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2 GiB
         /// Grow the temp DB file in small increments so throwaway DBs stay tiny on disk
         /// (reth pairs its 8 TB default with a 4 GiB step; mirror reth's `test()` 4 MiB step).

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1405,6 +1405,17 @@ impl RethEnv {
         task_manager: &TaskManager,
         rewards: Option<RewardsCounter>,
     ) -> eyre::Result<Self> {
+        /// MDBX map-size ceiling for throwaway temp-chain envs. reth defaults to 8 TB per
+        /// environment; `cargo test` runs a test binary as threads in ONE process, so N
+        /// concurrent 8 TB virtual reservations exhaust the address space and MDBX aborts
+        /// env-open with ENOMEM ("Cannot allocate memory (12)"). A temp chain never holds a
+        /// full node's history, so a small ceiling is safe and lets many envs coexist.
+        /// (`cargo nextest`, one process per test, never hit this — hence `make test` passed.)
+        const TEMP_CHAIN_DB_MAX_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2 GiB
+        /// Grow the temp DB file in small increments so throwaway DBs stay tiny on disk
+        /// (reth pairs its 8 TB default with a 4 GiB step; mirror reth's `test()` 4 MiB step).
+        const TEMP_CHAIN_DB_GROWTH_STEP: usize = 4 * 1024 * 1024; // 4 MiB
+
         let node_config = NodeConfig {
             datadir: DatadirArgs {
                 datadir: MaybePlatformPath::from(db_path.as_ref().to_path_buf()),
@@ -1414,6 +1425,12 @@ impl RethEnv {
                 pprof_dumps_path: None,
             },
             chain,
+            // Bound the MDBX geometry for throwaway temp chains (see const docs).
+            db: DatabaseArgs {
+                max_size: Some(TEMP_CHAIN_DB_MAX_SIZE),
+                growth_step: Some(TEMP_CHAIN_DB_GROWTH_STEP),
+                ..Default::default()
+            },
             ..NodeConfig::default()
         };
         let reth_config = RethConfig(node_config);


### PR DESCRIPTION
- Bound `RethEnv::new_for_temp_chain`'s MDBX geometry to a 2 GiB `max_size` / 4 MiB `growth_step` instead of reth's 8 TB default, since `cargo test` runs all tests as threads in one process and enough concurrent 8 TB virtual reservations exhaust address space, aborting env-open with ENOMEM. `cargo nextest` (one process per test) never hit this, which is why `make test` passed while `cargo test` didn't.
- Removed an unused `tokio::io::AsyncReadExt` import in `sync_codec.rs` tests.

closes #910 