### PR TITLE
fix(consensus/network): gate gossip cheap-first and set explicit per-topic publisher policy (#898)

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -62,6 +62,10 @@ type AuthEquivocationMap = HashMap<
 /// that have signed this result. See the `consensus_certs` field and GHSA-2r5c-c4h7-gp5h.
 type ConsensusCertTally = (u64, HashSet<BlsPublicKey>);
 
+/// Dedup key for an epoch vote at ingress: `(author, epoch, epoch-record hash)`. See the
+/// `epoch_votes_seen` field and issue #898.
+type EpochVoteKey = (BlsPublicKey, Epoch, EpochDigest);
+
 /// The type that handles requests from peers.
 #[derive(Clone, Debug)]
 pub(crate) struct RequestHandler<DB> {
@@ -83,6 +87,17 @@ pub(crate) struct RequestHandler<DB> {
     auth_last_vote: Arc<AuthEquivocationMap>,
     /// Track consensus headers until we hit a simple quorum then send on.
     consensus_certs: Arc<Mutex<HashMap<ConsensusResultDigest, ConsensusCertTally>>>,
+    /// Deduplicate epoch votes at ingress, keyed on `(author, epoch, epoch-record hash)`.
+    ///
+    /// The value is a monotonic recency sequence used to evict the least-recently-seen entry
+    /// once the map reaches [`MAX_EPOCH_VOTES`](super::MAX_EPOCH_VOTES), bounding memory
+    /// against a vote flood. A key is inserted only after its signature verifies, so this gate
+    /// skips repeated verifies of an already-accepted vote without letting a bad-signature vote
+    /// poison the slot of the real author. The `epoch` field is part of the key even though it is
+    /// not covered by the vote signature: this ensures a replay that tampers with `vote.epoch`
+    /// lands on a different key and cannot evict/pre-empt the real vote's slot. See the
+    /// `PrimaryGossip::EpochVote` handler and issue #898.
+    epoch_votes_seen: Arc<Mutex<HashMap<EpochVoteKey, u64>>>,
     /// Access to the consensus chain data.
     consensus_chain: ConsensusChain,
 }
@@ -111,6 +126,7 @@ where
             requested_parents: Default::default(),
             auth_last_vote: Arc::new(auth_last_vote),
             consensus_certs: Default::default(),
+            epoch_votes_seen: Default::default(),
             consensus_chain,
         }
     }
@@ -210,6 +226,38 @@ where
         } else {
             self.consensus_chain.epochs().get_committee_keys(epoch).await
         }
+    }
+
+    /// True if a vote for this `(author, epoch, epoch-record)` has already been verified and
+    /// forwarded.
+    ///
+    /// Cheap read used as a pre-verify gate: an accepted vote is re-gossiped by its author on a
+    /// timer and duplicated by the gossip mesh, so this caps repeated BLS verifies of the same
+    /// valid vote. See [`RequestHandler::record_epoch_vote`] and issue #898.
+    fn epoch_vote_seen(&self, author: BlsPublicKey, epoch: Epoch, epoch_hash: EpochDigest) -> bool {
+        self.epoch_votes_seen.lock().contains_key(&(author, epoch, epoch_hash))
+    }
+
+    /// Record a verified `(author, epoch, epoch-record)` vote so later replays are dropped before
+    /// the signature check.
+    ///
+    /// Callers MUST invoke this only after [`EpochVote::check_signature`] succeeds: recording a
+    /// bad-signature vote would let a Byzantine committee publisher poison the slot of the real
+    /// author and suppress their vote. Eviction is least-recently-seen once the map reaches
+    /// [`MAX_EPOCH_VOTES`](super::MAX_EPOCH_VOTES), so a flood of distinct keys cannot grow it
+    /// without bound; a false negative after eviction only costs one extra verify (the collector
+    /// dedups per signer downstream), never a dropped honest vote.
+    fn record_epoch_vote(&self, author: BlsPublicKey, epoch: Epoch, epoch_hash: EpochDigest) {
+        let key = (author, epoch, epoch_hash);
+        let mut guard = self.epoch_votes_seen.lock();
+        let next_seq = guard.values().copied().max().unwrap_or(0) + 1;
+        if guard.len() >= super::MAX_EPOCH_VOTES && !guard.contains_key(&key) {
+            let evict = guard.iter().min_by_key(|entry| *entry.1).map(|entry| *entry.0);
+            if let Some(evict) = evict {
+                guard.remove(&evict);
+            }
+        }
+        guard.insert(key, next_seq);
     }
 
     /// Process gossip from the committee.
@@ -385,31 +433,55 @@ where
                 }
             }
             PrimaryGossip::EpochVote(vote) => {
+                // Uniform gate ordering (issue #898): run the cheap, attacker-independent checks
+                // before the expensive BLS verify so unauthorized or duplicate votes are dropped
+                // without consuming verification resources.
+
+                // 1. Topic must match.
                 ensure!(
                     topic.to_string().eq(&tn_config::LibP2pConfig::epoch_vote_topic(
                         self.consensus_config.chain_id()
                     )),
                     PrimaryNetworkError::InvalidTopic
                 );
-                // Verify the BLS signature
-                ensure!(
-                    vote.check_signature(),
-                    PrimaryNetworkError::InvalidHeader(HeaderError::PeerNotAuthor)
-                );
-                // Verify committee membership if the epoch record is available
-                if let Some((epoch_rec, _)) =
-                    self.consensus_chain.epochs().get_epoch_by_hash(vote.epoch_hash).await
-                {
+                // 2. Committee membership BEFORE crypto. An epoch vote is signed by a member of the
+                //    committee for `vote.epoch` (see `EpochVote` and `manage_epoch_votes`), so a
+                //    non-member is rejected without a signature check. `get_committee` resolves the
+                //    current/next committee synchronously (the live-voting window) and falls back
+                //    to stored epoch records for older epochs.
+                if let Some(committee) = self.get_committee(vote.epoch).await {
                     ensure!(
-                        epoch_rec.committee.contains(&vote.public_key),
+                        committee.contains(&vote.public_key),
                         PrimaryNetworkError::InvalidHeader(HeaderError::UnknownAuthority(format!(
                             "{} not in committee for epoch {}",
-                            vote.public_key, vote.epoch_hash
+                            vote.public_key, vote.epoch
                         )))
                     );
+                    // 3. Drop votes already verified and forwarded for this (author, record).
+                    if !self.epoch_vote_seen(vote.public_key, vote.epoch, vote.epoch_hash) {
+                        // 4. Signature check LAST — the most expensive gate.
+                        ensure!(
+                            vote.check_signature(),
+                            PrimaryNetworkError::InvalidHeader(HeaderError::PeerNotAuthor)
+                        );
+                        // Record only AFTER a valid signature so a bad-signature vote cannot
+                        // poison the dedup slot for the real author.
+                        self.record_epoch_vote(vote.public_key, vote.epoch, vote.epoch_hash);
+                        // Fire-and-forget: no oneshot, no blocking.
+                        let _ = self.consensus_bus.new_epoch_votes().send(*vote).await;
+                    }
+                } else {
+                    // Committee for this epoch is not known yet (we are behind, or the epoch is
+                    // bogus). Drop without penalty and without writing request state from an
+                    // unverified, attacker-controlled epoch number; the author re-gossips its
+                    // vote and the epoch is learned via consensus / epoch-record sync.
+                    debug!(
+                        target: "primary",
+                        epoch = vote.epoch,
+                        author = ?vote.public_key,
+                        "dropping epoch vote for unknown committee epoch"
+                    );
                 }
-                // Fire-and-forget: no oneshot, no blocking
-                let _ = self.consensus_bus.new_epoch_votes().send(*vote).await;
             }
         }
 

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -81,6 +81,16 @@ pub const MAX_CONCURRENT_EPOCH_STREAMS: usize = 5;
 /// `PrimaryGossip::Consensus` handler and GHSA-2r5c-c4h7-gp5h.
 pub(crate) const MAX_CONSENSUS_CERTS: usize = 20;
 
+/// Hard cap on the number of distinct epoch votes deduplicated at ingress.
+///
+/// The handler's `epoch_votes_seen` map records one entry per `(author, epoch, epoch-record
+/// hash)` once a vote's signature has verified, so a replayed or flooded vote is dropped before the
+/// next (expensive) BLS verify. Sized well above a single committee's worth of votes across a
+/// few candidate epoch records. Eviction is least-recently-seen, so an over-flood only costs
+/// redundant verifies (never a dropped honest vote — the collector dedups per signer). See the
+/// `PrimaryGossip::EpochVote` handler and issue #898.
+pub(crate) const MAX_EPOCH_VOTES: usize = 1024;
+
 /// Maximum number of concurrent pending batch requests from a single peer.
 ///
 /// Prevents a single malicious peer from filling all global slots.

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -1498,13 +1498,15 @@ where
 
         let GossipMessage { topic, .. } = gossip;
 
-        // ensure publisher is authorized
+        // Ensure the publisher is authorized. Semantics per topic entry:
+        //   - absent  => topic not subscribed here: reject.
+        //   - `None`  => subscribed, any publisher allowed (open topic): accept.
+        //   - `Some`  => subscribed, committee-restricted: accept only a resolved BLS key that is
+        //     in the allowlist.
         if gossip.source.is_some_and(|id| {
             let bls_key = self.swarm.behaviour().peer_manager.peer_to_bls(&id);
             self.authorized_publishers.get(topic.as_str()).is_some_and(|auth| {
-                auth.is_none()
-                    || (bls_key.is_some()
-                        && auth.as_ref().expect("is some").contains(&bls_key.expect("is some")))
+                auth.as_ref().is_none_or(|set| bls_key.is_some_and(|key| set.contains(&key)))
             })
         }) {
             GossipAcceptance::Accept

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -877,14 +877,12 @@ where
         self.spawn_node_networks(node_task_spawner, &network_config, epoch).await?;
         let primary_network_handle =
             self.primary_network_handle.as_ref().expect("primary network").clone();
-        primary_network_handle
-            .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::epoch_vote_topic(network_config.chain_id()))
-            .await?;
-        primary_network_handle
-            .inner_handle()
-            .subscribe(tn_config::LibP2pConfig::consensus_output_topic(network_config.chain_id()))
-            .await?;
+        // `epoch_vote_topic` and `consensus_output_topic` are committee-only publish topics, so
+        // they are subscribed per-epoch in `spawn_primary_network_for_epoch` restricted to the
+        // current committee's publishers (like `primary_topic`). That makes the network layer
+        // drop non-committee messages before re-propagation and refreshes the authorized set on
+        // every committee rotation, rather than accepting any publisher once at node start. See
+        // issue #898.
         state_sync::spawn_epoch_record_collector(
             self.consensus_chain.clone(),
             primary_network_handle.clone(),

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -493,6 +493,15 @@ where
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
+        // Publishers authorized for the epoch-boundary topics (`epoch_vote_topic`,
+        // `consensus_output_topic`): the current committee UNION the previous one. Epoch-close
+        // votes and an epoch's final consensus output are authored by the OUTGOING committee and
+        // gossipped into the next epoch, so a current-committee-only allowlist would reject those
+        // in-flight boundary messages during rotation (and stop re-propagating them), stalling
+        // certification of the just-closed epoch. Built before `previous_committee_keys` is moved
+        // into `init_network_for_epoch` below. Never-committee peers are still excluded.
+        let boundary_publishers: HashSet<BlsPublicKey> =
+            committee_keys.iter().chain(previous_committee_keys.iter()).copied().collect();
         Self::init_network_for_epoch(
             network_handle.inner_handle(),
             bootstrap_peers,
@@ -514,12 +523,32 @@ where
             network_handle.inner_handle().start_listening(primary_address).await?;
         }
 
-        // update the authorized publishers for gossip every epoch
+        // Update the authorized publishers for gossip every epoch. `primary_topic`,
+        // `epoch_vote_topic` and `consensus_output_topic` are all committee-only publish topics:
+        // restricting the publisher set makes the network layer (`verify_gossip`) drop messages
+        // from non-committee sources before re-propagation, and re-subscribing here every epoch
+        // refreshes the allowlist across committee rotation (the swarm overwrites the previous
+        // set). `primary_topic` uses the current committee; the two boundary topics use the
+        // current-union-previous set (see `boundary_publishers` above). See issue #898.
         network_handle
             .inner_handle()
             .subscribe_with_publishers(
                 tn_config::LibP2pConfig::primary_topic(consensus_config.chain_id()),
-                committee_keys.into_iter().collect(),
+                committee_keys,
+            )
+            .await?;
+        network_handle
+            .inner_handle()
+            .subscribe_with_publishers(
+                tn_config::LibP2pConfig::epoch_vote_topic(consensus_config.chain_id()),
+                boundary_publishers.clone(),
+            )
+            .await?;
+        network_handle
+            .inner_handle()
+            .subscribe_with_publishers(
+                tn_config::LibP2pConfig::consensus_output_topic(consensus_config.chain_id()),
+                boundary_publishers,
             )
             .await?;
 


### PR DESCRIPTION
Closes #898.

### Problem
Consensus gossip handlers ran expensive per-message cryptography before cheap, attacker-independent gates, and committee-only topics used accept-any subscriptions:
- `EpochVote` verified the BLS signature before checking committee membership and had no dedup; its membership check was skipped when the epoch record was unavailable.
- `epoch_vote_topic` and `consensus_output_topic` were subscribed with a plain `subscribe()` (any publisher), so non-committee messages were accepted and re-propagated at the network layer before being dropped.

### Changes
1. **EpochVote gate reorder** (`primary/src/network/handler.rs`): topic → committee membership → dedup → BLS verify → forward.  Membership resolves via `get_committee(vote.epoch)` (the same committee source `manage_epoch_votes` uses);  unknown-committee votes are dropped without writing request state from the unauthenticated epoch field.
2. **Bounded epoch-vote dedup cache** (`handler.rs` + `network/mod.rs`): keyed on `(author, epoch, epoch_hash)`, recorded only after the signature verifies.  The BLS signature does not cover `vote.epoch`, so including `epoch` in the key prevents a Byzantine committee publisher from censoring a real author's vote by replaying it with a tampered epoch.  LRU-capped at `MAX_EPOCH_VOTES`.
3. **Committee-restricted, rotation-correct subscriptions** (`node.rs` + `node/start_epoch.rs`): `epoch_vote_topic` and `consensus_output_topic` move from `run()` into `spawn_primary_network_for_epoch` (per-epoch, all node modes) and use `subscribe_with_publishers`.  `verify_gossip` now drops non-committee publishers before re-propagation.  The two boundary topics authorize **current ∪ previous** committee keys, since epoch-close votes and an epoch's final consensus output are authored by the outgoing committee and gossipped into the next epoch . . . a current-only allowlist would reject those in-flight messages during rotation and stall certification of the just-closed epoch.
4. **verify_gossip cleanup** (`network-libp2p/src/consensus.rs`): removes two guarded `.expect` in favor of `is_none_or`, preserving the exact absent→reject / open→accept / restricted→membership semantics.

The `worker_txn_topic` ecrecover concern the issue also flagged is moot on current main: #820 removed that gossip path (non-validator txns now go to the committee via RPC).

### Testing
- `cargo fmt` + `cargo clippy` (`-p tn-primary -p tn-network-libp2p -p tn-node`): 0 errors, 0 warnings.
- The two security-sensitive paths (dedup-poisoning resistance and rotation handover) were reviewed adversarially.

### Follow-up
- Handler-level unit tests for the epoch-vote dedup / poison-resistance.

Refs GHSA-2r5c-c4h7-gp5h.
