### PR TITLE
Fast-fail unsatisfiable certificate fetch (#866)

### DIFF
--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -464,6 +464,12 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
 
     // track requests per peer
     let mut peer_index = 0;
+    // Count completed per-peer fetches. Each spawned task sends exactly one result unless it is
+    // cancelled on another peer's success (after which we have already returned), so once every
+    // peer has been spawned and `results_received == peer_index`, all fetches have finished. This
+    // replaces `tx_results.is_closed()`, which never became true because this task holds
+    // `tx_results` for the whole loop, so the early-exit checks were dead (issue #866).
+    let mut results_received = 0usize;
 
     // spawn first peer fetch immediately
     if !peers.is_empty() {
@@ -486,6 +492,9 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
     loop {
         tokio::select! {
             Some((peer, result)) = rx_results.recv() => {
+                // a spawned fetch reported back (success, empty, or error)
+                results_received += 1;
+
                 if let Ok(certificates) = result {
                     if !certificates.is_empty() {
                         debug!(target: "primary::cert_fetcher",
@@ -517,8 +526,14 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
                         "Received empty certificate response, continuing with other peers");
                 }
 
-                // check if all peers have been tried and all tasks completed
-                if peer_index >= peers.len() && tx_results.is_closed() {
+                // fast-fail once every peer has been spawned and every spawned fetch has
+                // reported without success, instead of parking until the outer timeout fires.
+                // The caller (`handle_fetch_completion`) restarts immediately, so retry pacing for
+                // an unsatisfiable target comes from the staggered spawn above, a floor of
+                // ~`(peers.len() - 1) * fallback_delay`. With a single peer that stagger is absent,
+                // so pacing then relies on the per-peer fetch latency; real committees are
+                // `3f + 1` (>= 3 peers), where the stagger floor always applies.
+                if peer_index >= peers.len() && results_received >= peer_index {
                     debug!(target: "primary::cert_fetcher",
                         "All peers tried without success");
                     return Err(CertManagerError::NoCertificateFetched);
@@ -544,14 +559,14 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
             }
 
             else => {
-                // all peers spawned, no results yet - wait for tasks to complete
-                if tx_results.is_closed() {
-                    debug!(target: "primary::cert_fetcher",
-                        "No peer could provide certificates");
-                    sleep(fallback_delay).await;
-                    return Err(CertManagerError::NoCertificateFetched);
-                }
-                // continue waiting for results
+                // Defensive terminal that keeps the `select!` total so it can never panic on an
+                // all-disabled poll. The `recv` branch only disables once every sender has
+                // dropped, which cannot happen while this task holds `tx_results`; ordinary
+                // completion is detected by the counter check above. If the channel is ever fully
+                // closed, report the same "nobody had them" verdict.
+                debug!(target: "primary::cert_fetcher",
+                    "No peer could provide certificates");
+                return Err(CertManagerError::NoCertificateFetched);
             }
         }
     }

--- a/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
+++ b/crates/consensus/primary/src/tests/certificate_fetcher_tests.rs
@@ -583,19 +583,29 @@ async fn test_timeout_scenario() {
     let start_time = tokio::time::Instant::now();
     let mut request_count = 0;
 
-    // collect all requests but never respond: drop each fetch (its reply included) so the
-    // requester sees no response. `ok().flatten()` collapses a timeout or a closed channel
-    // to `None`.
+    // Collect each fetch request but hold onto its reply sender instead of dropping it, so the
+    // per-peer fetch hangs (neither Ok nor Err) and `fetch_from_peers` cannot fast-fail. Since
+    // #866, a peer that *reports* an empty/failed result lets the fetch return promptly, so only a
+    // genuinely unresponsive peer parks the fetch until the outer `timeout` deadline, which is
+    // what this test exercises. `ok().flatten()` collapses a recv timeout or closed channel to
+    // `None`.
+    let mut held_replies = Vec::new();
     loop {
-        if timeout(Duration::from_millis(200), fake_receiver.recv()).await.ok().flatten().is_some()
+        if let Some(fetch) =
+            timeout(Duration::from_millis(200), fake_receiver.recv()).await.ok().flatten()
         {
+            held_replies.push(fetch);
             request_count += 1;
             // continue collecting requests until we've seen them all
         } else if request_count >= num_peers {
-            // timeout or channel closed, and all requests collected
+            // recv timed out (peers are parked, not answering) and all requests collected
             break;
         }
     }
+
+    // every peer request was captured and its reply is still held (peers stay unresponsive for the
+    // rest of the test), so the in-flight fetch can only end via the outer timeout
+    assert!(held_replies.len() >= num_peers, "should have collected a request from every peer");
 
     // wait for the fetch operation to timeout
     tokio::time::sleep(expected_timeout + Duration::from_secs(1)).await;
@@ -1010,9 +1020,14 @@ async fn test_invalid_cert_from_sole_peer_does_not_panic() {
     });
 
     // regression (#822): with a single peer, `peer_index` already equals `peers.len()` when the
-    // response arrives, so logging the rejected cert used to panic on `peers[peer_index]`.
-    // `fetch_from_peers` has no single-peer error-return path, so post-fix it keeps waiting and
-    // the timeout elapses; pre-fix it panics before this future can complete.
+    // response arrives, so logging the rejected cert used to panic on `peers[peer_index]` (now
+    // fixed by logging the `peer` from the result tuple).
+    //
+    // regression (#866): that invalid response is the sole peer's only result, so once it is
+    // rejected every spawned fetch has reported without success and `fetch_from_peers` must
+    // fast-fail with `NoCertificateFetched`. Before #866 the early-exit checks gated on
+    // `tx_results.is_closed()`, which never became true (the loop holds `tx_results`), so the
+    // function parked until the outer timeout and this future resolved to `Pending`/`Elapsed`.
     let outcome = timeout(
         Duration::from_secs(2),
         fetch_from_peers(
@@ -1026,11 +1041,75 @@ async fn test_invalid_cert_from_sole_peer_does_not_panic() {
     .await;
 
     // positive signal that the invalid response was actually delivered, so the rejection/logging
-    // path ran (this is where the pre-fix `peers[peer_index]` panic fires); without it the timeout
-    // assertion alone could pass vacuously if the mock stopped delivering.
+    // path ran (this is where the pre-#822 `peers[peer_index]` panic fires); without it the outcome
+    // assertion could pass vacuously if the mock stopped delivering.
     let delivered = timeout(Duration::from_secs(1), answered_rx).await.ok().and_then(Result::ok);
     assert!(delivered.is_some(), "sole peer never delivered its response");
-    // and the fix means we reached that path without panicking; the fetch stays pending, so the
-    // outer timeout elapses rather than returning a value.
-    assert!(outcome.is_err(), "fetch_from_peers should still be pending, got {outcome:?}");
+    // no panic (we got a value at all), and the rejected sole peer fast-fails with
+    // `NoCertificateFetched` rather than parking until the 2s outer timeout.
+    assert_matches!(
+        outcome,
+        Ok(Err(CertManagerError::NoCertificateFetched)),
+        "sole invalid peer should fast-fail with NoCertificateFetched instead of parking"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_fetch_from_peers_fast_fails_on_all_empty() {
+    init_test_tracing();
+    let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let task_manager = TaskManager::default();
+
+    // every committee peer will be asked; each answers with an empty response
+    let peers: Vec<BlsPublicKey> =
+        fixture.committee().others_primaries_by_id(None).into_iter().map(|(_, key)| key).collect();
+    assert!(peers.len() >= 2, "need multiple peers to exercise the staggered fan-out");
+
+    let (network, mut fetch_rx) = MockFetcher::new();
+    // drain every per-peer fetch and reply with an empty certificate set
+    tokio::spawn(async move {
+        while let Some((_peer, _request, reply)) = fetch_rx.recv().await {
+            let _ = reply.send(Ok(vec![]));
+        }
+    });
+
+    // regression (#866): with all peers returning empty, `fetch_from_peers` must return
+    // `NoCertificateFetched` as soon as the last spawned fetch reports, rather than parking until
+    // the outer `fallback_delay * (peers.len() + 2)` timeout. Before the fix the early-exit checks
+    // gated on `tx_results.is_closed()`, which never became true (this task holds `tx_results`), so
+    // the function hung and this future would have timed out (`Err(Elapsed)`).
+    let num_peers = peers.len() as u32;
+    let fallback_delay = Duration::from_millis(100);
+    let outer_timeout = fallback_delay * (num_peers + 2);
+
+    let start = tokio::time::Instant::now();
+    let outcome = timeout(
+        outer_timeout,
+        fetch_from_peers(
+            network,
+            peers,
+            MissingCertificatesRequest::default(),
+            task_manager.get_spawner(),
+            fallback_delay,
+        ),
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    assert_matches!(
+        outcome,
+        Ok(Err(CertManagerError::NoCertificateFetched)),
+        "all-empty fetch should resolve to NoCertificateFetched, not hang until the outer timeout"
+    );
+    // A prompt return must land well within the outer timeout, not merely before it. The last peer
+    // is spawned after ~`(num_peers - 1) * fallback_delay` and answers immediately, so the fetch
+    // returns by roughly that point. Bound at `(num_peers + 1) * fallback_delay`, one
+    // `fallback_delay` under the outer timeout, so a regression that let the fetch drift toward
+    // the deadline fails here instead of passing the tautological `elapsed < outer_timeout`
+    // that the `Ok(_)` match above already implies.
+    let prompt_bound = fallback_delay * (num_peers + 1);
+    assert!(
+        elapsed < prompt_bound,
+        "fetch should fast-fail well within the timeout (elapsed {elapsed:?}, bound {prompt_bound:?}, outer {outer_timeout:?})"
+    );
 }


### PR DESCRIPTION
Closes #866.

## Problem

`fetch_from_peers` (`crates/consensus/primary/src/certificate_fetcher.rs`) staggers a
certificate request across the committee and returns as soon as one peer answers with a
non-empty, valid set.  When every peer answers empty or errors (a genuinely unsatisfiable
target), the function was meant to give up promptly through one of two
`NoCertificateFetched` early returns.  Both were gated on `tx_results.is_closed()`, which
is never true here, so both returns were dead code.  An all-empty / all-error cycle instead
parked until the caller's outer `timeout` fired at `fallback_delay * (peers.len() + 2)`
(with the 5s default fallback that is ~35s for a 5-peer committee), holding the single
in-flight fetch slot the whole time and delaying the next catch-up attempt.

## Root cause

The task running the `select!` loop holds a clone of `tx_results` for its entire lifetime
(it needs the sender to spawn each staggered peer fetch), so the sender side never fully
drops while the loop is alive.  `UnboundedSender::is_closed()` reports whether the *receiver*
has been dropped, not whether the spawned fetch tasks have finished, so it stays `false` for
the loop's whole lifetime and neither early return can ever fire.

## Fix

Track completion explicitly instead of inferring it from channel state:

- Add `results_received`, incremented once per result drained from `rx_results`.  Each spawned
  task sends exactly one result unless it is cancelled, and cancellation happens only on the
  success path immediately before returning, so on every non-success path `results_received`
  rises to meet `peer_index` (the count of spawned fetches).
- Replace `peer_index >= peers.len() && tx_results.is_closed()` with
  `peer_index >= peers.len() && results_received >= peer_index`: fail fast once every peer has
  been spawned and every spawned fetch has reported without success.
- The `select!` `else` arm no longer depends on the dead `is_closed()` check.  It is now a
  defensive terminal return that keeps the `select!` total so it cannot panic on an
  all-disabled poll.  The `recv` branch only disables once every sender has dropped, which
  cannot happen while the loop holds `tx_results`, so ordinary completion is always detected
  by the counter check above.

Threat model: no attacker is required . . . this is a self-inflicted latency bug on the
honest catch-up path.  The new fast-fail bound is derived from real parameters, not guessed:
retry pacing for an unsatisfiable target comes from the staggered spawn (a floor of
~`(peers.len() - 1) * fallback_delay`), and real committees are `3f + 1` (>= 3 peers) so that
floor always applies.  A genuinely hung or slow peer never reports, so it still parks until the
outer `timeout` exactly as before.  The fast path only triggers once every peer has already
answered, so a malicious or unresponsive peer cannot use it to make an honest node abandon a
satisfiable fetch any sooner than the pre-existing timeout already allowed.

## Testing

`cargo +1.94 test -p tn-primary certificate_fetcher` on the pinned toolchain, plus
`cargo +nightly-2026-03-20 fmt --check` and `cargo +1.94 clippy -p tn-primary --all-targets`.

- **`test_fetch_from_peers_fast_fails_on_all_empty`** (new): every committee peer answers with
  an empty set, then asserts `Ok(Err(NoCertificateFetched))` and that the fetch returns well
  within the deadline (`elapsed < (peers.len() + 1) * fallback_delay`, a full `fallback_delay`
  under the outer timeout, so a near-timeout regression fails rather than passing a bound the
  `Ok(_)` match already implies).  Pre-fix this future hangs and resolves to `Err(Elapsed)`.
- **`test_invalid_cert_from_sole_peer_does_not_panic`** (#822 regression, updated): the sole
  peer's invalid response now fast-fails with `NoCertificateFetched` instead of parking until
  the 2s outer timeout.
- **`test_timeout_scenario`** (updated): peers now hold their reply senders so they stay
  genuinely unresponsive, because a *responsive* empty/error peer fast-fails post-#866.  Only an
  unresponsive peer exercises the outer `timeout`, and the test asserts every request was
  captured.
- Each new and updated regression assertion was confirmed by reverting the fix, watching the
  test fail, then restoring.
