### PR TITLE
Finish the wait_until migration for eject/epoch e2e helpers

### DIFF
--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -23,7 +23,7 @@ use nix::{
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use serde_json::Value;
 use std::{
-    cell::{Cell, RefCell},
+    cell::RefCell,
     collections::HashMap,
     fmt::Debug,
     ops::RangeInclusive,
@@ -169,44 +169,61 @@ impl ProcessGuard {
         }
     }
 
-    /// Wait (bounded) for the child at `idx` to exit on its own, without signaling it.
+    /// Wait (bounded) for every child at `indices` to exit on its own, without signaling any of
+    /// them. All not-yet-exited children are polled together each round against ONE shared
+    /// `timeout`, so the whole wait is bounded by `timeout` — not `timeout * indices.len()`, as a
+    /// sequence of per-child waits would be.
     ///
-    /// On success the child has been reaped, so its slot is cleared: `kill_all`/`Drop` signal
-    /// raw pids, and the OS may reuse a reaped child's pid, so the guard must never signal it
-    /// again. On timeout (or a `try_wait` error) the child stays guarded so `Drop` still cleans
-    /// it up, and a named-timeout error is returned.
-    pub(crate) fn wait_for_natural_exit(
+    /// On success every named child has been reaped, so its slot is cleared: `kill_all`/`Drop`
+    /// signal raw pids, and the OS may reuse a reaped child's pid, so the guard must never signal
+    /// it again. The returned `(index, status)` pairs are ordered by index. On timeout the
+    /// still-running children stay guarded so `Drop` still cleans them up, and a named-timeout
+    /// error (naming the pending children) is returned.
+    pub(crate) fn wait_for_natural_exits(
         &mut self,
-        idx: usize,
+        indices: impl IntoIterator<Item = usize>,
         timeout: Duration,
-    ) -> eyre::Result<ExitStatus> {
-        let child = self
-            .children
-            .get_mut(idx)
-            .and_then(|slot| slot.as_mut())
-            .ok_or_else(|| eyre::eyre!("no child process at index {idx}"))?;
-
-        // `wait_until_blocking` takes an `Fn` closure, but `try_wait` needs `&mut Child`, so
-        // thread the borrow through a `RefCell` (the poll loop is single-threaded).
-        let child = RefCell::new(child);
-        let status = Cell::new(None);
-        wait_until_blocking(timeout, &format!("child {idx} to exit on its own"), || {
-            match child.borrow_mut().try_wait()? {
-                Some(exit) => {
-                    status.set(Some(exit));
-                    Ok(true)
-                }
-                None => Ok(false),
+    ) -> eyre::Result<Vec<(usize, ExitStatus)>> {
+        let want: Vec<usize> = indices.into_iter().collect();
+        for &idx in &want {
+            if self.children.get(idx).and_then(|slot| slot.as_ref()).is_none() {
+                return Err(eyre::eyre!("no child process at index {idx}"));
             }
+        }
+
+        // `wait_until_blocking` takes an `Fn` closure, but `try_wait` needs `&mut Child`, so thread
+        // the children and the collected exit statuses through `RefCell`s (the poll loop is
+        // single-threaded). Polling every not-yet-exited child on each round lets one shared
+        // deadline cover them all.
+        let children = RefCell::new(&mut self.children);
+        let exits: RefCell<HashMap<usize, ExitStatus>> = RefCell::new(HashMap::new());
+        let description = format!("children {want:?} to exit on their own");
+        wait_until_blocking(timeout, &description, || {
+            let mut children = children.borrow_mut();
+            let mut exits = exits.borrow_mut();
+            for &idx in &want {
+                if exits.contains_key(&idx) {
+                    continue;
+                }
+                if let Some(child) = children[idx].as_mut() {
+                    if let Some(status) = child.try_wait()? {
+                        exits.insert(idx, status);
+                    }
+                }
+            }
+            Ok(exits.len() == want.len())
         })?;
 
-        // The child is reaped; clear its slot so `kill_all`/`Drop` never signal a
-        // possibly-reused pid.
-        self.children[idx] = None;
-
-        status.get().ok_or_else(|| {
-            eyre::eyre!("child {idx} exit status not captured despite exit condition holding")
-        })
+        // Every requested child is reaped; clear its slot so `kill_all`/`Drop` never signal a
+        // possibly-reused pid. The `children` borrow of `self.children` has already ended here —
+        // its last use was inside the poll closure above — so the Vec can be mutated directly.
+        let exits = exits.into_inner();
+        for &idx in exits.keys() {
+            self.children[idx] = None;
+        }
+        let mut statuses: Vec<(usize, ExitStatus)> = exits.into_iter().collect();
+        statuses.sort_by_key(|&(idx, _)| idx);
+        Ok(statuses)
     }
 }
 
@@ -900,16 +917,25 @@ pub(crate) async fn loop_epochs(
 
     let mut last_epoch_block_height = current_epoch_info.blockHeight;
     for i in start..start + iterations {
-        // poll until the epoch changes, with a generous timeout for parallel test load
+        // Poll until the epoch changes, with a generous timeout for parallel test load. Capture
+        // the changed `EpochInfo` from inside the poll (via `RefCell`, since `wait_until` takes
+        // an `Fn` closure) so the boundary is read exactly once instead of fetched again after.
+        let observed: RefCell<Option<ConsensusRegistry::EpochInfo>> = RefCell::new(None);
         wait_until(
             Duration::from_secs(epoch_duration * 4),
             &format!("epoch to change on iteration {i}"),
             || async {
-                Ok(consensus_registry.getCurrentEpochInfo().call().await? != current_epoch_info)
+                let info = consensus_registry.getCurrentEpochInfo().call().await?;
+                let changed = info != current_epoch_info;
+                if changed {
+                    *observed.borrow_mut() = Some(info);
+                }
+                Ok(changed)
             },
         )
         .await?;
-        let new_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
+        let new_epoch_info =
+            observed.into_inner().expect("wait_until returned Ok, so a changed epoch was observed");
 
         assert!(new_epoch_info.blockHeight > last_epoch_block_height);
         assert_eq!(new_epoch_info.epochDuration as u64, epoch_duration);

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -23,11 +23,12 @@ use nix::{
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use serde_json::Value;
 use std::{
+    cell::{Cell, RefCell},
     collections::HashMap,
     fmt::Debug,
     ops::RangeInclusive,
     path::Path,
-    process::Child,
+    process::{Child, ExitStatus},
     sync::{Arc, Condvar, Mutex},
     time::Duration,
 };
@@ -38,7 +39,7 @@ use tn_reth::{
     test_utils::TransactionFactory,
     RethChainSpec,
 };
-use tn_test_utils::wait_until_blocking;
+use tn_test_utils::{wait_until, wait_until_blocking};
 use tn_types::{
     address, get_available_tcp_port, keccak256,
     test_utils::{init_test_tracing, CommandParser},
@@ -166,6 +167,46 @@ impl ProcessGuard {
             }
             *slot = None;
         }
+    }
+
+    /// Wait (bounded) for the child at `idx` to exit on its own, without signaling it.
+    ///
+    /// On success the child has been reaped, so its slot is cleared: `kill_all`/`Drop` signal
+    /// raw pids, and the OS may reuse a reaped child's pid, so the guard must never signal it
+    /// again. On timeout (or a `try_wait` error) the child stays guarded so `Drop` still cleans
+    /// it up, and a named-timeout error is returned.
+    pub(crate) fn wait_for_natural_exit(
+        &mut self,
+        idx: usize,
+        timeout: Duration,
+    ) -> eyre::Result<ExitStatus> {
+        let child = self
+            .children
+            .get_mut(idx)
+            .and_then(|slot| slot.as_mut())
+            .ok_or_else(|| eyre::eyre!("no child process at index {idx}"))?;
+
+        // `wait_until_blocking` takes an `Fn` closure, but `try_wait` needs `&mut Child`, so
+        // thread the borrow through a `RefCell` (the poll loop is single-threaded).
+        let child = RefCell::new(child);
+        let status = Cell::new(None);
+        wait_until_blocking(timeout, &format!("child {idx} to exit on its own"), || {
+            match child.borrow_mut().try_wait()? {
+                Some(exit) => {
+                    status.set(Some(exit));
+                    Ok(true)
+                }
+                None => Ok(false),
+            }
+        })?;
+
+        // The child is reaped; clear its slot so `kill_all`/`Drop` never signal a
+        // possibly-reused pid.
+        self.children[idx] = None;
+
+        status.get().ok_or_else(|| {
+            eyre::eyre!("child {idx} exit status not captured despite exit condition holding")
+        })
     }
 }
 
@@ -860,19 +901,15 @@ pub(crate) async fn loop_epochs(
     let mut last_epoch_block_height = current_epoch_info.blockHeight;
     for i in start..start + iterations {
         // poll until the epoch changes, with a generous timeout for parallel test load
-        let deadline = Instant::now() + Duration::from_secs(epoch_duration * 4);
-        let new_epoch_info = loop {
-            let info = consensus_registry.getCurrentEpochInfo().call().await?;
-            if info != current_epoch_info {
-                break info;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "Epoch did not change within {}s on iteration {i}",
-                epoch_duration * 4
-            );
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        };
+        wait_until(
+            Duration::from_secs(epoch_duration * 4),
+            &format!("epoch to change on iteration {i}"),
+            || async {
+                Ok(consensus_registry.getCurrentEpochInfo().call().await? != current_epoch_info)
+            },
+        )
+        .await?;
+        let new_epoch_info = consensus_registry.getCurrentEpochInfo().call().await?;
 
         assert!(new_epoch_info.blockHeight > last_epoch_block_height);
         assert_eq!(new_epoch_info.epochDuration as u64, epoch_duration);
@@ -987,16 +1024,10 @@ pub(crate) struct EpochSnapshot {
 
 /// Poll a provider until its RPC answers `eth_chainId`.
 pub(crate) async fn wait_for_rpc<P: Provider>(provider: &P) -> eyre::Result<()> {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        match provider.get_chain_id().await {
-            Ok(_) => return Ok(()),
-            Err(_) if Instant::now() < deadline => {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-            Err(e) => return Err(eyre::eyre!("provider RPC never became available: {e}")),
-        }
-    }
+    wait_until(Duration::from_secs(30), "provider RPC answers eth_chainId", || async {
+        Ok(provider.get_chain_id().await.is_ok())
+    })
+    .await
 }
 
 /// Read the current epoch snapshot from the `ConsensusRegistry`.
@@ -1031,6 +1062,40 @@ pub(crate) async fn wait_for_epoch_at_least<P: Provider>(
         }
         // Poll ~4x/sec: with 5s epochs a 1s cadence adds up to ~1s of slop per boundary.
         tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Poll `node` until its latest execution block number is at least `min_height`.
+pub(crate) async fn wait_for_head_at_least(
+    node: &str,
+    min_height: u64,
+    timeout_secs: u64,
+) -> eyre::Result<()> {
+    wait_until(
+        Duration::from_secs(timeout_secs),
+        &format!("{node} head to reach block {min_height}"),
+        || async { Ok(get_block_number(node)? >= min_height) },
+    )
+    .await
+}
+
+/// Wait (bounded) for `epoch` to be reached on `http_url`, failing with a message that names the
+/// calling phase instead of hanging until the harness slow-timeout kills the test.
+pub(crate) async fn assert_epoch_reached(
+    http_url: &str,
+    epoch: u32,
+    phase: &str,
+) -> eyre::Result<()> {
+    let provider = ProviderBuilder::new().connect_http(http_url.parse()?);
+    let bound = EPOCH_DURATION * 6;
+    match timeout(Duration::from_secs(bound), wait_for_epoch_at_least(&provider, epoch)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => {
+            Err(eyre::eyre!("{phase}: node {http_url} failed reaching epoch {epoch}: {e}"))
+        }
+        Err(_) => {
+            Err(eyre::eyre!("{phase}: node {http_url} did not reach epoch {epoch} within {bound}s"))
+        }
     }
 }
 
@@ -1151,7 +1216,8 @@ pub(crate) async fn fetch_verified_epoch_record(
         {
             Ok(result) => break result,
             Err(_) if Instant::now() < deadline => {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                // Poll ~4x/sec so the record is picked up promptly once quorum voting completes.
+                tokio::time::sleep(Duration::from_millis(250)).await;
             }
             Err(e) => {
                 return Err(eyre::eyre!(
@@ -1172,7 +1238,12 @@ pub(crate) async fn fetch_verified_epoch_record(
 }
 
 /// Assert every node in `endpoints` serves a certified, verifying epoch record for every epoch in
-/// `epochs`, and that each node has executed the final block named by each record.
+/// `epochs`, and that each node has executed the final block named by each record with the exact
+/// hash the record commits to.
+///
+/// Hash equality is the cross-node divergence detector: two nodes can both HAVE a block at the
+/// recorded height while disagreeing on its contents (e.g. a different withdrawals_root ⇒ a
+/// different hash), so existence alone cannot catch divergence.
 pub(crate) async fn assert_epoch_records_verify(
     endpoints: &[NodeEndpoints],
     epochs: RangeInclusive<u32>,
@@ -1184,13 +1255,31 @@ pub(crate) async fn assert_epoch_records_verify(
                 fetch_verified_epoch_record(&ep.http_url, epoch, per_record_timeout_secs).await?;
             // Make sure the node has executed the final block from the epoch record.
             // This should prove it has the consensus output as well (i.e. verify the pack data).
-            get_block(&ep.http_url, Some(epoch_rec.final_state.number)).map_err(|e| {
+            let block =
+                get_block(&ep.http_url, Some(epoch_rec.final_state.number)).map_err(|e| {
+                    eyre::eyre!(
+                        "final block {} for epoch {epoch} missing on {}: {e}",
+                        epoch_rec.final_state.number,
+                        ep.http_url
+                    )
+                })?;
+            // The block must be the SAME block the record commits to, not merely one at the
+            // same height (the RPC serves hex strings; the record stores a typed hash).
+            let block_hash = block.get("hash").and_then(Value::as_str).ok_or_else(|| {
                 eyre::eyre!(
-                    "final block {} for epoch {epoch} missing on {}: {e}",
+                    "final block {} for epoch {epoch} on {} has no hash field",
                     epoch_rec.final_state.number,
                     ep.http_url
                 )
             })?;
+            let expected_hash = epoch_rec.final_state.hash.to_string();
+            eyre::ensure!(
+                block_hash.eq_ignore_ascii_case(&expected_hash),
+                "final block {} for epoch {epoch} on {} hash mismatch: node has {block_hash}, \
+                 record commits to {expected_hash}",
+                epoch_rec.final_state.number,
+                ep.http_url
+            );
         }
     }
     Ok(())

--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -768,10 +768,12 @@ async fn test_network_halts_when_ejections_shrink_committee_below_tolerance() ->
     //
     // All 5 must exit — the epoch cannot close for anyone. Known residual risk: a validator
     // lagging at the boundary could in principle miss the closing commit once its peers exit
-    // first; the 4-epoch-duration bound per node absorbs realistic same-host lag, and a genuine
+    // first; the single shared 4-epoch-duration deadline (bounding all validators at once, so the
+    // total wait is independent of node count) absorbs realistic same-host lag, and a genuine
     // stall should fail the test rather than be tolerated.
-    for idx in 0..nodes.len() {
-        let status = guard.wait_for_natural_exit(idx, Duration::from_secs(EPOCH_DURATION * 4))?;
+    let exits =
+        guard.wait_for_natural_exits(0..nodes.len(), Duration::from_secs(EPOCH_DURATION * 4))?;
+    for (idx, status) in exits {
         eyre::ensure!(
             status.code() == Some(1),
             "validator index {idx} exited with {status:?}; expected the designed error exit \

--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -1,7 +1,7 @@
 //! E2E coverage for governance ejection (`ConsensusRegistry::burn`) of validators.
 //!
 //! `burn` retires the validator, confiscates its stake, and swap-and-pops it out of the stored
-//! current/next/subsequent committee arrays. Two scenarios are covered:
+//! current/next/subsequent committee arrays. Three scenarios are covered:
 //!
 //! - [`test_validator_ejected_from_future_committee_only`]: the burned validator sits ONLY in
 //!   future committees, so no running committee changes shape. This test deliberately has NO
@@ -13,6 +13,11 @@
 //!   LIVE committee, which shrinks mid-epoch. This is the end-to-end acceptance test for the
 //!   `EpochRecord::committee_compatible` tolerance: on pre-fix code every node deterministically
 //!   halts at the first epoch boundary after the burn.
+//! - [`test_network_halts_when_ejections_shrink_committee_below_tolerance`]: governance burns TWO
+//!   of the five committee members in one epoch, shrinking the committee below the
+//!   `committee_compatible` tolerance. The tolerance is deliberately bounded, so the network
+//!   answers with a designed fail-stop: every validator exits with code 1 at the next epoch
+//!   boundary instead of running an unsafe committee.
 
 use crate::common::{
     acquire_test_permit, assert_epoch_reached, assert_epoch_records_verify,
@@ -38,11 +43,13 @@ use tn_types::{Address, EpochCertificate, EpochRecord, U256};
 use tokio::time::timeout;
 use tracing::info;
 
-/// Name of the genesis-configured non-committee node used by the mid-epoch ejection test.
+/// Name of the genesis-configured non-committee node used by the current-committee ejection
+/// tests.
 ///
 /// It is funded and key-configured at genesis (via [`create_genesis_for_test`]'s extra-node
 /// parameter) but never stakes, so it only follows the chain — an observer in behavior, without
-/// tightening the committee quorum when it is down.
+/// tightening the committee quorum when it is down. The below-tolerance halt test configures it
+/// (genesis creation requires the extra node) but never starts it.
 const GENESIS_OBSERVER: &str = "genesis-observer";
 
 /// Find the epoch that contains `block` by walking the epoch-info ring buffer down from the
@@ -61,6 +68,33 @@ async fn epoch_of_block<P: Provider>(provider: &P, block: u64) -> eyre::Result<u
         }
     }
     Err(eyre::eyre!("block {block} is older than the epoch info ring buffer"))
+}
+
+/// Submit a governance `burn` for `victim` with owner nonce `nonce` and wait for confirmation.
+///
+/// A confirmation straddling an epoch boundary can get orphaned and lost; on failure the
+/// identical tx is retried once with the same nonce (idempotent: same payload, same hash) from
+/// the next measured mid-epoch window. Returns the block the burn's receipt landed in.
+async fn burn_with_retry<P: Provider>(
+    provider: &P,
+    rpc_url: &str,
+    governance_wallet: &mut TransactionFactory,
+    chain: Arc<RethChainSpec>,
+    victim: Address,
+    nonce: u64,
+) -> eyre::Result<u64> {
+    let calldata: Bytes =
+        ConsensusRegistry::burnCall { validatorAddress: victim }.abi_encode().into();
+    match send_owner_tx(rpc_url, governance_wallet, chain.clone(), calldata.clone()).await {
+        Ok((_hash, block)) => Ok(block),
+        Err(first_try) => {
+            info!(target: "eject-test", %first_try, ?victim, "burn confirmation failed; retrying once");
+            governance_wallet.set_nonce(nonce);
+            wait_for_mid_epoch(provider, rpc_url).await?;
+            let (_hash, block) = send_owner_tx(rpc_url, governance_wallet, chain, calldata).await?;
+            Ok(block)
+        }
+    }
 }
 
 #[ignore = "only run independently from all other it tests"]
@@ -563,6 +597,215 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
     // transfer's block and it serves the shrunken epoch-E record with a verifying cert
     wait_for_head_at_least(&victim_url, tx_block + 1, EPOCH_DURATION * 3).await?;
     fetch_verified_epoch_record(&victim_url, e, EPOCH_DURATION * 3).await?;
+
+    Ok(())
+}
+
+#[ignore = "only run independently from all other it tests"]
+#[tokio::test(flavor = "multi_thread")]
+/// Prove the network halts BY DESIGN when governance ejections shrink the committee below the
+/// tolerated bound within one epoch.
+///
+/// On-chain there is no committee floor: `ConsensusRegistry::burn` only rejects an ejection that
+/// would leave a committee empty or larger than the eligible set, so back-to-back burns walk the
+/// stored committees 5 -> 4 -> 3 inside a single epoch. Three members is below both bounds of
+/// `EpochRecord::committee_compatible` (the 4-member floor and `ceil(2 * 5 / 3) = 4`), so at the
+/// next epoch boundary every validator's `build_epoch_record` rejects the shrunken committee
+/// read against the previous record's `next_committee`, the error propagates out of the epoch
+/// manager, and the process exits with code 1 — a deliberate fail-stop rather than running a
+/// committee too small to be safe against the promised set. Recovery is manual, so the test ends
+/// at the halt: every validator exits with code 1 carrying the incompatibility error on stderr,
+/// and no endpoint answers RPC afterwards.
+///
+/// If the two burns straddle an epoch boundary the halt shifts one epoch later: 5 -> 4 is a
+/// tolerated shrink and that boundary closes, then 4 -> 3 fails the 4-member floor. Either way
+/// the epoch containing the SECOND burn is the epoch that cannot close.
+async fn test_network_halts_when_ejections_shrink_committee_below_tolerance() -> eyre::Result<()> {
+    let _permit = acquire_test_permit();
+
+    // committee wallets; seed 33 = consensus registry owner
+    let nodes = vec![
+        ("validator-1", Address::from_slice(&[0x11; 20])),
+        ("validator-2", Address::from_slice(&[0x22; 20])),
+        ("validator-3", Address::from_slice(&[0x33; 20])),
+        ("validator-4", Address::from_slice(&[0x44; 20])),
+        ("validator-5", Address::from_slice(&[0x55; 20])),
+    ];
+    // the victims: committee validators 4 and 5
+    let (victim_a_name, victim_a_addr) = nodes[3];
+    let (victim_b_name, victim_b_addr) = nodes[4];
+
+    // setup genesis
+    let temp_dir = tempfile::TempDir::with_prefix("eject_halt")?;
+    let temp_path = temp_dir.path();
+
+    let mut governance_wallet =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+    // `create_genesis_for_test` always configures one extra non-committee node; it is funded and
+    // key-configured at genesis but deliberately NEVER STARTED: at the halt boundary every
+    // VALIDATOR deterministically fails `build_epoch_record` and exits, while a follower's fate
+    // is timing-dependent (it may stall waiting for consensus that never comes instead of
+    // exiting). Starting only validators keeps every spawned process's expected exit definite.
+    let unstarted_wallet = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(7));
+    let genesis = create_genesis_for_test(
+        temp_path,
+        (GENESIS_OBSERVER, unstarted_wallet.address()),
+        governance_wallet.address(),
+        &nodes,
+        EPOCH_DURATION,
+    )?;
+
+    // start ONLY the 5 committee validators
+    let (procs, endpoints) = start_nodes(temp_path, &nodes, "eject_halt", 1)?;
+    // Guard ensures processes are killed on drop (normal return, error, or panic).
+    let mut guard = ProcessGuard::new(procs);
+    let rpc_url = endpoints[0].http_url.clone();
+
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+    wait_for_rpc(&provider).await?;
+    let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, &provider);
+
+    // ---- Phase 0: cross the 0 -> 1 boundary before burning ----
+    // A burn during epoch 0 would be absorbed: record 0 is built without a previous record, so
+    // there is no promised `next_committee` for the shrunken committee read to be incompatible
+    // with. The halt requires a boundary whose previous record promised the pre-burn committee.
+    wait_for_epoch_at_least(&provider, 1).await?;
+
+    // pre-burn baseline: 5 eligible validators, size-5 committees, both victims unretired
+    assert_eq!(registry.getEligibleValidatorCount().call().await?, U256::from(5));
+    assert_eq!(registry.getNextCommitteeSize().call().await?, 5);
+    for victim in [victim_a_addr, victim_b_addr] {
+        assert!(
+            !registry.isRetired(victim).call().await?,
+            "victim {victim} must not be retired at baseline"
+        );
+    }
+
+    // victim BLS keys for by-key exclusion asserts
+    let mut victim_bls_keys = Vec::new();
+    for name in [victim_a_name, victim_b_name] {
+        let node_info = Config::load_from_path_or_default::<NodeInfo>(
+            temp_path.join(name).join("node-info.yaml").as_path(),
+            ConfigFmt::YAML,
+        )?;
+        let bls: Bytes = node_info.bls_public_key.compress().into();
+        victim_bls_keys.push(bls);
+    }
+
+    // ---- Two governance burns, launched mid-epoch away from the boundary ----
+    let burn_snap = wait_for_mid_epoch(&provider, &rpc_url).await?;
+    info!(target: "eject-test", epoch = burn_snap.epoch_id, "burning two committee validators");
+    let burn_a_block = burn_with_retry(
+        &provider,
+        &rpc_url,
+        &mut governance_wallet,
+        chain.clone(),
+        victim_a_addr,
+        0,
+    )
+    .await?;
+    let burn_b_block =
+        burn_with_retry(&provider, &rpc_url, &mut governance_wallet, chain, victim_b_addr, 1)
+            .await?;
+
+    // Anchor the halt to where the burns actually landed. Both in one epoch is the intended
+    // shape; a straddle across adjacent epochs is tolerated (the 5 -> 4 boundary closes and the
+    // halt shifts one epoch later — see the doc comment). Either way the epoch containing the
+    // SECOND burn cannot close.
+    let burn_a_epoch = epoch_of_block(&provider, burn_a_block).await?;
+    let burn_b_epoch = epoch_of_block(&provider, burn_b_block).await?;
+    eyre::ensure!(
+        burn_b_epoch == burn_a_epoch || burn_b_epoch == burn_a_epoch + 1,
+        "burns landed in epochs {burn_a_epoch} and {burn_b_epoch}; expected one epoch or an \
+         adjacent straddle"
+    );
+    let halt_epoch = burn_b_epoch;
+    info!(
+        target: "eject-test",
+        burn_a_block, burn_a_epoch, burn_b_block, burn_b_epoch, halt_epoch, "burns confirmed"
+    );
+
+    // ---- Post-burn shape: both retired, 3 eligible, stored committees shrink to 3 ----
+    for victim in [victim_a_addr, victim_b_addr] {
+        assert!(
+            registry.isRetired(victim).call().await?,
+            "burned validator {victim} must be retired"
+        );
+    }
+    assert_eq!(
+        registry.getEligibleValidatorCount().call().await?,
+        U256::from(3),
+        "eligible count must drop 5 -> 3"
+    );
+    assert_eq!(
+        registry.getNextCommitteeSize().call().await?,
+        3,
+        "next committee size must auto-decrement to the 3 remaining eligible validators"
+    );
+    // the next and subsequent committees relative to the halt epoch — the arrays the failing
+    // record build reads — exclude both victims by address and by BLS key
+    for target in halt_epoch + 1..=halt_epoch + 2 {
+        let vals = registry.getCommitteeValidators(target).call().await?;
+        assert_eq!(vals.len(), 3, "epoch {target} committee must shrink to 3 members");
+        assert!(
+            vals.iter().all(|v| {
+                v.validatorAddress != victim_a_addr && v.validatorAddress != victim_b_addr
+            }),
+            "victims must be swap-and-popped out of epoch {target} committee"
+        );
+        let keys = registry.getCommitteeBlsPubkeys(target).call().await?;
+        assert_eq!(keys.len(), 3);
+        assert!(keys.iter().all(|k| !victim_bls_keys.contains(k)));
+    }
+
+    // ---- THE HALT ASSERT: every validator exits, on its own, with code 1 ----
+    //
+    // At the close of `halt_epoch` every validator's `build_epoch_record` reads the 3-member
+    // committee, rejects it against the previous record's promise, and the node exits through
+    // `main`'s error path. Exit code 1 distinguishes the designed error-exit from a signal
+    // death (`ExitStatus::code()` returns `None` for signals).
+    //
+    // All 5 must exit — the epoch cannot close for anyone. Known residual risk: a validator
+    // lagging at the boundary could in principle miss the closing commit once its peers exit
+    // first; the 4-epoch-duration bound per node absorbs realistic same-host lag, and a genuine
+    // stall should fail the test rather than be tolerated.
+    for idx in 0..nodes.len() {
+        let status = guard.wait_for_natural_exit(idx, Duration::from_secs(EPOCH_DURATION * 4))?;
+        eyre::ensure!(
+            status.code() == Some(1),
+            "validator index {idx} exited with {status:?}; expected the designed error exit \
+             (code 1)"
+        );
+    }
+    info!(target: "eject-test", halt_epoch, "all validators fail-stopped at the halt boundary");
+
+    // ---- Tie each exit to the designed reason via the node's stderr log ----
+    // `main` prints the propagated error on stderr before exiting 1; the distinctive substring
+    // is from `build_epoch_record`'s error ("Last epochs next committee not compatible with
+    // this epochs committee!").
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
+    let log_dir = std::path::PathBuf::from(manifest_dir).join("test_logs").join("eject_halt");
+    for (name, _) in &nodes {
+        let stderr_path = log_dir.join(format!("node{name}-run1.stderr.log"));
+        let stderr = std::fs::read_to_string(&stderr_path)?;
+        eyre::ensure!(
+            stderr.contains("not compatible with this epochs committee"),
+            "{name} stderr ({}) lacks the epoch-record incompatibility error; the node exited \
+             with code 1 for the wrong reason",
+            stderr_path.display()
+        );
+    }
+
+    // ---- Liveness-negative: the network is down, no validator endpoint answers RPC ----
+    for endpoint in &endpoints {
+        let dead = ProviderBuilder::new().connect_http(endpoint.http_url.parse()?);
+        assert!(
+            dead.get_chain_id().await.is_err(),
+            "validator RPC {} still answers after the designed halt",
+            endpoint.http_url
+        );
+    }
 
     Ok(())
 }

--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -15,11 +15,11 @@
 //!   halts at the first epoch boundary after the burn.
 
 use crate::common::{
-    acquire_test_permit, assert_epoch_records_verify, create_genesis_for_test,
-    fetch_verified_epoch_record, generate_new_validator_txs, get_block_number,
-    get_tx_receipt_block, kill_child, loop_epochs, send_owner_tx, start_nodes,
-    wait_for_epoch_at_least, wait_for_mid_epoch, wait_for_rpc, ProcessGuard, EPOCH_DURATION,
-    INITIAL_STAKE_AMOUNT, NEW_VALIDATOR,
+    acquire_test_permit, assert_epoch_reached, assert_epoch_records_verify,
+    create_genesis_for_test, fetch_verified_epoch_record, generate_new_validator_txs,
+    get_block_number, get_tx_receipt_block, kill_child, loop_epochs, send_owner_tx, start_nodes,
+    wait_for_epoch_at_least, wait_for_head_at_least, wait_for_mid_epoch, wait_for_rpc,
+    ProcessGuard, EPOCH_DURATION, INITIAL_STAKE_AMOUNT, NEW_VALIDATOR,
 };
 use alloy::{
     primitives::{utils::parse_ether, Bytes},
@@ -35,7 +35,7 @@ use tn_reth::{
     RethChainSpec,
 };
 use tn_types::{Address, EpochCertificate, EpochRecord, U256};
-use tokio::time::{timeout, Instant};
+use tokio::time::timeout;
 use tracing::info;
 
 /// Name of the genesis-configured non-committee node used by the mid-epoch ejection test.
@@ -266,36 +266,9 @@ async fn test_validator_ejected_from_future_committee_only() -> eyre::Result<()>
     assert_epoch_records_verify(&endpoints, 0..=latest_closed, EPOCH_DURATION * 6).await?;
 
     // the burned validator's node keeps following the chain (epoch-close blocks keep coming)
-    let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 3);
-    loop {
-        let head_after = get_block_number(newval_url)?;
-        if head_after > head_before.max(burn_block) {
-            break;
-        }
-        eyre::ensure!(
-            Instant::now() < deadline,
-            "burned validator's node head stuck at {head_after} (started {head_before})"
-        );
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
+    wait_for_head_at_least(newval_url, head_before.max(burn_block) + 1, EPOCH_DURATION * 3).await?;
 
     Ok(())
-}
-
-/// Wait (bounded) for `epoch` to be reached on `http_url`, failing with a message that names the
-/// calling phase instead of hanging until the harness slow-timeout kills the test.
-async fn assert_epoch_reached(http_url: &str, epoch: u32, phase: &str) -> eyre::Result<()> {
-    let provider = ProviderBuilder::new().connect_http(http_url.parse()?);
-    let bound = EPOCH_DURATION * 6;
-    match timeout(Duration::from_secs(bound), wait_for_epoch_at_least(&provider, epoch)).await {
-        Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => {
-            Err(eyre::eyre!("{phase}: node {http_url} failed reaching epoch {epoch}: {e}"))
-        }
-        Err(_) => {
-            Err(eyre::eyre!("{phase}: node {http_url} did not reach epoch {epoch} within {bound}s"))
-        }
-    }
 }
 
 #[ignore = "only run independently from all other it tests"]
@@ -588,18 +561,7 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
 
     // the ejected validator's node keeps following as an observer: its head advances past the
     // transfer's block and it serves the shrunken epoch-E record with a verifying cert
-    let deadline = Instant::now() + Duration::from_secs(EPOCH_DURATION * 3);
-    loop {
-        let head = get_block_number(&victim_url)?;
-        if head > tx_block {
-            break;
-        }
-        eyre::ensure!(
-            Instant::now() < deadline,
-            "ejected validator's node head stuck at {head} (transfer landed at {tx_block})"
-        );
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
+    wait_for_head_at_least(&victim_url, tx_block + 1, EPOCH_DURATION * 3).await?;
     fetch_verified_epoch_record(&victim_url, e, EPOCH_DURATION * 3).await?;
 
     Ok(())

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -83,9 +83,7 @@ async fn test_epoch_boundary_inner(
     // track the number of times the new validator was in the epoch committee
     let mut new_validator_in_committee_count = 0;
 
-    // sleep for first epoch with 1s offset and begin assertions loop
-    tokio::time::sleep(std::time::Duration::from_secs(EPOCH_DURATION + 1)).await;
-
+    // No pre-pad sleep is needed here: the loop's first poll waits for the epoch to change.
     let mut shuffled = false;
     let mut latest_epoch = 0u32;
     // the new validator has a 1/6 chance of being selected for the new committee
@@ -296,9 +294,7 @@ async fn test_epoch_sync_inner(
     })
     .await?;
 
-    // sleep for first epoch with 1s offset and begin assertions loop
-    tokio::time::sleep(std::time::Duration::from_secs(EPOCH_DURATION + 1)).await;
-
+    // No pre-pad sleep is needed here: loop_epochs polls until the epoch changes.
     // Go through at least 5 epochs.
     loop_epochs(0, 5, &endpoints[0].http_url, EPOCH_DURATION).await?;
     // Kill a node


### PR DESCRIPTION
- Replace the remaining hand-rolled `Instant::now() + Duration` poll loops in `common.rs` (`loop_epochs`, `wait_for_rpc`) and `eject.rs` (post-burn head-advance checks) with `wait_until`/`wait_until_blocking`, each naming what it's waiting for.
- Add `wait_for_head_at_least` in `common.rs` and reuse it from both `test_validator_ejected_from_future_committee_only` and `test_validator_ejected_from_current_committee_mid_epoch`, replacing duplicated loop bodies.
- Move `assert_epoch_reached` from a private helper at the bottom of `eject.rs` into `common.rs` so it's reusable.
- Add `ProcessGuard::wait_for_natural_exit` — polls a specific child's `try_wait()` via `wait_until_blocking` and clears its slot once reaped, so `Drop`/`kill_all` never re-signal a reused pid.
- Add `burn_with_retry` in `eject.rs`: retries a governance burn tx once with the same nonce if its confirmation is lost to an epoch-boundary race.
- Strengthen `assert_epoch_records_verify` to compare the executed block's actual hash against the epoch record's committed hash, not just block existence — catches cross-node divergence that same-height-different-contents would otherwise miss.
- Remove now-redundant pre-pad `sleep(EPOCH_DURATION + 1)` calls in `epochs.rs` ahead of `loop_epochs`, since its first poll already waits for the epoch to change.
- New test: `test_network_halts_when_ejections_shrink_committee_below_tolerance` — burns two of five committee members in one epoch to prove every validator fail-stops (exit code 1, with the expected stderr) at the next epoch boundary when the committee shrinks below `committee_compatible` tolerance, and that no endpoint answers RPC afterward.

closes #950 