### PR TITLE
refactor(storage): converge persist and persist_durable into one durable barrier (#962)

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -939,7 +939,7 @@ where
         // recast guard would then read nothing and could sign a *different* vote for the same
         // author/round while the pre-crash vote is already held by the peer: equivocation from an
         // ordinary crash. See issue #934.
-        self.consensus_config.node_storage().persist_durable::<Votes>().await;
+        self.consensus_config.node_storage().persist::<Votes>().await;
 
         Ok(PrimaryResponse::Vote(vote))
     }

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -275,7 +275,7 @@ impl<DB: Database> Proposer<DB> {
         // anti-equivocation guard would then read nothing and build a *different* header for this
         // same round while the pre-crash header is already on the network: equivocation from an
         // ordinary crash. See issue #934.
-        proposer_store.persist_durable::<LastProposed>().await;
+        proposer_store.persist::<LastProposed>().await;
 
         // Send the new header to the `Certifier` that will broadcast and certify it.
         consensus_bus.headers().send(header.clone()).await.map_err(|e| Box::new(e).into())

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -41,7 +41,7 @@ tn-reth = { workspace = true }
 tn-test-utils = { workspace = true }
 rand = { workspace = true }
 roaring = { workspace = true }
-# Async barrier tests for `persist_durable` need a runtime + timers.
+# Async barrier tests for the durable `persist` need a runtime + timers.
 tokio = { workspace = true, features = [ "macros", "rt", "time" ] }
 
 [features]

--- a/crates/storage/src/composite_db.rs
+++ b/crates/storage/src/composite_db.rs
@@ -130,10 +130,6 @@ impl<DB: Database> Database for CompositeDatabase<DB> {
         self.get_db(T::HINT).persist::<T>()
     }
 
-    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
-        self.get_db(T::HINT).persist_durable::<T>()
-    }
-
     fn sync_persist(&self) {
         self.inner.epoch_db.sync_persist();
         self.inner.kad_db.sync_persist();

--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -490,19 +490,6 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
         let (tx, rx) = oneshot::channel();
         let r = self
             .tx
-            .send(DBMessage::CaughtUp(tx))
-            .map_err(|_| eyre::eyre!("DB thread gone, FATAL!"));
-        async move {
-            if r.is_ok() {
-                let _ = rx.await;
-            }
-        }
-    }
-
-    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
-        let (tx, rx) = oneshot::channel();
-        let r = self
-            .tx
             .send(DBMessage::DurableBarrier(tx))
             .map_err(|_| eyre::eyre!("DB thread gone, FATAL!"));
         async move {
@@ -620,11 +607,14 @@ enum DBMessage<DB: Database> {
     Insert(Box<dyn InsertTrait<DB>>),
     Remove(Box<dyn RemoveTrait<DB>>),
     Clear(Box<dyn ClearTrait<DB>>),
+    /// Catch-up ack that fires immediately, even while a write txn is open. Backs
+    /// [`Database::sync_persist`], which is synchronous and must never block on a txn commit
+    /// (the calling thread may hold that very txn open, which would self-deadlock).
     CaughtUp(tokio::sync::oneshot::Sender<()>),
-    /// Durability barrier: like [`DBMessage::CaughtUp`], but the ack is deferred while a write txn
-    /// is open so it fires only after that physical txn commits. A bare `Insert` enqueued while a
-    /// txn is open is absorbed into it (`db_run`), so a plain `CaughtUp` could ack before the
-    /// write is durable; this variant closes that window for anti-equivocation writes.
+    /// Durability barrier backing [`Database::persist`]: like [`DBMessage::CaughtUp`], but the ack
+    /// is deferred while a write txn is open so it fires only after that physical txn commits. A
+    /// bare `Insert` enqueued while a txn is open is absorbed into it (`db_run`), so an immediate
+    /// ack could return before the write is durable; deferring closes that window.
     DurableBarrier(tokio::sync::oneshot::Sender<()>),
     Stats(tokio::sync::oneshot::Sender<LayeredDbStats>),
     Shutdown,
@@ -987,41 +977,13 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_persist_acks_before_open_txn_flushes() {
-        // Documents the issue #934 window: a plain `persist` barrier resolves even though a
-        // concurrently open write txn (e.g. a certificate-store write on the same epoch DB) has
-        // absorbed the caller's bare insert and not yet committed it, so the "persisted" record is
-        // not on disk. `persist_durable` is the fix for exactly this.
+    async fn test_persist_waits_for_open_txn_commit() {
+        // `persist` resolves only after the physical txn that absorbed the write commits, so the
+        // record is guaranteed on disk before the barrier returns. This is the converged durable
+        // barrier (#962) that closes the issue #934 window a non-deferring `persist` left open.
         use tn_types::DbTxMut as _;
         let temp_dir = tempdir().expect("failed to create temp dir");
-        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_gap"));
-
-        // A concurrent writer holds an epoch-DB write txn open.
-        let concurrent = db.write_txn().expect("write txn");
-        // The anti-equivocation record is a bare insert; with the txn open it is absorbed into it.
-        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
-
-        // The plain barrier resolves immediately even though the write is not durable.
-        db.persist::<TestTable>().await;
-        assert_eq!(
-            raw.get::<TestTable>(&1).expect("get"),
-            None,
-            "plain persist acked before the absorbed write reached disk (the #934 window)"
-        );
-
-        // Only committing the concurrent txn flushes the absorbed write.
-        concurrent.commit().expect("commit");
-        db.sync_persist();
-        assert_eq!(raw.get::<TestTable>(&1).expect("get"), Some("one".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_persist_durable_waits_for_open_txn_commit() {
-        // The fix: `persist_durable` resolves only after the physical txn that absorbed the write
-        // commits, so the record is guaranteed on disk before the barrier returns.
-        use tn_types::DbTxMut as _;
-        let temp_dir = tempdir().expect("failed to create temp dir");
-        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_durable"));
+        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_defer"));
 
         // A concurrent writer holds an epoch-DB write txn open; the bare insert is absorbed into
         // it.
@@ -1029,7 +991,7 @@ mod test {
         db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
 
         // While the txn is open the barrier must not resolve: polling it for a window times out.
-        let barrier = db.persist_durable::<TestTable>();
+        let barrier = db.persist::<TestTable>();
         tokio::pin!(barrier);
         assert!(
             tokio::time::timeout(Duration::from_millis(200), &mut barrier).await.is_err(),
@@ -1054,13 +1016,13 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_persist_durable_acks_immediately_without_open_txn() {
+    async fn test_persist_acks_immediately_without_open_txn() {
         // With no concurrent txn the bare insert is written directly and durably, so the barrier
         // resolves without waiting.
         let temp_dir = tempdir().expect("failed to create temp dir");
-        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_durable_fast"));
+        let (raw, db) = open_mdbx_with_raw(&temp_dir.path().join("mdbx_persist_fast"));
         db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
-        db.persist_durable::<TestTable>().await;
+        db.persist::<TestTable>().await;
         assert_eq!(
             raw.get::<TestTable>(&1).expect("get"),
             Some("one".to_string()),

--- a/crates/types/src/database_traits.rs
+++ b/crates/types/src/database_traits.rs
@@ -128,28 +128,29 @@ pub trait Database: Send + Sync + Clone + Unpin + 'static {
         Ok(())
     }
 
-    /// Some implementations may perform perstance operations in the background.
-    /// If so they can return a future that will resolve when they are complete.
-    /// This allows us to use a mostly sync DB interface but still allow async
-    /// "catch-up".  Uses Table as a hint.
+    /// Await until this caller's background writes are durably committed to the physical store.
+    ///
+    /// Some backends persist in the background: an `insert` updates an in-memory layer and enqueues
+    /// the disk write, returning before it is durable. This barrier resolves only once every write
+    /// ordered before it is durably committed, including the subtle case where a concurrently-open
+    /// write txn has *absorbed* this caller's bare insert, in which case the ack is deferred until
+    /// that physical txn commits. Synchronously-durable backends (raw MDBX / redb, `MemDatabase`)
+    /// are already durable on return, so the default no-op is correct for them. Uses `Table` as a
+    /// hint so a composite backend only waits on the relevant physical store.
+    ///
+    /// This is the single durability barrier: await it at externalization points (the proposer's
+    /// header broadcast, the vote handler's vote return) where losing the record across a crash
+    /// would make an honest node equivocate. See issues #934 and #962.
     fn persist<T: Table>(&self) -> impl Future<Output = ()> + Send {
         std::future::ready(())
     }
-    /// Durable variant of [`Database::persist`].
+    /// Synchronous, catch-up-only sibling of [`Database::persist`], for tests that cannot `await`.
     ///
-    /// For a backend that persists in the background, a plain [`Database::persist`] barrier can
-    /// resolve while a concurrently-open write txn has *absorbed* this caller's write but not yet
-    /// committed it, so a crash in that window loses the record even though `persist` returned. The
-    /// future returned here resolves only once the write is durably committed to the physical
-    /// store, including that absorbed-into-an-open-txn case. Synchronously-durable backends
-    /// inherit the plain `persist` behaviour.
-    ///
-    /// Use at anti-equivocation externalization points (proposer header broadcast, vote return)
-    /// where losing the record on restart makes an honest node equivocate.
-    fn persist_durable<T: Table>(&self) -> impl Future<Output = ()> + Send {
-        std::future::ready(())
-    }
-    /// Sync version of persist- useful for test not for prod code.
-    /// Since this is intended for testing don't bother with the Table hint.
+    /// Unlike `persist` this deliberately does **not** provide the durability barrier: it must
+    /// never defer past an open write txn, because a caller holding that txn open on the calling
+    /// thread would self-deadlock (the txn it would wait on only commits after this returns). It
+    /// merely lets the background writer catch up for read-your-writes ordering. Test-only;
+    /// production code that needs durability awaits `persist`. The `Table` hint is unnecessary
+    /// here.
     fn sync_persist(&self) {}
 }


### PR DESCRIPTION
Closes #962.

## Summary

#940 made the proposer's `LastProposed` header and the vote handler's `Votes` record durable before they are externalized, closing an anti-equivocation window (#934).  It did so by adding a *second* provided `Database` barrier, `persist_durable::<T>()`, rather than changing `persist()`, on the stated grounds that making `persist()` wait for an absorbing open transaction would deadlock callers that hold a `write_txn` across the barrier.

This PR converges the two barriers into one.  `persist()` gains the durable, defer-until-the-absorbing-txn-commits semantics that `persist_durable()` had, and `persist_durable()` is deleted.  `sync_persist()` is kept as the deliberately non-durable synchronous sibling.

## Why the second barrier was avoidable

The deadlock argument only applies to callers that hold an open `write_txn` across the barrier, and there are no production callers of the `Database` trait's `persist` / `sync_persist` at all.  Every call site is under `#[cfg(test)]` or in `tests/it/`:

- The `crates/storage/src/lib.rs`, `crates/storage/src/composite_db.rs`, and `crates/network-libp2p/src/kad.rs` sites are all below their crate's `#[cfg(test)]`.
- The `crates/consensus/primary/tests/it/` sites are integration tests.

The only production callers of the barrier family are the two `persist_durable` sites #940 added, and both want durability.  So giving `persist` the durable semantics has zero production blast radius, and the second method is redundant.

(Disambiguation: this is only about the `Database` trait method at `crates/types/src/database_traits.rs`.  The unrelated same-named wrappers `EpochRecords::persist`, `ConsensusPack::persist`, `CertificatePack::persist`, and the latest-consensus channel `persist` take no `Table` parameter, do have production callers, and are untouched.)

## Change

- [x] `crates/types/src/database_traits.rs`: `persist::<T>()` now documents the durability contract (resolves only once the write is durably committed, including the case where a concurrently open write txn has absorbed the caller's bare insert).  The `persist_durable` provided method is removed.  Synchronously-durable backends (raw MDBX / redb, `MemDatabase`) keep the no-op default, which is already correct for them.
- [x] `crates/storage/src/layered_db.rs`: the `LayeredDatabase::persist` impl now sends `DBMessage::DurableBarrier` (was `CaughtUp`);  the `persist_durable` impl is removed.  The background thread's defer-until-commit drain (`pending_durable`, drained in the `CommitTxn` / `EndTxn` arms) is unchanged from #940.
- [x] `crates/storage/src/composite_db.rs`: the `persist_durable` impl is removed;  `persist` already routes by `TableHint`, so a barrier still only waits on the relevant physical store.
- [x] `crates/consensus/primary/src/proposer.rs` and `crates/consensus/primary/src/network/handler.rs`: the two anti-equivocation sites call `persist::<T>()` again instead of `persist_durable::<T>()`.  No behavior change . . . `persist` is now what `persist_durable` was.

## sync_persist: kept, non-durable, on purpose

`sync_persist()` cannot adopt the deferring semantics.  It is synchronous and spins on the calling thread, so if that thread holds an open `write_txn` across it, deferring the ack until the txn commits would self-deadlock (the txn only commits after `sync_persist` returns).  It therefore stays on the immediate-ack `CaughtUp` path and is documented as a read-your-writes catch-up primitive, not a durability barrier, for tests that cannot `await`.  The two txn-count-balancing tests that hold an open txn across `sync_persist` (`test_layereddb_overlapped_txn_drop_keeps_count_balanced`, `test_layereddb_cloned_txn_commit_sends_exactly_one_end`) are unaffected precisely because `sync_persist` is left non-deferring.

## Restored invariant (unchanged from #940)

An honest node still never externalizes a header or vote whose anti-equivocation record is not yet durable.  After a crash at any point after the header is broadcast or the vote is returned, on restart the node either re-proposes the identical header (re-signs the identical vote) or does not act for that round;  it never produces a different one, so an ordinary crash (no attacker required) cannot manufacture authority equivocation.  The barrier backing that guarantee is now `persist`, not a separate method.

## Testing

Storage tests (`crates/storage/src/layered_db.rs`):

- The old-behavior pin `test_persist_acks_before_open_txn_flushes` (which asserted that a plain `persist` acked before an absorbed write was durable) is deleted . . . that window no longer exists.
- The two durability tests are renamed to target `persist`: `test_persist_waits_for_open_txn_commit` (the barrier must not resolve while the absorbing txn is open, then resolves once it commits with the record on disk) and `test_persist_acks_immediately_without_open_txn`.  `test_persist_waits_for_open_txn_commit` is non-vacuous: it fails if `persist` does not defer (the old `CaughtUp` `persist` resolved inside the 200ms window and tripped the `is_err()` assertion), which is the differential the deleted test previously pinned in the other direction.

Commands (worktree off `origin/main`, pinned toolchain):

- `cargo +1.94 check -p tn-types -p tn-storage -p tn-primary`: clean.
- `cargo +nightly-2026-03-20 fmt --check` on the three crates: clean.
- `cargo +1.94 clippy --all-targets` on the three crates: 0 warnings on the changed lines.
- `tn-storage` lib: 149 passed.  `tn-primary`: proposer 4, vote 30.  Integration `storage_tests` 12, `recovery_tests` 5 (every `.persist::<T>()` settle site runs after its writes commit, so it acks immediately and does not hang under the durable barrier).
- `make attest` proxy: `cargo +1.94 test --no-run --workspace` in an isolated target dir: green (30 test binaries built, 0 errors).
- The renamed `test_persist_waits_for_open_txn_commit` was confirmed non-vacuous by mutation: reverting `persist` to the non-deferring `CaughtUp` path makes it fail on the "durable barrier resolved while the absorbing txn was still open" assertion, then restoring the `DurableBarrier` path makes it pass again.

## Sequencing note

The issue flags that this cleanup should follow the table-placement decision: if the anti-equivocation tables move off the layered DB to synchronously-durable storage, several sites that need any barrier disappear.  This PR does not depend on that decision.  It removes the redundant second method without changing which tables live where, so it composes with either outcome (if the tables later move, the single `persist` degrades to the no-op default at those sites rather than leaving a second method to also delete).
