### PR TITLE
Drop the debug_assert shadowing the close-time base-fee identity guard

### DIFF
--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -754,14 +754,14 @@ async fn adjust_base_fees(
     };
 
     let block_height = epoch_info.blockHeight;
-    debug_assert_eq!(
-        tip.number + 1,
-        block_height,
-        "close-time base-fee identity: canonical tip {} + 1 != entered-epoch {entered_epoch} \
-         blockHeight {block_height}",
-        tip.number,
-    );
     if tip.number + 1 != block_height {
+        error!(
+            target: "epoch-manager",
+            tip_number = tip.number,
+            entered_epoch,
+            block_height,
+            "close-time base-fee identity: canonical tip + 1 != entered-epoch blockHeight"
+        );
         return Err(eyre::eyre!(
             "close-time base-fee identity violated: canonical tip {} + 1 != entered-epoch \
              {entered_epoch} blockHeight {block_height} at tip {:?} - refusing to price base fees \
@@ -1125,6 +1125,35 @@ mod tests {
         assert_eq!(acc.base_fee(0).base_fee(), 4_242, "worker 0 fee unchanged");
         assert_eq!(acc.base_fee(1).base_fee(), 9_099, "worker 1 fee unchanged");
         assert_eq!(acc.get_values(0), (1, 1_000_000, 30_000_000), "worker 0 gas unchanged");
+
+        Ok(())
+    }
+
+    /// Identity-violation arm: with the registry present but NO closing block executed, the
+    /// canonical tip is genesis and the identity read succeeds with epoch 0's record
+    /// (`blockHeight` 0), so `tip + 1 != blockHeight` and the guard halts the close with the
+    /// descriptive error instead of pricing base fees off a non-closing block.
+    #[tokio::test]
+    async fn adjust_base_fees_errors_when_tip_is_not_a_closing_block() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(4);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::with_prefix("adjust_fees_identity_violation")?;
+        let task_manager = TaskManager::new("adjust fees identity violation");
+        let reth_env = RethEnv::new_for_temp_chain(chain, tmp_dir.path(), &task_manager, None)?;
+
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(4_242);
+
+        let err = adjust_base_fees(&reth_env, &acc)
+            .await
+            .expect_err("non-closing tip must violate the close-time identity");
+        assert!(
+            err.to_string().contains("close-time base-fee identity violated"),
+            "unexpected error: {err}"
+        );
+
+        // the guard trips before the config read, so fees stay untouched
+        assert_eq!(acc.base_fee(0).base_fee(), 4_242, "worker 0 fee unchanged");
 
         Ok(())
     }


### PR DESCRIPTION
- The identity guard in `adjust_base_fees` (canonical tip + 1 must equal the entered epoch's on-chain `blockHeight`) was preceded by a `debug_assert_eq!` of the same condition, so every debug build aborted on the assert before the recoverable `Err` could run: the guard was dead code in debug builds and its release-only live path had no test coverage.
- The assert is gone; the hard `Err` guard is now the single enforcement in all build profiles.
- The detection site now logs `error!` with `tip_number`, `entered_epoch`, and `block_height` before returning, the same tripwire shape as the epoch-start identity guard in tn-reth.
- New test `adjust_base_fees_errors_when_tip_is_not_a_closing_block`: registry deployed but no closing block executed, so the identity read succeeds against a genesis tip with epoch 0's `blockHeight` of 0 and the guard must trip. Asserts the identity-violation error and that worker fees stay untouched, since the guard fires before the config read.

closes #1019 