### PR TITLE
fix(network-kad): tolerate undecodable kad provider rows instead of panicking (#999)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -419,6 +419,19 @@ where
             kad_store.remove(&key);
         }
 
+        // Give the provider tables the same tolerant startup load: purge any provider
+        // rows whose bytes no longer decode (schema/version skew or corruption) so the
+        // first post-restart provider read can not panic the ConsensusNetwork task and
+        // then repeat that panic on every restart (issue #999).
+        let purged_providers = kad_store.scrub_corrupt_providers();
+        if purged_providers > 0 {
+            warn!(
+                target: "network-kad",
+                purged_providers,
+                "purged undecodable provider records from kad store at startup"
+            );
+        }
+
         let kademlia = kad::Behaviour::with_config(peer_id, kad_store.clone(), kad_config);
 
         // create custom behavior

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -19,7 +19,8 @@ use tn_config::KeyConfig;
 use tn_storage::tables::{
     KadProviderRecords, KadRecords, KadWorkerProviderRecords, KadWorkerRecords,
 };
-use tn_types::{decode, encode, BlockHash, Database, DefaultHashFunction};
+use tn_types::{decode, encode, try_decode, BlockHash, Database, DefaultHashFunction};
+use tracing::warn;
 
 /// A record stored in the DHT.
 /// This is a "shadow" struct for a kad Record so we can serialize/deserialize
@@ -159,6 +160,25 @@ fn instant_to_system(expires: &Option<Instant>) -> Option<SystemTime> {
     }
 }
 
+/// Decode a stored provider-record blob, tolerating bytes that no longer decode.
+///
+/// The provider tables persist `Vec<KadProviderRecord>` values. A schema/version skew
+/// across a restart, or on-disk corruption, can leave a row whose bytes the current
+/// software can no longer decode. The panicking [`decode`] would turn that single bad
+/// row into a crash of the whole `ConsensusNetwork` task on the first provider read
+/// after restart, and because the row is never purged the crash recurs on every
+/// restart. This returns `None` (logging a warning) instead, so the caller can skip
+/// the row on a read-only path or purge it on a mutating one. This is the provider-table
+/// analogue of the tolerant startup load the `KadRecords` table already gets in
+/// `consensus.rs` (issue #999).
+fn decode_providers(key: &BlockHash, raw: &[u8]) -> Option<Vec<KadProviderRecord>> {
+    try_decode::<Vec<KadProviderRecord>>(raw)
+        .inspect_err(|error| {
+            warn!(target: "network-kad", ?error, ?key, "skipping undecodable provider record");
+        })
+        .ok()
+}
+
 /// Provide a persistant store for kademlia data.
 /// Wraps around the consensus DB.
 #[derive(Clone, Debug)]
@@ -259,16 +279,24 @@ impl<DB: Database> KadStore<DB> {
                 .db
                 .iter::<KadProviderRecords>()
                 .filter_map(|(k, v)| {
-                    let recs: Vec<KadProviderRecord> = decode(v.as_ref());
-                    (!recs.is_empty() && recs.iter().all(|r| r.is_expired(now))).then_some(k)
+                    // An undecodable row is unusable; treat it as droppable so eviction
+                    // frees the slot and purges it instead of panicking (issue #999).
+                    let should_drop = decode_providers(&k, v.as_ref())
+                        .map(|recs| !recs.is_empty() && recs.iter().all(|r| r.is_expired(now)))
+                        .unwrap_or(true);
+                    should_drop.then_some(k)
                 })
                 .collect(),
             NetworkType::Worker(_) => self
                 .db
                 .iter::<KadWorkerProviderRecords>()
                 .filter_map(|(k, v)| {
-                    let recs: Vec<KadProviderRecord> = decode(v.as_ref());
-                    (!recs.is_empty() && recs.iter().all(|r| r.is_expired(now))).then_some(k)
+                    // An undecodable row is unusable; treat it as droppable so eviction
+                    // frees the slot and purges it instead of panicking (issue #999).
+                    let should_drop = decode_providers(&k, v.as_ref())
+                        .map(|recs| !recs.is_empty() && recs.iter().all(|r| r.is_expired(now)))
+                        .unwrap_or(true);
+                    should_drop.then_some(k)
                 })
                 .collect(),
         };
@@ -284,6 +312,64 @@ impl<DB: Database> KadStore<DB> {
         }
         self.num_providers = self.num_providers.saturating_sub(evicted);
         evicted
+    }
+
+    /// Purge provider-table rows whose stored bytes no longer decode, giving the provider
+    /// tables the tolerant startup load the `KadRecords` table already gets in
+    /// `consensus.rs`. Without this, a schema/version skew or on-disk corruption leaves a
+    /// row that panics the whole `ConsensusNetwork` task on the first provider read after
+    /// restart, and because the row is never purged the panic recurs on every restart.
+    /// Returns the number of rows removed and keeps `num_providers` in step (issue #999).
+    pub fn scrub_corrupt_providers(&mut self) -> usize {
+        let corrupt: Vec<BlockHash> = match self.kad_type {
+            NetworkType::Primary => self
+                .db
+                .iter::<KadProviderRecords>()
+                .filter_map(|(k, v)| decode_providers(&k, v.as_ref()).is_none().then_some(k))
+                .collect(),
+            NetworkType::Worker(_) => self
+                .db
+                .iter::<KadWorkerProviderRecords>()
+                .filter_map(|(k, v)| decode_providers(&k, v.as_ref()).is_none().then_some(k))
+                .collect(),
+        };
+        let evicted = corrupt
+            .iter()
+            .filter(|k| match self.kad_type {
+                NetworkType::Primary => self.db.remove::<KadProviderRecords>(k).is_ok(),
+                NetworkType::Worker(_) => self.db.remove::<KadWorkerProviderRecords>(k).is_ok(),
+            })
+            .count();
+        self.num_providers = self.num_providers.saturating_sub(evicted);
+        evicted
+    }
+
+    /// Merge a new provider record into an existing, already-decoded set for one key:
+    /// replace the entry that shares the provider peer if present, otherwise prune expired
+    /// entries, enforce the per-key cap, and append. Keyword-free analogue of the in-place
+    /// update loop, factored out so the caller can decide what to do when the stored row
+    /// does not decode.
+    fn merge_provider(
+        &self,
+        existing: Vec<KadProviderRecord>,
+        kr: KadProviderRecord,
+    ) -> libp2p::kad::store::Result<Vec<KadProviderRecord>> {
+        let found = existing.iter().any(|r| r.provider == kr.provider);
+        if found {
+            Ok(existing
+                .into_iter()
+                .map(|r| if r.provider == kr.provider { kr.clone() } else { r })
+                .collect())
+        } else {
+            let now = SystemTime::now();
+            let mut pruned: Vec<KadProviderRecord> =
+                existing.into_iter().filter(|r| !r.is_expired(now)).collect();
+            (pruned.len() < self.config.max_providers_per_key)
+                .then_some(())
+                .ok_or(Error::MaxProvidedKeys)?;
+            pruned.push(kr);
+            Ok(pruned)
+        }
     }
 }
 
@@ -404,69 +490,68 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         if self.num_providers >= self.config.max_provided_keys {
             // Try to free a slot by evicting fully-expired provider key groups.
             self.evict_expired_providers();
-            if self.num_providers >= self.config.max_provided_keys {
-                return Err(Error::MaxProvidedKeys);
-            }
         }
+        // Re-check after the eviction attempt; still full is a hard error.
+        (self.num_providers < self.config.max_provided_keys)
+            .then_some(())
+            .ok_or(Error::MaxProvidedKeys)?;
+
         let key = self.key_to_hash(&record.key);
         let kr: KadProviderRecord = record.into();
-        let mut inc_providers = false;
-        let records: Vec<KadProviderRecord> = if let Ok(Some(recs)) = match self.kad_type {
+        let stored = match self.kad_type {
             NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
             NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
-        } {
-            let mut recs: Vec<KadProviderRecord> = decode(&recs);
-            let mut found = false;
-            for r in recs.iter_mut() {
-                if r.provider == kr.provider {
-                    *r = kr.clone();
-                    found = true;
-                }
-            }
-            if !found {
-                // prune expired entries before checking the cap
-                let now = SystemTime::now();
-                recs.retain(|r| !r.is_expired(now));
-                if recs.len() >= self.config.max_providers_per_key {
-                    return Err(Error::MaxProvidedKeys);
-                }
-                recs.push(kr);
-            }
-            recs
-        } else {
-            inc_providers = true;
-            vec![kr]
-        };
+        }
+        .ok()
+        .flatten();
+
+        // A present-but-undecodable row is treated as absent for the merge: the new
+        // provider set overwrites (purges) it instead of the read panicking. Unlike a
+        // genuinely new key it is already counted in `num_providers`, so only a missing
+        // row bumps the gauge (issue #999).
+        let row_exists = stored.is_some();
+        let merged = stored
+            .as_deref()
+            .and_then(|raw| decode_providers(&key, raw))
+            .map(|existing| self.merge_provider(existing, kr.clone()))
+            .transpose()?;
+        let records: Vec<KadProviderRecord> = merged.unwrap_or_else(|| vec![kr]);
+
         match self.kad_type {
             NetworkType::Primary => self
                 .db
                 .insert::<KadProviderRecords>(&key, &encode(&records))
-                .map_err(|_| libp2p::kad::store::Error::ValueTooLarge)?,
+                .map_err(|_| Error::ValueTooLarge)?,
             NetworkType::Worker(_) => self
                 .db
                 .insert::<KadWorkerProviderRecords>(&key, &encode(&records))
-                .map_err(|_| libp2p::kad::store::Error::ValueTooLarge)?,
+                .map_err(|_| Error::ValueTooLarge)?,
         }
-        if inc_providers {
-            // If this was a new record and it was inserted then inc num_providers.
-            // I.E. Don't inc if this updated an existing provider record.
+        if !row_exists {
+            // A brand-new key: bump the counter. An overwrite (including of a purged
+            // corrupt row) leaves the count unchanged.
             self.num_providers += 1;
         }
         Ok(())
     }
 
     fn providers(&self, key: &RecordKey) -> Vec<ProviderRecord> {
-        let key = self.key_to_hash(key);
-        if let Ok(Some(recs)) = match self.kad_type {
-            NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
-            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
-        } {
-            let now = SystemTime::now();
-            let records: Vec<KadProviderRecord> = decode(&recs);
-            records.into_iter().filter(|r| !r.is_expired(now)).map(|r| r.into()).collect()
-        } else {
-            vec![]
-        }
+        let hash = self.key_to_hash(key);
+        let stored = match self.kad_type {
+            NetworkType::Primary => self.db.get::<KadProviderRecords>(&hash),
+            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&hash),
+        };
+        let now = SystemTime::now();
+        // Read-only path: an undecodable row is skipped (returns nothing) rather than
+        // panicking. The startup scrub and the mutating paths do the actual purge.
+        stored
+            .ok()
+            .flatten()
+            .and_then(|recs| decode_providers(&hash, &recs))
+            .map(|records| {
+                records.into_iter().filter(|r| !r.is_expired(now)).map(Into::into).collect()
+            })
+            .unwrap_or_default()
     }
 
     fn provided(&self) -> Self::ProvidedIter<'_> {
@@ -476,31 +561,38 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     }
 
     fn remove_provider(&mut self, key: &RecordKey, p: &PeerId) {
-        let key = self.key_to_hash(key);
-        if let Ok(Some(recs)) = match self.kad_type {
-            NetworkType::Primary => self.db.get::<KadProviderRecords>(&key),
-            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&key),
-        } {
-            let records: Vec<KadProviderRecord> = decode(&recs);
-            let records: Vec<KadProviderRecord> =
-                records.into_iter().filter(|r| r.provider != *p).collect();
-            if records.is_empty() {
-                if match self.kad_type {
-                    NetworkType::Primary => self.db.remove::<KadProviderRecords>(&key),
-                    NetworkType::Worker(_) => self.db.remove::<KadWorkerProviderRecords>(&key),
+        let hash = self.key_to_hash(key);
+        let stored = match self.kad_type {
+            NetworkType::Primary => self.db.get::<KadProviderRecords>(&hash),
+            NetworkType::Worker(_) => self.db.get::<KadWorkerProviderRecords>(&hash),
+        }
+        .ok()
+        .flatten();
+
+        if let Some(raw) = stored {
+            // An undecodable row is purged wholesale (it is unusable and would otherwise
+            // panic every read); a decodable row keeps every provider except `p`.
+            let remaining: Vec<KadProviderRecord> = decode_providers(&hash, &raw)
+                .map(|records| records.into_iter().filter(|r| r.provider != *p).collect())
+                .unwrap_or_default();
+            if remaining.is_empty() {
+                let removed = match self.kad_type {
+                    NetworkType::Primary => self.db.remove::<KadProviderRecords>(&hash),
+                    NetworkType::Worker(_) => self.db.remove::<KadWorkerProviderRecords>(&hash),
                 }
-                .is_ok()
-                {
-                    // Provider is empty and we removed it so dec num_providers.
-                    self.num_providers -= 1;
+                .is_ok();
+                if removed {
+                    // The key holds no providers now (all filtered out, or the row was
+                    // purged): drop the count once, saturating to avoid an underflow panic.
+                    self.num_providers = self.num_providers.saturating_sub(1);
                 }
             } else {
                 let _ = match self.kad_type {
                     NetworkType::Primary => {
-                        self.db.insert::<KadProviderRecords>(&key, &encode(&records))
+                        self.db.insert::<KadProviderRecords>(&hash, &encode(&remaining))
                     }
                     NetworkType::Worker(_) => {
-                        self.db.insert::<KadWorkerProviderRecords>(&key, &encode(&records))
+                        self.db.insert::<KadWorkerProviderRecords>(&hash, &encode(&remaining))
                     }
                 };
             }
@@ -977,5 +1069,155 @@ mod test {
             .build()
             .map(|_| ())
             .map_err(Into::into)
+    }
+
+    // ---- issue #999: provider tables tolerate undecodable rows instead of panicking ----
+
+    /// Bytes that are not a valid BCS `Vec<KadProviderRecord>`: the leading ULEB128 length
+    /// overflows a `u32`, so decoding always errors. This stands in for a row written by an
+    /// incompatible schema/version or corrupted on disk. Every test below relies on the
+    /// tolerant `decode_providers` helper: swap it back to the panicking `decode` and each
+    /// one fails (a panic), which is the guard-reversal check the issue asks for.
+    const CORRUPT_PROVIDER_BYTES: [u8; 5] = [0xff, 0xff, 0xff, 0xff, 0xff];
+
+    fn test_key_config() -> KeyConfig {
+        KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()))
+    }
+
+    /// A random, distinct provider key.
+    fn fresh_record_key() -> RecordKey {
+        RecordKey::new(&encode(&test_key_config().primary_public_key()))
+    }
+
+    fn inject_corrupt_primary_provider<DB: Database>(store: &KadStore<DB>, key: &RecordKey) {
+        let hash = store.key_to_hash(key);
+        store
+            .db
+            .insert::<KadProviderRecords>(&hash, &CORRUPT_PROVIDER_BYTES.to_vec())
+            .expect("inject corrupt provider row");
+    }
+
+    fn inject_corrupt_worker_provider<DB: Database>(store: &KadStore<DB>, key: &RecordKey) {
+        let hash = store.key_to_hash(key);
+        store
+            .db
+            .insert::<KadWorkerProviderRecords>(&hash, &CORRUPT_PROVIDER_BYTES.to_vec())
+            .expect("inject corrupt worker provider row");
+    }
+
+    fn live_provider_under(key: &RecordKey) -> ProviderRecord {
+        let provider = PeerId::random();
+        let expires = Instant::now().checked_add(Duration::from_secs(60 * 60 * 24));
+        ProviderRecord { key: key.clone(), provider, expires, addresses: vec![] }
+    }
+
+    /// `providers()` is a read-only path: an undecodable row must be skipped (empty result)
+    /// rather than panic the caller, and neighbouring good rows must be unaffected.
+    #[test]
+    fn test_kad_providers_skips_corrupt_row() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+        let mut store = KadStore::new(db, &key_config, NetworkType::Primary);
+
+        let good_key = fresh_record_key();
+        store.add_provider(live_provider_under(&good_key)).expect("add good provider");
+
+        let corrupt_key = fresh_record_key();
+        inject_corrupt_primary_provider(&store, &corrupt_key);
+
+        // The corrupt key yields nothing; the good key is untouched.
+        assert!(store.providers(&corrupt_key).is_empty(), "corrupt row skipped, not panicked");
+        assert_eq!(store.providers(&good_key).len(), 1, "good row still readable");
+    }
+
+    /// `remove_provider()` is a mutating path: an undecodable row is purged wholesale and the
+    /// provider count is decremented, modelling a restart where `new()` counted the bad row.
+    #[test]
+    fn test_kad_remove_provider_purges_corrupt_row() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+
+        let corrupt_key = fresh_record_key();
+        // Seed then "restart" so `new()` counts the injected row exactly as it would on disk.
+        let seed = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
+        inject_corrupt_primary_provider(&seed, &corrupt_key);
+        let mut store = KadStore::new(db, &key_config, NetworkType::Primary);
+        assert_eq!(store.num_providers, 1, "corrupt row counted at startup");
+
+        store.remove_provider(&corrupt_key, &PeerId::random());
+        assert!(store.providers(&corrupt_key).is_empty(), "corrupt row purged");
+        assert_eq!(store.num_providers, 0, "count decremented on purge");
+    }
+
+    /// `add_provider()` over a corrupt existing row overwrites (purges) it without panicking,
+    /// and must not double-count: the row was already counted at startup.
+    #[test]
+    fn test_kad_add_provider_over_corrupt_row_overwrites() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+
+        let key = fresh_record_key();
+        let seed = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
+        inject_corrupt_primary_provider(&seed, &key);
+        let mut store = KadStore::new(db, &key_config, NetworkType::Primary);
+        assert_eq!(store.num_providers, 1, "corrupt row counted at startup");
+
+        let rec = live_provider_under(&key);
+        store.add_provider(rec.clone()).expect("add over corrupt row must not panic");
+
+        assert_eq!(store.num_providers, 1, "overwrite of a corrupt row keeps the count stable");
+        let got = store.providers(&key);
+        assert_eq!(got.len(), 1, "corrupt row replaced by the new provider");
+        assert_eq!(got[0].provider, rec.provider);
+    }
+
+    /// The startup scrub purges every undecodable provider row (keeping the count in step) and
+    /// leaves decodable rows intact; a second pass is a no-op. This is the parity with the
+    /// `KadRecords` tolerant startup load that the issue asks for.
+    #[test]
+    fn test_kad_scrub_corrupt_providers_purges_bad_keeps_good() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+
+        let good_key = fresh_record_key();
+        let mut seed = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
+        seed.add_provider(live_provider_under(&good_key)).expect("add good provider");
+        let corrupt_key = fresh_record_key();
+        inject_corrupt_primary_provider(&seed, &corrupt_key);
+
+        // "restart": both rows are counted without being decoded.
+        let mut store = KadStore::new(db, &key_config, NetworkType::Primary);
+        assert_eq!(store.num_providers, 2, "good and corrupt rows both counted at startup");
+
+        let purged = store.scrub_corrupt_providers();
+        assert_eq!(purged, 1, "exactly the corrupt row is purged");
+        assert_eq!(store.num_providers, 1, "count reflects the purge");
+        assert_eq!(store.providers(&good_key).len(), 1, "good row survives the scrub");
+        assert!(store.providers(&corrupt_key).is_empty(), "corrupt row gone after scrub");
+
+        assert_eq!(store.scrub_corrupt_providers(), 0, "scrub is idempotent once clean");
+    }
+
+    /// The worker provider table gets the same tolerance as the primary one.
+    #[test]
+    fn test_kad_worker_provider_table_tolerates_corrupt_row() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+
+        let corrupt_key = fresh_record_key();
+        let seed = KadStore::new(db.clone(), &key_config, NetworkType::Worker(0));
+        inject_corrupt_worker_provider(&seed, &corrupt_key);
+        let mut store = KadStore::new(db, &key_config, NetworkType::Worker(0));
+        assert_eq!(store.num_providers, 1, "worker corrupt row counted at startup");
+
+        // read path does not panic, scrub purges it
+        assert!(store.providers(&corrupt_key).is_empty(), "worker read skips corrupt row");
+        assert_eq!(store.scrub_corrupt_providers(), 1, "worker scrub purges corrupt row");
+        assert_eq!(store.num_providers, 0, "worker count reflects the purge");
     }
 }


### PR DESCRIPTION
Closes #999.

## Problem

The kademlia provider tables (`KadProviderRecords` and the worker `KadWorkerProviderRecords`) had no non-panicking read path and no startup scrub.  Every provider read went through the panicking `decode()`:

- `crates/network-libp2p/src/kad.rs` `evict_expired_providers` (both the primary and worker arms)
- `add_provider` (the read of an existing row before the merge)
- `providers` (the hot read path)
- `remove_provider`

`decode()` is documented as "will panic on failure, use with data that should be valid".  So a single undecodable provider row is not a skipped entry, it is a panic of the whole `ConsensusNetwork` task.  A version or schema skew across a restart (a `KadProviderRecord` layout change shipped in a new binary), or plain on-disk corruption, produces exactly such a row.  Because `provided()` / `providers()` run on the local node key during bring-up, the first provider read after restart panics, and since nothing ever purges the offending row the same panic recurs on every subsequent restart.  The node is wedged with no operator recourse.

This needs no attacker (the fault is a self-inflicted corruption or an ordinary upgrade), which is why it is Medium rather than High, but the self-perpetuating restart loop is what makes it worth fixing rather than tolerating.

## Root cause

The sibling record table already learned this lesson.  `KadRecords` gets a tolerant startup load in `consensus.rs`: it collects rows whose value does not decode and purges them (with a warning) before the store is handed to the kademlia behaviour, so accounting stays accurate and no later read trips over them.  The provider tables never got the equivalent.  They kept the panicking `decode()` on every read and had no startup purge, so the one class of durable state that can outlive a schema bump had the least tolerance for one.

## Fix

Give the provider tables behavioral parity with `KadRecords`, on both axes the issue asks for: a non-panicking read path, and a startup scrub.

- **`decode_providers(key, raw) -> Option<Vec<KadProviderRecord>>`** (new, `kad.rs`).  The provider-table analogue of the `KadRecords` tolerant load: it runs the fallible `try_decode` (bcs), and on failure logs a `warn!` and returns `None` instead of panicking.  Every provider read now routes through it.
- **Read-only path** (`providers`) skips an undecodable row and returns nothing for that key.  It holds `&self`, so it cannot purge;  the scrub and the mutating paths do that.
- **Mutating paths purge** the bad row rather than leave it to trip the next read:
  - `remove_provider` purges an undecodable row wholesale (it is unusable) and decrements the count.
  - `add_provider` treats a present-but-undecodable row as absent-for-merge: the new provider set overwrites (purges) it.  Because that row was already counted at startup, the overwrite deliberately does not re-increment `num_providers`, so the count stays correct.
  - `evict_expired_providers` treats an undecodable row as droppable, so eviction frees the slot and purges it.
- **`KadStore::scrub_corrupt_providers(&mut self) -> usize`** (new).  Scans the active provider table, purges every row that no longer decodes (logging each), and keeps `num_providers` in step.  `consensus.rs` calls it during `ConsensusNetwork` bring-up immediately after the existing `KadRecords` purge, so both KAD tables now get the same one-shot tolerant load and the first post-restart provider read cannot panic (and cannot recur).
- The `num_providers -= 1` in `remove_provider` becomes `saturating_sub(1)`, matching the eviction code's existing saturating style and removing a second, latent underflow-panic on the same path.

Scope note: this is deliberately confined to the provider tables named in the issue.  The `KadRecord` read paths (`get`, the `records()` iterator, `evict_expired_records`) still use the panicking `decode()`;  hardening those is a separate change with its own tests and is not folded in here.

Threat model: a provider record is a best-effort DHT cache entry, not consensus-critical state, so the safe response to an undecodable one is to drop it and warn (fail-safe), not to halt the node (fail-stop).  Dropping a stale provider hint degrades DHT lookups gracefully and the entry is re-learned;  panicking the consensus task does not.  The purge is attacker-independent and one-shot per row: a corrupt row is removed once at startup, so a restart loop cannot form.

## Testing

`CARGO_TARGET_DIR=/Users/oobi/Documents/.tn-999-iso cargo +1.94 test -p tn-network-libp2p --lib kad::`

Five new regression tests in `kad.rs`, covering the read path, both mutating paths, the startup scrub, and worker-table parity:

- `test_kad_providers_skips_corrupt_row` . . . a read of an undecodable row returns empty (not a panic) and a neighbouring good row is unaffected.
- `test_kad_remove_provider_purges_corrupt_row` . . . removing against an undecodable row purges it and decrements the count.
- `test_kad_add_provider_over_corrupt_row_overwrites` . . . adding a provider over an undecodable row overwrites it without panicking and without double-counting.
- `test_kad_scrub_corrupt_providers_purges_bad_keeps_good` . . . the startup scrub purges only the corrupt row, keeps the count in step, leaves good rows readable, and is idempotent.
- `test_kad_worker_provider_table_tolerates_corrupt_row` . . . the same tolerance holds for `KadWorkerProviderRecords`.

Each test was confirmed by mutation: reverting `decode_providers` to the panicking `decode` makes every one of them fail (a panic), so they genuinely pin the guard and are not vacuous.

Full gate: `make attest` on the pinned 1.94 toolchain (fmt + clippy + workspace test-build).
