### PR TITLE
build(deps): gate rocksdb out of the default build (closes #941)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,18 +111,55 @@ jobs:
       - name: Run tests
         run: cargo nextest run --locked --workspace --exclude tn-faucet --no-fail-fast --profile ci
 
+  # Guard: rocksdb (librocksdb-sys, the entire RocksDB C++ engine and the single largest
+  # native compile in the tree) must stay out of the default feature graph. It is gated
+  # behind the off-by-default `rocksdb` feature; this catches a future reth bump whose
+  # default set silently re-introduces it. Resolves the graph only - nothing is compiled.
+  rocksdb-gate:
+    needs: skip-maintainers
+    if: >-
+      needs.skip-maintainers.outputs.is_maintainer == 'false' &&
+      github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+        with:
+          shared-key: rocksdb-gate-cache
+          cache-on-failure: "true"
+
+      - name: Assert rocksdb absent from default feature graph
+        run: |
+          # Structured check: count rocksdb packages in the feature-resolved metadata
+          # graph instead of scraping cargo's error wording. A cargo/jq failure fails
+          # the assignment (bash -e -o pipefail), so infrastructure errors fail closed.
+          hits=$(cargo metadata --locked --format-version 1 \
+            | jq '[.resolve.nodes[].id | select(test("[/#]rocksdb@"))] | length')
+          if [[ "$hits" -ne 0 ]]; then
+            echo "librocksdb-sys re-entered the default dependency graph ($hits rocksdb package(s) resolved):"
+            cargo tree --locked -e features -i rocksdb || true
+            exit 1
+          fi
+          echo "rocksdb absent from the default feature graph"
+
   # Gate job for branch protection - depends on all checks
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, clippy, test]
+    needs: [fmt, clippy, test, rocksdb-gate]
     steps:
       - name: Check all jobs passed
         run: |
           if [[ "${{ needs.fmt.result }}" == "failure" || \
                 "${{ needs.clippy.result }}" == "failure" || \
-                "${{ needs.test.result }}" == "failure" ]]; then
+                "${{ needs.test.result }}" == "failure" || \
+                "${{ needs.rocksdb-gate.result }}" == "failure" ]]; then
             echo "One or more checks failed"
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,24 @@ secp256k1 = { version = "0.31", default-features = false, features = [
 rpassword = "7.4.0"
 
 # execution
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+#
+# Default features minus `rocksdb`: librocksdb-sys (the entire RocksDB C++ engine, 332
+# translation units, the single largest native compile in the tree) enters the graph only
+# through reth's default set, and our storage is MDBX-only (`RocksDBProvider` resolves to
+# reth's zero-size stub with the feature off). Re-enable explicitly via the off-by-default
+# `rocksdb` feature on tn-reth / tn-node / telcoin-network-cli / telcoin-network.
+# `reth-revm/portable` (a dependency-feature, not nameable in this list) is re-enabled on
+# the `reth-revm` entry below and reaches reth's copy through feature unification.
+# NOTE: reth's `edge` feature implies `rocksdb`; do not enable it while this gate is off.
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false, features = [
+    "jemalloc",
+    "otlp",
+    "otlp-logs",
+    "js-tracer",
+    "keccak-cache-global",
+    "asm-keccak",
+    "min-debug-logs",
+] }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
@@ -115,7 +132,10 @@ reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3
 reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+# `portable` replaces the `reth-revm/portable` entry dropped from the curated `reth`
+# feature list above (dependency-features cannot appear in a dependency's `features` key);
+# tn-reth depends on reth-revm directly, so unification applies it to reth's copy too.
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", features = ["portable"] }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }

--- a/bin/telcoin-network/Cargo.toml
+++ b/bin/telcoin-network/Cargo.toml
@@ -20,6 +20,10 @@ tn-node = { workspace = true }
 # is actually compiled into the binary. Enabled for the `docker-adiri` image via a Docker build arg;
 # default/mainnet builds omit it. See `tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH`.
 adiri = ["telcoin-network-cli/adiri", "tn-node/adiri"]
+# Opt back in to reth's RocksDB storage backend (librocksdb-sys). Off by default: storage
+# is MDBX-only today, so the node uses reth's zero-size `RocksDBProvider` stub and skips
+# compiling the RocksDB C++ engine. Must be enabled before any storage-v2 experimentation.
+rocksdb = ["telcoin-network-cli/rocksdb", "tn-node/rocksdb"]
 
 [lints]
 workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -50,6 +50,8 @@ adiri = [
     "tn-storage/adiri",
     "tn-types/adiri",
 ]
+# Opt back in to reth's RocksDB storage backend; tn-node has no rocksdb code of its own.
+rocksdb = ["tn-reth/rocksdb"]
 
 [dev-dependencies]
 metrics-util = { workspace = true }

--- a/crates/telcoin-network-cli/Cargo.toml
+++ b/crates/telcoin-network-cli/Cargo.toml
@@ -78,3 +78,5 @@ workspace = true
 test-utils = ["tn-config/test-utils"]
 # Adiri testnet: propagate to the node graph + this crate's directly-gated fork logic.
 adiri = ["tn-node/adiri", "tn-reth/adiri", "tn-storage/adiri", "tn-types/adiri"]
+# Opt back in to reth's RocksDB storage backend: propagate to the node graph.
+rocksdb = ["tn-node/rocksdb", "tn-reth/rocksdb"]

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -77,6 +77,11 @@ default = []
 faucet = []
 test-utils = ["dep:secp256k1"]
 adiri = ["faucet", "tn-types/adiri"]
+# Opt back in to reth's RocksDB storage backend (librocksdb-sys, the RocksDB C++ engine).
+# Off by default: storage is MDBX-only today, so `RocksDBProvider` resolves to reth's
+# zero-size stub and the 332-translation-unit native compile is skipped entirely.
+# Required before any storage-v2 / `StorageSettings` experimentation.
+rocksdb = ["reth/rocksdb"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Problem

`librocksdb-sys` compiles the entire RocksDB 10.4.2 C++ engine from source: 332
translation units on a clean build, the single largest native compile in the tree.  It
reaches us only transitively, through the `reth` binary crate's `default` feature set:
`reth/rocksdb` -> `reth-ethereum-cli/rocksdb` -> `reth-cli-commands/rocksdb` ->
`reth-provider/rocksdb` (= `dep:rocksdb`) -> `librocksdb-sys`.  Nothing in the workspace
enables it directly (`cargo tree -e features -i rocksdb` roots solely at `reth feature
"default"`), and storage is MDBX-only.

This is the remaining half of #941: the dev/test `opt-level` carve-out landed via #913
(the `package."*"` glob is now `opt-level = 1`), and this change removes the rocksdb
compile from default builds outright.

## Why it is inert for current behavior

reth v1.11.3 selects the storage backend by cfg in
`crates/storage/provider/src/providers/mod.rs`:

```rust
#[cfg_attr(all(unix, feature = "rocksdb"), path = "rocksdb/mod.rs")]
#[cfg_attr(not(all(unix, feature = "rocksdb")), path = "rocksdb_stub.rs")]
```

With the feature off, `RocksDBProvider` resolves to a zero-size stub whose
`new(_path: impl AsRef<Path>)` returns `Ok(Self)`, signature-compatible with the real
provider.  Our sole touchpoint is `RocksDBProvider::new` in tn-reth's
`init_provider_factory` (`crates/tn-reth/src/lib.rs`), which just forwards the value into
`ProviderFactory::new`.  There is no `storage_v2` / `StorageSettings` usage in the tree,
so no rocksdb code path is reachable today.  No Rust changes are needed;  the diff is
manifests plus one CI job.

## Changes

- **Workspace `Cargo.toml`**: the `reth` dependency becomes `default-features = false`
  with the default set minus `rocksdb` (jemalloc, otlp, otlp-logs, js-tracer,
  keccak-cache-global, asm-keccak, min-debug-logs).  `reth-revm/portable`, the one
  default entry that is a dependency-feature rather than a reth feature key (and so
  cannot appear in a dependency's `features` list), moves to the workspace `reth-revm`
  entry;  tn-reth depends on reth-revm directly, so feature unification applies it to
  reth's copy in every build that contains reth.
- **Opt-in feature chain**: an off-by-default `rocksdb` feature propagates
  `tn-reth -> tn-node -> telcoin-network-cli -> telcoin-network`, mirroring the existing
  `adiri` chain, so `cargo build -p telcoin-network --features rocksdb` restores today's
  graph exactly.  It must be enabled before any storage-v2 / `StorageSettings`
  experimentation.
- **CI guard**: a `rocksdb-gate` job asserts rocksdb stays out of the default feature
  graph by counting rocksdb packages in the feature-resolved `cargo metadata` output (a
  structured check rather than scraping cargo's error wording;  a cargo or jq failure
  fails the job, so infrastructure errors fail closed rather than passing silently).  It
  resolves the dependency graph without compiling anything and is wired into
  `ci-success`.  This catches a future reth bump whose default set silently
  re-introduces the dep, and the `edge = ["rocksdb"]` implication as well.  Verified in
  both directions locally: 0 hits with default features, 1 hit with
  `--features telcoin-network/rocksdb`.

## Verification

All checks under the repo-pinned 1.94 toolchain, `--locked` throughout (Cargo.lock is
unchanged;  rocksdb stays locked for the opt-in path).

- `cargo tree --locked -e features -i rocksdb` now fails to match any package with
  default features, and restores the full chain
  (`rocksdb <- reth-provider <- reth <- tn-reth`) with `--features rocksdb`.
- Whole-graph equivalence, `cargo tree -f '{p} {f}'` rooted at `telcoin-network`, before
  vs after:
  - **With `--features rocksdb`**: identical to main's default graph except the vacuous
    `default` label on reth (all nine constituent features are enabled individually;  no
    code cfg-gates on `feature = "default"`) and the new tn `rocksdb` feature labels
    themselves.  The opt-in configuration is exactly what CI builds on main today, which
    is why no separate rocksdb-on compile is needed.
  - **With default features**: the only drops are the native compression pile
    (`librocksdb-sys`, `rocksdb`, `bzip2-sys`, `libz-sys`, `lz4-sys`, and `zstd-sys`
    entirely, since nothing else consumed it) plus `rocksdb` feature labels on reth
    crates.
- `cargo check --workspace --all-targets --locked` passes with the gate off (the
  unix-without-rocksdb stub path is the one genuinely new compile configuration).

## Behavioral note

`tikv-jemalloc-sys` loses `unprefixed_malloc_on_supported_platforms`, which entered the
graph only as `librocksdb-sys`'s jemalloc plumbing (so RocksDB's C++ allocations would
route through jemalloc).  With it gone, C-library allocations (e.g. MDBX's internal
mallocs;  the bulk of MDBX is mmap) revert to the system allocator.  The Rust global
allocator is unchanged.  If routing C allocations through jemalloc is considered
load-bearing, it is a one-line re-add on a direct `tikv-jemalloc-sys` entry;  flagging it
rather than deciding it here.

## Notes

- `cargo clippy --all --all-features` (CI clippy job) still compiles rocksdb by design:
  it keeps the opt-in configuration linting and compiling so the gated path cannot
  bit-rot, and its cost is absorbed by that job's dependency cache.  The default-features
  test job and every local dev/test build skip the 332-TU compile entirely.
- Every reth bump must re-reconcile the curated feature list against reth's default set;
  the `rocksdb-gate` job turns a silent re-introduction into a PR-time failure.

Closes #941.
