### PR TITLE
test(metrics): pin the falling-behind alarm trio and certificates_formed_total by  name

### DIFF
--- a/crates/consensus/primary/src/metrics.rs
+++ b/crates/consensus/primary/src/metrics.rs
@@ -212,6 +212,8 @@ mod tests {
         assert!(matches!(value, DebugValue::Counter(1)));
         let (_, _, _, value) = find("tn_primary.votes_received_total");
         assert!(matches!(value, DebugValue::Counter(3)));
+        let (_, _, _, value) = find("tn_primary.certificates_formed_total");
+        assert!(matches!(value, DebugValue::Counter(1)));
         let (_, _, _, value) = find("tn_primary.round");
         assert!(matches!(value, DebugValue::Gauge(g) if g.0 == 17.0));
         let (_, _, _, value) = find("tn_primary.committed_round");
@@ -226,7 +228,8 @@ mod tests {
         assert!(matches!(value, DebugValue::Gauge(g) if g.0 == 123.0));
     }
 
-    /// The mirror task must keep the round gauges in sync with the watch channels.
+    /// The mirror task must keep the round gauges in sync with the watch channels, and
+    /// its synchronous prime must register the consensus-height gauge trio by name.
     #[tokio::test]
     async fn test_bus_metrics_mirror() {
         use tn_types::{Notifier, TaskManager};
@@ -239,7 +242,27 @@ mod tests {
 
         let task_manager = TaskManager::default();
         let shutdown = Notifier::new();
-        spawn_bus_metrics_mirror(&bus, &task_manager.get_spawner(), shutdown.subscribe());
+        // the free-form `gauge!` calls in the prime bind at call time, so the spawn must
+        // also run under the local recorder for the trio to be observable here
+        metrics::with_local_recorder(&recorder, || {
+            spawn_bus_metrics_mirror(&bus, &task_manager.get_spawner(), shutdown.subscribe())
+        });
+
+        // a typo or deletion in `set_consensus_height_gauges` compiles clean; only this
+        // name pin (and the e2e scrape) catches it
+        let primed = snapshotter.snapshot().into_vec();
+        [
+            "tn_node.last_executed_consensus_height",
+            "tn_node.latest_gossip_consensus_height",
+            "tn_node.consensus_sync_distance",
+        ]
+        .iter()
+        .for_each(|name| {
+            assert!(
+                primed.iter().any(|(key, ..)| key.key().name() == *name),
+                "prime must register {name}"
+            );
+        });
 
         bus.primary_round_updates().send_replace(42);
         bus.committed_round_updates().send_replace(40);

--- a/crates/e2e-tests/tests/it/metrics.rs
+++ b/crates/e2e-tests/tests/it/metrics.rs
@@ -101,8 +101,14 @@ fn test_metrics_endpoint_serves_tn_and_reth_metrics() -> eyre::Result<()> {
             "reth_process_cpu_seconds_total",
             // per-crate instrumentation registered on a running validator
             "tn_primary_round",
+            "tn_primary_certificates_formed_total",
             "tn_epoch_current",
             "tn_node_mode{",
+            // the falling-behind alarm trio: free-form gauge! calls, so nothing but
+            // this scrape pins their names against a silent typo or deletion
+            "tn_node_last_executed_consensus_height",
+            "tn_node_latest_gossip_consensus_height",
+            "tn_node_consensus_sync_distance",
             "tn_engine_queued_outputs",
             "tn_worker_batches_sealed_total",
             "tn_batch_builder_base_fee",


### PR DESCRIPTION
Closes #738.

## Summary

Everything #738 asks for landed in #733 (recorder with the selective `tn`/`reth_` prefix installed before the reth DB, `--metrics` serving the endpoint with a fail-hard bind, all nine `tn_<scope>` derives, the watch-channel mirror task, operator docs, dead config removed), but that PR never cross-referenced the issue, so it stayed open. A follow-up audit of `origin/main` found no remaining metric gap . . . with one exception: the two series the issue names most directly are the only load-bearing ones whose *names* no test pins. This PR closes that regression class and the issue with it.

- `tn_node_last_executed_consensus_height` / `tn_node_latest_gossip_consensus_height` / `tn_node_consensus_sync_distance` (the falling-behind alarm) are free-form `gauge!("...")` calls in `set_consensus_height_gauges`, not derive fields. A typo, rename, or deleted line compiles clean and every test stays green.
- `tn_primary_certificates_formed_total` is a derive field, so a field rename silently renames the exported series (the compiler fixes all identifier use sites, including the test's `increment` call) while every dashboard and alert on the old name breaks.

## Changes

- [x] `crates/e2e-tests/tests/it/metrics.rs`: the scrape assertion now pins `tn_primary_certificates_formed_total` and the three `tn_node` consensus-height series end to end (registered on a running validator, rendered by the recorder, served by the endpoint).
- [x] `crates/consensus/primary/src/metrics.rs` (test module only): `test_metrics_register_and_update` pins `tn_primary.certificates_formed_total` by name with its expected count; `test_bus_metrics_mirror` now runs `spawn_bus_metrics_mirror` under the local recorder (the free-form `gauge!` calls bind at call time, so the spawn must run under the recorder for the prime to be observable) and asserts the height trio is registered by the synchronous prime.

No production code changes.

## Testing

`cargo +1.94 test -p tn-primary metrics` (pinned toolchain, `-j 2`): 2/2 green.

Each new pin was confirmed by mutation (the test was seen to fail, then the mutation reverted):

| Mutation (prod code) | Expected failure | Observed |
| --- | --- | --- |
| Typo `tn_node.consensus_sync_distance` -> `...distanc` in `set_consensus_height_gauges` | `test_bus_metrics_mirror` panics `prime must register tn_node.consensus_sync_distance` | FAILED as expected |
| Rename field `certificates_formed_total` -> `certificates_formed_totali` (all identifier sites, string pin untouched) | `test_metrics_register_and_update` panics `metric tn_primary.certificates_formed_total not registered` | FAILED as expected |

e2e: `test_metrics_endpoint_serves_tn_and_reth_metrics` green with the four new expected substrings, plus one mutation run (sync-distance typo) that fails the scrape wait, then reverted.

The Grafana dashboard refresh remains tracked in #930.
