### PR TITLE
fix(consensus): make anti-equivocation records durable before externalizing

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -18,7 +18,7 @@ use tn_config::ConsensusConfig;
 use tn_network_libp2p::{
     write_frame, GossipMessage, PrimarySyncRequest, Stream, SyncFrame, SyncFrameError,
 };
-use tn_storage::{consensus::ConsensusChain, CertificateStore, VoteDigestStore};
+use tn_storage::{consensus::ConsensusChain, tables::Votes, CertificateStore, VoteDigestStore};
 use tn_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
@@ -868,6 +868,14 @@ where
 
         // Update the vote digest store with the vote we just sent.
         self.consensus_config.node_storage().write_vote(&vote)?;
+
+        // Wait for the `Votes` record to be durable before returning the vote to the peer. The
+        // epoch DB persists asynchronously, so `write_vote` returns before the record hits disk;
+        // returning the vote first would let a crash in that window lose the record. On restart the
+        // recast guard would then read nothing and could sign a *different* vote for the same
+        // author/round while the pre-crash vote is already held by the peer: equivocation from an
+        // ordinary crash. See issue #934.
+        self.consensus_config.node_storage().persist_durable::<Votes>().await;
 
         Ok(PrimaryResponse::Vote(vote))
     }

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -25,7 +25,7 @@ use std::{
     collections::{BTreeMap, VecDeque},
 };
 use tn_config::ConsensusConfig;
-use tn_storage::ProposerStore;
+use tn_storage::{tables::LastProposed, ProposerStore};
 use tn_types::{
     now, AuthorityIdentifier, BlockHash, Certificate, Committee, Database, Epoch, Hash as _,
     Header, Noticer, Round, TaskManager, TaskSpawner, TnReceiver, TnSender, WorkerId,
@@ -268,6 +268,14 @@ impl<DB: Database> Proposer<DB> {
         proposer_store
             .write_last_proposed(header)
             .map_err(|e| ProposerError::StoreError(e.to_string()))?;
+
+        // Wait for the `LastProposed` record to be durable before broadcasting. The epoch DB
+        // persists asynchronously, so `write_last_proposed` returns before the record hits disk;
+        // broadcasting first would let a crash in that window lose the record. On restart the
+        // anti-equivocation guard would then read nothing and build a *different* header for this
+        // same round while the pre-crash header is already on the network: equivocation from an
+        // ordinary crash. See issue #934.
+        proposer_store.persist_durable::<LastProposed>().await;
 
         // Send the new header to the `Certifier` that will broadcast and certify it.
         consensus_bus.headers().send(header.clone()).await.map_err(|e| Box::new(e).into())

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -41,6 +41,8 @@ tn-reth = { workspace = true }
 tn-test-utils = { workspace = true }
 rand = { workspace = true }
 roaring = { workspace = true }
+# Async barrier tests for `persist_durable` need a runtime + timers.
+tokio = { workspace = true, features = [ "macros", "rt", "time" ] }
 
 [features]
 redb = []

--- a/crates/storage/src/composite_db.rs
+++ b/crates/storage/src/composite_db.rs
@@ -130,6 +130,10 @@ impl<DB: Database> Database for CompositeDatabase<DB> {
         self.get_db(T::HINT).persist::<T>()
     }
 
+    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
+        self.get_db(T::HINT).persist_durable::<T>()
+    }
+
     fn sync_persist(&self) {
         self.inner.epoch_db.sync_persist();
         self.inner.kad_db.sync_persist();

--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -179,6 +179,11 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
     let mut txn = None;
     let mut last_compact = Instant::now();
     let mut committed_inserts: Vec<Box<dyn InsertTrait<DB>>> = Vec::with_capacity(1000);
+    // Durability-barrier acks deferred because a write txn was open when they arrived. A bare
+    // `Insert` enqueued while a txn is open rides that txn (see the `Insert` arm below), so its
+    // durability is only settled once the txn commits; these are drained the moment `txn` returns
+    // to `None`.
+    let mut pending_durable: Vec<oneshot::Sender<()>> = Vec::new();
     if let Err(e) = db.compact() {
         tracing::error!(target: "layered_db_runner", "DB ERROR compacting DB on startup (background): {e}");
     }
@@ -198,6 +203,11 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
             }
             DBMessage::CommitTxn => {
                 end_txn(&mut txn, &mut committed_inserts, mem_db.as_ref());
+                if txn.is_none() {
+                    pending_durable.drain(..).for_each(|tx| {
+                        let _ = tx.send(());
+                    });
+                }
             }
             DBMessage::EndTxn => {
                 tracing::warn!(
@@ -205,6 +215,11 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
                     "write txn dropped without commit; committing it to keep persistence alive"
                 );
                 end_txn(&mut txn, &mut committed_inserts, mem_db.as_ref());
+                if txn.is_none() {
+                    pending_durable.drain(..).for_each(|tx| {
+                        let _ = tx.send(());
+                    });
+                }
             }
             DBMessage::Insert(ins) => {
                 if let Some((txn, _)) = &mut txn {
@@ -246,6 +261,17 @@ fn db_run<DB: Database>(db: DB, mem_db: Option<MemDatabase>, rx: Receiver<DBMess
             }
             DBMessage::CaughtUp(tx) => {
                 let _ = tx.send(());
+            }
+            DBMessage::DurableBarrier(tx) => {
+                // If a write txn is open, any bare insert this barrier is ordered after has been
+                // absorbed into it and is not yet durable, so hold the ack until that txn commits
+                // (drained in the `CommitTxn`/`EndTxn` arms). With no txn open, every prior insert
+                // was written directly and durably, so ack now.
+                if txn.is_some() {
+                    pending_durable.push(tx);
+                } else {
+                    let _ = tx.send(());
+                }
             }
             DBMessage::Stats(tx) => {
                 let _ = tx.send(LayeredDbStats {
@@ -473,6 +499,19 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
         }
     }
 
+    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
+        let (tx, rx) = oneshot::channel();
+        let r = self
+            .tx
+            .send(DBMessage::DurableBarrier(tx))
+            .map_err(|_| eyre::eyre!("DB thread gone, FATAL!"));
+        async move {
+            if r.is_ok() {
+                let _ = rx.await;
+            }
+        }
+    }
+
     fn sync_persist(&self) {
         let (tx, mut rx) = oneshot::channel();
         let r = self
@@ -582,6 +621,11 @@ enum DBMessage<DB: Database> {
     Remove(Box<dyn RemoveTrait<DB>>),
     Clear(Box<dyn ClearTrait<DB>>),
     CaughtUp(tokio::sync::oneshot::Sender<()>),
+    /// Durability barrier: like [`DBMessage::CaughtUp`], but the ack is deferred while a write txn
+    /// is open so it fires only after that physical txn commits. A bare `Insert` enqueued while a
+    /// txn is open is absorbed into it (`db_run`), so a plain `CaughtUp` could ack before the
+    /// write is durable; this variant closes that window for anti-equivocation writes.
+    DurableBarrier(tokio::sync::oneshot::Sender<()>),
     Stats(tokio::sync::oneshot::Sender<LayeredDbStats>),
     Shutdown,
 }
@@ -596,6 +640,7 @@ impl<DB: Database> Debug for DBMessage<DB> {
             DBMessage::Remove(_) => write!(f, "Remove"),
             DBMessage::Clear(_) => write!(f, "Clear"),
             DBMessage::CaughtUp(_) => write!(f, "CaughtUp"),
+            DBMessage::DurableBarrier(_) => write!(f, "DurableBarrier"),
             DBMessage::Stats(_) => write!(f, "Stats"),
             DBMessage::Shutdown => write!(f, "Shutdown"),
         }
@@ -611,7 +656,7 @@ mod test {
         mdbx::{database::MEGABYTE, MdbxDatabase},
         test::*,
     };
-    use std::path::Path;
+    use std::{path::Path, time::Duration};
     use tempfile::tempdir;
     use tn_types::Database as _;
 
@@ -938,6 +983,88 @@ mod test {
         assert_eq!(
             db.stats().expect("stats"),
             super::LayeredDbStats { retained_inserts: 0, open_txn_count: 0 }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persist_acks_before_open_txn_flushes() {
+        // Documents the issue #934 window: a plain `persist` barrier resolves even though a
+        // concurrently open write txn (e.g. a certificate-store write on the same epoch DB) has
+        // absorbed the caller's bare insert and not yet committed it, so the "persisted" record is
+        // not on disk. `persist_durable` is the fix for exactly this.
+        use tn_types::DbTxMut as _;
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_gap"));
+
+        // A concurrent writer holds an epoch-DB write txn open.
+        let concurrent = db.write_txn().expect("write txn");
+        // The anti-equivocation record is a bare insert; with the txn open it is absorbed into it.
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+
+        // The plain barrier resolves immediately even though the write is not durable.
+        db.persist::<TestTable>().await;
+        assert_eq!(
+            raw.get::<TestTable>(&1).expect("get"),
+            None,
+            "plain persist acked before the absorbed write reached disk (the #934 window)"
+        );
+
+        // Only committing the concurrent txn flushes the absorbed write.
+        concurrent.commit().expect("commit");
+        db.sync_persist();
+        assert_eq!(raw.get::<TestTable>(&1).expect("get"), Some("one".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_persist_durable_waits_for_open_txn_commit() {
+        // The fix: `persist_durable` resolves only after the physical txn that absorbed the write
+        // commits, so the record is guaranteed on disk before the barrier returns.
+        use tn_types::DbTxMut as _;
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_durable"));
+
+        // A concurrent writer holds an epoch-DB write txn open; the bare insert is absorbed into
+        // it.
+        let concurrent = db.write_txn().expect("write txn");
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+
+        // While the txn is open the barrier must not resolve: polling it for a window times out.
+        let barrier = db.persist_durable::<TestTable>();
+        tokio::pin!(barrier);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), &mut barrier).await.is_err(),
+            "durable barrier resolved while the absorbing txn was still open"
+        );
+        assert_eq!(
+            raw.get::<TestTable>(&1).expect("get"),
+            None,
+            "absorbed write must not be on disk while the txn is open"
+        );
+
+        // Committing the concurrent txn flushes the absorbed write; the barrier then resolves.
+        concurrent.commit().expect("commit");
+        tokio::time::timeout(Duration::from_secs(5), &mut barrier)
+            .await
+            .expect("durable barrier must resolve after the txn commits");
+        assert_eq!(
+            raw.get::<TestTable>(&1).expect("get"),
+            Some("one".to_string()),
+            "record must be durable before the durable barrier resolves"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persist_durable_acks_immediately_without_open_txn() {
+        // With no concurrent txn the bare insert is written directly and durably, so the barrier
+        // resolves without waiting.
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_durable_fast"));
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+        db.persist_durable::<TestTable>().await;
+        assert_eq!(
+            raw.get::<TestTable>(&1).expect("get"),
+            Some("one".to_string()),
+            "durable barrier must guarantee the write is on disk"
         );
     }
 

--- a/crates/types/src/database_traits.rs
+++ b/crates/types/src/database_traits.rs
@@ -135,6 +135,20 @@ pub trait Database: Send + Sync + Clone + Unpin + 'static {
     fn persist<T: Table>(&self) -> impl Future<Output = ()> + Send {
         std::future::ready(())
     }
+    /// Durable variant of [`Database::persist`].
+    ///
+    /// For a backend that persists in the background, a plain [`Database::persist`] barrier can
+    /// resolve while a concurrently-open write txn has *absorbed* this caller's write but not yet
+    /// committed it, so a crash in that window loses the record even though `persist` returned. The
+    /// future returned here resolves only once the write is durably committed to the physical
+    /// store, including that absorbed-into-an-open-txn case. Synchronously-durable backends
+    /// inherit the plain `persist` behaviour.
+    ///
+    /// Use at anti-equivocation externalization points (proposer header broadcast, vote return)
+    /// where losing the record on restart makes an honest node equivocate.
+    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
+        std::future::ready(())
+    }
     /// Sync version of persist- useful for test not for prod code.
     /// Since this is intended for testing don't bother with the Table hint.
     fn sync_persist(&self) {}


### PR DESCRIPTION
Closes #934 


## Problem

The proposer persists its `LastProposed` header and then immediately broadcasts it
(`store_and_send_header`, `crates/consensus/primary/src/proposer.rs`).  The vote handler writes its
`Votes` record and then returns the vote to the requesting peer (`vote_inner`,
`crates/consensus/primary/src/network/handler.rs`).

Both records are `TableHint::Epoch` tables, so they route to the epoch DB: a full-memory
`LayeredDatabase` whose `insert` updates an in-memory map and enqueues the durable disk write to a
background thread, returning **before** the write is durable.  There is no barrier between recording
what we are about to externalize and externalizing it.

If the node crashes in that window, on restart the in-memory map is repopulated from disk only, so a
record enqueued but not yet flushed at crash time is gone.  The anti-equivocation guard then reads
nothing and builds a *different* header (or signs a *different* vote) for the same `(epoch, round)`,
while the pre-crash header/vote is already on the network.  Two distinct, validly-signed messages
from the same honest author at the same round now exist: authority equivocation, produced by an
ordinary crash with no Byzantine actor.  Equivocation by an authority is exactly the accountability
fault DAG-BFT relies on honest nodes never committing.

## Why a plain persist barrier is not enough

The obvious fix, awaiting the existing `persist` barrier, does not fully close the window.  The
certificate store opens an epoch-DB write txn on essentially every round (`CertificateStore::write` /
`write_all`, all cert tables are `TableHint::Epoch`).  In the background writer (`db_run`), a bare
`insert` dequeued while a txn is open is **absorbed** into that open physical txn and only becomes
durable when it commits.  The current `CaughtUp` barrier (behind both `persist` and `sync_persist`)
acks unconditionally, so it can return while the absorbed record is still uncommitted.

Making `CaughtUp` wait for the open txn is not an option: callers that hold an open `write_txn`
across `sync_persist` would deadlock, and two existing tests
(`test_layereddb_overlapped_txn_drop_keeps_count_balanced`,
`test_layereddb_cloned_txn_commit_sends_exactly_one_end`) do exactly that on purpose.

## Fix

Add a dedicated durable barrier and leave `persist` / `sync_persist` byte-identical:

- **`tn-types`** — new provided `Database` method `persist_durable::<T>()`, a no-op by default (as
  `persist` is).  Synchronously-durable backends (raw MDBX / redb, `MemDatabase`) need no barrier;
  their inserts are already durable on return.
- **`tn-storage`** — new `DBMessage::DurableBarrier`.  The background thread acks it immediately
  when no write txn is open (every prior insert was written directly and durably);  otherwise it
  defers the ack and drains it once the physical txn that absorbed the write commits (the `CommitTxn`
  / `EndTxn` arms, guarded by `txn.is_none()`).  `txn` transitions to `None` only inside `end_txn`,
  which is reached only from those two arms, so no commit path can miss the drain.
  `LayeredDatabase` and `CompositeDatabase` implement it;  the composite routes by table hint, so an
  epoch-DB barrier only waits on epoch-DB txns.
- **`tn-primary`** — the proposer awaits `persist_durable::<LastProposed>()` after the store write
  and before broadcast;  the vote handler awaits `persist_durable::<Votes>()` after `write_vote` and
  before returning the vote.  The recast/resend paths only ever resend an already-stored record, so
  the single fresh-write site on each path is the only place a barrier is needed.

The MDBX backend commits durably (default `SyncMode::Durable`, fsync), so once the barrier resolves
the record is on disk.

## Restored invariant

An honest node never externalizes a header or vote whose anti-equivocation record is not yet durable.
After a crash at any point after the header is broadcast / the vote is returned, on restart the node
either re-proposes the identical header (re-signs the identical vote) or does not act for that round;
it never produces a different one.

## Changes

- [x] `persist_durable::<T>()` durable barrier on the `Database` trait (defaults to `persist`)
- [x] `DBMessage::DurableBarrier` with defer-until-commit drain in `db_run`; `LayeredDatabase` +
      `CompositeDatabase` impls (existing `persist` / `sync_persist` semantics unchanged)
- [x] Proposer awaits the barrier before broadcasting the header
- [x] Vote handler awaits the barrier before returning the vote
- [x] Storage tests: plain `persist` acks before an absorbed write is durable (documents the window);
      `persist_durable` stays pending until the absorbing txn commits and the record is then on disk
      (the fix);  with no open txn it resolves immediately against a durably-written record

## Testing

- `tn-storage` lib tests: 129 passed (3 new, plus the existing overlapped/cloned-txn tests that
  confirm the shared `CaughtUp` path is untouched)
- `tn-primary` proposer (3) and vote (30) tests pass
- `cargo fmt` + `clippy` clean on `tn-types`, `tn-storage`, `tn-primary`
