### PR TITLE
fix(epoch): write and persist the epoch record on all three epoch-close arms

### DIFF
--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -14,7 +14,7 @@
 //! next epoch starts from a clean slate. Historic data survives in the
 //! `ConsensusChain` store; only the per-epoch working tables are cleared.
 
-use crate::{engine::ExecutionNode, manager::EpochManager, primary::PrimaryNode};
+use crate::{engine::ExecutionNode, manager::EpochManager};
 use eyre::eyre;
 use std::collections::BTreeSet;
 use tn_config::TelcoinDirs;
@@ -112,7 +112,10 @@ where
     ///
     /// Returns the [`ConsensusHeaderDigest`] of the first output committed at or
     /// past the epoch boundary, signalling that an epoch-boundary output was
-    /// reached; `None` if no such output was found.
+    /// reached; `None` if no such output was found. That boundary output's header
+    /// is also stashed in `last_consensus_header` so the caller's close-and-write
+    /// sequence (`close_epoch`, then `write_epoch_record`) can commit the epoch's
+    /// record.
     pub(super) async fn send_leftover_consensus_output_to_engine(
         &mut self,
         consensus_output: &mut impl TnReceiver<ConsensusOutput>,
@@ -121,6 +124,8 @@ where
         // Phase 1: Drain broadcast channel (existing behavior)
         while let Ok(output) = consensus_output.try_recv() {
             let result = if output.committed_at() >= self.epoch_boundary {
+                // stash the boundary header for the caller's close-and-write sequence
+                self.last_consensus_header = Some(output.clone().into());
                 Some(output.consensus_header_hash())
             } else {
                 None
@@ -143,6 +148,8 @@ where
                 match self.consensus_chain.get_consensus_output_current(number).await {
                     Ok(output) => {
                         let result = if output.committed_at() >= self.epoch_boundary {
+                            // stash the boundary header for the caller's close-and-write sequence
+                            self.last_consensus_header = Some(output.clone().into());
                             Some(output.consensus_header_hash())
                         } else {
                             None
@@ -165,7 +172,10 @@ where
 
     /// Persist the finalized [`EpochRecord`] for the just-completed epoch and
     /// publish it on `epoch_record_watch` for downstream signing or signature
-    /// collection.
+    /// collection. The record is flushed durably to disk before returning: the
+    /// certificate-quorum path persists asynchronously, so without the explicit
+    /// flush a crash between this write and that persist would lose the record —
+    /// fatal for epoch 0, which has no peer-fetch anchor to heal from.
     ///
     /// Epoch 0 is a special case: it starts with an unsigned "dummy" record so
     /// the initial committee is available before any certificate exists. Once a
@@ -179,11 +189,9 @@ where
     /// inconsistent and is treated as an error rather than silently recorded.
     pub(super) async fn write_epoch_record(
         &mut self,
-        primary: &PrimaryNode<DB>,
+        epoch: Epoch,
         engine: &ExecutionNode,
     ) -> eyre::Result<()> {
-        let committee = primary.current_committee().await;
-        let epoch = committee.epoch();
         if epoch == 0 {
             // Epoch 0 will have a "dummy" epoch record to make the initial committee avaliable to
             // code using these records. In this case there will not be a cert so we
@@ -218,11 +226,12 @@ where
         // commits as `final_state`. `parent_state` is the bus's `recent_blocks` watch value,
         // not the reth canonical tip: the engine publishes each executed output's last block
         // and its consensus hash in ONE watch write, so the bus can lag the true tip
-        // mid-execution but never lead it. At the only call site (the live boundary arm of
-        // `run_epoch`, after `close_epoch`'s `wait_for_consensus_execution`) the wait resolved
-        // on the exact write that carries the closing block, so this read IS that block; the
-        // pin makes the record's committee reads and its `final_state` derive from the same
-        // header by construction instead of by timing.
+        // mid-execution but never lead it. At every call site (the live boundary arm and the
+        // two replay-and-close recovery arms of `run_epoch`, each running after `close_epoch`'s
+        // `wait_for_consensus_execution`) the wait resolved on the exact write that carries the
+        // closing block, so this read IS that block; the pin makes the record's committee reads
+        // and its `final_state` derive from the same header by construction instead of by
+        // timing.
         let parent_state = self.consensus_bus.latest_execution_block_num_hash();
         let committee_keys = engine.validators_for_epoch_at_block(epoch, parent_state.hash).await?;
         let next_committee_keys =
@@ -232,10 +241,9 @@ where
         } else {
             self.consensus_chain.epochs().record_by_epoch(epoch - 1).await
         };
-        let last_consensus_header = self
-            .last_consensus_header
-            .take()
-            .expect("epoch was finished with last consensus header");
+        let last_consensus_header = self.last_consensus_header.take().ok_or_else(|| {
+            eyre!("epoch {epoch} reached write_epoch_record without its boundary consensus header")
+        })?;
         let target_hash = last_consensus_header.digest();
 
         let epoch_rec = build_epoch_record(
@@ -248,6 +256,10 @@ where
         )?;
 
         self.consensus_chain.epochs().save_record(epoch_rec.clone()).await?;
+        // the cert-quorum path persists asynchronously; a crash before that flush would lose
+        // the record just saved — fatal for epoch 0, which has no peer-fetch anchor — so
+        // flush it durably here before publishing
+        self.consensus_chain.epochs().persist().await?;
         self.consensus_bus.epoch_record_watch().send_replace(Some(epoch_rec));
         Ok(())
     }

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -94,10 +94,10 @@ where
     ///    [`EpochRecord`] if missing so later lookups can treat epoch 0 like any other.
     /// 2. Create the per-epoch [`TaskManager`] and open the epoch pack files via `open_epoch_pack`.
     /// 3. If the mode calls for replay, re-forward any missed consensus output. If that replay
-    ///    crosses the epoch boundary, close the epoch immediately, clear the consensus DB, and
-    ///    return early as [`RunEpochMode::NewEpoch`] — consensus is never configured this
-    ///    iteration. Otherwise, block until the engine has executed the last replayed output before
-    ///    going live.
+    ///    crosses the epoch boundary, close the epoch immediately, write its [`EpochRecord`], clear
+    ///    the consensus DB, and return early as [`RunEpochMode::NewEpoch`] — consensus is never
+    ///    configured this iteration. Otherwise, block until the engine has executed the last
+    ///    replayed output before going live.
     /// 4. Subscribe to consensus output, configure consensus, and create the primary/worker
     ///    components. The one-time per-process network setup is gated on `network_first_init`,
     ///    which is driven by `self.network_initialized` (not by [`RunEpochMode::Initial`]) so the
@@ -107,11 +107,13 @@ where
     ///    builder, and the engine batch builder; reattach any orphaned batches.
     /// 6. `tokio::select!` over three exits: node shutdown, the epoch boundary
     ///    (`wait_for_epoch_boundary`), and the epoch task manager ending early (a CVV resync or a
-    ///    task error). Only the boundary arm closes the epoch and writes its [`EpochRecord`].
+    ///    task error). Of these, only the boundary arm closes the epoch and writes its
+    ///    [`EpochRecord`]; the replay-and-close (step 3) and leftover-drain (step 7) recovery paths
+    ///    write the record on their own closes.
     /// 7. Notify consensus shutdown, abort and drain the epoch task manager, then resolve the
     ///    outcome. On a non-boundary exit, drain leftover output to the engine: if that drain hits
-    ///    the boundary, close the epoch here too. Clear epoch-scoped DB tables when a boundary was
-    ///    crossed.
+    ///    the boundary, close the epoch and write its [`EpochRecord`] here too. Clear epoch-scoped
+    ///    DB tables when a boundary was crossed.
     ///
     /// The returned [`RunEpochMode`] tells the caller (`run_epochs` in the `node` module) which
     /// transition occurred: [`RunEpochMode::NewEpoch`] when the boundary was crossed (advance the
@@ -228,6 +230,10 @@ where
                 // If things go down at exactly the wrong time we might have to replay the epoch end
                 // so account for that.
                 self.close_epoch(None, &reth_env, &gas_accumulator, target_hash).await?;
+                // write the record before clearing tables: a crash after an epoch-0 replay-close
+                // that left no durable record 0 would trip the epoch-0 guard above on every
+                // restart (peers cannot backfill epoch 0), bricking the node
+                self.write_epoch_record(committee.epoch(), engine).await?;
                 self.clear_consensus_db_for_next_epoch()?;
                 return Ok(RunEpochMode::NewEpoch);
             }
@@ -366,7 +372,7 @@ where
                 .await?;
 
                 // Write the epoch record to DB and save in manager for next epoch.
-                self.write_epoch_record(&primary, engine).await?;
+                self.write_epoch_record(current_epoch, engine).await?;
 
                 info!(target: "epoch-manager", "epoch boundary success - clearing consensus db tables for next epoch");
                 epoch_boundary_reached = true;
@@ -421,6 +427,9 @@ where
             // If things go down at exactly the wrong time we might have reached the epoch end
             // so account for that.
             self.close_epoch(None, &reth_env, &gas_accumulator, target_hash).await?;
+            // this arm closed the epoch, so it writes the record too — otherwise the epoch has
+            // no durable record and the next live close fails as out-of-order
+            self.write_epoch_record(current_epoch, engine).await?;
             res = RunEpochMode::NewEpoch;
             clear_tables_for_next_epoch = true;
         } else {

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -70,7 +70,8 @@ where
     /// different leader epoch means execution fell behind across an epoch boundary, which this
     /// recovery path cannot reason about, so it errors rather than replay across the boundary.
     /// If a replayed output is itself the epoch close, the returned [`super::ReplayResult`]
-    /// reports its hash and replay stops there.
+    /// reports its hash, the boundary header is stashed in `last_consensus_header` for the
+    /// caller's close-and-write sequence, and replay stops there.
     pub(super) async fn replay_missed_consensus(
         &mut self,
         committee: Committee,
@@ -100,6 +101,9 @@ where
             self.metrics.replayed_outputs_total.increment(1);
             last_replayed_hash = Some(output_hash);
             if is_epoch_close {
+                // stash the boundary header (digest-identical to `output_hash`) for the caller's
+                // close-and-write sequence
+                self.last_consensus_header = Some(consensus_header);
                 return Ok(ReplayResult {
                     epoch_close_hash: Some(output_hash),
                     last_replayed_hash,

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -1389,4 +1389,51 @@ mod test {
         // Beyond the one-epoch fallback horizon there is nothing to serve.
         assert!(db.get_committee_keys(3).await.is_none());
     }
+
+    /// The dummy epoch-0 record is memory-only: `persist` never writes it, so a reopen loses
+    /// it entirely — no record 0, no committee anchor for validating downloaded records. This
+    /// is why every epoch-close path must overwrite the dummy with a real, persisted record
+    /// before a restart can be survived: a real record saved and persisted comes back from
+    /// reopen with its digest and committee anchor intact.
+    #[tokio::test]
+    async fn test_dummy_epoch0_lost_on_reopen_but_persisted_record_survives() {
+        let temp_dir = TempDir::with_prefix("test_dummy_epoch0_lost_on_reopen").expect("temp dir");
+        let mut rng = StdRng::from_os_rng();
+        let signers: Vec<TestSigner> = (0..4).map(|_| TestSigner::new(&mut rng)).collect();
+        let committee: Vec<BlsPublicKey> = signers.iter().map(|s| s.public_key()).collect();
+
+        // Save the dummy record 0 and persist: the dummy lives only in memory, so even an
+        // explicit persist leaves nothing durable behind.
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+        let dummy = EpochRecord {
+            epoch: 0,
+            committee: committee.clone(),
+            next_committee: committee.clone(),
+            ..Default::default()
+        };
+        db.save_dummy_epoch0(dummy).await.expect("save dummy epoch 0");
+        db.persist().await.expect("persist dummy");
+        // The dummy serves reads while this handle is open.
+        assert!(db.contains_epoch(0).await);
+        drop(db);
+
+        // Reopen: the dummy is gone — no record and no committee anchor.
+        let db = EpochRecordDb::open(temp_dir.path()).expect("reopen after dummy");
+        assert!(!db.contains_epoch(0).await, "dummy epoch 0 must not survive reopen");
+        assert!(db.record_by_epoch(0).await.is_none(), "no durable record 0 after reopen");
+        assert!(db.get_committee_keys(0).await.is_none(), "no committee anchor after reopen");
+
+        // A real record 0, saved and persisted, survives the same reopen cycle.
+        let (real0, _cert0) = make_test_pair(0, &signers, EpochDigest::default());
+        db.save_record(real0.clone()).await.expect("save real record 0");
+        db.persist().await.expect("persist real record 0");
+        drop(db);
+
+        let db = EpochRecordDb::open(temp_dir.path()).expect("reopen after real record");
+        assert!(db.contains_epoch(0).await, "persisted record 0 must survive reopen");
+        let survived = db.record_by_epoch(0).await.expect("record 0 after reopen");
+        assert_eq!(survived.digest(), real0.digest(), "record survives with equal digest");
+        let anchor = db.get_committee_keys(0).await.expect("committee anchor restored");
+        assert_eq!(anchor, committee.iter().copied().collect::<BTreeSet<_>>());
+    }
 }


### PR DESCRIPTION
- The replay-and-close and leftover-drain recovery arms now call `write_epoch_record` immediately after `close_epoch`, before clearing epoch-scoped tables; previously only the live boundary arm wrote the record, so a recovery close finished the epoch with no record at all.
- The stakes are highest for epoch 0: its dummy record lives in a memory-only slot that reopen resets, so a recovery-closed epoch 0 left no durable record 0 and every later restart died on the epoch-0 entry guard; peers cannot backfill it because `get_committee_keys(0)` returns nothing, downloaded record-0 validation reports `NoAnchor`, and state-sync's step-back retry saturates at 0.
- `write_epoch_record` takes the `Epoch` directly instead of `&PrimaryNode`: the replay arm closes before the epoch's primary exists, so reading the committee from a live primary was never callable there.
- Both replay paths stash the boundary consensus header into `last_consensus_header` when they detect the boundary output (`replay_missed_consensus`, plus both drain phases of `send_leftover_consensus_output_to_engine`); the record write needs that header, and its missing-header `expect` becomes an `eyre` error now that three arms call it.
- `write_epoch_record` calls `epochs().persist()` right after `save_record`: durability previously arrived only via the asynchronous cert-quorum path, so a crash between a live close and quorum lost the record, unrecoverable for epoch 0 (no peer-fetch anchor).
- Two more shapes this closes: a recovery-closed epoch 0 poisoned epoch 1's later live close with `EpochOutOfOrder` (the append index never saw record 0), and recovery-closed epochs never reached the record vote collector because nothing was published on `epoch_record_watch`.
- New storage test `test_dummy_epoch0_lost_on_reopen_but_persisted_record_survives`: the dummy epoch-0 record dies on reopen even after an explicit `persist`, while a real record 0, saved and persisted, survives with its digest and committee anchor intact.

closes #1015 