### PR TITLE
test: lower e2e round cadence and expose max_batch_delay genesis flag

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -191,9 +191,11 @@ fn config_local_testnet_inner(
         "--dev-funded-account".into(),
         "test-source".into(),
         "--max-header-delay-ms".into(),
-        "1000".into(),
-        "--min-header-delay-ms".into(),
         "500".into(),
+        "--min-header-delay-ms".into(),
+        "250".into(),
+        "--max-batch-delay-ms".into(),
+        "250".into(),
     ];
     if let Some(duration) = epoch_duration_secs {
         genesis_args.push("--epoch-duration-in-secs".into());

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -632,9 +632,11 @@ fn config_committee(
         "--dev-funded-account",
         "test-source",
         "--max-header-delay-ms",
-        "1000",
-        "--min-header-delay-ms",
         "500",
+        "--min-header-delay-ms",
+        "250",
+        "--max-batch-delay-ms",
+        "250",
     ]);
     create_committee_command.args.execute(shared_genesis_dir.to_path_buf())?;
 

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -239,12 +239,13 @@ fn run_restart_tests2(client_urls: &[String; 4]) -> eyre::Result<()> {
 /// A validator that misses more than `parameters.gc_depth - 10` (50 - 10 = 40) consensus
 /// rounds while offline is pushed outside the GC window (see the primary network handler's
 /// `outside_gc_window` check) and must rejoin via the follow/catch-up path rather than
-/// live consensus. The `min_secs` floor is the real guarantee: `max_header_delay = 1s`
-/// bounds a round to ~1s and the heavy restart tests run serially (nextest `e2e` group,
-/// max-threads = 1) so nothing else steals cores, so 60s reliably clears the ~40-round /
-/// ~40s threshold with margin while still cutting ~10s per test vs the old fixed 70s
-/// sleep. The peer-advancement check is only a stall-guard against the network wedging
-/// (which would make the downtime meaningless), not a substitute for the floor. Node
+/// live consensus. The `min_secs` floor is the real guarantee: with the e2e genesis's
+/// `max_header_delay = 500ms` an idle round is bounded to ~500ms (idle rounds are paced by
+/// the header delays, not `max_batch_delay`) and the heavy restart tests run serially
+/// (nextest `e2e` group, max-threads = 1) so nothing else steals cores, so 60s reliably
+/// clears the ~40-round (~20s) threshold with margin while still cutting ~10s per test vs
+/// the old fixed 70s sleep. The peer-advancement check is only a stall-guard against the network
+/// wedging (which would make the downtime meaningless), not a substitute for the floor. Node
 /// index 2 is the killed one; 0/1/3 stay live.
 fn wait_for_downtime(client_urls: &[String; 4], min_secs: u64) -> eyre::Result<()> {
     // Nodes 0/1/3 stay live (index 2 is the killed one).

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -206,6 +206,7 @@ telcoin-network genesis \
 | `--epoch-duration-in-secs`, `--epoch_length`         | `86400`        | Epoch duration in seconds (default: 24 hours)                                             |
 | `--max-header-delay-ms`                              | none           | Max delay between header proposals (milliseconds)                                         |
 | `--min-header-delay-ms`                              | none           | Min delay between header proposals (milliseconds)                                         |
+| `--max-batch-delay-ms`                               | none           | Max delay before a worker seals a batch of pending transactions (milliseconds)            |
 | `--dev-funded-account`                               | none           | Fund a deterministic test account. Never use in production                                |
 | `--accounts`                                         | none           | Path to a YAML file mapping addresses to genesis accounts                                 |
 

--- a/crates/telcoin-network-cli/src/genesis/mod.rs
+++ b/crates/telcoin-network-cli/src/genesis/mod.rs
@@ -106,6 +106,11 @@ pub struct GenesisArgs {
     /// Min delay for a node to produce a new header.
     #[arg(long)]
     pub min_header_delay_ms: Option<u64>,
+    /// Max time a worker waits before sealing a batch of pending transactions. Paces block
+    /// production under transaction load; it does not seal empty batches, so it does not
+    /// gate idle round advance (the header delays do that).
+    #[arg(long)]
+    pub max_batch_delay_ms: Option<u64>,
     /// Numeric chain id that will go in the genesis.
     /// Default is 0xde7e1 (911329).  Used mostly for testing.
     #[arg(long, default_value_t = 911329, value_parser=maybe_hex)]
@@ -302,6 +307,9 @@ impl GenesisArgs {
         if let Some(min_header_delay_ms) = self.min_header_delay_ms {
             parameters.min_header_delay = Duration::from_millis(min_header_delay_ms);
         }
+        if let Some(max_batch_delay_ms) = self.max_batch_delay_ms {
+            parameters.max_batch_delay = Duration::from_millis(max_batch_delay_ms);
+        }
         parameters.basefee_address = Some(self.basefee_address);
 
         // write genesis and config to file
@@ -338,6 +346,7 @@ mod tests {
             dev_funded_account: None,
             max_header_delay_ms: None,
             min_header_delay_ms: None,
+            max_batch_delay_ms: None,
             chain_id: 2017,
             worker_fee_configs: configs.into_iter().map(String::from).collect(),
             accounts: None,


### PR DESCRIPTION
Closes #918.

## Summary

Most e2e waits are "advance N consensus rounds" (epoch progress, restart demotion
windows, sync catch-up).  Those rounds are paced by three consensus `Parameters`, but
the e2e genesis only lowered two of them (`max_header_delay`, `min_header_delay`) and
left the third, `max_batch_delay`, at its 1s default and unexposed as a flag.

This lowers all three cadence params in the test genesis and exposes `max_batch_delay`
via `--max-batch-delay-ms`, so the whole cadence trio is tunable and set low for tests.
Nothing about what the tests assert changes: same epochs certify, same restart
demotion/rejoin, same records read.  Only the wall-clock per round shrinks.  No epoch
count, iteration count, or timeout constant is touched, and it stacks additively with
the EPOCH_DURATION cuts from #897/#907.

## What actually speeds up (mechanism)

I traced the cadence params end to end before finalizing the values:

- **Idle round advance is paced by the header delays**, not `max_batch_delay`.  When
  the tx pool is empty, the primary proposer still emits an empty-payload header on its
  `max_header_delay` / `min_header_delay` timers (`proposer.rs`), which is what lets an
  idle cluster keep advancing rounds.  So the `1000 -> 500` and `500 -> 250` header-delay
  reductions are what speed the idle-dominated epoch/restart/sync waits.
- **`max_batch_delay` is the worker's batch-seal timer under load.**  A worker seals a
  batch of *pending* transactions after this long even if the batch is not full
  (`batch-builder/src/lib.rs`);  it does **not** seal empty batches and does not gate idle
  rounds.  Lowering it `1000 -> 250` therefore speeds the tx-driven portions of the tests
  (batch sealing, block inclusion) and is harmless when idle.  Exposing it also completes
  the tunable cadence trio for future use.

## What changed

- **Expose `max_batch_delay` as a genesis flag** (`crates/telcoin-network-cli/src/genesis/mod.rs`),
  mirroring the two existing header-delay flags: new `--max-batch-delay-ms` arg on
  `GenesisArgs`, applied to `parameters.max_batch_delay` when set.
- **Lower the cadence at both e2e genesis call sites** (`crates/e2e-tests/src/lib.rs`
  and `crates/e2e-tests/tests/it/epochs.rs`), kept in lockstep:
  `max_header_delay 1000 -> 500`, `min_header_delay 500 -> 250`, add `max_batch_delay = 250`.
- **Fix a now-stale doc comment** in `crates/e2e-tests/tests/it/restarts.rs`: its
  downtime-floor rationale said `max_header_delay = 1s` bounds a round to ~1s, but those
  tests run through the edited `config_local_testnet`, so a round is now ~500ms.  Behavior
  is unaffected (the 60s floor clears the ~40-round GC threshold with even more margin);
  the comment is corrected so it no longer contradicts the config.
- **Document the flag** in the CLI README.

Chosen cadence: `max_header_delay = 500ms`, `min_header_delay = 250ms`,
`max_batch_delay = 250ms`.

## Why it is coverage-preserving

The delays only change how fast a round is produced, not what any round asserts.  The
same epochs certify, the same restart demotion/rejoin happens, the same records are
read.  The e2e waits are round-bounded ("advance N rounds") and epoch closure keys off
committed sub-dag timestamps, not wall-clock, so the tests observe the same sequence of
states, just sooner.

## Risk / bounds

- The values respect the issue's stated floors: `min_header_delay >= ~250ms` and
  `max_header_delay >= ~2x the observed loopback proposal latency`.  250ms is exactly the
  floor for `min_header_delay`;  do not lower it further without evidence.
- Over-lowering (a `min_header_delay` below proposal latency) is an unproven quorum-race
  / empty-header-spam risk on a 4-node loopback cluster under nextest CPU contention.  If
  any new flakiness shows up, back the two 250ms values up before tightening further.
- The two e2e genesis call sites are kept identical on purpose;  a mismatch would give
  the epochs tests a different cadence than the rest.
- The only cadence-sensitive quantity in the suite is the restart GC window (a round
  count derived from a wall-clock floor).  This change does not touch the live `min_secs`
  floors (2 and 60), so it stays well on the correct side of the ~40-round threshold;  it
  only widens the margin.
- Out of scope: `gc_depth` and the manual `etc/local-testnet.sh` / `etc/genesis.sh` dev
  scripts, which do not affect the automated e2e suite.

## Verification

- Built against the repo-pinned toolchain (`1.94`): `cargo check -p telcoin-network-cli`
  and `cargo check -p e2e-tests --tests` both pass.
- `cargo +nightly fmt` leaves the diff unchanged;  scoped `cargo +nightly clippy` on the
  affected crates is clean (no new warnings from this change).
- Recommend a few repeated `--run-ignored` e2e runs (`make test-e2e`) on
  `test_epoch_sync` / `test_epoch_boundary` to confirm the round-bounded wall-clock drop
  and no new flakiness before merge.
