### PR TITLE
test: build the e2e node binary under an opt-level-2 profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,3 +33,31 @@ debug = false
 [profile.test.build-override]
 opt-level = 0
 codegen-units = 256
+
+# End-to-end test profile (see crates/e2e-tests). Selected with `--profile e2e` when
+# building the `telcoin-network` node binary the e2e suite spawns - through the Makefile's
+# `build-e2e-bin` target and, when `TN_BIN_PATH` is unset, the escargot build in
+# `get_telcoin_network_binary`. Inheriting `release` builds every crate at opt-level 2,
+# including the revm/reth/BLS dependencies where consensus and EVM runtime is spent; the
+# `dev`/`test` profiles above cap those dependencies at opt-level 1, so a plain dev build
+# would leave the hot code unoptimized. `debug-assertions` and `overflow-checks` are turned
+# back on - `release` disables them - so the suite still exercises the payload-builder and
+# header-validation invariants it asserts against. As a distinct profile its artifacts live
+# under `target/e2e/`, not shared with the dev/test `target/debug/` graph, so the dependency
+# closure compiles once more: the one-time build cost of running the suite optimized.
+[profile.e2e]
+inherits = "release"
+opt-level = 2
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+debug-assertions = true
+overflow-checks = true
+# release's default of 16, stated explicitly: codegen stays parallel (not serialized to 1 or
+# LTO) so the optimized rebuild above stays as cheap as possible.
+codegen-units = 16
+
+# Dependencies still compile at the profile's opt-level 2 but skip their debuginfo: it is
+# never inspected for third-party crates, and dropping it avoids the I/O cost on the large
+# reth/revm graph, mirroring the `dev`/`test` profiles' `package."*"` overrides.
+[profile.e2e.package."*"]
+debug = false

--- a/Makefile
+++ b/Makefile
@@ -108,13 +108,16 @@ test-faucet:
 	cargo nextest run --package telcoin-network --features faucet --test it ;
 
 # Build the node binary once so e2e test processes reuse it via TN_BIN_PATH instead of
-# rebuilding it through escargot (~3-10s of cargo overhead per test process).
+# rebuilding it through escargot (~3-10s of cargo overhead per test process). Built under the
+# optimized `e2e` profile (opt-level 2 with debug-assertions/overflow-checks kept on; see
+# `[profile.e2e]` in .cargo/config.toml) so the reused binary runs consensus and EVM at speed.
 .PHONY: build-e2e-bin
 build-e2e-bin:
-	cargo build --bin telcoin-network --features tn-storage/test-utils --target-dir $(CURDIR)/target ;
+	cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir $(CURDIR)/target ;
 
 # Location of the binary built by build-e2e-bin, passed to the e2e tests via TN_BIN_PATH.
-E2E_BIN := $(CURDIR)/target/debug/telcoin-network
+# A named cargo profile emits into target/<profile>/, so the `e2e` profile binary lands here.
+E2E_BIN := $(CURDIR)/target/e2e/telcoin-network
 
 # run restart integration tests
 test-restarts: build-e2e-bin

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -4,7 +4,8 @@
 
 The heavy e2e tests (restart and epoch tests) are `#[ignore]`d and each needs the
 `telcoin-network` node binary. When `TN_BIN_PATH` is unset, the first test builds that binary
-in-process via `escargot`, which at `opt-level = 0` is a multi-minute compile. Under `nextest`'s
+in-process via `escargot`, which under the `e2e` profile (`opt-level = 2`) is a multi-minute
+compile. Under `nextest`'s
 default output capture that build is buffered, so the first test looks frozen for several minutes
 before it does anything.
 
@@ -17,8 +18,8 @@ make test-e2e          # builds the binary once, then runs the suite with TN_BIN
 or run the raw command yourself (for example from an IDE test runner):
 
 ```
-cargo build --bin telcoin-network --features tn-storage/test-utils
-TN_BIN_PATH="$(pwd)/target/debug/telcoin-network" \
+cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils
+TN_BIN_PATH="$(pwd)/target/e2e/telcoin-network" \
   cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
 ```
 

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -399,17 +399,18 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
             return TestBinary::Prebuilt(path);
         }
 
-        // TN_BIN_PATH is unset, so build the node binary in-process via escargot. At
-        // opt-level 0 this is a multi-minute compile, and nextest captures stdout/stderr, so
-        // without this notice the first e2e test looks frozen until the build finishes. Announce
-        // it on stderr (shown on completion, and live under `--no-capture`) so the delay is
-        // attributable rather than an invisible hang.
+        // TN_BIN_PATH is unset, so build the node binary in-process via escargot. Under the
+        // `e2e` profile (opt-level 2) this is a multi-minute compile, and nextest captures
+        // stdout/stderr, so without this notice the first e2e test looks frozen until the build
+        // finishes. Announce it on stderr (shown on completion, and live under `--no-capture`) so
+        // the delay is attributable rather than an invisible hang.
         eprintln!(
             "e2e: TN_BIN_PATH not set; building telcoin-network via cargo before the first test. \
-             This can take several minutes at opt-level 0, and nextest hides it until the build \
-             finishes (add `--no-capture` to watch it). To skip it, run `make test-e2e`, or \
-             prebuild with `cargo build --bin telcoin-network --features tn-storage/test-utils` \
-             and export TN_BIN_PATH=\"$(pwd)/target/debug/telcoin-network\" from the workspace root."
+             This can take several minutes (opt-level 2 under the `e2e` profile), and nextest \
+             hides it until the build finishes (add `--no-capture` to watch it). To skip it, run \
+             `make test-e2e`, or prebuild with `cargo build --profile e2e --bin telcoin-network \
+             --features tn-storage/test-utils` and export \
+             TN_BIN_PATH=\"$(pwd)/target/e2e/telcoin-network\" from the workspace root."
         );
         info!("building main binary for e2e tests");
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -417,15 +418,22 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
         let workspace_root =
             path.parent().and_then(|p| p.parent()).expect("Cannot find workspace root");
 
+        // Build under the `e2e` profile (opt-level 2, safety checks kept on; defined in
+        // .cargo/config.toml) so this in-process build and `make build-e2e-bin` produce and
+        // share one set of artifacts under `target/e2e/`.
+        //
         // No `.current_target()`: passing `--target <triple>` would emit into
-        // `target/<triple>/debug/`, a tree that shares no artifacts with the plain
-        // `target/debug/` that `make build-e2e-bin` and ordinary `cargo build` populate, forcing
-        // a guaranteed cold rebuild. Building into `target/debug/` lets escargot reuse an already
-        // compiled binary (reported "Fresh" by cargo) instead.
+        // `target/<triple>/e2e/`, a tree that shares no artifacts with the plain `target/e2e/`
+        // that `make build-e2e-bin` and ordinary `cargo build --profile e2e` populate, forcing a
+        // guaranteed cold rebuild. Building into `target/e2e/` lets escargot reuse an
+        // already-compiled binary (reported "Fresh" by cargo) instead.
         TestBinary::Cargo(
             CargoBuild::new()
                 .bin("telcoin-network")
                 .features("tn-storage/test-utils")
+                // Match the Makefile's `build-e2e-bin`: opt-level 2 with debug-assertions and
+                // overflow-checks kept on (see `[profile.e2e]` in .cargo/config.toml).
+                .args(["--profile", "e2e"])
                 .manifest_path(workspace_root.join("Cargo.toml"))
                 .target_dir(workspace_root.join("target"))
                 .run()

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -102,8 +102,8 @@ cargo nextest run --workspace --no-fail-fast
 # Prebuild the node binary once into the shared target tree and hand it to the e2e tests via
 # TN_BIN_PATH (mirroring `make test-e2e`), so the ignored suite reuses it instead of cold-building
 # the binary inside the first test, which nextest capture would otherwise hide as a multi-minute hang.
-cargo build --bin telcoin-network --features tn-storage/test-utils --target-dir "$(pwd)/target"
-TN_BIN_PATH="$(pwd)/target/debug/telcoin-network" \
+cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir "$(pwd)/target"
+TN_BIN_PATH="$(pwd)/target/e2e/telcoin-network" \
     cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
 
 echo "all checks passed - submitting attestation on-chain..."


### PR DESCRIPTION
Closes #916.

## Summary

The e2e suite spawns a real `telcoin-network` node process, and that binary was built with no profile flag, so it defaulted to the unoptimized dev profile (`opt-level = 0`).  The heavy e2e tests are CPU-bound on consensus and EVM execution, so running the node unoptimized dominates their wall-clock.

This adds a dedicated `e2e` build profile at `opt-level = 2` and points every path that produces the e2e binary at it.  Consensus and EVM results are unchanged:  `debug-assertions` and `overflow-checks` are kept on, so the invariants the suite relies on still fire, and only codegen (not semantics) changes.

## Changes

- [x] **`.cargo/config.toml`**:  new `[profile.e2e]` next to the existing `dev`/`test` profiles (the repo keeps all profile config here, not in `Cargo.toml`).  It `inherits = "release"` so every crate, including the revm/reth/BLS dependencies where the runtime is actually spent, is built at `opt-level = 2`.  The `dev`/`test` profiles cap dependencies at `opt-level = 1` via their `package."*"` overrides, so a plain dev build would leave the hot code unoptimized.  `debug-assertions` and `overflow-checks` are turned back on (release disables them).  `codegen-units = 16` is stated explicitly (release's default) to keep codegen parallel rather than serializing to LTO.  `[profile.e2e.package."*"] debug = false` drops third-party debuginfo (its I/O cost is what the `dev`/`test` profiles already avoid) while keeping deps at `opt-level = 2`.
- [x] **`Makefile`**:  `build-e2e-bin` now runs `cargo build --profile e2e`; `E2E_BIN` points at `target/e2e/telcoin-network` (a named profile emits into `target/<profile>/`).  This feeds `test-restarts`, `test-e2e`, and `public-tests` via `TN_BIN_PATH`.
- [x] **`etc/test-and-attest.sh`**:  the prebuild step (run by `make attest`) uses `--profile e2e` and sets `TN_BIN_PATH` to `target/e2e/telcoin-network`, so the built path and the consumed path stay in lockstep.
- [x] **`crates/e2e-tests/src/lib.rs`**:  the `TN_BIN_PATH`-unset fallback in `get_telcoin_network_binary()` passes `--profile e2e` to escargot's `CargoBuild`, matching the Makefile.  escargot resolves the artifact path from cargo's JSON output, so the `target/e2e/` location is found without assuming `target/debug/`.  Stale `opt-level 0` / `target/debug` wording in the surrounding comment and the operator-facing hint was corrected.
- [x] **`crates/e2e-tests/README.md`**:  the manual-run instructions now use `--profile e2e` and `target/e2e/telcoin-network`.

## Acceptance criteria

- [x] Binary is compiled with `opt-level = 2`:  `[profile.e2e]` sets it, `inherits = "release"` extends it to the dependency closure, and both the Makefile and escargot paths select `--profile e2e`.
- [x] No changes to test assertions, epoch counts, iteration counts, or timing constants:  the diff touches only build config, one escargot argument, and comments/docs.  Zero test files change.
- [x] Safety invariants preserved:  `debug-assertions = true` and `overflow-checks = true` keep `debug_assert!`/overflow panics and every `#[cfg(debug_assertions)]` path active, so consensus/EVM behavior is identical to the dev-profile binary.
- [ ] Measurable wall-clock reduction demonstrated:  captured by the reviewer's `make test-e2e` run (see Verification).  The optimized build is a one-time cost, so the win shows on the ignored suite, not on a single test.

## Verification

Confirmed in this change:

- `cargo check -p e2e-tests` builds clean, including `escargot` and the new `--profile e2e` argument.
- `cargo +nightly-2026-03-20 fmt --check` is clean (the `wrap_comments` reflow is applied).
- The profile resolves and emits to `target/e2e/` (verified against `cargo 1.96`;  a custom named profile defined in `.cargo/config.toml` is valid and builds into `target/<profile>/`).
- Every e2e-binary path moves together (`Makefile` `E2E_BIN`, `etc/test-and-attest.sh` `TN_BIN_PATH`, the escargot fallback, and the README), so the `is_file` assert in `get_telcoin_network_binary()` cannot be handed a stale `target/debug/` path.  The production `target/release/telcoin-network` references (README, Dockerfile) are intentionally untouched.

Wall-clock, to capture on a full checkout under the pinned toolchain:

```
make test-e2e     # builds --profile e2e once, then runs the ignored suite with TN_BIN_PATH set
```

The issue flags `test_eip1559_fee_rises_at_epoch_boundaries` and `test_epoch_sync` as the CPU-bound tests expected to improve.

## Notes / tradeoff

The `e2e` profile is a distinct optimization level, so its artifacts live under `target/e2e/` and do not share the `dev`/`test` `target/debug/` graph.  The dependency closure therefore compiles once more:  this is the inherent, one-time build cost of running the suite optimized, and is unavoidable for any profile that raises the dependencies above the dev/test `opt-level = 1`.  The issue accepts this and defers cold-build amortization to #897; `codegen-units = 16` keeps that extra compile parallel.
