### PR TITLE
fix(network-libp2p): ban-gate inbound Kademlia AddProvider at PutRecord parity

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -392,7 +392,7 @@ where
             .set_publication_interval(Some(libp2p.kad_publication_interval))
             .set_query_timeout(Duration::from_secs(60))
             .set_provider_record_ttl(Some(libp2p.kad_record_ttl));
-        let mut kad_store = KadStore::new(db.clone(), &key_config, network_type);
+        let mut kad_store = KadStore::new(db.clone(), peer_id, &key_config, network_type);
 
         // Load the Kad records from DB for the local peer cache, decoding with a legacy
         // fallback so records persisted by pre-upgrade software still load. Collect
@@ -1720,14 +1720,7 @@ where
                         num_provider_peers: _,
                     } => {}
                     kad::InboundRequest::AddProvider { record } => {
-                        if let Some(record) = record {
-                            self.swarm
-                                .behaviour_mut()
-                                .kademlia
-                                .store_mut()
-                                .add_provider(record)
-                                .map_err(|e| NetworkError::StoreKademliaRecord(e.to_string()))?;
-                        }
+                        self.process_kad_add_provider(record)?;
                     }
                     kad::InboundRequest::GetRecord { num_closer_peers: _, present_locally: _ } => {}
                     kad::InboundRequest::PutRecord { source, connection: _, record } => {
@@ -1955,6 +1948,40 @@ where
             trace!(target: "network-kad", ?source, "processing fatal penalty for invalid peer record");
             self.swarm.behaviour_mut().peer_manager.process_penalty(source, Penalty::Fatal);
         }
+
+        Ok(())
+    }
+
+    /// Process an inbound kad add-provider request.
+    ///
+    /// Brought to parity with [`Self::process_kad_put_request`]. Kademlia runs
+    /// under [`kad::StoreInserts::FilterBoth`], so this arm is the sole write
+    /// path for inbound provider records: an attacker-supplied record would
+    /// otherwise be persisted with no ban or authenticity check, unlike every
+    /// other sender-supplied write. libp2p has already verified that a provider
+    /// record's `provider` equals the authenticated request source, so gating on
+    /// [`PeerManager::peer_banned`] rejects records from banned peers (including a
+    /// peer banned at the application layer that the `PutRecord` path would also
+    /// reject) before anything reaches the store. Records from banned peers are
+    /// dropped rather than written. See issue #1001.
+    fn process_kad_add_provider(
+        &mut self,
+        record: Option<kad::ProviderRecord>,
+    ) -> NetworkResult<()> {
+        // The ban check borrows the swarm immutably and completes before the
+        // store write borrows it mutably, so the combinator chain avoids holding
+        // both borrows at once.
+        record
+            .filter(|record| !self.swarm.behaviour().peer_manager.peer_banned(&record.provider))
+            .map(|record| {
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut()
+                    .add_provider(record)
+                    .map_err(|e| NetworkError::StoreKademliaRecord(e.to_string()))
+            })
+            .transpose()?;
 
         Ok(())
     }

--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -165,6 +165,13 @@ fn instant_to_system(expires: &Option<Instant>) -> Option<SystemTime> {
 pub struct KadStore<DB> {
     db: DB,
     node_key: RecordKey,
+    /// This node's libp2p peer id.
+    ///
+    /// Used by [`RecordStore::provided`] to enumerate only the provider records
+    /// the node itself authored (via `start_providing`), mirroring upstream
+    /// `MemoryStore`'s `local_id`. Provider records supplied by inbound peers are
+    /// never re-announced as our own. See issue #1001.
+    local_peer_id: PeerId,
     /// Provide some sanity defaults for store sizing.
     /// Not bothering to expose these as knobs currenty since they are
     /// basically just here to prevent or mitigate attacks on the Kad store.
@@ -180,7 +187,17 @@ pub struct KadStore<DB> {
 
 impl<DB: Database> KadStore<DB> {
     /// Create a new KadStore backed by db.
-    pub fn new(db: DB, key_config: &KeyConfig, kad_type: NetworkType) -> Self {
+    ///
+    /// `local_peer_id` is this node's libp2p peer id (the identity the swarm is
+    /// built with); it must match the id libp2p stamps on records the node
+    /// publishes via `start_providing`, so [`RecordStore::provided`] re-announces
+    /// only the node's own provider records.
+    pub fn new(
+        db: DB,
+        local_peer_id: PeerId,
+        key_config: &KeyConfig,
+        kad_type: NetworkType,
+    ) -> Self {
         let node_key = RecordKey::new(&encode(&key_config.primary_public_key()));
         // Defaults for sanity.
         let config = MemoryStoreConfig::default();
@@ -193,7 +210,8 @@ impl<DB: Database> KadStore<DB> {
                 db.iter::<KadWorkerProviderRecords>().count(),
             ),
         };
-        let store = Self { db, node_key, config, num_records, num_providers, kad_type };
+        let store =
+            Self { db, node_key, local_peer_id, config, num_records, num_providers, kad_type };
         store.update_records_gauge();
         store
     }
@@ -470,9 +488,21 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     }
 
     fn provided(&self) -> Self::ProvidedIter<'_> {
-        let v = self.providers(&self.node_key);
+        // Enumerate only the provider records this node itself authored. Upstream
+        // `MemoryStore::provided` filters on `provider == local_id`; restore that
+        // guard here so the periodic republish job never re-announces a provider
+        // record supplied by an inbound peer. Paired with the ban gate on inbound
+        // `AddProvider` (`process_kad_add_provider` in consensus.rs), this closes
+        // the divergence described in issue #1001. The `Vec` is filtered before
+        // `into_iter().map(..)` so the concrete `ProvidedIter` type is preserved.
+        let local_peer_id = self.local_peer_id;
+        let provided: Vec<ProviderRecord> = self
+            .providers(&self.node_key)
+            .into_iter()
+            .filter(|record| record.provider == local_peer_id)
+            .collect();
 
-        v.into_iter().map(Cow::Owned)
+        provided.into_iter().map(Cow::Owned)
     }
 
     fn remove_provider(&mut self, key: &RecordKey, p: &PeerId) {
@@ -665,8 +695,10 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
-        let mut kad_store_worker = KadStore::new(db, &key_config, NetworkType::Worker(0));
+        let mut kad_store =
+            KadStore::new(db.clone(), PeerId::random(), &key_config, NetworkType::Primary);
+        let mut kad_store_worker =
+            KadStore::new(db, PeerId::random(), &key_config, NetworkType::Worker(0));
 
         let rec = test_record(false);
         let rec2 = test_record(false);
@@ -732,35 +764,33 @@ mod test {
         let provider_rec2 = test_provider_record();
         let provider_rec3 = test_provider_record();
         kad_store.db.sync_persist();
-        assert_eq!(kad_store.provided().count(), 0);
+        assert_eq!(kad_store.providers(&provider_rec1.key).len(), 0);
         kad_store.add_provider(provider_rec1.clone()).expect("add provider");
         kad_store.add_provider(provider_rec2.clone()).expect("add provider");
         kad_store.add_provider(provider_rec3.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store.num_providers, 3);
-        assert_eq!(kad_store.provided().count(), 1);
+        assert_eq!(kad_store.providers(&provider_rec1.key).len(), 1);
         kad_store.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store.add_provider(provider_rec1_2.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store.num_providers, 3);
-        assert_eq!(kad_store.provided().count(), 3);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 3);
         assert_eq!(kad_store.providers(&provider_rec2.key).len(), 1);
         assert_eq!(kad_store.providers(&provider_rec3.key).len(), 1);
 
         assert_eq!(kad_store_worker.num_providers, 0);
-        assert_eq!(kad_store_worker.provided().count(), 0);
+        assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 0);
         kad_store_worker.add_provider(provider_rec1.clone()).expect("add provider");
         kad_store_worker.add_provider(provider_rec2.clone()).expect("add provider");
         kad_store_worker.add_provider(provider_rec3.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store_worker.num_providers, 3);
-        assert_eq!(kad_store_worker.provided().count(), 1);
+        assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 1);
         kad_store_worker.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store_worker.add_provider(provider_rec1_2.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store_worker.num_providers, 3);
-        assert_eq!(kad_store_worker.provided().count(), 3);
         assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 3);
         assert_eq!(kad_store_worker.providers(&provider_rec2.key).len(), 1);
         assert_eq!(kad_store_worker.providers(&provider_rec3.key).len(), 1);
@@ -774,31 +804,25 @@ mod test {
         kad_store.remove_provider(&provider_rec1_1.key, &provider_rec1_1.provider);
         kad_store.db.sync_persist();
         assert_eq!(kad_store.num_providers, 3);
-        assert_eq!(kad_store.provided().count(), 2);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 2);
         kad_store.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store.db.sync_persist();
-        assert_eq!(kad_store.provided().count(), 3);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 3);
         kad_store.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store.num_providers, 3);
-        assert_eq!(kad_store.provided().count(), 3);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 3);
 
         kad_store_worker.remove_provider(&provider_rec1_1.key, &provider_rec1_1.provider);
         kad_store.db.sync_persist();
         assert_eq!(kad_store_worker.num_providers, 3);
-        assert_eq!(kad_store_worker.provided().count(), 2);
         assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 2);
         kad_store_worker.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store.db.sync_persist();
-        assert_eq!(kad_store_worker.provided().count(), 3);
         assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 3);
         kad_store_worker.add_provider(provider_rec1_1.clone()).expect("add provider");
         kad_store.db.sync_persist();
         assert_eq!(kad_store_worker.num_providers, 3);
-        assert_eq!(kad_store_worker.provided().count(), 3);
         assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 3);
 
         kad_store.remove_provider(&provider_rec1.key, &provider_rec1.provider);
@@ -808,7 +832,6 @@ mod test {
         kad_store.remove_provider(&provider_rec1_2.key, &provider_rec1_2.provider);
         kad_store.db.sync_persist();
         assert_eq!(kad_store.num_providers, 2);
-        assert_eq!(kad_store.provided().count(), 0);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 0);
         kad_store.remove_provider(&provider_rec2.key, &provider_rec2.provider);
         kad_store.db.sync_persist();
@@ -822,7 +845,6 @@ mod test {
         kad_store_worker.remove_provider(&provider_rec1_2.key, &provider_rec1_2.provider);
         kad_store.db.sync_persist();
         assert_eq!(kad_store_worker.num_providers, 2);
-        assert_eq!(kad_store_worker.provided().count(), 0);
         assert_eq!(kad_store_worker.providers(&provider_rec1.key).len(), 0);
         kad_store_worker.remove_provider(&provider_rec2.key, &provider_rec2.provider);
         kad_store.db.sync_persist();
@@ -840,6 +862,56 @@ mod test {
         assert_eq!(kad_store_worker.num_providers, 0);
     }
 
+    /// `provided()` enumerates only the provider records the node itself authored.
+    ///
+    /// The `node_key`-injection guard from issue #1001: an attacker can address an
+    /// `AddProvider` at this node's own key (`node_key` is derived from the public
+    /// primary key, which is not secret), landing a record in the exact slot
+    /// `provided()` reads. Both records are stored under `node_key`, but the
+    /// republish job must re-announce only the record whose `provider` is this
+    /// node. Removing the `provider == local_peer_id` filter in `provided()` makes
+    /// this test fail (the attacker record is enumerated), pinning the guard.
+    #[test]
+    fn test_provided_enumerates_only_self_authored_records() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config =
+            KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
+
+        // The store's identity: records authored by this peer id are "ours".
+        let local_peer_id = PeerId::random();
+        let mut kad_store = KadStore::new(db, local_peer_id, &key_config, NetworkType::Primary);
+
+        // Both records key on `node_key`, the slot `provided()` reads.
+        let node_key = RecordKey::new(&encode(&key_config.primary_public_key()));
+        let expires = Instant::now().checked_add(Duration::from_secs(60 * 60 * 24));
+        let ours = ProviderRecord {
+            key: node_key.clone(),
+            provider: local_peer_id,
+            expires,
+            addresses: vec![],
+        };
+        let attacker = ProviderRecord {
+            key: node_key.clone(),
+            provider: PeerId::random(),
+            expires,
+            addresses: vec![],
+        };
+
+        kad_store.add_provider(ours.clone()).expect("add our provider record");
+        kad_store.add_provider(attacker.clone()).expect("add attacker provider record");
+        kad_store.db.sync_persist();
+
+        // Both are physically stored under `node_key`...
+        assert_eq!(kad_store.providers(&node_key).len(), 2, "both records stored under node_key");
+
+        // ...but `provided()` re-announces only the record this node authored.
+        let provided: Vec<ProviderRecord> =
+            kad_store.provided().map(|record| record.into_owned()).collect();
+        assert_eq!(provided.len(), 1, "provided() enumerates only self-authored records");
+        assert_eq!(provided[0].provider, local_peer_id, "the enumerated record is ours");
+    }
+
     /// Expired records must be filtered from `get()` and `records()` even though
     /// they remain on disk until `put()` triggers eviction.
     #[test]
@@ -848,7 +920,7 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db, &key_config, NetworkType::Primary);
+        let mut kad_store = KadStore::new(db, PeerId::random(), &key_config, NetworkType::Primary);
 
         let expired = test_record(true);
         kad_store.put(expired.clone()).expect("put expired record");
@@ -865,7 +937,7 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db, &key_config, NetworkType::Primary);
+        let mut kad_store = KadStore::new(db, PeerId::random(), &key_config, NetworkType::Primary);
 
         let config = MemoryStoreConfig::default();
 
@@ -890,8 +962,10 @@ mod test {
         let db = open_db(tmp_dir.path());
         let key_config =
             KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut StdRng::from_os_rng()));
-        let mut kad_store = KadStore::new(db.clone(), &key_config, NetworkType::Primary);
-        let mut kad_store_worker = KadStore::new(db, &key_config, NetworkType::Worker(0));
+        let mut kad_store =
+            KadStore::new(db.clone(), PeerId::random(), &key_config, NetworkType::Primary);
+        let mut kad_store_worker =
+            KadStore::new(db, PeerId::random(), &key_config, NetworkType::Worker(0));
 
         let config = MemoryStoreConfig::default();
 

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2812,6 +2812,73 @@ async fn test_publisherless_put_cannot_delete_own_record() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Inbound `AddProvider` gates the store write on the provider's ban status, at
+/// parity with the `PutRecord` path (issue #1001). Under `StoreInserts::FilterBoth`
+/// this arm is the sole write path for inbound provider records, so an un-gated
+/// arm would persist an attacker-supplied record from a peer already banned at the
+/// application layer.
+///
+/// A record from an un-banned provider is stored; a record from a banned provider
+/// is dropped before it reaches the store. Deleting the ban filter in
+/// `process_kad_add_provider` (storing unconditionally, i.e. today's behaviour)
+/// makes the banned-provider assertion fail, pinning the gate.
+#[tokio::test]
+async fn test_add_provider_rejects_banned_provider() -> eyre::Result<()> {
+    use libp2p::kad;
+
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    // An un-banned provider: its record is persisted (positive path preserved).
+    // libp2p guarantees `provider == source`, so the provider id is authenticated;
+    // this test drives the handler directly and keys each record on its provider.
+    let honest = PeerId::random();
+    let honest_record = kad::ProviderRecord {
+        key: kad::RecordKey::new(&honest.to_bytes()),
+        provider: honest,
+        expires: None,
+        addresses: vec![],
+    };
+    assert!(!network.swarm.behaviour().peer_manager.peer_banned(&honest));
+    network.process_kad_add_provider(Some(honest_record.clone()))?;
+    assert_eq!(
+        network.swarm.behaviour_mut().kademlia.store_mut().providers(&honest_record.key).len(),
+        1,
+        "un-banned provider record is stored",
+    );
+
+    // A banned provider: register a default record then apply a Fatal penalty,
+    // which crosses the ban threshold on the first hit.
+    let attacker = PeerId::random();
+    network.swarm.behaviour_mut().peer_manager.disconnect_peer(attacker, false);
+    network.swarm.behaviour_mut().peer_manager.process_penalty(attacker, Penalty::Fatal);
+    assert!(
+        network.swarm.behaviour().peer_manager.peer_banned(&attacker),
+        "attacker provider is banned",
+    );
+
+    // Its `AddProvider` is dropped: nothing lands in the store for the attacker key.
+    let attacker_record = kad::ProviderRecord {
+        key: kad::RecordKey::new(&attacker.to_bytes()),
+        provider: attacker,
+        expires: None,
+        addresses: vec![],
+    };
+    network.process_kad_add_provider(Some(attacker_record.clone()))?;
+    assert!(
+        network
+            .swarm
+            .behaviour_mut()
+            .kademlia
+            .store_mut()
+            .providers(&attacker_record.key)
+            .is_empty(),
+        "banned provider record is not stored (issue #1001)",
+    );
+
+    Ok(())
+}
+
 /// A signed record advertising an RPC endpoint with a well-formed URL but the
 /// wrong scheme is accepted (the signature is authentic) and promoted with the
 /// malformed endpoint stripped, without penalizing the sender.
@@ -2916,7 +2983,12 @@ async fn test_startup_tolerates_legacy_and_corrupt_kad_records() -> eyre::Result
     // seed the DB before the network starts, simulating records that survived
     // a node restart from before the upgrade
     {
-        let mut kad_store = KadStore::new(db.clone(), config_1.key_config(), NetworkType::Primary);
+        let mut kad_store = KadStore::new(
+            db.clone(),
+            PeerId::random(),
+            config_1.key_config(),
+            NetworkType::Primary,
+        );
 
         // valid pre-upgrade record signed by authority 2 over the legacy encoding
         let old_info = OldNetworkInfo {
@@ -2976,7 +3048,7 @@ async fn test_startup_tolerates_legacy_and_corrupt_kad_records() -> eyre::Result
 
     // the corrupt record was purged from the persistent store; the legacy
     // record's original signed bytes were preserved
-    let store = KadStore::new(db, config_1.key_config(), NetworkType::Primary);
+    let store = KadStore::new(db, PeerId::random(), config_1.key_config(), NetworkType::Primary);
     assert!(store.get(&kad::RecordKey::new(&garbage_bls)).is_none(), "corrupt record purged");
     assert!(store.get(&kad::RecordKey::new(&owner_bls)).is_some(), "legacy record preserved");
 
@@ -3014,7 +3086,12 @@ async fn test_restored_records_survive_only_committee_rotation() -> eyre::Result
     // seed the DB before the network starts with two VALID records: one for a committee
     // authority and one for the non-committee outsider
     {
-        let mut kad_store = KadStore::new(db.clone(), config_1.key_config(), NetworkType::Primary);
+        let mut kad_store = KadStore::new(
+            db.clone(),
+            PeerId::random(),
+            config_1.key_config(),
+            NetworkType::Primary,
+        );
 
         let key_config_2 = config_2.key_config();
         let authority_record = NodeRecord::build(
@@ -3113,7 +3190,12 @@ async fn test_restore_skips_own_record() -> eyre::Result<()> {
     // seed the DB with a valid record for the node's OWN primary BLS key, built the same way
     // the node builds its own record
     {
-        let mut kad_store = KadStore::new(db.clone(), config_1.key_config(), NetworkType::Primary);
+        let mut kad_store = KadStore::new(
+            db.clone(),
+            PeerId::random(),
+            config_1.key_config(),
+            NetworkType::Primary,
+        );
         let key_config = config_1.key_config();
         let own_record = NodeRecord::build(
             key_config.primary_network_public_key(),


### PR DESCRIPTION
Closes #1001.

## Problem

Kademlia runs with `set_record_filtering(kad::StoreInserts::FilterBoth)` (`crates/network-libp2p/src/consensus.rs:390`), so libp2p never auto-stores an inbound record or provider. The application handles each inbound request and is the sole write path into the persistent store. The two write arms were asymmetric:

- `kad::InboundRequest::PutRecord` routes through `process_kad_put_request`, which ban-checks both publisher and source, validates the BLS signature, and enforces a newer-record check before it writes anything.
- `kad::InboundRequest::AddProvider` called `store_mut().add_provider(record)` unconditionally. Its only guard was the `if let Some(record)` `None`-filter. No ban check, no authenticity check.

Because `AddProvider` was the sole write path for inbound provider records under `FilterBoth`, any peer that could open an inbound connection (including a peer already banned at the application layer, whom `PutRecord` would reject) could persist an attacker-chosen provider record. libp2p enforces `provider == source`, so the provider identity is not forgeable, and no TN application logic reads provider records (`get_providers` has no call site in the crate; `GetProviders` results are only `debug!`-logged), so this was a hardening gap rather than an exploitable break. It was nonetheless a genuine pre-auth write surface, and the store additionally enumerated provider records under the node's own key without the upstream `provider == local` guard, so a future consumer of provider records or a libp2p bump could turn that divergence into a live escalation.

## Root cause

Providers were the one inbound Kademlia write not routed through the ban gate every other sender-supplied write passes through, and `KadStore::provided` returned every record stored under `node_key` (which is derived from a public key, so attacker-addressable) rather than only the records the node itself authored.

## Fix

1. **Ban-gate the inbound provider write at parity with `PutRecord`.** The `AddProvider` arm now delegates to a new `process_kad_add_provider`, the sibling of `process_kad_put_request`:

   ```rust
   record
       .filter(|record| !self.swarm.behaviour().peer_manager.peer_banned(&record.provider))
       .map(|record| {
           self.swarm.behaviour_mut().kademlia.store_mut()
               .add_provider(record)
               .map_err(|e| NetworkError::StoreKademliaRecord(e.to_string()))
       })
       .transpose()?;
   ```

   Threat model: libp2p has already verified that a provider record's `provider` equals the authenticated request source, so gating on `peer_manager.peer_banned(&record.provider)` needs no new trust assumption. The ban check is a cheap membership lookup and it borrows the swarm immutably, completing before the store write borrows it mutably, so the combinator chain holds only one borrow at a time. A record from a banned peer is dropped rather than written. `None` is a clean no-op. There is no publisher or replay dimension for providers (the provider is the authenticated source), so the `PutRecord` publisher-ban and `is_newer_record` checks have no analogue here; the ban check is the full parity.

2. **Restore the upstream `provider == local` filter in `provided()`.** `KadStore` now carries the node's `local_peer_id` (the identity the swarm is built with, threaded from the same `peer_id` handed to the kad behaviour), and `provided()` enumerates only records whose `provider` is this node:

   ```rust
   self.providers(&self.node_key)
       .into_iter()
       .filter(|record| record.provider == local_peer_id)
       .collect()
   ```

   The `Vec` is filtered before `into_iter().map(Cow::Owned)` so the concrete `ProvidedIter` type is preserved. With the ban gate above keeping non-banned foreign records out and this filter keeping any that slip through out of the republish set, the periodic republish job never re-announces a provider record the node did not author, closing the latent divergence.

## Testing

Run under the pinned toolchain:

```
cargo +1.94 test -p tn-network-libp2p --lib \
  -- test_kad_store test_provided_enumerates_only_self_authored_records test_add_provider_rejects_banned_provider
```

- `test_add_provider_rejects_banned_provider` (new): an un-banned provider's record is stored (positive path preserved); a provider banned via `disconnect_peer` + `process_penalty(Fatal)` has its `AddProvider` dropped, asserted by the store gaining no row for the attacker key.
- `test_provided_enumerates_only_self_authored_records` (new): the `node_key`-injection guard. Two records are stored under `node_key`, one authored by this node and one by an attacker; `providers(&node_key)` returns both but `provided()` enumerates only the node's own.
- `test_kad_store`: its `provided().count()` assertions were converted to `providers(&node_key).len()` (the unfiltered under-`node_key` count they were standing in for) because `provided()` is now self-authored-only; storage-accounting coverage is unchanged.

Both new regression tests were confirmed by mutation: disabling each filter makes only its own test fail (the banned record lands; the attacker record is enumerated), then the filter was restored. `cargo +nightly fmt -- --check` is clean and `cargo +nightly clippy --all-features -- -D warnings` passes on the crate.
