### PR TITLE
fix(epoch): Classify and retry provider faults on epoch-record and epoch-entry committee reads

### DIFF
--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -11,6 +11,7 @@ use tn_batch_validator::BatchValidator;
 use tn_config::Config;
 use tn_engine::ExecutorEngine;
 use tn_reth::{
+    error::{StateReadError, StateReadResult},
     system_calls::EpochState,
     worker::{WorkerComponents, WorkerNetwork},
     RethEnv, RpcServerHandle, WorkerTxPool,
@@ -378,34 +379,26 @@ impl ExecutionNodeInner {
 
     /// Read the current epoch's [EpochState] pinned to the previous epoch's closing block
     /// (genesis for epoch 0), returning the pin header alongside it.
-    pub(super) fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
-        Ok(self.reth_env.epoch_state_at_epoch_start()?)
-    }
-
-    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
-    /// On-chain BLS key bytes are decoded through [`decode_committee_keys`], so a decode failure
-    /// is a hard error, mirroring the epoch-entry committee read.
-    pub(super) fn validators_for_epoch_at_block(
+    ///
+    /// `tip` is the bootstrap sample the pin derives from, supplied by the caller so a retried
+    /// read can prove every attempt resolves the same pin (see
+    /// [`RethEnv::epoch_state_at_epoch_start_from_tip`]).
+    pub(super) fn epoch_state_at_epoch_start_from_tip(
         &self,
-        epoch: u32,
-        block_hash: B256,
-    ) -> eyre::Result<Vec<BlsPublicKey>> {
-        decode_committee_keys(
-            epoch,
-            block_hash,
-            self.reth_env.bls_pubkeys_for_epoch_at_block(epoch, block_hash)?,
-        )
+        tip: &SealedHeader,
+    ) -> StateReadResult<(EpochState, SealedHeader)> {
+        self.reth_env.epoch_state_at_epoch_start_from_tip(tip)
     }
 
     /// Read committee validator keys for epoch, pinned to `header`'s state.
     ///
-    /// Decodes through [`decode_committee_keys`], so it hard-errors on undecodable on-chain
-    /// bytes exactly like [`Self::validators_for_epoch_at_block`].
+    /// On-chain BLS key bytes are decoded through [`decode_committee_keys`], so a decode failure
+    /// is a hard error, mirroring the epoch-entry committee read.
     pub(super) fn validators_for_epoch_at_header(
         &self,
         epoch: u32,
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<BlsPublicKey>> {
+    ) -> StateReadResult<Vec<BlsPublicKey>> {
         decode_committee_keys(
             epoch,
             header.hash(),
@@ -422,12 +415,31 @@ impl ExecutionNodeInner {
         &self,
         epochs: &[Epoch],
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<Vec<BlsPublicKey>>> {
+    ) -> StateReadResult<Vec<Vec<BlsPublicKey>>> {
         self.reth_env
             .bls_pubkeys_for_epochs_at_header(epochs, header)?
             .into_iter()
             .zip(epochs)
             .map(|(raw, &epoch)| decode_committee_keys(epoch, header.hash(), raw))
+            .collect()
+    }
+
+    /// Read several epochs' committee validator keys, pinned to the block identified by
+    /// `block_hash` — the by-hash sibling of [`Self::validators_for_epochs_at_header`].
+    ///
+    /// ONE header lookup and ONE pinned EVM serve the whole batch, so every returned set provably
+    /// derives from the same block. Serves callers holding only a `BlockNumHash` (the
+    /// epoch-record close).
+    pub(super) fn validators_for_epochs_at_block(
+        &self,
+        epochs: &[Epoch],
+        block_hash: B256,
+    ) -> StateReadResult<Vec<Vec<BlsPublicKey>>> {
+        self.reth_env
+            .bls_pubkeys_for_epochs_at_block(epochs, block_hash)?
+            .into_iter()
+            .zip(epochs)
+            .map(|(raw, &epoch)| decode_committee_keys(epoch, block_hash, raw))
             .collect()
     }
 }
@@ -436,18 +448,24 @@ impl ExecutionNodeInner {
 ///
 /// A decode failure is a hard error: a silently short committee is a consensus-safety failure,
 /// while halting is a single-node liveness failure.
+///
+/// The failure is [`StateReadError::ChainGlobal`], never `Provider`: the decode is a pure function
+/// of the bytes at the pin plus this node's own code, so every node reading the same block fails
+/// identically and no retry can clear it. That classification is what lets the decode stay fused
+/// inside a caller's retried closure — `retry_provider_faults` short-circuits `ChainGlobal`, so a
+/// bad key set halts on the first attempt rather than after three.
 fn decode_committee_keys(
     epoch: Epoch,
     pin: B256,
     raw: Vec<Bytes>,
-) -> eyre::Result<Vec<BlsPublicKey>> {
+) -> StateReadResult<Vec<BlsPublicKey>> {
     raw.iter()
         .map(|bls| {
             BlsPublicKey::from_literal_bytes(bls.as_ref()).map_err(|err| {
-                eyre::eyre!(
+                StateReadError::ChainGlobal(format!(
                     "failed to create bls key from on-chain bytes for epoch {epoch} at block \
                      {pin:?}: {err:?}"
-                )
+                ))
             })
         })
         .collect()

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -379,7 +379,7 @@ impl ExecutionNodeInner {
     /// Read the current epoch's [EpochState] pinned to the previous epoch's closing block
     /// (genesis for epoch 0), returning the pin header alongside it.
     pub(super) fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
-        self.reth_env.epoch_state_at_epoch_start()
+        Ok(self.reth_env.epoch_state_at_epoch_start()?)
     }
 
     /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -16,8 +16,8 @@ use std::{future::Future, net::SocketAddr, sync::Arc};
 use tn_config::Config;
 use tn_exex::ExExInstallFn;
 use tn_reth::{
-    system_calls::EpochState, CanonStateNotificationStream, RethConfig, RethDb, RethEnv,
-    WorkerTxPool,
+    error::StateReadResult, system_calls::EpochState, CanonStateNotificationStream, RethConfig,
+    RethDb, RethEnv, WorkerTxPool,
 };
 use tn_rpc::EngineToPrimary;
 use tn_types::{
@@ -299,8 +299,8 @@ impl ExecutionNode {
     /// The committee arrays this returns mutate mid-epoch: a governance `burn` swap-and-pops the
     /// ejected validator out of the CURRENT epoch's stored committees immediately, so tip reads
     /// before and after the burn disagree. Epoch-scoped consensus reads must use
-    /// [`Self::epoch_state_at_epoch_start`] / [`Self::validators_for_epoch_at_block`] instead;
-    /// the tip read remains correct for point-in-time queries (its `epoch` scalar is
+    /// [`Self::epoch_state_at_epoch_start_from_tip`] / [`Self::validators_for_epochs_at_block`]
+    /// instead; the tip read remains correct for point-in-time queries (its `epoch` scalar is
     /// boundary-written-once).
     pub async fn epoch_state_from_canonical_tip(&self) -> eyre::Result<EpochState> {
         let guard = self.internal.read().await;
@@ -309,39 +309,32 @@ impl ExecutionNode {
 
     /// Read the current epoch's [EpochState] pinned to the previous epoch's closing block
     /// (genesis for epoch 0), returning the pin header alongside it.
-    pub async fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
-        let guard = self.internal.read().await;
-        guard.epoch_state_at_epoch_start()
-    }
-
-    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
     ///
-    /// Every committee-keys read the engine exposes is PINNED: an unpinned (canonical-tip)
-    /// variant would make the result depend on when the caller runs relative to a mid-epoch
-    /// governance burn. Callers must choose their pin explicitly. This by-hash front-door serves
-    /// callers holding only a `BlockNumHash` (the epoch-record close); the `_at_header` variants
-    /// ([`Self::validators_for_epoch_at_header`] / [`Self::validators_for_epochs_at_header`])
-    /// serve the entry path, which already holds the epoch-start header.
-    /// [`Self::epoch_state_from_canonical_tip`] still exposes tip-read committee fields, for
-    /// point-in-time queries only.
-    pub async fn validators_for_epoch_at_block(
+    /// The bootstrap `tip` is the caller's, not a fresh sample: the pin derives from the epoch
+    /// number and `blockHeight` read AT `tip`, both of which `concludeEpoch` rewrites at every
+    /// boundary, so only a caller-held sample makes a retried read provably resolve one pin.
+    pub async fn epoch_state_at_epoch_start_from_tip(
         &self,
-        epoch: u32,
-        block_hash: B256,
-    ) -> eyre::Result<Vec<BlsPublicKey>> {
+        tip: &SealedHeader,
+    ) -> StateReadResult<(EpochState, SealedHeader)> {
         let guard = self.internal.read().await;
-        guard.validators_for_epoch_at_block(epoch, block_hash)
+        guard.epoch_state_at_epoch_start_from_tip(tip)
     }
 
     /// Read committee validator keys for epoch, pinned to `header`'s state.
     ///
-    /// The `_at_header` sibling of [`Self::validators_for_epoch_at_block`] for callers that
-    /// already hold their pin header: same pinned read, minus the by-hash header lookup.
+    /// Every committee-keys read the engine exposes is PINNED: an unpinned (canonical-tip)
+    /// variant would make the result depend on when the caller runs relative to a mid-epoch
+    /// governance burn. Callers must choose their pin explicitly. The `_at_header` variants serve
+    /// the entry path, which already holds the epoch-start header;
+    /// [`Self::validators_for_epochs_at_block`] serves callers holding only a `BlockNumHash` (the
+    /// epoch-record close). [`Self::epoch_state_from_canonical_tip`] still exposes tip-read
+    /// committee fields, for point-in-time queries only.
     pub async fn validators_for_epoch_at_header(
         &self,
         epoch: u32,
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<BlsPublicKey>> {
+    ) -> StateReadResult<Vec<BlsPublicKey>> {
         let guard = self.internal.read().await;
         guard.validators_for_epoch_at_header(epoch, header)
     }
@@ -354,8 +347,23 @@ impl ExecutionNode {
         &self,
         epochs: &[Epoch],
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<Vec<BlsPublicKey>>> {
+    ) -> StateReadResult<Vec<Vec<BlsPublicKey>>> {
         let guard = self.internal.read().await;
         guard.validators_for_epochs_at_header(epochs, header)
+    }
+
+    /// Read several epochs' committee validator keys, pinned to the block identified by
+    /// `block_hash`.
+    ///
+    /// The by-hash sibling of [`Self::validators_for_epochs_at_header`]: ONE header lookup and
+    /// ONE pinned EVM for the whole batch, so every returned set provably derives from the same
+    /// block rather than from two independently-resolved reads.
+    pub async fn validators_for_epochs_at_block(
+        &self,
+        epochs: &[Epoch],
+        block_hash: B256,
+    ) -> StateReadResult<Vec<Vec<BlsPublicKey>>> {
+        let guard = self.internal.read().await;
+        guard.validators_for_epochs_at_block(epochs, block_hash)
     }
 }

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -286,10 +286,18 @@ where
         // closing block, so this read IS that block; the pin makes the record's committee reads
         // and its `final_state` derive from the same header by construction instead of by
         // timing.
+        // `parent_state` is sampled ONCE and both committees resolve through ONE batched by-hash
+        // read: the watch is live, so re-sampling it per read could straddle a block commit and
+        // desynchronize the two committees from each other and from the `final_state` this record
+        // commits below.
         let parent_state = self.consensus_bus.latest_execution_block_num_hash();
-        let committee_keys = engine.validators_for_epoch_at_block(epoch, parent_state.hash).await?;
-        let next_committee_keys =
-            engine.validators_for_epoch_at_block(epoch + 1, parent_state.hash).await?;
+        let [committee_keys, next_committee_keys]: [Vec<BlsPublicKey>; 2] = engine
+            .validators_for_epochs_at_block(&[epoch, epoch + 1], parent_state.hash)
+            .await?
+            .try_into()
+            .map_err(|_| {
+                eyre!("committee batch read arity mismatch for the epoch {epoch} record")
+            })?;
         let prev_record = if epoch == 0 {
             None
         } else {

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -14,6 +14,7 @@
 //! next epoch starts from a clean slate. Historic data survives in the
 //! `ConsensusChain` store; only the per-epoch working tables are cleared.
 
+use super::run_epoch::retry_provider_faults;
 use crate::{engine::ExecutionNode, manager::EpochManager, primary::PrimaryNode};
 use eyre::eyre;
 use std::{collections::BTreeSet, path::Path, time::Duration};
@@ -286,16 +287,38 @@ where
         // closing block, so this read IS that block; the pin makes the record's committee reads
         // and its `final_state` derive from the same header by construction instead of by
         // timing.
-        // `parent_state` is sampled ONCE and both committees resolve through ONE batched by-hash
-        // read: the watch is live, so re-sampling it per read could straddle a block commit and
-        // desynchronize the two committees from each other and from the `final_state` this record
-        // commits below.
+        //
+        // `parent_state` is sampled ONCE, before the retry below, and both committees resolve
+        // through ONE batched by-hash read. Sampling once is required, not merely tidy: the watch
+        // is live, so re-sampling it per attempt would both shift the pin between attempts and
+        // desynchronize the committee reads from the `parent_state` passed to
+        // `build_epoch_record` as `final_state`, destroying the same-header-by-construction
+        // property the paragraph above claims.
+        //
+        // READ-FAILURE POLICY: this is a consensus input, so its failure is classified by
+        // committee determinism (`StateReadError`) and BOTH classes halt. There is deliberately
+        // no fail-open arm, despite what `StateReadError::ChainGlobal`'s variant doc says about
+        // keep-current staying committee-consistent: a wrong committee in a SIGNED `EpochRecord`
+        // propagates to every syncing node, while halting is a single-node liveness failure.
+        // A Provider fault is node-local (peers reading the same block may succeed), so retry
+        // briefly before halting; ChainGlobal returns from the first attempt, halting exactly
+        // where it did before the retry existed. The net delta is two extra tries on Provider.
         let parent_state = self.consensus_bus.latest_execution_block_num_hash();
-        let [committee_keys, next_committee_keys]: [Vec<BlsPublicKey>; 2] = engine
-            .validators_for_epochs_at_block(&[epoch, epoch + 1], parent_state.hash)
-            .await?
-            .try_into()
-            .map_err(|_| {
+        let epochs = [epoch, epoch + 1];
+        let committees = retry_provider_faults("epoch-record committee reads", || {
+            engine.validators_for_epochs_at_block(&epochs, parent_state.hash)
+        })
+        .await
+        .map_err(|e| {
+            eyre!(
+                "failed committee read at epoch-closing block {} ({:?}) for the epoch {epoch} \
+                 record - halting rather than recording a committee this node cannot verify: {e}",
+                parent_state.number,
+                parent_state.hash
+            )
+        })?;
+        let [committee_keys, next_committee_keys]: [Vec<BlsPublicKey>; 2] =
+            committees.try_into().map_err(|_| {
                 eyre!("committee batch read arity mismatch for the epoch {epoch} record")
             })?;
         let prev_record = if epoch == 0 {

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -16,8 +16,15 @@
 //! `parse_listener_address_for_swarm`, `wait_for_network_peers` — plus the [`RunEpochMode`] /
 //! [`ReplayResult`] types that thread control flow through the loop.
 
-use crate::{engine::ExecutionNode, manager::EpochManager, worker::worker_task_manager_name};
-use std::{collections::HashSet, time::Duration};
+use crate::{
+    engine::ExecutionNode, manager::EpochManager, metrics::EpochMetrics,
+    worker::worker_task_manager_name,
+};
+use std::{
+    collections::HashSet,
+    future::{ready, Future},
+    time::Duration,
+};
 use tn_config::{NetworkConfig, TelcoinDirs};
 use tn_executor::subscriber::spawn_subscriber;
 use tn_primary::ConsensusBus;
@@ -263,30 +270,44 @@ where
         // is frozen once this epoch starts (a mid-epoch burn mutates the current and future
         // epochs' arrays, never a past epoch's), and the registry at the pin already serves the
         // next epoch's committee, so a post-burn re-entry derives the same sets (see the
-        // ENTRY-READ INVARIANT above). Both stay hard errors: either read failing already
-        // halted the entry before this hoist.
+        // ENTRY-READ INVARIANT above).
+        //
+        // READ-FAILURE POLICY: this is a consensus input, so the failure is classified by
+        // committee determinism (`StateReadError`) and BOTH classes halt - there is no fail-open
+        // arm here, despite what `StateReadError::ChainGlobal`'s variant doc says about
+        // keep-current staying committee-consistent. There is nothing to keep: the node is
+        // ENTERING the epoch, so it holds no prior neighbor sets, and entering with an
+        // unverifiable neighbor committee mis-scopes peer banning and next-committee
+        // pre-resolution for the whole epoch. Halting is a single-node liveness failure.
+        //
+        // A Provider fault is node-local (peers reading the same block may succeed), so retry
+        // briefly before halting; ChainGlobal returns from the first attempt. The pin is
+        // `epoch_start_header`, a fixed `SealedHeader` captured before this retry, so every
+        // attempt provably reads the same block. The `try_into` arity checks are `eyre`, not
+        // `StateReadError`, so they stay OUTSIDE the retried closure.
+        let epochs: Vec<_> =
+            if entered == 0 { vec![entered + 1] } else { vec![entered - 1, entered + 1] };
+        let sets = retry_provider_faults("neighbor committees at the epoch-start pin", || {
+            engine.validators_for_epochs_at_header(&epochs, &epoch_start_header)
+        })
+        .await
+        .map_err(|e| {
+            eyre::eyre!(
+                "failed neighbor-committee read at the epoch-start pin - halting rather than \
+                 entering epoch {entered} with an unverifiable neighbor committee: {e}"
+            )
+        })?;
         let (previous_committee_keys, next_committee_keys): (HashSet<BlsPublicKey>, Vec<_>) =
             if entered == 0 {
                 // epoch 0 has no previous committee
-                let [next] = engine
-                    .validators_for_epochs_at_header(&[entered + 1], &epoch_start_header)
-                    .await?
-                    .try_into()
-                    .map_err(|_| {
-                        eyre::eyre!("neighbor-committee batch arity mismatch for epoch 0")
-                    })?;
+                let [next] = sets.try_into().map_err(|_| {
+                    eyre::eyre!("neighbor-committee batch arity mismatch for epoch 0")
+                })?;
                 (HashSet::new(), next)
             } else {
-                let [previous, next] = engine
-                    .validators_for_epochs_at_header(
-                        &[entered - 1, entered + 1],
-                        &epoch_start_header,
-                    )
-                    .await?
-                    .try_into()
-                    .map_err(|_| {
-                        eyre::eyre!("neighbor-committee batch arity mismatch for epoch {entered}")
-                    })?;
+                let [previous, next] = sets.try_into().map_err(|_| {
+                    eyre::eyre!("neighbor-committee batch arity mismatch for epoch {entered}")
+                })?;
                 (previous.into_iter().collect(), next)
             };
 
@@ -771,7 +792,7 @@ async fn adjust_base_fees(
     // Only a proven identity VIOLATION or an exhausted provider fault halts.
     let (entered_epoch, epoch_info) = match retry_provider_faults(
         "close-time epoch info (identity check)",
-        || reth_env.get_current_epoch_info_at_header(&tip),
+        || ready(reth_env.get_current_epoch_info_at_header(&tip)),
     )
     .await
     {
@@ -825,7 +846,7 @@ async fn adjust_base_fees(
     // and move to the new fees), so it must never fail open: retry, then halt. Pinned to the SAME
     // `tip` the identity check validated (one-header discipline).
     match retry_provider_faults("close-time worker fee configs", || {
-        reth_env.get_worker_fee_configs_at_block(tip.hash())
+        ready(reth_env.get_worker_fee_configs_at_block(tip.hash()))
     })
     .await
     {
@@ -859,27 +880,42 @@ async fn adjust_base_fees(
     Ok(())
 }
 
-/// Total attempts (first try + retries) for each close-time chain read in [`adjust_base_fees`]
-/// before a node-local provider fault halts the close.
+/// Total attempts (first try + retries) for each classified pinned chain read at an epoch seam —
+/// the close-time reads in [`adjust_base_fees`], the epoch-record committee reads, and the
+/// epoch-entry reads — before a node-local provider fault escalates to the caller (a halt at every
+/// current site).
 const CLOSE_READ_ATTEMPTS: u32 = 3;
 
-/// Pause between close-time read retries in [`retry_provider_faults`].
+/// Pause between read retries in [`retry_provider_faults`].
 const CLOSE_READ_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 
 /// Run `read` up to [`CLOSE_READ_ATTEMPTS`] times, sleeping [`CLOSE_READ_RETRY_BACKOFF`] between
 /// tries, retrying ONLY on [`StateReadError::Provider`].
 ///
-/// Provider faults are node-local (a transient I/O error may clear on a re-read), so a bounded
-/// retry preserves liveness before the caller escalates to a halt. Chain-global failures are
-/// deterministic products of the pinned block — re-reading cannot change them — so they return
-/// immediately for the caller's fail-open arm. Success passes straight through.
-async fn retry_provider_faults<T>(
+/// Provider faults are node-local (a transient I/O error may clear on a re-read: every pinned
+/// read constructs a fresh state provider per attempt), so a bounded retry preserves liveness
+/// before the caller escalates to a halt. Chain-global failures are deterministic products of the
+/// pinned block — re-reading cannot change them — so they return immediately for the caller's
+/// fail-open-or-halt arm. Success passes straight through.
+///
+/// `read` returns a future so the async epoch-record and epoch-entry committee reads share this
+/// policy with the synchronous close-time reads (which adapt with [`std::future::ready`]). Each
+/// attempt calls `read` afresh, so every retry re-runs the whole read — which is why every caller
+/// must fix its pin OUTSIDE the closure, or successive attempts could resolve different blocks.
+///
+/// Every retry is counted through [`EpochMetrics::record_provider_fault_retry`], labelled by
+/// `what`. Once a provider fault at an epoch seam is survivable it becomes invisible until it is
+/// not, and a `warn!` alone will not surface a node quietly retrying at every boundary.
+pub(super) async fn retry_provider_faults<T, Fut>(
     what: &'static str,
-    mut read: impl FnMut() -> Result<T, StateReadError>,
-) -> Result<T, StateReadError> {
+    mut read: impl FnMut() -> Fut,
+) -> Result<T, StateReadError>
+where
+    Fut: Future<Output = Result<T, StateReadError>>,
+{
     let mut attempt = 1u32;
     loop {
-        match read() {
+        match read().await {
             Err(StateReadError::Provider(detail)) if attempt < CLOSE_READ_ATTEMPTS => {
                 warn!(
                     target: "epoch-manager",
@@ -887,8 +923,9 @@ async fn retry_provider_faults<T>(
                     max_attempts = CLOSE_READ_ATTEMPTS,
                     what,
                     detail,
-                    "node-local provider fault on close-time read - retrying"
+                    "node-local provider fault on pinned chain read - retrying"
                 );
+                EpochMetrics::record_provider_fault_retry(what);
                 attempt += 1;
                 tokio::time::sleep(CLOSE_READ_RETRY_BACKOFF).await;
             }
@@ -1013,7 +1050,7 @@ mod tests {
         let calls = Cell::new(0u32);
         let res: Result<(), StateReadError> = retry_provider_faults("test read", || {
             calls.set(calls.get() + 1);
-            Err(StateReadError::Provider("mdbx i/o fault".into()))
+            ready(Err(StateReadError::Provider("mdbx i/o fault".into())))
         })
         .await;
 
@@ -1028,11 +1065,11 @@ mod tests {
         let calls = Cell::new(0u32);
         let res = retry_provider_faults("test read", || {
             calls.set(calls.get() + 1);
-            if calls.get() == 1 {
+            ready(if calls.get() == 1 {
                 Err(StateReadError::Provider("transient i/o fault".into()))
             } else {
                 Ok(7u64)
-            }
+            })
         })
         .await;
 
@@ -1047,7 +1084,7 @@ mod tests {
         let calls = Cell::new(0u32);
         let res: Result<(), StateReadError> = retry_provider_faults("test read", || {
             calls.set(calls.get() + 1);
-            Err(StateReadError::ChainGlobal("contract absent".into()))
+            ready(Err(StateReadError::ChainGlobal("contract absent".into())))
         })
         .await;
 

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -134,10 +134,15 @@ where
         &self,
         engine: &ExecutionNode,
     ) -> eyre::Result<(Committee, EpochInfo, u64, SealedHeader)> {
+        // Sample the bootstrap tip ONCE: the pin this read resolves is a function of the tip
+        // (`concludeEpoch` rewrites both the epoch number and its `blockHeight` at every
+        // boundary), so holding the sample here is what makes the pin a property of this call
+        // rather than of when each chain read happens to run.
+        let tip = engine.get_reth_env().await.canonical_tip();
         let (
             EpochState { epoch, epoch_info, validators, bls_pubkeys, epoch_start },
             epoch_start_header,
-        ) = engine.epoch_state_at_epoch_start().await?;
+        ) = engine.epoch_state_at_epoch_start_from_tip(&tip).await?;
         let validators = validators
             .iter()
             .zip(bls_pubkeys.iter())

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -24,6 +24,7 @@
 //! yet executed is replayed to the engine, with a guard that refuses to cross an
 //! epoch boundary.
 
+use super::run_epoch::retry_provider_faults;
 use crate::{
     engine::ExecutionNode, manager::EpochManager, primary::PrimaryNode, worker::WorkerNode,
     EngineToPrimaryRpc,
@@ -130,19 +131,39 @@ where
     /// `EpochInfo`/epoch-start scalars are unchanged by the pin, since `concludeEpoch` writes them
     /// exactly once at the boundary.
     /// On-chain BLS key bytes are decoded here and a decode failure aborts committee construction.
+    ///
+    /// READ-FAILURE POLICY: the read is a consensus input, so its failure is classified by
+    /// committee determinism ([`StateReadError`](tn_reth::error::StateReadError)) and BOTH classes
+    /// halt. There is deliberately no fail-open arm, despite what
+    /// [`ChainGlobal`](tn_reth::error::StateReadError::ChainGlobal)'s variant doc says about
+    /// keep-current staying committee-consistent: the node is ENTERING the epoch, so it holds no
+    /// prior committee to keep, and entering on an unverifiable one is a consensus-safety failure
+    /// while halting is a single-node liveness failure. A
+    /// [`Provider`](tn_reth::error::StateReadError::Provider) fault is node-local (peers reading
+    /// the same block may succeed), so it is retried briefly first.
     pub(super) async fn get_committee_with_epoch_start_info(
         &self,
         engine: &ExecutionNode,
     ) -> eyre::Result<(Committee, EpochInfo, u64, SealedHeader)> {
-        // Sample the bootstrap tip ONCE: the pin this read resolves is a function of the tip
-        // (`concludeEpoch` rewrites both the epoch number and its `blockHeight` at every
-        // boundary), so holding the sample here is what makes the pin a property of this call
-        // rather than of when each chain read happens to run.
+        // Sample the bootstrap tip ONCE, OUTSIDE the retry below. This is what makes the retry
+        // safe: the pin the read resolves is a function of the tip (`concludeEpoch` rewrites
+        // both the epoch number and its `blockHeight` at EVERY boundary, not once ever), so
+        // re-sampling per attempt could resolve a different header on a later attempt. With the
+        // sample held here, every attempt provably resolves the same pin.
         let tip = engine.get_reth_env().await.canonical_tip();
         let (
             EpochState { epoch, epoch_info, validators, bls_pubkeys, epoch_start },
             epoch_start_header,
-        ) = engine.epoch_state_at_epoch_start_from_tip(&tip).await?;
+        ) = retry_provider_faults("epoch-entry state read", || {
+            engine.epoch_state_at_epoch_start_from_tip(&tip)
+        })
+        .await
+        .map_err(|e| {
+            eyre!(
+                "failed epoch-entry state read - halting rather than entering an epoch with an \
+                 unverifiable committee: {e}"
+            )
+        })?;
         let validators = validators
             .iter()
             .zip(bls_pubkeys.iter())
@@ -247,6 +268,11 @@ where
         // prefetch is a best-effort network warm-up: the next committee's keys are reused from
         // the config (already read at the pin — no second chain read to fail), and a failed
         // epoch + 2 read is logged and skipped rather than aborting epoch start.
+        //
+        // Deliberately NOT wrapped in `retry_provider_faults`, unlike the hard entry reads: a
+        // provider fault here costs a network warm-up, not correctness, and paying up to
+        // CLOSE_READ_ATTEMPTS x CLOSE_READ_RETRY_BACKOFF on the epoch-entry critical path to
+        // salvage one is a bad trade. Both failure classes skip.
         prefetches.extend(consensus_config.next_committee_keys().iter());
         match engine.validators_for_epoch_at_header(committee.epoch() + 2, epoch_start_header).await
         {

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -34,6 +34,18 @@ impl EpochMetrics {
         };
         metrics::counter!("tn_epoch.runs_total", "mode" => mode).increment(1);
     }
+
+    /// Record one retried pinned chain read at an epoch seam, labelled by which read it was.
+    ///
+    /// Emitted by `retry_provider_faults` on every node-local provider fault it absorbs. Once
+    /// such a fault is survivable it becomes invisible until it is not, so a node quietly
+    /// retrying at every boundary needs to show up somewhere other than a `warn!` line.
+    ///
+    /// An associated function, not a method: the retry helper is shared by the epoch entry,
+    /// record, and close paths and holds no `EpochMetrics`.
+    pub(crate) fn record_provider_fault_retry(read: &'static str) {
+        metrics::counter!("tn_epoch.provider_fault_retries_total", "read" => read).increment(1);
+    }
 }
 
 #[cfg(test)]
@@ -52,6 +64,7 @@ mod tests {
             metrics.boundary_timestamp_seconds.set(1_700_000_000.0);
             metrics.replayed_outputs_total.increment(2);
             metrics.record_epoch_run(&RunEpochMode::Initial);
+            EpochMetrics::record_provider_fault_retry("epoch-entry state read");
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
@@ -69,5 +82,11 @@ mod tests {
         assert!(key.key().labels().any(|l| l.key() == "mode" && l.value() == "initial"));
         find("tn_epoch.boundary_timestamp_seconds");
         find("tn_epoch.replayed_outputs_total");
+        let (key, _, _, value) = find("tn_epoch.provider_fault_retries_total");
+        assert!(matches!(value, DebugValue::Counter(1)));
+        assert!(key
+            .key()
+            .labels()
+            .any(|l| l.key() == "read" && l.value() == "epoch-entry state read"));
     }
 }

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -26,7 +26,10 @@
 //!   `test_utils.rs`; production reads the committee through
 //!   [`RethEnv::epoch_state_at_epoch_start`].
 //! - [`RethEnv::epoch_state_at_epoch_start`] pins to the entered epoch's start state: the previous
-//!   epoch's closing block (`epoch_info.blockHeight - 1`), or genesis for epoch 0.
+//!   epoch's closing block (`epoch_info.blockHeight - 1`), or genesis for epoch 0. It samples the
+//!   canonical tip to bootstrap that pin; callers that must prove every attempt of a retried read
+//!   resolves the SAME pin sample the tip themselves and use
+//!   [`RethEnv::epoch_state_at_epoch_start_from_tip`].
 //!
 //! Pinning matters because the registry's committee arrays mutate MID-epoch: a governance
 //! `burn` swap-and-pops the ejected validator out of the CURRENT epoch's stored committee
@@ -40,9 +43,9 @@
 //! a pruner — `PruningArgs` in `cli.rs` is built with every field disabled — so historical
 //! state always resolves fully indexed. If pruning were ever enabled, reth's historical
 //! provider could silently fall back to TIP state for a pruned block, turning a "pinned" read
-//! into exactly the nondeterminism pinning exists to prevent. See the ARCHIVE-MODE note in
-//! [`RethEnv::read_consensus_registry_batch_at_header`]; revisit every pinned read here before
-//! enabling pruning.
+//! into exactly the nondeterminism pinning exists to prevent. Every pinned read here builds its
+//! state through the one `pinned_state_and_env` helper, which carries the normative ARCHIVE-MODE
+//! note; revisit it before enabling pruning.
 //!
 //! # Error classification
 //!
@@ -53,16 +56,35 @@
 //! (revert, halt, decode failure, absent contract — identical on every node, so failing open
 //! stays fleet-consistent). The boundary lives in the private `classified_system_call` helper:
 //! `EVMError::Database` maps to `Provider`; every other transact failure maps to `ChainGlobal`.
+//!
+//! Every consensus-critical pinned read is classified. Epoch state:
+//! [`RethEnv::epoch_state_at_header`], [`RethEnv::epoch_state_at_epoch_start`] and its
+//! [`_from_tip`](RethEnv::epoch_state_at_epoch_start_from_tip) form, and
+//! [`RethEnv::get_current_epoch_info_at_header`]. Committee pubkeys:
+//! [`RethEnv::bls_pubkeys_for_epoch_at_header`], [`RethEnv::bls_pubkeys_for_epochs_at_header`],
+//! and their by-hash siblings [`RethEnv::bls_pubkeys_for_epoch_at_block`] /
+//! [`RethEnv::bls_pubkeys_for_epochs_at_block`]. Worker fees:
+//! [`RethEnv::get_worker_fee_configs_at_block`].
+//!
+//! [`RethEnv::epoch_state_from_canonical_tip`] deliberately stays `eyre`: it is a tip read, so no
+//! caller can act on the classification (a tip read is not committee-deterministic to begin
+//! with). The `read_consensus_registry*` family stays [`EvmReadResult`] because the RPC layer
+//! maps [`EvmReadError::Revert`]'s raw output bytes into an eth_call-style error, which
+//! [`StateReadError`]'s string-only variants cannot carry.
 
-use eyre::OptionExt as _;
 use reth_errors::ProviderError;
 use reth_eth_wire::BlockHashNumber;
-use reth_evm::{ConfigureEvm as _, Evm as _, EvmFactory as _};
+use reth_evm::{ConfigureEvm as _, Evm as _, EvmEnv, EvmFactory as _};
 use reth_provider::{
     BlockIdReader as _, BlockNumReader as _, ChainStateBlockReader as _,
     ChainStateBlockWriter as _, DBProvider as _, DatabaseProviderFactory as _, HeaderProvider as _,
+    StateProviderBox,
 };
-use reth_revm::context::result::{EVMError, ExecutionResult, ResultAndState};
+use reth_revm::{
+    context::result::{EVMError, ExecutionResult, ResultAndState},
+    database::StateProviderDatabase,
+    State,
+};
 use tn_config::WORKER_CONFIGS_ADDRESS;
 use tn_types::{
     gas_accumulator::WorkerFeeConfig, Address, Bytes, Epoch, ExecHeader, SealedHeader,
@@ -184,7 +206,9 @@ impl RethEnv {
     pub fn epoch_state_from_canonical_tip(&self) -> eyre::Result<EpochState> {
         let canonical_tip = self.canonical_tip();
         debug!(target: "engine", ?canonical_tip, "retrieving epoch state from canonical tip");
-        self.epoch_state_at_header(&canonical_tip)
+        // Stays `eyre` on purpose: this is a TIP read, so its result is not
+        // committee-deterministic to begin with and no caller can act on the classification.
+        Ok(self.epoch_state_at_header(&canonical_tip)?)
     }
 
     /// Read the committee and epoch information from the [ConsensusRegistry] at `header`.
@@ -194,24 +218,23 @@ impl RethEnv {
     /// `epoch_info.blockHeight..=header.number` (catchup and epoch-entry base-fee seeding) rely
     /// on this pin: reading the range start from a different header (e.g. the canonical tip)
     /// could yield a silently empty range if finality ever lags the canonical tip.
-    pub fn epoch_state_at_header(&self, header: &SealedHeader) -> eyre::Result<EpochState> {
+    ///
+    /// Failures are classified per [`StateReadError`] so consensus-critical callers can retry a
+    /// node-local provider fault instead of halting on it.
+    pub fn epoch_state_at_header(&self, header: &SealedHeader) -> StateReadResult<EpochState> {
         // create EVM with the state at the pinned header
-        let mut db = self.read_only_state_db(header.hash())?;
+        let (mut db, evm_env) = self.pinned_state_and_env(header)?;
         debug!(target: "engine", state=?db.bundle_state, hashes=?db.block_hashes, "retrieving epoch state at header");
-        let mut tn_evm = self
-            .inner
-            .evm_config
-            .evm_factory()
-            .create_evm(&mut db, self.inner.evm_config.evm_env(header)?);
+        let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         // current epoch number
-        let epoch = self.call_consensus_registry::<_, u32>(
+        let epoch = Self::classified_registry_read::<_, u32>(
             &mut tn_evm,
             ConsensusRegistry::getCurrentEpochCall {}.abi_encode().into(),
         )?;
 
         // current epoch info
-        let epoch_info = self.call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(
+        let epoch_info = Self::classified_registry_read::<_, ConsensusRegistry::EpochInfo>(
             &mut tn_evm,
             ConsensusRegistry::getCurrentEpochInfoCall {}.abi_encode().into(),
         )?;
@@ -223,21 +246,34 @@ impl RethEnv {
         // canonical chain resolve to this same header, and the
         // `epoch_state_at_epoch_start_pins_pre_burn_committee` test pins the tip/pinned
         // `epoch_start` equality.
+        //
+        // Both failures in the fetch branch are node-local (Provider), not chain-global:
+        // `header_by_number` reads the DATABASE while the caller's header may come from the
+        // in-memory canonical state, so an executed-but-not-yet-persisted closing block can
+        // legitimately miss on this node while every peer resolves it.
         let closing_number = epoch_info.blockHeight.saturating_sub(1);
         let epoch_start = if closing_number == header.number {
             header.timestamp
         } else {
-            self.header_by_number(closing_number)?
-                .ok_or_eyre("failed to retrieve closing epoch information")?
+            self.header_by_number(closing_number)
+                .map_err(|e| {
+                    StateReadError::Provider(format!("closing header {closing_number} lookup: {e}"))
+                })?
+                .ok_or_else(|| {
+                    StateReadError::Provider(format!(
+                        "failed to retrieve closing epoch information: missing block \
+                         {closing_number}"
+                    ))
+                })?
                 .timestamp
         };
 
         // retrieve the committee
-        let validators = self.call_consensus_registry::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
+        let validators = Self::classified_registry_read::<_, Vec<ConsensusRegistry::ValidatorInfo>>(
             &mut tn_evm,
             ConsensusRegistry::getCommitteeValidatorsCall { epoch }.abi_encode().into(),
         )?;
-        let bls_pubkeys = self.call_consensus_registry::<_, Vec<alloy::primitives::Bytes>>(
+        let bls_pubkeys = Self::classified_registry_read::<_, Vec<alloy::primitives::Bytes>>(
             &mut tn_evm,
             ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into(),
         )?;
@@ -272,20 +308,56 @@ impl RethEnv {
     /// report the entered epoch. If the pinned epoch disagrees with the tip's, the registry's
     /// `blockHeight == closing block + 1` convention broke; this method fails hard rather than
     /// return a possibly-stale committee.
-    pub fn epoch_state_at_epoch_start(&self) -> eyre::Result<(EpochState, SealedHeader)> {
+    ///
+    /// Samples the canonical tip itself, so two calls can bootstrap off two different tips. A
+    /// caller that RETRIES this read must sample the tip once and use
+    /// [`Self::epoch_state_at_epoch_start_from_tip`] instead — see that method's docs for why the
+    /// difference is load-bearing.
+    pub fn epoch_state_at_epoch_start(&self) -> StateReadResult<(EpochState, SealedHeader)> {
+        self.epoch_state_at_epoch_start_from_tip(&self.canonical_tip())
+    }
+
+    /// [`Self::epoch_state_at_epoch_start`] with the bootstrap tip supplied by the caller.
+    ///
+    /// The pin this resolves is a function of `tip`: the bootstrap read takes the current epoch
+    /// number and its `blockHeight` AT `tip`, and `concludeEpoch` rewrites both at EVERY epoch
+    /// boundary (they are written once per epoch, not once ever). A caller that re-samples the
+    /// canonical tip per attempt could therefore resolve a different pin on a later attempt; one
+    /// that samples `tip` ONCE outside its retry loop proves every attempt resolves the same
+    /// header. Retrying callers must use this form for that reason — see
+    /// `manager::node::start_epoch`'s epoch-entry read.
+    ///
+    /// `tip` need not be the live canonical tip, only a header whose registry state names the
+    /// epoch to enter; passing an older header pins that header's epoch instead.
+    pub fn epoch_state_at_epoch_start_from_tip(
+        &self,
+        tip: &SealedHeader,
+    ) -> StateReadResult<(EpochState, SealedHeader)> {
         // boundary-written-once identity read: deterministic at any tip
-        let (epoch, epoch_info) = self.get_current_epoch_info_at_header(&self.canonical_tip())?;
+        let (epoch, epoch_info) = self.get_current_epoch_info_at_header(tip)?;
 
         let pin_header = if epoch == 0 {
-            self.sealed_header_by_number(0)?.ok_or_else(|| eyre::eyre!("missing genesis header"))?
+            // The pin headers are node-local lookups: the block exists on the committee by
+            // construction, so a miss or an error reflects THIS node's database, not the chain.
+            self.sealed_header_by_number(0)
+                .map_err(|e| StateReadError::Provider(format!("genesis header lookup: {e}")))?
+                .ok_or_else(|| StateReadError::Provider("missing genesis header".into()))?
         } else {
-            let closing_number = epoch_info
-                .blockHeight
-                .checked_sub(1)
-                .ok_or_else(|| eyre::eyre!("current epoch {epoch} reports blockHeight 0"))?;
-            self.sealed_header_by_number(closing_number)?.ok_or_else(|| {
-                eyre::eyre!("missing closing block {closing_number} for current epoch {epoch}")
-            })?
+            // A `blockHeight` of 0 for a non-zero epoch is the registry contradicting its own
+            // `blockHeight == closing block + 1` convention: chain-global, identical on every
+            // node, and no retry can change it.
+            let closing_number = epoch_info.blockHeight.checked_sub(1).ok_or_else(|| {
+                StateReadError::ChainGlobal(format!("current epoch {epoch} reports blockHeight 0"))
+            })?;
+            self.sealed_header_by_number(closing_number)
+                .map_err(|e| {
+                    StateReadError::Provider(format!("closing header {closing_number} lookup: {e}"))
+                })?
+                .ok_or_else(|| {
+                    StateReadError::Provider(format!(
+                        "missing closing block {closing_number} for current epoch {epoch}"
+                    ))
+                })?
         };
         debug!(
             target: "engine",
@@ -305,6 +377,8 @@ impl RethEnv {
         // closing header already reports the entered epoch. This can only fire if the registry's
         // `blockHeight == closing block + 1` convention ever breaks — running a stale committee
         // is a consensus-safety failure, so fail hard instead of returning the mismatched state.
+        // Chain-global: both epochs are deterministic products of their pinned blocks, so every
+        // node reading the same pair observes the same disagreement and no retry can clear it.
         if state.epoch != epoch {
             error!(
                 target: "engine",
@@ -313,12 +387,11 @@ impl RethEnv {
                 tip_epoch = epoch,
                 "epoch-start pin and canonical tip disagree on the current epoch"
             );
-            return Err(eyre::eyre!(
+            return Err(StateReadError::ChainGlobal(format!(
                 "epoch state pinned to block {} reports epoch {} but the canonical tip reports \
                  epoch {epoch}",
-                pin_header.number,
-                state.epoch
-            ));
+                pin_header.number, state.epoch
+            )));
         }
 
         Ok((state, pin_header))
@@ -330,15 +403,33 @@ impl RethEnv {
     /// Every node issuing this read at the same block decodes the identical key set — even
     /// after a mid-epoch governance `burn` swap-and-pops the stored committee arrays; an
     /// unpinned canonical-tip read would not.
+    ///
+    /// Failures are classified per [`StateReadError`]; `block_hash` failing to resolve is
+    /// [`StateReadError::Provider`] (see [`Self::pinned_header_by_hash`]).
     pub fn bls_pubkeys_for_epoch_at_block(
         &self,
         epoch: u32,
         block_hash: B256,
-    ) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
-        let header = self
-            .sealed_header_by_hash(block_hash)?
-            .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
+    ) -> StateReadResult<Vec<alloy::primitives::Bytes>> {
+        let header = self.pinned_header_by_hash(block_hash)?;
         self.bls_pubkeys_for_epoch_at_header(epoch, &header)
+    }
+
+    /// Read the BLS pubkeys for several epochs' committees from the [ConsensusRegistry], pinned
+    /// to the state of the block identified by `block_hash`.
+    ///
+    /// The by-hash sibling of [`Self::bls_pubkeys_for_epochs_at_header`], for callers holding
+    /// only a block hash (the epoch-record close, which pins to the epoch-closing block it
+    /// records as `final_state`). ONE header lookup and ONE pinned EVM serve the whole batch, so
+    /// every set in the result provably derives from the same block — two separate single-epoch
+    /// by-hash reads would each resolve the header independently.
+    pub fn bls_pubkeys_for_epochs_at_block(
+        &self,
+        epochs: &[Epoch],
+        block_hash: B256,
+    ) -> StateReadResult<Vec<Vec<alloy::primitives::Bytes>>> {
+        let header = self.pinned_header_by_hash(block_hash)?;
+        self.bls_pubkeys_for_epochs_at_header(epochs, &header)
     }
 
     /// Read the BLS pubkeys for the committee of the provided epoch from the
@@ -351,30 +442,32 @@ impl RethEnv {
         &self,
         epoch: u32,
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<alloy::primitives::Bytes>> {
-        self.bls_pubkeys_for_epochs_at_header(&[epoch], header)?
-            .pop()
-            .ok_or_else(|| eyre::eyre!("consensus registry batch read returned no result"))
+    ) -> StateReadResult<Vec<alloy::primitives::Bytes>> {
+        // An arity mismatch on a one-element batch is a bug in this node's code, not a transient
+        // fault, so it is chain-global: retrying cannot change it.
+        self.bls_pubkeys_for_epochs_at_header(&[epoch], header)?.pop().ok_or_else(|| {
+            StateReadError::ChainGlobal("consensus registry batch read returned no result".into())
+        })
     }
 
     /// Read the BLS pubkeys for several epochs' committees from the [ConsensusRegistry], pinned
     /// to `header`'s state.
     ///
     /// One `getCommitteeBlsPubkeys` call per epoch, all executed against ONE pinned EVM via
-    /// [`Self::read_consensus_registry_batch_at_header`]; the returned key sets are ordered to
+    /// [`Self::classified_registry_batch_at_header`]; the returned key sets are ordered to
     /// match `epochs`.
     pub fn bls_pubkeys_for_epochs_at_header(
         &self,
         epochs: &[Epoch],
         header: &SealedHeader,
-    ) -> eyre::Result<Vec<Vec<alloy::primitives::Bytes>>> {
+    ) -> StateReadResult<Vec<Vec<alloy::primitives::Bytes>>> {
         let calldatas = epochs
             .iter()
             .map(|&epoch| {
                 ConsensusRegistry::getCommitteeBlsPubkeysCall { epoch }.abi_encode().into()
             })
             .collect();
-        self.read_consensus_registry_batch_at_header(header, calldatas).map_err(Into::into)
+        self.classified_registry_batch_at_header(header, calldatas)
     }
 
     /// Read the [`ConsensusRegistry`] [`EpochInfo`](ConsensusRegistry::EpochInfo) for `epoch` at
@@ -396,12 +489,8 @@ impl RethEnv {
         let header = self
             .sealed_header_by_hash(block_hash)?
             .ok_or_else(|| eyre::eyre!("sealed header not found for block hash {block_hash:?}"))?;
-        let mut db = self.read_only_state_db(header.hash())?;
-        let mut tn_evm = self
-            .inner
-            .evm_config
-            .evm_factory()
-            .create_evm(&mut db, self.inner.evm_config.evm_env(&header)?);
+        let (mut db, evm_env) = self.pinned_state_and_env(&header)?;
+        let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         let calldata = ConsensusRegistry::getEpochInfoCall { epoch }.abi_encode().into();
         self.call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut tn_evm, calldata)
@@ -420,8 +509,20 @@ impl RethEnv {
         &self,
         block_hash: B256,
     ) -> StateReadResult<(usize, Vec<WorkerFeeConfig>)> {
-        let header = self
-            .sealed_header_by_hash(block_hash)
+        let header = self.pinned_header_by_hash(block_hash)?;
+        self.worker_fee_configs_inner(&header)
+    }
+
+    /// Resolve `block_hash` to its sealed header for a pinned read, classified per
+    /// [`StateReadError`].
+    ///
+    /// Both the lookup error and a `None` are [`StateReadError::Provider`]: the pinned block
+    /// exists on the committee by construction, so failing to resolve it reflects THIS node's
+    /// local view (a provider fault, or a block this node has not indexed yet), not a
+    /// chain-global fact. A peer issuing the same read may succeed, so callers must retry or
+    /// halt rather than fail open.
+    fn pinned_header_by_hash(&self, block_hash: B256) -> StateReadResult<SealedHeader> {
+        self.sealed_header_by_hash(block_hash)
             .map_err(|e| {
                 StateReadError::Provider(format!("header lookup for {block_hash:?}: {e}"))
             })?
@@ -429,8 +530,7 @@ impl RethEnv {
                 StateReadError::Provider(format!(
                     "sealed header not found for block hash {block_hash:?}"
                 ))
-            })?;
-        self.worker_fee_configs_inner(&header)
+            })
     }
 
     /// Read fee configs for all workers from the [`WorkerConfigs`] contract at the given header.
@@ -454,12 +554,7 @@ impl RethEnv {
         &self,
         header: &SealedHeader,
     ) -> StateReadResult<(usize, Vec<WorkerFeeConfig>)> {
-        let mut db = self.read_only_state_db(header.hash()).map_err(|e| {
-            StateReadError::Provider(format!("state provider at {}: {e}", header.hash()))
-        })?;
-        let evm_env = self.inner.evm_config.evm_env(header).map_err(|e| {
-            StateReadError::ChainGlobal(format!("evm env for {}: {e}", header.hash()))
-        })?;
+        let (mut db, evm_env) = self.pinned_state_and_env(header)?;
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         let calldata = WorkerConfigs::getAllWorkerConfigsCall {}.abi_encode().into();
@@ -585,11 +680,12 @@ impl RethEnv {
     /// Build a single EVM at `header`'s state and execute several read-only [ConsensusRegistry]
     /// calls against it, decoding each result to `T`.
     ///
-    /// Every calldata in a batch must decode to the same Solidity type `T`. Current callers: the
-    /// tip-pinned five `getValidatorsInfo(status)` reads → `Vec<ValidatorInfo>` (through
-    /// [`Self::read_consensus_registry_batch`]), and
-    /// [`Self::bls_pubkeys_for_epochs_at_header`]'s per-epoch `getCommitteeBlsPubkeys` reads →
-    /// `Vec<Bytes>`, the first caller to batch at an explicit pin.
+    /// Every calldata in a batch must decode to the same Solidity type `T`. The current caller is
+    /// the tip-pinned five `getValidatorsInfo(status)` reads → `Vec<ValidatorInfo>` (through
+    /// [`Self::read_consensus_registry_batch`]). Consensus-critical pinned batches use the
+    /// classified sibling [`Self::classified_registry_batch_at_header`] instead; this form stays
+    /// for the RPC layer, which maps [`EvmReadError::Revert`]'s raw output bytes into an
+    /// eth_call-style error that [`StateReadError`]'s string-only variants cannot carry.
     ///
     /// All calls observe ONE pinned state snapshot, so a multi-call query (e.g. unioning
     /// per-status validator sets) cannot straddle a block commit and double-count or drop a
@@ -607,23 +703,10 @@ impl RethEnv {
             <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
         >,
     {
-        // Create EVM with the state at the pinned header.
-        //
-        // ARCHIVE-MODE ASSUMPTION: this node never constructs a pruner (`PruningArgs` are built
-        // with every field disabled and no `PrunerBuilder` exists in the repo), so
-        // `state_by_block_hash` always resolves fully indexed history. If pruning is ever
-        // enabled, reth's `HistoricalStateProvider` can hit a missing history shard and return
-        // `HistoryInfo::MaybeInPlainState`, silently falling back to TIP state for this
-        // "pinned" read — exactly the nondeterminism pinning exists to prevent. Revisit every
-        // pinned registry read before enabling pruning.
-        let mut db = self
-            .read_only_state_db(header.hash())
-            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
-        let evm_env = self
-            .inner
-            .evm_config
-            .evm_env(header)
-            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
+        // Downgrading the classification is lossless here: both setup failures already collapsed
+        // into `Internal` before the classified helper existed.
+        let (mut db, evm_env) =
+            self.pinned_state_and_env(header).map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         // reuse the one pinned EVM for every read; `call_consensus_registry` is non-committing,
@@ -633,6 +716,72 @@ impl RethEnv {
             .map(|calldata| self.call_consensus_registry(&mut tn_evm, calldata))
             .collect()
     }
+
+    /// Build a single EVM at `header`'s state and execute several read-only [ConsensusRegistry]
+    /// calls against it, decoding each result to `T`, with failures classified per
+    /// [`StateReadError`].
+    ///
+    /// The [`StateReadResult`]-typed sibling of
+    /// [`Self::read_consensus_registry_batch_at_header`]: same ONE-pinned-EVM batching and same
+    /// result ordering, but each call routes through [`Self::classified_registry_read`] so a
+    /// node-local provider fault stays distinguishable from a chain-global failure. Every
+    /// consensus-critical pinned batch — the per-epoch committee reads
+    /// ([`Self::bls_pubkeys_for_epochs_at_header`]) — uses this form.
+    fn classified_registry_batch_at_header<T>(
+        &self,
+        header: &SealedHeader,
+        calldatas: Vec<Bytes>,
+    ) -> StateReadResult<Vec<T>>
+    where
+        T: alloy::sol_types::SolValue,
+        T: From<
+            <<T as alloy::sol_types::SolValue>::SolType as alloy::sol_types::SolType>::RustType,
+        >,
+    {
+        let (mut db, evm_env) = self.pinned_state_and_env(header)?;
+        let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
+
+        // reuse the one pinned EVM for every read; `classified_registry_read` is non-committing,
+        // so each read sees the same base state.
+        calldatas
+            .into_iter()
+            .map(|calldata| Self::classified_registry_read(&mut tn_evm, calldata))
+            .collect()
+    }
+
+    /// Build the state database and EVM environment pinned to `header`, classified per
+    /// [`StateReadError`].
+    ///
+    /// Returns the `(db, env)` pair rather than a constructed EVM because `create_evm(&mut db,
+    /// env)` borrows `db`, so the caller must own both. This is the ONE place a pinned read's
+    /// state is built — every `*_at_header` / `*_at_block` reader here routes through it.
+    ///
+    /// The classification split: state-provider construction is [`StateReadError::Provider`]
+    /// (node-local — this node's database failing to resolve the pinned block's state, where a
+    /// peer issuing the same read may succeed), while EVM environment construction is
+    /// [`StateReadError::ChainGlobal`] (a deterministic function of the header's own fields and
+    /// the chain spec, identical on every node).
+    ///
+    /// ARCHIVE-MODE ASSUMPTION: this node never constructs a pruner (`PruningArgs` are built
+    /// with every field disabled and no `PrunerBuilder` exists in the repo), so
+    /// `state_by_block_hash` always resolves fully indexed history. If pruning is ever enabled,
+    /// reth's `HistoricalStateProvider` can hit a missing history shard and return
+    /// `HistoryInfo::MaybeInPlainState`, silently falling back to TIP state for this "pinned"
+    /// read — exactly the nondeterminism pinning exists to prevent. Revisit every pinned read
+    /// before enabling pruning.
+    fn pinned_state_and_env(
+        &self,
+        header: &SealedHeader,
+    ) -> StateReadResult<(State<StateProviderDatabase<StateProviderBox>>, EvmEnv)> {
+        let db = self.read_only_state_db(header.hash()).map_err(|e| {
+            StateReadError::Provider(format!("state provider at {}: {e}", header.hash()))
+        })?;
+        let evm_env = self.inner.evm_config.evm_env(header).map_err(|e| {
+            StateReadError::ChainGlobal(format!("evm env for {}: {e}", header.hash()))
+        })?;
+        Ok((db, evm_env))
+    }
+
     /// Extract the epoch number from a header's nonce.
     pub fn extract_epoch_from_header(header: &ExecHeader) -> Epoch {
         let nonce: u64 = header.nonce.into();
@@ -655,12 +804,7 @@ impl RethEnv {
         &self,
         header: &SealedHeader,
     ) -> StateReadResult<(Epoch, ConsensusRegistry::EpochInfo)> {
-        let mut db = self.read_only_state_db(header.hash()).map_err(|e| {
-            StateReadError::Provider(format!("state provider at {}: {e}", header.hash()))
-        })?;
-        let evm_env = self.inner.evm_config.evm_env(header).map_err(|e| {
-            StateReadError::ChainGlobal(format!("evm env for {}: {e}", header.hash()))
-        })?;
+        let (mut db, evm_env) = self.pinned_state_and_env(header)?;
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         // both reads observe the ONE pinned EVM state
@@ -1508,7 +1652,7 @@ mod tests {
         // capture pre-burn committee pubkeys for the current and both future epochs
         let pre_burn = (0u32..=2)
             .map(|e| reth_env.bls_pubkeys_for_epoch_at_block(e, reth_env.canonical_tip().hash()))
-            .collect::<eyre::Result<Vec<_>>>()?;
+            .collect::<StateReadResult<Vec<_>>>()?;
 
         // eject a middle slot so the swap-and-pop reorder is visible
         let target = committee[1].validatorAddress;
@@ -2290,10 +2434,15 @@ mod tests {
         let pinned_b3 = reth_env.bls_pubkeys_for_epoch_at_block(3, pin.hash())?;
         assert_eq!(pinned_b2, pre_b2, "epoch 2 pubkeys at the pin are the pre-burn set");
         assert_eq!(pinned_b3, pre_b3, "epoch 3 pubkeys at the pin are the pre-burn set");
-        // the batch variant resolves both epochs through ONE pinned EVM and orders its results
-        // to match the input: batch == the single pinned reads
+        // the batch variants resolve both epochs through ONE pinned EVM and order their results
+        // to match the input: batch == the single pinned reads, by header and by hash
         let batched = reth_env.bls_pubkeys_for_epochs_at_header(&[2, 3], &pin)?;
         assert_eq!(batched, vec![pinned_b2.clone(), pinned_b3.clone()]);
+        let batched_by_hash = reth_env.bls_pubkeys_for_epochs_at_block(&[2, 3], pin.hash())?;
+        assert_eq!(
+            batched_by_hash, batched,
+            "the by-hash batch resolves the same header as the by-header batch"
+        );
         assert!(pinned_b2.contains(&target_bls));
         assert!(pinned_b3.contains(&target_bls));
 
@@ -2615,6 +2764,57 @@ mod tests {
         assert!(
             matches!(err, StateReadError::ChainGlobal(_)),
             "absent registry must classify as ChainGlobal, got: {err}"
+        );
+
+        // the full epoch-state read splits the same way: unresolvable pin state is Provider...
+        let err = reth_env.epoch_state_at_header(&phantom).expect_err("phantom header must fail");
+        assert!(
+            matches!(err, StateReadError::Provider(_)),
+            "epoch state at an unresolvable header must classify as Provider, got: {err}"
+        );
+
+        // ...and an absent registry at a resolvable block is ChainGlobal
+        let err = reth_env
+            .epoch_state_at_header(&chain.sealed_genesis_header())
+            .expect_err("absent registry must fail");
+        assert!(
+            matches!(err, StateReadError::ChainGlobal(_)),
+            "epoch state with an absent registry must classify as ChainGlobal, got: {err}"
+        );
+
+        // the pinned committee-pubkey reads, single and batched, split identically: an
+        // unresolvable block hash never reaches the contract, so it is Provider...
+        let err = reth_env
+            .bls_pubkeys_for_epoch_at_block(0, B256::random())
+            .expect_err("unknown block hash must fail");
+        assert!(
+            matches!(err, StateReadError::Provider(_)),
+            "committee read at an unknown block hash must classify as Provider, got: {err}"
+        );
+        let err = reth_env
+            .bls_pubkeys_for_epochs_at_block(&[0, 1], B256::random())
+            .expect_err("unknown block hash must fail");
+        assert!(
+            matches!(err, StateReadError::Provider(_)),
+            "batched committee read at an unknown block hash must classify as Provider, got: {err}"
+        );
+
+        // ...while the absent registry at genesis is ChainGlobal for both shapes
+        let genesis_hash = chain.sealed_genesis_header().hash();
+        let err = reth_env
+            .bls_pubkeys_for_epoch_at_block(0, genesis_hash)
+            .expect_err("absent registry must fail");
+        assert!(
+            matches!(err, StateReadError::ChainGlobal(_)),
+            "committee read with an absent registry must classify as ChainGlobal, got: {err}"
+        );
+        let err = reth_env
+            .bls_pubkeys_for_epochs_at_block(&[0, 1], genesis_hash)
+            .expect_err("absent registry must fail");
+        assert!(
+            matches!(err, StateReadError::ChainGlobal(_)),
+            "batched committee read with an absent registry must classify as ChainGlobal, got: \
+             {err}"
         );
 
         Ok(())


### PR DESCRIPTION
- `epoch_state_at_header`, `epoch_state_at_epoch_start`, and the pinned committee-pubkey reads now return `StateReadResult`: state-provider construction, database faults during registry reads, and header lookups classify as `Provider` (node-local, may clear on re-read); EVM-env construction and everything downstream of a successfully executing EVM classify as `ChainGlobal` (identical on every node). The internal registry helpers route through the existing `classified_registry_read`.

- New `bls_pubkeys_for_epochs_at_block` reads several epochs' committees from one pinned EVM, results ordered as requested; the single-epoch read is now a wrapper over it.

- `retry_provider_faults` generalized to async reads and shared across the boundary modules; the sync close-time callers adapt with `ready`. Attempt budget and backoff unchanged.

- Record write at close: the two serial committee reads (two header resolutions, two state views) collapse into one retried batched read at the closing-block pin, halting on exhausted `Provider` retries or any `ChainGlobal` failure. Deliberately no fail-open — a wrong committee in a signed epoch record is permanent divergence every syncing node inherits, while a halt is a single-node liveness failure.

- Epoch entry: the epoch-state read and the previous/next committee reads retry provider faults, then halt. The epoch+2 prefetch retries first and keeps its warn-and-skip fail-open, so a transient blip no longer silently drops the warm-up.

- The registry-convention tripwire classifies `ChainGlobal` and is therefore never retried: re-reading cannot un-break a chain-state convention.

- The RPC-facing `read_consensus_registry_batch` stays on unclassified `EvmReadResult` on purpose: the RPC layer distinguishes contract reverts through it.

- Tests: classification asserts for the epoch-state and pubkey reads (unresolvable header or block hash is `Provider`, absent registry at a resolvable block is `ChainGlobal`), the batched read matches the single reads at the pin in epoch order, and the retry-helper tests carry over to the async signature.

closes #1018 