### PR TITLE
fix(config): reject consensus params below their operational floors (#954)

### DIFF
--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -57,6 +57,12 @@ where
         network_config: NetworkConfig,
         next_committee_keys: Vec<BlsPublicKey>,
     ) -> eyre::Result<Self> {
+        // Production entry point: enforce the operational floors that the shared, test-facing
+        // `new_with_committee` deliberately skips so DAG test fixtures may use small `gc_depth`
+        // values. The protocol ceilings are still validated for every constructor inside
+        // `new_with_committee`.
+        config.parameters.validate_operational_floors()?;
+
         // load committee from file
         let committee: Committee =
             Config::load_from_path_or_default(tn_datadir.committee_path(), ConfigFmt::YAML)?;
@@ -105,6 +111,11 @@ where
         network_config: NetworkConfig,
         next_committee_keys: Vec<BlsPublicKey>,
     ) -> eyre::Result<Self> {
+        // Production entry point: enforce the operational floors (see
+        // [`Parameters::validate_operational_floors`]); the shared test-facing constructor skips
+        // them so DAG fixtures may use small `gc_depth` values.
+        config.parameters.validate_operational_floors()?;
+
         Self::new_with_committee(
             config,
             node_storage,

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -371,16 +371,20 @@ impl Default for Parameters {
 }
 
 impl Parameters {
-    /// Validate protocol-critical parameters against the ceilings the rest of the protocol depends
-    /// on.
+    /// Validate the protocol **ceilings** every node (production or test fixture) must honor.
     ///
     /// `gc_depth` and `max_header_num_of_batches` together bound how many unique batches a single
     /// committed [`ConsensusOutput`](tn_types::ConsensusOutput) can reference. The consensus-pack
     /// reader derives its reconstruction bound from [`tn_types::MAX_GC_DEPTH`] and
     /// [`tn_types::MAX_HEADER_NUM_OF_BATCHES`], so a node configured above those ceilings could
     /// commit an output that no node (including itself, on restart) can later reconstruct.
-    /// Rejecting such a configuration at startup keeps the producing and reconstructing halves
-    /// in agreement.
+    /// Rejecting such a configuration keeps the producing and reconstructing halves in
+    /// agreement.
+    ///
+    /// These are safe to enforce everywhere, so this runs for every constructor. The lower
+    /// **operational floors** are enforced separately by
+    /// [`Parameters::validate_operational_floors`] at the production entry points only, so DAG
+    /// test fixtures may still use small `gc_depth` values.
     pub fn validate(&self) -> eyre::Result<()> {
         eyre::ensure!(
             self.gc_depth <= tn_types::MAX_GC_DEPTH,
@@ -393,6 +397,53 @@ impl Parameters {
             "max_header_num_of_batches {} exceeds the protocol maximum {}",
             self.max_header_num_of_batches,
             tn_types::MAX_HEADER_NUM_OF_BATCHES,
+        );
+        Ok(())
+    }
+
+    /// Validate the operational **floors** and cross-field coupling: the values below which a node
+    /// degrades silently instead of erroring.
+    ///
+    /// Unlike the ceilings in [`Parameters::validate`], these are enforced only at the production
+    /// startup entry points (`ConsensusConfig::new` / `new_for_epoch`), never in the shared
+    /// test-fixture constructor, so DAG tests that deliberately drive a small `gc_depth` keep
+    /// working (see issue #954, "retain test-only overrides for DAG tests requiring small values").
+    ///
+    /// - `gc_depth` must exceed [`tn_types::GC_ACTIVITY_BUFFER`]. The consensus network handler
+    ///   computes its activity window as `gc_depth - GC_ACTIVITY_BUFFER`; a `gc_depth` at or below
+    ///   the buffer collapses that window to zero and wedges the node inactive during normal
+    ///   operation. Coupling the floor to the same constant the handler subtracts keeps the two
+    ///   from drifting apart.
+    /// - `max_header_num_of_batches` must be at least one, otherwise the proposer caps every header
+    ///   at zero batch digests: it drains no transactions while its digest queue grows without
+    ///   bound.
+    /// - `header_num_of_batches_threshold` must be at least one and must not exceed
+    ///   `max_header_num_of_batches`. The proposer seals a header once it holds `threshold` digests
+    ///   but includes at most `max_header_num_of_batches` of them, so a zero threshold seals empty
+    ///   headers on the fast path and a threshold above the max makes the two conditions mutually
+    ///   inconsistent.
+    pub fn validate_operational_floors(&self) -> eyre::Result<()> {
+        eyre::ensure!(
+            self.gc_depth > tn_types::GC_ACTIVITY_BUFFER,
+            "gc_depth {} must exceed the activity buffer {} or the node cannot stay active",
+            self.gc_depth,
+            tn_types::GC_ACTIVITY_BUFFER,
+        );
+        eyre::ensure!(
+            self.max_header_num_of_batches >= 1,
+            "max_header_num_of_batches must be at least 1, got {}",
+            self.max_header_num_of_batches,
+        );
+        eyre::ensure!(
+            self.header_num_of_batches_threshold >= 1,
+            "header_num_of_batches_threshold must be at least 1, got {}",
+            self.header_num_of_batches_threshold,
+        );
+        eyre::ensure!(
+            self.header_num_of_batches_threshold <= self.max_header_num_of_batches,
+            "header_num_of_batches_threshold {} must not exceed max_header_num_of_batches {}",
+            self.header_num_of_batches_threshold,
+            self.max_header_num_of_batches,
         );
         Ok(())
     }
@@ -417,7 +468,14 @@ mod test {
 
     #[test]
     fn default_parameters_are_within_protocol_ceilings() {
-        Parameters::default().validate().expect("default parameters must validate");
+        Parameters::default().validate().expect("default parameters must be within ceilings");
+    }
+
+    #[test]
+    fn default_parameters_pass_operational_floors() {
+        Parameters::default()
+            .validate_operational_floors()
+            .expect("default parameters must satisfy the operational floors");
     }
 
     #[test]
@@ -435,6 +493,79 @@ mod test {
         assert!(
             params.validate().is_err(),
             "max_header_num_of_batches over the protocol ceiling must be rejected"
+        );
+    }
+
+    #[test]
+    fn parameters_reject_gc_depth_at_or_below_activity_buffer() {
+        let at_buffer = Parameters { gc_depth: tn_types::GC_ACTIVITY_BUFFER, ..Default::default() };
+        assert!(
+            at_buffer.validate_operational_floors().is_err(),
+            "gc_depth equal to the activity buffer collapses the activity window and must be rejected"
+        );
+        let below_buffer =
+            Parameters { gc_depth: tn_types::GC_ACTIVITY_BUFFER - 1, ..Default::default() };
+        assert!(
+            below_buffer.validate_operational_floors().is_err(),
+            "gc_depth below the activity buffer must be rejected"
+        );
+    }
+
+    #[test]
+    fn parameters_accept_gc_depth_one_above_activity_buffer() {
+        let params =
+            Parameters { gc_depth: tn_types::GC_ACTIVITY_BUFFER + 1, ..Default::default() };
+        assert!(
+            params.validate_operational_floors().is_ok(),
+            "the smallest gc_depth leaving a positive activity window must be accepted"
+        );
+    }
+
+    #[test]
+    fn parameters_reject_zero_max_header_num_of_batches() {
+        let params = Parameters {
+            max_header_num_of_batches: 0,
+            header_num_of_batches_threshold: 0,
+            ..Default::default()
+        };
+        assert!(
+            params.validate_operational_floors().is_err(),
+            "a zero max_header_num_of_batches drains no digests and must be rejected"
+        );
+    }
+
+    #[test]
+    fn parameters_reject_zero_header_num_of_batches_threshold() {
+        let params = Parameters { header_num_of_batches_threshold: 0, ..Default::default() };
+        assert!(
+            params.validate_operational_floors().is_err(),
+            "a zero header_num_of_batches_threshold seals empty headers and must be rejected"
+        );
+    }
+
+    #[test]
+    fn parameters_reject_threshold_above_max_header_num_of_batches() {
+        let params = Parameters {
+            max_header_num_of_batches: 2,
+            header_num_of_batches_threshold: 3,
+            ..Default::default()
+        };
+        assert!(
+            params.validate_operational_floors().is_err(),
+            "a threshold above max_header_num_of_batches is mutually inconsistent and must be rejected"
+        );
+    }
+
+    #[test]
+    fn parameters_accept_minimal_valid_batch_bounds() {
+        let params = Parameters {
+            max_header_num_of_batches: 1,
+            header_num_of_batches_threshold: 1,
+            ..Default::default()
+        };
+        assert!(
+            params.validate_operational_floors().is_ok(),
+            "threshold == max == 1 is the minimal consistent batch configuration and must be accepted"
         );
     }
 }

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -180,11 +180,19 @@ where
         let (_last_consensus_epoch, last_consensus_number, _) =
             self.consensus_bus.published_consensus_num_hash();
         // Use GC depth to estimate how many rounds we can be behind.
-        // Subtract ten here so if we are right on the GC depth we will still go inactive (small
-        // safety buffer).  Ten is arbitrary but should make sure we are comfortably within
-        // the current DAG. Trying to ride the GC window exactly can lead to subtle races
-        // (allow some time to get going).
-        let gc_depth = self.consensus_config.parameters().gc_depth.saturating_sub(10);
+        // Subtract `GC_ACTIVITY_BUFFER` here so if we are right on the GC depth we will still go
+        // inactive (small safety buffer).  The buffer is arbitrary but should make sure we are
+        // comfortably within the current DAG. Trying to ride the GC window exactly can lead to
+        // subtle races (allow some time to get going).  On a production node
+        // `Parameters::validate_operational_floors` keeps the configured `gc_depth` above this
+        // buffer, so the window is positive.  `saturating_sub` still guards the test-fixture path,
+        // where that floor is intentionally not enforced and a small `gc_depth` can zero the
+        // window.
+        let gc_depth = self
+            .consensus_config
+            .parameters()
+            .gc_depth
+            .saturating_sub(tn_types::GC_ACTIVITY_BUFFER);
         // is our round outside the GC window
         // Will be false when not the same epoch (can't compare rounds) but
         // epoch_behind will work in that case.

--- a/crates/types/src/primary/mod.rs
+++ b/crates/types/src/primary/mod.rs
@@ -44,6 +44,18 @@ pub const DEFAULT_BAD_NODES_STAKE_THRESHOLD: u64 = 33;
 /// over-estimate, so raising this value requires re-deriving that bound.
 pub const MAX_GC_DEPTH: Round = 50;
 
+/// Rounds subtracted from a node's configured `gc_depth` when the consensus network handler
+/// computes its "activity window", the number of rounds a node may lag execution before it steps
+/// back as too far behind to be an active voter.
+///
+/// The buffer makes a node go inactive *before* it rides the garbage-collection horizon exactly,
+/// where subtle races live.  Because the window is `gc_depth - GC_ACTIVITY_BUFFER`, a configured
+/// `gc_depth` at or below this buffer collapses the window to zero and wedges the node inactive
+/// during normal operation.  `Parameters::validate_operational_floors` therefore requires
+/// `gc_depth > GC_ACTIVITY_BUFFER` at the production startup entry points, keeping the floor
+/// coupled to the buffer so the two can never drift apart.
+pub const GC_ACTIVITY_BUFFER: Round = 10;
+
 /// Maximum number of batch digests a single primary `Header` may reference.
 ///
 /// The proposer caps its own headers at the configured `max_header_num_of_batches`, and


### PR DESCRIPTION
Addresses #954. Follow-up to #902.

## Summary

Consensus parameters `gc_depth` and `max_header_num_of_batches` were validated against their protocol ceilings only (added in #902), so a node could still be configured *below* the values at which consensus keeps working. This PR adds the missing lower floors and the cross-field coupling to `Parameters`, promotes the `gc_depth` activity buffer to a named `tn-types` constant so the floor and the buffer can never drift apart, and enforces the new floors at node startup while leaving DAG test fixtures free to use small `gc_depth` values.

This is the interim, independently shippable step called for in #954. Eliminating per-node tunability of `gc_depth` entirely (the "identical across validators by construction" acceptance criterion) is a larger consensus-wiring change and is left as a follow-up. see the scope note below.

## Problem

`Parameters::validate` enforced only upper ceilings (`gc_depth <= MAX_GC_DEPTH`, `max_header_num_of_batches <= MAX_HEADER_NUM_OF_BATCHES`). Three lower/cross-field footguns remained, none of which require an attacker: a single misconfigured `parameters.yaml` is enough.

1. **`gc_depth` has no floor, and `> 0` is not enough.** The consensus network handler computes a node's activity window as `gc_depth - 10` (`crates/consensus/primary/src/network/handler.rs:187`, `gc_depth.saturating_sub(10)`). Any configured `gc_depth <= 10` saturates that window to `0`, so `outside_gc_window` (`handler.rs:191`) fires as soon as the node is a single round behind, and the node steps itself down to an inactive CVV during normal operation. The true floor is `> 10`, coupled to that buffer, not `> 0`.

2. **`max_header_num_of_batches` has no floor.** With `0`, the proposer's per-header drain `self.digests.len().min(self.max_header_num_of_batches)` is `0` (`crates/consensus/primary/src/proposer.rs:598`), so `self.digests.drain(..0)` removes nothing while workers keep appending (`proposer.rs:706`). Headers keep being sealed on the delay timers but carry empty payloads: a permanent transaction stall plus unbounded digest-backlog growth. The floor is `>= 1`.

3. **`header_num_of_batches_threshold` is uncoupled from `max_header_num_of_batches`.** The proposer seals a header once it holds `threshold` digests (`proposer.rs:760`) but includes at most `max_header_num_of_batches` of them. A `0` threshold seals empty headers on the fast path, and a threshold above the max is a configuration that can never be satisfied as intended. The invariant is `1 <= header_num_of_batches_threshold <= max_header_num_of_batches`.

## Changes

- [x] `crates/types/src/primary/mod.rs`: add `pub const GC_ACTIVITY_BUFFER: Round = 10`, documenting that the handler's activity window is `gc_depth - GC_ACTIVITY_BUFFER` and that `Parameters::validate_operational_floors` keeps `gc_depth` above it.
- [x] `network/handler.rs`: replace the hardcoded `gc_depth.saturating_sub(10)` with `gc_depth.saturating_sub(tn_types::GC_ACTIVITY_BUFFER)` so the buffer the handler subtracts and the floor the config validates are one shared constant.
- [x] `crates/config/src/node.rs`: split validation into `validate` (the existing protocol **ceilings**, still run for every constructor) and a new `validate_operational_floors` (the **lower floors** and the `threshold <= max` cross-field invariant).
- [x] `crates/config/src/consensus.rs`: enforce `validate_operational_floors` at the production entry points `ConsensusConfig::new` and `new_for_epoch`; the shared test-facing `new_with_committee` is untouched, so it still enforces the ceilings for everyone while the DAG-test fixture constructor keeps its small `gc_depth` (the "retain test-only overrides" the issue asks for).
- [x] Unit tests for every new floor and the cross-field invariant, plus accept-tests for the minimal valid configuration and the default parameters.

## Threat model and design notes

- **No attacker required.** All three failures are reachable from a single validator's own `parameters.yaml`; the point of the change is to reject them loudly at startup instead of degrading silently once running.
- **The floor is derived, not guessed.** `gc_depth`'s floor is `> GC_ACTIVITY_BUFFER`, the exact constant the handler subtracts, so the two are one value and cannot drift on a future edit to the buffer.
- **Producer/reader symmetry from #902 is preserved.** The ceiling checks (`gc_depth <= MAX_GC_DEPTH`, `max_header_num_of_batches <= MAX_HEADER_NUM_OF_BATCHES`) still run for every constructor, and the reader-side `Header::validate` cap against `MAX_HEADER_NUM_OF_BATCHES` (`crates/types/src/primary/header.rs:121`) is unchanged. `max_header_num_of_batches` divergence between validators is therefore already benign (the reader checks the constant, not the peer's config); `gc_depth` is the divergence-sensitive one.
- **Scope note (why the interim).** A validated `[11, 50]` range bounds `gc_depth` but does not make it identical across validators, so it does not by itself close the divergence vector in #954's finding 3: `order_dag` (`crates/consensus/primary/src/consensus/utils.rs:13,22`) descends only to `leader.round() - gc_depth`, so two validators running different in-range `gc_depth` values can still commit different sub-DAGs once uncommitted ancestry outruns the smaller depth. Closing that "by construction" means making `gc_depth` a non-tunable protocol constant in the operative path (retaining test-only overrides), which is a larger consensus-wiring change. That divergence is latent (it needs sustained asynchrony or leader-stall, and the default `gc_depth = 50` masks it), so this PR ships the startup-validation hardening first and leaves de-tunabilization as a tracked follow-up.

## Testing

Pinned toolchain (`rust-toolchain.toml` = 1.94), OOM-capped at `-j 2`.

- `cargo +nightly fmt -- --check`: clean.
- `cargo +1.94 clippy -p tn-types -p tn-config -p tn-primary --all-targets`: clean (workspace `missing_docs = warn` covers `tn-types` / `tn-config`; every new item is documented).
- `cargo +1.94 test -p tn-config --lib node::test`: 10 passed. Each new reject-test was **confirmed by mutation**: removing the four floor `ensure!`s makes exactly the four floor/cross-field reject-tests fail while the accept-tests and ceiling-tests stay green; the floors were then restored.
- `cargo +1.94 test -p tn-primary --lib test_gc_round_update_during_fetch test_gc_pending_certs`: 2 passed. These two fixtures deliberately use `gc_depth = 5`; they build via the test-only constructor, which skips the operational floors, so they keep working unchanged.
- Attest-proxy build in an isolated target dir (the `--workspace` shape `make attest` runs, not a `-p` subset): `CARGO_TARGET_DIR=.tn-954-iso cargo +1.94 test --no-run --workspace -j 2`: green, every workspace test binary compiled on the pinned toolchain.
