### PR TITLE
build/dev profile compile speedups

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,9 +8,16 @@ incremental = true
 codegen-units = 256
 
 [profile.dev.package."*"]
-# Optimize dependencies (compiled once, cached)
-opt-level = 2
+# Lightly optimize dependencies (opt-1): keeps most of the runtime benefit of a
+# cached dep build while cutting LLVM codegen time on a cold/CI build.
+opt-level = 1
 debug = false
+
+# Build scripts and proc-macros run only at compile time and gain nothing from
+# optimization, so pin them to opt-0 instead of inheriting the package."*" bump.
+[profile.dev.build-override]
+opt-level = 0
+codegen-units = 256
 
 [profile.test]
 debug = "line-tables-only"
@@ -20,5 +27,9 @@ incremental = true
 codegen-units = 256
 
 [profile.test.package."*"]
-opt-level = 2
+opt-level = 1
 debug = false
+
+[profile.test.build-override]
+opt-level = 0
+codegen-units = 256

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 ```
 Install: `sudo apt install mold` (or see [mold releases](https://github.com/rui314/mold))
 
-These are not required -- the project builds without them. The project `.cargo/config.toml` already includes optimized profile settings (dependency opt-level=2, reduced debuginfo) that benefit all developers automatically.
+These are not required -- the project builds without them. The project `.cargo/config.toml` already includes optimized profile settings (dependency opt-level=1, reduced debuginfo) that benefit all developers automatically.
 
 #### Commits
 


### PR DESCRIPTION
## Summary

Reduce cold / CI-clean build time with two profile-only changes in `.cargo/config.toml`.  Both are strictly functionality-preserving: they touch only the `dev` and `test` profiles, and the release/attest path (`cargo build --release`, no `[profile.release]` override anywhere in the workspace) is unaffected.

## Changes

- **Dependency `opt-level` 2 → 1 (dev + test).** The `[profile.*.package."*"]` blocks currently force the entire third-party graph (reth git crates, libp2p, alloy, opentelemetry) through full LLVM optimization on every clean build, which is the single largest chunk of a cold/CI compile.  `opt-level = 1` keeps most of the runtime benefit of a cached dependency build at a fraction of the codegen cost.
- **`build-override` at opt-0 (dev + test).** The `package."*"` rule was also raising build scripts and proc-macros (`syn`/`quote`/`proc-macro2` and friends) to opt-2.  They run only at compile time and are never linked into any artifact, so optimizing them is pure overhead on the critical path (dependents block on proc-macros). Pin them back to opt-0.

## Why it is safe

- Release binary is byte-identical: no `[profile.release]` settings are touched.
- `opt-level` and `build-override` are speed knobs, not semantics; compiled output is functionally identical.
- Verified the TOML parses and both profile tables resolve as intended.

## Tradeoff

Dev/test binaries run somewhat slower on compute-bound tests.  The nextest `ci` profile uses `retries=2` and the e2e slow-timeout is 720s, so there is headroom.  If a specific hot test regresses, carve just that crate back to opt-2, e.g.:

```toml
[profile.test.package.reth-revm]
opt-level = 2
```

## Builds helped

Cold and CI-clean (CI runs with `CARGO_INCREMENTAL=0`, so dependency codegen dominates).  Warm/incremental builds see little, since deps are already cached by `cache-deps.yaml`.
