### PR TITLE
fix: restrict consensus-output and epoch-vote gossip to committee publishers (#912)

### DIFF
--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -805,8 +805,7 @@ where
     /// crash-window finalized-marker lag to the persisted canonical tip
     /// (`RethEnv::heal_finalized_to_persisted_tip` — before anything reads the marker), recover
     /// the [`GasAccumulator`] via [`catchup_accumulator`], spawn the long-running p2p networks
-    /// ([`spawn_node_networks`](Self::spawn_node_networks)), subscribe the primary to the
-    /// epoch-vote and consensus-output gossip topics, spawn the epoch-record and vote
+    /// ([`spawn_node_networks`](Self::spawn_node_networks)), spawn the epoch-record and vote
     /// collectors, restore execution state ([`try_restore_state`](Self::try_restore_state)),
     /// and spawn the engine-update task. It then requests any missing epoch pack files and
     /// launches the app-scoped consensus fetch workers.
@@ -877,14 +876,10 @@ where
         self.spawn_node_networks(node_task_spawner, &network_config, epoch).await?;
         let primary_network_handle =
             self.primary_network_handle.as_ref().expect("primary network").clone();
-        primary_network_handle
-            .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::epoch_vote_topic(network_config.chain_id()))
-            .await?;
-        primary_network_handle
-            .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::consensus_output_topic(network_config.chain_id()))
-            .await?;
+        // The epoch-vote and consensus-output gossip topics are subscribed per epoch in
+        // `spawn_primary_network_for_epoch` with a committee-restricted publisher set (issue
+        // #912), alongside `primary_topic`, so their authorized publishers track committee
+        // rotation. They are intentionally not subscribed here in the process-lifetime path.
         state_sync::spawn_epoch_record_collector(
             self.consensus_chain.clone(),
             primary_network_handle.clone(),

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -445,8 +445,12 @@ where
     ///
     /// This operates on the per-epoch interface, not the swarm itself. Every epoch refreshes
     /// the previous/current/next committee membership (via [`init_network_for_epoch`]) and the
-    /// gossip publisher set so the network bans and routes against the current committee. The
-    /// listener is bound only on the initial epoch.
+    /// gossip publisher sets so the network bans and routes against the current committee. The
+    /// `primary_topic` (certificates) is restricted to the current committee, while the
+    /// `consensus_output_topic` and `epoch_vote_topic` are restricted to the previous/current/next
+    /// committee window (issue #912): both carry epoch-boundary traffic from validators rotating
+    /// out or in, so their publisher set must span the same window the peer manager exempts from
+    /// penalties. The listener is bound only on the initial epoch.
     ///
     /// Peers are dialed when this node is a CVV (it must reach the other CVVs) or when it has no
     /// connected peers; a non-committee node that already has peers does not pester the
@@ -483,6 +487,18 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
+        // Consensus-output and epoch-vote gossip crosses epoch boundaries: a validator rotating
+        // out (now in the previous committee) may emit late gossip, and one rotating in (in the
+        // next committee) may start early. Their authorized-publisher set is therefore the
+        // previous/current/next committee window, the same window the peer manager exempts from
+        // penalties via `update_committees`. Build it here, before the committee sets are moved
+        // into `init_network_for_epoch`.
+        let boundary_publishers: HashSet<BlsPublicKey> = previous_committee_keys
+            .iter()
+            .chain(committee_keys.iter())
+            .chain(next_committee_keys.iter())
+            .copied()
+            .collect();
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
@@ -510,6 +526,25 @@ where
             .subscribe_with_publishers(
                 tn_config::LibP2pConfig::primary_topic(consensus_config.chain_id()),
                 committee_keys.into_iter().collect(),
+            )
+            .await?;
+        // Restrict consensus-output and epoch-vote gossip to committee publishers (issue #912),
+        // mirroring `primary_topic` above, so a non-committee node's gossip on these topics is
+        // rejected by `verify_gossip` and never propagated. Re-subscribing every epoch keeps the
+        // publisher set tracking committee rotation. Both use the wider boundary window so late
+        // gossip from a rotated-out validator and early gossip from a rotating-in one still relay.
+        network_handle
+            .inner_handle()
+            .subscribe_with_publishers(
+                tn_config::LibP2pConfig::consensus_output_topic(consensus_config.chain_id()),
+                boundary_publishers.clone(),
+            )
+            .await?;
+        network_handle
+            .inner_handle()
+            .subscribe_with_publishers(
+                tn_config::LibP2pConfig::epoch_vote_topic(consensus_config.chain_id()),
+                boundary_publishers,
             )
             .await?;
 


### PR DESCRIPTION
## Summary

Closes #912.  Restricts the `consensus_output_topic` and `epoch_vote_topic` gossip topics to a
committee-restricted publisher set, the way `primary_topic` (certificates) already is, so a
non-committee node's `ConsensusResult` / `EpochVote` gossip is rejected by `verify_gossip` and
never propagated by the mesh.

This is the propagation-side complement to #889/#871 (which re-attributes the *penalty* for the
content faults these two topics surface). #889 stops an honest relayer from being punished for a
fault it could not screen;  it does not stop a non-committee node from getting its gossip
propagated in the first place.  This change closes that at the front door for exactly those topics.

## The gap

`verify_gossip` (`crates/network-libp2p/src/consensus.rs`) gates propagation on the topic's
`authorized_publishers` entry:

- absent from the map -> reject;
- `None` (open) -> accept any signed source;
- `Some(set)` -> the authenticated author's BLS key must be in `set`.

`subscribe(topic)` inserts `None`;  `subscribe_with_publishers(topic, set)` inserts `Some(set)`.
Today `primary_topic` is subscribed every epoch with `subscribe_with_publishers` in the per-epoch
routine, so it is restricted and tracks rotation.  `consensus_output_topic` and `epoch_vote_topic`
were instead subscribed once at node startup with the plain `subscribe(...)`, i.e. open. Both
payload kinds are produced only by committee members in practice, so the open subscription was
broader than the legitimate publisher set.

## The change (issue Option 1)

Move the two subscriptions out of the one-time `run()` path (`crates/node/src/manager/node.rs`)
and into the per-epoch `spawn_primary_network_for_epoch`
(`crates/node/src/manager/node/start_epoch.rs`), next to the existing `primary_topic`
subscription, calling `subscribe_with_publishers(...)` and re-subscribing each epoch so the set
tracks committee rotation.

Publisher window: **previous ∪ current ∪ next committee**, not current-only.  Consensus output and
epoch votes are exactly the traffic that crosses an epoch boundary: a validator rotating out (now
in `previous`) may emit late gossip, and one rotating in (in `next`) may start early.  This is the
same window the peer manager already exempts from penalties (`update_committees(previous, current,
next)`), so the propagation-authorization window and the penalty-exemption window now agree.  The
union is built from the three committee-key sets already in scope in that function, before they are
moved into `init_network_for_epoch`.

`spawn_primary_network_for_epoch` runs every epoch for **all** node modes (it is reached
unconditionally via `create_consensus`, whose `_mode` is not branched on), so observers keep
subscribing to `consensus_output_topic` and continue to *receive* consensus-output gossip exactly
as before . . . the publisher restriction gates the message *author*, not the subscriber.

## Deliberate scoping decisions

- **`primary_topic` left at current-only.** The issue calls out that certificates currently use a
  narrower current-only window and asks whether to widen all three in the same change.  Certificates
  are consensus-critical and epoch-scoped; widening their publisher set is a separate behavioral
  change that deserves its own analysis, so it is intentionally out of scope here.  The two topics
  changed are the ones the acceptance criteria require and the ones whose faults #889 re-attributes.
- **Option 2 (have `verify_gossip` consult the peer-manager committee window directly) not taken.**
  It is the cleaner long-term shape but touches the gossip-validation core;  this PR is the low-risk
  increment that mirrors the established `primary_topic` pattern.  Option 2 can follow.

## Acceptance criteria

- [x] A non-committee node's `EpochVote` / `ConsensusResult` gossip is rejected by `verify_gossip`
      and not propagated (topic now `Some(committee window)`;  `verify_gossip` returns
      `Reject(UnauthorizedAuthor)` for an out-of-window author).
- [x] A validator in the `previous` or `next` window can still publish across a boundary (window is
      previous ∪ current ∪ next, not current-only).
- [x] The publisher set tracks rotation every epoch (re-subscribed in the per-epoch routine).
- [x] Deep payload validation stays deferred to the application layer (only a set-membership check
      runs pre-propagation; no added latency).

## Testing

The publisher-authorization mechanism this change wires up is already covered by
`test_msg_verification_ignores_unauthorized_publisher`
(`crates/network-libp2p/src/tests/network_tests.rs`), which asserts `verify_gossip` rejects an
author not in a topic's `subscribe_with_publishers` set.  This PR applies that proven mechanism to
two additional topics through the identical API `primary_topic` uses;  it adds no new
gossip-validation logic.  `cargo clippy -p tn-node` is clean.

## Open question carried from the issue

No legitimate non-committee publisher is believed to exist for these topics . . . observers / NVVs sync
consensus output via the request/response and stream paths, not gossip publishing.  This should be
re-confirmed against the NVV roadmap before relying on it broadly.
