### PR TITLE
test(storage): open test-build MDBX envs in SafeNoSync to drop hot-path fsync

### DIFF
--- a/crates/storage/src/mdbx/database.rs
+++ b/crates/storage/src/mdbx/database.rs
@@ -113,6 +113,14 @@ fn default_page_size() -> usize {
     os_page_size.clamp(min_page_size, libmdbx_max_page_size)
 }
 
+/// The MDBX sync mode compiled into `test` and `test-utils` builds. `SafeNoSync` removes the
+/// hot-path `fsync` while still surviving a process kill+restart (see [`MdbxDatabase::open`]);
+/// it must never be `UtterlyNoSync`, which risks whole-DB corruption on an OS/power crash. This
+/// is the single source of truth `open` applies, so a test can pin it exactly. Production builds
+/// enable neither cfg and this const does not exist for them (the env stays `Durable`).
+#[cfg(any(test, feature = "test-utils"))]
+const BUILD_SYNC_MODE: reth_libmdbx::SyncMode = reth_libmdbx::SyncMode::SafeNoSync;
+
 impl MdbxDatabase {
     /// Creates a new database at the specified path if it doesn't exist. Does NOT create tables.
     /// Check [`init_db`].
@@ -122,19 +130,51 @@ impl MdbxDatabase {
         max_size: usize,
         growth_step: usize,
     ) -> eyre::Result<Self> {
-        let env = Environment::builder()
-            .set_max_dbs(max_tables)
-            .write_map()
-            .set_geometry(Geometry {
-                // Maximum database size
-                size: Some(0..max_size),
-                // We grow the database in increments of 1 gigabyte
-                growth_step: Some(growth_step as isize),
-                // The database never shrinks
-                shrink_threshold: Some(0),
-                page_size: Some(PageSize::Set(default_page_size())),
-            })
-            .open(path.as_ref())?;
+        let mut builder = Environment::builder();
+        builder.set_max_dbs(max_tables).write_map().set_geometry(Geometry {
+            // Maximum database size
+            size: Some(0..max_size),
+            // We grow the database in increments of 1 gigabyte
+            growth_step: Some(growth_step as isize),
+            // The database never shrinks
+            shrink_threshold: Some(0),
+            page_size: Some(PageSize::Set(default_page_size())),
+        });
+
+        // Test and `test-utils` builds trade fsync durability for write speed: they open the
+        // env in `SafeNoSync` instead of the default `Durable`, which removes the meta+data
+        // `fsync` that MDBX performs at every `txn.commit()` on the consensus hot path.
+        //
+        // This is coverage-preserving. With `write_map()` + `SafeNoSync`, a committed
+        // transaction survives a *process* crash/kill+restart -- the only recovery the tests
+        // ever exercise (they restart a node by relaunching the process against the same
+        // on-disk datadir) -- because the data lives in the file-backed mmap / OS page cache
+        // and a relaunched process re-maps it. Durability is lost only on an *OS/power* crash,
+        // which no test induces.
+        //
+        // It must be `SafeNoSync`, never `UtterlyNoSync`. `SafeNoSync` keeps the last steady
+        // commit's pages untouched, so it is corruption-proof on *any* crash (it can always roll
+        // back to that steady commit) and merely loses the last transactions on an OS/power
+        // crash. `UtterlyNoSync` discards that steady commit for marginally faster writes and can
+        // corrupt the whole database on an OS/power crash -- a needless risk given our access
+        // pattern. Note the e2e suite would NOT reliably catch a drift to `UtterlyNoSync`: an
+        // OS-alive process restart recovers under either mode, so the `BUILD_SYNC_MODE` const and
+        // its `assert_eq!` are what actually enforce the choice, not the restart tests.
+        //
+        // The `feature = "test-utils"` arm is what reaches the e2e nodes: they are spawned as
+        // separate processes built with `--features tn-storage/test-utils`, where `cfg(test)`
+        // is not live, so no CLI plumbing is required to select the mode. Production builds
+        // enable neither cfg, so this block is compiled out and the default `Durable` stands.
+        #[cfg(any(test, feature = "test-utils"))]
+        {
+            use reth_libmdbx::{EnvironmentFlags, Mode};
+            builder.set_flags(EnvironmentFlags {
+                mode: Mode::ReadWrite { sync_mode: BUILD_SYNC_MODE },
+                ..Default::default()
+            });
+        }
+
+        let env = builder.open(path.as_ref())?;
 
         Ok(MdbxDatabase { inner: env })
     }
@@ -427,5 +467,35 @@ mod test {
         let temp_dir = tempdir().expect("failed to create temp dir");
         let db = open_db(temp_dir.path());
         db_simp_bench(db, "MDBX");
+    }
+
+    /// #917: under the `test`/`test-utils` cfg the env must open in `SafeNoSync` (no hot-path
+    /// `fsync`) -- specifically not `Durable` (would keep the fsync) and, critically, not
+    /// `UtterlyNoSync` (risks whole-DB corruption on an OS/power crash). The e2e restart suite
+    /// cannot tell the two no-sync modes apart, so this const-assert is the real guard.
+    #[test]
+    fn test_open_uses_safe_no_sync_under_test_cfg() {
+        use super::BUILD_SYNC_MODE;
+        use reth_libmdbx::{Mode, SyncMode};
+
+        // Pin the exact compiled mode. `SyncMode` is `PartialEq`, so this catches a drift to
+        // `Durable` (fsync back on) or to `UtterlyNoSync` (recovery broken) -- the latter is the
+        // one the readback below cannot see, so this assert is what guards the hard constraint.
+        assert_eq!(BUILD_SYNC_MODE, SyncMode::SafeNoSync);
+
+        // And prove the flag actually reached MDBX: the opened env reports a non-`Durable` mode,
+        // so the hot-path fsync is genuinely gone. NOTE: MDBX defines
+        // `MDBX_UTTERLY_NOSYNC = MDBX_SAFE_NOSYNC | <extra bit>`, and reth-libmdbx's `mode()`
+        // tests the UtterlyNoSync mask before the SafeNoSync one, so it reports `UtterlyNoSync`
+        // for a genuine `SafeNoSync` env. We therefore assert only "not Durable / not read-only"
+        // from the readback; the exact-mode guarantee is pinned by the const assert above. Do not
+        // "fix" this into `assert_eq!(mode, ..SafeNoSync)` -- it cannot pass by construction.
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let db = open_db(temp_dir.path());
+        let mode = db.inner.info().expect("read env info").mode();
+        assert!(
+            matches!(mode, Mode::ReadWrite { sync_mode } if sync_mode != SyncMode::Durable),
+            "test-build MDBX env must not be Durable (hot-path fsync must be off), got {mode:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #917.

## Summary

Every e2e node opens its consensus MDBX databases (epoch / kad / cache) in the
default **durable** sync mode, so every `txn.commit()` on the consensus hot path
`fsync`s the meta and data pages.  Under `#[cfg(test)]` / `feature = "test-utils"`
those nodes run on a throwaway `temp_path` that is deleted at teardown, and the
suite only ever restarts a node by **killing and relaunching the process on the
same host** . . . a recovery that `MDBX_SAFE_NOSYNC` already survives.  This switches
the test-build consensus MDBX envs to `SafeNoSync`, which removes the hot-path
`fsync` with **no change to any assertion and no loss of restart-recovery
coverage.**  Production builds are untouched and stay fully `Durable`.

The win is disk-dependent: near sub-second on warm local NVMe, several seconds per
long epoch/restart test on a slow CI disk.  This is a low-risk, stacking CI-runner
optimization (it pairs with a tmpfs datadir), not a guaranteed local speedup.

## Changes

- `crates/storage/src/mdbx/database.rs`
  - [x] Add `BUILD_SYNC_MODE`, a cfg-gated const that is the **single source of
    truth** for the sync mode: `SafeNoSync` under `#[cfg(any(test, feature =
    "test-utils"))]`, and *not defined at all* in production builds (where the env
    keeps the default `Durable`).
  - [x] `MdbxDatabase::open` applies `BUILD_SYNC_MODE` via `set_flags(...)` inside
    the same cfg gate.  `write_map()` (env *kind*) and `set_flags` (env *flags*)
    are independent builder fields, so the only bit this changes versus today is
    the sync mode;  every other flag keeps its existing default.
  - [x] Add `test_open_uses_safe_no_sync_under_test_cfg`, which pins the exact
    compiled mode and proves the flag reaches MDBX (see Verification).

The gate is `any(test, feature = "test-utils")` on purpose.  `cfg(test)` covers
`tn-storage`'s own unit tests;  `feature = "test-utils"` is what reaches the e2e
nodes, which are spawned as separate processes built with
`--features tn-storage/test-utils` (`crates/e2e-tests/src/lib.rs`), where
`cfg(test)` is not live.  No CLI plumbing is required to select the mode.

## Acceptance criteria

- [x] The test-build consensus MDBX env opens in `SafeNoSync` (asserted from the
  live env, not just the source const).
- [x] `SafeNoSync`, never `UtterlyNoSync`.  `SafeNoSync` keeps the last steady
  commit's pages untouched, so it is corruption-proof on *any* crash (it can always
  roll back to that steady commit) and merely loses the last transactions on an
  OS/power crash;  a committed txn always survives a **process** kill+restart because
  the data is in the file-backed mmap / OS page cache and a relaunched process
  re-maps it.  `UtterlyNoSync` discards that steady commit for marginally faster
  writes and can corrupt the whole database on an **OS/power** crash, a needless risk
  for our access pattern.  Note the e2e restart suite would **not** reliably catch a
  drift to `UtterlyNoSync` (an OS-alive process restart recovers under either
  no-sync mode), so the guard is the `BUILD_SYNC_MODE` const and its `assert_eq!`,
  not the restart tests.  This documentation-accuracy point was raised and fixed in
  adversarial review.
- [x] Production builds are unchanged.  The `test-utils` feature is enabled only
  through `[dev-dependencies]` edges (`tn-types`, `state-sync`, `batch-builder`,
  `consensus/primary`, `network-libp2p`), never a normal `[dependencies]` edge, so
  a release `cargo build --bin telcoin-network` never sees it and the cfg block is
  compiled out.  `test-utils` is not in `default`.
- [x] All existing storage assertions are unaffected . . . only `fsync` latency is
  removed.

## Scope: consensus MDBX only (reth block DB deferred)

The issue names an optional secondary half: reth's block DB
(`crates/tn-reth/src/lib.rs::new_database` via `init_db` +
`DatabaseArguments::with_sync_mode`).  It is deliberately **not** included here.
The e2e node binary is built with only `--features tn-storage/test-utils`;  nothing
enables a `tn-reth` test feature, and `cfg(test)` is not live in the spawned
binary.  So the reth half cannot reach the e2e nodes without adding a new `tn-reth`
feature *and* changing the e2e build command . . . exactly the CLI plumbing the
issue asked to avoid.  The consensus MDBX env is where every DAG round commits, so
it is the primary hot path;  the reth half can follow as its own change if the
extra build wiring is judged worthwhile.

## Verification

Pinned toolchain (`rust-toolchain.toml` = 1.94).

- `cargo +1.94 test -p tn-storage --lib` . . . **151 passed;  0 failed**, including
  the new `test_open_uses_safe_no_sync_under_test_cfg`.
- **Confirm-by-mutation** (the regression test was *seen* to fail): flipping
  `BUILD_SYNC_MODE` to `UtterlyNoSync` fails the guard with
  `assertion left == right failed  left: UtterlyNoSync  right: SafeNoSync`;
  restored to `SafeNoSync`.
- The test asserts in two ways.  (1) `assert_eq!(BUILD_SYNC_MODE,
  SyncMode::SafeNoSync)` pins the exact mode (`SyncMode: PartialEq`), which is what
  catches an accidental `UtterlyNoSync`.  (2) A read-back of the opened env
  (`db.inner.info().mode()`) asserts the env is **not** `Durable`, proving the flag
  actually took effect.  Note: MDBX defines
  `MDBX_UTTERLY_NOSYNC = MDBX_SAFE_NOSYNC | <extra bit>`, and reth-libmdbx's
  `mode()` tests the UtterlyNoSync mask before the SafeNoSync one, so it reports
  `UtterlyNoSync` for a genuine `SafeNoSync` env . . . which is why the exact-mode
  guarantee is pinned by the const assert, not the read-back.
- `cargo +nightly fmt -- --check` clean;  `cargo +1.94 clippy -p tn-storage
  --all-targets --features test-utils` adds no new warnings (the 54 reported are
  pre-existing storage-test lints unrelated to this diff).
- `make attest` on 1.94 (fmt + clippy + `--workspace` test-build in an isolated
  target dir) is the final gate;  run it against the pushed hash.

The full e2e suite (every restart-recovery path) is the acceptance surface for the
runtime win and is best measured on a CI runner with a slow disk . . . the change is
assertion-preserving by construction, so those tests should pass unchanged.
