### PR TITLE
test(engine): pin the UnknownAuthority fail-stop for the empty epoch-closing beneficiary lookup

### DIFF
--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -108,6 +108,24 @@ pub fn execute_consensus_output(
         let base_fee_per_gas = canonical_header.base_fee_per_gas.unwrap_or_default();
         let gas_limit = canonical_header.gas_limit;
         let leader = output.leader().author();
+        // INVARIANT: this lookup cannot miss for valid output, and the halt on `None` is a
+        // deliberate fail-safe for impossible state; do NOT replace it with a default
+        // beneficiary. A silent default is chain-consistent (every node computes the same
+        // wrong address from the same state), so nothing downstream would ever detect the
+        // regression. Four legs make the miss unreachable:
+        //   1. `set_committee` runs at every `run_epoch` start before any output is forwarded (both
+        //      the replay and live paths in `crates/node/src/manager/node/run_epoch.rs`).
+        //   2. `close_epoch` blocks on `wait_for_consensus_execution` before returning, so the next
+        //      epoch's `set_committee` cannot overwrite the committee while the closing output is
+        //      still executing.
+        //   3. `RewardsCounter::clear` clears only leader counts, never the committee.
+        //   4. A committed sub-dag leader is a committee member by construction:
+        //      `LeaderSchedule::leader` indexes `committee.authorities()`, and the swap table only
+        //      substitutes members of the same committee.
+        // The fail-stop is pinned by `test_empty_close_epoch_unknown_leader_fail_stops` and
+        // `test_empty_close_epoch_without_committee_fail_stops` (`tests/it/main.rs`), which
+        // mirror the subscriber's own fail-stop for the non-empty path
+        // (`SubscriberError::UnexpectedAuthority`).
         let beneficiary = gas_accumulator
             .get_authority_address(leader)
             .ok_or(TnEngineError::UnknownAuthority(leader.clone()))

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -509,6 +509,237 @@ async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()>
     Ok(())
 }
 
+/// This pins the fail-stop for an empty epoch-closing output whose leader is not a member of
+/// the committee installed on the rewards counter: the engine must terminate with
+/// [`TnEngineError::UnknownAuthority`], build no block, and send no tip update.
+///
+/// The lookup miss is unreachable for valid output (see the invariant comment at the
+/// `get_authority_address` call in `payload_builder.rs`), so this constructs the impossible
+/// state directly and asserts the engine refuses to paper over it with a default beneficiary.
+/// A "graceful default" regression here is chain-consistent (every node computes the same
+/// wrong beneficiary), so no downstream validation would ever catch it; only this test does.
+#[tokio::test]
+async fn test_empty_close_epoch_unknown_leader_fail_stops() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis_with_consensus_registry(4).into());
+    let tmp_dir = TempDir::new().expect("temp dir");
+    // execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.rewards_counter()),
+    )?;
+    // install a real committee so the miss comes from the leader, not an unset committee
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus
+    //
+    // create consensus output with no batches and close_epoch: true, authored by a non-member:
+    // keep the `Certificate::default()` author instead of overwriting it with a committee
+    // member's id (the delta from the happy-path test above)
+    let timestamp = now();
+    let mut leader = Certificate::default();
+    let sub_dag_index = 0;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    // update timestamp so it's not default 0
+    leader.update_header_created_at_for_test(timestamp);
+    let reputation_scores = ReputationScores::default();
+    let previous_sub_dag = None;
+    // the default author is not a committee member; capture it for the error assertion
+    let outside_leader = leader.header().author().clone();
+
+    let subdag = CommittedSubDag::new(
+        vec![leader.clone()],
+        leader,
+        sub_dag_index,
+        reputation_scores,
+        previous_sub_dag,
+    );
+    let consensus_output = ConsensusOutput::new(
+        subdag,
+        ConsensusHeaderDigest::default(),
+        0,
+        true,
+        VecDeque::new(),
+        vec![],
+    );
+
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
+    let reth_env = execution_node.get_reth_env().await;
+    let max_round = None;
+    let genesis_header = chain.sealed_genesis_header();
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let engine = ExecutorEngine::new(
+        reth_env.clone(),
+        max_round,
+        from_consensus,
+        genesis_header.clone(),
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        gas_accumulator,
+        engine_update_tx,
+    );
+
+    // send output
+    let broadcast_result = to_engine.send(consensus_output).await;
+    assert!(broadcast_result.is_ok());
+
+    // drop sending channel so the stream closes after the output is processed
+    drop(to_engine);
+
+    let (tx, rx) = oneshot::channel();
+
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+
+    // spawn engine task
+    task_manager.spawn_task("Test task eng", async move {
+        let res = engine.run().await;
+        let _ = tx.send(res);
+        Ok(())
+    });
+
+    let engine_task = timeout(Duration::from_secs(10), rx).await??;
+    // the engine must fail-stop on the lookup miss, carrying the offending identifier
+    assert_matches!(
+        engine_task,
+        Err(TnEngineError::UnknownAuthority(id)) if id == outside_leader
+    );
+
+    // no tip update may be sent on a lookup miss
+    assert!(
+        engine_update_rx.try_recv().is_err(),
+        "engine must not send an update for a failed epoch-closing output"
+    );
+
+    // no block may be built on a lookup miss
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.last_block_number()?, 0, "no block may be built on a lookup miss");
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    Ok(())
+}
+
+/// This pins the fail-stop for an empty epoch-closing output executed before any committee is
+/// installed on the rewards counter: even a leader that would be a valid committee member must
+/// terminate the engine with [`TnEngineError::UnknownAuthority`], build no block, and send no
+/// tip update.
+///
+/// Companion to [`test_empty_close_epoch_unknown_leader_fail_stops`]: together they pin both
+/// ways the beneficiary lookup can miss (non-member author, committee never set), so replacing
+/// the fail-stop with a silent default beneficiary turns at least one of them red.
+#[tokio::test]
+async fn test_empty_close_epoch_without_committee_fail_stops() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis_with_consensus_registry(4).into());
+    let tmp_dir = TempDir::new().expect("temp dir");
+    // execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.rewards_counter()),
+    )?;
+    // build the committee to obtain a legitimate member id, but never call `set_committee`:
+    // the rewards counter's committee stays `None` (the delta from the happy-path test above)
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+
+    //=== Consensus
+    //
+    // create consensus output with no batches and close_epoch: true, authored by a valid member
+    let timestamp = now();
+    let mut leader = Certificate::default();
+    let sub_dag_index = 0;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    // update timestamp so it's not default 0
+    leader.update_header_created_at_for_test(timestamp);
+    let reputation_scores = ReputationScores::default();
+    let previous_sub_dag = None;
+    leader.update_header_author_for_test(leader_id.clone());
+
+    let subdag = CommittedSubDag::new(
+        vec![leader.clone()],
+        leader,
+        sub_dag_index,
+        reputation_scores,
+        previous_sub_dag,
+    );
+    let consensus_output = ConsensusOutput::new(
+        subdag,
+        ConsensusHeaderDigest::default(),
+        0,
+        true,
+        VecDeque::new(),
+        vec![],
+    );
+
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
+    let reth_env = execution_node.get_reth_env().await;
+    let max_round = None;
+    let genesis_header = chain.sealed_genesis_header();
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let engine = ExecutorEngine::new(
+        reth_env.clone(),
+        max_round,
+        from_consensus,
+        genesis_header.clone(),
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        gas_accumulator,
+        engine_update_tx,
+    );
+
+    // send output
+    let broadcast_result = to_engine.send(consensus_output).await;
+    assert!(broadcast_result.is_ok());
+
+    // drop sending channel so the stream closes after the output is processed
+    drop(to_engine);
+
+    let (tx, rx) = oneshot::channel();
+
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+
+    // spawn engine task
+    task_manager.spawn_task("Test task eng", async move {
+        let res = engine.run().await;
+        let _ = tx.send(res);
+        Ok(())
+    });
+
+    let engine_task = timeout(Duration::from_secs(10), rx).await??;
+    // the engine must fail-stop on the lookup miss, carrying the offending identifier
+    assert_matches!(
+        engine_task,
+        Err(TnEngineError::UnknownAuthority(id)) if id == leader_id
+    );
+
+    // no tip update may be sent on a lookup miss
+    assert!(
+        engine_update_rx.try_recv().is_err(),
+        "engine must not send an update for a failed epoch-closing output"
+    );
+
+    // no block may be built on a lookup miss
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.last_block_number()?, 0, "no block may be built on a lookup miss");
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    Ok(())
+}
+
 /// This tests that leader count is incremented even when execution is skipped
 /// for empty non-epoch-closing output.
 #[tokio::test]


### PR DESCRIPTION
Closes #1034.

## Summary

The empty epoch-closing payload path resolves the block beneficiary through the rewards counter's committee and fail-stops the engine when the lookup misses (`TnEngineError::UnknownAuthority`, `crates/engine/src/payload_builder.rs`).  That halt is a deliberate fail-safe for impossible state, but nothing pinned it: the error variant is produced at exactly one site in the codebase and no test referenced it, so a future "graceful default" refactor (for example `.unwrap_or_default()` on the lookup) would pass the entire suite while deterministically changing the beneficiary of every epoch-closing block.

The regression class needs no attacker: a silent default is chain-consistent, every node computes the same wrong address from the same state, so there is no fork, no validation failure, and nothing downstream ever flags it.  The epoch-closing block's beneficiary is misdirected network-wide, forever.  The only defense is a test that refuses to let the fail-stop disappear, mirroring the subscriber's own fail-stop for the non-empty path (`SubscriberError::UnexpectedAuthority`).

This PR is tests plus a comment.  No behavior change.

## Changes

- [x] `crates/engine/tests/it/main.rs`: `test_empty_close_epoch_unknown_leader_fail_stops` . . . a real committee is installed on the rewards counter, but the output's leader keeps the `Certificate::default()` author (not a member).  Asserts the engine terminates with `Err(TnEngineError::UnknownAuthority(id))` carrying the offending identifier, builds no block (`last_block_number == 0`, canonical tip still genesis, in-memory canonical chain empty), and sends no tip update.
- [x] `crates/engine/tests/it/main.rs`: `test_empty_close_epoch_without_committee_fail_stops` . . . the leader is a legitimate committee member, but `set_committee` is never called (the counter's committee stays `None`).  Same three assertions, pinning the second way the lookup can miss: even a valid member fail-stops when the committee was never installed.
- [x] `crates/engine/src/payload_builder.rs`: invariant comment on the `None` branch recording the four legs that make the miss unreachable for valid output (`set_committee` runs at every `run_epoch` start before any output is forwarded;  `close_epoch` blocks on `wait_for_consensus_execution` so the next epoch's `set_committee` cannot overwrite the committee while the closing output executes;  `RewardsCounter::clear` clears only leader counts, never the committee;  a committed sub-dag leader is a committee member by construction of `LeaderSchedule::leader` and its swap table).  The next reader sees the halt is deliberate, and that "fixing" it with a default is the actual bug.

## Acceptance criteria

- [x] An empty `close_epoch: true` output whose leader misses the committee lookup terminates the engine with `TnEngineError::UnknownAuthority`, builds no block, and sends no tip update;  a test pins each of those three observations for both the leader-not-a-member and committee-never-set variants.
- [x] Both tests were seen to fail under the silent-default mutation and pass on the unmutated tree.
- [x] The `None` branch carries a comment stating the unreachability invariant and the fail-safe intent.
- [x] No behavior change: the diff is tests plus a comment.

## Verification

- `cargo +1.94 test -p tn-engine -j 2`: 13/13 green (12 integration + 1 unit), including the two new tests.  Both tests are deterministic: oneshot result channel under a 10s `timeout` ceiling (the sibling tests' pattern), no sleeps, no wall-clock assertions.
- Confirm-by-mutation: replaced the lookup's `.ok_or(TnEngineError::UnknownAuthority(..)) ... ?` with `.unwrap_or_default()`.  Both new tests went red on the missing-error assertion (`Err(ConsensusOutputStreamClosed)` does not match `Err(TnEngineError::UnknownAuthority(id))`) while the rest of the suite stayed green, which is precisely the gap this PR closes.  Restored the file byte-identically (checksum-verified) and re-ran green.
- `cargo +nightly fmt -- --check` clean;  `cargo +1.94 clippy` clean on the touched crate;  isolated-target `CARGO_TARGET_DIR=.tn-1034-iso cargo +1.94 test --no-run --workspace -j 2` green.
