### PR TITLE
fix(engine): roll back the in-memory canonical advance when a consensus output fails mid-batch

### DIFF
--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -79,6 +79,11 @@ pub fn execute_consensus_output(
     let mut executed_blocks = Vec::with_capacity(batches.len().max(1));
     let canonical_in_memory_state = reth_env.canonical_in_memory_state();
     let anchor_hash = canonical_header.hash();
+    // The pre-output canonical tip. Each block eagerly advances the shared in-memory state
+    // (see `execute_payload`), but the durable commit happens only after the whole output builds.
+    // If a later block fails, the earlier blocks' advance is rolled back to this header so no
+    // phantom canonical head survives (see `rollback_in_memory_output`).
+    let anchor_header = canonical_header.clone();
     let mut ancestors: Vec<DeferredTrieData> = Vec::with_capacity(batches.len().max(1));
 
     if batches.is_empty() {
@@ -124,7 +129,7 @@ pub fn execute_consensus_output(
         debug!(target: "engine", "executing empty batch payload");
 
         // execute the payload and update the current canonical header
-        canonical_header = execute_payload(
+        let executed = execute_payload(
             payload,
             &vec![],
             &mut executed_blocks,
@@ -132,7 +137,12 @@ pub fn execute_consensus_output(
             &canonical_in_memory_state,
             anchor_hash,
             &ancestors,
-        )?;
+        );
+        // On failure, revert the in-memory advance applied by any earlier block of this output so
+        // the propagated error never leaves a phantom canonical head observable to RPC.
+        canonical_header = executed.inspect_err(|_| {
+            rollback_in_memory_output(&canonical_in_memory_state, &anchor_header, &executed_blocks)
+        })?;
         if let Some(last_block) = executed_blocks.last() {
             ancestors.push(last_block.trie_data_handle());
         }
@@ -166,7 +176,7 @@ pub fn execute_consensus_output(
             );
 
             // execute the payload and update the current canonical header
-            canonical_header = execute_payload(
+            let executed = execute_payload(
                 payload,
                 &batch.transactions,
                 &mut executed_blocks,
@@ -174,7 +184,17 @@ pub fn execute_consensus_output(
                 &canonical_in_memory_state,
                 anchor_hash,
                 &ancestors,
-            )?;
+            );
+            // On failure of a later block, revert the in-memory advance applied by the earlier
+            // blocks of this output so the propagated (node-halting) error never leaves a phantom
+            // canonical head observable to RPC before the node restarts.
+            canonical_header = executed.inspect_err(|_| {
+                rollback_in_memory_output(
+                    &canonical_in_memory_state,
+                    &anchor_header,
+                    &executed_blocks,
+                )
+            })?;
             if let Some(last_block) = executed_blocks.last() {
                 ancestors.push(last_block.trie_data_handle());
             }
@@ -219,6 +239,11 @@ fn execute_payload(
     info!(target: "engine", hash = canonical_header.hash().to_string(), number = canonical_header.number, "next block executed");
     crate::metrics::ENGINE_METRICS.blocks_executed_total.increment(1);
     crate::metrics::ENGINE_METRICS.block_gas_used.record(canonical_header.gas_used as f64);
+    // Eagerly advance the shared in-memory state. This is load-bearing within a multi-block
+    // output: the next block in the loop resolves its parent state through this advance. The
+    // advance is speculative until the whole output commits durably after the loop; if a later
+    // block fails to build, `execute_consensus_output` compensates it via
+    // `rollback_in_memory_output`.
     canonical_in_memory_state.set_pending_block(next_canonical_block.clone());
     canonical_in_memory_state
         .update_chain(NewCanonicalChain::Commit { new: vec![next_canonical_block.clone()] });
@@ -228,4 +253,37 @@ fn execute_payload(
     executed_blocks.push(next_canonical_block);
 
     Ok(canonical_header)
+}
+
+/// Roll back the eager per-block in-memory canonical advance for a consensus output whose batch
+/// loop failed partway through.
+///
+/// `execute_payload` advances the shared `CanonicalInMemoryState` (pending block, in-memory chain
+/// segment, and canonical head) for every block it builds, because a later block in the same output
+/// resolves its parent state from that advance. The durable commit and the finalized/safe markers
+/// are written only once the whole output has built (`RethEnv::finish_executing_output` then
+/// `RethEnv::finalize_block`). So when a block after the first fails to build,
+/// `execute_consensus_output` propagates the error before any durable write, leaving the earlier
+/// blocks advanced in memory but absent from the database: a transient "phantom" canonical head
+/// that RPC `latest`/`pending` reads observe until a restart rebuilds in-memory state from the
+/// finalized tip.
+///
+/// This reverts that advance so the phantom head is never observable. The `advanced` blocks are
+/// removed from the in-memory chain with a reorg whose `new` chain is empty (which also clears any
+/// pending block), and the canonical head is reset to `anchor_header`, the output's pre-loop parent
+/// tip. It is a no-op when nothing advanced: an empty `advanced` slice reorgs no blocks and resets
+/// the head to the value it already holds, so it is safe to call on every error exit of the loop.
+///
+/// Scope: this compensates only the pre-durable-commit advance inside the batch loop. Once
+/// `finish_executing_output` commits the blocks they are canonical for real and must not be
+/// reverted; the durable two-transaction commit/finalize window is a separate concern handled by
+/// `RethEnv::heal_finalized_to_persisted_tip`.
+fn rollback_in_memory_output(
+    canonical_in_memory_state: &CanonicalInMemoryState,
+    anchor_header: &SealedHeader,
+    advanced: &[ExecutedBlock],
+) {
+    canonical_in_memory_state
+        .update_chain(NewCanonicalChain::Reorg { new: Vec::new(), old: advanced.to_vec() });
+    canonical_in_memory_state.set_canonical_head(anchor_header.clone());
 }

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -13,9 +13,11 @@ use std::{
 use tempfile::TempDir;
 use tn_batch_builder::test_utils::execute_test_batch;
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_engine::{ExecutorEngine, TnEngineError, MAX_QUEUED_OUTPUTS};
+use tn_engine::{execute_consensus_output, ExecutorEngine, TnEngineError, MAX_QUEUED_OUTPUTS};
 use tn_reth::{
-    calculate_gas_penalty, recover_signed_transaction,
+    calculate_gas_penalty,
+    payload::BuildArguments,
+    recover_signed_transaction,
     system_calls::EpochState,
     test_utils::{
         calculate_withdrawals_root, create_committee_from_state,
@@ -2363,6 +2365,151 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
         expected_governance_revenue, actual_governance_revenue,
         "governance revenue mismatch — penalty may be using post-refund gas instead of pre-refund gas"
     );
+
+    Ok(())
+}
+
+/// Regression test for issue #989: a later-block build failure inside a single consensus output
+/// must not leave the earlier blocks' eager in-memory canonical advance un-rolled-back (a transient
+/// "phantom" canonical head visible to RPC until the node restarts).
+///
+/// Drives `execute_consensus_output` with a two-batch output where the first block executes and
+/// advances the in-memory state, and the second block carries a single transaction whose gas limit
+/// exceeds the block gas limit. That is a fatal, non-`InvalidTx` build error, so the output fails
+/// after the first block already advanced. The test asserts the in-memory canonical state is
+/// reverted to the pre-output (genesis) tip, nothing was committed durably, and no canon-state
+/// notification or engine update was emitted for the failed output.
+///
+/// Confirm-by-mutation: with the `rollback_in_memory_output` compensation removed from
+/// `execute_consensus_output`, the first block's advance survives and the
+/// `canonical_chain().count() == 0` and `canonical_tip == genesis` assertions below fail — so this
+/// test genuinely pins the post-error in-memory contract rather than passing vacuously.
+#[tokio::test]
+async fn test_partial_output_failure_rolls_back_in_memory_state() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let mut batches = tn_reth::test_utils::batches(chain.clone(), 2);
+
+    // Craft the poison transaction for the second block: a gas limit strictly greater than the
+    // block gas limit (`max_batch_gas`). The block-gas check fires before any balance/nonce
+    // validation, so the sender does not need to be funded; the transaction only needs to be
+    // decodable and signer-recoverable.
+    let genesis = test_genesis_with_consensus_registry(4);
+    let mut tx_factory = TransactionFactory::new_random();
+    let poison_gas_limit = max_batch_gas(0) + 1;
+    let poison_tx = tx_factory
+        .create_explicit_eip1559(
+            Some(genesis.config.chain_id),
+            None, // nonce
+            None, // max_priority_fee_per_gas
+            Some(MAX_FEE_PER_GAS as u128),
+            Some(poison_gas_limit), // gas_limit > block gas limit -> fatal build error
+            Some(Address::random()), // to
+            None,                   // value
+            None,                   // input
+            None,                   // access_list
+        )
+        .encoded_2718();
+
+    // Replace the second block's transactions with only the poison transaction.
+    if let Some(second) = batches.get_mut(1) {
+        let txs = second.transactions_mut();
+        txs.clear();
+        txs.push(poison_tx);
+    }
+
+    // Seed genesis from the first block's transactions only, so the first block executes and
+    // advances the in-memory state before the second block fails.
+    let batch_1 = batches.first().cloned().expect("two batches");
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, std::iter::once(&batch_1));
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.rewards_counter()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // pre-conditions: nothing has advanced yet
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    // subscribe before execution to prove no canon-state notification is emitted for the failure
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // run the output on a blocking task, mirroring the production execution task
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    // the output fails: the second block's oversized-gas transaction is a fatal build error
+    assert_matches!(result, Err(_), "output with an oversized-gas block must fail to build");
+
+    //=== the phantom head must not survive: in-memory state is rolled back to genesis
+    assert_eq!(
+        canonical_in_memory_state.canonical_chain().count(),
+        0,
+        "the first block's in-memory advance must be rolled back after the later block failed"
+    );
+    assert_eq!(
+        reth_env.canonical_tip().hash(),
+        genesis_header.hash(),
+        "the canonical head must be reset to the pre-output (genesis) tip"
+    );
+
+    // no durable write: persisted tip and finalized marker stay at genesis
+    assert_eq!(reth_env.last_block_number()?, 0, "no block was committed durably");
+    assert_eq!(reth_env.last_finalized_block_number()?, 0, "no block was finalized");
+
+    // no external observer saw the phantom advance
+    assert!(
+        canon_rx.try_recv().is_err(),
+        "a failed output must not broadcast a canon-state notification"
+    );
+    assert!(engine_update_rx.try_recv().is_err(), "a failed output must not send an engine update");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #989.

## Summary

`execute_consensus_output` builds one execution block per batch in a loop, and each block eagerly
advances the shared `CanonicalInMemoryState` (pending block, in-memory chain segment, canonical
head).  The durable commit and the finalized/safe markers are written only once, after the whole
output has built.  If a block after the first fails to build, the loop propagates the error before
any durable write and leaves the earlier blocks advanced in memory but never persisted: a transient
"phantom" canonical head.  This adds a compensating rollback on the loop's error path so the phantom
head is never observable, plus a regression test that pins the post-error in-memory contract.

## Problem

A single consensus output can produce many blocks (one per batch).  In
`crates/engine/src/payload_builder.rs`:

- `execute_payload` advances the in-memory state for every block it builds
  (`set_pending_block` / `update_chain(Commit)` / `set_canonical_head`).
- The batch loop calls it once per batch.  The durable commit
  (`RethEnv::finish_executing_output` then `save_blocks` + `commit`) and the finalized/safe markers
  (`RethEnv::finalize_block`) run only after the loop.

If block N (N > 0) fails inside `build_block_from_batch_payload` with a non-`InvalidTx` execution
error (or any `?`-propagated error), `execute_payload` returns `Err`, the loop's `?` propagates it
out of `execute_consensus_output`, and the engine treats the payload-build error as fatal and halts.
Nothing rolls back the in-memory canonical-head, pending-block, and chain-segment mutations that the
earlier blocks of the same output already applied.

The result is a transient phantom canonical head: between the halt and the node restart,
`CanonicalInMemoryState` reports a canonical/pending head for blocks that were executed but never
committed, and RPC reads of `latest`/`pending`/canonical head observe it.  On restart the in-memory
state is rebuilt from the persisted finalized tip and the phantom prefix disappears, because it was
never persisted.

### Threat model / blast radius

This is a low-severity correctness/robustness gap, not a live exploit:

- **No durable corruption.**  The only durable writes for an output happen post-loop, so a failed
  output writes nothing durable and there is no on-disk state to repair.
- **No external notification.**  `notify_canon_state` is broadcast once, at the end of
  `finish_executing_output`, never per block, so no downstream subscriber ever observes the partial
  advance.
- **Self-heals on restart.**  The uncommitted blocks are absent from the database, so re-deriving
  canonical state from the finalized tip discards the phantom prefix.

The trigger is itself a should-never-happen, node-halting error, so the added exposure is only a
brief RPC-visible inconsistency in the halt window.  The value is defense-in-depth: a partial
in-memory advance can never be observed as canonical, even briefly, so any component that samples the
in-memory head during the halt window (an RPC client, a metrics scrape, a future in-process consumer)
can no longer read blocks that will never exist.

This is distinct from the durable-side two-transaction window that `heal_finalized_to_persisted_tip`
(and #986 / #987) address: that work heals a persisted finalized marker that lagged the persisted
tip.  This issue is about the in-memory advance being left un-rolled-back before any durable commit,
which none of that work touches.

## Fix

The per-block in-memory advance is load-bearing within an output: block N+1 resolves its parent
state through block N's `update_chain(Commit)`.  Deferring the advance would break that intra-output
parent resolution, so the advance stays eager and is instead compensated on failure.

A new private helper `rollback_in_memory_output` reverts the advance:

- it removes the already-advanced blocks from the in-memory chain with
  `update_chain(NewCanonicalChain::Reorg { new: vec![], old: advanced })` (an empty `new` chain also
  clears any pending block), and
- it resets the canonical head to `anchor_header`, the output's pre-loop parent tip.

It is invoked via `inspect_err` at both `execute_payload` call sites in the batch loop, and is a
no-op when nothing advanced (an empty slice reorgs no blocks and resets the head to the value it
already holds).

The rollback is scoped to the pre-durable-commit advance inside the loop.  Once
`finish_executing_output` commits the blocks they are canonical for real and must not be reverted.
That boundary is safe because `finish_executing_output` performs no per-block in-memory advance of
its own, and a successful output ends with `finalize_block` resetting the in-memory chain to zero, so
during a failed output the only in-memory blocks are that output's own phantoms.

## Testing

`make attest` gates (fmt on nightly-2026-03-20, clippy `-D warnings`, tests on 1.94) run locally.

New regression test `test_partial_output_failure_rolls_back_in_memory_state`
(`crates/engine/tests/it/main.rs`):

- It drives `execute_consensus_output` with a two-batch output.  The first block executes and
  advances the in-memory state.  The second block carries a single transaction whose gas limit
  exceeds the block gas limit (`max_batch_gas(epoch) + 1`), which is a fatal, non-`InvalidTx` build
  error (`TransactionGasLimitMoreThanAvailableBlockGas`), so the output fails after the first block
  already advanced.
- It asserts the in-memory canonical head and chain are rolled back to the pre-output (genesis) tip
  (`canonical_chain().count() == 0`, `canonical_tip == genesis`), that nothing was committed durably
  (persisted tip and finalized marker stay at genesis), and that no canon-state notification or
  engine update was emitted for the failed output.
- **Confirm-by-mutation:** with `rollback_in_memory_output` neutered, the first block's advance
  survives and the `count() == 0` / `canonical_tip == genesis` assertions fail, so the test pins the
  post-error contract rather than passing vacuously.

Existing multi-block happy-path tests (for example `test_execution_succeeds_with_duplicate_transactions`)
continue to pass: the rollback runs only on the error path (`inspect_err`), so successful outputs
commit and advance exactly as before, and intra-output parent resolution is unchanged.