### PR TITLE
Guard ExEx manager against empty canonical chains (#991)

### DIFF
--- a/crates/exex/src/context.rs
+++ b/crates/exex/src/context.rs
@@ -5,7 +5,7 @@ use futures::{stream, StreamExt};
 use std::pin::Pin;
 use tn_reth::RethEnv;
 use tn_storage::consensus::ConsensusChain;
-use tn_types::{BlockHeader as _, BlockNumber};
+use tn_types::BlockNumber;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -225,16 +225,21 @@ fn dedup_chain_executed(
 
     stream
         .scan(None::<BlockNumber>, |last_height, item| {
-            // Borrow `item` only long enough to read the execution height.
-            let height = match &item {
-                Ok(TnExExNotification::ChainExecuted { new }) => Some(new.tip().number()),
-                _ => None,
+            // A `ChainExecuted` is de-duplicated by execution height, read through
+            // the non-panicking `blocks()` map: `Chain::tip()` panics on an empty
+            // chain ("Chain should have at least one block"). An empty chain (never
+            // produced today, but guarded defensively) carries no height and is
+            // dropped; it advances nothing and has nothing to deliver. Every other
+            // item (errors, `Lagged` markers, certificate/output signals) carries
+            // no height and always passes through.
+            let keep = match &item {
+                Ok(TnExExNotification::ChainExecuted { new }) => new
+                    .blocks()
+                    .last_key_value()
+                    .is_some_and(|(&height, _)| keep_height(last_height, height)),
+                _ => true,
             };
-            let keep = match height {
-                Some(h) => keep_height(last_height, h).then_some(item),
-                None => Some(item),
-            };
-            futures::future::ready(Some(keep))
+            futures::future::ready(Some(keep.then_some(item)))
         })
         .filter_map(futures::future::ready)
 }
@@ -271,5 +276,22 @@ mod tests {
         assert!(matches!(out[0], Ok(TnExExNotification::Lagged { missed: 1 })));
         assert!(out[1].is_err());
         assert!(matches!(out[2], Ok(TnExExNotification::Lagged { missed: 2 })));
+    }
+
+    #[tokio::test]
+    async fn dedup_drops_empty_chain_without_panicking() {
+        // A (defensively) empty `ChainExecuted` carries no height, and
+        // `Chain::tip()` panics on it. dedup must drop the empty item and keep
+        // draining the stream: the trailing `Lagged` marker still passes through.
+        // Reverting the guard to `new.tip().number()` makes this test panic.
+        use crate::Chain;
+        use std::sync::Arc;
+        let items: Vec<eyre::Result<TnExExNotification>> = vec![
+            Ok(TnExExNotification::ChainExecuted { new: Arc::new(Chain::default()) }),
+            Ok(TnExExNotification::Lagged { missed: 7 }),
+        ];
+        let out: Vec<_> = dedup_chain_executed(stream::iter(items)).collect().await;
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], Ok(TnExExNotification::Lagged { missed: 7 })));
     }
 }

--- a/crates/exex/src/manager.rs
+++ b/crates/exex/src/manager.rs
@@ -337,21 +337,35 @@ impl Router {
     }
 
     /// Handle a canonical commit: detect any block-number gap (reth drops canonical-stream lag
-    /// silently), surface it as `Lagged`, then deliver the executed chain. Shared by the `Commit`
-    /// and degraded `Reorg` arms.
+    /// silently), surface it as `Lagged`, then deliver the executed chain. An empty commit is
+    /// ignored (no gap check, no fan-out), since reth's `Chain` accessors panic on it. Shared by
+    /// the `Commit` and degraded `Reorg` arms.
     fn handle_canon_commit(&mut self, new: Arc<Chain>) {
-        let range = new.range();
-        let first = *range.start();
-        canon_gap(&mut self.last_canon_tip, first, *range.end()).into_iter().for_each(|missed| {
-            warn!(
-                target: "exex::manager",
-                missed,
-                first,
-                "canonical ChainExecuted gap detected; surfacing Lagged",
+        // Defense-in-depth: reth's `Chain::range()` (and `Chain::tip()`) panic on
+        // an empty chain ("Chain should have at least one block"). The sole live
+        // producer, `RethEnv::finish_executing_output`, never commits an empty
+        // chain: it early-returns before building one. That guarantee lives only
+        // in the engine's control flow, not in a check here, so guard it. A panic
+        // on this task would permanently disable fan-out for every ExEx (or, with
+        // `exex_critical` set, crash the node); an empty commit is ignored instead.
+        if new.is_empty() {
+            warn!(target: "exex::manager", "ignoring empty canonical commit");
+        } else {
+            let range = new.range();
+            let first = *range.start();
+            canon_gap(&mut self.last_canon_tip, first, *range.end()).into_iter().for_each(
+                |missed| {
+                    warn!(
+                        target: "exex::manager",
+                        missed,
+                        first,
+                        "canonical ChainExecuted gap detected; surfacing Lagged",
+                    );
+                    self.fan_out(&TnExExNotification::Lagged { missed });
+                },
             );
-            self.fan_out(&TnExExNotification::Lagged { missed });
-        });
-        self.fan_out(&TnExExNotification::ChainExecuted { new });
+            self.fan_out(&TnExExNotification::ChainExecuted { new });
+        }
     }
 
     /// Record an ExEx progress event, then recompute the minimum finished height.
@@ -505,6 +519,28 @@ mod tests {
         // Exactly one notification, no spurious Lagged marker.
         assert!(matches!(rx.try_recv(), Ok(TnExExNotification::Lagged { missed: FILLER })));
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn empty_canonical_commit_is_ignored_not_panicked() {
+        // reth's `Chain::range()`/`tip()` panic on an empty chain. An empty
+        // canonical commit must be dropped (no fan-out, no gap-tracker advance)
+        // rather than panic the manager task and disable ExEx fan-out for the
+        // node's lifetime. Reverting the `is_empty` guard makes this test panic
+        // with "Chain should have at least one block".
+        let (tx, mut rx) = mpsc::channel(4);
+        let (min_finished_height_tx, _min_rx) = watch::channel(None);
+        let mut router = Router {
+            exexes: vec![ExExHandle::new("test".to_string(), tx)],
+            min_finished_height_tx,
+            last_canon_tip: None,
+        };
+
+        router.handle_canon_commit(Arc::new(Chain::default()));
+
+        // Nothing fanned out, and the discontinuity tracker did not advance.
+        assert!(rx.try_recv().is_err());
+        assert_eq!(router.last_canon_tip, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #991.

## Problem

The ExEx manager reaches reth `Chain` accessors that panic on an empty chain.  reth's `Chain::tip()`, `Chain::first()`, and `Chain::range()` each `.expect("Chain should have at least one block")`, so an empty `Chain` panics at two consumer sites:

- `crates/exex/src/manager.rs` `handle_canon_commit` calls `new.range()` (then dereferences `range.start()` / `range.end()`).
- `crates/exex/src/context.rs` `dedup_chain_executed` calls `new.tip().number()`.

This is latent, not a live crash today.  The sole live producer, `RethEnv::finish_executing_output`, never commits an empty chain because it early-returns before building one (`crates/engine/src/payload_builder.rs`), and the replay producer (`ReplayStream`) always yields single-block chains.  But that guarantee lives only in the engine's control flow, with no explicit check at either consumer.

No attacker is required: any future refactor that lets an empty commit through would panic the manager task.  Because the manager is spawned once and never respawned, that panic permanently disables the shared ExEx fan-out for every ExEx for the node's lifetime in the default mode, or crashes the whole node when an ExEx is registered with `exex_critical = true`.  `handle_canon_commit` is also the target of the degraded `Reorg` arm in `handle_canon`, so the guard covers that path as well.

## Fix

Guard both consumer sites independently (defense in depth), so neither relies on the producer's control-flow invariant:

- **`handle_canon_commit`** (`crates/exex/src/manager.rs`): ignore an empty commit (`if new.is_empty()` logs a `warn` and skips) before touching `new.range()`.  A non-empty commit takes the unchanged original path.
- **`dedup_chain_executed`** (`crates/exex/src/context.rs`): read the execution height through the non-panicking `blocks().last_key_value()` map instead of `Chain::tip()`, and drop an empty `ChainExecuted` (it carries no height and has nothing to deliver) rather than panic.  Every non-empty item keeps its previous keep / drop decision, and non-execution items (errors, `Lagged` markers, certificate / output signals) still pass through unchanged.
- Removed the now-unused `tn_types::BlockHeader` import (the trait supplied the `.number()` call that is gone).

The fix is confined to the two ExEx consumer sites and adds no cross-crate API surface.  The producer is left as is: its early-return already guarantees non-emptiness, and reth's own `Chain::new` carries a `debug_assert!(!blocks.is_empty())`, so the value of this change is at the consumers, where the panic actually lives.

## Testing

- `cargo +1.94 test -p tn-exex` . . . 9 tests pass.
- `cargo +1.94 clippy -p tn-exex --all-targets -- -D warnings` . . . clean.
- `cargo +nightly-2026-03-20 fmt -p tn-exex -- --check` . . . clean.

Two deterministic regression tests, each confirmed by mutation (reverting the guard makes the test panic with reth's `Chain should have at least one block`, observed to fail, then restored):

- `manager::tests::empty_canonical_commit_is_ignored_not_panicked`: drives an empty `Chain` through `handle_canon_commit`;  asserts nothing is fanned out and the gap tracker (`last_canon_tip`) does not advance.
- `context::tests::dedup_drops_empty_chain_without_panicking`: pushes an empty `ChainExecuted` followed by a `Lagged` marker through `dedup_chain_executed`;  asserts the empty item is dropped and the trailing marker still passes through.

The de-duplication decision itself (`keep_height`) keeps its existing in-isolation coverage (`keep_height_is_monotonic_and_dedups`), and the only new wiring is a single `blocks().last_key_value()` read that equals the pre-change `tip().number()` for any non-empty chain.  A dedup-level test over two real-height `ChainExecuted` items is deliberately left out: this crate carries no dev-dependencies and its tests avoid constructing execution types, so such a test would add `reth-ethereum-primitives` / `alloy-consensus` dev-deps to exercise one BTreeMap access.  Happy to add it if preferred.
