### PR TITLE
fix(network-libp2p): bound the temporarily-banned peer cache with a size cap

### DIFF
--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -373,6 +373,14 @@ pub struct PeerConfig {
     pub max_banned_peers: usize,
     /// The maximum number of disconnected peers to maintain before pruning.
     pub max_disconnected_peers: usize,
+    /// The maximum number of entries retained in the temporarily-banned reconnection cache.
+    ///
+    /// This bounds the `temporarily_banned` cache (`BannedPeerCache`), which is keyed by `PeerId`
+    /// and otherwise grows only with the reputation-ban rate between heartbeats. On overflow the
+    /// oldest entry is evicted, so the cache never exceeds this size regardless of ban admission
+    /// rate. This is distinct from `max_banned_peers`, which bounds the reputation-ban table in
+    /// `AllPeers`; this knob bounds the swarm-level reconnection-timeout cache.
+    pub max_temporarily_banned_peers: usize,
     /// The config for scoring peers.
     pub score_config: ScoreConfig,
 }
@@ -393,6 +401,7 @@ impl Default for PeerConfig {
             excess_peers_reconnection_timeout: Duration::from_secs(600),
             max_banned_peers: 100,
             max_disconnected_peers: 100,
+            max_temporarily_banned_peers: 100,
             score_config: ScoreConfig::default(),
         }
     }
@@ -519,6 +528,28 @@ mod tests {
             default.sync_config.max_skip_rounds_for_missing_certs
         );
         assert_eq!(parsed.quic_config.max_idle_timeout, default.quic_config.max_idle_timeout);
+    }
+
+    #[test]
+    fn temporarily_banned_cap_has_valid_default() {
+        // The temporarily-banned cache cap must ship with a sane, positive default so the cache is
+        // bounded out of the box, parallel to `max_banned_peers`.
+        let default = PeerConfig::default();
+        assert!(
+            default.max_temporarily_banned_peers > 0,
+            "max_temporarily_banned_peers default must be positive"
+        );
+        assert_eq!(
+            default.max_temporarily_banned_peers, 100,
+            "default should mirror the sibling max_banned_peers cap"
+        );
+
+        // an empty config falls back to the default, so operators inherit the bound automatically.
+        let parsed: NetworkConfig = serde_yaml::from_str("{}").expect("empty mapping deserializes");
+        assert_eq!(
+            parsed.peer_config.max_temporarily_banned_peers,
+            default.max_temporarily_banned_peers,
+        );
     }
 
     #[test]

--- a/crates/network-libp2p/src/peers/cache.rs
+++ b/crates/network-libp2p/src/peers/cache.rs
@@ -80,6 +80,9 @@ pub(super) struct BannedPeerCache<Key, C = SystemClock> {
     list: VecDeque<Element<Key>>,
     /// The duration an element remains in the cache.
     duration: Duration,
+    /// The maximum number of keys retained. On overflow the oldest key is evicted on insert, so
+    /// occupancy never exceeds this bound regardless of the ban admission rate between heartbeats.
+    max_len: usize,
     /// The clock used to timestamp insertions and evaluate expiry.
     clock: C,
 }
@@ -89,11 +92,16 @@ where
     Key: Eq + std::hash::Hash + Clone,
 {
     /// Create a new instance of `Self` backed by the real system clock.
-    pub(super) fn new(duration: Duration) -> Self {
+    ///
+    /// `max_len` caps the number of retained keys; on overflow the oldest is evicted. It is clamped
+    /// to at least one, because a zero cap would evict every freshly inserted key and leave the
+    /// cache permanently empty, defeating the ban lookup that reads it.
+    pub(super) fn new(duration: Duration, max_len: usize) -> Self {
         BannedPeerCache {
             map: HashSet::default(),
             list: VecDeque::new(),
             duration,
+            max_len: max_len.max(1),
             clock: SystemClock,
         }
     }
@@ -105,32 +113,60 @@ where
     C: Clock,
 {
     /// Create a new instance of `Self` backed by the provided clock.
+    ///
+    /// `max_len` is clamped to at least one, matching [`BannedPeerCache::new`].
     #[cfg(test)]
-    pub(super) fn with_clock(duration: Duration, clock: C) -> Self {
-        BannedPeerCache { map: HashSet::default(), list: VecDeque::new(), duration, clock }
+    pub(super) fn with_clock(duration: Duration, max_len: usize, clock: C) -> Self {
+        BannedPeerCache {
+            map: HashSet::default(),
+            list: VecDeque::new(),
+            duration,
+            max_len: max_len.max(1),
+            clock,
+        }
     }
 
-    /// Insert a key and return true if the key does not already exist.
+    /// Insert a key, reporting whether it was new and any key evicted to honor the size cap.
+    ///
+    /// The first element is `true` when `key` was not already present. The second is the oldest key
+    /// evicted to keep the cache within `max_len` (only ever `Some` on a new insert), so the caller
+    /// can keep dependent state in sync with that removal, mirroring the keys returned by
+    /// [`BannedPeerCache::heartbeat`] on age-based eviction.
     ///
     /// NOTE: this does not remove expired elements
-    pub(super) fn insert(&mut self, key: Key) -> bool {
+    pub(super) fn insert(&mut self, key: Key) -> (bool, Option<Key>) {
         // insert into the map
         let is_new = self.map.insert(key.clone());
 
         // add the new key to the list, if it doesn't already exist.
-        if is_new {
+        let evicted = if is_new {
             self.list.push_back(Element { key, inserted: self.clock.now() });
+
+            // Enforce the size ceiling. Only a brand-new key grows the list, and the cap is
+            // applied on every insert, so the list can exceed `max_len` by at most one here;
+            // evicting the single oldest entry restores `len() <= max_len` without a loop.
+            // `max_len >= 1` (clamped in the constructors) guarantees the evicted front is an
+            // older entry, never the key just inserted.
+            if self.list.len() > self.max_len {
+                self.list.pop_front().map(|oldest| {
+                    self.map.remove(&oldest.key);
+                    oldest.key
+                })
+            } else {
+                None
+            }
         } else {
             let position = self.list.iter().position(|e| e.key == key).expect("Key is not new");
             let mut element = self.list.remove(position).expect("Position is not occupied");
             element.inserted = self.clock.now();
             self.list.push_back(element);
-        }
+            None
+        };
 
         #[cfg(test)]
         self.check_invariant();
 
-        is_new
+        (is_new, evicted)
     }
 
     /// Remove a key from the cache and return true if the key existed.

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -129,7 +129,10 @@ impl PeerManager {
             config.max_banned_peers,
             config.max_disconnected_peers,
         );
-        let temporarily_banned = BannedPeerCache::new(config.excess_peers_reconnection_timeout);
+        let temporarily_banned = BannedPeerCache::new(
+            config.excess_peers_reconnection_timeout,
+            config.max_temporarily_banned_peers,
+        );
 
         // initialize global score config
         init_peer_score_config(config.score_config);
@@ -343,6 +346,19 @@ impl PeerManager {
         self.discovery_heartbeat();
     }
 
+    /// Temporarily ban `peer_id` in the bounded reconnection-timeout cache.
+    ///
+    /// If admitting the peer pushes the cache past its size cap, the oldest entry is evicted and a
+    /// [`PeerEvent::Unbanned`] is emitted for it, so dependent state (such as the gossipsub
+    /// blacklist maintained via `Banned`/`Unbanned`) stays in sync with the removal. This mirrors
+    /// the age-based eviction in [`Self::unban_temp_banned_peers`], which unbans each dropped peer.
+    fn temporarily_ban(&mut self, peer_id: PeerId) {
+        let (_is_new, evicted) = self.temporarily_banned.insert(peer_id);
+        if let Some(evicted_peer) = evicted {
+            self.push_event(PeerEvent::Unbanned(evicted_peer));
+        }
+    }
+
     /// Apply a [PeerAction].
     ///
     /// Actions on peers happen when their reputation or connection status changes.
@@ -350,18 +366,18 @@ impl PeerManager {
         match action {
             PeerAction::Ban(ip_addrs) => {
                 debug!(target: "peer-manager", ?peer_id, ?ip_addrs, "reputation update results in ban");
-                self.temporarily_banned.insert(peer_id);
+                self.temporarily_ban(peer_id);
                 self.process_ban(&peer_id);
             }
             PeerAction::Disconnect => {
                 debug!(target: "peer-manager", ?peer_id, "reputation update results in disconnect");
-                self.temporarily_banned.insert(peer_id);
+                self.temporarily_ban(peer_id);
                 self.push_event(PeerEvent::DisconnectPeer(peer_id));
             }
             PeerAction::DisconnectWithPX => {
                 debug!(target: "peer-manager", ?peer_id, "reputation update results in temp ban with PX");
                 // prevent immediate reconnection attempts
-                self.temporarily_banned.insert(peer_id);
+                self.temporarily_ban(peer_id);
                 let exchange = self.peers.peer_exchange();
                 self.events.push_back(PeerEvent::DisconnectPeerX(peer_id, exchange));
             }

--- a/crates/network-libp2p/src/tests/cache_peers.rs
+++ b/crates/network-libp2p/src/tests/cache_peers.rs
@@ -5,7 +5,7 @@ use libp2p::PeerId;
 
 #[test]
 fn test_cache_entries_exist() {
-    let mut cache = BannedPeerCache::new(Duration::from_secs(1));
+    let mut cache = BannedPeerCache::new(Duration::from_secs(1), 100);
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
 
@@ -13,8 +13,8 @@ fn test_cache_entries_exist() {
     cache.insert(peer2);
 
     // assert peers already exist
-    assert!(!cache.insert(peer2));
-    assert!(!cache.insert(peer1));
+    assert!(!cache.insert(peer2).0);
+    assert!(!cache.insert(peer1).0);
 
     // assert removal
     assert!(cache.remove(&peer1));
@@ -28,20 +28,20 @@ fn test_cache_entries_exist() {
 #[test]
 fn test_remove_expired() {
     let clock = ManualClock::new();
-    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), clock.clone());
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), 100, clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
 
     // insert peers into the cache
-    assert!(cache.insert(peer1), "Peer1 should be newly inserted");
-    assert!(cache.insert(peer2), "Peer2 should be newly inserted");
+    assert!(cache.insert(peer1).0, "Peer1 should be newly inserted");
+    assert!(cache.insert(peer2).0, "Peer2 should be newly inserted");
 
     // advance the clock, but not enough to expire anything
     clock.advance(Duration::from_millis(25));
 
     // insert third peer after the delay
-    assert!(cache.insert(peer3), "Peer3 should be newly inserted");
+    assert!(cache.insert(peer3).0, "Peer3 should be newly inserted");
 
     // assert no peers expired yet
     let expired = cache.heartbeat();
@@ -82,7 +82,7 @@ fn test_remove_expired() {
 fn test_remove_expired_with_reinsertions() {
     // create a cache with a short expiration time
     let clock = ManualClock::new();
-    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), clock.clone());
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), 100, clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
 
@@ -94,7 +94,7 @@ fn test_remove_expired_with_reinsertions() {
     clock.advance(Duration::from_millis(60));
 
     // reinsert peer1 - this should reset the expiration timer
-    assert!(!cache.insert(peer1), "Peer1 already inserted, but returned true");
+    assert!(!cache.insert(peer1).0, "Peer1 already inserted, but returned true");
 
     // advance another period that would expire peer2 but not the reinstated peer1
     clock.advance(Duration::from_millis(50));
@@ -117,7 +117,7 @@ fn test_remove_expired_with_reinsertions() {
 #[test]
 fn test_remove_expired_empty_cache() {
     // Create a cache
-    let mut cache: BannedPeerCache<String> = BannedPeerCache::new(Duration::from_millis(50));
+    let mut cache: BannedPeerCache<String> = BannedPeerCache::new(Duration::from_millis(50), 100);
 
     // assert removing from an empty cache works correctly
     let expired = cache.heartbeat();
@@ -127,7 +127,7 @@ fn test_remove_expired_empty_cache() {
 #[test]
 fn test_remove_expired_ordering() {
     let clock = ManualClock::new();
-    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(500), clock.clone());
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(500), 100, clock.clone());
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
@@ -159,4 +159,103 @@ fn test_remove_expired_ordering() {
     assert_eq!(expired.len(), 2, "Peer3 and Peer4 should be expired");
     assert_eq!(expired[0], peer3, "The first expired element should be peer3");
     assert_eq!(expired[1], peer4, "The second expired element should be peer4");
+}
+
+#[test]
+fn test_size_cap_evicts_oldest() {
+    // A cap of 3 with 5 distinct inserts must retain only the 3 newest, evicting the 2 oldest FIFO.
+    // The duration is long enough that nothing ages out, so eviction is driven purely by the cap.
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_secs(600), 3, clock.clone());
+    let peers: Vec<PeerId> = (0..5).map(|_| PeerId::random()).collect();
+
+    // advance between inserts so insertion order is strict; the cap trims on every insert, so the
+    // 4th and 5th inserts each surface the evicted oldest key.
+    let evicted: Vec<PeerId> = peers
+        .iter()
+        .filter_map(|&peer| {
+            let (_is_new, evicted) = cache.insert(peer);
+            clock.advance(Duration::from_millis(1));
+            evicted
+        })
+        .collect();
+
+    // the cache reports the two oldest keys as evicted, in FIFO order, so the manager can unban
+    // them and keep dependent state (the gossipsub blacklist) in sync.
+    assert_eq!(evicted, vec![peers[0], peers[1]], "cap eviction returns the oldest keys FIFO");
+
+    // occupancy is pinned at the cap, never the 5 inserted.
+    assert_eq!(cache.len(), 3, "cache length must never exceed its size cap");
+
+    // the two oldest keys were evicted...
+    assert!(!cache.contains(&peers[0]), "the oldest key should be evicted");
+    assert!(!cache.contains(&peers[1]), "the second-oldest key should be evicted");
+
+    // ...and the three newest remain.
+    assert!(cache.contains(&peers[2]), "the newest keys should be retained");
+    assert!(cache.contains(&peers[3]), "the newest keys should be retained");
+    assert!(cache.contains(&peers[4]), "the newest keys should be retained");
+}
+
+#[test]
+fn test_size_cap_preserves_expiry() {
+    // With headroom under the cap, age-based expiry must behave exactly as it does without a cap.
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_millis(100), 10, clock.clone());
+    let peer1 = PeerId::random();
+    let peer2 = PeerId::random();
+
+    cache.insert(peer1);
+    clock.advance(Duration::from_millis(50));
+    cache.insert(peer2);
+
+    // nothing has aged out yet, and the cap has not interfered.
+    assert!(cache.heartbeat().is_empty(), "no peer should expire before its duration elapses");
+
+    // advance past peer1's expiry but not peer2's.
+    clock.advance(Duration::from_millis(60));
+    let expired = cache.heartbeat();
+    assert_eq!(expired, vec![peer1], "only the aged-out peer should be evicted by expiry");
+    assert!(cache.contains(&peer2), "peer2 is still within its ban window");
+}
+
+#[test]
+fn test_reinsert_at_capacity_evicts_nothing() {
+    // Re-inserting an already-cached key must not trip the size cap: the list length is unchanged,
+    // so no distinct key is dropped.
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_secs(600), 3, clock.clone());
+    let peers: Vec<PeerId> = (0..3).map(|_| PeerId::random()).collect();
+    peers.iter().for_each(|&peer| {
+        cache.insert(peer);
+        clock.advance(Duration::from_millis(1));
+    });
+    assert_eq!(cache.len(), 3, "cache is full at the cap");
+
+    // re-insert the oldest key; it moves to the back but nothing is evicted.
+    let (is_new, evicted) = cache.insert(peers[0]);
+    assert!(!is_new, "re-inserting an existing key returns false");
+    assert!(evicted.is_none(), "re-insertion must not evict any key");
+    assert_eq!(cache.len(), 3, "re-insertion must not change occupancy");
+    assert!(cache.contains(&peers[0]), "the re-inserted key is still present");
+    assert!(cache.contains(&peers[1]), "other keys are untouched");
+    assert!(cache.contains(&peers[2]), "other keys are untouched");
+}
+
+#[test]
+fn test_zero_cap_is_clamped_to_one() {
+    // A zero cap is clamped to one so the cache is never permanently empty; the most recent key
+    // survives and older ones are evicted.
+    let clock = ManualClock::new();
+    let mut cache = BannedPeerCache::with_clock(Duration::from_secs(600), 0, clock.clone());
+    let peers: Vec<PeerId> = (0..3).map(|_| PeerId::random()).collect();
+    peers.iter().for_each(|&peer| {
+        cache.insert(peer);
+        clock.advance(Duration::from_millis(1));
+    });
+
+    assert_eq!(cache.len(), 1, "a zero cap is clamped to a single retained entry");
+    assert!(cache.contains(&peers[2]), "the most recently inserted key survives");
+    assert!(!cache.contains(&peers[0]), "older keys are evicted under the clamped cap");
+    assert!(!cache.contains(&peers[1]), "older keys are evicted under the clamped cap");
 }

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -1452,6 +1452,37 @@ async fn test_peer_action_ban_arms_temporarily_banned() {
     );
 }
 
+// A ban admission that overflows the bounded temporarily-banned cache must unban the evicted
+// oldest peer, mirroring the age-based eviction path. Otherwise the evicted peer would linger on
+// the gossipsub blacklist (installed via the `Banned` event) after leaving the reconnection cache.
+#[tokio::test]
+async fn test_size_cap_eviction_emits_unbanned() {
+    let mut network_config = NetworkConfig::default();
+    network_config.peer_config_mut().max_temporarily_banned_peers = 2;
+    let mut peer_manager = create_test_peer_manager(Some(network_config));
+
+    // ban three distinct peers into a cache capped at two; the first (oldest) is evicted.
+    let peers: Vec<PeerId> = (0..3).map(|_| PeerId::random()).collect();
+    peers.iter().for_each(|&peer| {
+        peer_manager.apply_peer_action(peer, PeerAction::Ban(Vec::new()));
+    });
+
+    // occupancy never exceeds the cap and the oldest peer was evicted.
+    assert_eq!(peer_manager.temporarily_banned.len(), 2, "cache must stay within its size cap");
+    assert!(
+        !peer_manager.temporarily_banned.contains(&peers[0]),
+        "the oldest peer must be evicted on overflow"
+    );
+
+    // the evicted oldest peer is unbanned, so downstream blacklist state is released for it.
+    let events = collect_all_events(&mut peer_manager);
+    let unbanned = extract_events(&events, |e| matches!(e, PeerEvent::Unbanned(_)));
+    assert!(
+        unbanned.iter().any(|e| matches!(e, PeerEvent::Unbanned(id) if *id == peers[0])),
+        "cap eviction must emit PeerEvent::Unbanned for the evicted oldest peer"
+    );
+}
+
 // Regression: an in-flight dial whose peer became banned mid-dial must be
 // rejected at `handle_pending_outbound_connection`. Pre-fix, the
 // `dial_attempt_already_registered` short-circuit returned `Ok(vec![])` with


### PR DESCRIPTION
Closes #1008.

## Problem

`BannedPeerCache` (the `temporarily_banned` set on `PeerManager`, `crates/network-libp2p/src/peers/cache.rs`) is a manual time-based LRU whose only eviction is age-based, run once per peer-manager heartbeat.  It had no capacity field and no overflow eviction, so between heartbeats it was strictly append-only for distinct keys.

The config surface looked like it bounded this cache but did not.  `PeerConfig::max_banned_peers` is documented as "the maximum number of banned peers to maintain before pruning," but at construction it is routed to `AllPeers` (the reputation-ban table), while `temporarily_banned` was built with only the reconnection timeout.  So the cache had no size ceiling: its occupancy was bounded only by (ban admission rate) x (600s expiry window), and a burst of distinct bans above the per-heartbeat eviction rate was retained in memory until each entry aged out.

Threat model: this is a defense-in-depth hardening gap, not an exploitable break.  Entries are single `PeerId`s (tens of bytes) that self-evict after `excess_peers_reconnection_timeout` (default 600s), and the collection is attacker-influenced only through the reputation-ban path (a peer must connect and earn a ban).  The alarming O(n^2)/CPU reading does not hold: re-inserting an already-cached key is gated out by the `peer_banned` check before a connection is accepted, so the only reachable growth is distinct O(1) inserts from fresh keypairs, bounded-rate and self-healing.  The residual is a missing size ceiling on a collection sibling to `max_banned_peers` / `max_disconnected_peers`, which already have caps.

## Fix

Give the cache a configurable size cap and evict the oldest on overflow, on the same footing as the sibling collections.

- `BannedPeerCache` gains a `max_len` field (clamped to at least one).  Because the cap is enforced on every insert, the list can exceed `max_len` by at most one per insert, so a single front eviction restores `len() <= max_len`.  No loop is needed, and the just-inserted key (at the back) is never the one evicted.
- The bound is wired from a new `PeerConfig::max_temporarily_banned_peers` (default `100`, parallel to `max_banned_peers`), so an empty or legacy config inherits the bound automatically through `serde(default)`.
- Age-based expiry is unchanged, and the list/map sync checked by `check_invariant` still holds after an overflow eviction.

The load-bearing subtlety: eviction must stay consistent with the gossipsub blacklist.  This codebase maintains the invariant that every removal from a ban-tracking collection emits `PeerEvent::Unbanned`.  The age-based eviction (`unban_temp_banned_peers`), the reputation `Unban` action, and the `AllPeers` pruning path all do, and consensus reacts to `Unbanned` by removing the peer from the gossipsub blacklist (`remove_blacklisted_peer`).  A `Ban`-origin peer is on that blacklist (installed via the paired `Banned` event).  A silent cap-eviction would therefore leave the evicted peer on the gossipsub blacklist after it left the reconnection cache, leaking exactly the kind of unbounded state this change is meant to bound.

So `BannedPeerCache::insert` now returns `(is_new, Option<evicted_key>)`, and a new `PeerManager::temporarily_ban` helper emits `PeerEvent::Unbanned` for the evicted peer, symmetric with the age-based path.  Evicting the oldest (closest to aging out anyway) and unbanning it early under cap pressure matches the existing "release the oldest" semantics;  the peer's separate reputation ban in `AllPeers` still refuses it at the `peer_banned` gate, so no ban is silently dropped.

## Changes

- [x] `crates/network-libp2p/src/peers/cache.rs`: add `max_len` field (clamped `>= 1`) to `BannedPeerCache`;  thread it through `new` / `with_clock`;  enforce the cap in `insert` with a single front eviction;  `insert` now returns `(bool, Option<Key>)` so the caller can keep dependent state in sync with the eviction.
- [x] `crates/config/src/network.rs`: add `PeerConfig::max_temporarily_banned_peers` (default `100`) with a doc comment distinguishing it from `max_banned_peers`.
- [x] `crates/network-libp2p/src/peers/manager.rs`: wire the config knob into `BannedPeerCache::new`;  add the `temporarily_ban` helper that inserts and emits `PeerEvent::Unbanned` for any cap-evicted peer;  route the three reputation arms (`Ban` / `Disconnect` / `DisconnectWithPX`) through it.
- [x] tests: cap eviction (FIFO, evicted-key return), reinsert-evicts-nothing, zero-cap clamp, expiry-still-works, config default present and positive, and a manager-level test that a cap-eviction emits `Unbanned` for the evicted peer.

## Testing

Pinned toolchain (`rust-toolchain.toml` -> 1.94):

- `cargo +nightly fmt -- --check`: clean (honors the repo's `wrap_comments` / `comment_width`).
- `cargo +1.94 clippy -p tn-config -p tn-network-libp2p --lib --tests`: clean on the changed files (the one remaining warning is pre-existing in untouched `network_tests.rs`).
- `cargo +1.94 test -p tn-config --lib temporarily_banned`: config default test passes.
- `cargo +1.94 test -p tn-network-libp2p --lib` over the cache and ban/unban surface: 54 tests pass, including the existing age-eviction `Unbanned` test and the consensus network unban tests.

Confirm-by-mutation (each new regression test was seen to fail, then restored):

- Deleting the cap eviction makes `test_size_cap_evicts_oldest` (len 5 != 3) and `test_zero_cap_is_clamped_to_one` (len 3 != 1) fail, while the expiry and reinsert tests stay green.
- Deleting the `PeerEvent::Unbanned` emission in `temporarily_ban` makes `test_size_cap_eviction_emits_unbanned` fail on the missing unban event.

## Acceptance criteria

- [x] `temporarily_banned` has a configurable maximum size;  `len()` never exceeds the cap regardless of ban admission rate between heartbeats.
- [x] The cap is wired from `PeerConfig` with a sane default, positive by construction (clamped `>= 1`).
- [x] Age-based expiry continues to function unchanged.
- [x] The `check_invariant` list/map sync still holds after overflow eviction.
- [x] Cap-eviction emits `Unbanned`, so it does not leak the evicted peer on the gossipsub blacklist.
- [x] Tests pin the size cap and the unban emission, each shown to fail under mutation.
