### PR TITLE
fix(config): validate ScoreConfig at startup to prevent a late clamp panic

### DIFF
--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -135,6 +135,12 @@ where
         // reconstruct.
         config.parameters.validate()?;
 
+        // Reject a peer-score configuration whose bounds would panic `Score::add`'s `f64::clamp`
+        // (a `min_score > max_score` or `NaN` bound) or silently disable reputation enforcement,
+        // on the same startup footing as the consensus parameters above, long before the first
+        // peer penalty routes the config through the running swarm.
+        network_config.peer_config().score_config.validate()?;
+
         let local_network = LocalNetwork::new(key_config.primary_public_key());
 
         let primary_public_key = key_config.primary_public_key();

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -496,6 +496,52 @@ impl ScoreConfig {
     pub fn halflife_decay(&self) -> f64 {
         -(2.0f64.ln()) / self.score_halflife
     }
+
+    /// Reject a score configuration that would panic or silently disable peer reputation.
+    ///
+    /// Every field here is read live on the peer-scoring path, so a bad value crashes or
+    /// corrupts scoring at an unpredictable later moment rather than at config load:
+    ///
+    /// - `Score::add` clamps the aggregate score into `[min_score, max_score]` with `f64::clamp`,
+    ///   which panics if `min_score > max_score` or if either bound is `NaN`.
+    /// - `min_score_before_disconnect` / `min_score_before_ban` gate every reputation decision; a
+    ///   `NaN` there makes each `score <= threshold` comparison false, so a misbehaving peer is
+    ///   never disconnected or banned (a silent DoS-tolerance failure).
+    /// - `default_score` seeds every new peer's score; a `NaN` there poisons the same comparisons
+    ///   for that peer.
+    /// - `Self::halflife_decay` divides `-ln(2)` by `score_halflife`; a `0.0` yields `-inf` and a
+    ///   negative value flips exponential decay into unbounded growth.
+    ///
+    /// Validate at startup, on the same footing as `Parameters::validate`, so a bad score
+    /// config fails fast with a field-named error rather than halting the running swarm at
+    /// the first peer penalty.
+    pub fn validate(&self) -> eyre::Result<()> {
+        [
+            ("default_score", self.default_score),
+            ("max_score", self.max_score),
+            ("min_score", self.min_score),
+            ("min_score_before_disconnect", self.min_score_before_disconnect),
+            ("min_score_before_ban", self.min_score_before_ban),
+            ("score_halflife", self.score_halflife),
+        ]
+        .into_iter()
+        .try_for_each(|(name, value)| {
+            eyre::ensure!(value.is_finite(), "ScoreConfig.{name} must be finite, got {value}");
+            Ok(())
+        })?;
+        eyre::ensure!(
+            self.min_score <= self.max_score,
+            "ScoreConfig.min_score ({}) must be <= max_score ({})",
+            self.min_score,
+            self.max_score,
+        );
+        eyre::ensure!(
+            self.score_halflife > 0.0,
+            "ScoreConfig.score_halflife must be > 0, got {}",
+            self.score_halflife,
+        );
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -621,5 +667,88 @@ hostname: "my-validator"
                 .expect("deserialize libp2p config with an explicit chain_id");
         assert_eq!(from_disk.chain_id, 0, "an on-disk chain_id must be ignored on read");
         assert_eq!(from_disk.max_rpc_message_size, 1, "other fields still load");
+    }
+
+    #[test]
+    fn default_score_config_validates() {
+        // Mirrors `Parameters::default().validate()` must succeed: the shipped default must
+        // never be the thing that trips the startup guard.
+        ScoreConfig::default().validate().expect("default score config must validate");
+    }
+
+    #[test]
+    fn score_config_rejects_min_greater_than_max() {
+        // Pins the `min_score <= max_score` invariant: without it, `Score::add`'s `f64::clamp`
+        // panics on the first non-fatal peer penalty. Confirmed by mutation: deleting that
+        // `ensure!` makes `validate()` return `Ok` for this config, so this test (asserting
+        // `is_err`) fails.
+        let config = ScoreConfig { min_score: 1.0, max_score: -1.0, ..Default::default() };
+        assert!(config.validate().is_err(), "min_score greater than max_score must be rejected");
+    }
+
+    #[test]
+    fn score_config_accepts_min_equal_to_max() {
+        // The clamp precondition is `min <= max`, so equal bounds are valid and must not be
+        // rejected (guards against an over-tight `<` check).
+        let config = ScoreConfig { min_score: 5.0, max_score: 5.0, ..Default::default() };
+        config.validate().expect("min_score == max_score must validate");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_max_score() {
+        // A `NaN` bound panics `f64::clamp` regardless of ordering.
+        let config = ScoreConfig { max_score: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN max_score must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_min_score() {
+        let config = ScoreConfig { min_score: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN min_score must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_default_score() {
+        // `default_score` seeds every new peer's score; a NaN there poisons every later
+        // threshold comparison for that peer.
+        let config = ScoreConfig { default_score: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN default_score must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_disconnect_threshold() {
+        // A NaN disconnect/ban threshold makes `score <= threshold` always false, so no peer
+        // is ever disconnected or banned: a silent reputation-enforcement failure.
+        let config = ScoreConfig { min_score_before_disconnect: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN disconnect threshold must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_ban_threshold() {
+        let config = ScoreConfig { min_score_before_ban: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN ban threshold must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_zero_halflife() {
+        // `halflife_decay` divides by `score_halflife`; `0.0` yields a `-inf` decay constant.
+        // Pins the `score_halflife > 0.0` invariant.
+        let config = ScoreConfig { score_halflife: 0.0, ..Default::default() };
+        assert!(config.validate().is_err(), "a zero score_halflife must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_negative_halflife() {
+        // A negative halflife flips exponential decay into unbounded growth.
+        let config = ScoreConfig { score_halflife: -1.0, ..Default::default() };
+        assert!(config.validate().is_err(), "a negative score_halflife must be rejected");
+    }
+
+    #[test]
+    fn score_config_rejects_nan_halflife() {
+        // A NaN halflife is caught by the finite check before the `> 0.0` comparison (which a
+        // NaN would fail anyway); pin it explicitly so the ordering of the two checks is safe.
+        let config = ScoreConfig { score_halflife: f64::NAN, ..Default::default() };
+        assert!(config.validate().is_err(), "a NaN score_halflife must be rejected");
     }
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -19,6 +19,42 @@ use tokio::{sync::mpsc, time::timeout};
 /// Test topic for gossip.
 const TEST_TOPIC: &str = "test-topic";
 
+/// Building a consensus config with a peer-score config whose `min_score > max_score` must fail
+/// at construction, before any `PeerManager`/`Score` exists. This pins the startup wiring of
+/// `ScoreConfig::validate` into `ConsensusConfig::new_with_committee`: without that call the bad
+/// bounds would install into the global score config and only panic later, inside the running
+/// swarm, at the first non-fatal peer penalty (`Score::add`'s `f64::clamp`).
+#[test]
+fn consensus_config_rejects_invalid_score_config() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    // Borrow one authority's valid base config/storage/keys so the only invalid input is the
+    // peer-score config we inject below.
+    let (base_config, node_storage, key_config) = {
+        let authority = fixture.authorities().next().expect("fixture yields an authority");
+        let cc = authority.consensus_config();
+        (cc.config().clone(), cc.node_storage().clone(), cc.key_config().clone())
+    };
+
+    let mut network_config = NetworkConfig::default();
+    let score = &mut network_config.peer_config_mut().score_config;
+    score.min_score = 1.0;
+    score.max_score = -1.0;
+
+    let Err(err) = ConsensusConfig::new_with_committee_for_test(
+        base_config,
+        node_storage,
+        key_config,
+        fixture.committee(),
+        network_config,
+    ) else {
+        panic!("min_score > max_score must be rejected when the consensus config is built");
+    };
+    assert!(
+        err.to_string().contains("min_score"),
+        "the rejection must name the offending field, got: {err}"
+    );
+}
+
 /// Helper function to create peers.
 fn create_test_peers<Req: TNMessage, Res: TNMessage>(
     num_peers: NonZeroUsize,

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -1108,6 +1108,17 @@ where
         network_config: &NetworkConfig,
         epoch: Epoch,
     ) -> eyre::Result<()> {
+        // Reject an invalid peer-score config before it is installed into the process-global,
+        // first-write-wins `GLOBAL_SCORE_CONFIG` by the `PeerManager` built below
+        // (`init_peer_score_config`). This is the boot-path install funnel, so validating here
+        // fails the node fast at start with a field-named error rather than letting a
+        // `min_score > max_score` or `NaN` bound poison the scoring path and later panic
+        // `Score::add`'s `f64::clamp` on the first peer penalty.
+        // `ConsensusConfig::new_with_committee` validates the same config for the
+        // construction path (tests, epoch transitions); this guard covers the node boot
+        // that actually performs the one-time install.
+        network_config.peer_config().score_config.validate()?;
+
         //
         //=== PRIMARY
         //


### PR DESCRIPTION
Closes #1006.

## Problem

`ScoreConfig` is deserialized straight from the on-disk node config with no post-deserialize
validation, and `Score::add` clamps a peer's aggregate score into `[min_score, max_score]` with
`f64::clamp` (`crates/network-libp2p/src/peers/score.rs`).  `f64::clamp` has a documented
precondition: it panics if `min > max`, or if either bound is `NaN`.  Nothing enforces that
precondition on the config type, so:

1. The default `ScoreConfig` (`min_score: -100.0`, `max_score: 100.0`) is serialized into the
   operator's config file on first run, so the `min_score` / `max_score` keys are visible and
   hand-editable.
2. Editing them to `min_score > max_score` (or setting either bound to `.nan`) deserializes
   cleanly through pure `serde_yaml::from_str` with no checks, and is installed into the global
   score config untouched by `init_peer_score_config` (`crates/network-libp2p/src/peers/manager.rs`).
3. The node then panics in `Score::add` the first time it applies a `Mild` / `Medium` / `Severe`
   penalty to any peer, which is routine operation on a live network.

The crash lands late (after startup, inside the running swarm on the first non-fatal peer penalty)
rather than at config load, and the symptom (a swarm task panic deep in `clamp`) points nowhere
near "you swapped two config values".  Two adjacent fields are load-bearing in the same way: a
`NaN` in `min_score_before_disconnect` / `min_score_before_ban` makes every `score <= threshold`
comparison false, so misbehaving peers are never disconnected or banned (a silent DoS-tolerance
failure with no error and no log), and a non-positive `score_halflife` turns
`halflife_decay() = -ln(2) / score_halflife` into `-inf` or flips exponential decay into unbounded
growth.

## Threat model

The trigger is the operator's own config, inside the trust boundary, with no remote or adversarial
path, so this is low as a security finding.  Its value is fail-fast robustness: the offending keys
are shipped into the operator's file (the node advertises exactly the knobs that will later crash
it), and the repo already fails fast at startup on out-of-range consensus parameters via
`Parameters::validate()`.  `ScoreConfig` had no equivalent.  This change adds one and wires it in
at the same startup chokepoint, so a bad score config is rejected on the same footing as a bad
`Parameters` config, before any peer is ever scored.

## Fix

`ScoreConfig::validate(&self) -> eyre::Result<()>` (`crates/config/src/network.rs`) rejects any
non-finite `f64` field (`default_score`, `max_score`, `min_score`, both thresholds,
`score_halflife`), enforces `min_score <= max_score` (the `f64::clamp` precondition), and enforces
`score_halflife > 0.0`.  Every error names the offending field and its value.

It is called fail-fast at the two funnels a score config flows through, so a bad config is rejected
before any peer is scored:

- **`crates/node/src/manager/node.rs`** (`spawn_node_networks`): the node-boot install funnel.  The
  process-global score config is a first-write-wins `OnceLock` (`GLOBAL_SCORE_CONFIG`) set exactly
  once, on this path, when node boot builds the `PeerManager`
  (`spawn_node_networks` -> `ConsensusNetwork::new_for_primary` / `new_for_worker` ->
  `TNBehavior::new` -> `PeerManager::new` -> `init_peer_score_config`).  Because that install
  happens at boot, before the per-epoch `ConsensusConfig` is built, validating at the top of
  `spawn_node_networks` (before the install) is what actually fails the node fast at start rather
  than letting a `min_score > max_score` or `NaN` bound poison the scoring path and later panic
  `Score::add`'s `f64::clamp` on the first peer penalty.  This guard does not depend on any later
  ordering.
- **`crates/config/src/consensus.rs`** (`ConsensusConfig::new_with_committee`): the
  config-construction funnel, immediately after the existing `config.parameters.validate()?`.  This
  mirrors `Parameters::validate()` and covers every `ConsensusConfig` construction (production
  `new` / `new_for_epoch`, epoch transitions, and the test constructor).

The check fails fast and surfaces the misconfiguration rather than defensively swapping or
sanitizing the bounds inside `Score::add`, which would hide the operator error instead of
reporting it.

## Testing

`cargo +1.94 test -p tn-config --lib` and `cargo +1.94 test -p tn-network-libp2p` (pinned
toolchain, `-j 2`).

- **Unit (`crates/config/src/network.rs`)**: the shipped default `ScoreConfig` validates `Ok`
  (mirrors `Parameters::default().validate()`);  equal bounds (`min == max`) validate `Ok`;  and
  each of `min > max`, a `NaN` in `default_score` / `min_score` / `max_score` / either threshold /
  `score_halflife`, a zero `score_halflife`, and a negative `score_halflife` is rejected `Err`.
  These tests never construct a `Score`, so they stay within the no-panic-in-tests rule.
- **Wiring (`crates/network-libp2p/src/tests/network_tests.rs`)**: building a `ConsensusConfig`
  through `new_with_committee_for_test` with a `min_score > max_score` peer-score config is rejected
  at construction, with the error naming `min_score`, before any `PeerManager` / `Score` exists.
- **Boot guard**: the `spawn_node_networks` call site shares the same exhaustively tested
  `validate()` and is compile-checked on 1.94;  it has no dedicated node-boot integration test
  because exercising it requires standing up a full `NodeManager`, and the invariant it enforces
  (reject a non-finite / `min > max` score config) is already pinned by the unit tests above.
- **Confirm-by-mutation**: each check was reverted and the corresponding test was seen to fail,
  then restored.  Disabling `min_score <= max_score` fails the ordering unit test and the wiring
  test;  disabling `score_halflife > 0.0` fails the zero / negative halflife tests;  disabling the
  finite check fails the `default_score` / disconnect-threshold / ban-threshold `NaN` tests (the
  fields not already caught by the ordering or halflife checks);  and removing the
  `score_config.validate()?` call from `new_with_committee` fails the wiring test.
