### PR TITLE
network-libp2p: cap concurrent established connections per peer (#1010)

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use futures::StreamExt as _;
 use libp2p::{
+    connection_limits::{self, ConnectionLimits},
     gossipsub::{
         self, Event as GossipEvent, IdentTopic, Message as GossipMessage, MessageAcceptance,
         PublishError, Topic, TopicHash,
@@ -79,6 +80,37 @@ const MAX_PUBLISHED_TO_PEERS: NonZeroUsize = NonZeroUsize::new(10_000).expect("1
 /// `MAX_MULTIADDRS_PER_PEER`; that set cap is what bounds accumulation across repeated records.
 const MAX_ADVERTISED_MULTIADDRS: usize = 16;
 
+/// Maximum number of concurrent established connections a single peer may hold, across both
+/// directions (inbound and outbound).
+///
+/// libp2p reports every established connection to the swarm but imposes no per-peer ceiling of its
+/// own. The peer-count admission gate (`PeerConfig::max_peers`) counts *distinct* `PeerId`s, so one
+/// peer holding many simultaneous connections still counts as one, and the inbound admission
+/// callback rejects only self-connections and banned peers. Without this cap a single unbanned peer
+/// could open connections up to the OS / QUIC file-descriptor and memory limits. Installing a
+/// [`connection_limits::Behaviour`] with this per-peer bound closes that gap (issue #1010).
+///
+/// The value is generous headroom over legitimate use: a peer needs at most one inbound and one
+/// outbound connection concurrently (this node dials with `PeerCondition::Disconnected`, so it does
+/// not stack redundant outbound dials), and brief reconnection churn adds only a small transient
+/// overlap. Eight leaves room for that churn while bounding a hostile peer to a fixed, small number
+/// of connections instead of an unbounded fan-out.
+const MAX_ESTABLISHED_CONNECTIONS_PER_PEER: u32 = 8;
+
+/// Build the [`connection_limits::Behaviour`] that caps concurrent established connections per peer
+/// at [`MAX_ESTABLISHED_CONNECTIONS_PER_PEER`].
+///
+/// Only the per-peer bound is set; the other `connection_limits` dimensions (pending / established
+/// totals and per-direction caps) are intentionally left unbounded so this change adds exactly the
+/// missing per-peer ceiling and nothing else. Shared by [`TNBehavior::new`] and its regression test
+/// so both exercise the identical limit.
+fn connection_limits_behaviour() -> connection_limits::Behaviour {
+    connection_limits::Behaviour::new(
+        ConnectionLimits::default()
+            .with_max_established_per_peer(Some(MAX_ESTABLISHED_CONNECTIONS_PER_PEER)),
+    )
+}
+
 /// Custom network libp2p behaviour type for Telcoin Network.
 ///
 /// The behavior composes multiple sub-behaviors:
@@ -101,6 +133,13 @@ where
     /// The peer manager — first so banned-peer denials short-circuit
     /// before other behaviors register the connection.
     pub(crate) peer_manager: peers::PeerManager,
+    /// Per-peer connection ceiling (issue #1010).
+    ///
+    /// Placed immediately after `peer_manager` so self / banned denials still fire first (a banned
+    /// peer is rejected before it is counted here), and before the remaining behaviors so an
+    /// over-cap connection is denied before `req_res` / `gossipsub` / `kademlia` register any
+    /// per-peer state for it.
+    pub(crate) connection_limits: connection_limits::Behaviour,
     /// The gossipsub network behavior.
     pub(crate) gossipsub: gossipsub::Behaviour,
     /// The request-response network behavior.
@@ -137,9 +176,18 @@ where
         stream_protocol: StreamProtocol,
     ) -> Self {
         let peer_manager = PeerManager::new(local_peer_id, peer_config, metrics);
+        let connection_limits = connection_limits_behaviour();
         let (req_res, peer_exchange) = req_res;
         let stream = StreamBehavior::new(stream_protocol);
-        Self { peer_manager, gossipsub, req_res, peer_exchange, kademlia, stream }
+        Self {
+            peer_manager,
+            connection_limits,
+            gossipsub,
+            req_res,
+            peer_exchange,
+            kademlia,
+            stream,
+        }
     }
 }
 
@@ -667,6 +715,10 @@ where
                 TNBehaviorEvent::ReqRes(event) => self.process_reqres_event(event)?,
                 TNBehaviorEvent::PeerExchange(event) => self.process_peer_exchange_event(event)?,
                 TNBehaviorEvent::PeerManager(event) => self.process_peer_manager_event(event)?,
+                // `connection_limits::Behaviour` emits no events (its `ToSwarm` is `Infallible`);
+                // this arm is uninhabited and exists only to keep the match exhaustive over the
+                // derived event enum.
+                TNBehaviorEvent::ConnectionLimits(event) => match event {},
                 TNBehaviorEvent::Kademlia(event) => self.process_kad_event(event)?,
                 TNBehaviorEvent::Stream(event) => self.process_stream_event(event)?,
             },

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -281,7 +281,7 @@ impl Peer {
         self.note_multiaddr(multiaddr);
 
         match &mut self.connection_status {
-            ConnectionStatus::Connected { num_in, .. } => *num_in += 1,
+            ConnectionStatus::Connected { num_in, .. } => *num_in = num_in.saturating_add(1),
             ConnectionStatus::Disconnected { .. }
             | ConnectionStatus::Banned { .. }
             | ConnectionStatus::Dialing { .. }
@@ -307,7 +307,7 @@ impl Peer {
         self.note_multiaddr(multiaddr);
 
         match &mut self.connection_status {
-            ConnectionStatus::Connected { num_out, .. } => *num_out += 1,
+            ConnectionStatus::Connected { num_out, .. } => *num_out = num_out.saturating_add(1),
             ConnectionStatus::Disconnected { .. }
             | ConnectionStatus::Banned { .. }
             | ConnectionStatus::Dialing { .. }
@@ -465,5 +465,51 @@ mod tests {
             "the most recent address must be recorded even at the cap boundary"
         );
         assert!(peer.multiaddrs.len() <= MAX_MULTIADDRS_PER_PEER);
+    }
+
+    /// Regression (issue #1010, informational): the per-connection counters are `u8` and were
+    /// incremented with a plain `*num_in += 1`. In a debug build (overflow checks on) the 256th
+    /// inbound connection from one peer panicked; in a release build it wrapped `255 -> 0`.
+    /// `saturating_add` makes the counter well-defined for a hostile peer: it clamps at `u8::MAX`
+    /// instead of panicking or wrapping. This test would panic on the 256th call before the fix.
+    #[test]
+    fn register_incoming_saturates_and_never_panics() {
+        // constructing a `Peer` builds its `Score`, which reads the global score config
+        super::super::score::init_peer_score_config(ScoreConfig::default());
+        let mut peer = Peer::default_for_test();
+
+        // far more inbound connections than `u8::MAX`; a plain `+= 1` panics here in a debug build
+        (0..300).for_each(|_| peer.register_incoming(create_multiaddr(None)));
+
+        if let ConnectionStatus::Connected { num_in, num_out } = peer.connection_status {
+            assert_eq!(num_in, u8::MAX, "inbound counter must saturate at u8::MAX, not wrap");
+            assert_eq!(num_out, 0, "no outbound connections were registered");
+        } else {
+            panic!(
+                "peer must be Connected after inbound registrations: {:?}",
+                peer.connection_status
+            );
+        }
+    }
+
+    /// Regression (issue #1010, informational): the outbound counter mirror of
+    /// [`register_incoming_saturates_and_never_panics`]. `register_outgoing` must clamp `num_out`
+    /// at `u8::MAX` rather than panic (debug) or wrap (release).
+    #[test]
+    fn register_outgoing_saturates_and_never_panics() {
+        super::super::score::init_peer_score_config(ScoreConfig::default());
+        let mut peer = Peer::default_for_test();
+
+        (0..300).for_each(|_| peer.register_outgoing(create_multiaddr(None)));
+
+        if let ConnectionStatus::Connected { num_in, num_out } = peer.connection_status {
+            assert_eq!(num_out, u8::MAX, "outbound counter must saturate at u8::MAX, not wrap");
+            assert_eq!(num_in, 0, "no inbound connections were registered");
+        } else {
+            panic!(
+                "peer must be Connected after outbound registrations: {:?}",
+                peer.connection_status
+            );
+        }
     }
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -3359,3 +3359,96 @@ async fn oversized_publish_is_refused_locally() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// Regression (issue #1010): the swarm must cap the number of concurrent established connections a
+/// single peer may hold. Without the `connection_limits::Behaviour` installed by `TNBehavior::new`,
+/// one unbanned peer could open connections with no per-peer ceiling: the peer-count gate counts
+/// *distinct* `PeerId`s, and the inbound admission callback rejects only self-connections and
+/// banned peers.
+///
+/// This drives the exact behaviour the production path installs (`connection_limits_behaviour`)
+/// through the swarm's admission + registration sequence and asserts the cap (1) fires at
+/// `MAX_ESTABLISHED_CONNECTIONS_PER_PEER + 1`, (2) is per-peer (a distinct peer is unaffected), and
+/// (3) counts *concurrent* connections (closing one frees a slot). Before the fix there is no such
+/// behaviour, so no admission is ever denied on this basis.
+#[test]
+fn connection_limit_caps_established_connections_per_peer() {
+    use libp2p::{
+        core::ConnectedPoint,
+        swarm::{
+            behaviour::ConnectionEstablished, ConnectionClosed, ConnectionId, FromSwarm,
+            NetworkBehaviour as _,
+        },
+    };
+
+    // exactly the behaviour installed in production
+    let mut limits = super::connection_limits_behaviour();
+    let cap = usize::try_from(super::MAX_ESTABLISHED_CONNECTIONS_PER_PEER).expect("cap fits usize");
+
+    let peer = PeerId::random();
+    let addr = create_multiaddr(None);
+    let listener =
+        ConnectedPoint::Listener { local_addr: addr.clone(), send_back_addr: addr.clone() };
+
+    // the first `cap` inbound connections from one peer are admitted and registered
+    (0..cap).for_each(|i| {
+        let id = ConnectionId::new_unchecked(i);
+        assert!(
+            limits.handle_established_inbound_connection(id, peer, &addr, &addr).is_ok(),
+            "connection {i} from a peer within the cap must be admitted"
+        );
+        // production path: a successful admission is followed by
+        // `FromSwarm::ConnectionEstablished`, which is what actually increments the
+        // per-peer counter inside `connection_limits`
+        limits.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
+            peer_id: peer,
+            connection_id: id,
+            endpoint: &listener,
+            failed_addresses: &[],
+            other_established: i,
+        }));
+    });
+
+    // the next connection from the SAME peer is denied by the per-peer cap
+    let over_cap = ConnectionId::new_unchecked(cap);
+    assert!(
+        limits.handle_established_inbound_connection(over_cap, peer, &addr, &addr).is_err(),
+        "connection number {} from the same peer must be denied by the per-peer cap",
+        cap + 1
+    );
+
+    // a distinct peer is unaffected: the cap is per-peer, not global
+    let other_peer = PeerId::random();
+    assert!(
+        limits
+            .handle_established_inbound_connection(
+                ConnectionId::new_unchecked(cap + 1),
+                other_peer,
+                &addr,
+                &addr,
+            )
+            .is_ok(),
+        "a distinct peer must not be denied because another peer reached the cap"
+    );
+
+    // closing one of the first peer's connections frees a slot: the cap tracks *concurrent*
+    // connections, and the decrement path must work
+    limits.on_swarm_event(FromSwarm::ConnectionClosed(ConnectionClosed {
+        peer_id: peer,
+        connection_id: ConnectionId::new_unchecked(0),
+        endpoint: &listener,
+        cause: None,
+        remaining_established: cap - 1,
+    }));
+    assert!(
+        limits
+            .handle_established_inbound_connection(
+                ConnectionId::new_unchecked(cap + 2),
+                peer,
+                &addr,
+                &addr,
+            )
+            .is_ok(),
+        "after one of the peer's connections closes, a fresh connection from it must be admitted"
+    );
+}


### PR DESCRIPTION
(Closes #1010)

## Summary

Installs a libp2p `connection_limits::Behaviour` with `max_established_per_peer(Some(8))` as a
member of the composite swarm behaviour `TNBehavior`, so a single unbanned peer can no longer hold
an unbounded number of simultaneous established connections.  Also hardens the two `u8`
per-connection counters (`num_in` / `num_out`) against wrap/panic by switching their increments to
`saturating_add`.

Addresses issue #1010.  Scoped to `crates/network-libp2p`;  no config-crate or protocol changes.

## Problem

libp2p reports every newly established connection to the peer manager, which records it against the
peer's state, but nothing in the stack bounds how many concurrent connections a single `PeerId` may
hold:

- The inbound admission gate `handle_established_inbound_connection`
  (`peers/behavior.rs`) rejects only a self-connection and a banned peer.  It does not reject a
  redundant connection from an already-connected peer.
- The peer-count gate `peer_limit_reached` (`peers/manager.rs`) counts *distinct* peers
  (`connected_or_dialing_peers().len() >= max_peers()`), so one `PeerId` holding N concurrent
  connections still counts as one.  It is also a soft, post-establishment disconnect that is bypassed
  for important peers.
- The swarm builder installed no `ConnectionLimits`: a repo-wide scan of `network-libp2p/src` for
  `ConnectionLimits` / `with_connection_limits` / `max_established_per_peer` returned zero hits.

**Threat model.**  A single unbanned remote peer can open many simultaneous inbound connections,
each costing a QUIC connection's worth of file descriptors and memory, bounded only by the OS and
QUIC defaults rather than by any application policy.  This is a DoS-hardening gap (Low): it does not
compromise consensus safety, but it lets one peer consume disproportionate local resources.

Separately, the per-connection counters `ConnectionStatus::Connected { num_in, num_out }`
(`peers/status.rs`) are `u8` and were incremented with a plain `*x += 1` (`peers/peer.rs`, inbound
and outbound).  In the shipped `--release` build (overflow-checks off) the 256th connection from one
peer wraps `255 -> 0` silently;  in a debug/test build the same path panics.  This is inert today
because the counters are never read by any production path, but it leaves the counters ill-defined
for a hostile peer.  (The original review's release-build-panic framing does not hold;  the real,
modest issue is the missing per-peer cap, with the counter wrap as an informational cleanup.)

## Fix

1. **Per-peer connection cap.**  Add `connection_limits: connection_limits::Behaviour` to
   `TNBehavior`, built by a shared `connection_limits_behaviour()` constructor from a documented
   `const MAX_ESTABLISHED_CONNECTIONS_PER_PEER: u32 = 8`.  Only the per-peer dimension is bounded;
   the other `connection_limits` dimensions are left unset so the change adds exactly the missing
   ceiling and nothing else.  The field is placed immediately after `peer_manager` so self / banned
   denials still short-circuit first (a banned peer is denied before it is counted), and before the
   remaining behaviours so an over-cap connection is denied before `req_res` / `gossipsub` /
   `kademlia` register any per-peer state.  The cap is enforced by libp2p at the
   `handle_established_{inbound,outbound}_connection` admission points, covering both directions.

   `connection_limits::Behaviour` emits no events (`ToSwarm = Infallible`);  the new
   `TNBehaviorEvent::ConnectionLimits(event) => match event {}` arm keeps the derived-event match
   exhaustive over an uninhabited payload (no wildcard, no runtime path).

   The value 8 is generous headroom over legitimate use: a peer needs at most one inbound and one
   outbound connection concurrently (this node dials with `PeerCondition::Disconnected`, so it does
   not stack redundant outbound dials), and brief reconnection churn adds only a small transient
   overlap.  Eight bounds a hostile peer to a fixed, small number of connections while leaving room
   for honest churn.  No Cargo feature change is required: `libp2p-connection-limits` is already a
   transitive dependency, so `libp2p::connection_limits` is available as-is.

2. **Counter hardening.**  `Peer::register_incoming` / `register_outgoing` now increment via
   `*num_in = num_in.saturating_add(1)` / `*num_out = num_out.saturating_add(1)`, so the counters
   clamp at `u8::MAX` instead of wrapping (release) or panicking (debug).  This makes them
   well-defined for a hostile peer;  with the per-peer cap now at 8 the counters never approach the
   bound in practice, so this is defence in depth.

## Testing

`cargo nextest run -p tn-network-libp2p` — full crate suite, 230 passed / 0 failed on the pinned
1.94 toolchain.  The per-peer cap regresses none of the existing multi-connection tests
(`test_multi_peer_mesh_formation`, `test_peer_exchange_with_excess_peers`, etc.), evidence that 8 is
liveness-safe.

Three new tests, each confirmed non-vacuous by mutation (each was watched to fail when its guarded
fix was reverted, then restored):

- `connection_limit_caps_established_connections_per_peer` (`tests/network_tests.rs`) drives the
  exact production behaviour (`connection_limits_behaviour()`) through the swarm admission +
  registration sequence and asserts the cap fires at the 9th connection from one peer, is per-peer
  (a distinct peer is unaffected), and tracks *concurrent* connections (closing one frees a slot).
  Reverting the cap to `None` makes it fail on "connection number 9 ... must be denied".
- `register_incoming_saturates_and_never_panics` / `register_outgoing_saturates_and_never_panics`
  (`peers/peer.rs`) drive 300 registrations and assert the counter saturates at `u8::MAX`.  Reverting
  to `*x += 1` makes each panic with "attempt to add with overflow" at the exact increment site.

`cargo +nightly fmt -- --check` and `cargo +nightly clippy -p tn-network-libp2p -- -D warnings`
(matching the attest gate, which does not lint test targets) are clean.
