### PR TITLE
Pin epoch-entry reads to the previous epoch's closing block

### DIFF
--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -1,7 +1,7 @@
 //! E2E coverage for governance ejection (`ConsensusRegistry::burn`) of validators.
 //!
 //! `burn` retires the validator, confiscates its stake, and swap-and-pops it out of the stored
-//! current/next/subsequent committee arrays. Three scenarios are covered:
+//! current/next/subsequent committee arrays. Four scenarios are covered:
 //!
 //! - [`test_validator_ejected_from_future_committee_only`]: the burned validator sits ONLY in
 //!   future committees, so no running committee changes shape. This test deliberately has NO
@@ -13,6 +13,12 @@
 //!   LIVE committee, which shrinks mid-epoch. This is the end-to-end acceptance test for the
 //!   `EpochRecord::committee_compatible` tolerance: on pre-fix code every node deterministically
 //!   halts at the first epoch boundary after the burn.
+//! - [`test_committee_member_restarted_mid_epoch_after_ejection`]: after the burn shrinks the live
+//!   committee's stored arrays, a DIFFERENT committee member is killed and restarted inside the
+//!   same epoch. This is the regression test for the epoch-entry read pinning: the restart must
+//!   re-derive the epoch view from the previous epoch's closing block (not the post-burn canonical
+//!   tip), rejoin consensus mid-epoch, and close the epoch with records identical to the rest of
+//!   the fleet.
 //! - [`test_network_halts_when_ejections_shrink_committee_below_tolerance`]: governance burns TWO
 //!   of the five committee members in one epoch, shrinking the committee below the
 //!   `committee_compatible` tolerance. The tolerance is deliberately bounded, so the network
@@ -21,8 +27,9 @@
 
 use crate::common::{
     acquire_test_permit, assert_epoch_reached, assert_epoch_records_verify,
-    create_genesis_for_test, fetch_verified_epoch_record, generate_new_validator_txs,
-    get_block_number, get_tx_receipt_block, kill_child, loop_epochs, send_owner_tx, start_nodes,
+    create_genesis_for_test, current_epoch, fetch_verified_epoch_record,
+    generate_new_validator_txs, get_block_number, get_latest_consensus_header_number,
+    get_tx_receipt_block, kill_child, loop_epochs, send_owner_tx, start_nodes,
     wait_for_epoch_at_least, wait_for_head_at_least, wait_for_mid_epoch, wait_for_rpc,
     ProcessGuard, EPOCH_DURATION, INITIAL_STAKE_AMOUNT, NEW_VALIDATOR,
 };
@@ -39,6 +46,7 @@ use tn_reth::{
     test_utils::TransactionFactory,
     RethChainSpec,
 };
+use tn_test_utils::wait_until;
 use tn_types::{Address, EpochCertificate, EpochRecord, U256};
 use tokio::time::timeout;
 use tracing::info;
@@ -51,6 +59,16 @@ use tracing::info;
 /// tightening the committee quorum when it is down. The below-tolerance halt test configures it
 /// (genesis creation requires the extra node) but never starts it.
 const GENESIS_OBSERVER: &str = "genesis-observer";
+
+/// Per-test epoch duration (seconds) for the mid-epoch restart regression.
+///
+/// [`test_committee_member_restarted_mid_epoch_after_ejection`] must fit its whole in-epoch
+/// sequence — fresh-boundary entry, one full leader rotation, the governance burn, the burn-block
+/// execution pin, kill, restart, and the mid-epoch consensus rejoin — inside ONE epoch. That
+/// sequence's worst case is ~29s, so the module-wide [`EPOCH_DURATION`] (10s) cannot host it;
+/// 40s banks comfortable margin without stretching the test into extra epochs. Every timeout in
+/// that test which scales with epoch length derives from this constant, not [`EPOCH_DURATION`].
+const RESTART_EPOCH_DURATION: u64 = 40;
 
 /// Find the epoch that contains `block` by walking the epoch-info ring buffer down from the
 /// current epoch.
@@ -597,6 +615,295 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
     // transfer's block and it serves the shrunken epoch-E record with a verifying cert
     wait_for_head_at_least(&victim_url, tx_block + 1, EPOCH_DURATION * 3).await?;
     fetch_verified_epoch_record(&victim_url, e, EPOCH_DURATION * 3).await?;
+
+    Ok(())
+}
+
+#[ignore = "only run independently from all other it tests"]
+#[tokio::test(flavor = "multi_thread")]
+/// Regression test for epoch-entry read pinning: a committee member killed and restarted
+/// MID-EPOCH, AFTER a governance burn ejected a DIFFERENT committee member, must rejoin the SAME
+/// epoch view its peers are running and close the epoch with identical records.
+///
+/// THE INVARIANT: every epoch-scoped entry read — committee membership, epoch info, fee and
+/// rewards seeding — pins to the previous epoch's closing block, which `concludeEpoch` writes
+/// exactly once at the boundary. A fresh boundary crossing, a crash-restart, and a mode-change
+/// re-entry therefore all re-derive the identical epoch view: same rewards rows, same quorum
+/// threshold, same round-robin leader schedule. Without the pin, a restart reads the canonical
+/// TIP, which a mid-epoch `burn` has already mutated (swap-and-pop of the victim from the stored
+/// current-committee array). The restarted node then enters epoch E with a 4-member view while
+/// its peers run the 5-member epoch: it cannot verify their consensus certificates (wrong quorum,
+/// wrong leader schedule) so its consensus height freezes until the boundary, and any close it
+/// reaches seeds rewards without the ejected leader's row — a divergent withdrawals_root, hence a
+/// divergent closing-block hash, hence a divergent epoch-record digest.
+///
+/// Scenario: 5 genesis committee validators plus the genesis-configured follower, all six
+/// started (the follower extends the record-consistency assert to the sync path). Mid-epoch E,
+/// governance burns committee member `validator-5` (the victim, whose node stays up); then
+/// `validator-2` (the kill target) is killed and restarted on its same datadir inside the SAME
+/// epoch. Premise gates make the scenario airtight rather than timing-lucky:
+///
+/// - VICTIM-LED COMMIT: one full leader rotation (5 commits) is observed inside epoch E before the
+///   burn. The leader schedule is strict round-robin over the 5 authorities and a fresh epoch's
+///   leader swap table is empty, so the victim led at least one commit — its leader-rewards row is
+///   nonzero, and an entry view that drops the row provably diverges at the close (with a zero row
+///   both views would close identically and the test would prove nothing).
+/// - REPRO PIN: the kill target must have EXECUTED the burn block before dying. Otherwise its
+///   restart tip would still be pre-burn state, and even an unpinned tip read would derive the
+///   correct 5-member committee — an accidental pass.
+/// - IN-EPOCH GUARDS: the epoch is entered exactly at its boundary flip (banking the full duration
+///   for the sequence above), and every wait re-checks that epoch E is still current, failing
+///   loudly as "premise broken" if the sequence straddles a boundary.
+///
+/// The detectors, in order: (a) the restarted node's consensus height re-advances past
+/// everything it could have held at death — commits it can only acquire by verifying the
+/// 5-member committee's certificates — while the fleet is still in epoch E; (b) the E -> E+1
+/// boundary closes on all six nodes; (c) epoch records 0..=E verify on all six nodes with
+/// final-state HASH equality (the record-divergence detector); (d) a transfer submitted through
+/// the RESTARTED node's own RPC confirms, and the burned validator keeps following the chain as
+/// an observer.
+async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Result<()> {
+    let _permit = acquire_test_permit();
+
+    // committee wallets + a follower wallet; seed 33 = consensus registry owner
+    let observer_wallet = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(7));
+    let mut nodes = vec![
+        ("validator-1", Address::from_slice(&[0x11; 20])),
+        ("validator-2", Address::from_slice(&[0x22; 20])),
+        ("validator-3", Address::from_slice(&[0x33; 20])),
+        ("validator-4", Address::from_slice(&[0x44; 20])),
+        ("validator-5", Address::from_slice(&[0x55; 20])),
+    ];
+    // the victim (burned mid-epoch, node stays up); the kill target is validator-2 = index 1
+    let victim_addr = nodes[4].1;
+
+    // setup genesis with the longer per-test epoch (see RESTART_EPOCH_DURATION)
+    let temp_dir = tempfile::TempDir::with_prefix("eject_restart")?;
+    let temp_path = temp_dir.path();
+
+    let mut governance_wallet =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+    let genesis = create_genesis_for_test(
+        temp_path,
+        (GENESIS_OBSERVER, observer_wallet.address()),
+        governance_wallet.address(),
+        &nodes,
+        RESTART_EPOCH_DURATION,
+    )?;
+
+    // start all six nodes (committee + genesis observer)
+    nodes.push((GENESIS_OBSERVER, observer_wallet.address()));
+    let (procs, mut endpoints) = start_nodes(temp_path, &nodes, "eject_restart", 1)?;
+    // Guard ensures processes are killed on drop (normal return, error, or panic).
+    let mut guard = ProcessGuard::new(procs);
+    let victim_url = endpoints[4].http_url.clone();
+    let rpc_url = endpoints[0].http_url.clone();
+
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+    wait_for_rpc(&provider).await?;
+    let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, &provider);
+
+    // ---- Phase 0: cross the 0 -> 1 boundary ----
+    wait_for_epoch_at_least(&provider, 1).await?;
+
+    // Before killing validator-2, require ITS datadir to hold the certified epoch-0 record.
+    // `save_dummy_epoch0` is in-memory only, so a node killed after executing the epoch-0
+    // closing block but before persisting the real record 0 cannot restart (`run_epoch` exits:
+    // "We have epoch 0 in our database if we are past epoch 0"). That crash window is a
+    // pre-existing product issue orthogonal to the pinning fix under test; gating the kill on
+    // the kill target serving certified record 0 keeps this test deterministic.
+    fetch_verified_epoch_record(&endpoints[1].http_url, 0, RESTART_EPOCH_DURATION * 2).await?;
+
+    // ---- Fresh-boundary entry: catch the flip into epoch E ----
+    // The in-epoch sequence below (rotation, burn, pin, kill, restart, rejoin) worst-cases at
+    // ~29s; entering exactly at the flip banks the full epoch duration for it, where a
+    // mid-epoch entry would squander half.
+    let pre_flip = current_epoch(&provider).await?.epoch_id;
+    wait_until(
+        Duration::from_secs(RESTART_EPOCH_DURATION * 2),
+        &format!("fresh-boundary entry: waiting for the epoch to flip past {pre_flip} on node 0"),
+        || async { Ok(current_epoch(&provider).await?.epoch_id > pre_flip) },
+    )
+    .await?;
+    let e = current_epoch(&provider).await?.epoch_id;
+    // the flip poll re-checks every ~10ms, so observing a double-flip means this thread stalled
+    // for a whole epoch — the "fresh entry" premise is gone
+    eyre::ensure!(
+        e == pre_flip + 1,
+        "premise broken: entered epoch {e}, expected the fresh flip to {}",
+        pre_flip + 1
+    );
+    info!(target: "eject-test", epoch = e, "entered epoch at a fresh boundary");
+
+    // ---- Victim-led premise: observe one full leader rotation inside epoch E ----
+    // The leader schedule is strict round-robin over the committee (leader(round) =
+    // authorities[round/2 - 1 mod 5]) and a fresh epoch starts with an empty leader swap table
+    // (reputation scores only finalize a swap after many more sub-dags), so with all five
+    // validators live, five consecutive commits are one full rotation containing a victim-led
+    // commit. Each commit appends exactly one consensus header, so height h0 + 5 == five
+    // commits, all inside epoch E because h0 is read after the flip and the wait re-checks the
+    // epoch. This guarantees the victim's leader-rewards row is nonzero before the burn.
+    let h0 = get_latest_consensus_header_number(&rpc_url)?;
+    wait_until(
+        Duration::from_secs(RESTART_EPOCH_DURATION),
+        &format!(
+            "victim-led premise: waiting for consensus height {} (h0 {h0} + one full \
+             rotation) on node 0",
+            h0 + 5
+        ),
+        || async {
+            let now = current_epoch(&provider).await?.epoch_id;
+            eyre::ensure!(
+                now == e,
+                "premise broken: epoch flipped to {now} before one full leader rotation \
+                 completed inside epoch {e}"
+            );
+            Ok(get_latest_consensus_header_number(&rpc_url)? >= h0 + 5)
+        },
+    )
+    .await?;
+    info!(target: "eject-test", epoch = e, "one full leader rotation observed");
+
+    // ---- Governance burn of the victim, mid-epoch E — deliberately NO retry ----
+    // A retry could slide the burn across the boundary and silently break the mid-epoch
+    // premise; the ensure below turns that into a loud failure instead. Nonce 0: the burn is
+    // this wallet's first transaction.
+    let calldata: Bytes =
+        ConsensusRegistry::burnCall { validatorAddress: victim_addr }.abi_encode().into();
+    let (_burn_hash, burn_block) =
+        send_owner_tx(&rpc_url, &mut governance_wallet, chain.clone(), calldata).await?;
+    let burn_epoch = epoch_of_block(&provider, burn_block).await?;
+    eyre::ensure!(
+        burn_epoch == e,
+        "premise broken: burn landed in epoch {burn_epoch}, not mid-epoch {e}"
+    );
+    info!(target: "eject-test", burn_block, epoch = e, "victim burned mid-epoch");
+
+    // brief on-chain shape check: the victim is retired and the eligible set shrank 5 -> 4
+    assert!(registry.isRetired(victim_addr).call().await?, "victim must be retired");
+    assert_eq!(
+        registry.getEligibleValidatorCount().call().await?,
+        U256::from(4),
+        "eligible count must drop 5 -> 4"
+    );
+
+    // ---- Repro pin: the kill target must EXECUTE the burn block before dying ----
+    // The pre-fix bug is an entry read of POST-burn registry state at the canonical tip. If the
+    // node died before executing the burn block, its tip at restart would still be pre-burn
+    // state and even an unpinned read would derive the correct 5-member committee — the test
+    // would pass pre-fix by accident. Requiring the burn block on the kill target's head makes
+    // the restart provably face post-burn state at its tip.
+    wait_for_head_at_least(&endpoints[1].http_url, burn_block, 10).await?;
+
+    // ---- Kill validator-2 (datadir preserved), still mid-epoch E ----
+    // h_kill: the kill target's own consensus tip just before death — a floor for the rejoin
+    // assert below.
+    let h_kill = get_latest_consensus_header_number(&endpoints[1].http_url)?;
+    let mut target_child = guard.take(1).ok_or_else(|| eyre::eyre!("no kill-target process"))?;
+    kill_child(&mut target_child);
+    let downed_provider = ProviderBuilder::new().connect_http(endpoints[1].http_url.parse()?);
+    assert!(downed_provider.get_chain_id().await.is_err(), "kill target must be down");
+    info!(target: "eject-test", h_kill, epoch = e, "kill target down mid-epoch");
+
+    // ---- Restart validator-2 on its same datadir, still mid-epoch E ----
+    let (mut new_children, mut new_endpoints) =
+        start_nodes(temp_path, &nodes[1..2], "eject_restart", 2)?;
+    let new_child = new_children.pop().ok_or_else(|| eyre::eyre!("no restarted process"))?;
+    let new_endpoint = new_endpoints.pop().ok_or_else(|| eyre::eyre!("no restarted endpoint"))?;
+    guard.replace(1, new_child);
+    endpoints[1] = new_endpoint;
+    let restarted_provider = ProviderBuilder::new().connect_http(endpoints[1].http_url.parse()?);
+    wait_for_rpc(&restarted_provider).await?;
+
+    // ---- Premise: the kill/restart round trip stayed inside epoch E on both sides ----
+    // A restart that straddled the boundary re-enters at E+1, where even an unpinned tip read
+    // is correct — the test would prove nothing, so fail loudly instead of silently passing.
+    let anchor_epoch = current_epoch(&provider).await?.epoch_id;
+    let restarted_epoch = current_epoch(&restarted_provider).await?.epoch_id;
+    eyre::ensure!(
+        anchor_epoch == e && restarted_epoch == e,
+        "premise broken: restart straddled the epoch boundary (node 0 at {anchor_epoch}, \
+         restarted node at {restarted_epoch}, wanted {e})"
+    );
+
+    // ---- (a) THE MID-EPOCH REJOIN ASSERT: consensus re-advances within epoch E ----
+    // The rejoin floor is everything the restarted node could hold WITHOUT verifying new
+    // certificates: its own tip at death (h_kill) and node 0's tip observed after the restart
+    // came back up (h_peer covers commits that landed between the h_kill snapshot and process
+    // death). Exceeding the max of both proves the node verified and followed commits produced
+    // by the 5-member committee AFTER its restart — impossible on an entry view read from the
+    // post-burn tip, where the 4-member quorum and leader schedule reject every peer
+    // certificate and the node's consensus height freezes until the boundary.
+    let h_peer = get_latest_consensus_header_number(&rpc_url)?;
+    let rejoin_floor = h_kill.max(h_peer);
+    info!(
+        target: "eject-test",
+        h_kill, h_peer, rejoin_floor, "waiting for the mid-epoch consensus rejoin"
+    );
+    wait_until(
+        Duration::from_secs(RESTART_EPOCH_DURATION),
+        &format!(
+            "mid-epoch rejoin: waiting for the restarted node's consensus height to exceed \
+             {rejoin_floor} within epoch {e}"
+        ),
+        || async {
+            let now = current_epoch(&provider).await?.epoch_id;
+            eyre::ensure!(
+                now == e,
+                "REGRESSION (mid-epoch rejoin failed): epoch flipped to {now} while the \
+                 restarted node's consensus height was still <= {rejoin_floor} — a committee \
+                 member restarted after the ejection never re-verified its peers' certificates \
+                 inside epoch {e}"
+            );
+            Ok(get_latest_consensus_header_number(&endpoints[1].http_url)? > rejoin_floor)
+        },
+    )
+    .await?;
+    info!(target: "eject-test", epoch = e, "restarted node rejoined consensus mid-epoch");
+
+    // ---- (b) The E -> E+1 boundary closes on ALL SIX nodes ----
+    for (idx, endpoint) in endpoints.iter().enumerate() {
+        assert_epoch_reached(
+            &endpoint.http_url,
+            e + 1,
+            &format!("POST-RESTART BOUNDARY (node index {idx})"),
+        )
+        .await?;
+    }
+    info!(target: "eject-test", epoch = e + 1, "boundary closed on all six nodes");
+
+    // ---- (c) THE RECORD-DIVERGENCE ASSERT: records 0..=E hash-identical on all six ----
+    // `assert_epoch_records_verify` requires every node to serve a CERTIFIED record for every
+    // epoch AND to have executed each record's final block with the exact hash the record
+    // commits to. An entry view that dropped the ejected leader's rewards row surfaces here:
+    // divergent withdrawals in the closing block -> divergent closing-block hash -> divergent
+    // record digest, reported as a hash mismatch on the restarted node.
+    assert_epoch_records_verify(&endpoints, 0..=e, RESTART_EPOCH_DURATION * 2).await?;
+    info!(target: "eject-test", epoch = e, "epoch records verify hash-identical on all six nodes");
+
+    // ---- (d) Liveness through the restarted node; the burned validator keeps following ----
+    // Submit the transfer via the RESTARTED node's own RPC: its pool/batch path must be live
+    // again, not merely its sync path.
+    let recipient = Address::from_slice(&[0x77; 20]);
+    let transfer = governance_wallet.create_eip1559_encoded(
+        chain,
+        None,
+        100,
+        Some(recipient),
+        parse_ether("1")?,
+        Bytes::default(),
+    );
+    let pending = restarted_provider.send_raw_transaction(&transfer).await?;
+    // a confirmation straddling a boundary can get orphaned and re-injected; allow two epochs
+    let hash =
+        timeout(Duration::from_secs(RESTART_EPOCH_DURATION * 2 + 11), pending.watch()).await??;
+    let tx_block = get_tx_receipt_block(&endpoints[1].http_url, &hash.to_string())?;
+    info!(target: "eject-test", tx_block, "post-restart transfer confirmed via the restarted node");
+
+    // the burned validator's node keeps following as an observer: its head advances past the
+    // transfer's block (the next block arrives at latest with the E+2 closing block)
+    wait_for_head_at_least(&victim_url, tx_block + 1, RESTART_EPOCH_DURATION * 3).await?;
 
     Ok(())
 }

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -382,16 +382,6 @@ impl ExecutionNodeInner {
         self.reth_env.epoch_state_at_epoch_start()
     }
 
-    /// Read committee validator keys for epoch.
-    pub(super) fn validators_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<BlsPublicKey>> {
-        Ok(self
-            .reth_env
-            .bls_pubkeys_for_epoch(epoch)?
-            .iter()
-            .filter_map(|bls| BlsPublicKey::from_literal_bytes(bls.as_ref()).ok())
-            .collect())
-    }
-
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
     pub(super) fn validators_for_epoch_at_block(
         &self,

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -19,7 +19,7 @@ use tn_rpc::{EngineToPrimary, TelcoinNetworkRpcExt, TelcoinNetworkRpcExtApiServe
 use tn_types::{
     gas_accumulator::GasAccumulator, Address, BatchSender, BatchValidation, BlockHeader,
     BlsPublicKey, ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer,
-    SealedHeader, TaskSpawner, WorkerId,
+    SealedHeader, TaskSpawner, WorkerId, B256,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::mpsc;
@@ -376,11 +376,31 @@ impl ExecutionNodeInner {
         self.reth_env.epoch_state_from_canonical_tip()
     }
 
+    /// Read the current epoch's [EpochState] pinned to the previous epoch's closing block
+    /// (genesis for epoch 0), returning the pin header alongside it.
+    pub(super) fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
+        self.reth_env.epoch_state_at_epoch_start()
+    }
+
     /// Read committee validator keys for epoch.
     pub(super) fn validators_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<BlsPublicKey>> {
         Ok(self
             .reth_env
             .bls_pubkeys_for_epoch(epoch)?
+            .iter()
+            .filter_map(|bls| BlsPublicKey::from_literal_bytes(bls.as_ref()).ok())
+            .collect())
+    }
+
+    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
+    pub(super) fn validators_for_epoch_at_block(
+        &self,
+        epoch: u32,
+        block_hash: B256,
+    ) -> eyre::Result<Vec<BlsPublicKey>> {
+        Ok(self
+            .reth_env
+            .bls_pubkeys_for_epoch_at_block(epoch, block_hash)?
             .iter()
             .filter_map(|bls| BlsPublicKey::from_literal_bytes(bls.as_ref()).ok())
             .collect())

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -23,7 +23,7 @@ use tn_rpc::EngineToPrimary;
 use tn_types::{
     gas_accumulator::GasAccumulator, BatchSender, BatchValidation, BlsPublicKey,
     ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer, SealedHeader,
-    TaskSpawner, WorkerId,
+    TaskSpawner, WorkerId, B256,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::{mpsc, RwLock};
@@ -298,9 +298,26 @@ impl ExecutionNode {
         guard.epoch_state_from_canonical_tip()
     }
 
+    /// Read the current epoch's [EpochState] pinned to the previous epoch's closing block
+    /// (genesis for epoch 0), returning the pin header alongside it.
+    pub async fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
+        let guard = self.internal.read().await;
+        guard.epoch_state_at_epoch_start()
+    }
+
     /// Read committee validator keys for epoch.
     pub async fn validators_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<BlsPublicKey>> {
         let guard = self.internal.read().await;
         guard.validators_for_epoch(epoch)
+    }
+
+    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
+    pub async fn validators_for_epoch_at_block(
+        &self,
+        epoch: u32,
+        block_hash: B256,
+    ) -> eyre::Result<Vec<BlsPublicKey>> {
+        let guard = self.internal.read().await;
+        guard.validators_for_epoch_at_block(epoch, block_hash)
     }
 }

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -305,13 +305,12 @@ impl ExecutionNode {
         guard.epoch_state_at_epoch_start()
     }
 
-    /// Read committee validator keys for epoch.
-    pub async fn validators_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<BlsPublicKey>> {
-        let guard = self.internal.read().await;
-        guard.validators_for_epoch(epoch)
-    }
-
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
+    ///
+    /// This is deliberately the ONLY committee read the engine exposes: an unpinned
+    /// (canonical-tip) variant would make the result depend on when the caller runs
+    /// relative to a mid-epoch governance burn. Callers must choose their pin header
+    /// explicitly (epoch-start for entry reads, the epoch-closing block for the record).
     pub async fn validators_for_epoch_at_block(
         &self,
         epoch: u32,

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -206,8 +206,24 @@ where
             return Ok(());
         }
 
-        let committee_keys = engine.validators_for_epoch(epoch).await?;
-        let next_committee_keys = engine.validators_for_epoch(epoch + 1).await?;
+        // CLOSE-TIME READS, INTENTIONALLY POST-BURN: these committee reads see the on-chain
+        // state at epoch CLOSE, not the epoch-start pin used by the entry path. That is by
+        // design: a mid-epoch governance burn swap-and-pops the ejected validator out of the
+        // ConsensusRegistry's committee arrays immediately, and the epoch record is meant to
+        // commit that shrunken committee (`build_epoch_record` tolerates the shrink against
+        // the previous record's `next_committee` promise). Do NOT "fix" these reads to the
+        // epoch-start pin.
+        //
+        // They ARE pinned, though — to `parent_state`, the epoch-closing block this record
+        // commits as `final_state`. At the only call site (the live boundary arm of
+        // `run_epoch`, after `close_epoch`'s `wait_for_consensus_execution`) the canonical
+        // tip IS that closing block, so the pin is behavior-neutral; it makes the record's
+        // committee reads and its `final_state` derive from the same header by construction
+        // instead of by timing.
+        let parent_state = self.consensus_bus.latest_execution_block_num_hash();
+        let committee_keys = engine.validators_for_epoch_at_block(epoch, parent_state.hash).await?;
+        let next_committee_keys =
+            engine.validators_for_epoch_at_block(epoch + 1, parent_state.hash).await?;
         let prev_record = if epoch == 0 {
             None
         } else {
@@ -218,7 +234,6 @@ where
             .take()
             .expect("epoch was finished with last consensus header");
         let target_hash = last_consensus_header.digest();
-        let parent_state = self.consensus_bus.latest_execution_block_num_hash();
 
         let epoch_rec = build_epoch_record(
             epoch,
@@ -262,7 +277,8 @@ where
 /// Build the finalized [`EpochRecord`] for a just-completed epoch.
 ///
 /// The committee keys are the fresh on-chain reads for `epoch` and `epoch + 1`
-/// at the canonical tip; `prev` is the stored record for `epoch - 1`, required
+/// pinned to the epoch-closing block the record commits as `final_state`;
+/// `prev` is the stored record for `epoch - 1`, required
 /// for every epoch after 0. The new record chains to `prev` via `parent_hash`,
 /// and the committee read for this epoch must be compatible with the previous
 /// record's `next_committee` under [`EpochRecord::committee_compatible`]: the

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -215,11 +215,14 @@ where
         // epoch-start pin.
         //
         // They ARE pinned, though — to `parent_state`, the epoch-closing block this record
-        // commits as `final_state`. At the only call site (the live boundary arm of
-        // `run_epoch`, after `close_epoch`'s `wait_for_consensus_execution`) the canonical
-        // tip IS that closing block, so the pin is behavior-neutral; it makes the record's
-        // committee reads and its `final_state` derive from the same header by construction
-        // instead of by timing.
+        // commits as `final_state`. `parent_state` is the bus's `recent_blocks` watch value,
+        // not the reth canonical tip: the engine publishes each executed output's last block
+        // and its consensus hash in ONE watch write, so the bus can lag the true tip
+        // mid-execution but never lead it. At the only call site (the live boundary arm of
+        // `run_epoch`, after `close_epoch`'s `wait_for_consensus_execution`) the wait resolved
+        // on the exact write that carries the closing block, so this read IS that block; the
+        // pin makes the record's committee reads and its `final_state` derive from the same
+        // header by construction instead of by timing.
         let parent_state = self.consensus_bus.latest_execution_block_num_hash();
         let committee_keys = engine.validators_for_epoch_at_block(epoch, parent_state.hash).await?;
         let next_committee_keys =

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -135,7 +135,7 @@ where
         self.last_consensus_header = None;
         // We have not created this epoch's primary yet (no committee) so get it from chain
         // ourselves... Note, any consensus output to replay should be in the same epoch...
-        let (committee, epoch_info, epoch_start) =
+        let (committee, epoch_info, epoch_start, epoch_start_header) =
             self.get_committee_with_epoch_start_info(engine).await?;
         self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
         self.metrics.current.set(committee.epoch() as f64);
@@ -143,26 +143,34 @@ where
 
         let reth_env = engine.get_reth_env().await;
 
-        // ENTRY-READ INVARIANT: the previous epoch's closing state rules the entire epoch.
-        // `entered` and `epoch_info.blockHeight` come from the ONE atomic canonical-tip read
-        // above (`get_committee_with_epoch_start_info`), and `concludeEpoch` writes an epoch's
-        // `blockHeight` exactly once at the boundary, so both are immutable within the epoch: a
-        // ModeChange re-entry re-reads IDENTICAL values and re-derives identical fees (a pure
-        // function of prior-epoch closing state). That value-stability is the safety argument
-        // under concurrent execution - `send_leftover_consensus_output_to_engine` forwards
-        // leftover output without waiting, so the engine may still be executing (calling
-        // `inc_block`) while this entry runs: `apply`'s resize no-ops, its fee writes rewrite
-        // the same values, and `GasAccumulator::set_num_workers` refuses to shrink below an
-        // in-flight worker id - NOT quiescence. See the `mode_change_reentry_is_idempotent` IT.
+        // ENTRY-READ INVARIANT: the previous epoch's closing block rules the entire epoch.
+        // Every epoch-scoped entry read - committee membership, `epoch_info`, and the fee
+        // derivation below - derives from the ONE pinned header returned by the atomic
+        // `epoch_state_at_epoch_start` read above (via `get_committee_with_epoch_start_info`):
+        // the previous epoch's closing block, `getEpochInfo(entered).blockHeight - 1` (genesis
+        // for epoch 0). `concludeEpoch` writes an epoch's `blockHeight` exactly once at the
+        // boundary, so the pin itself is re-derivable at ANY tip: a fresh boundary crossing, a
+        // crash-restart replay, and a ModeChange re-entry all resolve the same header. The
+        // consequence: a re-entry AFTER a mid-epoch governance `burn` (which swap-and-pops the
+        // CURRENT epoch's stored committee arrays immediately) re-reads the IDENTICAL
+        // epoch-start membership - RewardsCounter rows, quorum thresholds, leader schedule -
+        // instead of the post-burn tip set, so entry timing can no longer change the node's
+        // view of the epoch.
+        //
+        // That value-stability is also the safety argument under concurrent execution -
+        // `send_leftover_consensus_output_to_engine` forwards leftover output without waiting,
+        // so the engine may still be executing (calling `inc_block`) while this entry runs:
+        // `apply`'s resize no-ops, its fee writes rewrite the same values, and
+        // `GasAccumulator::set_num_workers` refuses to shrink below an in-flight worker id -
+        // NOT quiescence. See the `mode_change_reentry_is_idempotent` IT.
         //
         // Seed the accumulator's worker count and per-worker base fees for the entered epoch
-        // from the previous epoch's closing block (`getEpochInfo(entered).blockHeight - 1`).
-        // This is the single seam every entry shape converges on: a live producer that just
-        // crossed the boundary (recomputing the value `adjust_base_fees` produced at close),
-        // every close_epoch(None) recovery shape (replay-and-close, crash-after-close,
-        // leftover-drain), and a mid-epoch sync or restart all derive the same values from the
-        // same pinned state. Runs before replay drives `inc_block`, so replay operates on a
-        // correctly sized accumulator.
+        // from the pinned header (the previous epoch's closing block). This is the single seam
+        // every entry shape converges on: a live producer that just crossed the boundary
+        // (recomputing the value `adjust_base_fees` produced at close), every close_epoch(None)
+        // recovery shape (replay-and-close, crash-after-close, leftover-drain), and a mid-epoch
+        // sync or restart all derive the same values from the same pinned state. Runs before
+        // replay drives `inc_block`, so replay operates on a correctly sized accumulator.
         let entered = committee.epoch();
         if entered == 0 {
             // Epoch 0 has no prior epoch: fees stay at the MIN defaults (epoch-0 blocks carry
@@ -180,14 +188,7 @@ where
             // prior-epoch header scan here (~86k headers for a 24h epoch of 1s blocks -
             // seconds, and the derive logs its elapsed time); acceptable because entries are
             // rare.
-            let closing_number = epoch_info
-                .blockHeight
-                .checked_sub(1)
-                .ok_or_else(|| eyre::eyre!("entered epoch {entered} reports blockHeight 0"))?;
-            let closing = reth_env.sealed_header_by_number(closing_number)?.ok_or_else(|| {
-                eyre::eyre!("missing closing block {closing_number} for entered epoch {entered}")
-            })?;
-            super::derive_base_fees_for_entered_epoch(&reth_env, entered, &closing)?
+            super::derive_base_fees_for_entered_epoch(&reth_env, entered, &epoch_start_header)?
                 .apply(&gas_accumulator);
         }
         // Produce a "dummy" epoch 0 EpochRecord if missing.
@@ -263,6 +264,7 @@ where
                 gas_accumulator.clone(),
                 consensus_bus.clone(),
                 consensus_config.clone(),
+                &epoch_start_header,
             )
             .await?;
         // Networks are now set up; subsequent epochs rotate committees instead of re-seeding.

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -29,7 +29,7 @@ use tn_types::{
     EpochRecord, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
 };
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Name of the per-epoch [`TaskManager`], created fresh and torn down each epoch.
 const EPOCH_TASK_MANAGER: &str = "Epoch Task Manager";
@@ -138,6 +138,7 @@ where
         let (committee, epoch_info, epoch_start, epoch_start_header) =
             self.get_committee_with_epoch_start_info(engine).await?;
         self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
+        debug!(target: "epoch-manager", new_epoch_boundary=self.epoch_boundary, "resetting epoch boundary");
         self.metrics.current.set(committee.epoch() as f64);
         self.metrics.boundary_timestamp_seconds.set(self.epoch_boundary as f64);
 
@@ -222,7 +223,7 @@ where
             // If we are starting up then make sure that any consensus we previously validated goes
             // to the engine and is executed.  Otherwise we could miss consensus execution.
             gas_accumulator.rewards_counter().set_committee(committee.clone());
-            let mut replay = self.replay_missed_consensus(committee, to_engine).await?;
+            let mut replay = self.replay_missed_consensus(committee.clone(), to_engine).await?;
             if let Some(target_hash) = replay.take_epoch_close_hash() {
                 // If things go down at exactly the wrong time we might have to replay the epoch end
                 // so account for that.
@@ -243,7 +244,9 @@ where
 
         // subscribe to output early to prevent missed messages
         let mut consensus_output = self.consensus_bus.subscribe_consensus_output();
-        let consensus_config = self.configure_consensus(engine, network_config).await?;
+        let consensus_config = self
+            .configure_consensus(engine, network_config, committee, &epoch_start_header)
+            .await?;
 
         // The networks need their one-time, per-process setup (start listening, register bootstrap
         // peers) on the first iteration that actually reaches `create_consensus`. This is usually

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -113,8 +113,9 @@ where
     ///
     /// The single atomic `epoch_state_at_epoch_start` read yields the committee, the `EpochInfo`,
     /// the epoch-start timestamp, and the pin header (the previous epoch's closing block; genesis
-    /// for epoch 0), returned together so [`configure_consensus`] can compute the epoch boundary
-    /// and issue further pinned reads without a second system call. The pin is what makes every
+    /// for epoch 0), returned together so the caller (`run_epoch`) can compute the epoch boundary
+    /// and thread the committee and pin into [`configure_consensus`] and [`create_consensus`] for
+    /// further pinned reads without a second system call. The pin is what makes every
     /// entry shape — fresh boundary crossing, crash-restart replay, or ModeChange re-entry, before
     /// or after a mid-epoch governance `burn` — derive the IDENTICAL committee; the
     /// `EpochInfo`/epoch-start scalars are unchanged by the pin, since `concludeEpoch` writes them
@@ -268,25 +269,20 @@ where
     /// Assemble the per-epoch [`ConsensusConfig`] from state pinned to the previous epoch's
     /// closing block.
     ///
-    /// Reads the committee and epoch-start info at that pin (via
-    /// [`Self::get_committee_with_epoch_start_info`]), resets `epoch_boundary` to
-    /// `epoch_start + epochDuration` (the timestamp at which this epoch closes, used elsewhere
-    /// to detect the boundary), and folds in the next committee's keys — read at the same pin —
-    /// so the network can pre-resolve the successor committee. Produces a config scoped to this
-    /// epoch only.
+    /// `committee` and `epoch_start_header` are threaded in from `run_epoch`'s single entry
+    /// read ([`Self::get_committee_with_epoch_start_info`]) — this method issues no epoch-start
+    /// read of its own, so the config cannot derive from a different pin than the rest of the
+    /// entry path. It folds in the next committee's keys — read at the same pin — so the
+    /// network can pre-resolve the successor committee. Produces a config scoped to this epoch
+    /// only.
     pub(super) async fn configure_consensus(
-        &mut self,
+        &self,
         engine: &ExecutionNode,
         network_config: &NetworkConfig,
+        committee: Committee,
+        epoch_start_header: &SealedHeader,
     ) -> eyre::Result<ConsensusConfig<DB>> {
-        // retrieve epoch information pinned to the previous epoch's closing block
-        let (committee, epoch_info, epoch_start, epoch_start_header) =
-            self.get_committee_with_epoch_start_info(engine).await?;
         let validators = committee.bls_keys();
-
-        self.epoch_boundary = epoch_start + epoch_info.epochDuration as u64;
-        debug!(target: "epoch-manager", new_epoch_boundary=self.epoch_boundary, "resetting epoch boundary");
-
         debug!(target: "epoch-manager", ?validators, "creating committee for validators");
 
         // Pinned like every other epoch-scoped read in this path: the registry at the pin

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -1,8 +1,10 @@
 //! Epoch-start setup driven by `run_epoch` in [`super`].
 //!
 //! Everything here runs once per epoch, before consensus begins voting. The
-//! committee and epoch-start info are read from the canonical execution tip,
-//! then turned into a [`Committee`] and a per-epoch [`ConsensusConfig`]. From
+//! committee and epoch-start info are read pinned to the previous epoch's
+//! closing block — the closing block rules the entire epoch, so every entry
+//! shape derives the identical committee no matter when it runs — then turned
+//! into a [`Committee`] and a per-epoch [`ConsensusConfig`]. From
 //! that the node's mode is identified (CVV, CVV-inactive, or observer) and the
 //! [`PrimaryNode`] and [`WorkerNode`] are created together with their per-epoch
 //! [`PrimaryNetwork`]/[`WorkerNetwork`] interfaces.
@@ -45,7 +47,8 @@ use tn_rpc::RpcNodeInfo;
 use tn_types::{
     gas_accumulator::GasAccumulator, BatchValidation, BlsPublicKey, BlsSigner, Committee,
     CommitteeBuilder, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase, Epoch,
-    Multiaddr, NetworkPublicKey, P2pNode, TaskManager, TaskSpawner, DEFAULT_WORKER_ID,
+    Multiaddr, NetworkPublicKey, P2pNode, SealedHeader, TaskManager, TaskSpawner,
+    DEFAULT_WORKER_ID,
 };
 use tn_worker::{WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -106,18 +109,25 @@ where
         Ok(ReplayResult { epoch_close_hash: None, last_replayed_hash })
     }
 
-    /// Read the canonical execution tip once and derive the current [`Committee`].
+    /// Derive the current [`Committee`] from state pinned to the previous epoch's closing block.
     ///
-    /// The single `epoch_state_from_canonical_tip` read also yields the `EpochInfo` and
-    /// epoch-start timestamp, which are returned alongside the committee so [`configure_consensus`]
-    /// can compute the epoch boundary without issuing a second system call against the same tip.
+    /// The single atomic `epoch_state_at_epoch_start` read yields the committee, the `EpochInfo`,
+    /// the epoch-start timestamp, and the pin header (the previous epoch's closing block; genesis
+    /// for epoch 0), returned together so [`configure_consensus`] can compute the epoch boundary
+    /// and issue further pinned reads without a second system call. The pin is what makes every
+    /// entry shape — fresh boundary crossing, crash-restart replay, or ModeChange re-entry, before
+    /// or after a mid-epoch governance `burn` — derive the IDENTICAL committee; the
+    /// `EpochInfo`/epoch-start scalars are unchanged by the pin, since `concludeEpoch` writes them
+    /// exactly once at the boundary.
     /// On-chain BLS key bytes are decoded here and a decode failure aborts committee construction.
     pub(super) async fn get_committee_with_epoch_start_info(
         &self,
         engine: &ExecutionNode,
-    ) -> eyre::Result<(Committee, EpochInfo, u64)> {
-        let EpochState { epoch, epoch_info, validators, bls_pubkeys, epoch_start } =
-            engine.epoch_state_from_canonical_tip().await?;
+    ) -> eyre::Result<(Committee, EpochInfo, u64, SealedHeader)> {
+        let (
+            EpochState { epoch, epoch_info, validators, bls_pubkeys, epoch_start },
+            epoch_start_header,
+        ) = engine.epoch_state_at_epoch_start().await?;
         let validators = validators
             .iter()
             .zip(bls_pubkeys.iter())
@@ -128,20 +138,26 @@ where
             .collect::<Result<HashMap<_, _>, _>>()
             .map_err(|err| eyre!("failed to create bls key from on-chain bytes: {err:?}"))?;
 
-        Ok((self.create_committee_from_state(epoch, validators).await?, epoch_info, epoch_start))
+        Ok((
+            self.create_committee_from_state(epoch, validators).await?,
+            epoch_info,
+            epoch_start,
+            epoch_start_header,
+        ))
     }
 
     /// Build the epoch's [`PrimaryNode`] and [`WorkerNode`] and their per-epoch networks.
     ///
     /// These components are short-lived: they exist only for the current epoch and are torn
     /// down at its close. The node mode is (re)identified first, and the previous epoch's
-    /// committee is read from on-chain state so peers from the outgoing committee are not
-    /// banned during the handover. `initial_epoch` is threaded down to gate the one-time
-    /// per-process network setup (see [`init_network_for_epoch`]).
+    /// committee is read from on-chain state at `epoch_start_header` so peers from the outgoing
+    /// committee are not banned during the handover. `initial_epoch` is threaded down to gate
+    /// the one-time per-process network setup (see [`init_network_for_epoch`]).
     ///
     /// After both nodes are up, the next two committees' validator keys are prefetched through
     /// the primary and worker network handles so their network info is already resolved when
     /// those epochs arrive — a best-effort warm-up whose failure is intentionally ignored.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn create_consensus(
         &mut self,
         engine: &ExecutionNode,
@@ -150,16 +166,25 @@ where
         gas_accumulator: GasAccumulator,
         consensus_bus: ConsensusBus,
         consensus_config: ConsensusConfig<DB>,
+        epoch_start_header: &SealedHeader,
     ) -> eyre::Result<(PrimaryNode<DB>, WorkerNode<DB>)> {
         // create config for consensus
         let _mode = self.identify_node_mode(&consensus_config, &consensus_bus).await?;
         let epoch = consensus_config.committee().epoch();
 
-        // previous committee from on-chain state - canonical source of truth
+        // Previous committee from on-chain state - canonical source of truth. The previous
+        // epoch's committee array is frozen once this epoch starts (a mid-epoch burn mutates
+        // the current and future epochs' arrays, never a past epoch's), so this pinned read is
+        // value-identical to a tip read — pinned purely so every epoch-scoped read in this
+        // path derives from the one epoch-start header.
         let previous_committee_keys: HashSet<BlsPublicKey> = if epoch == 0 {
             HashSet::new() // no previous committee
         } else {
-            engine.validators_for_epoch(epoch - 1).await?.into_iter().collect()
+            engine
+                .validators_for_epoch_at_block(epoch - 1, epoch_start_header.hash())
+                .await?
+                .into_iter()
+                .collect()
         };
 
         let consensus_bus_app = consensus_bus.app().clone();
@@ -214,9 +239,20 @@ where
         let primary_handle = primary.network_handle().await;
         let committee = consensus_config.committee();
         let mut prefetches = committee.bls_keys().clone();
-        let next_committee_keys = engine.validators_for_epoch(committee.epoch() + 1).await?;
+        // At the previous epoch's closing header the registry already serves the two future
+        // epochs' committees (genesis seeds epochs 0-2; the `concludeEpoch` that seats epoch N
+        // writes epoch N+2's committee inside that same closing block), and pinning keeps a
+        // post-burn re-entry prefetching the same sets an on-time entry prefetched — the
+        // prefetch is a best-effort network warm-up either way.
+        let next_committee_keys = engine
+            .validators_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
+            .await?;
         prefetches.extend(next_committee_keys.iter());
-        prefetches.extend(engine.validators_for_epoch(committee.epoch() + 2).await?);
+        prefetches.extend(
+            engine
+                .validators_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
+                .await?,
+        );
         // Attempt to pre-load the next couple of committee's network info.
         let _ = primary_handle
             .inner_handle()
@@ -229,19 +265,22 @@ where
         Ok((primary, worker))
     }
 
-    /// Assemble the per-epoch [`ConsensusConfig`] from the canonical execution tip.
+    /// Assemble the per-epoch [`ConsensusConfig`] from state pinned to the previous epoch's
+    /// closing block.
     ///
-    /// Reads the committee and epoch-start info from the tip, resets `epoch_boundary` to
+    /// Reads the committee and epoch-start info at that pin (via
+    /// [`Self::get_committee_with_epoch_start_info`]), resets `epoch_boundary` to
     /// `epoch_start + epochDuration` (the timestamp at which this epoch closes, used elsewhere
-    /// to detect the boundary), and folds in the next committee's keys so the network can
-    /// pre-resolve the successor committee. Produces a config scoped to this epoch only.
+    /// to detect the boundary), and folds in the next committee's keys — read at the same pin —
+    /// so the network can pre-resolve the successor committee. Produces a config scoped to this
+    /// epoch only.
     pub(super) async fn configure_consensus(
         &mut self,
         engine: &ExecutionNode,
         network_config: &NetworkConfig,
     ) -> eyre::Result<ConsensusConfig<DB>> {
-        // retrieve epoch information from canonical tip
-        let (committee, epoch_info, epoch_start) =
+        // retrieve epoch information pinned to the previous epoch's closing block
+        let (committee, epoch_info, epoch_start, epoch_start_header) =
             self.get_committee_with_epoch_start_info(engine).await?;
         let validators = committee.bls_keys();
 
@@ -250,7 +289,12 @@ where
 
         debug!(target: "epoch-manager", ?validators, "creating committee for validators");
 
-        let next_committee_keys = engine.validators_for_epoch(committee.epoch() + 1).await?;
+        // Pinned like every other epoch-scoped read in this path: the registry at the pin
+        // already serves the next epoch's committee, and a post-burn re-entry folds the same
+        // next-committee keys into the config as an on-time entry.
+        let next_committee_keys = engine
+            .validators_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
+            .await?;
 
         // create config for consensus
         let consensus_config = ConsensusConfig::new_for_epoch(

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -243,17 +243,18 @@ where
         // At the previous epoch's closing header the registry already serves the two future
         // epochs' committees (genesis seeds epochs 0-2; the `concludeEpoch` that seats epoch N
         // writes epoch N+2's committee inside that same closing block), and pinning keeps a
-        // post-burn re-entry prefetching the same sets an on-time entry prefetched — the
-        // prefetch is a best-effort network warm-up either way.
-        let next_committee_keys = engine
-            .validators_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
-            .await?;
-        prefetches.extend(next_committee_keys.iter());
-        prefetches.extend(
-            engine
-                .validators_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
-                .await?,
-        );
+        // post-burn re-entry prefetching the same sets an on-time entry prefetched. The
+        // prefetch is a best-effort network warm-up: the next committee's keys are reused from
+        // the config (already read at the pin — no second chain read to fail), and a failed
+        // epoch + 2 read is logged and skipped rather than aborting epoch start.
+        prefetches.extend(consensus_config.next_committee_keys().iter());
+        match engine
+            .validators_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
+            .await
+        {
+            Ok(keys) => prefetches.extend(keys),
+            Err(e) => warn!(target: "epoch-manager", ?e, "skipping epoch + 2 committee prefetch"),
+        }
         // Attempt to pre-load the next couple of committee's network info.
         let _ = primary_handle
             .inner_handle()

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -2202,7 +2202,10 @@ async fn test_epoch_record_chain_across_mid_epoch_ejection() -> eyre::Result<()>
     let reth_env =
         RethEnv::new_for_temp_chain(chain.clone(), reth_dir.path(), &task_manager, None)?;
 
-    // committee reads exactly as the node's engine performs them for `write_epoch_record`
+    // committee reads through the same `getCommitteeBlsPubkeys` path the node performs for
+    // `write_epoch_record`. The node pins that read to the epoch-closing block; every read
+    // below happens while the canonical tip IS the relevant closing block, so the tip read
+    // resolves the identical state.
     let keys_for_epoch = |e: u32| -> eyre::Result<Vec<BlsPublicKey>> {
         Ok(reth_env
             .bls_pubkeys_for_epoch(e)?

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -2316,6 +2316,169 @@ async fn test_epoch_record_chain_across_mid_epoch_ejection() -> eyre::Result<()>
     Ok(())
 }
 
+/// ENTRY-READ INVARIANT end-to-end: the previous epoch's closing block rules the ENTIRE epoch —
+/// re-entry timing cannot change the committee or the rewards rows.
+///
+/// A governance `burn` swap-and-pops the ejected validator out of the CURRENT epoch's stored
+/// committee arrays immediately, so a node re-entering `run_epoch` mid-epoch (crash-restart or
+/// ModeChange) that read the canonical tip would seed `RewardsCounter::set_committee` with the
+/// shrunken post-burn committee. `get_address_counts` resolves tallied authorities through that
+/// committee, so the ejected leader's accumulated reward row silently vanishes and the
+/// `generate_withdrawals` set the closing block commits diverges from peers that kept the
+/// epoch-start committee — a different `withdrawals_root`, a different closing-block hash, and
+/// a different epoch-record digest across the fleet. The entry read is therefore pinned to the
+/// previous epoch's closing block (`epoch_state_at_epoch_start`), making every entry shape
+/// derive the identical committee.
+///
+/// Four legs:
+/// - A: on-time entry (before the burn) derives the full committee from the pinned read and seeds
+///   the counter exactly as `run_epoch` does; every member tallies leader blocks.
+/// - B: after a mid-epoch burn, the RE-ENTRY pinned read returns the identical committee (victim
+///   included) while the tip read shows the shrunken set; re-seeding from the pinned read preserves
+///   the victim's row and the production close consumer (`generate_withdrawals`, the
+///   `withdrawals_root` input) still emits all N entries.
+/// - C: control proving the machinery detects the pre-fix bug — the same tallies seeded from the
+///   post-burn TIP committee drop the victim's row and emit N-1 withdrawals.
+/// - D: epoch 0 pins genesis, and the pinned-read committee equals the tip-read committee — entry
+///   semantics for the genesis epoch are unchanged.
+#[tokio::test]
+async fn mid_epoch_burn_reentry_keeps_epoch_start_committee_and_rewards() -> eyre::Result<()> {
+    const VICTIM_LEADER_BLOCKS: u32 = 7;
+
+    let reth_dir = TempDir::with_prefix("burn_reentry_reth")?;
+    // 5-validator registry genesis: one ejection leaves 4 members, so pinned (5) and tip (4)
+    // committee sizes are distinguishable
+    let genesis = test_genesis_with_consensus_registry(5);
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let task_manager = TaskManager::new("burn reentry test");
+    let reth_env =
+        RethEnv::new_for_temp_chain(chain.clone(), reth_dir.path(), &task_manager, None)?;
+
+    // block 1: close epoch 0 — this closing block seats epoch 1's committee and is the pin
+    // every epoch-1 entry read must derive from
+    let worker_id: WorkerId = 0;
+    let output1 = manual_consensus_output(1, 0, 1, true);
+    let payload1 = payload_with_base_fee(
+        chain.sealed_genesis_header(),
+        &output1,
+        MIN_PROTOCOL_BASE_FEE,
+        worker_id,
+    );
+    let block1 = execute_payload_and_update_canonical_chain(&reth_env, payload1, vec![])?;
+    let header1 = block1.recovered_block.clone_sealed_header();
+    assert_eq!(reth_env.epoch_state_from_canonical_tip()?.epoch, 1);
+
+    // Leg A — entry BEFORE the burn: the pinned read production performs at every entry
+    let (state_a, pin_a) = reth_env.epoch_state_at_epoch_start()?;
+    assert_eq!(state_a.epoch, 1);
+    assert_eq!(pin_a.hash(), header1.hash(), "pin is epoch 0's closing block");
+    // the soon-to-be-burned victim: a middle slot so swap-and-pop visibly reorders survivors
+    let victim_addr = state_a.validators[1].validatorAddress;
+    let victim_bls = BlsPublicKey::from_literal_bytes(state_a.bls_pubkeys[1].as_ref())
+        .map_err(|err| eyre::eyre!("failed to decode victim bls key: {err:?}"))?;
+    let committee_a = create_committee_from_state(state_a).await?;
+    assert_eq!(committee_a.epoch(), 1);
+    assert_eq!(committee_a.size(), 5, "on-time entry derives the full epoch-start committee");
+
+    // seed the counter exactly as run_epoch does at entry, then tally leader blocks for every
+    // member — the victim's count is distinctive so its row is unmistakable
+    let gas_accumulator = GasAccumulator::new(1);
+    let rewards = gas_accumulator.rewards_counter();
+    rewards.set_committee(committee_a.clone());
+    for authority in committee_a.authorities() {
+        let count =
+            if authority.execution_address() == victim_addr { VICTIM_LEADER_BLOCKS } else { 1 };
+        for _ in 0..count {
+            rewards.inc_leader_count(&authority.id());
+        }
+    }
+    let counts_a = rewards.get_address_counts();
+    assert_eq!(counts_a.len(), 5, "every committee member has a reward row");
+    assert_eq!(counts_a.get(&victim_addr), Some(&VICTIM_LEADER_BLOCKS));
+
+    // Leg B — mid-epoch burn, then re-entry (the crash-restart / ModeChange shape)
+    let mut governance = governance_owner_factory();
+    let burn_tx = governance_burn_tx(&mut governance, chain.clone(), victim_addr);
+    let output2 = manual_consensus_output(1, 1, 2, false);
+    let payload2 = payload_with_base_fee(header1, &output2, MIN_PROTOCOL_BASE_FEE, worker_id);
+    execute_payload_and_update_canonical_chain(&reth_env, payload2, vec![burn_tx])?;
+
+    // the tip view shrinks immediately — this is what a pre-fix re-entry would have read
+    let tip_state = reth_env.epoch_state_from_canonical_tip()?;
+    assert_eq!(tip_state.epoch, 1);
+    assert_eq!(tip_state.validators.len(), 4, "tip committee shrank post-burn");
+    assert!(tip_state.validators.iter().all(|v| v.validatorAddress != victim_addr));
+
+    // RE-ENTRY read: pinned to the same closing block, so the committee is IDENTICAL to leg
+    // A's — victim included; the pin is exactly what differs from the tip read above
+    let (state_b, pin_b) = reth_env.epoch_state_at_epoch_start()?;
+    assert_eq!(pin_b.hash(), pin_a.hash(), "pin unchanged by the burn");
+    let committee_b = create_committee_from_state(state_b).await?;
+    assert_eq!(
+        committee_b.bls_keys(),
+        committee_a.bls_keys(),
+        "re-entry derives the exact epoch-start committee"
+    );
+    assert!(committee_b.bls_keys().contains(&victim_bls), "the burned victim is still a member");
+
+    // re-seed from the pinned read as a real re-entry does: every accumulated reward row
+    // survives, and the production close consumer (generate_withdrawals feeds the closing
+    // block's withdrawals_root) still emits all 5 entries
+    rewards.set_committee(committee_b);
+    let counts_b = rewards.get_address_counts();
+    assert_eq!(counts_b, counts_a, "re-entry preserves every reward row");
+    let withdrawals_b = rewards.generate_withdrawals();
+    assert_eq!(withdrawals_b.len(), 5, "the epoch close pays every epoch-start member");
+    assert!(withdrawals_b
+        .iter()
+        .any(|w| w.address == victim_addr && w.amount == VICTIM_LEADER_BLOCKS as u64));
+
+    // Leg C — control: the same tallies seeded from the post-burn TIP committee drop the
+    // victim's row — the divergence the pin prevents, proving the assertions above would
+    // catch a regression to tip-seeded entry
+    let tip_committee = create_committee_from_state(tip_state).await?;
+    assert_eq!(tip_committee.size(), 4);
+    let control = GasAccumulator::new(1).rewards_counter();
+    for authority in committee_a.authorities() {
+        let count =
+            if authority.execution_address() == victim_addr { VICTIM_LEADER_BLOCKS } else { 1 };
+        for _ in 0..count {
+            control.inc_leader_count(&authority.id());
+        }
+    }
+    control.set_committee(tip_committee);
+    let control_counts = control.get_address_counts();
+    assert_eq!(control_counts.len(), 4, "tip seeding silently drops the ejected leader's row");
+    assert!(!control_counts.contains_key(&victim_addr));
+    let control_withdrawals = control.generate_withdrawals();
+    assert_eq!(control_withdrawals.len(), 4);
+    assert_ne!(
+        control_withdrawals, withdrawals_b,
+        "tip-seeded close builds different withdrawals — a divergent withdrawals_root"
+    );
+
+    // Leg D — epoch 0: a fresh chain pins genesis, and the pinned committee equals the tip
+    // committee — genesis-epoch entry semantics are unchanged by the pin
+    let fresh_dir = TempDir::with_prefix("burn_reentry_epoch0")?;
+    let fresh_task_manager = TaskManager::new("burn reentry epoch 0");
+    let fresh_env =
+        RethEnv::new_for_temp_chain(chain.clone(), fresh_dir.path(), &fresh_task_manager, None)?;
+    let (state_0, pin_0) = fresh_env.epoch_state_at_epoch_start()?;
+    assert_eq!(pin_0.number, 0, "epoch 0 pins genesis");
+    assert_eq!(state_0.epoch, 0);
+    let committee_0 = create_committee_from_state(state_0).await?;
+    let committee_0_tip =
+        create_committee_from_state(fresh_env.epoch_state_from_canonical_tip()?).await?;
+    assert_eq!(committee_0.size(), 5);
+    assert_eq!(
+        committee_0.bls_keys(),
+        committee_0_tip.bls_keys(),
+        "epoch 0's pinned view matches the tip view"
+    );
+
+    Ok(())
+}
+
 /// Helper to spawn consensus components.
 async fn spawn_consensus(
     fixture: &CommitteeFixture<MemDatabase>,

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -2012,18 +2012,19 @@ async fn test_derive_idle_worker_fee_eip1559_decays_from_last_produced_epoch() -
     Ok(())
 }
 
-/// One epoch-entry pass over the accumulator exactly as `run_epoch` performs it: read the
-/// entered epoch's state from the canonical tip, resolve the previous epoch's closing block
-/// (`blockHeight - 1`, written once at the boundary), and derive+apply the worker count and
-/// every worker's base fee from that pinned state. Epoch 0 has no prior epoch: the count syncs
-/// from genesis `WorkerConfigs` state and fees keep the MIN defaults.
+/// One epoch-entry pass over the accumulator exactly as `run_epoch` performs it: the atomic
+/// `epoch_state_at_epoch_start` read yields the entered epoch's state together with the pin
+/// header — the previous epoch's closing block (`blockHeight - 1`, written once at the
+/// boundary) — and the worker count and every worker's base fee derive+apply from that pinned
+/// state. Epoch 0 has no prior epoch: the count syncs from genesis `WorkerConfigs` state and
+/// fees keep the MIN defaults.
 fn run_epoch_entry_sequence(
     reth_env: &RethEnv,
     gas_accumulator: &GasAccumulator,
 ) -> eyre::Result<()> {
-    // run_epoch reads the entered epoch's info from the canonical tip; the values are written
-    // once at the boundary, so any mid-epoch tip serves identical ones
-    let entered_state = reth_env.epoch_state_from_canonical_tip()?;
+    // run_epoch's entry read is pinned to the previous epoch's closing block; the pin resolves
+    // from boundary-written-once scalars, so any mid-epoch tip yields the identical header
+    let (entered_state, epoch_start_header) = reth_env.epoch_state_at_epoch_start()?;
     if entered_state.epoch == 0 {
         sync_num_workers_from_chain(
             reth_env,
@@ -2031,15 +2032,7 @@ fn run_epoch_entry_sequence(
             entered_state.epoch_info.blockHeight,
         )?;
     } else {
-        let closing_number = entered_state
-            .epoch_info
-            .blockHeight
-            .checked_sub(1)
-            .ok_or_else(|| eyre::eyre!("entered epoch reports blockHeight 0"))?;
-        let closing = reth_env
-            .sealed_header_by_number(closing_number)?
-            .ok_or_else(|| eyre::eyre!("missing closing block {closing_number}"))?;
-        derive_base_fees_for_entered_epoch(reth_env, entered_state.epoch, &closing)?
+        derive_base_fees_for_entered_epoch(reth_env, entered_state.epoch, &epoch_start_header)?
             .apply(gas_accumulator);
     }
     Ok(())

--- a/crates/storage/src/consensus.rs
+++ b/crates/storage/src/consensus.rs
@@ -416,6 +416,31 @@ impl ConsensusChain {
         // original pack is load-bearing: this epoch's consensus output must be
         // decoded and verified against the committee the epoch started with.
         if old_pack.epoch() == committee.epoch() && !old_pack.is_static() {
+            // TRIPWIRE (diagnostics only): the pack's persisted committee is the epoch-START
+            // snapshot, and the entry `committee` is derived from a read pinned to that same
+            // epoch-start state — so the two BLS key sets can differ only if an unpinned
+            // (canonical-tip) entry read is ever reintroduced. Warn loudly at the first
+            // mid-epoch re-entry after a governance burn instead of staying silent until the
+            // epoch record splits. Do NOT error: either way the pack's epoch-start snapshot
+            // remains authoritative for decoding this epoch's output, and the re-entry must
+            // proceed.
+            let pack_keys = old_pack.committee().bls_keys();
+            let entry_keys = committee.bls_keys();
+            if pack_keys != entry_keys {
+                let missing_from_entry: Vec<_> = pack_keys.difference(&entry_keys).collect();
+                let added_in_entry: Vec<_> = entry_keys.difference(&pack_keys).collect();
+                warn!(
+                    target: "consensus-chain",
+                    epoch = committee.epoch(),
+                    pack_committee_len = pack_keys.len(),
+                    entry_committee_len = entry_keys.len(),
+                    ?missing_from_entry,
+                    ?added_in_entry,
+                    "same-epoch re-entry committee differs from the pack's epoch-start snapshot; \
+                     an unpinned (tip-based) entry read has likely been reintroduced — keeping \
+                     the pack's committee"
+                );
+            }
             return Ok(());
         }
         old_pack.persist().await?;
@@ -1403,6 +1428,7 @@ mod test {
 
     use crate::consensus::{ConsensusSlot, LatestConsensus};
     use std::{
+        collections::BTreeMap,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
@@ -1411,8 +1437,8 @@ mod test {
     };
 
     use tn_types::{
-        test_genesis, ConsensusHeader, ConsensusHeaderDigest, ConsensusNumHash, Epoch, EpochRecord,
-        Hash as _,
+        test_genesis, Authority, BlsPublicKey, Committee, ConsensusHeader, ConsensusHeaderDigest,
+        ConsensusNumHash, Epoch, EpochRecord, Hash as _,
     };
 
     use crate::{
@@ -2313,6 +2339,58 @@ mod test {
                 .expect("imported output readable after restart");
             compare_outputs(&got, output);
         }
+    }
+
+    /// A same-epoch `new_epoch` re-entry whose committee differs from the pack's persisted
+    /// epoch-start snapshot — what a canonical-tip-seeded entry read would pass after a
+    /// mid-epoch governance burn swap-and-pops a validator — must still return Ok and keep
+    /// the original pack untouched. The committee cross-check on that path is a warn-only
+    /// tripwire; the pack's epoch-start snapshot stays authoritative for decoding this
+    /// epoch's output.
+    #[tokio::test]
+    async fn test_same_epoch_reentry_with_shrunken_committee_keeps_pack() {
+        let temp_dir = TempDir::with_prefix("test_reentry_shrunken").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        let consensus_chain =
+            ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
+        // Open epoch 0 with committee A (the epoch-start snapshot the pack persists).
+        consensus_chain.new_epoch(previous_epoch.clone(), committee.clone()).await.unwrap();
+        assert_eq!(consensus_chain.current_pack().epoch(), 0);
+        assert_eq!(consensus_chain.current_pack().committee().bls_keys(), committee.bls_keys());
+
+        // Committee B: same epoch with one member dropped, mirroring the post-burn on-chain
+        // committee a tip-based read would return.
+        let mut authorities: BTreeMap<BlsPublicKey, Authority> =
+            committee.authorities().into_iter().map(|a| (*a.protocol_key(), a)).collect();
+        let (dropped, _) = authorities.pop_last().expect("fixture committee is non-empty");
+        let shrunken = Committee::new_for_test(authorities, 0, BTreeMap::default());
+        assert_eq!(shrunken.epoch(), committee.epoch());
+        assert!(shrunken.bls_keys().len() < committee.bls_keys().len());
+
+        // Same-epoch re-entry with the mismatched committee: Ok (the tripwire only warns),
+        // and the current pack is unchanged — same epoch, still committee A.
+        consensus_chain
+            .new_epoch(previous_epoch, shrunken)
+            .await
+            .expect("same-epoch re-entry with a mismatched committee must remain Ok");
+        let pack = consensus_chain.current_pack();
+        assert_eq!(pack.epoch(), 0, "re-entry must not change the current pack's epoch");
+        assert_eq!(
+            pack.committee().bls_keys(),
+            committee.bls_keys(),
+            "pack must retain the epoch-start committee snapshot"
+        );
+        assert!(
+            pack.committee().bls_keys().contains(&dropped),
+            "the burned member stays in the pack's snapshot for decoding this epoch"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -338,6 +338,16 @@ impl ConsensusPack {
         self.epoch
     }
 
+    /// Return the committee persisted in this pack's [`EpochMeta`] — the epoch-START
+    /// snapshot this epoch's consensus output is decoded and verified against.
+    ///
+    /// Every open path keeps this handle-level copy faithful to the on-disk meta:
+    /// `open_append` either writes it as the new meta or errors on a meta mismatch, and
+    /// the reopen/import paths clone it out of the persisted record.
+    pub(crate) fn committee(&self) -> &Committee {
+        &self.committee
+    }
+
     /// Save all the batches and consensus header from the ConsensusOutput the pack file.
     /// Returns when save is complete and provides how many bytes the output took in the pack file.
     pub async fn save_consensus_output(

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1709,6 +1709,12 @@ impl RethEnv {
     /// - get current epoch info
     /// - getValidator token id by address
     /// - getValidator info by token id
+    ///
+    /// The committee arrays this returns mutate mid-epoch: a governance `burn` swap-and-pops the
+    /// ejected validator out of the CURRENT epoch's stored committees immediately, so tip reads
+    /// before and after the burn disagree. Epoch-scoped consensus reads (committee construction,
+    /// rewards seeding, quorum) must use [`Self::epoch_state_at_epoch_start`] instead; the tip
+    /// read remains correct for point-in-time queries.
     pub fn epoch_state_from_canonical_tip(&self) -> eyre::Result<EpochState> {
         let canonical_tip = self.canonical_tip();
         debug!(target: "engine", ?canonical_tip, "retrieving epoch state from canonical tip");
@@ -1756,6 +1762,71 @@ impl RethEnv {
         Ok(epoch_state)
     }
 
+    /// Read the CURRENT epoch's [`EpochState`] pinned to the epoch's start state — the previous
+    /// epoch's closing block (genesis for epoch 0) — returning the pin header alongside it.
+    ///
+    /// Bootstrapping reads the current epoch number and its
+    /// [`EpochInfo`](ConsensusRegistry::EpochInfo) at the canonical tip. This is deterministic at
+    /// ANY tip because `concludeEpoch` writes the epoch number and the `EpochInfo` scalars this
+    /// method consumes (`blockHeight`) exactly once at the boundary and never mid-epoch — only
+    /// the committee ARRAYS mutate mid-epoch (governance `burn` swap-and-pops immediately,
+    /// including the committee embedded in `EpochInfo`), which is why the full state read below
+    /// is pinned instead of taken at the tip.
+    ///
+    /// The pin: `epoch_info.blockHeight` is the entered epoch's first block, so `blockHeight - 1`
+    /// is the previous epoch's closing block — the block whose execution ran `concludeEpoch` and
+    /// seated the entered committee. For epoch 0 the pin is genesis, whose execution seeds the
+    /// registry: genesis state IS epoch 0's start state.
+    ///
+    /// Every field of the returned state derives from the previous epoch's closing block, so any
+    /// node entering (or re-entering) the same epoch — fresh boundary crossing, crash-restart
+    /// replay, or ModeChange re-entry, before or after a mid-epoch burn — derives an IDENTICAL
+    /// epoch view (committee membership included).
+    pub fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
+        // boundary-written-once identity read: deterministic at any tip
+        let (epoch, epoch_info) = self.get_current_epoch_info_at_header(&self.canonical_tip())?;
+
+        let pin_header = if epoch == 0 {
+            self.sealed_header_by_number(0)?.ok_or_else(|| eyre::eyre!("missing genesis header"))?
+        } else {
+            let closing_number = epoch_info
+                .blockHeight
+                .checked_sub(1)
+                .ok_or_else(|| eyre::eyre!("current epoch {epoch} reports blockHeight 0"))?;
+            self.sealed_header_by_number(closing_number)?.ok_or_else(|| {
+                eyre::eyre!("missing closing block {closing_number} for current epoch {epoch}")
+            })?
+        };
+        debug!(
+            target: "engine",
+            ?epoch,
+            pin_number = pin_header.number,
+            pin_hash = ?pin_header.hash(),
+            "retrieving epoch state at epoch start"
+        );
+
+        let state = self.epoch_state_at_header(&pin_header)?;
+
+        // Tripwire: `concludeEpoch` executes INSIDE the closing block, so the registry at the
+        // closing header already reports the entered epoch. This can only fire if the registry's
+        // `blockHeight == closing block + 1` convention ever breaks — running a stale committee
+        // is a consensus-safety failure, so fail hard instead of returning the mismatched state.
+        debug_assert_eq!(
+            state.epoch, epoch,
+            "epoch state pinned to the closing block reports a different epoch"
+        );
+        if state.epoch != epoch {
+            return Err(eyre::eyre!(
+                "epoch state pinned to block {} reports epoch {} but the canonical tip reports \
+                 epoch {epoch}",
+                pin_header.number,
+                state.epoch
+            ));
+        }
+
+        Ok((state, pin_header))
+    }
+
     /// Read the latest committee and epoch information from the [ConsensusRegistry] on-chain.
     pub fn validators_for_epoch(
         &self,
@@ -1766,11 +1837,48 @@ impl RethEnv {
         self.read_consensus_registry(calldata).map_err(Into::into)
     }
 
+    /// Read the committee validators for the provided epoch from the [ConsensusRegistry], pinned
+    /// to the state of the block identified by `block_hash`.
+    ///
+    /// Unlike [`Self::validators_for_epoch`], which reads the mutable canonical tip, every node
+    /// issuing this read at the same block decodes the identical committee — even after a
+    /// mid-epoch governance `burn` swap-and-pops the stored committee arrays.
+    pub fn validators_for_epoch_at_block(
+        &self,
+        epoch: u32,
+        block_hash: B256,
+    ) -> eyre::Result<Vec<ConsensusRegistry::ValidatorInfo>> {
+        debug!(target: "engine", ?block_hash, "retrieving validators for epoch {epoch} at pinned block");
+        let header = self
+            .sealed_header_by_hash(block_hash)?
+            .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
+        let calldata = ConsensusRegistry::getCommitteeValidatorsCall { epoch }.abi_encode().into();
+        self.read_consensus_registry_at_header(&header, calldata).map_err(Into::into)
+    }
+
     /// Read the BLS pubkeys for the committee of the provided epoch from the [ConsensusRegistry]
     /// on-chain.
     pub fn bls_pubkeys_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
         let calldata = ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into();
         self.read_consensus_registry(calldata).map_err(Into::into)
+    }
+
+    /// Read the BLS pubkeys for the committee of the provided epoch from the
+    /// [ConsensusRegistry], pinned to the state of the block identified by `block_hash`.
+    ///
+    /// Unlike [`Self::bls_pubkeys_for_epoch`], which reads the mutable canonical tip, every node
+    /// issuing this read at the same block decodes the identical key set — even after a
+    /// mid-epoch governance `burn` swap-and-pops the stored committee arrays.
+    pub fn bls_pubkeys_for_epoch_at_block(
+        &self,
+        epoch: u32,
+        block_hash: B256,
+    ) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
+        let header = self
+            .sealed_header_by_hash(block_hash)?
+            .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
+        let calldata = ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into();
+        self.read_consensus_registry_at_header(&header, calldata).map_err(Into::into)
     }
 
     /// Build an EVM at the canonical tip, execute a read-only [ConsensusRegistry] call, and
@@ -1790,7 +1898,45 @@ impl RethEnv {
         })
     }
 
+    /// Build an EVM at `header`'s state, execute a read-only [ConsensusRegistry] call, and
+    /// decode the returned data to `T`.
+    ///
+    /// Convenience wrapper over [`Self::read_consensus_registry_batch_at_header`] for the common
+    /// single-read case (one pinned EVM, one call).
+    pub fn read_consensus_registry_at_header<T>(
+        &self,
+        header: &SealedHeader,
+        calldata: Bytes,
+    ) -> EvmReadResult<T>
+    where
+        T: alloy::sol_types::SolValue,
+        T: From<
+            <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
+        >,
+    {
+        self.read_consensus_registry_batch_at_header(header, vec![calldata])?.pop().ok_or_else(
+            || EvmReadError::Internal("consensus registry batch read returned no result".into()),
+        )
+    }
+
     /// Build a single EVM at the canonical tip and execute several read-only [ConsensusRegistry]
+    /// calls against it, decoding each result to `T`.
+    ///
+    /// Thin specialization of [`Self::read_consensus_registry_batch_at_header`] that pins the
+    /// batch to the canonical tip.
+    pub fn read_consensus_registry_batch<T>(&self, calldatas: Vec<Bytes>) -> EvmReadResult<Vec<T>>
+    where
+        T: alloy::sol_types::SolValue,
+        T: From<
+            <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
+        >,
+    {
+        let canonical_tip = self.canonical_tip();
+        debug!(target: "engine", ?canonical_tip, "reading consensus registry batch at canonical tip");
+        self.read_consensus_registry_batch_at_header(&canonical_tip, calldatas)
+    }
+
+    /// Build a single EVM at `header`'s state and execute several read-only [ConsensusRegistry]
     /// calls against it, decoding each result to `T`.
     ///
     /// Every calldata in a batch must decode to the same Solidity type `T` (current caller: five
@@ -1801,27 +1947,29 @@ impl RethEnv {
     /// validator that changes status between reads. Each call still runs under its own fresh 30M
     /// gas budget (`transact_system_call`), so splitting a large query across calls keeps gas
     /// bounded per call.
-    pub fn read_consensus_registry_batch<T>(&self, calldatas: Vec<Bytes>) -> EvmReadResult<Vec<T>>
+    pub fn read_consensus_registry_batch_at_header<T>(
+        &self,
+        header: &SealedHeader,
+        calldatas: Vec<Bytes>,
+    ) -> EvmReadResult<Vec<T>>
     where
         T: alloy::sol_types::SolValue,
         T: From<
             <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
         >,
     {
-        // create EVM with latest state
-        let canonical_tip = self.canonical_tip();
-        debug!(target: "engine", ?canonical_tip, "reading consensus registry batch at canonical tip");
+        // create EVM with the state at the pinned header
         let state_provider = self
             .inner
             .blockchain_provider
-            .state_by_block_hash(canonical_tip.hash())
+            .state_by_block_hash(header.hash())
             .map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder().with_database(state).with_bundle_update().build();
         let evm_env = self
             .inner
             .evm_config
-            .evm_env(&canonical_tip)
+            .evm_env(header)
             .map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
@@ -3768,6 +3916,199 @@ mod tests {
             assert_eq!(epoch, close);
             assert!(committee.iter().all(|v| v.validatorAddress != target));
         }
+
+        Ok(())
+    }
+
+    /// `epoch_state_at_epoch_start` pins every read to the previous epoch's closing block, so a
+    /// mid-epoch governance `burn` — which swap-and-pops the CURRENT epoch's stored committee
+    /// arrays immediately — moves the canonical-tip view but never the epoch-start view. A node
+    /// entering (or re-entering) the epoch before or after the burn derives the identical
+    /// committee.
+    #[tokio::test]
+    async fn epoch_state_at_epoch_start_pins_pre_burn_committee() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Epoch Start Pin Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        // block 1: plain epoch-0 block
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let header1 = block1.recovered_block.clone_sealed_header();
+
+        // block 2: close epoch 0 — `concludeEpoch` executes inside this block, making it epoch
+        // 0's closing block (the header that rules all of epoch 1)
+        let consensus_output = consensus_output_for_tests(2, 1, 2, true);
+        let payload = TNPayload::new_for_test(header1, &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let closing_header = block2.recovered_block.clone_sealed_header();
+
+        // snapshot A: epoch 1's start state, pinned to epoch 0's closing block
+        let (snapshot_a, pin_a) = reth_env.epoch_state_at_epoch_start()?;
+        assert_eq!(snapshot_a.epoch, 1);
+        assert_eq!(snapshot_a.validators.len(), 5, "full pre-burn committee");
+        assert_eq!(snapshot_a.bls_pubkeys.len(), 5);
+        assert_eq!(pin_a.hash(), closing_header.hash(), "pin is epoch 0's closing block");
+
+        // block 3: governance burns a committee member mid-epoch-1
+        let target = snapshot_a.validators[1].validatorAddress;
+        let target_bls = snapshot_a.bls_pubkeys[1].clone();
+        let mut governance = governance_owner_factory();
+        let burn_tx = governance_burn_tx(&mut governance, chain.clone(), target);
+        let consensus_output = consensus_output_for_tests(2, 1, 3, false);
+        let payload = TNPayload::new_for_test(closing_header, &consensus_output);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![burn_tx])?;
+
+        // the tip view shrinks immediately (swap-and-pop)
+        let tip_state = reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(tip_state.epoch, 1);
+        assert_eq!(tip_state.validators.len(), 4, "tip committee shrank post-burn");
+        assert_eq!(tip_state.bls_pubkeys.len(), 4);
+        assert!(tip_state.validators.iter().all(|v| v.validatorAddress != target));
+        assert!(!tip_state.bls_pubkeys.contains(&target_bls));
+
+        // the epoch-start view still returns the full pre-burn set, byte-identical to snapshot A
+        let (snapshot_b, pin_b) = reth_env.epoch_state_at_epoch_start()?;
+        assert_eq!(pin_b.hash(), pin_a.hash(), "pin unchanged by the burn");
+        assert_eq!(snapshot_b.epoch, snapshot_a.epoch);
+        assert_eq!(snapshot_b.epoch_info, snapshot_a.epoch_info);
+        assert_eq!(snapshot_b.epoch_start, snapshot_a.epoch_start);
+        assert_eq!(snapshot_b.validators, snapshot_a.validators);
+        assert_eq!(snapshot_b.bls_pubkeys, snapshot_a.bls_pubkeys);
+        assert!(snapshot_b.validators.iter().any(|v| v.validatorAddress == target));
+        assert!(snapshot_b.bls_pubkeys.contains(&target_bls));
+
+        // the boundary-written-once EpochInfo scalars agree between the tip and pinned reads;
+        // the committee array embedded in EpochInfo is exactly what the burn mutates, so it is
+        // the only field that diverges
+        assert_eq!(tip_state.epoch, snapshot_b.epoch);
+        assert_eq!(tip_state.epoch_info.blockHeight, snapshot_b.epoch_info.blockHeight);
+        assert_eq!(tip_state.epoch_info.epochId, snapshot_b.epoch_info.epochId);
+        assert_eq!(tip_state.epoch_info.epochDuration, snapshot_b.epoch_info.epochDuration);
+        assert_eq!(tip_state.epoch_info.epochIssuance, snapshot_b.epoch_info.epochIssuance);
+        assert_eq!(tip_state.epoch_info.stakeVersion, snapshot_b.epoch_info.stakeVersion);
+        assert_eq!(tip_state.epoch_start, snapshot_b.epoch_start);
+        assert_eq!(tip_state.epoch_info.committee.len(), 4, "burn mutates EpochInfo's committee");
+        assert_eq!(snapshot_b.epoch_info.committee.len(), 5);
+
+        Ok(())
+    }
+
+    /// Next-committee prefetches pinned to the epoch-start header read the PRE-burn future
+    /// committees. At epoch 0's closing block the registry already reports epoch 1 and serves
+    /// `getCommitteeValidators`/`getCommitteeBlsPubkeys` for epochs 2 and 3 (genesis seeds
+    /// epochs 0-2; `concludeEpoch` writes epoch 3's committee inside the closing block), so a
+    /// node re-entering epoch 1 after a mid-epoch burn derives the same future sets it would
+    /// have derived entering before the burn. The tip variants of the same reads observe the
+    /// post-burn (shrunken) sets, proving the pin is what makes the difference.
+    #[tokio::test]
+    async fn pinned_next_committee_prefetch_reads_pre_burn_sets() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Pinned Prefetch Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        // block 1: plain epoch-0 block
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let header1 = block1.recovered_block.clone_sealed_header();
+
+        // block 2: close epoch 0 (epoch 0's closing block)
+        let consensus_output = consensus_output_for_tests(2, 1, 2, true);
+        let payload = TNPayload::new_for_test(header1, &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let closing_header = block2.recovered_block.clone_sealed_header();
+
+        // pre-burn snapshots of the epoch 2 and 3 committees (the tip IS the closing block here)
+        let pre_v2 = reth_env.validators_for_epoch(2)?;
+        let pre_v3 = reth_env.validators_for_epoch(3)?;
+        let pre_b2 = reth_env.bls_pubkeys_for_epoch(2)?;
+        let pre_b3 = reth_env.bls_pubkeys_for_epoch(3)?;
+        assert_eq!(pre_v2.len(), 5);
+        assert_eq!(pre_v3.len(), 5);
+
+        // block 3: governance burns a committee member mid-epoch-1 (with exactly 5 eligible
+        // validators every committee seats all 5, so the target sits in epochs 1, 2, and 3)
+        let EpochState { validators, bls_pubkeys, .. } =
+            reth_env.epoch_state_from_canonical_tip()?;
+        let target = validators[1].validatorAddress;
+        let target_bls = bls_pubkeys[1].clone();
+        let mut governance = governance_owner_factory();
+        let burn_tx = governance_burn_tx(&mut governance, chain.clone(), target);
+        let consensus_output = consensus_output_for_tests(2, 1, 3, false);
+        let payload = TNPayload::new_for_test(closing_header.clone(), &consensus_output);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![burn_tx])?;
+
+        // pinned prefetches at the epoch-start header: epoch+1 and epoch+2 relative to the
+        // running epoch 1 still return the PRE-burn sets
+        let (state, pin) = reth_env.epoch_state_at_epoch_start()?;
+        assert_eq!(state.epoch, 1);
+        assert_eq!(pin.hash(), closing_header.hash());
+        let pinned_v2 = reth_env.validators_for_epoch_at_block(2, pin.hash())?;
+        let pinned_v3 = reth_env.validators_for_epoch_at_block(3, pin.hash())?;
+        assert_eq!(pinned_v2, pre_v2, "epoch 2 committee at the pin is the pre-burn set");
+        assert_eq!(pinned_v3, pre_v3, "epoch 3 committee at the pin is the pre-burn set");
+        assert!(pinned_v2.iter().any(|v| v.validatorAddress == target));
+        assert!(pinned_v3.iter().any(|v| v.validatorAddress == target));
+        let pinned_b2 = reth_env.bls_pubkeys_for_epoch_at_block(2, pin.hash())?;
+        let pinned_b3 = reth_env.bls_pubkeys_for_epoch_at_block(3, pin.hash())?;
+        assert_eq!(pinned_b2, pre_b2, "epoch 2 pubkeys at the pin are the pre-burn set");
+        assert_eq!(pinned_b3, pre_b3, "epoch 3 pubkeys at the pin are the pre-burn set");
+        assert!(pinned_b2.contains(&target_bls));
+        assert!(pinned_b3.contains(&target_bls));
+
+        // the tip variant of the same read shows the post-burn set: the pin is what makes the
+        // difference
+        let tip_v2 = reth_env.validators_for_epoch(2)?;
+        assert_eq!(tip_v2.len(), 4);
+        assert!(tip_v2.iter().all(|v| v.validatorAddress != target));
+
+        Ok(())
+    }
+
+    /// In epoch 0 the pin is genesis: genesis execution seeds the registry, so genesis state IS
+    /// epoch 0's start state. The pinned view matches the canonical-tip view field for field at
+    /// genesis and keeps pinning genesis after the chain advances within the epoch.
+    #[tokio::test]
+    async fn epoch_state_at_epoch_start_epoch_zero_pins_genesis() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Epoch Zero Pin Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        // fresh chain still in epoch 0: the pin is the genesis header
+        let (state, pin) = reth_env.epoch_state_at_epoch_start()?;
+        assert_eq!(pin.number, 0, "epoch 0 pins genesis");
+        assert_eq!(pin.hash(), chain.sealed_genesis_header().hash());
+
+        // at genesis the tip and the pin are the same block, so the views agree field for field
+        let tip_state = reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(state.epoch, 0);
+        assert_eq!(state.epoch, tip_state.epoch);
+        assert_eq!(state.epoch_info, tip_state.epoch_info);
+        assert_eq!(state.epoch_start, tip_state.epoch_start);
+        assert_eq!(state.validators, tip_state.validators);
+        assert_eq!(state.bls_pubkeys, tip_state.bls_pubkeys);
+        assert_eq!(state.validators.len(), 5);
+
+        // the pin stays genesis after the chain advances within epoch 0
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let (state_after, pin_after) = reth_env.epoch_state_at_epoch_start()?;
+        assert_eq!(pin_after.number, 0);
+        assert_eq!(state_after.epoch, 0);
+        assert_eq!(state_after.validators, state.validators);
+        assert_eq!(state_after.bls_pubkeys, state.bls_pubkeys);
 
         Ok(())
     }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1961,7 +1961,15 @@ impl RethEnv {
             <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
         >,
     {
-        // create EVM with the state at the pinned header
+        // Create EVM with the state at the pinned header.
+        //
+        // ARCHIVE-MODE ASSUMPTION: this node never constructs a pruner (`PruningArgs` are built
+        // with every field disabled and no `PrunerBuilder` exists in the repo), so
+        // `state_by_block_hash` always resolves fully indexed history. If pruning is ever
+        // enabled, reth's `HistoricalStateProvider` can hit a missing history shard and return
+        // `HistoryInfo::MaybeInPlainState`, silently falling back to TIP state for this
+        // "pinned" read — exactly the nondeterminism pinning exists to prevent. Revisit every
+        // pinned registry read before enabling pruning.
         let state_provider = self
             .inner
             .blockchain_provider

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1811,11 +1811,14 @@ impl RethEnv {
         // closing header already reports the entered epoch. This can only fire if the registry's
         // `blockHeight == closing block + 1` convention ever breaks — running a stale committee
         // is a consensus-safety failure, so fail hard instead of returning the mismatched state.
-        debug_assert_eq!(
-            state.epoch, epoch,
-            "epoch state pinned to the closing block reports a different epoch"
-        );
         if state.epoch != epoch {
+            error!(
+                target: "engine",
+                pin_number = pin_header.number,
+                pinned_epoch = state.epoch,
+                tip_epoch = epoch,
+                "epoch-start pin and canonical tip disagree on the current epoch"
+            );
             return Err(eyre::eyre!(
                 "epoch state pinned to block {} reports epoch {} but the canonical tip reports \
                  epoch {epoch}",

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -618,4 +618,85 @@ mod tests {
         evm_handle.inc_leader_count(&leader);
         assert_eq!(acc.rewards_counter().leader_counts.lock().get(&leader), Some(&1));
     }
+
+    /// `get_address_counts` resolves every tallied [`AuthorityIdentifier`] through the
+    /// CURRENTLY-set committee: a tallied authority the committee no longer contains is silently
+    /// skipped — its row vanishes from the map (and therefore from `generate_withdrawals`),
+    /// neither zeroed nor errored. The underlying tally survives, so restoring the original
+    /// committee restores the row: the drop is a property of the committee view, not data loss.
+    ///
+    /// This drop semantic is why the epoch-entry committee read must be pinned to the epoch's
+    /// start state (the previous epoch's closing block): a node re-entering an epoch after a
+    /// mid-epoch governance burn that seeds this counter from the post-burn tip committee
+    /// silently drops the ejected leader's reward row, and the withdrawals it builds at the
+    /// epoch close diverge from peers that kept the epoch-start committee — a different
+    /// `withdrawals_root`, so a different closing-block hash.
+    #[test]
+    fn get_address_counts_drops_rows_for_non_committee_authorities() {
+        use crate::{BlsKeypair, CommitteeBuilder};
+        use rand::rng;
+
+        const VICTIM_LEADER_BLOCKS: u32 = 7;
+
+        let mut rng = rng();
+        let keypairs: Vec<BlsKeypair> = (0..4).map(|_| BlsKeypair::generate(&mut rng)).collect();
+        let addresses: Vec<Address> = (0..4).map(|i| Address::repeat_byte(i as u8 + 1)).collect();
+
+        // committee A: all 4 authorities (the epoch-start committee)
+        let mut builder = CommitteeBuilder::new(1);
+        for (keypair, address) in keypairs.iter().zip(addresses.iter()) {
+            builder.add_authority(*keypair.public(), *address);
+        }
+        let committee_a = builder.build();
+
+        let counter = RewardsCounter::default();
+        counter.set_committee(committee_a.clone());
+
+        // tally every member; the victim (index 0) gets a distinctive count
+        let ids: Vec<AuthorityIdentifier> = keypairs
+            .iter()
+            .map(|keypair| {
+                committee_a
+                    .authority_by_key(keypair.public())
+                    .expect("keypair is a committee member")
+                    .id()
+            })
+            .collect();
+        let victim_address = addresses[0];
+        for (i, id) in ids.iter().enumerate() {
+            let count = if i == 0 { VICTIM_LEADER_BLOCKS } else { 1 };
+            for _ in 0..count {
+                counter.inc_leader_count(id);
+            }
+        }
+
+        // with committee A set, every member has a row
+        let counts = counter.get_address_counts();
+        assert_eq!(counts.len(), 4);
+        assert_eq!(counts.get(&victim_address), Some(&VICTIM_LEADER_BLOCKS));
+        for address in &addresses[1..] {
+            assert_eq!(counts.get(address), Some(&1));
+        }
+
+        // committee B = A minus the victim (a post-burn tip read's committee)
+        let mut builder = CommitteeBuilder::new(1);
+        for (keypair, address) in keypairs.iter().zip(addresses.iter()).skip(1) {
+            builder.add_authority(*keypair.public(), *address);
+        }
+        counter.set_committee(builder.build());
+
+        // the victim's accumulated count is silently dropped — not zeroed, not an error
+        let counts = counter.get_address_counts();
+        assert_eq!(counts.len(), 3, "the non-member's row is dropped from the view");
+        assert!(!counts.contains_key(&victim_address));
+        for address in &addresses[1..] {
+            assert_eq!(counts.get(address), Some(&1), "surviving rows are unchanged");
+        }
+
+        // the tally itself survived: restoring committee A restores the row intact
+        counter.set_committee(committee_a);
+        let counts = counter.get_address_counts();
+        assert_eq!(counts.len(), 4);
+        assert_eq!(counts.get(&victim_address), Some(&VICTIM_LEADER_BLOCKS));
+    }
 }


### PR DESCRIPTION
- Add `RethEnv::epoch_state_at_epoch_start` plus pinned `validators_for_epoch_at_block` / `bls_pubkeys_for_epoch_at_block` reads, and generalize the ConsensusRegistry EVM-read helpers to run against an arbitrary header instead of only the canonical tip.
- Route every epoch-entry read in `run_epoch`/`start_epoch` and the engine layer through the pinned primitive; the engine no longer exposes an unpinned committee read on the entry path, so it can't be reached by accident.
- Keep epoch-close reads (`close_epoch.rs`) pinned to the epoch-closing block on purpose — refactored to compute that header once up front (one-header discipline) rather than changing what it reads.
- Add a warn-only tripwire in the consensus pack's committee cross-check that flags a same-epoch re-entry whose derived committee disagrees with the pack's persisted epoch-start snapshot.
- New coverage: a `RewardsCounter` unit test isolating the row-drop semantics that make an unpinned re-entry dangerous, a four-leg `RethEnv` determinism test around a mid-epoch burn + re-entry, and a flagship e2e test that kills and restarts a committee member mid-epoch after a different validator's ejection — asserting the restart rejoins consensus and every node closes the epoch with hash-identical records.

closes #968 