### PR TITLE
Epoch read docs and consolidation

### DIFF
--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -18,8 +18,8 @@ use tn_reth::{
 use tn_rpc::{EngineToPrimary, TelcoinNetworkRpcExt, TelcoinNetworkRpcExtApiServer};
 use tn_types::{
     gas_accumulator::GasAccumulator, Address, BatchSender, BatchValidation, BlockHeader,
-    BlsPublicKey, ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader, Noticer,
-    SealedHeader, TaskSpawner, WorkerId, B256,
+    BlsPublicKey, Bytes, ConsensusHeaderDigest, ConsensusOutput, EngineUpdate, Epoch, ExecHeader,
+    Noticer, SealedHeader, TaskSpawner, WorkerId, B256,
 };
 use tn_worker::WorkerNetworkHandle;
 use tokio::sync::mpsc;
@@ -383,24 +383,72 @@ impl ExecutionNodeInner {
     }
 
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
-    /// On-chain BLS key bytes are decoded here; a decode failure is a hard error, mirroring the
-    /// epoch-entry committee read.
+    /// On-chain BLS key bytes are decoded through [`decode_committee_keys`], so a decode failure
+    /// is a hard error, mirroring the epoch-entry committee read.
     pub(super) fn validators_for_epoch_at_block(
         &self,
         epoch: u32,
         block_hash: B256,
     ) -> eyre::Result<Vec<BlsPublicKey>> {
+        decode_committee_keys(
+            epoch,
+            block_hash,
+            self.reth_env.bls_pubkeys_for_epoch_at_block(epoch, block_hash)?,
+        )
+    }
+
+    /// Read committee validator keys for epoch, pinned to `header`'s state.
+    ///
+    /// Decodes through [`decode_committee_keys`], so it hard-errors on undecodable on-chain
+    /// bytes exactly like [`Self::validators_for_epoch_at_block`].
+    pub(super) fn validators_for_epoch_at_header(
+        &self,
+        epoch: u32,
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<BlsPublicKey>> {
+        decode_committee_keys(
+            epoch,
+            header.hash(),
+            self.reth_env.bls_pubkeys_for_epoch_at_header(epoch, header)?,
+        )
+    }
+
+    /// Read several epochs' committee validator keys, pinned to `header`'s state — ONE pinned
+    /// EVM for the whole batch, results ordered to match `epochs`.
+    ///
+    /// Each set decodes through [`decode_committee_keys`] under its own epoch, so an
+    /// undecodable key fails the whole batch and names the epoch it came from.
+    pub(super) fn validators_for_epochs_at_header(
+        &self,
+        epochs: &[Epoch],
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<Vec<BlsPublicKey>>> {
         self.reth_env
-            .bls_pubkeys_for_epoch_at_block(epoch, block_hash)?
-            .iter()
-            .map(|bls| {
-                BlsPublicKey::from_literal_bytes(bls.as_ref()).map_err(|err| {
-                    eyre::eyre!(
-                        "failed to create bls key from on-chain bytes for epoch {epoch} at block \
-                         {block_hash:?}: {err:?}"
-                    )
-                })
-            })
+            .bls_pubkeys_for_epochs_at_header(epochs, header)?
+            .into_iter()
+            .zip(epochs)
+            .map(|(raw, &epoch)| decode_committee_keys(epoch, header.hash(), raw))
             .collect()
     }
+}
+
+/// Decode on-chain BLS key bytes into committee keys for `epoch`, read at pin block `pin`.
+///
+/// A decode failure is a hard error: a silently short committee is a consensus-safety failure,
+/// while halting is a single-node liveness failure.
+fn decode_committee_keys(
+    epoch: Epoch,
+    pin: B256,
+    raw: Vec<Bytes>,
+) -> eyre::Result<Vec<BlsPublicKey>> {
+    raw.iter()
+        .map(|bls| {
+            BlsPublicKey::from_literal_bytes(bls.as_ref()).map_err(|err| {
+                eyre::eyre!(
+                    "failed to create bls key from on-chain bytes for epoch {epoch} at block \
+                     {pin:?}: {err:?}"
+                )
+            })
+        })
+        .collect()
 }

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -295,6 +295,13 @@ impl ExecutionNode {
     }
 
     /// Read [EpochState] from the canonical tip.
+    ///
+    /// The committee arrays this returns mutate mid-epoch: a governance `burn` swap-and-pops the
+    /// ejected validator out of the CURRENT epoch's stored committees immediately, so tip reads
+    /// before and after the burn disagree. Epoch-scoped consensus reads must use
+    /// [`Self::epoch_state_at_epoch_start`] / [`Self::validators_for_epoch_at_block`] instead;
+    /// the tip read remains correct for point-in-time queries (its `epoch` scalar is
+    /// boundary-written-once).
     pub async fn epoch_state_from_canonical_tip(&self) -> eyre::Result<EpochState> {
         let guard = self.internal.read().await;
         guard.epoch_state_from_canonical_tip()
@@ -309,10 +316,12 @@ impl ExecutionNode {
 
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
     ///
-    /// This is deliberately the ONLY committee read the engine exposes: an unpinned
-    /// (canonical-tip) variant would make the result depend on when the caller runs
-    /// relative to a mid-epoch governance burn. Callers must choose their pin header
+    /// This is deliberately the only *pinned* committee-keys accessor the engine exposes: an
+    /// unpinned (canonical-tip) variant of THIS read would make the result depend on when the
+    /// caller runs relative to a mid-epoch governance burn. Callers must choose their pin header
     /// explicitly (epoch-start for entry reads, the epoch-closing block for the record).
+    /// [`Self::epoch_state_from_canonical_tip`] still exposes tip-read committee fields, for
+    /// point-in-time queries only.
     pub async fn validators_for_epoch_at_block(
         &self,
         epoch: u32,

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -316,10 +316,12 @@ impl ExecutionNode {
 
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
     ///
-    /// This is deliberately the only *pinned* committee-keys accessor the engine exposes: an
-    /// unpinned (canonical-tip) variant of THIS read would make the result depend on when the
-    /// caller runs relative to a mid-epoch governance burn. Callers must choose their pin header
-    /// explicitly (epoch-start for entry reads, the epoch-closing block for the record).
+    /// Every committee-keys read the engine exposes is PINNED: an unpinned (canonical-tip)
+    /// variant would make the result depend on when the caller runs relative to a mid-epoch
+    /// governance burn. Callers must choose their pin explicitly. This by-hash front-door serves
+    /// callers holding only a `BlockNumHash` (the epoch-record close); the `_at_header` variants
+    /// ([`Self::validators_for_epoch_at_header`] / [`Self::validators_for_epochs_at_header`])
+    /// serve the entry path, which already holds the epoch-start header.
     /// [`Self::epoch_state_from_canonical_tip`] still exposes tip-read committee fields, for
     /// point-in-time queries only.
     pub async fn validators_for_epoch_at_block(
@@ -329,5 +331,31 @@ impl ExecutionNode {
     ) -> eyre::Result<Vec<BlsPublicKey>> {
         let guard = self.internal.read().await;
         guard.validators_for_epoch_at_block(epoch, block_hash)
+    }
+
+    /// Read committee validator keys for epoch, pinned to `header`'s state.
+    ///
+    /// The `_at_header` sibling of [`Self::validators_for_epoch_at_block`] for callers that
+    /// already hold their pin header: same pinned read, minus the by-hash header lookup.
+    pub async fn validators_for_epoch_at_header(
+        &self,
+        epoch: u32,
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<BlsPublicKey>> {
+        let guard = self.internal.read().await;
+        guard.validators_for_epoch_at_header(epoch, header)
+    }
+
+    /// Read several epochs' committee validator keys, pinned to `header`'s state.
+    ///
+    /// The whole batch executes against ONE pinned EVM and the returned key sets are ordered to
+    /// match `epochs`; each set decodes like [`Self::validators_for_epoch_at_header`].
+    pub async fn validators_for_epochs_at_header(
+        &self,
+        epochs: &[Epoch],
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<Vec<BlsPublicKey>>> {
+        let guard = self.internal.read().await;
+        guard.validators_for_epochs_at_header(epochs, header)
     }
 }

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -163,9 +163,13 @@ where
         // That value-stability is also the safety argument under concurrent execution -
         // `send_leftover_consensus_output_to_engine` forwards leftover output without waiting,
         // so the engine may still be executing (calling `inc_block`) while this entry runs:
-        // `apply`'s resize no-ops, its fee writes rewrite the same values, and
-        // `GasAccumulator::set_num_workers` refuses to shrink below an in-flight worker id -
-        // NOT quiescence. See the `mode_change_reentry_is_idempotent` IT.
+        // `apply`'s resize no-ops and its fee writes rewrite the same values. The guard is
+        // value-stability, NOT quiescence and NOT any refusal inside `set_num_workers` (it
+        // truncates unconditionally): the pinned re-read yields the identical count so the resize
+        // no-ops, and a shrink below an in-flight worker id would trip `inc_block`'s production
+        // panic rather than pass silently. `GasAccumulator::set_num_workers`'s own doc states
+        // that bound canonically - keep the two in sync. See the
+        // `mode_change_reentry_is_idempotent` IT.
         //
         // Seed the accumulator's worker count and per-worker base fees for the entered epoch
         // from the pinned header (the previous epoch's closing block). This is the single seam

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -99,10 +99,11 @@ where
     ///    configured this iteration. Otherwise, block until the engine has executed the last
     ///    replayed output before going live.
     /// 4. Subscribe to consensus output, configure consensus, and create the primary/worker
-    ///    components. The one-time per-process network setup is gated on `network_first_init`,
-    ///    which is driven by `self.network_initialized` (not by [`RunEpochMode::Initial`]) so the
-    ///    replay-and-close return above can defer setup to a following iteration without skipping
-    ///    it.
+    ///    components. The previous and next committees' keys are resolved first in ONE batched read
+    ///    pinned to the epoch-start header and threaded into both steps as parameters. The one-time
+    ///    per-process network setup is gated on `network_first_init`, which is driven by
+    ///    `self.network_initialized` (not by [`RunEpochMode::Initial`]) so the replay-and-close
+    ///    return above can defer setup to a following iteration without skipping it.
     /// 5. Start the primary (if this node is an active CVV), the subscriber, the worker batch
     ///    builder, and the engine batch builder; reattach any orphaned batches.
     /// 6. `tokio::select!` over three exits: node shutdown, the epoch boundary
@@ -158,7 +159,9 @@ where
         // CURRENT epoch's stored committee arrays immediately) re-reads the IDENTICAL
         // epoch-start membership - RewardsCounter rows, quorum thresholds, leader schedule -
         // instead of the post-burn tip set, so entry timing can no longer change the node's
-        // view of the epoch.
+        // view of the epoch. The neighbor-committee hoist below (previous and next, batched in
+        // one pinned EVM at the same header) is an entry read too and inherits the same
+        // stability.
         //
         // That value-stability is also the safety argument under concurrent execution -
         // `send_leftover_consensus_output_to_engine` forwards leftover output without waiting,
@@ -254,9 +257,37 @@ where
 
         // subscribe to output early to prevent missed messages
         let mut consensus_output = self.consensus_bus.subscribe_consensus_output();
-        let consensus_config = self
-            .configure_consensus(engine, network_config, committee, &epoch_start_header)
-            .await?;
+
+        // Neighbor committees from on-chain state - canonical source of truth - resolve through
+        // ONE pinned EVM at the held epoch-start header. The previous epoch's committee array
+        // is frozen once this epoch starts (a mid-epoch burn mutates the current and future
+        // epochs' arrays, never a past epoch's), and the registry at the pin already serves the
+        // next epoch's committee, so a post-burn re-entry derives the same sets (see the
+        // ENTRY-READ INVARIANT above). Both stay hard errors: either read failing already
+        // halted the entry before this hoist.
+        let (previous_committee_keys, next_committee_keys): (HashSet<BlsPublicKey>, Vec<_>) =
+            if entered == 0 {
+                // epoch 0 has no previous committee
+                let [next] = engine
+                    .validators_for_epochs_at_header(&[entered + 1], &epoch_start_header)
+                    .await?
+                    .try_into()
+                    .map_err(|_| eyre::eyre!("neighbor-committee batch arity mismatch"))?;
+                (HashSet::new(), next)
+            } else {
+                let [previous, next] = engine
+                    .validators_for_epochs_at_header(
+                        &[entered - 1, entered + 1],
+                        &epoch_start_header,
+                    )
+                    .await?
+                    .try_into()
+                    .map_err(|_| eyre::eyre!("neighbor-committee batch arity mismatch"))?;
+                (previous.into_iter().collect(), next)
+            };
+
+        let consensus_config =
+            self.configure_consensus(network_config, committee, next_committee_keys).await?;
 
         // The networks need their one-time, per-process setup (start listening, register bootstrap
         // peers) on the first iteration that actually reaches `create_consensus`. This is usually
@@ -278,6 +309,7 @@ where
                 consensus_bus.clone(),
                 consensus_config.clone(),
                 &epoch_start_header,
+                previous_committee_keys,
             )
             .await?;
         // Networks are now set up; subsequent epochs rotate committees instead of re-seeding.

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -272,7 +272,9 @@ where
                     .validators_for_epochs_at_header(&[entered + 1], &epoch_start_header)
                     .await?
                     .try_into()
-                    .map_err(|_| eyre::eyre!("neighbor-committee batch arity mismatch"))?;
+                    .map_err(|_| {
+                        eyre::eyre!("neighbor-committee batch arity mismatch for epoch 0")
+                    })?;
                 (HashSet::new(), next)
             } else {
                 let [previous, next] = engine
@@ -282,7 +284,9 @@ where
                     )
                     .await?
                     .try_into()
-                    .map_err(|_| eyre::eyre!("neighbor-committee batch arity mismatch"))?;
+                    .map_err(|_| {
+                        eyre::eyre!("neighbor-committee batch arity mismatch for epoch {entered}")
+                    })?;
                 (previous.into_iter().collect(), next)
             };
 

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -4,7 +4,11 @@
 //! committee and epoch-start info are read pinned to the previous epoch's
 //! closing block — the closing block rules the entire epoch, so every entry
 //! shape derives the identical committee no matter when it runs — then turned
-//! into a [`Committee`] and a per-epoch [`ConsensusConfig`]. From
+//! into a [`Committee`] and a per-epoch [`ConsensusConfig`]. The neighbor
+//! (previous/next) committee key sets arrive as parameters, resolved by
+//! `run_epoch` in one batched read at the same pin; the only chain read issued
+//! here is the best-effort epoch + 2 prefetch, which reuses the held pin
+//! header. From
 //! that the node's mode is identified (CVV, CVV-inactive, or observer) and the
 //! [`PrimaryNode`] and [`WorkerNode`] are created together with their per-epoch
 //! [`PrimaryNetwork`]/[`WorkerNetwork`] interfaces.
@@ -117,9 +121,10 @@ where
     ///
     /// The single atomic `epoch_state_at_epoch_start` read yields the committee, the `EpochInfo`,
     /// the epoch-start timestamp, and the pin header (the previous epoch's closing block; genesis
-    /// for epoch 0), returned together so the caller (`run_epoch`) can compute the epoch boundary
-    /// and thread the committee and pin into [`configure_consensus`] and [`create_consensus`] for
-    /// further pinned reads without a second system call. The pin is what makes every
+    /// for epoch 0), returned together so the caller (`run_epoch`) can compute the epoch boundary,
+    /// batch the neighbor-committee reads at the same pin, and thread the committee into
+    /// [`configure_consensus`] and the pin into [`create_consensus`] for the remaining pinned
+    /// read — all without a second system call. The pin is what makes every
     /// entry shape — fresh boundary crossing, crash-restart replay, or ModeChange re-entry, before
     /// or after a mid-epoch governance `burn` — derive the IDENTICAL committee; the
     /// `EpochInfo`/epoch-start scalars are unchanged by the pin, since `concludeEpoch` writes them
@@ -155,9 +160,10 @@ where
     ///
     /// These components are short-lived: they exist only for the current epoch and are torn
     /// down at its close. The node mode is (re)identified first, and the previous epoch's
-    /// committee is read from on-chain state at `epoch_start_header` so peers from the outgoing
-    /// committee are not banned during the handover. `initial_epoch` is threaded down to gate
-    /// the one-time per-process network setup (see [`init_network_for_epoch`]).
+    /// committee keys — resolved by `run_epoch`'s batched read pinned to `epoch_start_header` —
+    /// are threaded in so peers from the outgoing committee are not banned during the handover.
+    /// `initial_epoch` is threaded down to gate the one-time per-process network setup (see
+    /// [`init_network_for_epoch`]).
     ///
     /// After both nodes are up, the next two committees' validator keys are prefetched through
     /// the primary and worker network handles so their network info is already resolved when
@@ -172,25 +178,10 @@ where
         consensus_bus: ConsensusBus,
         consensus_config: ConsensusConfig<DB>,
         epoch_start_header: &SealedHeader,
+        previous_committee_keys: HashSet<BlsPublicKey>,
     ) -> eyre::Result<(PrimaryNode<DB>, WorkerNode<DB>)> {
         // create config for consensus
         let _mode = self.identify_node_mode(&consensus_config, &consensus_bus).await?;
-        let epoch = consensus_config.committee().epoch();
-
-        // Previous committee from on-chain state - canonical source of truth. The previous
-        // epoch's committee array is frozen once this epoch starts (a mid-epoch burn mutates
-        // the current and future epochs' arrays, never a past epoch's), so this pinned read is
-        // value-identical to a tip read — pinned purely so every epoch-scoped read in this
-        // path derives from the one epoch-start header.
-        let previous_committee_keys: HashSet<BlsPublicKey> = if epoch == 0 {
-            HashSet::new() // no previous committee
-        } else {
-            engine
-                .validators_for_epoch_at_block(epoch - 1, epoch_start_header.hash())
-                .await?
-                .into_iter()
-                .collect()
-        };
 
         let consensus_bus_app = consensus_bus.app().clone();
         let primary = self
@@ -252,9 +243,7 @@ where
         // the config (already read at the pin — no second chain read to fail), and a failed
         // epoch + 2 read is logged and skipped rather than aborting epoch start.
         prefetches.extend(consensus_config.next_committee_keys().iter());
-        match engine
-            .validators_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
-            .await
+        match engine.validators_for_epoch_at_header(committee.epoch() + 2, epoch_start_header).await
         {
             Ok(keys) => prefetches.extend(keys),
             Err(e) => warn!(target: "epoch-manager", ?e, "skipping epoch + 2 committee prefetch"),
@@ -274,28 +263,20 @@ where
     /// Assemble the per-epoch [`ConsensusConfig`] from state pinned to the previous epoch's
     /// closing block.
     ///
-    /// `committee` and `epoch_start_header` are threaded in from `run_epoch`'s single entry
-    /// read ([`Self::get_committee_with_epoch_start_info`]) — this method issues no epoch-start
-    /// read of its own, so the config cannot derive from a different pin than the rest of the
-    /// entry path. It folds in the next committee's keys — read at the same pin — so the
-    /// network can pre-resolve the successor committee. Produces a config scoped to this epoch
-    /// only.
+    /// `committee` and `next_committee_keys` are threaded in from `run_epoch`'s pinned entry
+    /// reads ([`Self::get_committee_with_epoch_start_info`] and the batched neighbor-committee
+    /// hoist) — this method issues no chain read of its own, so the config cannot derive from a
+    /// different pin than the rest of the entry path. Folding in the next committee's keys —
+    /// read at the same pin — lets the network pre-resolve the successor committee. Produces a
+    /// config scoped to this epoch only.
     pub(super) async fn configure_consensus(
         &self,
-        engine: &ExecutionNode,
         network_config: &NetworkConfig,
         committee: Committee,
-        epoch_start_header: &SealedHeader,
+        next_committee_keys: Vec<BlsPublicKey>,
     ) -> eyre::Result<ConsensusConfig<DB>> {
         let validators = committee.bls_keys();
         debug!(target: "epoch-manager", ?validators, "creating committee for validators");
-
-        // Pinned like every other epoch-scoped read in this path: the registry at the pin
-        // already serves the next epoch's committee, and a post-burn re-entry folds the same
-        // next-committee keys into the config as an on-time entry.
-        let next_committee_keys = engine
-            .validators_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
-            .await?;
 
         // create config for consensus
         let consensus_config = ConsensusConfig::new_for_epoch(

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -2277,11 +2277,10 @@ async fn test_epoch_record_chain_across_mid_epoch_ejection() -> eyre::Result<()>
 
     // committee reads through the same `getCommitteeBlsPubkeys` path the node performs for
     // `write_epoch_record`. The node pins that read to the epoch-closing block; every read
-    // below happens while the canonical tip IS the relevant closing block, so the tip read
-    // resolves the identical state.
+    // below happens while the canonical tip IS the relevant closing block.
     let keys_for_epoch = |e: u32| -> eyre::Result<Vec<BlsPublicKey>> {
         Ok(reth_env
-            .bls_pubkeys_for_epoch(e)?
+            .bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash())?
             .iter()
             .filter_map(|bls| BlsPublicKey::from_literal_bytes(bls.as_ref()).ok())
             .collect())

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -15,12 +15,16 @@
 //! Contract reads come in two flavors, and picking the wrong one is a consensus hazard:
 //!
 //! - **Tip reads** — [`RethEnv::epoch_state_from_canonical_tip`],
-//!   [`RethEnv::validators_for_epoch`], [`RethEnv::bls_pubkeys_for_epoch`],
 //!   [`RethEnv::read_consensus_registry`] and its batch form — run against the MUTABLE canonical
 //!   tip. Point-in-time only: two nodes (or one node at two moments) may decode different answers,
-//!   so they are unsafe for consensus decisions.
+//!   so they are unsafe for consensus decisions. No per-epoch committee reader is a tip read: the
+//!   unpinned `validators_for_epoch` / `bls_pubkeys_for_epoch` pair was removed, so every committee
+//!   read must name its pin.
 //! - **Pinned reads** — the `*_at_header` / `*_at_block` variants — run against one explicit block;
-//!   every node issuing the same read at the same block decodes identical bytes.
+//!   every node issuing the same read at the same block decodes identical bytes. The per-epoch
+//!   validator-info variant (`validators_for_epoch_at_block`) is `test-utils`-gated and lives in
+//!   `test_utils.rs`; production reads the committee through
+//!   [`RethEnv::epoch_state_at_epoch_start`].
 //! - [`RethEnv::epoch_state_at_epoch_start`] pins to the entered epoch's start state: the previous
 //!   epoch's closing block (`epoch_info.blockHeight - 1`), or genesis for epoch 0.
 //!
@@ -320,40 +324,12 @@ impl RethEnv {
         Ok((state, pin_header))
     }
 
-    /// Read the committee validators for `epoch` from the [ConsensusRegistry] at the MUTABLE
-    /// canonical tip.
-    ///
-    /// WARNING: point-in-time only — a mid-epoch governance `burn` swap-and-pops the stored
-    /// committee arrays, so two nodes (or one node at two moments) can decode different
-    /// committees. Unsafe for consensus-critical use; pin the read instead via the block-pinned
-    /// sibling `validators_for_epoch_at_block` (`test-utils`-gated today, in `test_utils.rs`) or
-    /// take the whole committee from [`Self::epoch_state_at_epoch_start`].
-    pub fn validators_for_epoch(
-        &self,
-        epoch: u32,
-    ) -> eyre::Result<Vec<ConsensusRegistry::ValidatorInfo>> {
-        debug!(target: "engine", "retrieving validators for epoch {epoch}");
-        let calldata = ConsensusRegistry::getCommitteeValidatorsCall { epoch }.abi_encode().into();
-        self.read_consensus_registry(calldata).map_err(Into::into)
-    }
-
-    /// Read the BLS pubkeys for the committee of the provided epoch from the [ConsensusRegistry]
-    /// at the MUTABLE canonical tip.
-    ///
-    /// WARNING: point-in-time only — a mid-epoch governance `burn` swap-and-pops the stored
-    /// committee arrays, so this read is unsafe for consensus-critical use. Pin the read with
-    /// [`Self::bls_pubkeys_for_epoch_at_block`] instead.
-    pub fn bls_pubkeys_for_epoch(&self, epoch: u32) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
-        let calldata = ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into();
-        self.read_consensus_registry(calldata).map_err(Into::into)
-    }
-
     /// Read the BLS pubkeys for the committee of the provided epoch from the
     /// [ConsensusRegistry], pinned to the state of the block identified by `block_hash`.
     ///
-    /// Unlike [`Self::bls_pubkeys_for_epoch`], which reads the mutable canonical tip, every node
-    /// issuing this read at the same block decodes the identical key set — even after a
-    /// mid-epoch governance `burn` swap-and-pops the stored committee arrays.
+    /// Every node issuing this read at the same block decodes the identical key set — even
+    /// after a mid-epoch governance `burn` swap-and-pops the stored committee arrays; an
+    /// unpinned canonical-tip read would not.
     pub fn bls_pubkeys_for_epoch_at_block(
         &self,
         epoch: u32,
@@ -1531,7 +1507,7 @@ mod tests {
 
         // capture pre-burn committee pubkeys for the current and both future epochs
         let pre_burn = (0u32..=2)
-            .map(|e| reth_env.bls_pubkeys_for_epoch(e))
+            .map(|e| reth_env.bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash()))
             .collect::<eyre::Result<Vec<_>>>()?;
 
         // eject a middle slot so the swap-and-pop reorder is visible
@@ -1573,7 +1549,8 @@ mod tests {
         // current + both future committees shrink with EXACT swap-and-pop order: the last
         // element moves into the burned slot and the array truncates by one
         for e in 0u32..=2 {
-            let post = reth_env.bls_pubkeys_for_epoch(e)?;
+            let post =
+                reth_env.bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash())?;
             let mut expected = pre_burn[e as usize].clone();
             let idx = expected
                 .iter()
@@ -1590,8 +1567,10 @@ mod tests {
         // positional zip pin: the address committee and pubkey committee stay index-aligned
         // (the node zips these arrays by position to build its committee)
         for e in 0u32..=2 {
-            let infos = reth_env.validators_for_epoch(e)?;
-            let keys = reth_env.bls_pubkeys_for_epoch(e)?;
+            let infos =
+                reth_env.validators_for_epoch_at_block(e, reth_env.canonical_tip().hash())?;
+            let keys =
+                reth_env.bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash())?;
             assert_eq!(infos.len(), keys.len());
             for (info, key) in infos.iter().zip(keys.iter()) {
                 let direct =
@@ -1624,7 +1603,8 @@ mod tests {
         assert_eq!(epoch, 1);
         assert_eq!(committee.len(), 4);
         assert!(committee.iter().all(|v| v.validatorAddress != target));
-        let shuffled = reth_env.bls_pubkeys_for_epoch(3)?;
+        let shuffled =
+            reth_env.bls_pubkeys_for_epoch_at_block(3, reth_env.canonical_tip().hash())?;
         assert_eq!(shuffled.len(), 4);
         assert!(!shuffled.contains(&target_bls));
 
@@ -1833,7 +1813,8 @@ mod tests {
         let reth_env =
             RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
 
-        let committee = reth_env.validators_for_epoch(0)?;
+        let committee =
+            reth_env.validators_for_epoch_at_block(0, reth_env.canonical_tip().hash())?;
         assert_eq!(committee.len(), 5);
         let victim = committee[0].validatorAddress;
 
@@ -1899,7 +1880,8 @@ mod tests {
         let reth_env =
             RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
 
-        let committee = reth_env.validators_for_epoch(0)?;
+        let committee =
+            reth_env.validators_for_epoch_at_block(0, reth_env.canonical_tip().hash())?;
         let victim = committee[0].validatorAddress;
         let mut tn_evm = reth_env.tn_evm(chain.sealed_genesis_header().hash())?;
 
@@ -2045,7 +2027,11 @@ mod tests {
         // one (with 6 eligible validators and 5 seats every shuffled committee excludes
         // exactly one; the shuffle is seed-deterministic so the arrangement is stable)
         let committee_addrs = |e: u32| -> eyre::Result<Vec<Address>> {
-            Ok(reth_env.validators_for_epoch(e)?.into_iter().map(|v| v.validatorAddress).collect())
+            Ok(reth_env
+                .validators_for_epoch_at_block(e, reth_env.canonical_tip().hash())?
+                .into_iter()
+                .map(|v| v.validatorAddress)
+                .collect())
         };
         let mut current_epoch = 0u32;
         let mut subdag_index = 2u64;
@@ -2076,9 +2062,12 @@ mod tests {
         let target_bls = reth_env.get_bls_pubkey(canonical_header.hash(), target)?;
 
         // pre-burn snapshots of the running + both future committees
-        let pre_current = reth_env.bls_pubkeys_for_epoch(w)?;
-        let pre_next = reth_env.bls_pubkeys_for_epoch(w + 1)?;
-        let pre_subsequent = reth_env.bls_pubkeys_for_epoch(w + 2)?;
+        let pre_current =
+            reth_env.bls_pubkeys_for_epoch_at_block(w, reth_env.canonical_tip().hash())?;
+        let pre_next =
+            reth_env.bls_pubkeys_for_epoch_at_block(w + 1, reth_env.canonical_tip().hash())?;
+        let pre_subsequent =
+            reth_env.bls_pubkeys_for_epoch_at_block(w + 2, reth_env.canonical_tip().hash())?;
         assert!(!pre_current.contains(&target_bls));
         assert!(
             pre_next.contains(&target_bls) || pre_subsequent.contains(&target_bls),
@@ -2099,11 +2088,15 @@ mod tests {
 
         // the running committee is byte-identical: future-only ejection cannot perturb the
         // current epoch (so on-chain reads for epoch W match any pre-burn snapshot exactly)
-        assert_eq!(reth_env.bls_pubkeys_for_epoch(w)?, pre_current);
+        assert_eq!(
+            reth_env.bls_pubkeys_for_epoch_at_block(w, reth_env.canonical_tip().hash())?,
+            pre_current
+        );
 
         // future committees shrink via swap-and-pop exactly where the target was seated
         for (e, pre) in [(w + 1, &pre_next), (w + 2, &pre_subsequent)] {
-            let post = reth_env.bls_pubkeys_for_epoch(e)?;
+            let post =
+                reth_env.bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash())?;
             if let Some(idx) = pre.iter().position(|k| k == &target_bls) {
                 let mut expected = pre.to_vec();
                 let last = expected.len() - 1;
@@ -2263,10 +2256,10 @@ mod tests {
         let closing_header = block2.recovered_block.clone_sealed_header();
 
         // pre-burn snapshots of the epoch 2 and 3 committees (the tip IS the closing block here)
-        let pre_v2 = reth_env.validators_for_epoch(2)?;
-        let pre_v3 = reth_env.validators_for_epoch(3)?;
-        let pre_b2 = reth_env.bls_pubkeys_for_epoch(2)?;
-        let pre_b3 = reth_env.bls_pubkeys_for_epoch(3)?;
+        let pre_v2 = reth_env.validators_for_epoch_at_block(2, reth_env.canonical_tip().hash())?;
+        let pre_v3 = reth_env.validators_for_epoch_at_block(3, reth_env.canonical_tip().hash())?;
+        let pre_b2 = reth_env.bls_pubkeys_for_epoch_at_block(2, reth_env.canonical_tip().hash())?;
+        let pre_b3 = reth_env.bls_pubkeys_for_epoch_at_block(3, reth_env.canonical_tip().hash())?;
         assert_eq!(pre_v2.len(), 5);
         assert_eq!(pre_v3.len(), 5);
 
@@ -2304,9 +2297,9 @@ mod tests {
         assert!(pinned_b2.contains(&target_bls));
         assert!(pinned_b3.contains(&target_bls));
 
-        // the tip variant of the same read shows the post-burn set: the pin is what makes the
-        // difference
-        let tip_v2 = reth_env.validators_for_epoch(2)?;
+        // the same read pinned to the post-burn canonical tip shows the post-burn set: the pin
+        // block is what makes the difference
+        let tip_v2 = reth_env.validators_for_epoch_at_block(2, reth_env.canonical_tip().hash())?;
         assert_eq!(tip_v2.len(), 4);
         assert!(tip_v2.iter().all(|v| v.validatorAddress != target));
 

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -213,11 +213,20 @@ impl RethEnv {
         )?;
         debug!(target: "engine", ?epoch, ?epoch_info, "retrieved epoch info at header");
 
-        // retrieve closing timestamp for previous epoch
-        let epoch_start = self
-            .header_by_number(epoch_info.blockHeight.saturating_sub(1))?
-            .ok_or_eyre("failed to retrieve closing epoch information")?
-            .timestamp;
+        // retrieve closing timestamp for previous epoch. On the epoch-start path the pin IS the
+        // closing block, so reuse the held header instead of re-fetching it by number; tip
+        // callers keep the fetch branch. Value-preserving for both: equal numbers on the
+        // canonical chain resolve to this same header, and the
+        // `epoch_state_at_epoch_start_pins_pre_burn_committee` test pins the tip/pinned
+        // `epoch_start` equality.
+        let closing_number = epoch_info.blockHeight.saturating_sub(1);
+        let epoch_start = if closing_number == header.number {
+            header.timestamp
+        } else {
+            self.header_by_number(closing_number)?
+                .ok_or_eyre("failed to retrieve closing epoch information")?
+                .timestamp
+        };
 
         // retrieve the committee
         let validators = self.call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
@@ -282,6 +291,10 @@ impl RethEnv {
             "retrieving epoch state at epoch start"
         );
 
+        // The pinned EVM re-reads the epoch number and `EpochInfo` inside this call. That
+        // re-read is load-bearing, not redundant with the bootstrap read above: every field of
+        // the returned state must derive from the pin (provenance), and the re-read is the
+        // input the tripwire below checks against the tip's view.
         let state = self.epoch_state_at_header(&pin_header)?;
 
         // Tripwire: `concludeEpoch` executes INSIDE the closing block, so the registry at the
@@ -349,8 +362,43 @@ impl RethEnv {
         let header = self
             .sealed_header_by_hash(block_hash)?
             .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
-        let calldata = ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into();
-        self.read_consensus_registry_at_header(&header, calldata).map_err(Into::into)
+        self.bls_pubkeys_for_epoch_at_header(epoch, &header)
+    }
+
+    /// Read the BLS pubkeys for the committee of the provided epoch from the
+    /// [ConsensusRegistry], pinned to `header`'s state.
+    ///
+    /// Convenience wrapper over [`Self::bls_pubkeys_for_epochs_at_header`] for the common
+    /// single-epoch case: callers already holding the pin header skip the by-hash header lookup
+    /// [`Self::bls_pubkeys_for_epoch_at_block`] performs.
+    pub fn bls_pubkeys_for_epoch_at_header(
+        &self,
+        epoch: u32,
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
+        self.bls_pubkeys_for_epochs_at_header(&[epoch], header)?
+            .pop()
+            .ok_or_else(|| eyre::eyre!("consensus registry batch read returned no result"))
+    }
+
+    /// Read the BLS pubkeys for several epochs' committees from the [ConsensusRegistry], pinned
+    /// to `header`'s state.
+    ///
+    /// One `getCommitteeBlsPubkeys` call per epoch, all executed against ONE pinned EVM via
+    /// [`Self::read_consensus_registry_batch_at_header`]; the returned key sets are ordered to
+    /// match `epochs`.
+    pub fn bls_pubkeys_for_epochs_at_header(
+        &self,
+        epochs: &[Epoch],
+        header: &SealedHeader,
+    ) -> eyre::Result<Vec<Vec<alloy::primitives::Bytes>>> {
+        let calldatas = epochs
+            .iter()
+            .map(|&epoch| {
+                ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into()
+            })
+            .collect();
+        self.read_consensus_registry_batch_at_header(header, calldatas).map_err(Into::into)
     }
 
     /// Read the [`ConsensusRegistry`] [`EpochInfo`](ConsensusRegistry::EpochInfo) for `epoch` at
@@ -561,8 +609,11 @@ impl RethEnv {
     /// Build a single EVM at `header`'s state and execute several read-only [ConsensusRegistry]
     /// calls against it, decoding each result to `T`.
     ///
-    /// Every calldata in a batch must decode to the same Solidity type `T` (current caller: five
-    /// `getValidatorsInfo(status)` reads → `Vec<ValidatorInfo>`).
+    /// Every calldata in a batch must decode to the same Solidity type `T`. Current callers: the
+    /// tip-pinned five `getValidatorsInfo(status)` reads → `Vec<ValidatorInfo>` (through
+    /// [`Self::read_consensus_registry_batch`]), and
+    /// [`Self::bls_pubkeys_for_epochs_at_header`]'s per-epoch `getCommitteeBlsPubkeys` reads →
+    /// `Vec<Bytes>`, the first caller to batch at an explicit pin.
     ///
     /// All calls observe ONE pinned state snapshot, so a multi-call query (e.g. unioning
     /// per-status validator sets) cannot straddle a block commit and double-count or drop a
@@ -2246,6 +2297,10 @@ mod tests {
         let pinned_b3 = reth_env.bls_pubkeys_for_epoch_at_block(3, pin.hash())?;
         assert_eq!(pinned_b2, pre_b2, "epoch 2 pubkeys at the pin are the pre-burn set");
         assert_eq!(pinned_b3, pre_b3, "epoch 3 pubkeys at the pin are the pre-burn set");
+        // the batch variant resolves both epochs through ONE pinned EVM and orders its results
+        // to match the input: batch == the single pinned reads
+        let batched = reth_env.bls_pubkeys_for_epochs_at_header(&[2, 3], &pin)?;
+        assert_eq!(batched, vec![pinned_b2.clone(), pinned_b3.clone()]);
         assert!(pinned_b2.contains(&target_bls));
         assert!(pinned_b3.contains(&target_bls));
 

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -237,9 +237,11 @@ impl RethEnv {
     /// Read the committee validators for the provided epoch from the [ConsensusRegistry], pinned
     /// to the state of the block identified by `block_hash`.
     ///
-    /// Unlike [`Self::validators_for_epoch`], which reads the mutable canonical tip, every node
-    /// issuing this read at the same block decodes the identical committee — even after a
-    /// mid-epoch governance `burn` swap-and-pops the stored committee arrays.
+    /// Every node issuing this read at the same block decodes the identical committee — even
+    /// after a mid-epoch governance `burn` swap-and-pops the stored committee arrays; an
+    /// unpinned canonical-tip read would not. No unpinned sibling exists: this is the only
+    /// per-epoch validator-info accessor, and it is `test-utils`-gated because production takes
+    /// the whole committee from `RethEnv::epoch_state_at_epoch_start` instead.
     pub fn validators_for_epoch_at_block(
         &self,
         epoch: u32,


### PR DESCRIPTION
- Docs: the ENTRY-READ INVARIANT's concurrent-execution argument credited `GasAccumulator::set_num_workers` with refusing to shrink below an in-flight worker id — it truncates unconditionally. The comment now names the real guard: the pinned re-read yields the identical worker count so the resize no-ops, and a genuine shrink would trip `inc_block`'s production panic rather than pass silently.

- Docs: `validators_for_epoch_at_block` claimed to be "the ONLY committee read the engine exposes", but `epoch_state_from_canonical_tip` also returns committee fields, read at the tip. The claim is now the true one (every committee-keys read the engine exposes is pinned), and the tip reader documents that a mid-epoch governance burn mutates the committee arrays it returns, so it is for point-in-time queries only.

- Consolidation: entry goes from five EVM constructions and five header lookups to four and one. The previous/next committee resolution moves out of `create_consensus`/`configure_consensus` into `run_epoch`'s entry sequence as one batched read (`validators_for_epochs_at_header`) against a single pinned EVM at the held epoch-start header, with the key sets threaded in as parameters; `configure_consensus` drops its engine parameter and performs no chain read, so the config cannot derive from a different pin than the rest of the entry.

- Consolidation: `RethEnv::bls_pubkeys_for_epochs_at_header` batches one `getCommitteeBlsPubkeys` call per epoch through the existing `read_consensus_registry_batch_at_header`, results ordered to match the input; a unit test asserts the batch equals the single pinned reads. `bls_pubkeys_for_epoch_at_block` now delegates to the single-epoch `_at_header` wrapper, and `epoch_state_at_header` reuses the held header for the closing timestamp when the pin IS the closing block (the epoch-start path) instead of re-fetching it by number.

- Consolidation: no read changes value — same pin, same state. Neighbor reads stay hard errors (each already halted entry on failure), the epoch+2 prefetch keeps its documented fail-open (warn and skip) and only switches to the held header, and decode (`from_literal_bytes(...).ok()` filtering) is deliberately untouched; a separate branch hardens decode.

- Reader deletion: `RethEnv::validators_for_epoch` and `bls_pubkeys_for_epoch` read the canonical tip unpinned, had zero production callers, and their results shift under a mid-epoch governance burn — an open invitation for new unpinned epoch-scoped reads. Deleted; test callers (tn-reth unit tests and the epoch-record IT) migrate to the `_at_block` variants pinned to an explicit canonical-tip hash, value-identical where they ran.

closes #1017 