### PR TITLE
feat(network): delete frozen legacy request-response variants, bump req-res to /0.0.2 (739)

### DIFF
--- a/crates/consensus/primary/src/network/message.rs
+++ b/crates/consensus/primary/src/network/message.rs
@@ -56,11 +56,6 @@ pub enum PrimaryRequest {
         /// missing them. The peer requires parent certs in order to vote.
         parents: Vec<Certificate>,
     },
-    /// Request for missing certificates.
-    MissingCertificates {
-        /// Inner type with specific helper methods for requesting missing certificates.
-        inner: MissingCertificatesRequest,
-    },
     /// Exchange peer information.
     ///
     /// This "request" is sent to peers when this node disconnects
@@ -77,35 +72,6 @@ pub enum PrimaryRequest {
         epoch: Option<Epoch>,
         /// Block hash requesting if not None.
         hash: Option<EpochDigest>,
-    },
-    /// Request to stream a pack file of the consensus data for epoch.
-    StreamEpoch {
-        /// The epoch we are requesting consensus data for.
-        epoch: Epoch,
-    },
-    /// Request to stream the raw (serialized) consensus output bytes for a consensus chain number.
-    ///
-    /// Unlike [`Self::ConsensusHeader`], this returns the full pack-file encoded output
-    /// (batches + consensus header) rather than just the header, so a peer can reconstruct
-    /// the [`tn_types::ConsensusOutput`] without separately fetching its batches.
-    ///
-    /// The output is streamed (rather than returned via request/response) because a single
-    /// output can exceed the request/response codec's message size limit.
-    StreamConsensusOutput {
-        /// The consensus chain number being requested.
-        number: u64,
-    },
-    /// Request to stream a verifiable PREFIX of an epoch's pack file, stopping after the consensus
-    /// output with `last_consensus_number`.
-    ///
-    /// Unlike [`Self::StreamEpoch`] (which streams a complete epoch), this streams the in-progress
-    /// current epoch up to an already-committed, verifiable point. The number is a chain consensus
-    /// header number, not a pack-relative index.
-    StreamEpochPartial {
-        /// The epoch we are requesting consensus data for.
-        epoch: Epoch,
-        /// The final (inclusive) consensus header number to stream up to.
-        last_consensus_number: u64,
     },
 }
 
@@ -289,8 +255,6 @@ impl From<PeerExchangeMap> for PrimaryRequest {
 pub enum PrimaryResponse {
     /// The peer's vote if the peer considered the proposed header valid.
     Vote(Vote),
-    /// The requested certificates requested by a peer.
-    RequestedCertificates(Vec<Certificate>),
     /// Missing certificates in order to vote.
     ///
     /// If the peer was unable to verify parents for a proposed header, they respond requesting
@@ -309,15 +273,6 @@ pub enum PrimaryResponse {
     /// This is an application-layer error response.
     /// This error is likely to succeed in the future and can be retried.
     RecoverableError(PrimaryRPCError),
-    /// Response to a stream-based request (epoch pack or single consensus output).
-    ///
-    /// If `ack` is true, the requestor should open a stream with the
-    /// request digest in the header. The responder will send the requested
-    /// data over that stream.
-    StreamRequestAck {
-        /// Whether the request is accepted.
-        ack: bool,
-    },
 }
 
 impl PrimaryResponse {

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -411,9 +411,6 @@ impl PrimaryNetworkHandle {
             PrimaryResponse::Vote(vote) => Ok(RequestVoteResult::Vote(vote)),
             PrimaryResponse::RecoverableError(PrimaryRPCError(s))
             | PrimaryResponse::Error(PrimaryRPCError(s)) => Err(NetworkError::RPCError(s)),
-            PrimaryResponse::RequestedCertificates(_vec) => Err(NetworkError::RPCError(
-                "Got wrong response, not a vote is requested certificates!".to_string(),
-            )),
             PrimaryResponse::MissingParents(parents) => {
                 Ok(RequestVoteResult::MissingParents(parents))
             }
@@ -422,9 +419,6 @@ impl PrimaryNetworkHandle {
             )),
             PrimaryResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a vote is peer exchange!".to_string(),
-            )),
-            PrimaryResponse::StreamRequestAck { .. } => Err(NetworkError::RPCError(
-                "Got wrong response, not a vote is stream ack!".to_string(),
             )),
         }
     }
@@ -1263,23 +1257,11 @@ where
                         cancel,
                     );
                 }
-                PrimaryRequest::MissingCertificates { inner } => {
-                    self.process_request_for_missing_certs(peer, inner, channel, cancel)
-                }
                 PrimaryRequest::PeerExchange { .. } => {
                     warn!(target: "primary::network", "primary application received unexpected peer exchange message");
                 }
                 PrimaryRequest::EpochRecord { epoch, hash } => {
                     self.process_epoch_record_request(peer, epoch, hash, channel, cancel)
-                }
-                PrimaryRequest::StreamEpoch { .. } => {
-                    self.process_epoch_stream(peer, channel, cancel)
-                }
-                PrimaryRequest::StreamEpochPartial { .. } => {
-                    self.process_epoch_stream(peer, channel, cancel)
-                }
-                PrimaryRequest::StreamConsensusOutput { .. } => {
-                    self.process_consensus_output_stream(peer, channel, cancel)
                 }
             },
             NetworkEvent::Gossip { message, relayer, author } => {
@@ -1341,35 +1323,6 @@ where
         });
     }
 
-    /// Answer a legacy request-response `MissingCertificates` request.
-    ///
-    /// Item 7 (#739) cut the certificate fetch fully over to the `/tn-primary-sync`
-    /// protocol, so this request-response path is no longer served: peers fetch
-    /// certificates over sync. The request variant is retained for wire compatibility
-    /// (BCS variant indices stay until the coordinated `/0.0.2` bump, item 9); a legacy
-    /// requester is answered with a typed error rather than served.
-    fn process_request_for_missing_certs(
-        &self,
-        peer: BlsPublicKey,
-        _request: MissingCertificatesRequest,
-        channel: ResponseChannel<PrimaryResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("MissingCertsDeprecated-{peer}");
-        let response = PrimaryResponse::Error(PrimaryRPCError(
-            "missing certificates are served over the sync protocol only".to_string(),
-        ));
-        self.task_spawner.spawn_task(task_name, async move {
-            tokio::select! {
-                _ = network_handle.handle.send_response(response, channel) => (),
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
-        });
-    }
-
     /// Attempt to retrieve consensus chain header from the database.
     fn process_epoch_record_request(
         &self,
@@ -1420,62 +1373,6 @@ where
                         let response = header.into_response();
                         let _ = network_handle.handle.send_response(response, channel).await;
                     }
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
-        });
-    }
-
-    /// Answer a legacy request-response `StreamEpoch` / `StreamEpochPartial` request.
-    ///
-    /// Item 9c (#739) removed the raw `/tn-stream` epoch-pack path, so peers fetch full
-    /// and partial epoch packs over the `/tn-primary-sync` protocol. The request variants
-    /// are retained for wire compatibility (BCS variant indices stay until the coordinated
-    /// `/0.0.2` bump); a legacy requester is answered with a typed error rather than served.
-    fn process_epoch_stream(
-        &self,
-        peer: BlsPublicKey,
-        channel: ResponseChannel<PrimaryResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("EpochPackDeprecated-{peer}");
-        let response = PrimaryResponse::Error(PrimaryRPCError(
-            "epoch packs are served over the sync protocol only".to_string(),
-        ));
-        self.task_spawner.spawn_task(task_name, async move {
-            tokio::select! {
-                _ = network_handle.handle.send_response(response, channel) => (),
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
-        });
-    }
-
-    /// Answer a legacy request-response `StreamConsensusOutput` request.
-    ///
-    /// Item 9b (#739) cut the consensus-output fetch fully over to the
-    /// `/tn-primary-sync` protocol, so this request-response path is no longer served:
-    /// peers fetch a single consensus output over sync. The request variant is retained
-    /// for wire compatibility (BCS variant indices stay until the coordinated `/0.0.2`
-    /// bump, item 9c); a legacy requester is answered with a typed error rather than
-    /// served.
-    fn process_consensus_output_stream(
-        &self,
-        peer: BlsPublicKey,
-        channel: ResponseChannel<PrimaryResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("ConsensusOutputDeprecated-{peer}");
-        let response = PrimaryResponse::Error(PrimaryRPCError(
-            "consensus output is served over the sync protocol only".to_string(),
-        ));
-        self.task_spawner.spawn_task(task_name, async move {
-            tokio::select! {
-                _ = network_handle.handle.send_response(response, channel) => (),
                 // cancel notification from network layer
                 _ = cancel => (),
             }

--- a/crates/consensus/primary/src/state_sync/cert_collector.rs
+++ b/crates/consensus/primary/src/state_sync/cert_collector.rs
@@ -59,11 +59,11 @@ where
     ) -> PrimaryNetworkResult<Self> {
         let start_time = Instant::now();
         // `max_response_size` is unused on the sync fetch path: the reply is streamed and ended
-        // explicitly, so the legacy request-response size cap no longer applies. The field is kept
-        // only for BCS wire compatibility of the retained `/0.0.1`
-        // `PrimaryRequest::MissingCertificates` variant (removed at the coordinated `/0.0.2` bump,
-        // item 9 of #739); this local rebuild exists solely to reuse `get_bounds`, which ignores
-        // it, so a fixed dummy is correct.
+        // explicitly, so the request-response size cap does not apply. The
+        // `PrimaryRequest::MissingCertificates` variant that once carried this field on the wire
+        // was deleted at the `/0.0.2` bump (item 9 of #739); the field remains on the struct only
+        // so this local rebuild can reuse `get_bounds`, which ignores it, so a fixed dummy is
+        // correct.
         const SYNC_PATH_UNUSED_RESPONSE_CAP: usize = 0;
         let request = MissingCertificatesRequest {
             exclusive_lower_bound,

--- a/crates/consensus/worker/src/network/README.md
+++ b/crates/consensus/worker/src/network/README.md
@@ -1,130 +1,137 @@
 # Worker Network Module
 
 This module implements the worker's network layer for batch synchronization between consensus peers.
-It provides both request-response RPC and stream-based transfer for efficient batch replication.
+Batches are replicated over the typed sync-stream protocol (`/tn-worker-{id}-sync`); the request
+travels in the opening frame, and the response is streamed back frame by frame.
 
 ## Overview
 
 Workers need to synchronize batches (collections of transactions) with peers.
 When a worker receives batch digests it doesn't have locally, it requests the full batches from peers who have them.
-For large transfers, stream-based transfer is more efficient than individual RPC calls.
+A single fetch can exceed the request-response message-size limit, so the transfer is streamed rather than returned in one RPC.
+
+The legacy request-response `/tn-stream` batch path (an ack-plus-digest handshake that then opened a
+correlated raw stream) has been removed. Batch fetch now folds the request into the opening
+[`SyncFrame::Req`] frame of a sync stream, so there is no separate handshake or `(peer, digest)`
+correlation map to maintain.
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                      WorkerNetworkHandle                        │
+│                      WorkerNetworkHandle                         │
 │  (Public API for batch operations)                              │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  request_batches() ──► Negotiates stream with peer              │
-│                        Opens libp2p::Stream                     │
-│                        Calls read_and_validate_batches()        │
+│  request_batches() ──► Tries connected peers with bounded retry │
+│                        request_batches_from_peer_sync()         │
+│                          opens a /tn-worker-{id}-sync stream    │
+│                          writes SyncFrame::Req(Batches{..})     │
+│                          reads Ack, then read_sync_batches()    │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
                                 │
                                 ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                       RequestHandler                            │
-│  (Processes incoming requests from peers)                       │
+│  (Serves inbound sync streams from peers)                       │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  process_request_batches_stream() ──► Validates request         │
-│                                       Calls stream_codec::      │
-│                                       send_batches_over_stream  │
+│  process_inbound_sync_stream() ──► try_admit_sync() (or Deny)   │
+│                                    reads opening Req frame       │
+│  process_sync_batches_stream() ──► stream_codec::               │
+│                                    send_sync_batches_over_stream │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
                                 │
                                 ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                        stream_codec                             │
-│  (Wire protocol for batch streaming)                            │
+│  (Serves batches as typed sync frames)                          │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  send_batches_over_stream()  ──► Chunked sending with backpres. │
-│  write_batch()               ──► Single batch serialization     │
-│  read_batch()                ──► Single batch deserialization   │
+│  send_sync_batches_over_stream() ──► Ack, then one Data frame   │
+│                                      per batch, then End        │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-## Stream Protocol
+## Sync Protocol
 
-### Wire Format
+### Frame Sequence
 
-Batches are transferred in chunks to prevent memory exhaustion. Each chunk follows this format:
+A batch fetch is a single sync-stream exchange:
+
+```
+requester                         responder
+─────────                         ─────────
+Req(Batches{digests, epoch})  ──►
+                              ◄──  Ack            (accepted; serving begins)
+                              ◄──  Data(batch_0)
+                              ◄──  Data(batch_1)
+                              ◄──  ...
+                              ◄──  End            (transfer complete)
+```
+
+Instead of `Ack`, a responder that is shedding load writes `Deny(DenyReason::AtCapacity)` and closes
+without reading, so the requester gives up on that peer immediately and tries another. A serve that
+fails partway (storage or encoding error) is terminated with `Err(SyncFrameError::Internal)`, and a
+malformed opening frame is answered with `Err(SyncFrameError::Malformed)`.
+
+Each batch is one [`SyncFrame::Data`] frame carrying the BCS-encoded batch. The stream is delimited
+by the terminating `End` frame; there is no on-wire batch count. The responder reads batches from the
+database in chunks of `BATCH_DIGESTS_READ_CHUNK_SIZE` (200) to bound the working set of a single
+serve — this is a database-read batching detail, not a wire-visible framing.
+
+### Frame Wire Format
+
+Every frame is length-prefixed and Snappy-compressed by the shared frame codec
+(`tn_network_libp2p`'s `encode_message` / `decode_message`):
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ CHUNK                                                           │
-├─────────────┬───────────────────────────────────────────────────┤
-│ Batch Count │ Batch 0 │ Batch 1 │ ... │ Batch N │ <flush>       │
-│ (4 bytes)   │         │         │     │         │               │
-└─────────────┴───────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│ BATCH                                                           │
+│ FRAME BODY                                                      │
 ├──────────────────┬─────────────────┬────────────────────────────┤
 │ Uncompressed Len │ Compressed Len  │ Snappy-Compressed Data     │
 │ (4 bytes LE)     │ (4 bytes LE)    │ (variable)                 │
 └──────────────────┴─────────────────┴────────────────────────────┘
 ```
 
-A complete transfer consists of one or more chunks, where each chunk contains up to `BATCH_DIGESTS_READ_CHUNK_SIZE` (200) batches.
-
 ### Why Two Length Fields?
 
-The batch header includes both uncompressed and compressed lengths for precise stream parsing:
+Each frame body carries both its uncompressed and compressed lengths for safe, precise stream parsing:
 
-1. **Uncompressed length**: Used to validate against `max_batch_size` before allocation, preventing memory exhaustion attacks.
+1. **Uncompressed length**: Validated against the per-epoch frame-size bound
+   (`max_batch_size(epoch) + SYNC_FRAME_OVERHEAD`) *before* any buffer is grown, preventing memory
+   exhaustion attacks.
 
-2. **Compressed length**: Required for exact stream reading. Without it, the receiver cannot determine where one batch ends and the next begins in a multi-batch stream.
-
-TCP is a byte stream, not a message stream.
-The receiver's `read_exact()` calls have no relationship to the sender's `write_all()` calls.
-Including the compressed length allows the receiver to read exactly the right number of bytes for each batch.
+2. **Compressed length**: Required for exact stream reading. TCP is a byte stream, not a message
+   stream, so the receiver's `read_exact()` calls have no relationship to the sender's `write_all()`
+   calls. Knowing the compressed length lets the receiver read exactly the right number of bytes for
+   each frame instead of over-reading into the next one.
 
 #### Why Not Derive Compressed Length?
 
-While `snap::raw::max_compress_len(uncompressed_len)` gives an upper bound, using it with `read_to_end()` would over-read into subsequent batches.
-The snappy `FrameDecoder` doesn't provide a way to know how many compressed bytes it consumed from the underlying reader.
-
-### Chunking Strategy
-
-Batches are sent in chunks of up to 200 for several reasons:
-
-1. **Memory bounds**: Limits database reads and in-memory batch accumulation on the sender.
-
-2. **Backpressure**: Each chunk is flushed before starting the next, allowing TCP flow control to naturally throttle the sender if the receiver falls behind.
-
-3. **Progress visibility**: The receiver can begin validation as chunks complete rather than waiting for the entire transfer.
-
-### Flush Strategy
-
-The stream is flushed once per chunk (not per batch) because:
-
-1. **Throughput**: Fewer syscalls and better TCP segment packing. Flushing per batch would generate up to 200x more flush operations.
-
-2. **No latency benefit**: The receiver reads batches sequentially with `read_exact()`, which blocks until all bytes arrive regardless of flush timing.
-
-3. **Logical unit**: A chunk represents a complete unit of work from the sender's database read.
+While `snap::raw::max_compress_len(uncompressed_len)` gives an upper bound, using it with
+`read_to_end()` would over-read into subsequent frames. The snappy `FrameDecoder` doesn't provide a
+way to know how many compressed bytes it consumed from the underlying reader.
 
 ## Retry Logic
 
 ### `request_batches()` — Bounded Retries with Backoff
 
 When a worker needs batches it doesn't have locally, `request_batches()` tries connected peers
-one at a time. If a peer rejects the request (e.g., its concurrency semaphore is full and it
-returns `ack: false`), the next peer is tried.
+one at a time. If a peer is unavailable (it sheds with `Deny`, or a transient stream error occurs),
+the next peer is tried.
 
-If **all** peers reject a single pass, the method retries up to `MAX_BATCH_REQUEST_RETRIES` (3)
+If **all** peers fail a single pass, the method retries up to `MAX_BATCH_REQUEST_RETRIES` (3)
 times through the full peer list, with a `BATCH_REQUEST_RETRY_DELAY` (500ms) pause between
-attempts. This gives peer semaphores time to release permits.
+attempts. This gives peer capacity time to free up.
 
 ```
-Attempt 1: peer_a → rejected, peer_b → rejected, peer_c → rejected
+Attempt 1: peer_a → deny, peer_b → deny, peer_c → deny
   ↓ sleep 500ms
-Attempt 2: peer_a → accepted → batches received → return Ok
+Attempt 2: peer_a → Ack → batches received → return Ok
 ```
 
 Key behaviors:
@@ -133,9 +140,9 @@ Key behaviors:
 - **Accumulates batches** across retries — digests fulfilled on earlier attempts are removed.
 - **Returns `RPCError`** only after all retries are exhausted with zero batches.
 
-The caller (`fetch_for_primary()` in `batch_fetcher.rs`) wraps this in an infinite loop that
-re-checks local storage between iterations. The inner retry with backoff prevents tight-spinning
-when all peers are temporarily at capacity.
+A transient post-negotiation failure (a slow but sync-capable peer) is classified as a retryable
+failure rather than an "unsupported" verdict, so a momentarily-slow peer is not cached as unusable
+for the rest of the epoch.
 
 ## Security Measures
 
@@ -144,112 +151,84 @@ when all peers are temporarily at capacity.
 #### Global Semaphore (`MAX_CONCURRENT_BATCH_STREAMS`)
 
 A tokio `Semaphore` with `MAX_CONCURRENT_BATCH_STREAMS` (5) permits bounds the total number of
-concurrent batch stream operations (pending + active). A permit is acquired when an inbound
-`RequestBatchesStream` RPC is accepted and held through the entire stream lifecycle via the
-`PendingBatchStream` struct's `_permit` field (RAII pattern — dropped when the struct is dropped).
+concurrent inbound batch serves. Admission happens in `try_admit_sync()` *before* the serving task
+is spawned; the permit is held for the whole serve via the `SyncStreamPermit` RAII guard and released
+when it drops.
 
-If no permits are available, the request gets `ack: false` and the requesting peer tries another node.
+If no permit is available, the responder writes `Deny(DenyReason::AtCapacity)` and the requesting peer
+tries another node.
 
 #### Per-Peer Rate Limiting (`MAX_PENDING_REQUESTS_PER_PEER`)
 
-Each peer is limited to `MAX_PENDING_REQUESTS_PER_PEER` (2) concurrent in-flight batch
-streams. This prevents a single malicious peer from monopolizing all global semaphore slots.
-
-The cap is the combined limit across every in-flight source that holds a global permit, so
-admission on either path counts all three together (`peer_in_flight`):
-
-```rust
-let peer_count = peer_in_flight(&pending_map, &active_legacy, &sync_stream_peers, &peer);
-if peer_count >= MAX_PENDING_REQUESTS_PER_PEER {
-    // reject — permit drops, freeing the global slot
-}
-```
-
-- **legacy pending requests** — entries in `pending_batch_requests` awaiting a stream open.
-- **legacy serving streams** (`active_legacy_streams`) — a legacy request leaves
-  `pending_batch_requests` the moment its stream opens, but still holds its global permit while
-  being served. It is counted here for the full serving lifetime (via `LegacyStreamGuard`), so a
-  peer cannot bypass the cap by promptly opening its pending streams and re-arming new ones.
-- **sync streams** (`sync_stream_peers`) — sync-path exchanges, counted via `SyncStreamPermit`.
-
-Admission takes the locks in the order `pending_batch_requests` -> `active_legacy_streams` ->
-`sync_stream_peers` on both paths, so the two never deadlock.
-
-#### Stale Request Cleanup (`PENDING_REQUEST_TIMEOUT`)
-
-A periodic prune task runs every 15 seconds and removes pending requests older than
-`PENDING_REQUEST_TIMEOUT` (30s). This prevents slot leaks when a peer negotiates a stream
-via RPC but never opens the actual libp2p stream. Dropping stale `PendingBatchStream` entries
-releases their semaphore permits back to the pool.
+Each peer is limited to `MAX_PENDING_REQUESTS_PER_PEER` (2) concurrent in-flight batch serves,
+tracked in the `sync_stream_peers` map. This prevents a single malicious peer from monopolizing all
+global semaphore slots. `try_admit_sync()` admits a stream only when both the global semaphore has a
+permit and the peer is below its per-peer cap, incrementing the peer's count on admission;
+`SyncStreamPermit::drop` decrements it (and removes the entry at zero).
 
 #### Oversized Request Truncation (`MAX_BATCH_DIGESTS_PER_REQUEST`)
 
 Requests exceeding `MAX_BATCH_DIGESTS_PER_REQUEST` (500) digests are truncated rather than
-rejected. This processes as many batches as possible while bounding memory:
+rejected, on both the requester and responder sides. This serves as many batches as possible while
+bounding memory:
 
 ```
 Worst-case allocation: 500 entries × ~1MB per batch ≈ 500MB
-vs. uncapped: ~33k digests (1MB RPC limit) × 1MB ≈ 33GB
+vs. uncapped: ~33k digests (1MB message limit) × 1MB ≈ 33GB
 ```
 
 ### Size Validation Before Allocation
 
 ```rust
-let max_batch_size = max_batch_size(epoch);
-if uncompressed_length > max_batch_size {
-    return Err(WorkerNetworkError::InvalidRequest(...));
+if uncompressed_len > max_message_size {
+    return Err(...);
 }
 ```
 
-The uncompressed length is validated against protocol limits before any buffer allocation.
-This prevents a malicious peer from causing memory exhaustion by claiming an enormous batch size.
+Each frame's uncompressed length is validated against the per-epoch bound before any buffer is grown,
+and decompression is capped at that length. This prevents a malicious peer from causing memory
+exhaustion by claiming an enormous size.
 
 ### Compressed Length Validation
 
 ```rust
-let max_compressed = snap::raw::max_compress_len(max_batch_size);
-if compressed_len > max_compressed {
-    return Err(...);
-}
-
-// Cross-check: compressed size must be consistent with claimed uncompressed size
-let expected_max = snap::raw::max_compress_len(uncompressed_len);
-if compressed_len > expected_max {
+if compressed_len > snap::raw::max_compress_len(uncompressed_len) {
     return Err(...);
 }
 ```
 
-The compressed length is validated against both absolute limits and consistency with the uncompressed length.
-This catches malicious peers claiming small uncompressed sizes but large compressed sizes.
+The compressed length is validated for consistency with the claimed uncompressed length, and the
+compressed body is streamed in bounded chunks so committed memory tracks bytes actually received.
+This catches peers claiming small uncompressed sizes but large compressed sizes.
 
 ### Batch Count Validation
 
 ```rust
-if batch_count > requested_digests.len() {
-    return Err(NetworkError::ProtocolError(...));
+if batches.len() >= requested_digests.len() {
+    return Err(...); // peer sent too many batches
 }
 ```
 
-The receiver validates that the peer isn't sending more batches than were requested.
-This also allows peers to partially support batch syncing (may also be syncing).
+The receiver (`read_sync_batches()`) validates that the peer isn't sending more batches than were
+requested. Partial responses are allowed (a peer may hold only some of the requested batches).
 
 ### Digest Verification
 
 ```rust
 let batch_digest = batch.digest();
 if !requested_digests.contains(&batch_digest) {
-    return Err(NetworkError::ProtocolError(...));
+    return Err(...); // unexpected batch
 }
 ```
 
-After deserializing each batch, its digest is computed and verified against the set of requested digests.
+After decoding each batch, its digest is recomputed and verified against the set of requested digests.
 This ensures peers cannot substitute arbitrary data.
 
 ### Duplicate Detection
 
 ```rust
 if !received_digests.insert(batch_digest) {
-    return Err(NetworkError::ProtocolError(...));
+    return Err(...); // duplicate batch
 }
 ```
 
@@ -257,14 +236,9 @@ The receiver tracks which digests have been received and rejects duplicates.
 
 ### Buffer Reuse
 
-Buffers are allocated once at the start of a transfer and reused across batches:
-
-```rust
-let mut encode_buffer = Vec::with_capacity(max_size);
-let mut compressed_buffer = Vec::with_capacity(snap::raw::max_compress_len(max_size));
-```
-
-This prevents repeated allocations and ensures consistent memory bounds throughout the transfer.
+The decode and decompression buffers are allocated once at the start of a transfer and reused across
+every frame in the read loop, so a long transfer does not repeatedly reallocate and stays within
+consistent memory bounds.
 
 ## Compression
 
@@ -283,7 +257,7 @@ Snappy handles this gracefully by emitting uncompressed frames when compression 
 
 All stream operations return `WorkerNetworkResult`, with errors categorized as:
 
-- `StreamClosed`: Peer closed connection (may indicate peer doesn't have requested batches)
+- `StreamClosed`: Peer closed connection (may indicate the peer doesn't have the requested batches)
 - `InvalidRequest`: Protocol violation (malformed data, size limits exceeded)
 - `Internal`: Unexpected errors (database failures, encoding errors)
 
@@ -294,10 +268,9 @@ Protocol violations should trigger peer penalties via the peer manager.
 Stream codec functions are tested in isolation with mock streams.
 Integration tests in `tests/it/network_tests.rs` verify end-to-end batch synchronization between workers.
 
-Semaphore and concurrency tests cover:
-- Global semaphore exhaustion returns `ack: false`
-- RAII permit release when `PendingBatchStream` is dropped
+Concurrency tests cover:
+- Global semaphore exhaustion sheds with `Deny(AtCapacity)`
+- RAII permit release when a `SyncStreamPermit` is dropped
 - Per-peer limit enforcement across distinct peers
-- Stale request cleanup and permit recovery
 - Capacity at exactly `MAX_CONCURRENT_BATCH_STREAMS` across multiple peers
 - Retry logic succeeding after initial peer rejection

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -146,9 +146,6 @@ impl WorkerNetworkHandle {
         let res = res.await??.result;
         match res {
             WorkerResponse::ReportBatch => Ok(()),
-            WorkerResponse::RequestBatchesStream { .. } => Err(NetworkError::RPCError(
-                "Got wrong response, not a report batch is stream ack!".to_string(),
-            )),
             WorkerResponse::PeerExchange { .. } => Err(NetworkError::RPCError(
                 "Got wrong response, not a report batch is peer exchange!".to_string(),
             )),

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -1,7 +1,5 @@
 //! Messages sent between workers.
 
-use std::collections::BTreeSet;
-
 use crate::network::error::WorkerNetworkError;
 use serde::{Deserialize, Serialize};
 use tn_network_libp2p::{PeerExchangeMap, TNMessage};
@@ -38,18 +36,6 @@ pub enum WorkerRequest {
         /// The sealed batch that this worker is reporting.
         sealed_batch: SealedBatch,
     },
-    /// Request batches via stream.
-    ///
-    /// This initiates a stream-based batch transfer. The responder will
-    /// return `WorkerResponse::RequestBatchesStream` with acceptance status.
-    /// If accepted, the requestor opens a stream with the request digest
-    /// in the header for correlation.
-    RequestBatchesStream {
-        /// The batch digests being requested.
-        batch_digests: BTreeSet<BlockHash>,
-        /// The epoch these batches were produced.
-        epoch: Epoch,
-    },
     /// Exchange peer information.
     ///
     /// This "request" is sent to peers when this node disconnects
@@ -78,15 +64,6 @@ impl From<PeerExchangeMap> for WorkerRequest {
 pub enum WorkerResponse {
     /// Status 200 response when a peer accepts a proposed batch.
     ReportBatch,
-    /// Response to stream-based batch request.
-    ///
-    /// If `ack` is true, the requestor should open a stream with the
-    /// request digest in the header. The responder will send batches
-    /// over that stream.
-    RequestBatchesStream {
-        /// Whether the request is accepted.
-        ack: bool,
-    },
     /// Exchange peer information.
     PeerExchange {
         /// The peer information being exchanged.

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -43,7 +43,7 @@ pub(crate) type Res = WorkerResponse;
 /// so this bounds the true concurrent count—not just the pending map size.
 pub const MAX_CONCURRENT_BATCH_STREAMS: usize = 5;
 
-/// Maximum batch digests allowed per `RequestBatchesStream` request.
+/// Maximum batch digests allowed per sync batch request (`WorkerSyncRequest::Batches`).
 ///
 /// Derivation: 10 committee nodes * 6 max commit rounds * 5 batches per cert = 300.
 /// We use 500 for forward-compatibility headroom (committee growth, parameter changes).
@@ -195,9 +195,6 @@ where
                 WorkerRequest::ReportBatch { sealed_batch } => {
                     self.process_report_batch(peer, sealed_batch, channel, cancel);
                 }
-                WorkerRequest::RequestBatchesStream { .. } => {
-                    self.process_request_batches_stream(peer, channel, cancel);
-                }
                 WorkerRequest::PeerExchange { .. } => {
                     // expect this is intercepted by network layer
                     warn!(target: "worker::network", "worker application received unexpected peer exchange message");
@@ -291,33 +288,6 @@ where
             } else {
                 Ok(())
             }
-        });
-    }
-
-    /// Answer a legacy request-response `RequestBatchesStream` request.
-    ///
-    /// Item 9c (#739) removed the raw `/tn-stream` batch path, so peers fetch batches over
-    /// the `/tn-worker-{id}-sync` protocol. The request variant is retained for wire
-    /// compatibility (BCS variant indices stay until the coordinated `/0.0.2` bump); a legacy
-    /// requester is answered with a typed error rather than served.
-    fn process_request_batches_stream(
-        &self,
-        peer: BlsPublicKey,
-        channel: ResponseChannel<WorkerResponse>,
-        cancel: oneshot::Receiver<()>,
-    ) {
-        let network_handle = self.network_handle.clone();
-        let task_name = format!("BatchStreamDeprecated-{peer}");
-        let response = WorkerResponse::Error(message::WorkerRPCError(
-            "batches are served over the sync protocol only".to_string(),
-        ));
-        self.network_handle.get_task_spawner().spawn_task(task_name, async move {
-            tokio::select! {
-                _ = network_handle.inner_handle().send_response(response, channel) => (),
-                // cancel notification from network layer
-                _ = cancel => (),
-            }
-            Ok(())
         });
     }
 

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -919,18 +919,18 @@ mod test {
     /// negotiating with each other (issue #765).
     #[test]
     fn test_network_type_protocol_names() -> crate::types::NetworkResult<()> {
-        assert_eq!(NetworkType::Primary.req_res_protocol(2017)?.as_ref(), "/tn-primary-2017/0.0.1");
+        assert_eq!(NetworkType::Primary.req_res_protocol(2017)?.as_ref(), "/tn-primary-2017/0.0.2");
         assert_eq!(NetworkType::Primary.kad_protocol(2017)?.as_ref(), "/tn-primary-kad-2017/0.0.1");
         assert_eq!(
             NetworkType::Worker(0).req_res_protocol(2017)?.as_ref(),
-            "/tn-worker-0-2017/0.0.1"
+            "/tn-worker-0-2017/0.0.2"
         );
         assert_eq!(
             NetworkType::Worker(0).kad_protocol(2017)?.as_ref(),
             "/tn-worker-0-kad-2017/0.0.1"
         );
         // worker id and chain id are both interpolated, not literal
-        assert_eq!(NetworkType::Worker(3).req_res_protocol(7)?.as_ref(), "/tn-worker-3-7/0.0.1");
+        assert_eq!(NetworkType::Worker(3).req_res_protocol(7)?.as_ref(), "/tn-worker-3-7/0.0.2");
         assert_eq!(NetworkType::Worker(3).kad_protocol(7)?.as_ref(), "/tn-worker-3-kad-7/0.0.1");
         // the per-role sync protocol is chain-namespaced as well
         assert_eq!(

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -92,7 +92,6 @@ ban itself was applied elsewhere.
 | ------------------------------------------------ | ------------------------------------------------------ | ----------------------------------------------- |
 | `crates/consensus/worker/src/network/mod.rs:246` | `process_report_batch`                                 | `WorkerNetworkError::into() -> Option<Penalty>` |
 | `crates/consensus/worker/src/network/mod.rs:271` | `process_gossip`                                       | `WorkerNetworkError::penalty()`                 |
-| `crates/consensus/worker/src/network/mod.rs:379` | `process_request_batches_stream` response-error branch | `WorkerNetworkError::into() -> Option<Penalty>` |
 | `crates/consensus/worker/src/network/mod.rs:435` | `process_inbound_stream`                               | `WorkerNetworkError::penalty()`                 |
 
 ### 4.2 `WorkerNetworkError::penalty()` mapping
@@ -141,7 +140,6 @@ Source: `crates/consensus/worker/src/network/error.rs:76-138`.
 | `crates/consensus/primary/src/network/mod.rs:682` | `retrieve_missing_certs`                   | `(&PrimaryNetworkError).into() -> Option<Penalty>` |
 | `crates/consensus/primary/src/network/mod.rs:719` | `retrieve_consensus_header`                | `(&PrimaryNetworkError).into()` — only reachable variant `UnknownConsensusHeaderDigest` → `None` |
 | `crates/consensus/primary/src/network/mod.rs:751` | `retrieve_epoch_record`                    | `(&PrimaryNetworkError).into()`                    |
-| `crates/consensus/primary/src/network/mod.rs:835` | `process_epoch_stream` response-err branch | `(&PrimaryNetworkError).into()`                    |
 | `crates/consensus/primary/src/network/mod.rs:863` | `process_gossip`                           | `(&PrimaryNetworkError).into()`                    |
 | `crates/consensus/primary/src/network/mod.rs:912` | `process_inbound_stream`                   | `(&PrimaryNetworkError).into()`                    |
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1267,11 +1267,12 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
 /// A pruned peer that does not support the dedicated peer-exchange protocol still
 /// receives the goodbye.
 ///
-/// The raw swarm below advertises only the legacy `/tn-primary-{chain}/0.0.1`
-/// req-res protocol, exactly the wire surface of a not-yet-upgraded node. The
-/// target's goodbye attempt on `/tn-primary-peer-exchange-{chain}/0.0.1` fails
-/// with `UnsupportedProtocols` (penalty-exempt) and must fall back to the
-/// `PeerExchange` variant embedded in the legacy request enum.
+/// The raw swarm below advertises only the `/tn-primary-{chain}/0.0.2` req-res
+/// protocol and not the dedicated peer-exchange protocol, exactly the wire
+/// surface of a peer that has not adopted peer-exchange. The target's goodbye
+/// attempt on `/tn-primary-peer-exchange-{chain}/0.0.1` fails with
+/// `UnsupportedProtocols` (penalty-exempt) and must fall back to the
+/// `PeerExchange` variant embedded in the request enum.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer() -> eyre::Result<()> {
     tn_types::test_utils::init_test_tracing();

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -77,10 +77,21 @@ impl NetworkType {
     /// Request-response wire protocol, isolated per role (and per worker) and
     /// namespaced by `chain_id` so nodes on different chains never negotiate a
     /// connection.
+    ///
+    /// Bumped to `/0.0.2` by the #739 legacy-variant deletion: the migration
+    /// removed the dead-but-positional request/response variants that were kept
+    /// on the wire during the rollout (`StreamEpoch`, `StreamEpochPartial`,
+    /// `StreamConsensusOutput`, `MissingCertificates`, the worker
+    /// `RequestBatchesStream`, and their acks/replies). Deleting them shifts BCS
+    /// variant discriminants, so the protocol version is bumped in the same
+    /// change: a `/0.0.2` node never negotiates request-response with a
+    /// not-yet-upgraded `/0.0.1` peer, so the two never exchange a stale
+    /// discriminant. Only this protocol changed; kad, sync, and peer-exchange
+    /// stay at `/0.0.1`.
     pub(crate) fn req_res_protocol(&self, chain_id: u64) -> NetworkResult<StreamProtocol> {
         match self {
-            Self::Primary => owned_protocol(format!("/tn-primary-{chain_id}/0.0.1")),
-            Self::Worker(id) => owned_protocol(format!("/tn-worker-{id}-{chain_id}/0.0.1")),
+            Self::Primary => owned_protocol(format!("/tn-primary-{chain_id}/0.0.2")),
+            Self::Worker(id) => owned_protocol(format!("/tn-worker-{id}-{chain_id}/0.0.2")),
         }
     }
 


### PR DESCRIPTION
Final PR of the hybrid-streams migration (#739).  Steps 1 through 9c consolidated every
bulk request-response path onto the typed sync-stream protocol and froze the legacy
`/tn-stream` path.  Along the way, several request-response enum variants were kept on the
wire as dead-but-positional entries, each documented as "retained for wire compatibility;
removed at the coordinated `/0.0.2` bump".  This change performs that coordinated bump and
deletes them, closing the epic.

### What changed

Bumped the request-response wire protocol from `/0.0.1` to `/0.0.2`
(`/tn-primary-{chain}` and `/tn-worker-{id}-{chain}`) and deleted the eight frozen
variants plus their now-dead answer-with-error handlers:

- `PrimaryRequest`: `StreamEpoch`, `StreamEpochPartial`, `StreamConsensusOutput`,
  `MissingCertificates` (all four were answered with a typed error since their cutovers;
  handlers `process_epoch_stream`, `process_consensus_output_stream`, and
  `process_request_for_missing_certs` are removed).
- `PrimaryResponse`: `StreamRequestAck` and `RequestedCertificates` (neither had a
  producer left; `RequestedCertificates` was the reply paired with the deleted req-res
  `MissingCertificates`).
- `WorkerRequest` / `WorkerResponse`: `RequestBatchesStream` (handler
  `process_request_batches_stream` removed).

The surviving request-response variants are the live ones: primary `Vote`, `PeerExchange`,
`EpochRecord`;  primary responses `Vote`, `MissingParents`, `EpochRecord`, `PeerExchange`,
`Error`, `RecoverableError`;  worker `ReportBatch`, `PeerExchange`;  worker responses
`ReportBatch`, `PeerExchange`, `Error`, `RecoverableError`.

Also rewrote `crates/consensus/worker/src/network/README.md`, which still documented the
deleted legacy chunked-batch path (`send_batches_over_stream`, `PendingBatchStream`,
`LegacyStreamGuard`, the pending-request map and prune task).  It now describes the
sync-only batch path (request folded into the opening `SyncFrame::Req`, `try_admit_sync` /
`SyncStreamPermit` admission, `send_sync_batches_over_stream` serving `Ack` + `Data`* +
`End`).  This was the confirmed follow-up from the #939 review.

Also drops two now-dangling rows in `crates/network-libp2p/src/peers/penalty.md` that
documented the deleted `process_request_batches_stream` and `process_epoch_stream`
handlers (an adversarial review of this diff surfaced them;  penalty.md is not compiled or
`include_str!`d, so there is no build impact).  Other pre-existing line-number drift in
that file is left untouched.

### Why the version bump is mandatory and atomic with the deletion

Deleting a variant changes BCS discriminants.  In the worker enums the deletion is
mid-enum: removing `RequestBatchesStream` (discriminant 1) shifts `PeerExchange` (and, on
the response, `Error` / `RecoverableError`) down by one.  In the primary enums
`MissingCertificates` (discriminant 1) shifts the surviving variants too.  A `/0.0.1` peer
that still encodes one of these would be misdecoded by a node with the new layout.

Bumping the request-response protocol to `/0.0.2` in the same change fences this off: a
`/0.0.2` node never negotiates request-response with a not-yet-upgraded `/0.0.1` peer, so
the two never exchange a message under mismatched discriminants.  Only the request-response
protocol changed;  kad, sync, and peer-exchange stay at `/0.0.1` (their enums are
unchanged, and bumping them would needlessly fracture those subsystems).

### Rollout gate (important)

This is the "telemetry + epoch-gated" bump the migration deferred.  Because a `/0.0.2` node
stops speaking request-response to `/0.0.1` peers, it should land only once telemetry
confirms the legacy request-response variants see no live traffic and the rollout is
coordinated across the committee (an epoch boundary), exactly as the retained-variant
comments intended.  The code change is safe and self-contained;  the *deployment* is the
gated part.

### Scope notes / deliberately out of scope

- The `MissingCertificatesRequest` struct and its `max_response_size` field are kept: the
  struct is still used by the sync fetch path (`cert_collector` rebuilds it to reuse
  `get_bounds`).  Only the request-response variant that carried it on the wire is deleted;
  the field's comment is updated.  Removing the now-vestigial field is a possible follow-up.
- The embedded `PeerExchange` goodbye fallback (`send_legacy_goodbye` and the `PeerExchange`
  variants embedded in the request enums) is left in place.  That is a separate feature's
  deferred cleanup that was parked at the same `/0.0.2` coordination point;  this bump now
  unblocks it, but it touches the peer-manager goodbye path and belongs in its own PR.

### Gates

Toolchains: build/test stable 1.94;  fmt/clippy nightly-2026-03-20.  OOM-safe `-j 2`.

- check (`tn-network-libp2p`, `tn-worker`, `tn-primary`): clean.
- fmt `--check`: clean.
- clippy (`-D warnings`): `tn-primary --all-features --lib` clean.  `tn-network-libp2p` +
  `tn-worker --all-features --all-targets` adds no new warnings from this diff;  the only
  lint is a pre-existing test-only `collapsible_match` in `network_tests.rs`, byte-identical
  on origin/main (the same pre-existing test lint the earlier #739 PRs noted).  `tn-primary`
  uses `--lib` because `--all-targets` also hits a pre-existing `never_loop` in
  `certificate_fetcher_tests.rs`, not in this diff.
- tests: `tn-network-libp2p` 227, `tn-worker` 15 + 24, `tn-primary --lib` 158 (1 ignored).
  All pass.
- doc (`-D warnings`): `tn-network-libp2p` clean.  `tn-primary` / `tn-worker` have
  pre-existing private-intra-doc-link warnings on unchanged lines (there is no cargo-doc CI
  gate);  this diff adds zero new doc warnings.

No consumer-crate edits: the enums are internal to the consensus network modules.  The test
fixtures (`TestWorkerRequest` etc.) are independent test-only types decoded by their own
codec on both ends, so they are unaffected by the real-enum layout change.
