### PR TITLE
network-libp2p: box the oversized NetworkEvent::Gossip payload (#881)

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1282,8 +1282,8 @@ where
                     self.process_consensus_output_stream(peer, channel, cancel)
                 }
             },
-            NetworkEvent::Gossip { message, relayer, author } => {
-                self.process_gossip(message, relayer, author);
+            NetworkEvent::Gossip(gossip) => {
+                self.process_gossip(gossip.message, gossip.relayer, gossip.author);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = PrimaryResponse::Error(PrimaryRPCError(msg));

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -203,8 +203,8 @@ where
                     warn!(target: "worker::network", "worker application received unexpected peer exchange message");
                 }
             },
-            NetworkEvent::Gossip { message, relayer, author } => {
-                self.process_gossip(message, relayer, author);
+            NetworkEvent::Gossip(gossip) => {
+                self.process_gossip(gossip.message, gossip.relayer, gossip.author);
             }
             NetworkEvent::Error(msg, channel) => {
                 let err = WorkerResponse::Error(message::WorkerRPCError(msg));

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -11,8 +11,9 @@ use crate::{
     send_or_log_error,
     stream::{StreamBehavior, StreamEvent},
     types::{
-        KadQuery, NetworkCommand, NetworkEvent, NetworkHandle, NetworkInfo, NetworkResponseMessage,
-        NetworkResponseSender, NetworkResult, NetworkType, NodeRecord, ResponseChannel, RpcInfo,
+        GossipPayload, KadQuery, NetworkCommand, NetworkEvent, NetworkHandle, NetworkInfo,
+        NetworkResponseMessage, NetworkResponseSender, NetworkResult, NetworkType, NodeRecord,
+        ResponseChannel, RpcInfo,
     },
     PeerExchangeMap,
 };
@@ -2191,5 +2192,5 @@ fn accepted_gossip_event<Req, Res>(
     relayer: Option<BlsPublicKey>,
     author: Option<BlsPublicKey>,
 ) -> NetworkEvent<Req, Res> {
-    NetworkEvent::Gossip { message, relayer, author }
+    NetworkEvent::Gossip(Box::new(GossipPayload { message, relayer, author }))
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -950,8 +950,8 @@ async fn test_publish_to_one_peer() -> eyre::Result<()> {
         timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
 
     // assert gossip message
-    if let NetworkEvent::Gossip { message: msg, .. } = event {
-        assert_eq!(msg.data, expected_result);
+    if let NetworkEvent::Gossip(gossip) = event {
+        assert_eq!(gossip.message.data, expected_result);
     } else {
         panic!("unexpected network event received");
     }
@@ -1022,10 +1022,10 @@ async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<
         timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
 
     // assert gossip message and that the resolved relayer identity is carried
-    if let NetworkEvent::Gossip { message: msg, relayer, .. } = event {
-        assert_eq!(msg.data, expected_result);
+    if let NetworkEvent::Gossip(gossip) = event {
+        assert_eq!(gossip.message.data, expected_result);
         assert_eq!(
-            relayer,
+            gossip.relayer,
             Some(target_peer_bls),
             "resolved relayer's BLS identity must be attached to the delivered gossip"
         );
@@ -1241,8 +1241,9 @@ async fn test_peer_exchange_with_excess_peers() -> eyre::Result<()> {
 
     while !received && start.elapsed() < timeout {
         match tokio::time::timeout(Duration::from_millis(500), nvv_events.recv()).await {
-            Ok(Some(NetworkEvent::Gossip { message: msg, relayer: from, .. })) => {
-                assert_eq!(msg.data, expected_msg, "Gossip message data mismatch");
+            Ok(Some(NetworkEvent::Gossip(gossip))) => {
+                assert_eq!(gossip.message.data, expected_msg, "Gossip message data mismatch");
+                let from = gossip.relayer;
                 debug!(target: "network", ?from, "nvv received gossip from peer");
                 received = true;
             }
@@ -2231,8 +2232,8 @@ async fn test_gossip_explicit_peer_includes_next_committee() -> eyre::Result<()>
     publisher.publish(TEST_TOPIC.into(), expected.clone()).await?;
     let event =
         timeout(Duration::from_secs(2), next_peer_events.recv()).await?.expect("gossip received");
-    if let NetworkEvent::Gossip { message: msg, .. } = event {
-        assert_eq!(msg.data, expected);
+    if let NetworkEvent::Gossip(gossip) = event {
+        assert_eq!(gossip.message.data, expected);
     } else {
         panic!("unexpected network event received");
     }
@@ -2377,8 +2378,8 @@ async fn test_get_kad_records() -> eyre::Result<()> {
 
     // wait for gossip from disconnected peer
     match timeout(Duration::from_secs(5), nvv_events.recv()).await {
-        Ok(Some(NetworkEvent::Gossip { message: msg, .. })) => {
-            let GossipMessage { source, data, .. } = msg;
+        Ok(Some(NetworkEvent::Gossip(gossip))) => {
+            let GossipMessage { source, data, .. } = gossip.message;
             assert_eq!(source, Some(target_peer_id));
             assert_eq!(data, expected_msg);
         }
@@ -3201,8 +3202,10 @@ fn accepted_gossip_with_unresolved_relayer_is_delivered() -> eyre::Result<()> {
         accepted_gossip_event(message.clone(), None, None);
     assert_matches!(
         event,
-        NetworkEvent::Gossip { message: delivered, relayer: None, author: None }
-            if delivered.data == message.data
+        NetworkEvent::Gossip(payload)
+            if payload.relayer.is_none()
+                && payload.author.is_none()
+                && payload.message.data == message.data
     );
     Ok(())
 }
@@ -3214,7 +3217,7 @@ fn accepted_gossip_with_resolved_relayer_carries_identity() -> eyre::Result<()> 
     let message = test_gossip_message();
     let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
         accepted_gossip_event(message, Some(bls), None);
-    assert_matches!(event, NetworkEvent::Gossip { relayer: Some(got), .. } if got == bls);
+    assert_matches!(event, NetworkEvent::Gossip(payload) if payload.relayer == Some(bls));
     Ok(())
 }
 
@@ -3298,7 +3301,7 @@ fn accepted_gossip_carries_resolved_author_identity() -> eyre::Result<()> {
     let message = test_gossip_message();
     let event: NetworkEvent<TestWorkerRequest, TestWorkerResponse> =
         accepted_gossip_event(message, None, Some(author));
-    assert_matches!(event, NetworkEvent::Gossip { author: Some(got), .. } if got == author);
+    assert_matches!(event, NetworkEvent::Gossip(payload) if payload.author == Some(author));
     Ok(())
 }
 

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -200,12 +200,6 @@ impl<Res> ResponseChannel<Res> {
 }
 
 /// Events created from network activity.
-// The `Gossip` variant carries the payload plus two resolved BLS identities (relayer + author)
-// for penalty attribution, making it the largest variant. `NetworkEvent` is a short-lived message
-// moved across a small-capacity channel, so the per-slot size is immaterial, whereas boxing a
-// field would add a heap allocation to the hot gossip-delivery path; the peer-manager event enum
-// takes the same allowance (see `peers/types.rs`).
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum NetworkEvent<Req, Res> {
     /// Direct request from peer.
@@ -232,14 +226,9 @@ pub enum NetworkEvent<Req, Res> {
     /// `GossipMessage::source`) are distinct peers, and charging a content fault to the wrong
     /// one bans honest peers (see issues #801/#819); they are named rather than positional so
     /// the two cannot be transposed.
-    Gossip {
-        /// The gossip message payload.
-        message: GossipMessage,
-        /// BLS identity of the relaying peer (`propagation_source`), when resolved.
-        relayer: Option<BlsPublicKey>,
-        /// BLS identity of the message author (`GossipMessage::source`), when resolved.
-        author: Option<BlsPublicKey>,
-    },
+    ///
+    /// The payload is boxed as [`GossipPayload`] so this variant does not size the whole enum.
+    Gossip(Box<GossipPayload>),
     /// Send an error back the requester.
     Error(String, ResponseChannel<Res>),
     /// An inbound stream was established by a peer.
@@ -253,6 +242,22 @@ pub enum NetworkEvent<Req, Res> {
         /// The established raw p2p stream for reading data.
         stream: Stream,
     },
+}
+
+/// Boxed payload of [`NetworkEvent::Gossip`].
+///
+/// Held behind a `Box` in the variant so `NetworkEvent` is not sized to two inline
+/// `BlsPublicKey`s (288 B each); that indirection is what lets `NetworkEvent` carry no
+/// `#[allow(clippy::large_enum_variant)]`. See [`NetworkEvent::Gossip`] for the relayer
+/// and author identity semantics.
+#[derive(Debug)]
+pub struct GossipPayload {
+    /// The gossip message payload.
+    pub message: GossipMessage,
+    /// BLS identity of the relaying peer (`propagation_source`), when resolved.
+    pub relayer: Option<BlsPublicKey>,
+    /// BLS identity of the message author (`GossipMessage::source`), when resolved.
+    pub author: Option<BlsPublicKey>,
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #881.

## Summary

Box the oversized `NetworkEvent::Gossip` payload so `enum NetworkEvent<Req, Res>`
no longer needs `#[allow(clippy::large_enum_variant)]`.  This is a zero-behavior
change refactor: the three gossip fields move behind one `Box` as a named
`GossipPayload` struct, the blanket allow (and the comment justifying it) are
deleted, and the four match / construction sites are updated.  No wire format,
control flow, or public behavior changes.

## Problem

`crates/network-libp2p/src/types.rs` carried `#[allow(clippy::large_enum_variant)]`
on `NetworkEvent` with a comment arguing the suppression was justified.  Two of that
comment's load-bearing claims did not hold against current code:

- "moved across a small-capacity channel" . . . `NetworkEvent` actually flows over a
  `QueChannel` built with `CHANNEL_CAPACITY = 10_000` (`crates/types/src/sync.rs`,
  `crates/consensus/primary/src/consensus_bus.rs`, `crates/node/src/manager/node.rs`).
- "the per-slot size is immaterial" . . . an enum is always sized to its largest
  variant, so every buffered `NetworkEvent` occupies the `Gossip` footprint even when
  it is a small `Error`.  The `Gossip` variant measures ~744 B (a `GossipMessage` plus
  two `Option<BlsPublicKey>` at 296 B each, since `BlsPublicKey` eagerly caches both
  the decompressed curve point and the compressed bytes).  Under backpressure a filled
  10k queue is therefore ~7.4 MB of buffered events versus ~4.2 MB with `Gossip` boxed
  down to the next-largest variant.  No attacker is required: a slow consumer suffices.

The codebase already prefers boxing over an allow for exactly this shape in an adjacent
gossip enum (`PrimaryGossip { Certificate(Box<Certificate>), ... }`,
`crates/consensus/primary/src/network/message.rs`), and these were the only two
`#[allow(clippy::large_enum_variant)]` in the workspace.

## Changes

- [x] `network-libp2p/src/types.rs`: introduce `pub struct GossipPayload { message,
  relayer, author }` (named fields, so the two BLS identities still cannot be
  transposed) and change the variant to `Gossip(Box<GossipPayload>)`.  This takes the
  variant from the enum's largest (~744 B) to a pointer, leaving `InboundStream`
  (~425 B) as the largest, which clears the 200 B lint threshold with margin.
- [x] Delete `#[allow(clippy::large_enum_variant)]` and the now-inaccurate justifying
  comment.  The `#[allow]` on `PeerIdentity` in `peers/types.rs` is left untouched: it
  is justified by a different rationale (preserving `Copy` on a map key), and deleting
  this comment also removes its stale cross-reference to that site.
- [x] Update the sole constructor (`accepted_gossip_event`, `network-libp2p/src/consensus.rs`)
  and the two production consumers (`primary/src/network/mod.rs`,
  `worker/src/network/mod.rs`) to a `Box::new(...)` / field deref.
- [x] Update the gossip match / construction sites in
  `network-libp2p/src/tests/network_tests.rs` (the variant is now a tuple, so the
  `if let` and `assert_matches!` sites bind the boxed payload and read its fields).

The payload struct is named `GossipPayload`, not `GossipEvent` as the issue sketched,
because `consensus.rs` (the construction site) already binds `GossipEvent` as an alias
for `libp2p::gossipsub::Event`, and `network_tests.rs` inherits that alias through
`use super::*`.  `GossipPayload` avoids the collision.

## Why boxing `Gossip` alone is sufficient (generics honesty check)

`clippy::large_enum_variant` sizes the generic `Req` / `Res` as zero sized, and both
concrete `Res` types are `Arc`-indirect through `ResponseChannel`, so only `Req` could
threaten the ordering after boxing `Gossip`.  It does not, for either instantiation:
`NetworkEvent<WorkerRequest, WorkerResponse>` (largest `WorkerRequest` variant ~112 B,
`Vec`-indirect) and `NetworkEvent<PrimaryRequest, PrimaryResponse>` (~40 to 48 B,
`Arc` / `Vec`-indirect).  This holds because every `Req` variant's bulk sits behind
`Vec` / `Arc`;  the durable guard against a future large-by-value `Req` variant is the
lint itself, which is now active on `NetworkEvent` again.

## Testing

Run under the pinned toolchains, no `#[allow]` on `NetworkEvent`:

- `cargo +nightly-2026-03-20 fmt -- --check` . . . passes.
- `RUSTFLAGS="-D warnings -D unused_extern_crates" cargo +nightly-2026-03-20 clippy
  --workspace --all-features -- -D warnings` . . . passes with no
  `large_enum_variant` warning (this is the CI clippy gate;  removing the allow without
  the fix would fail it).
- `cargo +1.94 test --no-run --workspace` (isolated target dir) . . . builds.
- `cargo +1.94 test -p tn-network-libp2p accepted_gossip` . . . the three
  `accepted_gossip_*` unit tests (construct via `accepted_gossip_event`, match the
  boxed variant, assert the carried relayer / author identities) pass;  they exercise
  the new construct-and-destructure path directly.

No behavioral change, so no new test is added: the reinstated lint is the regression
guard, which is precisely the issue's acceptance criterion.
