### PR TITLE
fix(worker): validate gossip-prefetched batches before caching (#933)

### DIFF
--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -23,8 +23,8 @@ use tn_network_libp2p::{
 use tn_network_types::{WorkerOthersBatchMessage, WorkerToPrimaryClient};
 use tn_storage::{consensus::ConsensusChain, tables::NodeBatchesCache};
 use tn_types::{
-    ensure, now, try_decode, BatchValidation, BlsPublicKey, Database, Epoch, SealedBatch, WorkerId,
-    B256,
+    ensure, now, try_decode, Batch, BatchValidation, BlsPublicKey, Database, Epoch, SealedBatch,
+    WorkerId, B256,
 };
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, warn};
@@ -159,8 +159,6 @@ where
                 // most likely be removed before we can use it and will be fetched
                 // later when needed.
                 ensure!(my_epoch == epoch, WorkerNetworkError::BatchEpochMismatch(epoch, my_epoch));
-                // Retrieve the batch...
-                let store = self.consensus_config.node_storage();
                 // Since we are precaching Batches for the current epoch we only need to check if it
                 // is in the local cache. There should not have been an opertunity
                 // for it to be in the consensus chain yet.
@@ -191,29 +189,10 @@ where
                     let mut missing = BTreeSet::from([batch_hash]);
                     match self.network_handle.request_batches(&mut missing).await {
                         Ok(batches) => {
+                            // Note: retrieving this batch for no reason is wasteful, it should
+                            // only effect nodes catching up old epochs though...
                             if let Some((digest, batch)) = batches.first() {
-                                // Storing batches for future epochs can cause problems.  This might
-                                // open an attack for rogue
-                                // validator to fill disk space, the cache is cleared on
-                                // epoch boundaries anyway, etc.
-                                // Note: retrieving this batch for no reason is wasteful, it should
-                                // only effect nodes catching up old epochs though...
-                                if batch.epoch == self.consensus_config.epoch() {
-                                    store.insert::<NodeBatchesCache>(digest, batch).map_err(
-                                        |e| {
-                                            WorkerNetworkError::Internal(format!(
-                                                "failed to write to batch store: {e}"
-                                            ))
-                                        },
-                                    )?;
-                                } else {
-                                    debug!(
-                                        target: "worker:network",
-                                        batch_epoch = batch.epoch,
-                                        current_epoch = self.consensus_config.epoch(),
-                                        "gossipped batch epoch mismatch - discarding"
-                                    );
-                                }
+                                self.validate_and_cache_prefetched_batch(digest, batch)?;
                             }
                         }
                         Err(e) => {
@@ -225,6 +204,61 @@ where
         }
 
         Ok(())
+    }
+
+    /// Validate a gossip-prefetched batch body, then cache it on success.
+    ///
+    /// The vote-path sync (`PrimaryReceiverHandler::synchronize`) treats a digest
+    /// already present in `NodeBatchesCache` as validated-and-available and skips
+    /// `validate_batch` for it. A body fetched by the gossip prefetch must therefore
+    /// be validated here before it enters that cache, exactly as
+    /// `process_report_batch` does; an invalid body is dropped (never cached) and the
+    /// failure recorded. Without this, a Byzantine committee member could gossip and
+    /// serve a semantically-invalid batch, have every honest worker cache it
+    /// unvalidated, and then get it voted on and certified (issue #933).
+    ///
+    /// A batch for a future epoch is discarded rather than cached: the cache is
+    /// cleared on epoch boundaries and storing it would let a rogue validator waste
+    /// disk on batches that can never be used.
+    fn validate_and_cache_prefetched_batch(
+        &self,
+        digest: &B256,
+        batch: &Batch,
+    ) -> WorkerNetworkResult<()> {
+        if batch.epoch != self.consensus_config.epoch() {
+            debug!(
+                target: "worker:network",
+                batch_epoch = batch.epoch,
+                current_epoch = self.consensus_config.epoch(),
+                "gossipped batch epoch mismatch - discarding"
+            );
+            return Ok(());
+        }
+
+        // `request_batches` guarantees the fetched body hashes to `digest`, so seal
+        // with it and let `validate_batch` re-check the digest along with byte size,
+        // per-transaction decode/recovery, blob exclusion, gas limit, and base fee. A
+        // validation failure means a peer served an invalid body: drop it (do not
+        // cache) and record the failure. This is a content fault of the served body,
+        // not of the gossip relayer, so it is not propagated as an error.
+        let sealed_batch = batch.clone().seal(*digest);
+        if let Err(err) = self
+            .validator
+            .validate_batch(sealed_batch)
+            .inspect_err(|_| self.metrics.record_batch_validation_failure())
+        {
+            warn!(
+                target: "worker:network",
+                ?digest,
+                %err,
+                "gossip-prefetched batch failed validation - discarding"
+            );
+            return Ok(());
+        }
+
+        self.consensus_config.node_storage().insert::<NodeBatchesCache>(digest, batch).map_err(
+            |e| WorkerNetworkError::Internal(format!("failed to write to batch store: {e}")),
+        )
     }
 
     /// Process a new reported batch.
@@ -430,6 +464,16 @@ where
         sealed_batch: SealedBatch,
     ) -> WorkerNetworkResult<()> {
         self.process_report_batch(peer, sealed_batch).await
+    }
+
+    /// Publicly available for tests.
+    /// See [Self::validate_and_cache_prefetched_batch].
+    pub fn pub_validate_and_cache_prefetched_batch(
+        &self,
+        digest: &B256,
+        batch: &Batch,
+    ) -> WorkerNetworkResult<()> {
+        self.validate_and_cache_prefetched_batch(digest, batch)
     }
 
     /// Publicly available for tests.

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -8,9 +8,12 @@ use tn_network_libp2p::{
     types::{NetworkCommand, NetworkHandle, NetworkResponseMessage},
     GossipMessage, Penalty, StreamError, StreamKind, TopicHash,
 };
-use tn_storage::mem_db::MemDatabase;
+use tn_storage::{mem_db::MemDatabase, tables::NodeBatchesCache};
 use tn_test_utils::CommitteeFixture;
-use tn_types::{BlsPublicKey, SealedBatch, TaskManager, B256};
+use tn_types::{
+    Batch, BatchValidation, BatchValidationError, BlsPublicKey, Database, SealedBatch, TaskManager,
+    B256,
+};
 use tn_worker::{
     PendingBatchStream, RequestHandler, WorkerGossip, WorkerNetworkError, WorkerNetworkHandle,
     WorkerRequest, WorkerResponse, MAX_BATCH_DIGESTS_PER_REQUEST, MAX_CONCURRENT_BATCH_STREAMS,
@@ -56,6 +59,38 @@ fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
         WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, chain_id);
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
+}
+
+/// Like [`create_test_types`], but injects a custom batch validator and also returns a handle to
+/// the shared node store, so a test can assert exactly what the handler chose to cache.
+fn create_test_types_with_validator(
+    validator: Arc<dyn BatchValidation>,
+) -> (TestTypes, MemDatabase) {
+    let committee = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let authority = committee.first_authority();
+    let config = authority.consensus_config();
+    // clone shares the same in-memory backing, so reads see the handler's writes
+    let store = config.node_storage().clone();
+    let task_manager = TaskManager::default();
+    let worker_id = 0;
+    let (tx, network_commands_rx) = mpsc::channel(10);
+    let network_handle =
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
+    let handler = RequestHandler::new(worker_id, validator, config, network_handle);
+    (TestTypes { committee, handler, task_manager, network_commands_rx }, store)
+}
+
+/// A [`BatchValidation`] that rejects every batch. Used to prove the gossip-prefetch path
+/// validates a fetched body before caching it.
+#[derive(Debug)]
+struct RejectingBatchValidator;
+
+impl BatchValidation for RejectingBatchValidator {
+    fn validate_batch(&self, _batch: SealedBatch) -> Result<(), BatchValidationError> {
+        Err(BatchValidationError::EmptyBatch)
+    }
+
+    fn submit_txn_if_mine(&self, _tx_bytes: &[u8], _committee_size: u64, _committee_slot: u64) {}
 }
 
 /// Deny a sync-protocol `OpenStream` command, simulating a legacy-only peer so
@@ -316,6 +351,52 @@ async fn test_batch_gossip_prefetch_deduplicates_in_flight_digest() {
         network_commands_rx.try_recv(),
         Err(mpsc::error::TryRecvError::Empty),
         "duplicate gossip must not trigger a second batch fetch"
+    );
+}
+
+/// A batch fetched by the gossip prefetch is validated before it is cached: a body that fails
+/// validation is dropped, never written to `NodeBatchesCache`.
+///
+/// This is the fix for issue #933. The vote-path sync (`PrimaryReceiverHandler::synchronize`)
+/// treats a digest already present in `NodeBatchesCache` as validated-and-available and skips
+/// `validate_batch` for it, so an unvalidated prefetched body reaching that cache would let a
+/// Byzantine committee member get a semantically-invalid batch voted on and certified.
+#[tokio::test]
+async fn test_gossip_prefetch_rejects_invalid_batch() {
+    let (TestTypes { handler, .. }, store) =
+        create_test_types_with_validator(Arc::new(RejectingBatchValidator));
+    // current-epoch batch (fixture epoch is 0), so only validation can reject it
+    let batch = Batch::default();
+    let digest = batch.digest();
+
+    // dropping an invalid body is not an error (it is a peer content fault, not a local one)
+    let res = handler.pub_validate_and_cache_prefetched_batch(&digest, &batch);
+    assert_matches!(res, Ok(()));
+
+    // the security property: an unvalidated body never reaches the cache the vote path trusts
+    assert!(
+        store.get::<NodeBatchesCache>(&digest).expect("read store").is_none(),
+        "an invalid gossip-prefetched batch must not be cached"
+    );
+}
+
+/// The counterpart to [`test_gossip_prefetch_rejects_invalid_batch`]: an identical current-epoch
+/// batch that passes validation *is* cached, so presence in `NodeBatchesCache` faithfully means
+/// "validated" for the vote path. This isolates validation (not the epoch check) as the reason the
+/// rejected batch above was dropped.
+#[tokio::test]
+async fn test_gossip_prefetch_caches_valid_batch() {
+    let (TestTypes { handler, .. }, store) =
+        create_test_types_with_validator(Arc::new(NoopBatchValidator));
+    let batch = Batch::default();
+    let digest = batch.digest();
+
+    let res = handler.pub_validate_and_cache_prefetched_batch(&digest, &batch);
+    assert_matches!(res, Ok(()));
+
+    assert!(
+        store.get::<NodeBatchesCache>(&digest).expect("read store").is_some(),
+        "a validated gossip-prefetched batch must be cached"
     );
 }
 

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -763,21 +763,31 @@ impl RethEnv {
         // Phase 1: Recover all transactions (ECDSA ecrecover) in parallel via rayon.
         // Always use par_iter — the slight overhead on small batches is negligible
         // compared to the savings on large ones, and avoids an extra code path.
+        //
+        // A transaction whose signer cannot be recovered cannot be executed, but a
+        // certified sub-DAG is fixed and identical on every honest node, so returning
+        // an error here would deterministically halt (and, on restart-replay,
+        // crash-loop) the whole network on a single undecodable transaction. Instead
+        // drop the unrecoverable transactions and continue, mirroring the `InvalidTx`
+        // tolerance of the execute phase below: every node drops the same
+        // transactions from the same certified bytes, so the resulting block stays
+        // deterministic (issue #933). The primary defense is validating batches before
+        // they can be certified; this only bounds the blast radius if one ever is.
         let recovered_txs = transactions
             .par_iter()
-            .map(|tx_bytes| {
+            .filter_map(|tx_bytes| {
                 reth_recover_raw_transaction::<TransactionSigned>(tx_bytes)
                     .inspect_err(|e| {
                         error!(
                             target: "engine",
                             batch=?batch_digest,
                             ?tx_bytes,
-                            "failed to recover signer: {e}"
+                            "failed to recover signer, dropping transaction: {e}"
                         )
                     })
-                    .map_err(TnRethError::from)
+                    .ok()
             })
-            .collect::<TnRethResult<Vec<_>>>()?;
+            .collect::<Vec<_>>();
 
         // Phase 2: Execute recovered transactions sequentially.
         for recovered in recovered_txs {

--- a/crates/tn-reth/tests/it/main.rs
+++ b/crates/tn-reth/tests/it/main.rs
@@ -5,6 +5,7 @@
 mod bls_precompile_props;
 mod economics_props;
 mod pipeline_helpers;
+mod recover_drop_props;
 
 // testnet
 #[cfg(feature = "faucet")]

--- a/crates/tn-reth/tests/it/recover_drop_props.rs
+++ b/crates/tn-reth/tests/it/recover_drop_props.rs
@@ -1,0 +1,46 @@
+//! Defense-in-depth regression for issue #933.
+//!
+//! The certified-output execution path (`RethEnv::build_block_from_batch_payload`) must not
+//! fatally halt the engine on a transaction that fails signer recovery. A certified sub-DAG is
+//! fixed and identical on every honest node, so an unrecoverable transaction is dropped
+//! deterministically (mirroring the `InvalidTx` tolerance of the execute phase) rather than
+//! aborting the whole block. Aborting would return `Err` into the engine loop, halting the
+//! network and, on restart-replay of the same certified output, crash-looping every node.
+
+use crate::pipeline_helpers::PipelineTestEnv;
+
+/// Bytes that cannot be decoded as an EIP-2718 typed transaction, so
+/// `reth_recover_raw_transaction` fails on them.
+const UNDECODABLE_TX: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+
+/// A batch whose only transaction is undecodable builds an (empty) block instead of returning a
+/// fatal error. Before the fix, the recover phase's fallible `collect` aborted the whole block on
+/// the first unrecoverable transaction, propagating an error that stopped the engine loop.
+#[test]
+fn undecodable_only_batch_builds_empty_block_instead_of_halting() {
+    let mut env = PipelineTestEnv::new();
+    let block = env
+        .execute_block(vec![UNDECODABLE_TX.to_vec()])
+        .expect("undecodable-only batch must not fatally halt block building");
+    assert!(
+        block.execution_output.result.receipts.is_empty(),
+        "the undecodable transaction must be dropped, leaving an empty block"
+    );
+}
+
+/// A batch mixing an undecodable transaction with a valid one drops only the undecodable one and
+/// still executes the valid transaction, so a single bad transaction cannot suppress the rest of a
+/// certified batch.
+#[test]
+fn undecodable_tx_is_dropped_valid_tx_survives() {
+    let mut env = PipelineTestEnv::new();
+    let valid_tx = env.user_precompile_tx(Vec::new());
+    let block = env
+        .execute_block(vec![UNDECODABLE_TX.to_vec(), valid_tx])
+        .expect("a batch with one undecodable tx must still build");
+    assert_eq!(
+        block.execution_output.result.receipts.len(),
+        1,
+        "only the undecodable transaction should be dropped; the valid one must execute"
+    );
+}


### PR DESCRIPTION
Fixes #933.

## Summary

Closes the batch-validation bypass described in #933 and adds a defense-in-depth guard so a certified-but-invalid batch can never fatally halt execution.

**Root cause.**  `NodeBatchesCache` is used by the vote path as a proxy for "validated and available," but the gossip-prefetch path wrote *unvalidated* bodies into it.  `synchronize` then took the "already in store" short-circuit and voted without ever calling `validate_batch`.

## Changes

1. **Primary fix: validate before caching on the prefetch path** (`crates/consensus/worker/src/network/handler.rs`).  `process_gossip` now routes the fetched `(digest, batch)` through a new `validate_and_cache_prefetched_batch`, which seals the body with the fetched digest and calls `self.validator.validate_batch` (the same gate as `process_report_batch`) before inserting into `NodeBatchesCache`.  An invalid body is dropped and `record_batch_validation_failure` is recorded;  it is a content fault of the served body (not of the gossip relayer), so it is not propagated as an error.  Only a genuine storage-write error still propagates.

2. **Defense in depth: non-fatal transaction recovery on the execute path** (`crates/tn-reth/src/lib.rs`, `build_block_from_batch_payload`).  The signer-recovery phase changed from a fallible `map(...).collect::<Result>()?` (fatal on the first unrecoverable transaction) to `filter_map(...).ok()`, which now drops unrecoverable transactions and continues, exactly as the adjacent execute phase already tolerates `InvalidTx`.  The block already may contain a subset of a batch's transactions, so this preserves determinism (every honest node drops the same transactions from the same certified bytes).

## Why the primary fix is complete

Every production writer into `NodeBatchesCache` was audited:

| Writer | Validated? | Reachable by vote path pre-certification? |
|---|---|---|
| gossip prefetch (`handler.rs`) | **now yes** (this PR) | yes (the gap) |
| report batch (`handler.rs`) | yes (`validate_batch`) | n/a |
| sync during vote (`primary.rs` `store_synced_batches`) | yes when `!is_certified` | yes, already gated |
| own batch production (`worker.rs`) | valid by construction (own pool) | n/a |
| certificate-payload fetch (`batch_fetcher.rs` `fetch_for_primary`) | trusted-because-certified | no (post-certification) |

The gossip prefetch was the only unvalidated writer that could seed the cache before the vote, so closing it restores the "cached implies validated" invariant the vote path relies on.

## Tests

- `crates/consensus/worker/tests/it/network_tests.rs`
  - `test_gossip_prefetch_rejects_invalid_batch`: with a rejecting validator, a current-epoch prefetched body is dropped and never written to `NodeBatchesCache`.
  - `test_gossip_prefetch_caches_valid_batch`: the identical batch with an accepting validator *is* cached, isolating validation (not the epoch check) as the reason the first batch was dropped.
- `crates/tn-reth/tests/it/recover_drop_props.rs`
  - `undecodable_only_batch_builds_empty_block_instead_of_halting`: an undecodable-only batch builds an empty block instead of returning a fatal error.
  - `undecodable_tx_is_dropped_valid_tx_survives`: a batch mixing an undecodable transaction with a valid one drops only the undecodable one and still executes the valid transaction.

`cargo fmt`, `clippy` (tn-worker + tn-reth), and all four new tests pass.

## Acceptance criteria (from #933)

- [x] Every batch a node votes to certify has passed `validate_batch` regardless of how it entered the store;  presence in `NodeBatchesCache` is never treated as validity for the vote path.
- [x] An invalid batch cannot be admitted into a certified header via the gossip prefetch path.
- [x] A certified batch that fails transaction recovery no longer fatally terminates the engine loop (defense-in-depth).
