### PR TITLE
test: replace fixed real-time sleeps with condition polling (shared wait_until)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
  "tn-config",
  "tn-node",
  "tn-reth",
+ "tn-test-utils",
  "tn-types",
  "tokio",
  "tracing",
@@ -11634,6 +11635,7 @@ dependencies = [
  "tn-network-types",
  "tn-reth",
  "tn-storage",
+ "tn-test-utils",
  "tn-types",
  "tn-worker",
  "tokio",
@@ -11645,9 +11647,11 @@ name = "tn-batch-validator"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "eyre",
  "rayon",
  "tempfile",
  "tn-reth",
+ "tn-test-utils",
  "tn-types",
  "tokio",
 ]
@@ -11860,6 +11864,7 @@ dependencies = [
  "tn-primary",
  "tn-reth",
  "tn-storage",
+ "tn-test-utils",
  "tn-test-utils-committee",
  "tn-types",
  "tokio",
@@ -11973,6 +11978,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "eyre",
+ "futures",
  "indexmap 2.13.0",
  "telcoin-network-cli",
  "tempfile",
@@ -11981,6 +11987,7 @@ dependencies = [
  "tn-reth",
  "tn-test-utils-committee",
  "tn-types",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/batch-builder/Cargo.toml
+++ b/crates/batch-builder/Cargo.toml
@@ -36,6 +36,7 @@ tn-storage = { workspace = true, features = ["test-utils"] }
 tn-batch-validator = { workspace = true }
 tn-engine = { workspace = true }
 tn-batch-builder = { workspace = true, features = ["test-utils"] }
+tn-test-utils = { workspace = true }
 
 [features]
 default = []

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -15,6 +15,7 @@ use tn_reth::{
     RethChainSpec, RethEnv,
 };
 use tn_storage::{open_db, tables::NodeBatchesCache};
+use tn_test_utils::wait_until;
 use tn_types::{
     gas_accumulator::GasAccumulator, test_genesis, Address, Batch, BatchValidation, Bytes,
     Certificate, CertifiedBatch, CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database,
@@ -26,7 +27,7 @@ use tokio::time::timeout;
 use tracing::debug;
 
 #[tokio::test]
-async fn test_make_batch_el_to_cl() {
+async fn test_make_batch_el_to_cl() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().expect("temp dir");
     let task_manager = TaskManager::default();
     //
@@ -138,17 +139,17 @@ async fn test_make_batch_el_to_cl() {
     //=== Test batch flow
     //
 
-    // wait for new batch
-    let mut sealed_batch = None;
-    for _ in 0..5 {
-        let _ = tokio::time::sleep(Duration::from_secs(1)).await;
-        // Ensure the batch is stored
-        if let Some((digest, wb)) = store.iter::<NodeBatchesCache>().next() {
-            sealed_batch = Some(SealedBatch::new(wb, digest));
-            break;
-        }
-    }
-    let sealed_batch = sealed_batch.unwrap();
+    // wait for new batch to be stored
+    wait_until(Duration::from_secs(5), "batch stored", || async {
+        Ok(store.iter::<NodeBatchesCache>().next().is_some())
+    })
+    .await?;
+    // re-fetch the stored batch once the store has converged
+    let sealed_batch = store
+        .iter::<NodeBatchesCache>()
+        .next()
+        .map(|(digest, wb)| SealedBatch::new(wb, digest))
+        .expect("batch in store after wait");
 
     // ensure batch validator succeeds
     let batch_validator =
@@ -172,12 +173,16 @@ async fn test_make_batch_el_to_cl() {
     let batch_txs = sealed_batch.batch().transactions();
     assert_eq!(batch_txs, expected_batch.batch().transactions());
 
-    // ensure enough time passes for store to pass
-    let _ = tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    // ensure the batch is stored before reading it back
+    wait_until(Duration::from_secs(5), "batch stored by digest", || async {
+        Ok(store
+            .get::<NodeBatchesCache>(&expected_batch.digest())
+            .is_ok_and(|maybe| maybe.is_some()))
+    })
+    .await?;
     let first_batch = store.iter::<NodeBatchesCache>().next();
     debug!("first batch? {:?}", first_batch);
 
-    // Ensure the batch is stored
     let batch_from_store = store
         .get::<NodeBatchesCache>(&expected_batch.digest())
         .expect("store searched for batch")
@@ -189,6 +194,8 @@ async fn test_make_batch_el_to_cl() {
     let pending_pool_len = txpool.pool_size().pending;
     debug!("pool_size(): {:?}", txpool.pool_size());
     assert_eq!(pending_pool_len, 0);
+
+    Ok(())
 }
 
 /// Create 5 transactions.
@@ -379,7 +386,7 @@ async fn test_batch_builder_produces_valid_batches() {
 /// First 3 mined in first block.
 /// Before a canonical state change, mine the 4th transaction in the next block.
 #[tokio::test]
-async fn test_canonical_notification_updates_pool() {
+async fn test_canonical_notification_updates_pool() -> eyre::Result<()> {
     //
     //=== Execution Layer
     //
@@ -503,8 +510,11 @@ async fn test_canonical_notification_updates_pool() {
     let _final_header = execute_consensus_output(args, GasAccumulator::default(), engine_update_tx)
         .expect("output executed");
 
-    // sleep to ensure canonical update received before ack
-    let _ = tokio::time::sleep(Duration::from_secs(1)).await;
+    // wait for canonical update to settle the pool before ack
+    wait_until(Duration::from_secs(5), "pool pending reaches 1 after canonical update", || async {
+        Ok(txpool.pool_size().pending == 1)
+    })
+    .await?;
 
     // assert 4th transaction demoted to queued pool
     let pool_size = txpool.pool_size();
@@ -537,4 +547,6 @@ async fn test_canonical_notification_updates_pool() {
     let pool_size = txpool.pool_size();
     assert_eq!(pool_size.queued, 0);
     assert_eq!(pool_size.pending, 0);
+
+    Ok(())
 }

--- a/crates/batch-validator/Cargo.toml
+++ b/crates/batch-validator/Cargo.toml
@@ -18,9 +18,11 @@ rayon = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+eyre = { workspace = true }
 assert_matches = { workspace = true }
 tn-reth = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["sync", "time"] }
+tn-test-utils = { workspace = true }
 
 [features]
 default = []

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -236,6 +236,7 @@ mod tests {
     use std::{path::Path, str::FromStr, sync::Arc};
     use tempfile::TempDir;
     use tn_reth::{test_utils::TransactionFactory, RethChainSpec};
+    use tn_test_utils::wait_until;
     use tn_types::{
         max_batch_gas, test_genesis, Address, Batch, Bytes, Encodable2718 as _, FromHex,
         GenesisAccount, TaskManager, B256, MIN_PROTOCOL_BASE_FEE, U256,
@@ -673,7 +674,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_submit_txn_if_mine_routes_to_correct_slot() {
+    async fn test_submit_txn_if_mine_routes_to_correct_slot() -> eyre::Result<()> {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();
         let TestTools { validator, tx_pool, .. } = test_tools(tmp_dir.path(), &task_manager).await;
@@ -695,12 +696,13 @@ mod tests {
         validator.submit_txn_if_mine(&encoded, committee_size, expected_slot);
 
         // Poll for the spawned task to complete
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        while tx_pool.pool_size().pending == 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            assert!(tokio::time::Instant::now() < deadline, "timeout waiting for tx in pool");
-        }
+        wait_until(std::time::Duration::from_secs(5), "txs inserted into pool", || async {
+            Ok(tx_pool.pool_size().pending >= 1)
+        })
+        .await?;
         assert_eq!(tx_pool.pool_size().pending, 1);
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -732,7 +734,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_submit_txn_if_mine_same_sender_same_slot() {
+    async fn test_submit_txn_if_mine_same_sender_same_slot() -> eyre::Result<()> {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();
         let TestTools { validator, tx_pool, .. } = test_tools(tmp_dir.path(), &task_manager).await;
@@ -756,12 +758,13 @@ mod tests {
         }
 
         // Poll for all 3 spawned tasks to complete
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        while tx_pool.pool_size().pending < 3 {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            assert!(tokio::time::Instant::now() < deadline, "timeout waiting for txs in pool");
-        }
+        wait_until(std::time::Duration::from_secs(5), "txs inserted into pool", || async {
+            Ok(tx_pool.pool_size().pending >= 3)
+        })
+        .await?;
         assert_eq!(tx_pool.pool_size().pending, 3);
+
+        Ok(())
     }
 
     #[test]

--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -52,6 +52,7 @@ tn-storage = { workspace = true, features = ["test-utils"] }
 assert_matches = { workspace = true }
 tn-types = { workspace = true, features = ["test-utils"] }
 tn-primary = { workspace = true, features = ["test-utils"] }
+tn-test-utils = { workspace = true }
 tn-test-utils-committee = { workspace = true }
 
 [features]

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -15,6 +15,7 @@ use std::{collections::BTreeSet, future::Future as _, time::Duration};
 use tn_config::Parameters;
 use tn_network_libp2p::{error::NetworkError, types::NetworkResult};
 use tn_storage::{mem_db::MemDatabase, CertificateStore, PayloadStore};
+use tn_test_utils::wait_until;
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     test_utils::init_test_tracing, BlsPublicKey, BlsSignature, Certificate, Hash as _, Header,
@@ -34,38 +35,34 @@ async fn verify_certificates_in_store<DB: CertificateStore>(
     expected_verified_directly_count: u64,
     expected_verified_indirectly_count: u64,
 ) {
-    let mut missing = None;
+    // Poll until every input certificate is readable in the store (positive convergence),
+    // rather than sleeping a fixed interval between passes.
+    wait_until(
+        Duration::from_secs(20),
+        "all fetched certificates present in store",
+        move || async move {
+            certificates
+                .iter()
+                .try_fold(true, |acc, c| Ok(acc && certificate_store.read(c.digest())?.is_some()))
+        },
+    )
+    .await
+    .expect("all fetched certificates present in store");
+
+    // Re-read once now that convergence is proven, tallying the verification states.
     let mut verified_indirectly = 0;
     let mut verified_directly = 0;
-    for _ in 0..20 {
-        missing = None;
-        verified_directly = 0;
-        verified_indirectly = 0;
-        for (i, _) in certificates.iter().enumerate() {
-            if let Ok(Some(cert)) = certificate_store.read(certificates[i].digest()) {
-                match cert.signature_verification_state() {
-                    SignatureVerificationState::VerifiedDirectly(_) => verified_directly += 1,
-                    SignatureVerificationState::VerifiedIndirectly(_) => verified_indirectly += 1,
-                    _ => panic!(
-                        "Found unexpected stored signature state {:?}",
-                        cert.signature_verification_state()
-                    ),
-                };
-                continue;
-            }
-            missing = Some(i);
-            break;
+    for (i, _) in certificates.iter().enumerate() {
+        if let Ok(Some(cert)) = certificate_store.read(certificates[i].digest()) {
+            match cert.signature_verification_state() {
+                SignatureVerificationState::VerifiedDirectly(_) => verified_directly += 1,
+                SignatureVerificationState::VerifiedIndirectly(_) => verified_indirectly += 1,
+                _ => panic!(
+                    "Found unexpected stored signature state {:?}",
+                    cert.signature_verification_state()
+                ),
+            };
         }
-        if missing.is_none() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
-    }
-    if let Some(i) = missing {
-        panic!(
-            "Missing certificate in store: input index {}, certificate: {:?}",
-            i, certificates[i]
-        );
     }
 
     assert_eq!(
@@ -494,14 +491,17 @@ async fn test_fetch_cancellation_on_success() {
     // Poll under a generous deadline so a slow CI runner simply waits longer rather than
     // failing. Reaching this point also proves the fetch task returned, which is when the
     // fan-out is cancelled.
-    timeout(Duration::from_secs(10), async {
-        while !round1_certs
-            .iter()
-            .all(|cert| certificate_store.read(cert.digest()).unwrap().is_some())
-        {
-            sleep(Duration::from_millis(10)).await;
-        }
-    })
+    let round1_certs_ref = &round1_certs;
+    let certificate_store_ref = &certificate_store;
+    wait_until(
+        Duration::from_secs(10),
+        "Round 1 certificates should be stored after a successful fetch",
+        move || async move {
+            round1_certs_ref.iter().try_fold(true, |acc, cert| {
+                Ok(acc && certificate_store_ref.read(cert.digest())?.is_some())
+            })
+        },
+    )
     .await
     .expect("Round 1 certificates should be stored after a successful fetch");
 

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -32,6 +32,7 @@ alloy = { workspace = true }
 [dev-dependencies]
 futures = { workspace = true }
 tn-reth = { workspace = true, features = ["test-utils"] }
+tn-test-utils = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -24,6 +24,7 @@ use std::{
     sync::{Condvar, Mutex},
     time::Duration,
 };
+use tn_test_utils::wait_until_blocking;
 use tn_types::{
     address, get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address,
 };
@@ -296,24 +297,9 @@ pub(crate) fn network_advancing(client_urls: &[String; 4]) -> eyre::Result<()> {
     // exist or an epoch closes, so we cannot rely on block_number advancing
     // during idle periods. Actual block production is verified later by
     // send_and_confirm().
-    let mut i = 0;
-    loop {
-        let mut all_responsive = true;
-        for url in client_urls {
-            if get_block_number(url).is_err() {
-                all_responsive = false;
-                break;
-            }
-        }
-        if all_responsive {
-            return Ok(());
-        }
-        std::thread::sleep(Duration::from_secs(1));
-        i += 1;
-        if i > 45 {
-            return Err(eyre::eyre!("Network not responding within 45 seconds!"));
-        }
-    }
+    wait_until_blocking(Duration::from_secs(45), "all nodes advancing", || {
+        Ok(client_urls.iter().all(|url| get_block_number(url).is_ok()))
+    })
 }
 
 /// Start a process running a validator node.
@@ -499,8 +485,6 @@ pub(crate) fn send_and_confirm(
     let expected = current + amount;
     send_tel(node, key, to_account, amount, 250, 21000, nonce)?;
 
-    // sleep
-    std::thread::sleep(Duration::from_millis(1000));
     info!(target: "restart-test", "calling get_positive_balance_with_retry...");
 
     // get positive bal and kill child2 if error

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -19,11 +19,12 @@ use tn_reth::{
     test_utils::TransactionFactory,
     RethChainSpec,
 };
+use tn_test_utils::wait_until;
 use tn_types::{
     get_available_tcp_port, test_utils::CommandParser, Address, EpochCertificate, EpochRecord,
     Genesis, GenesisAccount, U256,
 };
-use tokio::time::{timeout, Instant};
+use tokio::time::timeout;
 use tracing::{debug, info};
 
 const NEW_VALIDATOR: &str = "new-validator";
@@ -107,19 +108,11 @@ async fn test_epoch_boundary_inner(
     // n ~= 25 iterations
     for i in 0..25 {
         // poll until the epoch changes, with a generous timeout for parallel test load
-        let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 4);
-        let new_epoch_info = loop {
-            let info = consensus_registry.getCurrentEpochInfo().call().await?;
-            if info != current_epoch_info {
-                break info;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "Epoch did not change within {}s on iteration {i}",
-                EPOCH_DURATION * 4
-            );
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        };
+        wait_until(Duration::from_secs(EPOCH_DURATION * 4), "epoch to change", || async {
+            Ok(consensus_registry.getCurrentEpochInfo().call().await? != current_epoch_info)
+        })
+        .await?;
+        let new_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
 
         assert!(new_epoch_info.blockHeight > last_epoch_block_height);
         assert_eq!(new_epoch_info.epochDuration as u64, EPOCH_DURATION);
@@ -153,27 +146,25 @@ async fn test_epoch_boundary_inner(
             for epoch in 0..=latest_epoch {
                 // Certificate availability is a fixed async quorum-voting cost, so floor
                 // this deadline at 30s instead of letting it shrink with EPOCH_DURATION.
-                let deadline = Instant::now() + Duration::from_secs((EPOCH_DURATION * 3).max(30));
-                let (epoch_rec, cert) = loop {
-                    match provider
-                        .raw_request::<_, (EpochRecord, EpochCertificate)>(
-                            "tn_epochRecord".into(),
-                            (epoch,),
-                        )
-                        .await
-                    {
-                        Ok(result) => break result,
-                        Err(_) if Instant::now() < deadline => {
-                            tokio::time::sleep(Duration::from_secs(1)).await;
-                        }
-                        Err(e) => {
-                            return Err(eyre::eyre!(
-                                "epoch record not available for epoch {epoch} on {}: {e}",
-                                ep.http_url
-                            ));
-                        }
-                    }
-                };
+                wait_until(
+                    Duration::from_secs((EPOCH_DURATION * 3).max(30)),
+                    "epoch record certificate to become available",
+                    || async {
+                        Ok(provider
+                            .raw_request::<_, (EpochRecord, EpochCertificate)>(
+                                "tn_epochRecord".into(),
+                                (epoch,),
+                            )
+                            .await
+                            .is_ok())
+                    },
+                )
+                .await
+                .map_err(|_| {
+                    eyre::eyre!("epoch record not available for epoch {epoch} on {}", ep.http_url)
+                })?;
+                let (epoch_rec, cert): (EpochRecord, EpochCertificate) =
+                    provider.raw_request("tn_epochRecord".into(), (epoch,)).await?;
                 assert!(epoch_rec.verify_with_cert(&cert), "invalid epoch record!");
             }
         }
@@ -318,21 +309,13 @@ async fn loop_epochs(start: u32, iterations: u32, rpc_url: &str) -> eyre::Result
     let mut current_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
 
     let mut last_epoch_block_height = current_epoch_info.blockHeight;
-    for i in start..start + iterations {
+    for _ in start..start + iterations {
         // poll until the epoch changes, with a generous timeout for parallel test load
-        let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 4);
-        let new_epoch_info = loop {
-            let info = consensus_registry.getCurrentEpochInfo().call().await?;
-            if info != current_epoch_info {
-                break info;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "Epoch did not change within {}s on iteration {i}",
-                EPOCH_DURATION * 4
-            );
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        };
+        wait_until(Duration::from_secs(EPOCH_DURATION * 4), "epoch to change", || async {
+            Ok(consensus_registry.getCurrentEpochInfo().call().await? != current_epoch_info)
+        })
+        .await?;
+        let new_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
 
         assert!(new_epoch_info.blockHeight > last_epoch_block_height);
         assert_eq!(new_epoch_info.epochDuration as u64, EPOCH_DURATION);
@@ -417,27 +400,28 @@ async fn test_epoch_sync_inner(
             // fallback runs. The spawn_epoch_record_collector retries every 5s
             // independently, so 60s gives enough time for it to succeed. This is a fixed
             // cost, so floor the deadline at 60s rather than scaling it with EPOCH_DURATION.
-            let deadline = Instant::now() + Duration::from_secs((EPOCH_DURATION * 6).max(60));
-            let (epoch_rec, cert) = loop {
-                match provider
-                    .raw_request::<_, (EpochRecord, EpochCertificate)>(
-                        "tn_epochRecord".into(),
-                        (epoch,),
-                    )
-                    .await
-                {
-                    Ok(result) => break result,
-                    Err(_) if Instant::now() < deadline => {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                    }
-                    Err(e) => {
-                        return Err(eyre::eyre!(
-                            "epoch record not available for validator {val_name} epoch {epoch} on {}: {e}",
-                            ep.http_url
-                        ));
-                    }
-                }
-            };
+            wait_until(
+                Duration::from_secs((EPOCH_DURATION * 6).max(60)),
+                "epoch record certificate to become available",
+                || async {
+                    Ok(provider
+                        .raw_request::<_, (EpochRecord, EpochCertificate)>(
+                            "tn_epochRecord".into(),
+                            (epoch,),
+                        )
+                        .await
+                        .is_ok())
+                },
+            )
+            .await
+            .map_err(|_| {
+                eyre::eyre!(
+                    "epoch record not available for validator {val_name} epoch {epoch} on {}",
+                    ep.http_url
+                )
+            })?;
+            let (epoch_rec, cert): (EpochRecord, EpochCertificate) =
+                provider.raw_request("tn_epochRecord".into(), (epoch,)).await?;
             assert!(
                 epoch_rec.verify_with_cert(&cert),
                 "invalid epoch record: {} {}/{} {}!",

--- a/crates/e2e-tests/tests/it/faucet.rs
+++ b/crates/e2e-tests/tests/it/faucet.rs
@@ -14,6 +14,7 @@ use tn_reth::{
     faucet_mint_role_slot, test_utils::TransactionFactory, RethChainSpec, RethEnv,
     TELCOIN_PRECOMPILE_ADDRESS,
 };
+use tn_test_utils::wait_until;
 use tn_types::{
     adiri_genesis, hex, sol, Address, Encodable2718 as _, Genesis, GenesisAccount, SolValue,
     TaskManager, B256, U256,
@@ -344,15 +345,20 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let genesis: Genesis = Config::load_from_path(&genesis_file, ConfigFmt::YAML)?;
     let chain: Arc<RethChainSpec> = Arc::new(genesis.clone().into());
 
-    info!(target: "faucet-test", "nodes started - sleeping for 15s...");
-
-    tokio::time::sleep(Duration::from_secs(15)).await;
-
-    // verify all three transports (HTTP, WS, IPC) are reachable
-    verify_all_transports(&endpoints[0]).await?;
+    info!(target: "faucet-test", "nodes started - waiting for the network to produce a block...");
 
     let rpc_url = endpoints[0].http_url.clone();
     let client = HttpClientBuilder::default().build(&rpc_url)?;
+
+    // wait for network convergence by polling until the network produces a block
+    wait_until(Duration::from_secs(30), "network produced a block", || async {
+        let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
+        Ok(U256::from_str(&block_number)? > U256::ZERO)
+    })
+    .await?;
+
+    // verify all three transports (HTTP, WS, IPC) are reachable
+    verify_all_transports(&endpoints[0]).await?;
 
     // assert deployer starting balance is properly seeded
     let mut caller = TransactionFactory::new();
@@ -428,32 +434,13 @@ async fn test_faucet_drip_tel_and_xyz_e2e() -> eyre::Result<()> {
     let stablecoin_contract = Stablecoin::new(stablecoin_address, provider.clone());
     let expected_xyz_balance = U256::from(1_000_000); // 1e6 (1 XYZ)
 
-    let result = timeout(duration, async {
-        loop {
-            let actual_xyz_balance: U256 =
-                stablecoin_contract.balanceOf(new_recipient).call().await?;
-            debug!(target: "faucet-test", "actual XYZ balance: {:?}", actual_xyz_balance);
-
-            if actual_xyz_balance == expected_xyz_balance {
-                return Ok::<_, eyre::Report>(actual_xyz_balance);
-            }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
+    wait_until(duration, "recipient XYZ balance credited", || async {
+        let actual_xyz_balance: U256 = stablecoin_contract.balanceOf(new_recipient).call().await?;
+        debug!(target: "faucet-test", "actual XYZ balance: {:?}", actual_xyz_balance);
+        Ok(actual_xyz_balance == expected_xyz_balance)
     })
-    .await;
-
-    match result {
-        Ok(Ok(balance)) => {
-            info!(target: "faucet-test", "XYZ balance check completed successfully: {}", balance);
-        }
-        Ok(Err(e)) => {
-            panic!("Error while checking XYZ balance: {e:?}");
-        }
-        Err(_) => {
-            panic!("XYZ balance check timed out");
-        }
-    }
+    .await?;
+    info!(target: "faucet-test", "XYZ balance check completed successfully");
 
     // submit concurrent drip calls for TEL to multiple random addresses
     // prepare all txs from the funded caller (nonces increment sequentially)

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -17,6 +17,7 @@ use std::{
     process::Child,
     time::{Duration, Instant},
 };
+use tn_test_utils::wait_until_blocking;
 use tn_types::get_available_tcp_port;
 use tracing::{error, info};
 
@@ -555,29 +556,18 @@ fn test_observer_late_join_catchup() -> eyre::Result<()> {
     let obs_url = format!("http://127.0.0.1:{obs_rpc_port}");
     guard.push(start_observer(4, &bin, &temp_path, obs_rpc_port, "late_join", 0));
 
-    // Observer must catch up to at least the validator consensus height we recorded
-    let mut retries = 0;
-    let max_retries = 120; // 120 seconds max
-    let caught_up = loop {
-        if let Ok(obs_consensus_height) = get_latest_consensus_header_number(&obs_url) {
-            if obs_consensus_height >= validator_consensus_height {
-                info!(target: "restart-test", ?obs_consensus_height, ?validator_consensus_height, "observer caught up");
-                break true;
-            }
-            info!(target: "restart-test", ?obs_consensus_height, ?validator_consensus_height, retries, "observer still catching up");
-        }
-        retries += 1;
-        if retries >= max_retries {
-            break false;
-        }
-        std::thread::sleep(Duration::from_secs(1));
-    };
-
-    // Guard cleanup handles all process shutdown on drop
-    assert!(
-        caught_up,
-        "Observer did not catch up within {max_retries}s. Check logs in test_logs/late_join/"
-    );
+    // Observer must catch up to at least the validator consensus height we recorded.
+    // Guard cleanup handles all process shutdown on drop; on timeout the `?` surfaces the
+    // same effective failure ("observer did not catch up") the old assert produced.
+    wait_until_blocking(
+        Duration::from_secs(120),
+        "observer caught up to validator (test_logs/late_join/)",
+        || {
+            Ok(get_latest_consensus_header_number(&obs_url)
+                .map(|h| h >= validator_consensus_height)
+                .unwrap_or(false))
+        },
+    )?;
     Ok(())
 }
 
@@ -641,24 +631,17 @@ fn test_observer_reconnect_after_pause() -> eyre::Result<()> {
     signal::kill(obs_pid, Signal::SIGCONT)?;
     info!(target: "restart-test", "observer resumed, waiting for catchup");
 
-    // Observer must catch up
-    let mut retries = 0;
-    let max_retries = 60;
-    let caught_up = loop {
-        if let Ok(obs_consensus_height) = get_latest_consensus_header_number(&obs_url) {
-            if obs_consensus_height >= validator_consensus_height_during_pause {
-                info!(target: "restart-test", ?obs_consensus_height, ?validator_consensus_height_during_pause, "observer recovered");
-                break true;
-            }
-        }
-        retries += 1;
-        if retries >= max_retries {
-            break false;
-        }
-        std::thread::sleep(Duration::from_secs(1));
-    };
-
-    // Guard cleanup handles all process shutdown on drop
-    assert!(caught_up, "Observer did not recover within {max_retries}s after SIGCONT. Check logs in test_logs/reconnect/");
+    // Observer must catch up. Guard cleanup handles all process shutdown on drop; on timeout
+    // the `?` surfaces the same effective failure ("observer did not recover") the old assert
+    // produced.
+    wait_until_blocking(
+        Duration::from_secs(60),
+        "observer recovered after SIGCONT (test_logs/reconnect/)",
+        || {
+            Ok(get_latest_consensus_header_number(&obs_url)
+                .map(|h| h >= validator_consensus_height_during_pause)
+                .unwrap_or(false))
+        },
+    )?;
     Ok(())
 }

--- a/crates/e2e-tests/tests/it/sync.rs
+++ b/crates/e2e-tests/tests/it/sync.rs
@@ -4,8 +4,8 @@ use alloy::providers::{Provider, ProviderBuilder};
 use e2e_tests::config_local_testnet_with_epoch_duration;
 use std::time::Duration;
 use tn_reth::system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS};
+use tn_test_utils::wait_until;
 use tn_types::{get_available_tcp_port, EpochCertificate, EpochRecord};
-use tokio::time::Instant;
 use tracing::info;
 
 use crate::common::{
@@ -80,36 +80,28 @@ async fn test_observer_pack_imports_after_epoch_close_inner() -> eyre::Result<()
     let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, &provider);
 
     // (a) wait for epoch 0 to close
-    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 4);
-    loop {
-        let info = registry.getCurrentEpochInfo().call().await?;
-        if info.epochId > 0 {
-            info!(target: "restart-test", current_epoch = info.epochId, "epoch 0 closed");
-            break;
-        }
-        if Instant::now() >= deadline {
-            return Err(eyre::eyre!(
-                "epoch 0 did not close within {}s",
-                PACK_IMPORT_EPOCH_DURATION * 4
-            ));
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
+    wait_until(Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 4), "epoch 0 to close", || async {
+        Ok(registry.getCurrentEpochInfo().call().await?.epochId > 0)
+    })
+    .await?;
+    let info = registry.getCurrentEpochInfo().call().await?;
+    info!(target: "restart-test", current_epoch = info.epochId, "epoch 0 closed");
 
     // (b) wait for tn_epochRecord(0) to return a certified record
-    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3);
-    let validator_record_0: (EpochRecord, EpochCertificate) = loop {
-        match provider
-            .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
-            .await
-        {
-            Ok(rec) => break rec,
-            Err(_) if Instant::now() < deadline => {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-            Err(e) => return Err(eyre::eyre!("epoch 0 record never certified: {e}")),
-        }
-    };
+    wait_until(
+        Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3),
+        "epoch 0 record to be certified on validator",
+        || async {
+            Ok(provider
+                .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+                .await
+                .is_ok())
+        },
+    )
+    .await?;
+    let validator_record_0: (EpochRecord, EpochCertificate) = provider
+        .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+        .await?;
     assert!(
         validator_record_0.0.verify_with_cert(&validator_record_0.1),
         "validator-side epoch-0 record fails self-verify"
@@ -126,39 +118,35 @@ async fn test_observer_pack_imports_after_epoch_close_inner() -> eyre::Result<()
     // racing with EVM execution lag. The deadline allows pack download + verify + apply
     // on top of normal observer startup.
     let validator_height = get_latest_consensus_header_number(&client_urls[0])?;
-    let max_secs = (PACK_IMPORT_EPOCH_DURATION * 6).max(60) as i32;
-    let mut caught_up = false;
-    for _ in 0..max_secs {
-        if let Ok(obs_height) = get_latest_consensus_header_number(&obs_url) {
-            if obs_height >= validator_height {
-                info!(target: "restart-test", obs_height, validator_height, "observer caught up via pack import");
-                caught_up = true;
-                break;
-            }
-        }
-        std::thread::sleep(Duration::from_secs(1));
-    }
-    assert!(
-        caught_up,
-        "observer did not catch up within {max_secs}s — pack import likely failed. Check logs in test_logs/observer_pack_import/"
-    );
+    let max_secs = (PACK_IMPORT_EPOCH_DURATION * 6).max(60);
+    wait_until(
+        Duration::from_secs(max_secs),
+        "observer to catch up via pack import (check logs in test_logs/observer_pack_import/)",
+        || async {
+            Ok(get_latest_consensus_header_number(&obs_url)
+                .is_ok_and(|obs_height| obs_height >= validator_height))
+        },
+    )
+    .await?;
+    info!(target: "restart-test", validator_height, "observer caught up via pack import");
 
     // The observer must reconstruct the epoch-0 pack chain: ask for tn_epochRecord(0)
     // and confirm it self-verifies and matches the validator's record byte-for-byte.
     let obs_provider = ProviderBuilder::new().connect_http(obs_url.parse()?);
-    let deadline = Instant::now() + Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3);
-    let observer_record_0: (EpochRecord, EpochCertificate) = loop {
-        match obs_provider
-            .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
-            .await
-        {
-            Ok(rec) => break rec,
-            Err(_) if Instant::now() < deadline => {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-            Err(e) => return Err(eyre::eyre!("observer epoch 0 record never available: {e}")),
-        }
-    };
+    wait_until(
+        Duration::from_secs(PACK_IMPORT_EPOCH_DURATION * 3),
+        "epoch 0 record to be available on observer",
+        || async {
+            Ok(obs_provider
+                .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+                .await
+                .is_ok())
+        },
+    )
+    .await?;
+    let observer_record_0: (EpochRecord, EpochCertificate) = obs_provider
+        .raw_request::<_, (EpochRecord, EpochCertificate)>("tn_epochRecord".into(), (0u32,))
+        .await?;
     assert!(
         observer_record_0.0.verify_with_cert(&observer_record_0.1),
         "observer epoch-0 record fails self-verify after pack import"

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroUsize;
 use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::mem_db::MemDatabase;
-use tn_test_utils::CommitteeFixture;
+use tn_test_utils::{wait_until, CommitteeFixture};
 use tn_types::{BlsKeypair, Certificate, Header, TaskManager};
 use tokio::{sync::mpsc, time::timeout};
 
@@ -215,55 +215,10 @@ async fn wait_for_peer_discovery<Req: TNMessage, Res: TNMessage>(
     expected_bls: BlsPublicKey,
     timeout_duration: Duration,
 ) -> eyre::Result<()> {
-    let deadline = tokio::time::Instant::now() + timeout_duration;
-    loop {
-        let peers = handle.connected_peers().await?;
-        if peers.contains(&expected_bls) {
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(eyre!("timed out waiting for peer BLS key discovery via kademlia"));
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
-
-/// Poll an async `condition` until it returns `true`, or fail once `timeout_duration` elapses.
-///
-/// A bounded, self-synchronizing replacement for a fixed `sleep` that only guesses
-/// at how long an asynchronous swarm event (gossip mesh grafting, subscription
-/// propagation, connection teardown plus pending-request cleanup) takes. It folds
-/// over a bounded sequence of ~10ms poll attempts, carrying the first resolved
-/// verdict forward: `Some(Ok(()))` once the condition holds, `Some(Err(_))` if a
-/// poll itself errors, and `None` while still waiting. An exhausted fold (still
-/// `None`) means the deadline passed. Mirrors the poll shape of
-/// [`wait_for_peer_discovery`] but is generic over the polled condition.
-async fn wait_until<F, Fut>(
-    timeout_duration: Duration,
-    description: &str,
-    condition: F,
-) -> eyre::Result<()>
-where
-    F: Fn() -> Fut,
-    Fut: std::future::Future<Output = eyre::Result<bool>>,
-{
-    const POLL_INTERVAL: Duration = Duration::from_millis(10);
-    let attempts = (timeout_duration.as_millis() / POLL_INTERVAL.as_millis()).max(1);
-    let condition = &condition;
-
-    futures::stream::iter(0..attempts)
-        .fold(None, move |resolved: Option<eyre::Result<()>>, attempt| async move {
-            if resolved.is_some() {
-                resolved
-            } else {
-                if attempt > 0 {
-                    tokio::time::sleep(POLL_INTERVAL).await;
-                }
-                condition().await.map(|met| met.then_some(())).transpose()
-            }
-        })
-        .await
-        .unwrap_or_else(|| Err(eyre!("timed out waiting for condition: {description}")))
+    wait_until(timeout_duration, "peer BLS key discovery via kademlia", move || async move {
+        Ok(handle.connected_peers().await?.contains(&expected_bls))
+    })
+    .await
 }
 
 #[tokio::test]
@@ -885,7 +840,10 @@ async fn test_unsupported_protocol_does_not_penalize() -> eyre::Result<()> {
         )
         .await?;
     primary.dial_by_bls(worker_bls).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    wait_until(Duration::from_secs(5), "transport connection across roles establishes", || async {
+        Ok(primary.connected_peer_ids().await?.contains(&worker_peer_id))
+    })
+    .await?;
     assert!(
         primary.connected_peer_ids().await?.contains(&worker_peer_id),
         "transport connection across roles should establish"
@@ -1162,8 +1120,12 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
         // connect to target
         peer.network_handle.dial_by_bls(target_peer_bls).await?;
 
-        // give time for connection to establish and libp2p state to stabilize
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // wait for the connection to establish and libp2p state to stabilize
+        let peer_handle = &peer.network_handle;
+        wait_until(Duration::from_secs(5), "peer connects to target", move || async move {
+            Ok(peer_handle.connected_peers().await?.contains(&target_peer_bls))
+        })
+        .await?;
     }
 
     // allow heartbeat to trigger peer pruning - increased to give libp2p time to
@@ -1361,8 +1323,12 @@ async fn test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer() -> eyre:
             .await?;
         peer.network_handle.dial_by_bls(target_peer_bls).await?;
 
-        // give time for connection to establish and libp2p state to stabilize
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // wait for the connection to establish and libp2p state to stabilize
+        let peer_handle = &peer.network_handle;
+        wait_until(Duration::from_secs(5), "peer connects to target", move || async move {
+            Ok(peer_handle.connected_peers().await?.contains(&target_peer_bls))
+        })
+        .await?;
     }
 
     // raw legacy peer: the target's main req-res protocol only, no dedicated
@@ -1422,16 +1388,15 @@ async fn test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer() -> eyre:
     );
 
     // the ack resolves the pending exchange and the target disconnects promptly
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let mut still_connected = true;
-    while still_connected && tokio::time::Instant::now() < deadline {
-        still_connected =
-            target_peer.network_handle.connected_peer_ids().await?.contains(&raw_peer_id);
-        if still_connected {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    }
-    assert!(!still_connected, "target should disconnect the raw legacy peer after the goodbye");
+    let target_handle = &target_peer.network_handle;
+    wait_until(Duration::from_secs(10), "target disconnects the raw legacy peer", || async {
+        Ok(!target_handle.connected_peer_ids().await?.contains(&raw_peer_id))
+    })
+    .await?;
+    assert!(
+        !target_peer.network_handle.connected_peer_ids().await?.contains(&raw_peer_id),
+        "target should disconnect the raw legacy peer after the goodbye"
+    );
 
     Ok(())
 }
@@ -1476,8 +1441,11 @@ async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
     // Connect peers
     peer1.dial_by_bls(peer2_bls).await?;
 
-    // Wait a beat for peer2 to recieve peer1 bls key.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for peer2 to be connected (receives peer1 bls key).
+    wait_until(Duration::from_secs(5), "peer2 is connected", || async {
+        Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+    })
+    .await?;
 
     // Verify connection established
     let connected_peers = peer1.connected_peer_ids().await?;
@@ -1488,9 +1456,13 @@ async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
         peer1.report_penalty(peer2_bls, Penalty::Medium).await;
     }
 
-    // Wait briefly for penalties to be processed by the network task,
-    // but capture score before the next heartbeat can decay it
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Wait for the penalties to lower peer2's score below the default.
+    wait_until(
+        Duration::from_secs(5),
+        "peer2 score drops below default after penalties",
+        || async { Ok(peer1.peer_score(peer2_id).await?.is_some_and(|s| s < default_score)) },
+    )
+    .await?;
 
     // Check peer2's score is lower but still connected
     let score_after_penalty = peer1.peer_score(peer2_id).await?.unwrap();
@@ -1499,8 +1471,13 @@ async fn test_score_decay_and_reconnection() -> eyre::Result<()> {
         "{score_after_penalty} not less than {default_score}"
     );
 
-    // Wait for scores to recover through heartbeats
-    tokio::time::sleep(Duration::from_secs(4 * TEST_HEARTBEAT_INTERVAL)).await;
+    // Wait for scores to recover (decay toward 0) through heartbeats.
+    wait_until(
+        Duration::from_secs(4 * TEST_HEARTBEAT_INTERVAL + 5),
+        "peer2 score recovers above the post-penalty low",
+        || async { Ok(peer1.peer_score(peer2_id).await?.is_some_and(|s| s > score_after_penalty)) },
+    )
+    .await?;
 
     // Check score improved (decayed toward 0)
     let score_after_decay = peer1.peer_score(peer2_id).await?.unwrap();
@@ -1561,8 +1538,11 @@ async fn test_banned_peer_reconnection_attempt() -> eyre::Result<()> {
         .await?;
     malicious_peer.dial_by_bls(config_1.key_config().primary_public_key()).await?;
 
-    // Wait for connection to establish
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // Wait for the connection to establish
+    wait_until(Duration::from_secs(5), "malicious peer connects to honest", || async {
+        Ok(honest_peer.connected_peer_ids().await?.contains(&malicious_id))
+    })
+    .await?;
 
     debug!(target: "peer-manager", ?malicious_id, ?malicious_bls, "assessing fatal penalty!!");
     // Report fatal penalty for malicious peer
@@ -1716,8 +1696,12 @@ async fn test_multi_peer_mesh_formation() -> eyre::Result<()> {
             .await?;
         peer.network_handle.dial_by_bls(target_bls).await?;
 
-        // Give time for connection to establish
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Wait for the connection to establish
+        let peer_handle = &peer.network_handle;
+        wait_until(Duration::from_secs(5), "peer connects to target", move || async move {
+            Ok(peer_handle.connected_peers().await?.contains(&target_bls))
+        })
+        .await?;
 
         // subscribe to test topic with target peer as authorized publisher
         peer.network_handle
@@ -1801,8 +1785,11 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
         .await?;
     peer1.dial_by_bls(config_2.key_config().primary_public_key()).await?;
 
-    // Wait for connection to establish
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for the connection to establish
+    wait_until(Duration::from_secs(5), "peer2 connects initially", || async {
+        Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+    })
+    .await?;
 
     // Verify connection established
     let connected_peers = peer1.connected_peer_ids().await?;
@@ -1851,8 +1838,11 @@ async fn test_new_epoch_unbans_committee_members() -> eyre::Result<()> {
     // peer2 should dial peer1 - but try dial to reconnecting peer2 and ignore `AlreadyConnectedErr`
     let _ = peer1.dial_by_bls(config_2.key_config().primary_public_key()).await;
 
-    // Wait for connection to reestablish
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for the connection to reestablish
+    wait_until(Duration::from_secs(5), "peer2 reconnects after unban", || async {
+        Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+    })
+    .await?;
 
     // Verify connection reestablished
     let connected_peers_after = peer1.connected_peer_ids().await?;
@@ -1928,8 +1918,12 @@ async fn test_new_epoch_unbans_committee_member_ip() -> eyre::Result<()> {
         )
         .await?;
 
-    // Wait for connection to establish
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for the connection to establish
+    let target_handle = &target_peer.network_handle;
+    wait_until(Duration::from_secs(5), "target connects to peer1", || async {
+        Ok(target_handle.connected_peer_ids().await?.contains(&peer1_id))
+    })
+    .await?;
 
     // Apply fatal penalty to peer1 - should ban it and its IP
     target_peer
@@ -2009,8 +2003,11 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
     // Connect peers
     peer1.dial_by_bls(peer2_bls).await?;
 
-    // Wait for connection to establish
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Wait for the connection to establish
+    wait_until(Duration::from_secs(5), "peer2 connects initially", || async {
+        Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+    })
+    .await?;
 
     // Verify connection established
     let connected_peers = peer1.connected_peer_ids().await?;
@@ -2044,8 +2041,13 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
     })
     .await?;
 
-    // Wait for epoch processing
-    tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;
+    // Wait for epoch processing to lift peer2's score above zero.
+    wait_until(
+        Duration::from_secs(TEST_HEARTBEAT_INTERVAL + 5),
+        "peer2 score turns positive after new epoch",
+        || async { Ok(peer1.peer_score(peer2_id).await?.is_some_and(|s| s > 0.0)) },
+    )
+    .await?;
 
     // Verify peer2's score has improved and is trusted
     let score_after_epoch = peer1.peer_score(peer2_id).await?.unwrap();
@@ -2056,8 +2058,11 @@ async fn test_new_epoch_handles_disconnecting_pending_ban() -> eyre::Result<()> 
         let dial_result = peer1.dial_by_bls(peer2_bls).await;
         assert!(dial_result.is_ok(), "Should be able to reconnect to peer2 after new epoch");
 
-        // Wait for connection to reestablish
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for the connection to reestablish
+        wait_until(Duration::from_secs(5), "peer2 reconnects after new epoch", || async {
+            Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+        })
+        .await?;
     }
 
     // Verify connection is established
@@ -2097,7 +2102,10 @@ async fn test_rotate_does_not_disconnect_previous_committee() -> eyre::Result<()
         )
         .await?;
     peer1.dial_by_bls(peer2_bls).await?;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_until(Duration::from_secs(5), "peer2 connects before rotation", || async {
+        Ok(peer1.connected_peer_ids().await?.contains(&peer2_id))
+    })
+    .await?;
     assert!(
         peer1.connected_peer_ids().await?.contains(&peer2_id),
         "peer2 should be connected before rotation"
@@ -2207,7 +2215,10 @@ async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()>
         .await?;
 
     // Allow the connection to establish and gossipsub to graft.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_until(Duration::from_secs(5), "next-committee peer connects to publisher", || async {
+        Ok(publisher.connected_peer_ids().await?.contains(&next_id))
+    })
+    .await?;
 
     assert!(
         publisher.connected_peer_ids().await?.contains(&next_id),
@@ -2287,8 +2298,12 @@ async fn test_get_kad_records() -> eyre::Result<()> {
             )
             .await?;
 
-        // Give time for connection to establish
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for the connection to establish
+        let peer_handle = &peer.network_handle;
+        wait_until(Duration::from_secs(5), "peer connects to target", move || async move {
+            Ok(peer_handle.connected_peers().await?.contains(&target_peer_bls))
+        })
+        .await?;
 
         peer.network_handle
             .subscribe_with_publishers(TEST_TOPIC.into(), peer.config.committee_pub_keys())
@@ -2452,16 +2467,10 @@ async fn test_killed_peer_record_expires_local_record_survives() -> eyre::Result
     // Poll until peer1 has stored peer2's record. `publish_our_data_to_peer`
     // fires on PeerConnected, but the actual record-store write only lands
     // after a round trip.
-    let kad_recv_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if peer1_handle.kad_store_get(peer2_bls).await?.is_some() {
-            break;
-        }
-        if tokio::time::Instant::now() >= kad_recv_deadline {
-            return Err(eyre!("timed out waiting for peer1 to receive peer2's kad record"));
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
+    wait_until(Duration::from_secs(5), "peer1 receives peer2's kad record", || async {
+        Ok(peer1_handle.kad_store_get(peer2_bls).await?.is_some())
+    })
+    .await?;
 
     // Sanity: peer1's own record also present before peer2 dies.
     assert!(
@@ -2604,7 +2613,11 @@ async fn test_advertise_rpc_via_kad() -> eyre::Result<()> {
                 target_peer_addr.clone(),
             )
             .await?;
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let peer_handle = &peer.network_handle;
+        wait_until(Duration::from_secs(5), "peer connects to target", move || async move {
+            Ok(peer_handle.connected_peers().await?.contains(&target_peer_bls))
+        })
+        .await?;
     }
 
     tokio::time::sleep(Duration::from_secs(TEST_HEARTBEAT_INTERVAL)).await;

--- a/crates/node/src/health.rs
+++ b/crates/node/src/health.rs
@@ -242,9 +242,6 @@ mod tests {
         // liveness path never polls the readiness probe
         let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { false }).await?;
 
-        // give server time to start listening
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
         let response = roundtrip(addr, b"GET / HTTP/1.1\r\n\r\n").await?;
 
         // verify http status line
@@ -267,7 +264,6 @@ mod tests {
 
         let port = get_available_tcp_port("127.0.0.1").expect("tcp port assigned by host");
         let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { false }).await?;
-        tokio::time::sleep(Duration::from_millis(10)).await;
 
         let response = roundtrip(addr, b"GET /health/workers HTTP/1.1\r\n\r\n").await?;
 
@@ -293,7 +289,6 @@ mod tests {
 
         let port = get_available_tcp_port("127.0.0.1").expect("tcp port assigned by host");
         let addr = HealthcheckServer::spawn(task_spawner.clone(), port, || async { true }).await?;
-        tokio::time::sleep(Duration::from_millis(10)).await;
 
         let response = roundtrip(addr, b"GET /health/workers HTTP/1.1\r\n\r\n").await?;
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -13,6 +13,8 @@ publish = false
 [dependencies]
 tempfile = { workspace = true }
 eyre = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 clap = { workspace = true, features = ["env"] }
 indexmap = { workspace = true }
 tn-node = { workspace = true }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -9,3 +9,5 @@ mod execution;
 pub use execution::*;
 mod temp_dirs;
 pub use temp_dirs::*;
+mod wait;
+pub use wait::*;

--- a/crates/test-utils/src/wait.rs
+++ b/crates/test-utils/src/wait.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded condition-polling helpers for tests.
+//!
+//! A self-synchronizing replacement for a fixed `sleep(N)` "wait for
+//! convergence" call, which only guesses at how long an asynchronous event
+//! (a store write becoming visible, a swarm connection settling, a subscription
+//! propagating) takes. Instead of sleeping a fixed pad and hoping, poll a cheap
+//! predicate on a bounded ~10ms cadence until it holds, failing with a
+//! descriptive message once the deadline passes.
+//!
+//! [`wait_until`] is for `async` call sites; [`wait_until_blocking`] is the
+//! synchronous analogue, for helpers that poll with `std::thread::sleep` /
+//! `block_on` rather than `.await`.
+
+use std::time::Duration;
+
+/// Cadence between poll attempts. Small enough to keep the settle latency low,
+/// large enough not to busy-spin.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Number of `POLL_INTERVAL` attempts that fit in `timeout` (at least one).
+fn attempts_for(timeout: Duration) -> u128 {
+    (timeout.as_millis() / POLL_INTERVAL.as_millis()).max(1)
+}
+
+/// Poll an async `condition` until it returns `true`, or fail once `timeout` elapses.
+///
+/// A bounded, self-synchronizing replacement for a fixed `sleep` that only
+/// guesses at how long an asynchronous event takes. It folds over a bounded
+/// sequence of ~10ms poll attempts, carrying the first resolved verdict forward:
+/// `Some(Ok(()))` once the condition holds, `Some(Err(_))` if a poll itself
+/// errors, and `None` while still waiting. An exhausted fold (still `None`) means
+/// the deadline passed. Under `tokio::test(start_paused = true)` the interval
+/// sleeps advance virtual time between attempts, so the spawned work being waited
+/// on makes progress without burning real wall-clock.
+pub async fn wait_until<F, Fut>(
+    timeout: Duration,
+    description: &str,
+    condition: F,
+) -> eyre::Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = eyre::Result<bool>>,
+{
+    use futures::StreamExt as _;
+
+    let condition = &condition;
+
+    futures::stream::iter(0..attempts_for(timeout))
+        .fold(None, move |resolved: Option<eyre::Result<()>>, attempt| async move {
+            if resolved.is_some() {
+                resolved
+            } else {
+                if attempt > 0 {
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                condition().await.map(|met| met.then_some(())).transpose()
+            }
+        })
+        .await
+        .unwrap_or_else(|| Err(eyre::eyre!("timed out waiting for condition: {description}")))
+}
+
+/// Poll a synchronous `condition` until it returns `true`, or fail once `timeout` elapses.
+///
+/// The blocking analogue of [`wait_until`], for helpers that observe state with
+/// `std::thread::sleep` / `block_on` rather than `.await` (the `e2e-tests`
+/// deadline loops). It folds over the same bounded attempt sequence, carrying the
+/// first resolved verdict forward and sleeping the current thread `POLL_INTERVAL`
+/// between attempts. An exhausted fold means the deadline passed.
+pub fn wait_until_blocking<F>(
+    timeout: Duration,
+    description: &str,
+    condition: F,
+) -> eyre::Result<()>
+where
+    F: Fn() -> eyre::Result<bool>,
+{
+    (0..attempts_for(timeout))
+        .fold(None, |resolved: Option<eyre::Result<()>>, attempt| {
+            if resolved.is_some() {
+                resolved
+            } else {
+                if attempt > 0 {
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+                condition().map(|met| met.then_some(())).transpose()
+            }
+        })
+        .unwrap_or_else(|| Err(eyre::eyre!("timed out waiting for condition: {description}")))
+}


### PR DESCRIPTION
Closes #883.

Adds a shared, bounded condition-poll helper and migrates the fixed
`sleep(N)` "wait for convergence" calls across the test suite to it,
following the pattern established by #859 and extending it repo-wide as
@grantkee requested.  Each converted site now polls a named accessor with
a bounded timeout and a descriptive failure message instead of guessing
how long an asynchronous event takes.

Item 0 (prerequisite): lift the helper into tn-test-utils
- New crates/test-utils/src/wait.rs exports `wait_until` (async) and
  `wait_until_blocking` (the synchronous analogue for the e2e helpers
  that poll with std::thread::sleep / block_on). Both fold over a bounded
  ~10ms poll sequence and carry the first resolved verdict forward, so
  they behave under tokio start_paused virtual time as well as wall clock.
- Added tn-test-utils as a dev-dependency to tn-primary, tn-batch-builder,
  tn-batch-validator, and e2e-tests (network-libp2p and tn-node already
  had it).

Item 1: network-libp2p/src/tests/network_tests.rs
- Deleted the file-local `wait_until` (now imported from tn-test-utils).
- Converted 18 fixed convergence sleeps: connection-establishment and
  disconnect settles now poll connected_peer_ids()/connected_peers(), and
  the penalty/decay/unban tests poll peer_score() for the score threshold
  the following assertion checks.
- Folded 3 hand-rolled poll loops (wait_for_peer_discovery plus two inline
  loops) onto the shared helper.
- Left the genuine wall-clock waits untouched: heartbeat-driven ban/prune
  windows, OS port reuse, kad record TTL, and dial-timeout / "confirm the
  connection was rejected" negative assertions.

Item 2: consensus/primary
- certificate_fetcher_tests.rs: folded the two positive-wait loops
  (verify_certificates_in_store and the round-1 timeout loop).  The six
  "wait, then assert the certificate is NOT in the store / no new request
  arrived" sleeps are deliberately left as fixed waits: polling for an
  absence returns immediately and would stop the test from giving the
  system a fair chance to (wrongly) act.

Item 3: node/src/health.rs
- Deleted the three "give server time to start listening" sleeps.
  HealthcheckServer::spawn binds and listens on the TcpListener
  synchronously before it returns the address, so the kernel accepts
  connections into the backlog before the accept loop runs;  the roundtrip
  helper already bounds connect and exchange with a 500ms timeout.

Item 4: batch layer
- batch-builder/tests/it/build_batches.rs: three store-write /
  pool-maintenance sleeps now poll the same accessor the following
  assertion checks (NodeBatchesCache read, pool_size().pending).
- batch-validator/src/validator.rs: folded the two pool_size().pending
  deadline loops onto the helper.

Item 5: e2e-tests
- common.rs: removed the redundant send_and_confirm 1s pad (the next line
  already polls get_balance_above_with_retry); folded network_advancing.
- faucet.rs: the 15s network-converge pad now polls block production;
  folded the stablecoin balanceOf loop.
- restarts.rs: folded the two observer catch-up loops.  Left the
  deliberate "pause so a lagging node fails the check" settles and the
  SIGSTOP pause untouched.
- sync.rs and epochs.rs: folded the epoch-boundary / tn_epochRecord
  deadline loops (poll the condition, then re-read the idempotent RPC
  value) and switched the block_on'd std::thread::sleep loop to the async
  helper.

Finding, out of scope here: crates/consensus/primary/src/tests/
synchronizer_tests.rs (item 2's other half) is orphaned dead code on main.
No source module declares it via #[path], `cargo nextest list` shows zero
tests from it, and wiring it in fails to compile against current APIs (it
still imports crate::synchronizer, tn_primary::CommitteeFixture,
tn_storage::traits, and BlsAggregateSignatureBytes, all since renamed or
removed).  Its sleeps therefore never build or run, so there is nothing to
de-flake; this change leaves the file untouched and flags it for the
maintainers to either repair-and-rewire or delete.

Deliberately deferred (noted for a follow-up, to keep this change honest):
the two epoch-roll read-consistency retry loops in epochs.rs (bounded
3-attempt guards, not convergence waits);  the get_block /
get_balance_above_with_retry internal loops in common.rs (they return a
value, folding would change their signatures);  one ambiguous max-capacity
dial in network_tests.rs;  and one pre-action pause in
certificate_fetcher_tests.rs with no observable predicate to poll.

Verification: cargo check --tests passes for every affected crate;
cargo +nightly fmt --check and clippy are clean (the change adds no new
lint warnings).  The node/health.rs tests (which lost their sleeps, 5 passed) and the
certificate_fetcher_tests suite (which exercises the folded store polls and
the deliberately-retained absence-assertion sleeps, 9 passed) were run and
pass.  The heavier network-libp2p and e2e suites were compile-verified
rather than run here.

Signed-off-by: Onyeka Obi <softwareengineerasaservant@isurvivable.cv>
