### PR TITLE
fix(consensus): close the two anti-equivocation guards #940 left non-durable (#963)

### DIFF
--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -445,6 +445,23 @@ impl<DB: Database> Certifier<DB> {
                             return Err(TaskError::from_message(e.to_string()));
                         }
 
+                        // Release the proposal lock now that the guard record is written.
+                        //
+                        // The lock exists to make the already-certified check at the top of this
+                        // method atomic with the insert above, and that pair is now complete: the
+                        // insert updates the in-memory layer synchronously, so any later proposal
+                        // reaching that check already observes this certificate. Nothing below
+                        // needs the exclusion.
+                        //
+                        // Holding it across the barrier would be actively harmful, because
+                        // `persist_durable` is a *whole-DB* barrier - the table parameter is unused
+                        // and only selects which of the three DBs to target - so it defers while
+                        // any write txn on the epoch DB is open and drains only at refcount zero,
+                        // with no timeout. Under catch-up or epoch close that is tens to hundreds
+                        // of milliseconds during which every other proposal would queue behind this
+                        // lock. Do not widen this critical section back out.
+                        drop(_guard);
+
                         // Wait for the `ProposedCertificates` record to be durable before
                         // externalizing. The epoch DB persists asynchronously, so the insert above
                         // returns before the record hits disk; `process_own_certificate` below already

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -444,6 +444,18 @@ impl<DB: Database> Certifier<DB> {
                             error!(target: "primary::certifier", "error accepting own certificate, unable to save the certificate: {e}");
                             return Err(TaskError::from_message(e.to_string()));
                         }
+
+                        // Wait for the `ProposedCertificates` record to be durable before
+                        // externalizing. The epoch DB persists asynchronously, so the insert above
+                        // returns before the record hits disk; `process_own_certificate` below already
+                        // externalizes (it forwards the certificate on the parents bus and triggers
+                        // fetching), and the gossip publish follows. A crash in that window loses the
+                        // record, so on restart the guard at the top of this method misses and the
+                        // certifier re-proposes the same header, re-collecting votes over an unordered
+                        // channel, which can aggregate a different 2f+1 subset into a distinct aggregate
+                        // signature and thereby perturb the leader-signature randomness. See #934, #963.
+                        self.config.node_storage().persist_durable::<ProposedCertificates>().await;
+
                         // pass to state_sync for internal processing
                         if let Err(e) = self.state_sync.process_own_certificate(&mut certificate).await {
                             error!(target: "primary::certifier", "error accepting own certificate: {e}");

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -878,37 +878,28 @@ where
                         self.consensus_config.key_config(),
                     );
                     if vote.digest() != vote_info.vote_digest() {
-                        // Check if a certificate was already formed for this header author at this
-                        // round. If one exists, the old vote contributed to a real certificate, so
-                        // voting for a different header at the same round would be equivocation.
-                        // If no certificate exists, the old vote was never aggregated (e.g. the
-                        // proposer was killed before collecting enough votes, then restarted and
-                        // created a new header at the same round). In that case it is safe to
-                        // re-vote for the new header.
-                        let cert_exists = self
-                            .consensus_config
-                            .node_storage()
-                            .read_by_index(header.author(), header.round())
-                            .unwrap_or(None)
-                            .is_some();
-                        if cert_exists {
-                            warn!(
-                                "Authority {} submitted different header {:?} for voting",
-                                header.author(),
-                                header,
-                            );
-                            return Err(
-                                HeaderError::AlreadyVoted(header.digest(), header.round()).into()
-                            );
-                        }
-                        // No certificate was formed for the old vote — allow re-voting.
+                        // We have already signed a *different* vote for this author at
+                        // this (epoch, round); refuse to sign a second one.
+                        //
+                        // The previous behavior re-voted whenever `read_by_index` found no
+                        // certificate for the earlier vote. That probe is unsound across a
+                        // crash: the certificate tables are `TableHint::Epoch`, written
+                        // non-durably through the layered epoch DB, so a certificate that
+                        // *was* formed can be lost on restart and read back as absent,
+                        // letting the node sign a distinct vote for a slot already
+                        // aggregated into a live certificate. (`.unwrap_or(None)` also
+                        // failed a storage error open into the same branch.) A `false` or
+                        // errored read cannot prove the earlier vote was never certified,
+                        // so the only safe action is to refuse. See #934, #963.
                         warn!(
-                            "Authority {} re-proposing at round {} with a different header; \
-                         previous vote was for an uncertified header — allowing re-vote",
+                            "Authority {} submitted a different header {:?} for a round it was \
+                             already voted on; refusing to re-vote to avoid equivocation",
                             header.author(),
-                            header.round(),
+                            header,
                         );
-                        // Fall through to create and store the new vote below.
+                        return Err(
+                            HeaderError::AlreadyVoted(header.digest(), header.round()).into()
+                        );
                     } else {
                         debug!(
                             "Resending vote {vote:?} for {} at round {}",

--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -60,10 +60,26 @@ impl<DB: Database> Primary<DB> {
         leader_schedule: LeaderSchedule,
         task_manager: &TaskManager,
     ) {
-        // Probably don't need this for a non-committee member but it keeps channels drained and is
-        // not a problem.
-        self.state_sync.spawn(task_manager);
-
+        // Every `spawn` below subscribes to its channels synchronously and only then starts its
+        // task, so the order of these calls decides which channels are live before the first
+        // message is sent. `QueChannel::send` silently DROPS when nothing is subscribed (it returns
+        // `Ok(())` without enqueuing), so a sender that starts before its consumer subscribes loses
+        // messages with no error anywhere. Two such dependencies exist here:
+        //
+        //   - `StateSynchronizer` replays the last two rounds of certificates onto the `parents`
+        //     channel from `recover_state`, and the `Proposer` is the only subscriber.
+        //   - `StateSynchronizer` also drives the `certificate_fetcher` channel, whose only
+        //     subscriber is the `CertificateFetcher`.
+        //
+        // So `state_sync` is spawned LAST, after every consumer it feeds is already subscribed.
+        // Previously it was spawned first, which raced both subscriptions: a restarted proposer
+        // could lose its recovery parents outright and be left with nothing to advance on.
+        //
+        // Spawning the consumers first is safe in the other direction because none of them can
+        // send to a not-yet-subscribed channel before `state_sync` is up: the certifier blocks on
+        // `rx_headers` until the proposer proposes, and the proposer's first header cannot be sent
+        // until the certifier has subscribed, because `Certifier::spawn` runs before the proposer
+        // task can reach its first send.
         Certifier::spawn(
             config.clone(),
             consensus_bus.clone(),
@@ -96,6 +112,12 @@ impl<DB: Database> Primary<DB> {
 
             proposer.spawn(task_manager);
         }
+
+        // Probably don't need this for a non-committee member but it keeps channels drained and is
+        // not a problem.
+        //
+        // Spawned last: see the ordering note above.
+        self.state_sync.spawn(task_manager);
 
         // NOTE: This log entry is used to compute performance.
         info!(

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -134,6 +134,18 @@ impl<DB: Database> Proposer<DB> {
     ///
     /// The proposer's intervals and genesis certificate are created in this function.
     /// Also set `advance_round` to true.
+    ///
+    /// The starting round is recovered from the `LastProposed` guard record rather than always
+    /// starting at zero. `prime_consensus` restores `primary_round` from the last *committed*
+    /// leader round, which trails the last *proposed* round after a crash, so a proposer that
+    /// started at zero would propose fresh at `committed + 1` and only reach the last proposed
+    /// round `P` again after recovery parents arrive - by which point `LastProposed` has been
+    /// overwritten and the round-`P` header is rebuilt with a *different* digest (`created_at` is
+    /// wall-clock and sits inside the digest preimage). Voters holding a durable `Votes` record
+    /// for round `P` then reject that new digest with `AlreadyVoted` forever, because nothing
+    /// converts elapsed time into progress. Seeding `round` to `P - 1` makes the first proposal
+    /// land on `P`, so the repropose filter in `Self::propose_next_header` hits and the
+    /// byte-identical header is re-sent - the premise the fail-closed vote guard depends on.
     pub(crate) fn new(
         config: ConsensusConfig<DB>,
         authority_id: AuthorityIdentifier, // We need to be a validator so must have an id.
@@ -146,6 +158,31 @@ impl<DB: Database> Proposer<DB> {
         // create min/max delay intervals
         let min_delay_interval = tokio::time::interval(config.parameters().min_header_delay);
         let max_delay_interval = tokio::time::interval(config.parameters().max_header_delay);
+
+        // Recover the round of the last header this authority proposed.
+        //
+        // A read failure is not fatal: it only costs the reproposal, so log it and fall back to
+        // the pre-recovery behavior of starting at round 0. The stored header is ignored unless it
+        // is from the current epoch (the epoch DB is cleared on a clean rollover, but two exit
+        // paths skip that clear, so a stale record can outlive its epoch) and unless it is ahead
+        // of `primary_round` (a node that already caught up past `P` via state sync must not be
+        // dragged backwards - `propose_next_header` would ignore the seed anyway).
+        let recovered_round = config
+            .node_storage()
+            .get_last_proposed()
+            .inspect_err(|e| {
+                error!(
+                    target: "primary::proposer",
+                    ?e,
+                    "failed to read last proposed header - starting from round 0",
+                );
+            })
+            .ok()
+            .flatten()
+            .filter(|header| header.epoch() == config.committee().epoch())
+            .map(|header| header.round())
+            .filter(|round| *round > consensus_bus.app().primary_round())
+            .map_or(0, |round| round.saturating_sub(1));
 
         Self {
             authority_id,
@@ -160,7 +197,7 @@ impl<DB: Database> Proposer<DB> {
             rx_shutdown,
             consensus_bus,
             proposer_store: config.node_storage().clone(),
-            round: 0,
+            round: recovered_round,
             last_parents: genesis,
             last_leader: None,
             digests: VecDeque::with_capacity(2 * config.parameters().max_header_num_of_batches),
@@ -259,23 +296,55 @@ impl<DB: Database> Proposer<DB> {
     }
 
     /// Store the header in the `ProposerStore` and send to `Certifier`.
+    ///
+    /// `LastProposed` is a single-slot record (its key is the constant `LAST_PROPOSAL_KEY`), so
+    /// every write replaces the previous one. It is only overwritten by a header that supersedes
+    /// the stored one, so a transient proposal at a *lower* round cannot erase the guard record
+    /// for a higher round that this authority has already broadcast. Losing that record is what
+    /// lets a restart rebuild a round-`P` header with a fresh digest and deadlock against voters
+    /// holding a durable `Votes` record for `P`.
+    ///
+    /// The comparison is epoch-aware. Rounds restart per epoch, so a round-only test would refuse
+    /// every write in a new epoch for as long as a higher-round record from the previous epoch
+    /// survived - which is reachable, because the epoch-close table clear is both conditional and
+    /// not durability-barriered. That would silently disable the anti-equivocation guard for a
+    /// whole epoch, so a header from a different epoch always supersedes.
+    ///
+    /// The round test is `>=`, not `>`, and the equality case is load-bearing: reproposing the
+    /// identical header for the *same* round must still take the write branch, because that is what
+    /// keeps the reproposal behind the durability barrier below. The certifier depends on this. It
+    /// releases its proposal lock before its own barrier, which is only safe because a reproposed
+    /// header cannot reach the certifier until this barrier acks - and since the barrier is
+    /// whole-DB and FIFO, that ack implies the certifier's earlier `ProposedCertificates` insert is
+    /// durable too. Narrowing this to `>` would let a reproposal skip the barrier and overtake that
+    /// insert, so a certificate could be re-gossiped from a record that is still memory-only.
     async fn store_and_send_header(
         header: &Header,
         proposer_store: DB,
         consensus_bus: &ConsensusBus,
     ) -> ProposerResult<()> {
-        // Store the last header.
-        proposer_store
-            .write_last_proposed(header)
+        // A read error is fatal here: failing it open would fall through to the write and clobber
+        // the very record this guard exists to preserve.
+        let stored = proposer_store
+            .get_last_proposed()
             .map_err(|e| ProposerError::StoreError(e.to_string()))?;
+        let supersedes_stored = stored
+            .is_none_or(|last| last.epoch() != header.epoch() || header.round() >= last.round());
 
-        // Wait for the `LastProposed` record to be durable before broadcasting. The epoch DB
-        // persists asynchronously, so `write_last_proposed` returns before the record hits disk;
-        // broadcasting first would let a crash in that window lose the record. On restart the
-        // anti-equivocation guard would then read nothing and build a *different* header for this
-        // same round while the pre-crash header is already on the network: equivocation from an
-        // ordinary crash. See issue #934.
-        proposer_store.persist_durable::<LastProposed>().await;
+        if supersedes_stored {
+            // Store the last header.
+            proposer_store
+                .write_last_proposed(header)
+                .map_err(|e| ProposerError::StoreError(e.to_string()))?;
+
+            // Wait for the `LastProposed` record to be durable before broadcasting. The epoch DB
+            // persists asynchronously, so `write_last_proposed` returns before the record hits
+            // disk; broadcasting first would let a crash in that window lose the record. On
+            // restart the anti-equivocation guard would then read nothing and build a *different*
+            // header for this same round while the pre-crash header is already on the network:
+            // equivocation from an ordinary crash. See issue #934.
+            proposer_store.persist_durable::<LastProposed>().await;
+        }
 
         // Send the new header to the `Certifier` that will broadcast and certify it.
         consensus_bus.headers().send(header.clone()).await.map_err(|e| Box::new(e).into())

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -1129,6 +1129,53 @@ async fn test_vote_different_digest_same_round_rejected() -> eyre::Result<()> {
     Ok(())
 }
 
+/// A recast with a different digest at the same (author, epoch, round) must fail closed
+/// after a crash: even when no certificate is found in storage, the node must refuse to
+/// sign a second, different vote, because a crash could have lost a certificate formed
+/// from the earlier vote (issue #963). This exercises `vote_inner`'s storage-backed guard
+/// directly, with the in-memory `auth_last_vote` guard empty as it would be after restart.
+#[tokio::test]
+async fn test_vote_recast_different_digest_fails_closed() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, parent, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    // Simulate crash recovery: a durable vote_info for this author at the current
+    // (epoch, round) survives on disk, but the in-memory `auth_last_vote` guard is empty
+    // (fresh handler). The placeholder vote_digest will not match the fresh vote computed
+    // below, so `vote_inner` reaches the recast guard.
+    let author_id = committee.last_authority().id();
+    let seeded = VoteInfo {
+        epoch: committee.committee().epoch(),
+        round: 1,
+        vote_digest: VoteDigest::default(),
+    };
+    committee
+        .first_authority()
+        .consensus_config()
+        .node_storage()
+        .insert::<Votes>(&author_id, &seeded)?;
+
+    // A different header at the same (author, epoch, round) => a different vote digest.
+    let header = committee
+        .header_builder_last_authority()
+        .latest_execution_block(BlockNumHash::new(parent.number(), parent.hash()))
+        .created_at(1)
+        .build();
+    let peer = *committee.last_authority().authority().protocol_key();
+
+    // No certificate exists in storage, but the node must still refuse: a crash could have
+    // lost a certificate formed from the earlier vote, so re-voting could equivocate.
+    let res = handler.vote(peer, header, vec![]).await;
+    assert_matches!(
+        res,
+        Err(PrimaryNetworkError::InvalidHeader(HeaderError::AlreadyVoted(_, _))),
+        "recast with a different digest at the same round must fail closed"
+    );
+
+    Ok(())
+}
+
 /// Test that voting for older round after voting for newer round is rejected.
 #[tokio::test]
 async fn test_vote_older_round_rejected() -> eyre::Result<()> {

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -158,6 +158,169 @@ async fn test_equivocation_protection_after_restart() {
     }
 }
 
+/// Helper to build a header with the given author, round, epoch, and payload digests.
+///
+/// Unlike [`build_test_header`] the epoch is caller-supplied, so a test can construct the
+/// stale-cross-epoch record that the recovery and guard predicates must reject.
+fn build_header_at(
+    author: &AuthorityIdentifier,
+    round: Round,
+    epoch: Epoch,
+    digests: &[BlockHash],
+) -> Header {
+    let payload: IndexMap<BlockHash, u16> = digests.iter().map(|&d| (d, 0u16)).collect();
+    HeaderBuilder::default()
+        .author(author.clone())
+        .round(round)
+        .epoch(epoch)
+        .parents(BTreeSet::new())
+        .created_at(now())
+        .payload(payload)
+        .build()
+}
+
+/// The proposer recovers its round from the `LastProposed` guard record.
+///
+/// `prime_consensus` restores `primary_round` from the last *committed* leader round, which trails
+/// the last *proposed* round `P` after a crash. Starting at zero would make the restarted node
+/// propose a fresh header well below `P`, clobber the guard record, and later rebuild round `P`
+/// with a different digest - which voters holding a durable `Votes` record for `P` reject forever.
+#[tokio::test]
+async fn test_proposer_recovers_round_from_last_proposed() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let author = primary.id();
+    let config = primary.consensus_config();
+    let epoch = committee.epoch();
+    let task_manager = TaskManager::default();
+
+    let build_proposer = |bus: ConsensusBus| {
+        Proposer::new(
+            config.clone(),
+            config.authority_id().expect("authority"),
+            bus,
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+            task_manager.get_spawner(),
+        )
+    };
+
+    // an empty store keeps the pre-recovery behavior of starting at round 0
+    assert_eq!(build_proposer(ConsensusBus::new()).round, 0, "empty store must start at round 0");
+
+    // a header from the current epoch seeds `round` to P - 1, so the first proposal lands on P
+    // and the repropose filter in `propose_next_header` hits
+    config.node_storage().write_last_proposed(&build_header_at(&author, 7, epoch, &[])).unwrap();
+    assert_eq!(build_proposer(ConsensusBus::new()).round, 6, "round must be seeded to P - 1");
+
+    // a node that already advanced past P via state sync must not be dragged backwards
+    let ahead = ConsensusBus::new();
+    ahead.app().primary_round_updates().send_replace(9);
+    assert_eq!(build_proposer(ahead).round, 0, "must not seed behind an already-advanced node");
+
+    // rounds restart per epoch, so a record that outlived its epoch must not seed the round
+    config
+        .node_storage()
+        .write_last_proposed(&build_header_at(&author, 7, epoch + 1, &[]))
+        .unwrap();
+    assert_eq!(
+        build_proposer(ConsensusBus::new()).round,
+        0,
+        "stale cross-epoch record must not seed the round"
+    );
+}
+
+/// A restarted proposer re-sends the byte-identical header rather than rebuilding it.
+///
+/// `created_at` is wall-clock and sits inside the digest preimage, so a rebuilt header for the same
+/// round carries a *different* digest. This is the premise the fail-closed vote guard depends on:
+/// voters holding a durable `Votes` record for round `P` only recast their vote for the identical
+/// digest, and reject anything else with `AlreadyVoted`.
+#[tokio::test]
+async fn test_restart_reproposes_identical_header() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let config = primary.consensus_config();
+
+    // the header this authority proposed before the crash, still in the guard record
+    let proposed = build_header_at(&primary.id(), 7, committee.epoch(), &[B256::random()]);
+    config.node_storage().write_last_proposed(&proposed).unwrap();
+
+    let cb = ConsensusBus::new();
+    let mut rx_headers = cb.subscribe_headers();
+    let task_manager = TaskManager::default();
+    let proposer = Proposer::new(
+        config.clone(),
+        config.authority_id().expect("authority"),
+        cb.clone(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
+    );
+
+    proposer.spawn(&task_manager);
+
+    let header = tokio::time::timeout(Duration::from_secs(5), rx_headers.recv())
+        .await
+        .expect("proposer emitted a header before the timeout")
+        .expect("header channel stayed open");
+
+    assert_eq!(header.round(), proposed.round(), "first proposal must land back on round P");
+    assert_eq!(header, proposed, "restart must repropose the identical header");
+    assert_eq!(header.digest(), proposed.digest(), "the reproposed digest must be unchanged");
+}
+
+/// A proposal at a lower round must not erase the guard record for a higher round.
+///
+/// `LastProposed` is a single-slot record, so an unguarded write lets a transient low-round
+/// proposal clobber the record for a round this authority has already broadcast - which is exactly
+/// what makes the restarted node rebuild that round with a fresh digest.
+#[tokio::test]
+async fn test_last_proposed_guard_record_is_not_clobbered() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let author = primary.id();
+    let config = primary.consensus_config();
+    let store = config.node_storage().clone();
+    let epoch = committee.epoch();
+
+    let cb = ConsensusBus::new();
+    // keep the header channel subscribed so `send` is not silently dropped
+    let _rx_headers = cb.subscribe_headers();
+    let stored = || store.get_last_proposed().unwrap().unwrap();
+
+    let high = build_header_at(&author, 7, epoch, &[B256::random()]);
+    Proposer::store_and_send_header(&high, store.clone(), &cb).await.unwrap();
+    assert_eq!(stored(), high, "the first proposal is recorded");
+
+    // a lower round must leave the round-7 record intact
+    let low = build_header_at(&author, 3, epoch, &[B256::random()]);
+    Proposer::store_and_send_header(&low, store.clone(), &cb).await.unwrap();
+    assert_eq!(stored(), high, "a lower round must not clobber the guard record");
+
+    // the same round still rewrites, so the in-round repropose path keeps working
+    let same = build_header_at(&author, 7, epoch, &[B256::random()]);
+    Proposer::store_and_send_header(&same, store.clone(), &cb).await.unwrap();
+    assert_eq!(stored(), same, "an equal round must still be recorded");
+
+    // and so does a higher round
+    let higher = build_header_at(&author, 8, epoch, &[B256::random()]);
+    Proposer::store_and_send_header(&higher, store.clone(), &cb).await.unwrap();
+    assert_eq!(stored(), higher, "a higher round must be recorded");
+
+    // a new epoch restarts the rounds, so a low round from a later epoch must supersede.
+    // Without this the guard would refuse every write for a whole epoch, silently disabling the
+    // anti-equivocation record it exists to protect.
+    let next_epoch = build_header_at(&author, 1, epoch + 1, &[B256::random()]);
+    Proposer::store_and_send_header(&next_epoch, store.clone(), &cb).await.unwrap();
+    assert_eq!(
+        stored(),
+        next_epoch,
+        "a header from a new epoch must supersede regardless of round"
+    );
+}
+
 /// Helper to build a header with the given author, round, and payload digests.
 fn build_test_header(author: &AuthorityIdentifier, round: Round, digests: &[BlockHash]) -> Header {
     let mut payload = IndexMap::new();


### PR DESCRIPTION
Closes #963.  Follow-up to #940 (#934).

## Background

#940 closed the crash-loss equivocation window for two guard records by awaiting a
durable barrier before externalizing: `LastProposed` before the proposer broadcasts,
and `Votes` before the vote handler returns its vote.  Issue #963 inventories the
primary crate and finds two more records in the same hazard class.  Both are
`TableHint::Epoch`, so both route to the full-memory layered epoch DB whose `insert`
enqueues the durable disk write to a background thread and returns before it is on
disk.  A crash in the write-to-externalize window loses the record;  on restart the
guard reads nothing and an honest node can equivocate with no Byzantine actor.

#940 makes both gaps *easier* to reach, not harder: now that a restarted node
deterministically re-proposes the identical header, it reliably re-enters both
guards below on every restart.

## Changes

- **Site 1, certifier own-certificate (`ProposedCertificates`)**: add the #940
  durability barrier.  `spawn_header_proposal` inserts its own certificate and then
  calls `process_own_certificate` (already an externalization point: it forwards the
  certificate on the parents bus and triggers fetching) followed by
  `publish_certificate`, with no barrier in between.  This awaits
  `persist_durable::<ProposedCertificates>()` immediately after the insert and before
  `process_own_certificate`.  On crash-loss of the record, the guard at the top of the
  method would otherwise miss on restart and the certifier would re-propose the same
  header, re-collecting votes over an unordered channel and potentially aggregating a
  different `2f+1` subset into a distinct aggregate signature, which also perturbs the
  leader-signature randomness (`keccak256(leader.aggregated_signature())`).  This is a
  one-line change in #940's own pattern.

- **Site 2, vote-recast certificate-existence check**: fail closed.  The recast guard
  decided whether to sign a *second, different* vote for the same
  `(author, epoch, round)` by probing `read_by_index` for an existing certificate and
  re-voting when none was found.  That probe reads the same non-durable epoch tables
  (`Certificates` / `CertificateDigestByOrigin`), so a certificate that *was* formed
  from the earlier vote can be lost on restart and read back as absent, letting the
  node sign a distinct vote for a slot already aggregated into a live certificate: a
  directly distinct signed message.  The `.unwrap_or(None)` additionally failed a
  storage *error* open into the same permissive branch.  Since a `false`/errored read
  cannot prove the earlier vote was never certified, the guard now refuses (returns
  `AlreadyVoted`) whenever a different vote already exists for the slot.  The now-unused
  `read_by_index` probe is removed.

## The Site 2 decision (please weigh in)

Issue #963 flags Site 2 as a real design decision rather than a one-liner, with two
viable options:

1. **Fail closed** (this PR): treat an unknown or errored read as "cannot re-vote" and
   refuse.  Self-contained and cheap, with no barrier on the certificate hot path.  It
   costs a bounded, one-round liveness delay on exactly one recovery path: a proposer
   killed before quorum that restarts with a new header at the same round will not get
   this validator's vote and must advance a round.

2. **Durable certificate acceptance**: make certificate acceptance synchronously
   durable before the node can act as if it voted.  Larger, and it reintroduces a
   durability barrier on the certificate hot path (`write_all` in `cert_manager`).

I chose fail-closed to keep the fix contained to the primary crate and off the
certificate hot path, and because safety on a BFT layer outweighs a bounded,
single-path liveness cost.  Happy to switch to option 2 (or gate the strictness) if
you would rather preserve the permissive re-vote path.

## Severity

Both sites are crash-recovery-only: the epoch DB is `full_memory`, so the in-memory
map holds each record for the process lifetime and neither guard can false-negative on
a running node.  The exposure is a crash inside the write-to-externalize window.  The
consequence (equivocation or a distinct aggregate signature on a BFT consensus layer,
undetectable because the certificate digest excludes the signature) is why the issue
tracks these as mainnet blockers.

## Verification

- `cargo fmt` (nightly-2026-03-20) clean on the changed crate.
- `cargo check -p tn-primary` (1.94) clean.
- `cargo clippy` clean on the changed crate.
- New regression test `test_vote_recast_different_digest_fails_closed` (in
  `network_tests.rs`).  It simulates crash recovery: a durable `Votes` row for the author
  at the current `(epoch, round)` survives while the in-memory `auth_last_vote` guard is
  empty (fresh handler), so `vote_inner`'s storage-backed recast guard becomes load-bearing.
  With no certificate in storage, the recast of a different-digest header now returns
  `AlreadyVoted` instead of signing a second vote.  (On a running node the earlier
  in-memory guard catches this first;  only after a restart does Site 2 carry the weight,
  which is exactly the window #940 makes deterministic.)
- All `test_vote*` tests pass (18/18), including the existing equivocation tests
  `test_vote_different_digest_same_round_rejected` and `test_vote_older_round_rejected`.

## Scope note

One nearby write is deliberately left alone: the inactive-CVV catch-up cache in the
handler writes a peer certificate to the same tables but externalizes nothing and does
not vote, so a lost cache entry causes only a re-fetch, not a distinct signed message.
It is not a hazard, and its `CertificateStore::write` call keeps that import in use.

## Related observations (out of scope, flagged for a follow-up)

- Site 1's barrier trades the re-proposal equivocation window for a narrower, recoverable
  one: a crash between `persist_durable` and `process_own_certificate` leaves
  `ProposedCertificates` durable while the certificate was never processed into the local
  DAG, so on restart the guard re-publishes the cert on gossip but does not re-run
  `process_own_certificate`.  Nothing was externalized before the crash (the barrier
  precedes the first externalization), and the outcome is a local liveness edge the node
  recovers from by re-ingesting its own re-published cert, which is strictly preferable to
  a distinct aggregate signature.  The barrier must precede `process_own_certificate`
  because that call is itself an externalization point, so this trade is inherent.
- Site 1's *guard read* itself (`if let Ok(Some(cert)) = get::<ProposedCertificates>(..)`)
  still fails open on a storage read *error*, the same error-open shape Site 2 fixes.  On
  the full-memory epoch map a read error is not a realistic path, and hardening it is
  outside this issue's stated Site 1 scope (add the barrier), so it is left as is.  Happy
  to fail that read closed in a follow-up if you would like the symmetry.
- `persist_durable` acks a barrier even when the underlying epoch-DB write or commit
  errored and was logged-and-dropped in the background writer.  That is a property of
  #940's merged barrier primitive (used identically by the `LastProposed` / `Votes`
  barriers), not something this PR changes;  worth a separate look if best-effort durability
  on a disk error is a concern.
