### PR TITLE
fix(execution): commit the finalized/safe markers atomically

### DIFF
--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -192,7 +192,8 @@ pub fn execute_consensus_output(
         executed_blocks,
         Some((leader_round, consensus_num_hash, engine_update_tx)),
     )?;
-    // remove blocks from memory and stores them in the database
+    // update the in-memory finalized/safe watches and prune persisted blocks from memory
+    // (the database markers committed atomically with the blocks above)
     reth_env.finalize_block(canonical_header.clone())?;
 
     // return new canonical header for next engine task

--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -55,13 +55,13 @@ impl TnExExContext {
     /// Handle to reth for querying EVM chain state and history — for reads only.
     ///
     /// Use this **only** for reads. `RethEnv`'s public surface is *not*
-    /// mutation-free: it also exposes DB-writing methods — notably
-    /// `finish_executing_output` (commits blocks and broadcasts a canonical-state
-    /// notification) and `finalize_block` (persists the finalized/safe block
-    /// numbers) — and this handle shares state with the node's live execution
-    /// writer. Calling a writing method from an ExEx would corrupt the follower's
-    /// chain state. The read-only contract here is by convention, not enforced by
-    /// the type.
+    /// mutation-free: it also exposes state-writing methods — notably
+    /// `finish_executing_output` (commits blocks with the finalized/safe markers
+    /// and broadcasts a canonical-state notification) and `finalize_block`
+    /// (updates the in-memory finalized/safe watches) — and this handle shares
+    /// state with the node's live execution writer. Calling a writing method from
+    /// an ExEx would corrupt the follower's chain state. The read-only contract
+    /// here is by convention, not enforced by the type.
     ///
     /// Reads commonly useful to an ExEx (see [`RethEnv`] for the full surface):
     ///

--- a/crates/exex/src/lib.rs
+++ b/crates/exex/src/lib.rs
@@ -42,7 +42,7 @@
 //!   epoch records, and committed sub-DAGs by number or digest.
 //!
 //! Both handles are for reads only, and **neither** is mutation-free at the type
-//! level: `reth_env` exposes DB-writing methods (e.g. `finish_executing_output`,
+//! level: `reth_env` exposes state-writing methods (e.g. `finish_executing_output`,
 //! `finalize_block`) and `consensus_chain` exposes consensus-DB writers. An ExEx
 //! must treat both as read handles and never call their writing methods — doing
 //! so would corrupt the follower's state. The read-only contract is by

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -240,13 +240,13 @@ impl ExecutionNodeInner {
     /// This returns the hash of the last executed ConsensusHeader on the consensus chain.
     /// since the execution layer is confirming the last executing block.
     pub(super) fn last_executed_output(&self) -> eyre::Result<ConsensusHeaderDigest> {
-        // The payload builder commits an output's blocks and the finalized marker in separate
-        // transactions; a crash between them leaves the marker lagging the persisted tip.
-        // Startup heals that lag (`RethEnv::heal_finalized_to_persisted_tip`) before anything
-        // reads the marker, so the finalized block read here is the last block of the last
-        // consensus output whose execution was fully committed — the digest recovered below
-        // names exactly the last executed output, and the primary re-requests everything after
-        // it.
+        // The payload builder commits an output's blocks and the finalized marker in ONE
+        // transaction, so a crash can no longer leave the marker lagging the persisted tip.
+        // Startup additionally heals databases written by pre-fix versions that committed the
+        // marker separately (`RethEnv::heal_finalized_to_persisted_tip`) before anything reads
+        // the marker, so the finalized block read here is the last block of the last consensus
+        // output whose execution was fully committed — the digest recovered below names
+        // exactly the last executed output, and the primary re-requests everything after it.
         //
         // recover finalized block's nonce: this is the last subdag index from consensus (round)
         let finalized_block_num = self.reth_env.last_finalized_block_number()?;

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -202,19 +202,18 @@ pub async fn catchup_accumulator(
 
         // Cross-view guard: a finalized header pinned in a different epoch than the canonical
         // tip would pin the whole restore (scan range, worker count, leader-count bound) to the
-        // wrong epoch's state. Startup heals the finalized marker to the persisted canonical
-        // tip (`RethEnv::heal_finalized_to_persisted_tip`) before this restore runs, so the
-        // benign crash-window lag can no longer reach this comparison — a firing guard means
-        // the two views still disagree after the heal: genuine database inconsistency.
-        // Investigate the database; do not restart-loop past this.
+        // wrong epoch's state. The marker commits atomically with the blocks, and startup
+        // heals any lag left by a pre-fix database (`RethEnv::heal_finalized_to_persisted_tip`)
+        // before this restore runs, so a benign marker lag can no longer reach this comparison
+        // — a firing guard means the two views still disagree after the heal: genuine database
+        // inconsistency. Investigate the database; do not restart-loop past this.
         if epoch_state.epoch != canonical_epoch {
             return Err(eyre!(
                 "startup accumulator restore: finalized header {} pins epoch {} but the \
                  canonical tip reports epoch {canonical_epoch} — the views disagree across an \
                  epoch boundary even though startup heals the finalized marker to the canonical \
-                 tip before this restore. This is database inconsistency, not the benign \
-                 crash-window marker lag; refusing to rebuild gas stats against the wrong \
-                 epoch's state",
+                 tip before this restore. This is database inconsistency, not a benign marker \
+                 lag; refusing to rebuild gas stats against the wrong epoch's state",
                 block.number,
                 epoch_state.epoch,
             ));
@@ -803,7 +802,7 @@ where
     /// Build the process-lifetime components, then drive the epoch loop until shutdown.
     ///
     /// Startup proceeds in order: create the execution engine and start it, heal any
-    /// crash-window finalized-marker lag to the persisted canonical tip
+    /// finalized-marker lag left by a pre-fix database to the persisted canonical tip
     /// (`RethEnv::heal_finalized_to_persisted_tip` — before anything reads the marker), recover
     /// the [`GasAccumulator`] via [`catchup_accumulator`], spawn the long-running p2p networks
     /// ([`spawn_node_networks`](Self::spawn_node_networks)), spawn the epoch-record and vote
@@ -857,9 +856,11 @@ where
             )
             .await?;
 
-        // Heal a finalized marker left lagging the persisted canonical tip by a crash between
-        // the blocks-commit and finalize-commit transactions BEFORE anything reads the marker:
-        // the catchup below pins every chain-derived input to the finalized header.
+        // Heal a finalized marker left lagging the persisted canonical tip by a pre-fix
+        // version (which committed blocks and the marker in separate transactions) BEFORE
+        // anything reads the marker: the catchup below pins every chain-derived input to the
+        // finalized header. Current versions commit the marker atomically with the blocks, so
+        // this is defense-in-depth for old databases.
         let reth_env = engine.get_reth_env().await;
         reth_env.heal_finalized_to_persisted_tip()?;
         // retrieve epoch information from canonical tip on startup

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -28,9 +28,9 @@ use tn_reth::{
     payload::TNPayload,
     test_utils::{
         create_committee_from_state, execute_payload_and_update_canonical_chain,
-        governance_burn_tx, governance_owner_factory, seeded_genesis_from_random_batches,
-        test_genesis_with_consensus_registry, test_genesis_with_consensus_registry_and_workers,
-        TransactionFactory,
+        governance_burn_tx, governance_owner_factory, plant_finalized_marker,
+        seeded_genesis_from_random_batches, test_genesis_with_consensus_registry,
+        test_genesis_with_consensus_registry_and_workers, TransactionFactory,
     },
     ExecutedBlock, NewCanonicalChain, RethChainSpec, RethEnv,
 };
@@ -198,14 +198,15 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
     assert_eq!(expected, gas_accumulator.rewards_counter().get_address_counts());
     assert_eq!(expected, recovered.rewards_counter().get_address_counts());
 
-    // Simulate the crash window: rewind the finalized marker to a mid-chain header, as if the
-    // node died between the blocks-commit and finalize-commit transactions. Calling
-    // finalize_block directly is safe here: the watches are plain non-monotonic setters, and
-    // the engine has exited so the in-memory tree is empty and remove_persisted_blocks no-ops.
+    // Simulate a pre-fix database: rewind the persisted finalized marker to a mid-chain header
+    // and seed the watches to match, as if this node restarted on a database written by a
+    // version that committed blocks and the marker in separate transactions and died between
+    // them. Current versions commit both atomically, so only a pre-fix database presents this
+    // lag.
     let tip_header = reth_env.finalized_header()?.expect("live run finalized the tip");
     let rewind_to =
         reth_env.sealed_header_by_number(tip_header.number / 2)?.expect("mid-chain header exists");
-    reth_env.finalize_block(rewind_to.clone())?;
+    plant_finalized_marker(&reth_env, rewind_to.clone())?;
     let stale = reth_env.finalized_header()?.expect("rewound finalized header");
     assert_eq!(stale.number, rewind_to.number, "precondition: the marker lags the tip");
 
@@ -769,12 +770,16 @@ async fn test_sync_then_catchup_recovers_two_worker_accumulator() -> eyre::Resul
             .expect("engine update per output");
     }
 
-    // The engine update is sent from finish_executing_output AFTER the blocks commit but
-    // BEFORE finalize_block writes the finalized marker in its own transaction, so under load
-    // the marker can still lag the persisted tip here. A real restart never reads through that
-    // window: startup heals the marker before anything consults it. Mirror that startup step
-    // so catchup pins the settled tip instead of racing the marker write.
-    reth_env.heal_finalized_to_persisted_tip()?;
+    // finish_executing_output commits the blocks AND the finalized/safe markers in one
+    // transaction before it sends the engine update, so the persisted marker cannot lag the
+    // persisted tip here. The in-memory finalized watch catchup reads, though, is set by
+    // finalize_block moments later in the engine task — settle it deterministically with the
+    // same header the engine writes (idempotent) instead of racing that update. A real restart
+    // never sees this transient: the watch is seeded from the settled database rows.
+    let settled_tip = reth_env
+        .sealed_header_by_number(reth_env.last_block_number()?)?
+        .expect("persisted tip header exists");
+    reth_env.finalize_block(settled_tip)?;
 
     // simulate node recovery at startup: catchup sizes the accumulator from pinned chain state
     // and rebuilds gas stats (fees are owned by the entry seeding)
@@ -920,8 +925,10 @@ fn payload_with_base_fee(
 
 /// Make an executed block canonical, mirroring `tn_engine`'s payload-builder chain update.
 ///
-/// Finalization is intentionally left to the caller so tests can construct a chain whose
-/// finality lags the canonical tip.
+/// `finish_executing_output` commits the finalized/safe markers atomically with the block, so
+/// the persisted marker tracks the tip here; the in-memory watch update (`finalize_block`) is
+/// left to the caller. Tests that need a chain whose finality lags the canonical tip plant the
+/// lag afterwards via `plant_finalized_marker` (simulating a pre-fix database).
 fn extend_canonical_chain(reth_env: &RethEnv, block: ExecutedBlock) -> eyre::Result<SealedHeader> {
     let header = block.recovered_block.clone_sealed_header();
     let canonical_in_memory_state = reth_env.canonical_in_memory_state();
@@ -934,9 +941,10 @@ fn extend_canonical_chain(reth_env: &RethEnv, block: ExecutedBlock) -> eyre::Res
 /// Catchup pins every chain-derived input (scan range, worker-count read block, leader-count
 /// bound) to the ONE finalized header, and startup heals that marker to the persisted
 /// canonical tip BEFORE catchup runs (`RethEnv::heal_finalized_to_persisted_tip`). A lagging
-/// marker is the crash-window artifact of blocks and the marker committing in separate
-/// transactions; healing it is sound because every persisted canonical block is
-/// consensus-final by construction.
+/// marker is the artifact of pre-fix versions that committed blocks and the marker in
+/// separate transactions — current versions commit both atomically, so each phase plants the
+/// lag directly (`plant_finalized_marker`) to model such a database. Healing is sound because
+/// every persisted canonical block is consensus-final by construction.
 ///
 /// Phase A — mid-epoch lag (block 1 finalized; block 2 canonical-only; both carry a real
 /// transfer): catchup ALONE still pins its scan to the stale marker and undercounts (control),
@@ -1006,8 +1014,9 @@ async fn catchup_heals_finality_lag_across_epoch_boundary() -> eyre::Result<()> 
     reth_env.finalize_block(block1_header.clone())?;
     assert!(block1_header.gas_used > 0, "block 1's transfer must land for sharp gas assertions");
 
-    // block 2 (epoch 0): canonical but NOT finalized - the crash-window mid-epoch lag - with a
-    // second executed transfer so the healed recount is measurably larger than the control
+    // block 2 (epoch 0): canonical but NOT finalized - the pre-fix crash-window mid-epoch lag
+    // - with a second executed transfer so the healed recount is measurably larger than the
+    // control
     let transfer2 = tx_factory.create_eip1559_encoded(
         chain.clone(),
         None,
@@ -1025,6 +1034,9 @@ async fn catchup_heals_finality_lag_across_epoch_boundary() -> eyre::Result<()> 
         &[],
     )?;
     let block2_header = extend_canonical_chain(&reth_env, block2)?;
+    // extend committed the marker atomically with block 2; rewind it to block 1 (database rows
+    // + watches) to model a pre-fix database whose separate marker write was lost in a crash
+    plant_finalized_marker(&reth_env, block1_header.clone())?;
     assert!(block2_header.gas_used > 0, "block 2's transfer must land for sharp gas assertions");
 
     // Phase A control: catchup ALONE pins its scan to the stale marker (block 1), passes the
@@ -1043,8 +1055,8 @@ async fn catchup_heals_finality_lag_across_epoch_boundary() -> eyre::Result<()> 
     // catchup leaves fees to the entry seeding: block 1's non-MIN fee is NOT adopted
     assert_eq!(recovered.base_fee(worker_id).base_fee(), MIN_PROTOCOL_BASE_FEE);
 
-    // Phase A heal: the marker advances to the persisted canonical tip through finalize_block,
-    // updating the in-memory watch catchup reads alongside the database row
+    // Phase A heal: the marker advances to the persisted canonical tip - the heal rewrites the
+    // database rows and updates the in-memory watch catchup reads through finalize_block
     reth_env.heal_finalized_to_persisted_tip()?;
     let healed = reth_env.finalized_header()?.expect("healed finalized header");
     assert_eq!(healed.number, block2_header.number, "heal advances the marker to the tip");
@@ -1068,9 +1080,12 @@ async fn catchup_heals_finality_lag_across_epoch_boundary() -> eyre::Result<()> 
     let block3 =
         reth_env.build_block_from_batch_payload(payload3, &no_txs, block2_header.hash(), &[])?;
     let block3_header = extend_canonical_chain(&reth_env, block3)?;
+    // rewind the atomically-committed marker to block 2: the pre-fix lag now crosses the
+    // epoch boundary
+    plant_finalized_marker(&reth_env, block2_header.clone())?;
 
     // precondition: the views genuinely disagree at epoch granularity - the canonical tip's
-    // epoch state places the epoch start PAST the finalized header (block 2 after Phase A)
+    // epoch state places the epoch start PAST the finalized header (block 2)
     let finalized = reth_env.finalized_header()?.expect("finalized header");
     assert_eq!(finalized.number, block2_header.number, "finality pinned at block 2");
     let tip_state = reth_env.epoch_state_from_canonical_tip()?;
@@ -1127,8 +1142,9 @@ async fn catchup_heals_finality_lag_across_epoch_boundary() -> eyre::Result<()> 
 }
 
 /// The heal refuses a node whose finalized marker points PAST the persisted canonical tip: the
-/// marker only ever trails the tip (blocks commit first), so a marker ahead of it means the
-/// execution database lost blocks this node already attested as final.
+/// marker only ever trails or equals the tip (it commits atomically with the blocks; pre-fix
+/// versions committed the blocks first), so a marker ahead of it means the execution database
+/// lost blocks this node already attested as final.
 #[tokio::test]
 async fn heal_errors_when_finalized_marker_ahead_of_tip() -> eyre::Result<()> {
     let temp_dir = TempDir::with_prefix("heal_marker_ahead")?;
@@ -1136,10 +1152,11 @@ async fn heal_errors_when_finalized_marker_ahead_of_tip() -> eyre::Result<()> {
         default_test_execution_node(None, None, &temp_dir.path().join("reth"), None)?;
     let reth_env = execution_node.get_reth_env().await;
 
-    // Plant a marker past the (genesis-only) tip. finalize_block with a fabricated header is
-    // safe here: its hash is not in the in-memory block map, so remove_persisted_blocks no-ops.
+    // Plant a marker past the (genesis-only) tip via a direct database write - only a
+    // corrupted or pre-fix database can present this state, since the production path commits
+    // the marker atomically with the blocks and can never run ahead of them.
     let ahead = SealedHeader::new(ExecHeader { number: 5, ..Default::default() }, B256::random());
-    reth_env.finalize_block(ahead)?;
+    plant_finalized_marker(&reth_env, ahead)?;
 
     let err = reth_env
         .heal_finalized_to_persisted_tip()
@@ -1166,6 +1183,58 @@ async fn heal_noop_on_fresh_genesis() -> eyre::Result<()> {
     assert!(
         reth_env.finalized_header()?.is_none(),
         "fresh genesis stays unfinalized after the heal",
+    );
+
+    Ok(())
+}
+
+/// The kill-between-commits gap can no longer open: blocks and the finalized/safe markers
+/// commit in ONE database transaction (`RethEnv::finish_executing_output`), so a node that
+/// dies immediately after the blocks-commit — before `finalize_block`'s in-memory update ever
+/// runs — restarts on a database whose finalized marker ALREADY equals the persisted tip.
+/// There is no between-commits state, so the startup heal has nothing to repair and takes its
+/// no-op path (no warn-path heal needed).
+#[tokio::test]
+async fn finalized_marker_commits_atomically_with_blocks() -> eyre::Result<()> {
+    let temp_dir = TempDir::with_prefix("atomic_finalized_marker")?;
+    let chain: Arc<RethChainSpec> = Arc::new(adiri_genesis().into());
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        &temp_dir.path().join("reth"),
+        None,
+    )?;
+    let reth_env = execution_node.get_reth_env().await;
+
+    // execute one consensus output and commit it WITHOUT calling finalize_block: the exact
+    // on-disk state of a node killed right after finish_executing_output's commit
+    let genesis_header = chain.sealed_genesis_header();
+    let no_txs: Vec<Vec<u8>> = vec![];
+    let output = manual_consensus_output(0, 0, 1, false);
+    let payload = payload_with_base_fee(genesis_header.clone(), &output, MIN_PROTOCOL_BASE_FEE, 0);
+    let block =
+        reth_env.build_block_from_batch_payload(payload, &no_txs, genesis_header.hash(), &[])?;
+    let block_header = extend_canonical_chain(&reth_env, block)?;
+
+    // fresh read-only provider reads: the persisted marker already equals the persisted tip
+    assert_eq!(reth_env.last_block_number()?, block_header.number);
+    assert_eq!(
+        reth_env.last_finalized_block_number()?,
+        block_header.number,
+        "the finalized marker commits atomically with the blocks",
+    );
+
+    // the heal has nothing to repair: it takes the no-op path, which never touches the
+    // in-memory watches (still unset because finalize_block never ran)
+    reth_env.heal_finalized_to_persisted_tip()?;
+    assert!(
+        reth_env.finalized_header()?.is_none(),
+        "a no-op heal leaves the watches untouched - no warn-path heal was needed",
+    );
+    assert_eq!(
+        reth_env.last_finalized_block_number()?,
+        block_header.number,
+        "the no-op heal leaves the settled marker in place",
     );
 
     Ok(())

--- a/crates/tn-reth/src/error.rs
+++ b/crates/tn-reth/src/error.rs
@@ -53,11 +53,11 @@ pub enum TnRethError {
     SignerRecovery(#[from] alloy::consensus::crypto::RecoveryError),
     /// The persisted finalized marker points past the persisted canonical tip.
     ///
-    /// The marker only ever trails the tip (blocks and the marker commit in separate
-    /// transactions, blocks first), so a marker ahead of the tip means the execution
-    /// database lost blocks this node already attested as final. Surfaced by the
-    /// startup heal (`RethEnv::heal_finalized_to_persisted_tip`) to refuse startup
-    /// instead of silently re-executing past attested state.
+    /// The marker only ever trails or equals the tip (it commits atomically with the
+    /// blocks; pre-fix versions committed the blocks first), so a marker ahead of the
+    /// tip means the execution database lost blocks this node already attested as
+    /// final. Surfaced by the startup heal (`RethEnv::heal_finalized_to_persisted_tip`)
+    /// to refuse startup instead of silently re-executing past attested state.
     #[error(
         "finalized marker {finalized} is ahead of the persisted canonical tip {tip}: \
          execution db is behind a marker this node already attested; refusing to start"

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -830,25 +830,19 @@ impl RethEnv {
         Ok(res)
     }
 
-    /// Finalize block (header) executed from consensus output and update chain info.
+    /// Finalize the block (header) executed from consensus output in memory.
     ///
-    /// This stores the finalized block number in the
-    /// database, but still need to set_finalized afterwards for utilization in-memory for
-    /// components, like RPC
+    /// The finalized/safe database markers are persisted atomically with the blocks in
+    /// [`Self::finish_executing_output`]; this method only updates the in-memory
+    /// finalized/safe watches (consumed by components like RPC) and prunes persisted blocks
+    /// from the canonical in-memory state.
     pub fn finalize_block(&self, header: SealedHeader) -> TnRethResult<()> {
         let num_hash = header.num_hash();
-        // persiste final block info for node recovery
-        let provider = self.inner.blockchain_provider.database_provider_rw()?;
-        provider.save_finalized_block_number(header.number)?;
         // this clears up old blocks in-memory
         self.inner.blockchain_provider.set_finalized(header.clone());
 
         // update safe block last because this is less time sensitive but still needs to happen
-        provider.save_safe_block_number(header.number)?;
         self.inner.blockchain_provider.set_safe(header);
-
-        // commit db transaction
-        provider.commit()?;
 
         // cleanup chain state in memory
         // this returns the `canonical_chain().count()` back to 0
@@ -862,22 +856,25 @@ impl RethEnv {
 
     /// Advance a lagging finalized marker to the persisted canonical tip.
     ///
-    /// Blocks commit in [`Self::finish_executing_output`] and the finalized/safe markers commit
-    /// in [`Self::finalize_block`] — two separate database transactions. A crash between them
-    /// restarts the node with `finalized marker < persisted canonical tip`, hiding the gap
-    /// blocks from every marker reader (accumulator catchup, the tx-pool's last-seen seed, the
-    /// RPC `finalized`/`safe` tags).
+    /// Blocks and the finalized/safe markers commit in a single database transaction in
+    /// [`Self::finish_executing_output`], so a crash can no longer leave the marker behind the
+    /// persisted tip — the two-transaction crash window this heal was written for does not
+    /// exist for new writes. The heal is retained as defense-in-depth for databases written by
+    /// pre-fix versions, which committed the markers separately in `finalize_block`: a crash
+    /// between the two transactions restarted the node with `finalized marker < persisted
+    /// canonical tip`, hiding the gap blocks from every marker reader (accumulator catchup,
+    /// the tx-pool's last-seen seed, the RPC `finalized`/`safe` tags).
     ///
     /// Advancing the marker is sound because every persisted canonical block is consensus-final
     /// by construction: blocks only enter the canonical database from committed consensus
     /// output, so there is no speculative or reorgable segment the marker could overrun. The
-    /// lag is purely a two-transaction persistence artifact.
+    /// lag is purely a persistence artifact of the pre-fix two-transaction design.
     ///
-    /// The heal MUST route through [`Self::finalize_block`] rather than a bare
-    /// `save_finalized_block_number` write: the in-memory finalized/safe watches are seeded
-    /// from the (stale) database at provider construction, and startup marker readers like the
-    /// accumulator catchup consult the watch — a DB-only write would leave them reading the
-    /// stale value.
+    /// The heal persists the marker itself ([`Self::finalize_block`] no longer writes the
+    /// database) and then routes through `finalize_block` for the in-memory half: the
+    /// finalized/safe watches are seeded from the (stale) database at provider construction,
+    /// and startup marker readers like the accumulator catchup consult the watch — a DB-only
+    /// write would leave them reading the stale value.
     ///
     /// Replay is unaffected: the missed-consensus watermark derives from the persisted
     /// execution tip (which this method never moves), not the finalized marker, so healing
@@ -899,7 +896,7 @@ impl RethEnv {
         let provider = self.inner.blockchain_provider.database_provider_ro()?;
         let tip = provider.last_block_number()?;
         // None = never finalized (fresh genesis). Some(0) is unreachable in production (the
-        // first finalize_block call is for block >= 1), so collapsing None to 0 is safe.
+        // first marker write covers block >= 1), so collapsing None to 0 is safe.
         let finalized = provider.last_finalized_block_number()?.unwrap_or(0);
 
         if finalized > tip {
@@ -919,15 +916,25 @@ impl RethEnv {
             target: "tn::reth",
             finalized,
             tip,
-            "finalized marker lags the persisted canonical tip (crash between the \
-             blocks-commit and finalize-commit transactions); healing marker to tip"
+            "finalized marker lags the persisted canonical tip (database written by a pre-fix \
+             version that committed blocks and the marker separately); healing marker to tip"
         );
+        // durably fix the marker on disk before touching the watches: finalize_block only
+        // updates in-memory state, so a lagging pre-fix database needs its rows rewritten here
+        let provider_rw = self.inner.blockchain_provider.database_provider_rw()?;
+        provider_rw.save_finalized_block_number(tip)?;
+        provider_rw.save_safe_block_number(tip)?;
+        provider_rw.commit()?;
         self.finalize_block(header)
     }
 
     /// This makes all blocks canonical, commits them to the database,
     /// broadcasts new chain on `canon_state_notification_sender`
     /// and set last executed header as the tracked header.
+    ///
+    /// The finalized/safe markers commit in the same database transaction as the blocks, so a
+    /// crash can never leave the persisted marker behind the persisted tip. The in-memory
+    /// finalized/safe watches are updated afterwards by [`Self::finalize_block`].
     ///
     /// It also clears the canonical in-memory state.
     pub fn finish_executing_output(
@@ -951,6 +958,15 @@ impl RethEnv {
         // insert blocks to db
         let provider_rw = self.inner.blockchain_provider.database_provider_rw()?;
         provider_rw.save_blocks(blocks.clone(), reth_provider::SaveBlocksMode::Full)?;
+        // advance the finalized/safe markers in the same transaction as the blocks: every
+        // canonical block comes from committed consensus output, so the last saved block is
+        // final by construction, and the single commit leaves no crash window where the
+        // persisted tip outruns the marker
+        if let Some(last) = blocks.last() {
+            let last_number = last.recovered_block.number;
+            provider_rw.save_finalized_block_number(last_number)?;
+            provider_rw.save_safe_block_number(last_number)?;
+        }
         provider_rw.commit()?;
 
         // process update

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -23,7 +23,10 @@ use reth_chainspec::{ChainSpec as RethChainSpec, EthChainSpec};
 use reth_evm::{execute::Executor as _, ConfigureEvm, EvmFactory as _};
 use reth_primitives::sign_message;
 use reth_primitives_traits::SignerRecoverable;
-use reth_provider::{StateProvider, StateProviderBox, StateProviderFactory};
+use reth_provider::{
+    CanonChainTracker as _, ChainStateBlockWriter as _, DBProvider as _,
+    DatabaseProviderFactory as _, StateProvider, StateProviderBox, StateProviderFactory,
+};
 use reth_revm::{database::StateProviderDatabase, db::BundleState, State};
 use reth_transaction_pool::{EthPoolTransaction, EthPooledTransaction, PoolTransaction};
 use secp256k1::{
@@ -737,6 +740,26 @@ pub fn execute_payload_and_update_canonical_chain(
     reth_env.finish_executing_output(vec![block.clone()], None)?;
     reth_env.finalize_block(canonical_header.clone())?;
     Ok(block)
+}
+
+/// Plant the persisted finalized/safe markers at `header` and seed the in-memory watches to
+/// match, simulating a restart on a database written by a pre-fix node version.
+///
+/// Pre-fix versions committed blocks and the finalized/safe markers in separate database
+/// transactions, so a crash between the two commits restarted the node with the marker lagging
+/// the persisted canonical tip — the state `RethEnv::heal_finalized_to_persisted_tip` repairs.
+/// Current versions commit both atomically in `RethEnv::finish_executing_output`, so tests use
+/// this direct write to construct the pre-fix state.
+pub fn plant_finalized_marker(reth_env: &RethEnv, header: SealedHeader) -> eyre::Result<()> {
+    let provider = reth_env.inner.blockchain_provider.database_provider_rw()?;
+    provider.save_finalized_block_number(header.number)?;
+    provider.save_safe_block_number(header.number)?;
+    provider.commit()?;
+    // a restarting node seeds the finalized/safe watches from the (stale) database rows at
+    // provider construction; mirror that so watch readers see the planted marker
+    reth_env.inner.blockchain_provider.set_finalized(header.clone());
+    reth_env.inner.blockchain_provider.set_safe(header);
+    Ok(())
 }
 
 /// Build a test genesis whose `ConsensusRegistry` is freshly deployed from the current artifact


### PR DESCRIPTION
- `RethEnv::finish_executing_output` now persists the finalized/safe block numbers in the same database transaction as the blocks (derived from the last saved block), closing the crash window where a restart could observe the persisted tip ahead of the persisted marker.
- `RethEnv::finalize_block` no longer writes the database — it only updates the in-memory finalized/safe watches and prunes in-memory canonical state, since the DB write now happens earlier alongside the blocks.
- `RethEnv::heal_finalized_to_persisted_tip` is retained as defense-in-depth for databases written by pre-fix versions, and now rewrites the persisted marker rows directly instead of relying on `finalize_block` for the DB half.
- Added `plant_finalized_marker` test helper to construct a pre-fix-style lagging database directly, since `finalize_block` no longer writes the DB and can't be (ab)used to fabricate that state.
- Added `finalized_marker_commits_atomically_with_blocks`, asserting the persisted marker equals the persisted tip immediately after commit and that the heal takes its no-op path.
- Updated comments/docs across `payload_builder.rs`, `exex/context.rs`, `exex/lib.rs`, `engine/inner.rs`, `manager/node.rs`, and `error.rs` to describe the atomic-commit behavior and reframe the heal as legacy-database defense-in-depth rather than an expected steady-state repair.
