### PR TITLE
Collapse the redundant warm-up epoch in the mid-epoch-restart eject test

### DIFF
--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -1181,6 +1181,27 @@ pub(crate) async fn wait_for_mid_epoch<P: Provider>(
     }
 }
 
+/// Seconds of runway left before `snap`'s epoch closes, measured from the host clock against the
+/// epoch's start.
+///
+/// Mirrors the phase arithmetic [`wait_for_mid_epoch`] performs: the block before the epoch's
+/// first block (`block_height - 1`) is the previous epoch's closing block, produced exactly at the
+/// boundary, so its timestamp is when this epoch started; every testnet node runs on this host, so
+/// the host-clock vs block-timestamp comparison is sound. Saturates to 0 once the boundary is due.
+/// `as_secs()` floors the host clock while the block timestamp is already whole seconds, so the
+/// result can over-report the true remaining budget by strictly under a second; a caller must keep
+/// a margin over its worst-case sequence rather than treat the value as exact.
+pub(crate) fn epoch_seconds_remaining(node: &str, snap: &EpochSnapshot) -> eyre::Result<u64> {
+    let boundary_block = snap.block_height.saturating_sub(1);
+    let epoch_start = read_block_timestamp(node, boundary_block)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("host clock is after the unix epoch")
+        .as_secs();
+    let phase = now.saturating_sub(epoch_start);
+    Ok(snap.epoch_duration.saturating_sub(phase))
+}
+
 /// Fetch the receipt for `tx_hash` from `node` via `eth_getTransactionReceipt` and return the
 /// `blockNumber` it landed in.
 ///

--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -27,7 +27,7 @@
 
 use crate::common::{
     acquire_test_permit, assert_epoch_reached, assert_epoch_records_verify,
-    create_genesis_for_test, current_epoch, fetch_verified_epoch_record,
+    create_genesis_for_test, current_epoch, epoch_seconds_remaining, fetch_verified_epoch_record,
     generate_new_validator_txs, get_block_number, get_latest_consensus_header_number,
     get_tx_receipt_block, kill_child, loop_epochs, send_owner_tx, start_nodes,
     wait_for_epoch_at_least, wait_for_head_at_least, wait_for_mid_epoch, wait_for_rpc,
@@ -651,9 +651,10 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
 /// - REPRO PIN: the kill target must have EXECUTED the burn block before dying. Otherwise its
 ///   restart tip would still be pre-burn state, and even an unpinned tip read would derive the
 ///   correct 5-member committee — an accidental pass.
-/// - IN-EPOCH GUARDS: the epoch is entered exactly at its boundary flip (banking the full duration
-///   for the sequence above), and every wait re-checks that epoch E is still current, failing
-///   loudly as "premise broken" if the sequence straddles a boundary.
+/// - IN-EPOCH GUARDS: epoch E is entered only when it holds enough runway for the sequence above
+///   (the current epoch when its remaining budget clears the margin, otherwise a fresh flip into
+///   the next epoch), and every wait re-checks that epoch E is still current, failing loudly as
+///   "premise broken" if the sequence straddles a boundary.
 ///
 /// The detectors, in order: (a) the restarted node's consensus height re-advances past
 /// everything it could have held at death — commits it can only acquire by verifying the
@@ -715,26 +716,49 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
     // the kill target serving certified record 0 keeps this test deterministic.
     fetch_verified_epoch_record(&endpoints[1].http_url, 0, RESTART_EPOCH_DURATION * 2).await?;
 
-    // ---- Fresh-boundary entry: catch the flip into epoch E ----
-    // The in-epoch sequence below (rotation, burn, pin, kill, restart, rejoin) worst-cases at
-    // ~29s; entering exactly at the flip banks the full epoch duration for it, where a
-    // mid-epoch entry would squander half.
-    let pre_flip = current_epoch(&provider).await?.epoch_id;
-    wait_until(
-        Duration::from_secs(RESTART_EPOCH_DURATION * 2),
-        &format!("fresh-boundary entry: waiting for the epoch to flip past {pre_flip} on node 0"),
-        || async { Ok(current_epoch(&provider).await?.epoch_id > pre_flip) },
-    )
-    .await?;
-    let e = current_epoch(&provider).await?.epoch_id;
-    // the flip poll re-checks every ~10ms, so observing a double-flip means this thread stalled
-    // for a whole epoch — the "fresh entry" premise is gone
-    eyre::ensure!(
-        e == pre_flip + 1,
-        "premise broken: entered epoch {e}, expected the fresh flip to {}",
-        pre_flip + 1
-    );
-    info!(target: "eject-test", epoch = e, "entered epoch at a fresh boundary");
+    // ---- Enter epoch E: reuse the epoch we are already in when it still has runway ----
+    // Phase 0 crossed into the current epoch within a poll cadence of the flip, so we are already
+    // fresh in it. The in-epoch sequence below (rotation, burn, pin, kill, restart, rejoin)
+    // worst-cases at ~29s; if the current epoch still holds that much runway plus margin, run the
+    // sequence here and save a whole ~40s warm-up epoch. Otherwise (for example a slow record-0
+    // certification above that burned into the budget) fall back to the next fresh boundary, which
+    // banks the full epoch duration. The fall-back branch is exactly the prior behavior, so this
+    // is a strict improvement; the budget guard is REQUIRED, not cosmetic: without it a
+    // degraded-network record-0 fetch could shove the ~29s sequence past the boundary and trip a
+    // spurious "premise broken" at one of the in-epoch guards below.
+    //
+    // ~29s worst-case sequence (see `RESTART_EPOCH_DURATION`) plus ~4s margin.
+    const SEQUENCE_BUDGET_SECS: u64 = 33;
+    let entry = current_epoch(&provider).await?;
+    let e = if epoch_seconds_remaining(&rpc_url, &entry)? >= SEQUENCE_BUDGET_SECS {
+        info!(
+            target: "eject-test",
+            epoch = entry.epoch_id,
+            "running the regression in the current epoch (sufficient budget)"
+        );
+        entry.epoch_id
+    } else {
+        // Not enough runway left in this epoch: wait out the flip and run fresh in the next one.
+        let pre_flip = entry.epoch_id;
+        wait_until(
+            Duration::from_secs(RESTART_EPOCH_DURATION * 2),
+            &format!(
+                "fresh-boundary entry: waiting for the epoch to flip past {pre_flip} on node 0"
+            ),
+            || async { Ok(current_epoch(&provider).await?.epoch_id > pre_flip) },
+        )
+        .await?;
+        let flipped = current_epoch(&provider).await?.epoch_id;
+        // the flip poll re-checks every ~10ms, so observing a double-flip means this thread stalled
+        // for a whole epoch (the "fresh entry" premise is gone)
+        eyre::ensure!(
+            flipped == pre_flip + 1,
+            "premise broken: entered epoch {flipped}, expected the fresh flip to {}",
+            pre_flip + 1
+        );
+        info!(target: "eject-test", epoch = flipped, "entered epoch at a fresh boundary");
+        flipped
+    };
 
     // ---- Victim-led premise: observe one full leader rotation inside epoch E ----
     // The leader schedule is strict round-robin over the committee (leader(round) =


### PR DESCRIPTION
## Summary

Speeds up the ignored e2e regression `eject::test_committee_member_restarted_mid_epoch_after_ejection`
by collapsing one redundant warm-up epoch.  The test drops from ~120s to ~80s solo (~33%) with no loss
of coverage: it still enters at a fresh epoch boundary, still runs the full in-epoch sequence (leader
rotation, governance burn, burn-block pin, kill, restart, mid-epoch rejoin), and still fires every
detector (mid-epoch rejoin, boundary close on all six nodes, and the record-divergence hash check).

Resolves #1003.

## Problem

Epoch close is pure wall-clock (`committed_at() >= epoch_start + epoch_duration`), and this test
overrides the module epoch length with `RESTART_EPOCH_DURATION = 40s` so its whole in-epoch sequence
(worst case ~29s) fits inside one epoch.  Every `RESTART_EPOCH_DURATION * N` bound in the body is a
hang-ceiling that returns the instant its predicate holds, so the only real wall-clock cost is full
epoch closes.  The test paid for three of them:

1. epoch 0 -> 1 (`wait_for_epoch_at_least(&provider, 1)`): irreducible.  Certified epoch record 0 only
   exists after the 0 -> 1 close, and the kill target must serve it before the kill.
2. epoch 1 -> 2 (the old "fresh-boundary entry" block): redundant.  Phase 0 already lands fresh in
   epoch 1, and this block then waited out the whole of epoch 1 purely to re-enter fresh at epoch 2.
3. epoch E (the regression itself): the in-epoch sequence runs as ceilings (~its real cost), then the
   `E -> E+1` boundary close is banked.

Step 2 is one full ~40s epoch spent on nothing but re-entering fresh one epoch later.  Nothing in the
regression requires epoch 2 rather than epoch 1.

## Fix

Run the regression in the epoch we are already in (epoch 1) instead of waiting out a second epoch,
guarded by a phase-margin check so the change is a strict improvement over the old behavior:

- **`common.rs`: new `epoch_seconds_remaining(node, snap)` helper.**  Returns the seconds of runway
  left before the current epoch closes, mirroring the phase arithmetic `wait_for_mid_epoch` already
  performs: the block before the epoch's first block (`block_height - 1`) is the previous epoch's
  closing block, produced exactly at the boundary, so its timestamp is when this epoch started;  every
  testnet node runs on this host, so the host-clock vs block-timestamp comparison is sound.  It
  saturates to 0 once the boundary is due;  because the host clock is floored to whole seconds the
  value can over-report the remaining budget by strictly under a second, which the guard's margin
  over the worst-case sequence absorbs.

- **`eject.rs`: budget-guarded epoch entry.**  After Phase 0 (which crosses into epoch 1 within a poll
  cadence of the flip), check the remaining budget.  If it is at least `SEQUENCE_BUDGET_SECS = 33s`
  (the ~29s worst-case sequence plus ~4s margin), run the regression in the current epoch.  Otherwise
  fall back to the previous next-fresh-boundary wait, which banks the full epoch duration.  The
  fall-back branch is byte-for-byte the prior behavior, so the change can only ever match or beat it.

**Why the guard is required, not cosmetic.**  `fetch_verified_epoch_record` for record 0 backs off in
2500ms steps up to 24x under a degraded network.  Without the guard, a slow record-0 certification
would burn into epoch 1's budget and could shove the ~29s sequence past the boundary, tripping a
spurious "premise broken" failure at one of the in-epoch guards.  The guard defers to the next fresh
boundary in exactly that case, so a slow run degrades to today's timing instead of flaking.

**Coverage is unchanged.**  The regression reproduces mechanically identically at E = 1: the product
fix under test pins the restarted node's entry read to epoch 0's real 5-member closing block rather
than the post-burn 4-member canonical tip.  `epoch_of_block` walks `current.saturating_sub(3)..=current`,
which at E = 1 is `[0, 1]` and still classifies `burn_block` correctly; `assert_epoch_records_verify(
&endpoints, 0..=e, ...)` at e = 1 verifies records {0, 1}.  Every budget-straddle path remains a loud
`ensure` on real consensus heights (burn-mid-epoch, restart-inside-E, mid-epoch rejoin), never a
silent or vacuous pass, and the record-0 kill gate that keeps the pre-existing `save_dummy_epoch0`
restart-crash window closed is preserved verbatim.

Only the primary lever from #1003 is applied.  The optional poll-cadence tightening (change 2, worth
~1-5s) is deliberately deferred: it edits shared observation helpers used by every e2e test, widening
the blast radius and overlapping the in-flight #978 e2e-speedup work, for a fraction of this change's
win.  The rejected duration cut (lowering `RESTART_EPOCH_DURATION`) is not applied: its ~11s of
headroom protects the IO/CPU-bound restart under CI contention.

## Testing

- `cargo nextest run -p e2e-tests --no-run --all-features` compiles clean on the pinned toolchain
  (full dep tree + `e2e-tests` test binary).
- Static multi-agent review across six lenses (arithmetic, coverage, budget-guard soundness,
  fallback parity, downstream integration, house conventions), each finding adversarially verified.

Runtime acceptance (run on a host with disk headroom;  the e2e binary is prebuilt via
`make build-e2e-bin` so restart cost is warm):

```
# 1. solo timing + fast-path engagement (expect ~80s and the log line
#    "running the regression in the current epoch (sufficient budget)")
TN_BIN_PATH=./target/debug/telcoin-network \
  cargo nextest run -p e2e-tests --run-ignored ignored-only \
  -E 'test(test_committee_member_restarted_mid_epoch_after_ejection)'

# 2. confirm-by-mutation at E = 1: revert the restarted node's entry-read pinning fix and confirm
#    the record-divergence assert and/or the mid-epoch rejoin assert fail loudly, then restore.

# 3. exercise the guard's fall-back branch (e.g. force a slow record-0 certification) and confirm
#    it defers to the next fresh boundary rather than straddling.
```
