### PR TITLE
test(storage): open the epoch data file, not the directory, in test_consensus_pack

### DIFF
--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -2346,8 +2346,10 @@ pub(crate) mod test {
             assert!(pack.get_consensus_output(num_outputs as u64 * 2).await.is_ok());
             drop(pack);
 
-            let mut f1 = File::open(temp_dir.path().join("epoch-0")).expect("log file");
-            let mut f2 = File::open(temp_dir2.path().join("epoch-0")).expect("log file");
+            let mut f1 = File::open(temp_dir.path().join("epoch-0").join(Inner::DATA_NAME))
+                .expect("log file");
+            let mut f2 = File::open(temp_dir2.path().join("epoch-0").join(Inner::DATA_NAME))
+                .expect("log file");
             assert_eq!(
                 f1.seek(SeekFrom::End(0)).unwrap(),
                 f2.seek(SeekFrom::End(0)).unwrap(),


### PR DESCRIPTION
Closes #955.

## Problem

`storage::consensus_pack::test::test_consensus_pack` fails with `EINVAL` on any host
whose `/tmp` is **tmpfs** (the systemd >= 256 default: Ubuntu 25.10, Fedora, Arch). Two
length-comparison opens in the test target the `epoch-0` **directory** instead of the
`epoch-0/data` pack file, then call `seek(SeekFrom::End(0))` on it. `lseek(SEEK_END)` on a
directory fd is rejected with `EINVAL` by the libfs `dcache_dir_lseek` that tmpfs uses,
while ext4/overlayfs (CI runners, the `rust:1.94-slim-bookworm` builder image, most dev
machines) accept it. The failure hard-stops `cargo nextest` and therefore `make attest` on
current distros.

## Root cause

Each epoch is laid out as a directory `epoch-{n}/` holding the data file `data`
(`Inner::DATA_NAME`). Every open in the test appends `.join(Inner::DATA_NAME)` to reach the
pack file except these two, which stop at the directory. `File::open()` on a directory
succeeds on Linux, so `.expect("log file")` passes; the subsequent `seek(SeekFrom::End(0))`
is what diverges by filesystem. The assertion is also semantically wrong even where it
passes, since it compares two directory seek results rather than the two pack files'
lengths.

## Fix

Append `.join(Inner::DATA_NAME)` to both opens, matching every other open in the test.
`"files not the same length"` now compares the two `data` files' lengths (the intent) and
no directory seek remains, so the test is portable across filesystems.

Test-only change; no production code is touched.

## Validation

- `cargo +1.94 test -p tn-storage --lib consensus_pack::test::test_consensus_pack` passes
  under the repo-pinned toolchain.
- `cargo +nightly fmt --check` clean.
