### PR TITLE
fix(engine): Hard-error on undecodable BLS keys in the pinned committee read

### DIFF
--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -383,16 +383,24 @@ impl ExecutionNodeInner {
     }
 
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
+    /// On-chain BLS key bytes are decoded here; a decode failure is a hard error, mirroring the
+    /// epoch-entry committee read.
     pub(super) fn validators_for_epoch_at_block(
         &self,
         epoch: u32,
         block_hash: B256,
     ) -> eyre::Result<Vec<BlsPublicKey>> {
-        Ok(self
-            .reth_env
+        self.reth_env
             .bls_pubkeys_for_epoch_at_block(epoch, block_hash)?
             .iter()
-            .filter_map(|bls| BlsPublicKey::from_literal_bytes(bls.as_ref()).ok())
-            .collect())
+            .map(|bls| {
+                BlsPublicKey::from_literal_bytes(bls.as_ref()).map_err(|err| {
+                    eyre::eyre!(
+                        "failed to create bls key from on-chain bytes for epoch {epoch} at block \
+                         {block_hash:?}: {err:?}"
+                    )
+                })
+            })
+            .collect()
     }
 }


### PR DESCRIPTION
- `validators_for_epoch_at_block` decoded on-chain BLS key bytes with `filter_map(... .ok())`, so an undecodable key was silently dropped and the returned committee shrank; the decode is now a hard error naming the epoch and pinned block, matching the epoch-entry committee read, which already hard-errors on this decode.
- The silent shrink was worst at epoch close: this read supplies the committee sets written into the epoch record, and record validation tolerates shrunken committees (mid-epoch burns are legitimate ejections), so a corrupt key meant committing a permanently wrong record instead of halting.
- No signature changes: the function already returned `eyre::Result` and every caller propagates with `?`. The epoch+2 prefetch keeps its own warn-and-skip, so the best-effort warm-up still cannot abort epoch start.
- The read's doc comment now states the decode-failure contract.

closes #1016 