### PR TITLE
consensus/executor: fail-stop the graceful-shutdown drain on a batch-fetch Err

### DIFF
--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -1,7 +1,7 @@
 //! Subscriber gathers all information needed from consensus and forwards to the execution engine.
 
 use crate::{errors::SubscriberResult, metrics::ExecutorMetrics, SubscriberError};
-use futures::{stream::FuturesOrdered, StreamExt};
+use futures::{stream::FuturesOrdered, StreamExt, TryStreamExt};
 use state_sync::{last_consensus_parent, save_consensus, spawn_state_sync};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
@@ -390,30 +390,13 @@ impl<DB: Database> Subscriber<DB> {
                     // Drain any pending consensus outputs to prevent data loss.
                     // Without this, committed subdags whose batch downloads are in-flight
                     // would be lost on restart, causing consensus chain divergence.
-                    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-                    while !waiting.is_empty() {
-                        tokio::select! {
-                            Some(output) = waiting.next() => {
-                                if let Ok(output) = output {
-                                    if let Err(e) = save_consensus(
-                                        output.clone(),
-                                        &mut consensus_chain,
-                                        self.consensus_bus.metrics(),
-                                    ).await {
-                                        warn!(target: "subscriber", "error saving consensus during shutdown: {e}");
-                                        break;
-                                    }
-                                    // Best-effort broadcast: if epoch manager already exited, this is a no-op.
-                                    // The DB-aware drain (Phase 2) handles the gap regardless.
-                                    let _ = self.consensus_bus.consensus_output().send(output).await;
-                                }
-                            }
-                            _ = tokio::time::sleep_until(deadline) => {
-                                warn!(target: "subscriber", "timed out draining pending consensus during shutdown");
-                                break;
-                            }
-                        }
-                    }
+                    drain_pending_on_shutdown(
+                        &self.consensus_bus,
+                        &mut consensus_chain,
+                        waiting,
+                        Duration::from_secs(3),
+                    )
+                    .await;
                     return Ok(())
                 }
 
@@ -599,5 +582,272 @@ impl<DB: Database> Subscriber<DB> {
         }
 
         Ok(fetched_blocks)
+    }
+}
+
+/// Drain the batch-fetch futures still pending when graceful shutdown fires.
+///
+/// This is the shutdown counterpart of the steady-state arm in [`Subscriber::run`] and is
+/// deliberately symmetric with it: a fetch `Err` is fail-stop, not skippable. `waiting` is a
+/// [`FuturesOrdered`] that yields in consensus (push) order, so every `Ok` output ahead of a
+/// failed fetch is the contiguous prefix. `try_fold` threads the consensus chain as its
+/// accumulator and short-circuits at the first error, so the drain saves and broadcasts that
+/// contiguous prefix and then stops at the gap: nothing at or past the failed fetch is saved or
+/// broadcast. In steady state the same fetch `Err` returns an error that shuts the node down;
+/// here, already shutting down, the fold simply stops, leaving the drained prefix persisted for
+/// the Phase-2 DB drain and normal restart. Stopping here makes the shutdown path self-evidently
+/// fail-stop instead of relying on the downstream pack/load/replay guards to reject the
+/// non-contiguous consensus number a swallowed fetch `Err` would otherwise let it march past.
+///
+/// `take_until` bounds only the wait for the next completed fetch, not an in-flight save: once
+/// `deadline` passes the drain stops pulling new outputs, but an output already dequeued is always
+/// saved and broadcast to completion. This preserves the original select-based drain's guarantee
+/// that a committed output, once dequeued, is never dropped mid-save during graceful shutdown.
+async fn drain_pending_on_shutdown<Fut>(
+    consensus_bus: &ConsensusBusApp,
+    consensus_chain: &mut ConsensusChain,
+    waiting: FuturesOrdered<Fut>,
+    deadline: Duration,
+) where
+    Fut: std::future::Future<Output = SubscriberResult<ConsensusOutput>>,
+{
+    let stop_at = tokio::time::Instant::now() + deadline;
+    let _ = waiting
+        .take_until(tokio::time::sleep_until(stop_at))
+        .map_err(|e| {
+            // A fetch `Err` is the same fatal condition the steady-state arm fail-stops on;
+            // short-circuiting the fold here stops the drain at the gap.
+            error!(target: "subscriber", "error fetching batches during shutdown drain: {e}");
+        })
+        .try_fold(consensus_chain, |chain, output| async move {
+            if let Err(e) = save_consensus(output.clone(), chain, consensus_bus.metrics()).await {
+                warn!(target: "subscriber", "error saving consensus during shutdown: {e}");
+                Err(())
+            } else {
+                // Best-effort broadcast: if epoch manager already exited, this is a no-op.
+                // The DB-aware drain (Phase 2) handles the gap regardless.
+                let _ = consensus_bus.consensus_output().send(output).await;
+                Ok(chain)
+            }
+        })
+        .await;
+    // A drain that stops because the deadline passed (rather than because `waiting` emptied) has
+    // reached `stop_at`; surface that the way the original select-based drain did.
+    if tokio::time::Instant::now() >= stop_at {
+        warn!(target: "subscriber", "timed out draining pending consensus during shutdown");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drain_pending_on_shutdown;
+    use crate::SubscriberError;
+    use futures::{future, stream::FuturesOrdered};
+    use std::{
+        collections::{BTreeSet, VecDeque},
+        time::Duration,
+    };
+    use tempfile::TempDir;
+    use tn_primary::ConsensusBusApp;
+    use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase};
+    use tn_test_utils::CommitteeFixture;
+    use tn_types::{
+        Certificate, CommittedSubDag, Committee, ConsensusHeader, ConsensusHeaderDigest,
+        ConsensusOutput, ReputationScores, TnReceiver as _, B256,
+    };
+
+    /// Build a valid `ConsensusOutput` at `number` (parent `parent`, sub-dag index `sub_dag_index`)
+    /// from the fixture's certificates, returning it with its consensus-header digest so a caller
+    /// can use that digest as the next output's parent.
+    fn output_at(
+        certificates: &[Certificate],
+        committee: &Committee,
+        number: u64,
+        sub_dag_index: u64,
+        parent: ConsensusHeaderDigest,
+    ) -> (ConsensusOutput, ConsensusHeaderDigest) {
+        let leader = certificates.last().cloned().unwrap();
+        let sub_dag = CommittedSubDag::new(
+            certificates.to_vec(),
+            leader,
+            sub_dag_index,
+            ReputationScores::new(committee),
+            None,
+        );
+        let digest = ConsensusHeader::digest_from_parts(parent, &sub_dag, number);
+        let output = ConsensusOutput::new(sub_dag, parent, number, false, VecDeque::new(), vec![]);
+        (output, digest)
+    }
+
+    /// A save error mid-drain must fail-stop the drain the same way a fetch `Err` does: the output
+    /// whose save fails is not broadcast, and no later output is saved or broadcast. Reverting the
+    /// save-error arm to swallow-and-continue lets the following contiguous output be saved and
+    /// broadcast, which this test rejects.
+    #[tokio::test]
+    async fn shutdown_drain_fail_stops_at_save_error() {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let temp_dir = TempDir::new().unwrap();
+        let mut consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone())
+                .await
+                .unwrap();
+        let consensus_bus = ConsensusBusApp::new();
+
+        let genesis: BTreeSet<_> = fixture.genesis().collect();
+        let (_, headers) = fixture.headers_round(0, &genesis);
+        let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
+
+        let parent0: ConsensusHeaderDigest = B256::ZERO.into();
+        // Output 1 saves fine (contiguous).
+        let (out1, digest1) = output_at(&certificates, &committee, 1, 0, parent0);
+        // A NON-contiguous number (3, skipping 2) makes save_consensus reject the write, forcing
+        // the save-error short-circuit.
+        let (out_bad, _) = output_at(&certificates, &committee, 3, 2, digest1);
+        // Output 2 would save fine if the drain wrongly continued past the save failure.
+        let (out_next, _) = output_at(&certificates, &committee, 2, 1, digest1);
+
+        let mut waiting = FuturesOrdered::new();
+        waiting.push_back(future::ready(Ok::<_, SubscriberError>(out1)));
+        waiting.push_back(future::ready(Ok(out_bad)));
+        waiting.push_back(future::ready(Ok(out_next)));
+
+        let mut rx = consensus_bus.subscribe_consensus_output();
+
+        drain_pending_on_shutdown(
+            &consensus_bus,
+            &mut consensus_chain,
+            waiting,
+            Duration::from_secs(3),
+        )
+        .await;
+
+        // Only output 1 is broadcast: out_bad's save fails (never broadcast) and stops the drain,
+        // so output 2 is never reached.
+        assert!(rx.recv().await.is_some(), "the drained prefix (output 1) must be broadcast");
+        assert!(rx.try_recv().is_err(), "no output at or past the save failure may be broadcast",);
+        assert!(
+            matches!(consensus_chain.consensus_header_by_number(1).await, Ok(Some(_))),
+            "output 1 (the drained prefix) must be persisted",
+        );
+        assert!(
+            !matches!(consensus_chain.consensus_header_by_number(2).await, Ok(Some(_))),
+            "output 2 (past the save failure) must not be persisted",
+        );
+    }
+
+    /// A fetch that never completes must not hang the drain: the deadline stops it. This pins the
+    /// `take_until` cap added for graceful shutdown.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_drain_stops_on_deadline() {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let temp_dir = TempDir::new().unwrap();
+        let mut consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone())
+                .await
+                .unwrap();
+        let consensus_bus = ConsensusBusApp::new();
+
+        // A single fetch future that never resolves. With the tokio test clock paused and auto-
+        // advanced, the drain must return when the deadline elapses rather than hang forever.
+        let mut waiting = FuturesOrdered::new();
+        waiting.push_back(future::pending::<Result<ConsensusOutput, SubscriberError>>());
+
+        let mut rx = consensus_bus.subscribe_consensus_output();
+
+        drain_pending_on_shutdown(
+            &consensus_bus,
+            &mut consensus_chain,
+            waiting,
+            Duration::from_secs(3),
+        )
+        .await;
+
+        // Nothing was ever fetched, so nothing is saved or broadcast; the point is that the call
+        // returned instead of hanging on the stalled fetch.
+        assert!(rx.try_recv().is_err(), "a stalled fetch must not save or broadcast anything");
+    }
+
+    /// A fetch `Err` in the middle of the graceful-shutdown drain must fail-stop the drain: the
+    /// contiguous prefix ahead of it is saved and broadcast, and nothing at or past the failed
+    /// fetch is. Reverting `drain_pending_on_shutdown` to the old "swallow the `Err` and keep
+    /// draining" shape makes the post-gap output get saved and broadcast, which this test rejects
+    /// (both the broadcast and the persistence assertions flip), so the test genuinely pins the
+    /// fail-stop semantics rather than passing vacuously.
+    #[tokio::test]
+    async fn shutdown_drain_fail_stops_at_fetch_error() {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let temp_dir = TempDir::new().unwrap();
+        let mut consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee.clone())
+                .await
+                .unwrap();
+        let consensus_bus = ConsensusBusApp::new();
+
+        // Two valid, CONTIGUOUS consensus outputs (numbers 1 and 2). Number 2 is contiguous so
+        // that if the drain wrongly continued past the failed fetch, its save would succeed and
+        // it would be broadcast -- making the swallow-and-continue bug observable rather than
+        // masked by the pack rejecting a non-contiguous number.
+        let genesis: BTreeSet<_> = fixture.genesis().collect();
+        let (_, headers) = fixture.headers_round(0, &genesis);
+        let certificates: Vec<_> = headers.iter().map(|h| fixture.certificate(h)).collect();
+        let leader = certificates.last().cloned().unwrap();
+
+        let parent0: ConsensusHeaderDigest = B256::ZERO.into();
+        let sub_dag1 = CommittedSubDag::new(
+            certificates.clone(),
+            leader.clone(),
+            0,
+            ReputationScores::new(&committee),
+            None,
+        );
+        let out1 =
+            ConsensusOutput::new(sub_dag1.clone(), parent0, 1, false, VecDeque::new(), vec![]);
+
+        let digest1 = ConsensusHeader::digest_from_parts(parent0, &sub_dag1, 1);
+        let sub_dag2 = CommittedSubDag::new(
+            certificates.clone(),
+            leader,
+            1,
+            ReputationScores::new(&committee),
+            None,
+        );
+        let out2 = ConsensusOutput::new(sub_dag2, digest1, 2, false, VecDeque::new(), vec![]);
+
+        // Pending fetch results in consensus (push) order: Ok(1), Err (failed fetch), Ok(2).
+        let mut waiting = FuturesOrdered::new();
+        waiting.push_back(future::ready(Ok(out1)));
+        waiting.push_back(future::ready(Err(SubscriberError::ClientRequestsFailed)));
+        waiting.push_back(future::ready(Ok(out2)));
+
+        // Subscribe before draining so we observe exactly what is broadcast.
+        let mut rx = consensus_bus.subscribe_consensus_output();
+
+        drain_pending_on_shutdown(
+            &consensus_bus,
+            &mut consensus_chain,
+            waiting,
+            Duration::from_secs(3),
+        )
+        .await;
+
+        // The contiguous prefix (output 1) is broadcast, and nothing past the failed fetch is:
+        // output 2 was never broadcast.
+        assert!(rx.recv().await.is_some(), "the drained prefix (output 1) must be broadcast");
+        assert!(rx.try_recv().is_err(), "no output at or past the failed fetch may be broadcast",);
+
+        // The prefix is persisted; the post-gap output is not. Querying a consensus number beyond
+        // the chain head returns either `Ok(None)` or a "number too high" `Err`; either way the
+        // output is absent, whereas a bug that saved output 2 would return `Ok(Some(_))`.
+        assert!(
+            matches!(consensus_chain.consensus_header_by_number(1).await, Ok(Some(_))),
+            "output 1 (the drained prefix) must be persisted",
+        );
+        assert!(
+            !matches!(consensus_chain.consensus_header_by_number(2).await, Ok(Some(_))),
+            "output 2 (past the failed fetch) must not be persisted",
+        );
     }
 }


### PR DESCRIPTION
## Summary

The consensus subscriber's graceful-shutdown drain silently swallowed a batch-fetch `Err` and kept draining, treating a fatal fetch failure as skippable.  That is asymmetric with the steady-state path in the same loop, which treats a fetch `Err` as fatal and returns it to trigger a clean node shutdown.  This PR makes the shutdown drain fail-stop at the first fetch `Err`, matching the steady-state path, so the shutdown path is self-evidently correct instead of relying on downstream guards.

Severity: **Low**.  This is a defensive-robustness / symmetry fix, not a live data-loss fix (see "Why this is Low" below).  Closes #993.

## Problem

`Subscriber::run` runs a biased `tokio::select!` loop.  Pending batch-fetch futures live in a `FuturesOrdered` (`waiting`), pushed in consensus order, and each future is `fetch_batches(..)`, which is fallible and propagates `Err(SubscriberError::ClientRequestsFailed)` when the peer fetch fails.

The loop handled a completed fetch in two places that disagreed on what a fetch `Err` means:

- **Steady state**: a fetch `Err` is fatal.  It logs and returns the error, which triggers a clean node shutdown.
- **Graceful-shutdown drain** (the `_ = &rx_shutdown =>` arm): the drain matched the completed fetch with `if let Ok(output)` and **no `else`**, so an `Err` yielded by `waiting.next()` was discarded and the drain advanced to the next pending future as if nothing happened.

Because `waiting` is a `FuturesOrdered` that yields in consensus (push) order, a swallowed `Err` at the head means the drain skips the failed consensus number and keeps saving and broadcasting the outputs after the gap.  The exact condition that fail-stops the node in steady state was silently swallowed during shutdown.

### Why this is Low (not data loss)

A swallowed fetch `Err` could not, today, produce a persisted, loadable gap: three downstream guards each independently refuse a non-contiguous consensus number (the pack rejects a non-contiguous write before writing anything, the load path re-validates the chain, and the Phase-2 DB-aware drain is gap-aware).  So the worst case today is a clean contiguous-prefix truncation recovered on restart.  The value of this change is that the shutdown path stops relying on those downstream guards being correct and becomes self-evidently fail-stop, symmetric with the steady-state path.

## Fix

The graceful-shutdown drain is extracted into a small private helper, `drain_pending_on_shutdown`, and a fetch `Err` now fail-stops the drain instead of being swallowed:

- The drain runs `waiting.take_until(deadline).try_fold(consensus_chain, save + broadcast)`.  `try_fold` threads the consensus chain as its accumulator and short-circuits at the first error, so:
  - every `Ok` output ahead of the failed fetch (the contiguous prefix) is saved and broadcast, exactly as before, and
  - the drain stops at the gap: nothing at or past the failed fetch is saved or broadcast.
- A save error stops the drain the same way (the fold short-circuits).  The deadline is a `take_until` that bounds only the wait for the next fetch, not an in-flight save: once it passes, the drain stops pulling new outputs, but an output already dequeued is always saved and broadcast to completion.  This preserves the original drain's guarantee that a committed output, once dequeued, is not dropped mid-save during graceful shutdown.

This is the shutdown counterpart of the steady-state arm: steady state returns the error to shut the node down, whereas here (already shutting down) the fold simply stops, leaving the already-drained contiguous prefix persisted for the Phase-2 DB drain and normal restart.

The drain was rewritten from the imperative `while` / `break` form into the `try_fold` + `take_until` combinator form.  This is behavior-preserving for every case except the intended fix (a swallowed fetch `Err` now stops the drain), and it made the drain testable in isolation (see below).  The helper is private;  there is no public API change.

## Testing

Three deterministic unit tests exercise `drain_pending_on_shutdown` in isolation, each built from `CommitteeFixture` plus an in-memory `ConsensusChain`:

- `shutdown_drain_fail_stops_at_fetch_error` drives the drain with `[Ok(output 1), Err(fetch failed), Ok(output 2)]`, where output 2 is deliberately contiguous (number 2) so that, if the drain wrongly continued past the failed fetch, its save would succeed and it would be broadcast, making the swallow-and-continue bug observable rather than masked by the pack rejecting a non-contiguous number.  It asserts the contiguous prefix (output 1) is saved and broadcast, and nothing at or past the failed fetch is (output 2 never broadcast, never persisted).
- `shutdown_drain_fail_stops_at_save_error` drives `[Ok(1), Ok(3), Ok(2)]`: output 3 is non-contiguous, so its save is rejected and the fold short-circuits on the save-error arm.  It asserts output 2 (which would save fine if reached) is neither saved nor broadcast.
- `shutdown_drain_stops_on_deadline` (paused tokio clock) pushes a fetch future that never resolves and asserts the drain returns when the deadline elapses instead of hanging.

Confirm-by-mutation pins both fail-stop sources (neither is vacuous):

- Reverting the fetch-`Err` fail-stop to the old "swallow and keep draining" shape makes output 2 get broadcast and persisted, which fails `shutdown_drain_fail_stops_at_fetch_error` (it fires the "no output at or past the failed fetch may be broadcast" assertion).
- Flipping the save-error arm from short-circuit to continue makes output 2 get saved and broadcast, which fails `shutdown_drain_fail_stops_at_save_error`.

`cargo +1.94 fmt` and `cargo +1.94 clippy -p tn-executor --all-targets` are clean for the changed file;  all three tests pass on the pinned 1.94 toolchain.
