### PR TITLE
fix(node): keep the healthcheck accept loop alive across transient accept errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11835,6 +11835,7 @@ dependencies = [
  "tn-types",
  "tn-worker",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -15,6 +15,7 @@ authors = [
 [dependencies]
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 tn-executor = { workspace = true }

--- a/crates/node/src/health.rs
+++ b/crates/node/src/health.rs
@@ -14,14 +14,16 @@
 
 use std::{future::Future, net::SocketAddr, time::Duration};
 
+use futures::{Stream, StreamExt};
 use serde::Serialize;
 use tn_types::{TaskSpawner, WorkerId, DEFAULT_WORKER_ID};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
     time::timeout,
 };
-use tracing::info;
+use tokio_stream::wrappers::TcpListenerStream;
+use tracing::{debug, info};
 
 /// Request path that serves the per-worker readiness envelope.
 const WORKERS_PATH: &str = "/health/workers";
@@ -157,9 +159,43 @@ impl HealthcheckServer {
         let listen_on = listener.local_addr()?;
         info!(target: "epoch-manager", ?listen_on, "healthcheck listening");
 
+        // wrap the listener in a stream so the accept loop is a testable seam
+        // (`serve` below): production feeds it the real `TcpListenerStream`, and
+        // tests feed it a stream that injects a failing accept.
         task_spawner.spawn_critical_task("healthcheck", async move {
-            // accept loop - no connection limits; bounded read timeout per conn
-            while let Ok((mut socket, _)) = listener.accept().await {
+            serve(TcpListenerStream::new(listener), worker_ready).await;
+            Ok(())
+        });
+
+        Ok(listen_on)
+    }
+}
+
+/// Drive the accept loop over a stream of accepted connections.
+///
+/// Serves each connection synchronously (bounded per-connection read timeout),
+/// routing the workers path to readiness and everything else to liveness.
+///
+/// A transient `accept()` error (fd exhaustion `EMFILE`/`ENFILE`,
+/// `ECONNABORTED`, `EINTR`, `ENOBUFS`) is logged and skipped: the loop must
+/// keep serving. The caller spawns this as a *critical* task, so ending the
+/// loop would resolve the task `Ok` and notify a whole-node shutdown - exactly
+/// the outage this endpoint is supposed to warn about. This mirrors the metrics
+/// server (`tn_metrics::server`), whose accept loop swallows the same errors.
+async fn serve<S, F, Fut>(mut incoming: S, worker_ready: F)
+where
+    S: Stream<Item = std::io::Result<TcpStream>> + Unpin,
+    F: Fn() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    // the loop survives a transient accept error because the `Some(Err(..))`
+    // arm below logs and skips instead of breaking. `worker_ready` is called
+    // inline in the loop body (rather than from a per-connection `for_each`
+    // closure) for a separate reason: it keeps a `Sync` bound off the public
+    // `spawn` signature.
+    loop {
+        match incoming.next().await {
+            Some(Ok(mut socket)) => {
                 // read the request with a bounded timeout so a slow or idle
                 // client cannot stall the loop; treat a timeout/error/empty
                 // read as "no path" and fall through to the liveness response.
@@ -190,10 +226,12 @@ impl HealthcheckServer {
                     let _ = socket.write_all(LIVENESS_RESPONSE).await;
                 }
             }
-            Ok(())
-        });
-
-        Ok(listen_on)
+            // transient accept errors (e.g. fd exhaustion) must not kill the node
+            Some(Err(e)) => debug!(target: "epoch-manager", ?e, "healthcheck accept error"),
+            // the production `TcpListenerStream` is infinite; a finite test
+            // stream ends here once drained.
+            None => break,
+        }
     }
 }
 
@@ -216,7 +254,8 @@ mod tests {
         net::TcpStream,
     };
 
-    use super::{readiness_json, request_path, HealthcheckServer};
+    use super::{readiness_json, request_path, serve, HealthcheckServer};
+    use futures::StreamExt;
     use tn_types::{get_available_tcp_port, TaskManager};
 
     /// Send `request` to the spawned server at `addr` and return the response.
@@ -297,6 +336,42 @@ mod tests {
             body,
             r#"{"version":1,"workers":[{"worker_id":0,"accepting_transactions":true}]}"#
         );
+
+        Ok(())
+    }
+
+    /// Regression for #943: a failed `accept()` must not end the loop.
+    ///
+    /// Before the fix the accept loop was `while let Ok(..) = accept()`, so the
+    /// first `Err` fell out of the loop, the critical task resolved `Ok`, and
+    /// the whole node was shut down. Inject a failing accept ahead of a real
+    /// listener and assert the endpoint still serves the next connection.
+    #[tokio::test]
+    async fn test_accept_error_does_not_end_loop() -> eyre::Result<()> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        // a transient accept() error (fd exhaustion, ECONNABORTED, ...) followed
+        // by the real listener stream. `Box::pin` makes the chained stream Unpin.
+        let incoming = Box::pin(
+            futures::stream::once(async {
+                Err::<tokio::net::TcpStream, _>(std::io::Error::other("simulated accept error"))
+            })
+            .chain(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+        let handle = tokio::spawn(async move { serve(incoming, || async { false }).await });
+
+        // the loop logged+skipped the injected error and kept serving
+        let response = roundtrip(addr, b"GET / HTTP/1.1\r\n\r\n").await?;
+        assert!(
+            response.starts_with("HTTP/1.1 200 OK"),
+            "endpoint should still serve after a failed accept, got: {response}"
+        );
+        assert!(response.ends_with("OK"), "expected liveness body 'OK', got: {response}");
+
+        // the serve loop is still running (it did not resolve on the error)
+        assert!(!handle.is_finished(), "accept error must not end the serve loop");
+        handle.abort();
 
         Ok(())
     }


### PR DESCRIPTION
Closes #943 

## Problem

The healthcheck endpoint (`--healthcheck <PORT>` / `HEALTHCHECK_TCP_PORT`) runs its accept loop as a
**critical** task (`crates/node/src/health.rs`), but the loop was written as
`while let Ok((mut socket, _)) = listener.accept().await { .. }` with `Ok(())` below it.

A `while let Ok(..)` binds only on `Ok`, so the first `Err` from `accept()` falls out of the loop and
the closure returns `Ok(())`.  Because the task is critical, `TaskManager` treats that `Ok` return
(while the node is not already shutting down) as `CriticalExitOk` and notifies a **whole-node
shutdown** (`crates/types/src/task_manager.rs`).

`accept()` returns `Err` on ordinary, transient conditions, most importantly `EMFILE`/`ENFILE`
(per-process or system-wide file-descriptor exhaustion), and also `ECONNABORTED`, `ENOBUFS`/`ENOMEM`,
and `EINTR`.  So the liveness probe an operator enables to watch node health becomes the thing that
takes the node down, and it does so precisely under fd/resource pressure, exactly when the node should
stay up.  Because that pressure often persists across a restart, it can turn into a restart loop.

The endpoint is off by default and only bites operators who enable it, but enabling a
liveness/readiness probe is the standard production and Kubernetes setup, so the blast radius is any
operator following the documented monitoring path.

## Fix

The repo already handles this exact case correctly in the metrics server
(`crates/tn-metrics/src/server.rs`), whose accept loop swallows transient accept errors and keeps
serving, with a comment saying so.  This change makes the healthcheck loop do the same.

The accept loop is extracted into a small `serve` seam over a stream of accepted connections:

- **`serve<S, F, Fut>(incoming: S, worker_ready: F)`** where `S: Stream<Item = io::Result<TcpStream>>
  + Unpin` runs `loop { match incoming.next().await { Some(Ok(socket)) => serve one connection,
  Some(Err(e)) => log at `debug` and skip, None => break } }`.  A transient accept error is logged and
  skipped instead of ending the loop, so the critical task never resolves `Ok` on it.  `worker_ready`
  is called inline in the loop body, so **no `Send`/`Sync` bound change** is needed on the public
  `spawn` signature.
- **Production wraps the real listener**: `serve(TcpListenerStream::new(listener),
  worker_ready).await`.  `TcpListenerStream` is infinite, so `None => break` is only reachable by the
  finite stream a test supplies.  Per-connection behavior (bounded read timeout, path routing, exact
  response bytes and headers, socket close) is byte-for-byte unchanged;  serving stays sequential.
- **`tokio-stream`** is added to the node crate for `TcpListenerStream`.  It is already a workspace
  dependency and already used in `engine` and `exex`, so this pulls in nothing new.

### Why the seam (rather than an inline `loop { match listener.accept() }`)

Wrapping the listener in a `Stream` lets a test substitute a stream that yields a failing accept
followed by real connections.  A raw `TcpListener` cannot be made to fail `accept()` on demand
without process-wide fd exhaustion, which is flaky and non-portable.  The seam is the minimum needed
to make the acceptance-criteria regression test deterministic.  `worker_ready` is driven inline via
`incoming.next()` (not a per-connection `for_each` closure) specifically so the fix needs no `Sync`
bound on the public API.

## Testing

- New regression test `test_accept_error_does_not_end_loop`: injects a failing `accept()` ahead of a
  real listener via `stream::once(Err).chain(TcpListenerStream::new(listener))`, then asserts the
  endpoint still serves the next connection (`200 OK`) and the serve task has not resolved.
- The test was mutation-checked: it **fails** if the `Some(Err(..))` arm is changed to end the loop
  (the pre-fix behavior), and passes with the fix.
- Full `crates/node` health suite passes under the repo-pinned `1.94` toolchain (6/6);  `cargo +1.94
  clippy` and nightly `cargo fmt` are clean.

## Consistency check (per the issue)

`health.rs` was the only critical task using the `while let Ok(..)`-over-`accept()` shape (`rg 'while
let Ok'` finds no other).  The remaining `spawn_critical_task` call sites run epoch-scoped `run(..)`
loops that return `Ok` deliberately at the epoch boundary, which the manager already treats as an
expected graceful exit.

## Note on behavior under persistent fd pressure

Like the metrics server precedent, the loop logs and immediately retries;  under a *persistent*
`EMFILE` it will spin at `debug` level until fds free up.  This is intentional parity with the metrics
server and keeps the diff minimal.  A shared, backed-off accept helper for both endpoints would be a
reasonable follow-up but is out of scope for this fix.
