### PR TITLE
fix: floor the parent-round GC key in insert_pending to avoid a round-0 underflow

### DIFF
--- a/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
@@ -55,13 +55,19 @@ impl PendingCertificateManager {
     /// Attempts to insert a new pending certificate.
     ///
     /// Callers must ensure certificates are verified before inserting into pending state.
+    /// The sole caller only admits certificates above `gc_round + 1`, so the round is expected
+    /// to be >= 2; the parent-round key below floors at 0 regardless, so this helper stays
+    /// underflow-safe independent of that caller-side gate (see #887).
     pub(super) fn insert_pending(
         &mut self,
         certificate: Certificate,
         missing_parents: HashSet<HeaderDigest>,
     ) -> CertManagerResult<()> {
         let digest = certificate.digest();
-        let parent_round = certificate.round() - 1;
+        // `saturating_sub` keeps this helper underflow-safe on its own: a round-0 certificate
+        // must not wrap to `u32::MAX`, a key `next_for_gc_round` would never collect
+        // (see #887, the pending-path sibling of #789).
+        let parent_round = certificate.round().saturating_sub(1);
         debug!(target: "primary::pending_certs", ?digest, "Processing certificate with missing parents");
 
         // track pending certificate

--- a/crates/consensus/primary/src/tests/certificate_processing_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_processing_tests.rs
@@ -3,7 +3,10 @@
 //! Certificates are validated and sent to the [CertificateManager].
 //! The [CertificateManager] tracks pending certificates and accepts certificates that are complete.
 
-use super::{cert_manager::CertificateManager, cert_validator::CertificateValidator};
+use super::{
+    cert_manager::CertificateManager, cert_validator::CertificateValidator,
+    pending_cert_manager::PendingCertificateManager,
+};
 use crate::{error::CertManagerError, state_sync::HeaderValidator, ConsensusBus};
 use assert_matches::assert_matches;
 use std::{collections::BTreeSet, time::Duration};
@@ -430,6 +433,35 @@ async fn test_filter_unknown_parents() -> eyre::Result<()> {
     let mut expected: Vec<_> = first_round.iter().map(|c| c.digest()).collect();
     expected.sort_by(sort_by_digest);
     assert_eq!(expected, unknown);
+
+    Ok(())
+}
+
+/// Regression test for #887: `insert_pending` keys `missing_for_pending` by the certificate's
+/// parent round. A round-0 certificate must floor that key at round 0 instead of underflowing
+/// `round - 1` (on the release binary `0u32 - 1` wraps to `u32::MAX`, an entry
+/// `next_for_gc_round` can never collect; in debug the subtraction panics). The only current
+/// caller gates on `round > gc_round + 1`, so this exercises the helper's own defense-in-depth
+/// guard rather than a reachable production path.
+#[test]
+fn test_insert_pending_floors_parent_round_at_genesis() -> eyre::Result<()> {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let committee = fixture.committee();
+
+    // round-0 (genesis) certificates: one to insert as pending, another to act as the
+    // missing-parent digest
+    let genesis = Certificate::genesis(&committee);
+    let cert = genesis.first().cloned().ok_or_else(|| eyre::eyre!("no genesis certificates"))?;
+    let parent =
+        genesis.last().map(|c| c.digest()).ok_or_else(|| eyre::eyre!("no parent digest"))?;
+
+    let mut pending = PendingCertificateManager::new();
+    pending.insert_pending(cert, std::iter::once(parent).collect())?;
+
+    // the missing-parent key floors at round 0 and stays reachable for garbage collection
+    // (an underflowed `(u32::MAX, digest)` key would make `next_for_gc_round` return `None`
+    // forever)
+    assert_eq!(pending.next_for_gc_round(0), Some((0, parent)));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #887.  `PendingCertificateManager::insert_pending` computes `certificate.round() - 1` with no `saturating_sub` and no local guarantee that `round >= 1` (`pending_cert_manager.rs:64`).  `Round` is `u32`, so a round-0 certificate would evaluate `0u32 - 1`: on the release binary (overflow-checks off) it wraps to `u32::MAX`, and in debug it panics.  The result keys `missing_for_pending`, whose GC cursor (`next_for_gc_round`) stops as soon as the smallest remaining key's round exceeds the gc round, so a `(u32::MAX, digest)` entry would never be collected and its pending certificate could never be unblocked.

This is not reachable in the current code.  The sole caller, `CertificateManager::process_verified_certificates`, only calls `insert_pending` behind `cert.round() > self.gc_round() + 1`, and `gc_round()` floors at 0, so only certificates with `round >= 2` reach the subtraction.  The fragility is that the invariant lives in a different function in a different file;  the helper itself neither enforced nor documented it.  Same latent class as the header-path `header.round() - 1` underflow fixed by #888 (issue #789), which established the convention of not leaving an unchecked `round - 1` whose safety is a cross-module invariant.

## Fix

- `certificate.round().saturating_sub(1)` at the GC-key computation, so the helper is underflow-safe on its own: a round-0 certificate floors to parent round 0 (collectable) instead of wrapping to `u32::MAX` (never collectable).
- Document the `round >= 2` expectation on `insert_pending` alongside the existing "callers must ensure certificates are verified" precondition, so the caller-side gate is at least visible at the helper.

No behavior change on any reachable path: for every certificate that reaches this code today (`round >= 2`), `saturating_sub(1)` and `- 1` are identical.

### Why not `debug_assert!(round >= 2)` instead?

The issue offered either enforcing the precondition locally or documenting it.  Flooring makes the helper total (safe for any input), which is strictly stronger than asserting, and an assert would turn a hypothetical future round-0/1 caller into a debug-only crash rather than a benign floor.  The regression test also deliberately exercises the helper at round 0, which an assert would forbid.

## Tests

- `test_insert_pending_floors_parent_round_at_genesis` (in `certificate_processing_tests.rs`, which is mounted inside `state_sync` and can reach the `pub(super)` API): inserts a round-0 genesis certificate with a missing parent and asserts `next_for_gc_round(0)` returns the `(0, parent)` key.  Pre-fix this test panics in debug (`attempt to subtract with overflow`) and fails in release (`next_for_gc_round` returns `None` forever, the leak described above).

## References

- `crates/consensus/primary/src/state_sync/pending_cert_manager.rs` (the subtraction, the GC-keyed insert, `next_for_gc_round`)
- `crates/consensus/primary/src/state_sync/cert_manager.rs:108-111` (the sole guarding gate and only caller)
- Sibling: #789 / #888 (same `round - 1` underflow class on the header/vote path)
