### PR TITLE
backpressure when engine channel full instead of dropping output

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -689,9 +689,13 @@ mod tests {
             // execute output to trigger canonical update
             let args = BuildArguments::new(reth_env.clone(), output.clone(), parent);
             let (engine_update_tx, _engine_update_rx) = tokio::sync::mpsc::channel(64);
-            let final_header =
-                execute_consensus_output(args, gas_accumulator.clone(), engine_update_tx)
-                    .expect("output executed");
+            // spawn blocking for payload_builder::blocking_recv
+            let owned_ga = gas_accumulator.clone();
+            let final_header = tokio::task::spawn_blocking(move || {
+                execute_consensus_output(args, owned_ga, engine_update_tx).expect("output executed")
+            })
+            .await
+            .unwrap();
 
             // update values for next loop
             parent = final_header;

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -500,8 +500,11 @@ async fn test_canonical_notification_updates_pool() {
     // execute output to trigger canonical update
     let args = BuildArguments::new(reth_env.clone(), output, chain.sealed_genesis_header());
     let (engine_update_tx, _engine_update_rx) = tokio::sync::mpsc::channel(64);
-    let _final_header = execute_consensus_output(args, GasAccumulator::default(), engine_update_tx)
-        .expect("output executed");
+    // spawn blocking for payload_builder::blocking_recv
+    let _final_header = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, GasAccumulator::default(), engine_update_tx)
+            .expect("output executed")
+    });
 
     // sleep to ensure canonical update received before ack
     let _ = tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -89,10 +89,12 @@ pub fn execute_consensus_output(
             crate::metrics::ENGINE_METRICS.empty_outputs_skipped_total.increment(1);
             span.record("executed_blocks", "0");
             // Notify consensus that this round was processed (no block produced)
-            engine_update_tx.try_send((leader_round, consensus_num_hash, None)).map_err(|e| {
-                error!(target: "engine", ?e, "engine update channel send failed");
-                TnEngineError::ChannelClosed
-            })?;
+            engine_update_tx.blocking_send((leader_round, consensus_num_hash, None)).map_err(
+                |e| {
+                    error!(target: "engine", ?e, "engine update channel send failed");
+                    TnEngineError::ChannelClosed
+                },
+            )?;
             return Ok(canonical_header);
         }
 

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -959,7 +959,7 @@ impl RethEnv {
 
         if let Some((leader_round, consensus_num_hash, engine_update_tx)) = engine_update {
             engine_update_tx
-                .try_send((
+                .blocking_send((
                     leader_round,
                     consensus_num_hash,
                     Some(canonical_head.clone_sealed_header()),


### PR DESCRIPTION
- use `blocking_send` in the spawned blocking task instead of erroring on backpressure

closes #924 