### PR TITLE
Rename engine committee read to `committee_keys_for_epoch_at_block`

### DIFF
--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -382,8 +382,8 @@ impl ExecutionNodeInner {
         self.reth_env.epoch_state_at_epoch_start()
     }
 
-    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
-    pub(super) fn validators_for_epoch_at_block(
+    /// Read the committee's BLS keys for `epoch`, pinned to the block identified by `block_hash`.
+    pub(super) fn committee_keys_for_epoch_at_block(
         &self,
         epoch: u32,
         block_hash: B256,

--- a/crates/node/src/engine/mod.rs
+++ b/crates/node/src/engine/mod.rs
@@ -305,18 +305,18 @@ impl ExecutionNode {
         guard.epoch_state_at_epoch_start()
     }
 
-    /// Read committee validator keys for epoch, pinned to the block identified by `block_hash`.
+    /// Read the committee's BLS keys for `epoch`, pinned to the block identified by `block_hash`.
     ///
     /// This is deliberately the ONLY committee read the engine exposes: an unpinned
     /// (canonical-tip) variant would make the result depend on when the caller runs
     /// relative to a mid-epoch governance burn. Callers must choose their pin header
     /// explicitly (epoch-start for entry reads, the epoch-closing block for the record).
-    pub async fn validators_for_epoch_at_block(
+    pub async fn committee_keys_for_epoch_at_block(
         &self,
         epoch: u32,
         block_hash: B256,
     ) -> eyre::Result<Vec<BlsPublicKey>> {
         let guard = self.internal.read().await;
-        guard.validators_for_epoch_at_block(epoch, block_hash)
+        guard.committee_keys_for_epoch_at_block(epoch, block_hash)
     }
 }

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -224,9 +224,10 @@ where
         // pin makes the record's committee reads and its `final_state` derive from the same
         // header by construction instead of by timing.
         let parent_state = self.consensus_bus.latest_execution_block_num_hash();
-        let committee_keys = engine.validators_for_epoch_at_block(epoch, parent_state.hash).await?;
+        let committee_keys =
+            engine.committee_keys_for_epoch_at_block(epoch, parent_state.hash).await?;
         let next_committee_keys =
-            engine.validators_for_epoch_at_block(epoch + 1, parent_state.hash).await?;
+            engine.committee_keys_for_epoch_at_block(epoch + 1, parent_state.hash).await?;
         let prev_record = if epoch == 0 {
             None
         } else {

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -182,7 +182,7 @@ where
             HashSet::new() // no previous committee
         } else {
             engine
-                .validators_for_epoch_at_block(epoch - 1, epoch_start_header.hash())
+                .committee_keys_for_epoch_at_block(epoch - 1, epoch_start_header.hash())
                 .await?
                 .into_iter()
                 .collect()
@@ -249,7 +249,7 @@ where
         // epoch + 2 read is logged and skipped rather than aborting epoch start.
         prefetches.extend(consensus_config.next_committee_keys().iter());
         match engine
-            .validators_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
+            .committee_keys_for_epoch_at_block(committee.epoch() + 2, epoch_start_header.hash())
             .await
         {
             Ok(keys) => prefetches.extend(keys),
@@ -290,7 +290,7 @@ where
         // already serves the next epoch's committee, and a post-burn re-entry folds the same
         // next-committee keys into the config as an on-time entry.
         let next_committee_keys = engine
-            .validators_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
+            .committee_keys_for_epoch_at_block(committee.epoch() + 1, epoch_start_header.hash())
             .await?;
 
         // create config for consensus


### PR DESCRIPTION
- The engine's pinned committee read was named `validators_for_epoch_at_block` but returns `Vec<BlsPublicKey>`; reth has a different method with the same name that returns `Vec<ValidatorInfo>`. Same name, different return types, one layer apart — a trap for anyone reading or grepping across the boundary.
- The old name also implied a delegation that never existed: the engine method wraps reth's `bls_pubkeys_for_epoch_at_block`, not its `validators_for_epoch_at_block` namesake.
- Rename covers the engine definition, its public wrapper, and the five call sites in the epoch close/entry paths; doc comments now say "BLS keys" instead of "validator keys".
- Call sites already bound the result to `committee_keys`, `next_committee_keys`, and `previous_committee_keys`; the method name now matches its bindings.
- Reth's `validators_for_epoch_at_block` keeps its name: its return type matches it. Zero behavior change.

closes #1020 