### PR TITLE
fix(network-libp2p): carry worse reputation across anonymous-inbound merge (#998)

### DIFF
--- a/crates/network-libp2p/src/peers/all_peers.rs
+++ b/crates/network-libp2p/src/peers/all_peers.rs
@@ -224,12 +224,15 @@ impl AllPeers {
         // `bls_by_peer_id` entry derived from its previous network key
         let rotated = (current != confirmed).then(|| self.evict(&confirmed)).flatten();
         // migrate any record reachable from the new peer id (anonymous-inbound promotion or a
-        // repeat upsert); a rotated record it displaces releases its counter bookkeeping
-        // NOTE: when the anonymous record wins this merge it keeps its fresh score, so a banned
-        // peer that reconnects anonymously before its kad record arrives sheds its ban here
-        // (pre-existing semantics); carrying reputation across the merge is a possible follow-up
-        let migrated = self.peers.remove(&current);
-        if let (Some(_), Some(displaced)) = (migrated.as_ref(), rotated.as_ref()) {
+        // repeat upsert). when such a record collides with a rotated record already stored under
+        // the confirmed identity, the promoted record wins the merge - but reputation belongs to
+        // the confirmed identity, not to the transport key, so carry the worse of the two
+        // reputations onto the promoted record before releasing the displaced record's counter
+        // bookkeeping. Otherwise a banned peer could shed its ban by reconnecting anonymously under
+        // a fresh network key before its kad record arrives (issue #998).
+        let mut migrated = self.peers.remove(&current);
+        if let (Some(promoted), Some(displaced)) = (migrated.as_mut(), rotated.as_ref()) {
+            promoted.retain_worse_reputation(displaced);
             self.release_displaced_record(displaced);
         }
         // otherwise the rotated record carries forward (same domain peer, new transport key),

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -267,6 +267,25 @@ impl Peer {
         &self.score
     }
 
+    /// Adopt `other`'s reputation if it is worse than this peer's own.
+    ///
+    /// Reputation (the accumulated [Score], and therefore any ban it encodes) is a property of the
+    /// peer's confirmed domain identity, not of the transport key it currently presents. When an
+    /// anonymous-inbound record is promoted over a record already stored under that identity
+    /// (`AllPeers::upsert_peer`), the promoted record must not shed a ban - or any worse score -
+    /// held by the record it displaces, or a peer could reset its own reputation simply by
+    /// reconnecting under a fresh network key before its kad record arrives (issue #998). The whole
+    /// [Score] is adopted, not just its aggregate, so the ban-decay lockout that keeps the ban in
+    /// force also carries across; `reputation()` and `AllPeers::peer_banned` then keep reporting
+    /// the ban after the rotation. This is a no-op when this peer's own score is already the
+    /// worse (or equal) of the two, so a genuinely better-behaved displaced record never drags
+    /// the promoted record down.
+    pub(super) fn retain_worse_reputation(&mut self, other: &Peer) {
+        if other.score < self.score {
+            self.score = other.score.clone();
+        }
+    }
+
     /// Register the dialing peer as connected.
     ///
     /// This method also updates the number of incoming connections +1.

--- a/crates/network-libp2p/src/tests/peers.rs
+++ b/crates/network-libp2p/src/tests/peers.rs
@@ -536,9 +536,12 @@ fn test_upsert_peer_merge_releases_displaced_banned_record() {
     all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
     assert_eq!(all_peers.banned_peers.total(), 1);
 
-    // the peer reconnects anonymously with its rotated key, then its kad record arrives;
-    // the anonymous record wins the merge and the displaced banned record releases its
-    // bookkeeping as it is dropped (the ban itself is shed: pre-existing merge semantics)
+    // this record was banned purely at the connection-status layer (`Disconnecting { banned }`);
+    // its *score* was never lowered, so it carries no reputation ban. the peer reconnects
+    // anonymously with its rotated key, then its kad record arrives: the anonymous record wins the
+    // merge and the displaced record releases its `banned_peers` counter as it is dropped. because
+    // there is no reputation ban to carry (issue #998), the merged record stays Trusted - the
+    // reputation-ban case is covered by `test_upsert_peer_anonymous_inbound_merge_retains_ban`.
     let addr2 = create_multiaddr(None);
     all_peers.update_connection_status(
         &peer_id_2,
@@ -555,6 +558,163 @@ fn test_upsert_peer_merge_releases_displaced_banned_record() {
     assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
     let peer = all_peers.get_peer(&peer_id_2).expect("promoted peer resolves");
     assert!(matches!(peer.connection_status(), ConnectionStatus::Connected { .. }));
+    assert_eq!(peer.reputation(), Reputation::Trusted);
+}
+
+#[test]
+fn test_upsert_peer_anonymous_inbound_merge_retains_ban() {
+    // Regression (issue #998): a peer must not shed a *reputation* ban by reconnecting anonymously
+    // under a fresh network key before its kad record arrives. The anonymous-inbound record wins
+    // the merge in `upsert_peer`, but it must inherit the worse (banned) reputation of the record
+    // it displaces instead of resetting to a default (Trusted) score. On unpatched code the
+    // promoted record keeps its fresh score and the final `reputation()`/`peer_banned` assertions
+    // fail.
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(37);
+    let addr = create_multiaddr(None);
+
+    // establish a real reputation ban under the first network key: connect, then a Fatal penalty
+    // drops the score below the ban threshold; the follow-up disconnect completes the ban
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.process_penalty(&peer_id_1, Penalty::Fatal);
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(
+        all_peers.get_peer(&peer_id_1).map(|p| p.reputation()),
+        Some(Reputation::Banned),
+        "precondition: the peer is reputation-banned under its first network key",
+    );
+    assert!(all_peers.peer_banned(&peer_id_1));
+    assert_eq!(all_peers.banned_peers.total(), 1);
+
+    // the banned peer reconnects anonymously under a fresh network key (new peer id), creating a
+    // live inbound record, then publishes its self-signed kad record so `upsert_peer` merges the
+    // anonymous record onto the confirmed identity
+    let addr2 = create_multiaddr(None);
+    all_peers.update_connection_status(
+        &peer_id_2,
+        NewConnectionStatus::Connected {
+            multiaddr: addr2.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.upsert_peer(bls, net2, vec![addr2]);
+
+    // the merged record keeps the worse (banned) reputation: the ban survives the rotation and
+    // `peer_banned` still reports it under the new peer id
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    let peer = all_peers.get_peer(&peer_id_2).expect("promoted peer resolves");
+    assert_eq!(
+        peer.reputation(),
+        Reputation::Banned,
+        "the anonymous-inbound merge must retain the displaced record's reputation ban",
+    );
+    assert!(
+        all_peers.peer_banned(&peer_id_2),
+        "the reputation ban must survive a network-key rotation via anonymous inbound",
+    );
+}
+
+#[test]
+fn test_upsert_peer_cold_rotation_preserves_reputation_ban() {
+    // Regression (issue #998): the ordinary "cold" network-key rotation, where there is NO live
+    // anonymous-inbound record. `migrated` is None, so the new `(migrated, rotated)` merge arm is
+    // NOT exercised; the banned record carries forward via `migrated.or(rotated)` = rotated and
+    // `normalize_carried_status` re-applies its ban. This pins that the fix leaves cold-rotation
+    // ban preservation intact. The over-correction guard - that the merge does not drag a worse
+    // promoted record UP to a better displaced score - is
+    // `test_upsert_peer_anonymous_inbound_merge_keeps_promoted_worse_ban`, which does run the new
+    // arm's no-op branch.
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(38);
+    let addr = create_multiaddr(None);
+
+    // establish a real reputation ban under the first network key
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    all_peers.update_connection_status(
+        &peer_id_1,
+        NewConnectionStatus::Connected {
+            multiaddr: addr.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.process_penalty(&peer_id_1, Penalty::Fatal);
+    all_peers.update_connection_status(&peer_id_1, NewConnectionStatus::Disconnected);
+    assert_eq!(all_peers.get_peer(&peer_id_1).map(|p| p.reputation()), Some(Reputation::Banned),);
+
+    // rotate the network key with NO live anonymous inbound record present: `migrated` is None, so
+    // the banned record carries forward wholesale and normalizes its transport status
+    all_peers.upsert_peer(bls, net2, vec![addr]);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    let peer = all_peers.get_peer(&peer_id_2).expect("rotated peer resolves");
+    assert_eq!(peer.reputation(), Reputation::Banned);
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Banned { .. }));
+    assert!(all_peers.peer_banned(&peer_id_2));
+    assert_eq!(all_peers.banned_peers.total(), 1);
+}
+
+#[test]
+fn test_upsert_peer_anonymous_inbound_merge_keeps_promoted_worse_ban() {
+    // Over-correction guard (issue #998): the merge must retain the WORSE of the two reputations in
+    // BOTH directions. Here the promoted anonymous-inbound record is itself banned while the
+    // record it displaces under the confirmed identity is better-behaved (Trusted). The
+    // `retain_worse_reputation` no-op branch (`other.score < self.score` is false) must leave the
+    // promoted record's ban intact and NOT drag it up to the displaced record's Trusted score. This
+    // is the direction that kills the "always copy the displaced score" mutation, which the
+    // same-direction retains-ban test cannot detect.
+    let mut all_peers = create_all_peers(None);
+    let (bls, net1, peer_id_1, net2, peer_id_2) = rotation_keys(39);
+    let addr = create_multiaddr(None);
+
+    // a Trusted, better-behaved record under the confirmed identity via the first network key (its
+    // score is never lowered), which will become the displaced `rotated` record in the merge
+    all_peers.upsert_peer(bls, net1, vec![addr.clone()]);
+    assert_eq!(all_peers.get_peer(&peer_id_1).map(|p| p.reputation()), Some(Reputation::Trusted));
+
+    // the peer connects anonymously under a fresh network key and misbehaves BEFORE its kad record
+    // arrives, so the anonymous record (still `Unidentified`, not yet resolved to `bls`) is itself
+    // reputation-banned by a Fatal penalty
+    let addr2 = create_multiaddr(None);
+    all_peers.update_connection_status(
+        &peer_id_2,
+        NewConnectionStatus::Connected {
+            multiaddr: addr2.clone(),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    all_peers.process_penalty(&peer_id_2, Penalty::Fatal);
+    assert_eq!(
+        all_peers.get_peer(&peer_id_2).map(|p| p.reputation()),
+        Some(Reputation::Banned),
+        "precondition: the anonymous inbound record is itself banned before its kad record arrives",
+    );
+
+    // the kad record arrives and binds the banned anonymous record to `bls`, whose confirmed record
+    // is merely Trusted: the promoted (banned) record must keep its own worse reputation
+    all_peers.upsert_peer(bls, net2, vec![addr2]);
+    assert_eq!(all_peers.peers.len(), 1);
+    assert!(all_peers.bls_for_peer(&peer_id_1).is_none());
+    assert_eq!(all_peers.bls_for_peer(&peer_id_2), Some(bls));
+    let peer = all_peers.get_peer(&peer_id_2).expect("promoted peer resolves");
+    assert_eq!(
+        peer.reputation(),
+        Reputation::Banned,
+        "the merge must not upgrade a banned promoted record to a better displaced score",
+    );
+    assert!(
+        all_peers.peer_banned(&peer_id_2),
+        "the promoted record's own ban must survive binding to a better-behaved identity",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #998.

## Problem

`AllPeers::upsert_peer` (`crates/network-libp2p/src/peers/all_peers.rs`) merges the record reachable from a new network key with the record already stored under a peer's confirmed domain identity `Confirmed(bls)`.  The merge deliberately preserves accumulated reputation for the ordinary network-key-rotation case.  There was exactly one path where it did the opposite: when a live anonymous-inbound record (`migrated = Some`) collided with a banned record stored under `Confirmed(bls)` (`rotated = Some`), the merge released the banned record's accounting and let the fresh inbound record win with a default score.  The reconnecting peer came back `Trusted`.

Because a reputation ban was bound only to that discardable transport-scoped record (there is no `BlsPublicKey`-keyed ban set, and the persistent ban stores are IP-keyed and `PeerId`-keyed), a peer that controls its own banned `bls` key could shed its reputation ban by generating a new network keypair and reconnecting inbound before its kad record arrived.  The score/ban layer exists to make misbehavior accumulate cost;  this was a repeatable, attacker-controlled reset of that cost.  The in-code NOTE at the merge already flagged the behavior as an unaddressed follow-up.

Threat model: the exploit is self-evasion (the banned peer resets its own ban), attacker-controlled but multi-step.  It needs a fresh, non-banned source IP (the standard ban-evasion assumption;  the IP ban leg is released during the merge anyway) and the anonymous inbound connection to land before the self-signed kad record so that `migrated = Some`.  The attacker fully controls that ordering (connect first, then publish).  No third party is required.

## Root cause

`upsert_peer` already intends to preserve reputation across a network-key rotation (the cold-rotation branch, where the rotated record carries forward and `normalize_carried_status` re-applies its ban).  But it treated an anonymous-inbound promotion as authoritative and discarded the reputation of the record it displaced.  Combined with the fact that no ban is keyed by the stable domain identity, a reputation ban was bound to a discardable transport-scoped record instead of to the identity it is meant to punish.

## Fix

Carry the worse reputation across the merge (issue Option A), keeping the change record-level and minimal:

- **`crates/network-libp2p/src/peers/peer.rs`** . . . add `Peer::retain_worse_reputation(&mut self, other: &Peer)`.  It adopts `other`'s `Score` only when `other`'s score is the worse (lower aggregate) of the two.  The whole `Score` is adopted (not just the aggregate) so the ban-decay lockout that keeps the ban in force carries across the rotation.
- **`crates/network-libp2p/src/peers/all_peers.rs`** . . . in the `(migrated = Some, rotated = Some)` arm, call `promoted.retain_worse_reputation(displaced)` before releasing the displaced record's counter bookkeeping.  The stale NOTE that documented the shed-on-merge behavior is replaced with the reasoning for the carry.

The promoted record keeps the live transport identity (its own observed IPs and connection status), so per-IP ban accounting is unaffected (an attacker still cannot get an honest peer's advertised IP banned . . . GHSA-6qcj-p42p-779j), while `reputation()` and therefore `AllPeers::peer_banned` keep reporting the ban under the new peer id.  This lands the record in the reputation-`Banned` + `Connected` "pending ban" state that `peer_banned` is explicitly documented to model ("the peer can still be in a connected status but pending a ban, so the connection status is not used");  its live connection is then gated and torn down by the normal ban path on the peer's next action, exactly as for any freshly-banned connected peer.

The cold-rotation branch (`migrated = None`) is untouched: the banned record still carries forward wholesale and `normalize_carried_status` re-applies its ban, so the ordinary rotation case does not regress.

## Testing

`cargo +1.94 test -p tn-network-libp2p --lib` on the pinned toolchain, built in an isolated `CARGO_TARGET_DIR`.  All 142 peers-module tests pass;  `nightly` `fmt --check` is clean and `clippy` is clean on the touched files.

- `test_upsert_peer_anonymous_inbound_merge_retains_ban` (new) . . . establishes a real reputation ban under the first network key (a `Fatal` penalty actually drops the score below the ban threshold), reconnects anonymously under a fresh key, then merges the self-advertised record.  Asserts the merged record's reputation is still `Banned` and `peer_banned` reports it under the new peer id.  **Confirmed by mutation**: with the `retain_worse_reputation` call removed, this test fails exactly as the bug predicts (`left: Trusted, right: Banned`);  restoring the call turns it green.
- `test_upsert_peer_anonymous_inbound_merge_keeps_promoted_worse_ban` (new) . . . the over-correction guard, covering the other direction: the promoted anonymous-inbound record is itself banned while the record it displaces is `Trusted`, so the merge must keep the promoted record's worse reputation and not upgrade it.  **Confirmed by mutation**: dropping the `other.score < self.score` guard (always copy the displaced score) makes only this test fail (`left: Trusted, right: Banned`), so it pins the guard's no-op branch.
- `test_upsert_peer_cold_rotation_preserves_reputation_ban` (new) . . . a cold-rotation regression: with no anonymous-inbound record present (`migrated = None`), a real reputation ban still carries forward `Banned`, pinning that the fix leaves ordinary-rotation ban preservation intact.
- `test_upsert_peer_merge_releases_displaced_banned_record` (updated) . . . its displaced record was banned only at the connection-status layer (its score was never lowered), so there is no reputation ban to carry;  the comment and an added assertion now make explicit that this scenario stays `Trusted` and the counter release is unchanged.
