### PR TITLE
docs(engine): explain why reward accounting is advanced before finalization

### DIFF
--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -26,7 +26,17 @@ pub fn execute_consensus_output(
 ) -> EngineResult<SealedHeader> {
     // rename canonical header for clarity
     let BuildArguments { reth_env, output, parent_header } = args;
-    let mut canonical_header = parent_header; // Last canonical header executed.
+    // Last canonical header executed.
+    let mut canonical_header = parent_header;
+    // Reward accounting is advanced here, before this output is durably finalized at the end of
+    // this function, and is deliberately not rewound on any error path below. The ordering is safe
+    // by construction: any error returns from this function and halts the engine task in-process
+    // (the `?` on the execution result in `ExecutorEngine::run`), so no later output is ever
+    // processed and a premature increment can never be consumed. On restart the accumulator is
+    // rebuilt from the finalized tip by `catchup_accumulator`, whose replay boundary lines up with
+    // the executed tip, so an increment for a not-yet-finalized output is reconstructed from
+    // scratch rather than carried across the restart. Do not add a compensating decrement to the
+    // error paths below: it would double-subtract against that rebuild.
     gas_accumulator.rewards_counter().inc_leader_count(output.leader().author());
     let epoch = output.leader().epoch();
     // output digest returns the `ConsensusHeader` digest
@@ -139,7 +149,9 @@ pub fn execute_consensus_output(
             &ancestors,
         );
         // On failure, revert the in-memory advance applied by any earlier block of this output so
-        // the propagated error never leaves a phantom canonical head observable to RPC.
+        // the propagated error never leaves a phantom canonical head observable to RPC. The leader
+        // count incremented above is intentionally left in place; see the note at the top of this
+        // function for why that is safe.
         canonical_header = executed.inspect_err(|_| {
             rollback_in_memory_output(&canonical_in_memory_state, &anchor_header, &executed_blocks)
         })?;
@@ -187,7 +199,10 @@ pub fn execute_consensus_output(
             );
             // On failure of a later block, revert the in-memory advance applied by the earlier
             // blocks of this output so the propagated (node-halting) error never leaves a phantom
-            // canonical head observable to RPC before the node restarts.
+            // canonical head observable to RPC before the node restarts. The reward-accounting
+            // increments already applied for this output (the leader count and earlier blocks'
+            // `inc_block`) are intentionally left in place here; see the note at the top of this
+            // function for why that is safe.
             canonical_header = executed.inspect_err(|_| {
                 rollback_in_memory_output(
                     &canonical_in_memory_state,
@@ -198,6 +213,9 @@ pub fn execute_consensus_output(
             if let Some(last_block) = executed_blocks.last() {
                 ancestors.push(last_block.trie_data_handle());
             }
+            // Advances gas accounting before durable finalization, safe for the reason documented
+            // at the top of this function. `inc_block` skips any block whose `gas_used` is zero, so
+            // a restart replay does not inflate the per-worker block count.
             gas_accumulator.inc_block(
                 batch.worker_id,
                 canonical_header.gas_used,


### PR DESCRIPTION
## Summary

`execute_consensus_output` advances reward accounting (`RewardsCounter::inc_leader_count`, then a per-block `GasAccumulator::inc_block`) before the output is durably finalized, and it does not rewind those increments on any of its error paths.  A recent review confirmed this ordering is safe by construction, but the reasoning that makes it safe lives entirely in other files (`ExecutorEngine::run`, `catchup_accumulator`, `GasAccumulator::inc_block`) and is invisible at the mutation sites.  A future refactor could therefore break the invariant silently (for example by making an execution error non-fatal, or by "fixing" the in-memory rollback to also revert the accumulator).

This PR records that reasoning as comments at the three relevant points in `payload_builder.rs`.  It is documentation only . . . no behavior, types, or items change.

## Why the ordering is safe (threat model)

The safety is attacker-independent: it rests on two invariants that no external actor can influence.

1. **Halt on error.**  Any error returns from `execute_consensus_output` and halts the engine task in-process, via the `?` on the execution result in `ExecutorEngine::run` (`crates/engine/src/lib.rs:264`).  No later output is processed after an error, so a premature increment can never be consumed downstream.
2. **Rebuild on restart.**  On restart the in-memory accumulator is rebuilt from the finalized tip by `catchup_accumulator` (`crates/node/src/manager/node.rs:190`).  The count/replay boundary lines up exactly with the executed tip: `count_leaders(last_executed_round)` covers rounds at or below the executed tip, and `replay_missed_consensus` re-executes rounds above it, so a not-yet-finalized increment is reconstructed from scratch rather than carried across the restart.  `inc_block` also skips any block whose `gas_used` is zero (`crates/types/src/gas_accumulator.rs:291`), so replay does not inflate per-worker block counts.

The in-memory rollback on the error paths (`rollback_in_memory_output`) deliberately reverts canonical state but not the accumulator.  Adding a compensating decrement there would double-subtract against the restart rebuild, so the comments call that out explicitly at both rollback sites.

## Changes

- `crates/engine/src/payload_builder.rs`:
  - A note at the `inc_leader_count` site explaining the mutate-before-finalize ordering and the two invariants above.
  - A shorter cross-reference at the per-block `inc_block` site, including the `gas_used == 0` skip.
  - A note at each of the two in-memory rollback sites (empty epoch-close block and the batch loop) that the reward-accounting increments already applied for the output are intentionally left in place.

## Verification

Comment-only change with no functional effect.

- `cargo +nightly fmt -- --check` clean (the repo sets `wrap_comments = true` / `comment_width = 100`, so the comments are wrapped by nightly rustfmt).
- `diffclass` classifies the diff as `skip`: the change is comments only and has no compilation impact.
- No new or touched items (these are regular statement comments, not `///` doc comments), so there is no `missing_docs` or clippy surface change.
- Every factual claim in the added comments was re-verified against the cited code at `origin/main` (`84c79ddc`).
