### PR TITLE
test(node): heal the finalized marker before mid-run accumulator catchup

### DIFF
--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -757,7 +757,7 @@ async fn test_sync_then_catchup_recovers_two_worker_accumulator() -> eyre::Resul
     let mut closing_output = outputs.pop().expect("epoch-closing output");
 
     // forward every pre-close output, then wait for the engine to execute each (the engine
-    // sends exactly one update per consensus output) so recovery scans a settled chain
+    // sends exactly one update per consensus output) so every block recovery scans is committed
     let sent = outputs.len();
     for output in outputs {
         to_engine.send(output).await?;
@@ -767,6 +767,13 @@ async fn test_sync_then_catchup_recovers_two_worker_accumulator() -> eyre::Resul
             .await?
             .expect("engine update per output");
     }
+
+    // The engine update is sent from finish_executing_output AFTER the blocks commit but
+    // BEFORE finalize_block writes the finalized marker in its own transaction, so under load
+    // the marker can still lag the persisted tip here. A real restart never reads through that
+    // window: startup heals the marker before anything consults it. Mirror that startup step
+    // so catchup pins the settled tip instead of racing the marker write.
+    reth_env.heal_finalized_to_persisted_tip()?;
 
     // simulate node recovery at startup: catchup sizes the accumulator from pinned chain state
     // and rebuilds gas stats (fees are owned by the entry seeding)


### PR DESCRIPTION
## Problem

`tn-node::it test_sync_then_catchup_recovers_two_worker_accumulator` is a load-dependent flake.  In a
full local CI run (`make attest`, 1038 tests in parallel) it failed once at 9.3s on the phase-1
worker-0 totals assertion, while passing in isolation in 2-3s.  All of the test's internal timeouts
are 30s, so the failure is an assertion race, not a timeout.

The test drives recovery mid-run: it forwards every pre-close consensus output to the engine, waits
for one engine update per output, then immediately reads `finalized_header()` to run
`catchup_accumulator`.  That engine update is not a "fully settled" signal.  In
`execute_consensus_output` (`crates/engine/src/payload_builder.rs`), the update is sent from inside
`RethEnv::finish_executing_output` after the blocks commit (`crates/tn-reth/src/lib.rs`, `save_blocks` plus `commit`, then `try_send`), and only afterwards does the caller run `RethEnv::finalize_block`, which
writes the finalized marker in its own transaction and publishes it to the in-memory watch via
`set_finalized`.

So there is a window between the update the test awaits and the marker becoming visible.  Under
full-suite CPU contention the test task can win that race: `finalized_header()` returns the previous
output's tip, `catchup_accumulator` pins its scan range, worker-count read, and leader bound to the
stale header (it pins everything to the one finalized header by design), the last pre-close output's
blocks drop out of the rebuilt totals, and the phase-1 `assert_eq!` on worker-0 `get_values` fails.

This window is a known, intentional artifact of the two-transaction persistence design:
`catchup_accumulator`'s docs state that the production path heals the marker to the persisted tip at
startup (`RethEnv::heal_finalized_to_persisted_tip`, #891) before anything reads it, and explicitly
flag heal-skipping callers ("e.g. tests") as the case the epoch-granularity guard does not cover.
This test was exactly such a caller.

## Fix

Mirror the startup sequence the phase is simulating: call `reth_env.heal_finalized_to_persisted_tip()?`
before the phase-1 recovery reads.  By the time the test has received the last engine update, the
blocks are committed, so the heal deterministically advances the marker to the settled tip (or no-ops
if the engine's own `finalize_block` already won).  `test_catchup_accumulator` in the same file
already uses the heal as the startup mirror, so this follows an existing precedent.

Phases 2 and 3 need no change: the engine-exit oneshot the test awaits there only resolves after the
closing output's execution task completes, which includes its `finalize_block`, so those reads are
already ordered.

Also corrects the comment on the update-drain loop, which claimed the updates leave "a settled chain";
they guarantee committed blocks, not a settled finalized marker.

## Testing

- Fixed test: 8/8 green while a heavy suite (`-p tn-storage`) looped alongside, with runtimes from
  2.8s to 10.0s, straddling the 9.3s regime the failure occurred in.
- Unfixed tree under the same local contention: 12/12 green, consistent with the window being a rare,
  preemption-timed race that needs full-suite oversubscription to hit;  the mechanism above is
  established from the code ordering rather than from a local reproduction.
- `cargo +nightly fmt` clean under the repo-pinned nightly;  the change is test-only (+8/-1 in
  `crates/node/tests/it/main.rs`).
