### PR TITLE
test: reuse the prebuilt e2e node binary on every path, not only make (#926)

### DIFF
--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -1,5 +1,32 @@
 # E2E Tests
 
+## Running the ignored e2e suite
+
+The heavy e2e tests (restart and epoch tests) are `#[ignore]`d and each needs the
+`telcoin-network` node binary. When `TN_BIN_PATH` is unset, the first test builds that binary
+in-process via `escargot`, which at `opt-level = 0` is a multi-minute compile. Under `nextest`'s
+default output capture that build is buffered, so the first test looks frozen for several minutes
+before it does anything.
+
+Point the suite at a prebuilt binary to avoid the in-test build:
+
+```
+make test-e2e          # builds the binary once, then runs the suite with TN_BIN_PATH set
+```
+
+or run the raw command yourself (for example from an IDE test runner):
+
+```
+cargo build --bin telcoin-network --features tn-storage/test-utils
+TN_BIN_PATH="$(pwd)/target/debug/telcoin-network" \
+  cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
+```
+
+`TN_BIN_PATH` must be an absolute path: `nextest` runs each test with its working directory set
+to the package (`crates/e2e-tests`), not the workspace root, so a relative path would not resolve.
+If `TN_BIN_PATH` is left unset the suite still runs; add `--no-capture` to watch the one-time build
+instead of waiting on a silent first test.
+
 ## Test Log Output
 
 The e2e integration tests (restart and epoch tests) spawn multiple validator node processes. Each node's stdout is captured to a separate log file under `test_logs/` so that failures can be debugged without sifting through interleaved output from all nodes.

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -397,19 +397,35 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
             return TestBinary::Prebuilt(path);
         }
 
+        // TN_BIN_PATH is unset, so build the node binary in-process via escargot. At
+        // opt-level 0 this is a multi-minute compile, and nextest captures stdout/stderr, so
+        // without this notice the first e2e test looks frozen until the build finishes. Announce
+        // it on stderr (shown on completion, and live under `--no-capture`) so the delay is
+        // attributable rather than an invisible hang.
+        eprintln!(
+            "e2e: TN_BIN_PATH not set; building telcoin-network via cargo before the first test. \
+             This can take several minutes at opt-level 0, and nextest hides it until the build \
+             finishes (add `--no-capture` to watch it). To skip it, run `make test-e2e`, or \
+             prebuild with `cargo build --bin telcoin-network --features tn-storage/test-utils` \
+             and export TN_BIN_PATH=\"$(pwd)/target/debug/telcoin-network\" from the workspace root."
+        );
         info!("building main binary for e2e tests");
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
         let path = PathBuf::from(manifest_dir);
         let workspace_root =
             path.parent().and_then(|p| p.parent()).expect("Cannot find workspace root");
 
+        // No `.current_target()`: passing `--target <triple>` would emit into
+        // `target/<triple>/debug/`, a tree that shares no artifacts with the plain
+        // `target/debug/` that `make build-e2e-bin` and ordinary `cargo build` populate, forcing
+        // a guaranteed cold rebuild. Building into `target/debug/` lets escargot reuse an already
+        // compiled binary (reported "Fresh" by cargo) instead.
         TestBinary::Cargo(
             CargoBuild::new()
                 .bin("telcoin-network")
                 .features("tn-storage/test-utils")
                 .manifest_path(workspace_root.join("Cargo.toml"))
                 .target_dir(workspace_root.join("target"))
-                .current_target()
                 .run()
                 .expect("Failed to build telcoin-network binary"),
         )

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -98,8 +98,13 @@ echo "clippy for workspace: default and all features passed"
 #
 # default features
 cargo nextest run --workspace --no-fail-fast
-# run the e2e restart and epoch tests, they are seperate to avoid any port/node confusion
-cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
+# run the e2e restart and epoch tests, they are seperate to avoid any port/node confusion.
+# Prebuild the node binary once into the shared target tree and hand it to the e2e tests via
+# TN_BIN_PATH (mirroring `make test-e2e`), so the ignored suite reuses it instead of cold-building
+# the binary inside the first test, which nextest capture would otherwise hide as a multi-minute hang.
+cargo build --bin telcoin-network --features tn-storage/test-utils --target-dir "$(pwd)/target"
+TN_BIN_PATH="$(pwd)/target/debug/telcoin-network" \
+    cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
 
 echo "all checks passed - submitting attestation on-chain..."
 


### PR DESCRIPTION
## Summary

Follow-up to #900 (which closed #897). #900 added the `TN_BIN_PATH` escape hatch so the
ignored e2e suite can reuse a prebuilt `telcoin-network` binary instead of compiling it lazily
inside the first test, but it only wired that hatch into the `make` targets.  Every other way of
running the ignored suite still cold-builds the node binary inside the first test, which under
`nextest` output capture looks like the first test frozen for several minutes.

This closes the gap on the paths people actually run, with **no** change to any test's
assertions, counts, features, coverage, or node configuration.  Test-infrastructure only.

## What changed

**`crates/e2e-tests/src/lib.rs`** (`get_telcoin_network_binary()` escargot fallback):
- Removed `.current_target()`.  It passed `--target <host-triple>`, so the fallback built into
  `target/<triple>/debug/`, a tree that shares no artifacts with the plain `target/debug/` that
  `make build-e2e-bin` and ordinary `cargo build` populate.  That made the fallback a *guaranteed*
  cold rebuild even when a matching binary already existed.  Building into `target/debug/` lets
  cargo report the binary `Fresh` and skip the rebuild.
- Added a stderr diagnostic before the build.  The pre-existing `info!` goes through `tracing`,
  which has no subscriber at that point under `nextest`, so the multi-minute build was invisible.
  `eprintln!` is captured by nextest and shown on completion (and live under `--no-capture`), so
  the delay is attributable instead of an apparent hang.  The message points at `make test-e2e` /
  `TN_BIN_PATH` as the way to skip it.

**`etc/test-and-attest.sh`** (the maintainer attest script, which #900 did not rewire):
- The raw `cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features` line now
  prebuilds the binary and passes `TN_BIN_PATH`, mirroring `make test-e2e` exactly.  The script
  already `cd`s to the project root, so `$(pwd)/target/debug/telcoin-network` matches the
  Makefile's `$(CURDIR)/target/debug/telcoin-network`. `--target-dir "$(pwd)/target"` keeps the
  build location consistent with `TN_BIN_PATH` even if `CARGO_TARGET_DIR` is set in the env.

**`crates/e2e-tests/README.md`**:
- Added a "Running the ignored e2e suite" section documenting the cold build, the `make test-e2e`
  fast path, and the `TN_BIN_PATH` escape hatch.  This is the one persistent doc a contributor
  debugging a "frozen first test" would open, and it survives nextest's output capture (which
  otherwise buffers the stderr notice until the build finishes).  It also flags that `TN_BIN_PATH`
  must be an absolute path, since nextest runs each test with its cwd set to the package
  (`crates/e2e-tests`), not the workspace root, so a relative path would not resolve.

## Scope / safety

- The `make` targets (`test-e2e`, `test-restarts`, `public-tests`) set `TN_BIN_PATH` and so take
  the `Prebuilt` branch; they never reach the changed fallback and are behaviorally unchanged.
- PR CI (`.github/workflows/pr.yaml`) runs `cargo nextest run --workspace ... --profile ci` with
  no `--run-ignored`, so it never runs the ignored e2e tests and never touches this code path.
- No production code changes.  Same binary, same `tn-storage/test-utils` feature;  it is just built
  once into the shared target tree and reused on every invocation path rather than only via `make`.

## Out of scope (separate issue)

This removes the *redundant / invisible* build from the non-`make` paths.  It does not make the
one-time `opt-level = 0` node-binary build *faster*; that is tracked separately.

Closes #926.
