### PR TITLE
consensus: harden always-active assert/expect panics on the commit hot path and startup recovery (defense-in-depth)

### DIFF
--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -1,8 +1,8 @@
 //! Bullshark
 
 use crate::consensus::{
-    utils, ConsensusError, ConsensusInvariant, ConsensusState, Dag, LeaderSchedule, LeaderSwapTable,
-    Outcome,
+    utils, ConsensusError, ConsensusInvariant, ConsensusState, Dag, LeaderSchedule,
+    LeaderSwapTable, Outcome,
 };
 use std::collections::VecDeque;
 use tn_types::{
@@ -244,7 +244,8 @@ impl Bullshark {
             debug!(min_round, "Subdag has {} certificates", num_certificates);
 
             // We resolve the reputation score that should be stored alongside with this sub dag.
-            let reputation_score = self.resolve_reputation_score(state, &sequence, sub_dag_index)?;
+            let reputation_score =
+                self.resolve_reputation_score(state, &sequence, sub_dag_index)?;
 
             let sub_dag: CommittedSubDag = CommittedSubDag::new(
                 sequence,

--- a/crates/consensus/primary/src/consensus/bullshark.rs
+++ b/crates/consensus/primary/src/consensus/bullshark.rs
@@ -1,7 +1,8 @@
 //! Bullshark
 
 use crate::consensus::{
-    utils, ConsensusError, ConsensusState, Dag, LeaderSchedule, LeaderSwapTable, Outcome,
+    utils, ConsensusError, ConsensusInvariant, ConsensusState, Dag, LeaderSchedule, LeaderSwapTable,
+    Outcome,
 };
 use std::collections::VecDeque;
 use tn_types::{
@@ -62,7 +63,7 @@ impl Bullshark {
         state: &mut ConsensusState,
         committed_sequence: &[Certificate],
         sub_dag_index: u64,
-    ) -> ReputationScores {
+    ) -> Result<ReputationScores, ConsensusError> {
         // we reset the scores for every schedule change window, or initialise when it's the first
         // sub dag we are going to create.
         // sub_dag_index is based on epoch and round so / 2 so this check works on commit rounds
@@ -97,10 +98,18 @@ impl Bullshark {
             ((sub_dag_index / 2) + 1).is_multiple_of(self.num_sub_dags_per_schedule as u64);
 
         // Always ensure that all the authorities are present in the reputation scores - even
-        // when score is zero.
-        assert_eq!(reputation_score.total_authorities() as usize, self.committee.size());
-
-        reputation_score
+        // when score is zero. This is a construction invariant: every committed certificate's
+        // origin is committee-checked upstream, so it holds under the `< f` fault assumption.
+        // If a future regression ever breaks it, surface a typed error and shut down cleanly
+        // rather than panicking on the single consensus task.
+        let authorities = reputation_score.total_authorities() as usize;
+        (authorities == self.committee.size()).then_some(reputation_score).ok_or_else(|| {
+            ConsensusInvariant::ReputationAuthorityCount {
+                actual: authorities,
+                expected: self.committee.size(),
+            }
+            .into()
+        })
     }
 
     #[instrument(level = "debug", skip_all, fields(round = certificate.round(), origin = ?certificate.origin()))]
@@ -194,7 +203,7 @@ impl Bullshark {
         let voting_power: VotingPower = state
             .dag
             .get(&(leader_round + 1))
-            .expect("We should have the whole history by now")
+            .ok_or(ConsensusInvariant::MissingLeaderChildRound(leader_round + 1))?
             .values()
             .filter(|(_, x)| x.header().parents().contains(&leader_digest))
             .map(|(_, x)| self.committee.voting_power_by_id(x.origin()))
@@ -212,7 +221,7 @@ impl Bullshark {
         // the last committed leader, and commit all preceding leaders in the right order.
         // Committing a leader block means committing all its dependencies.
         let mut committed_sub_dags = Vec::new();
-        let mut leaders_to_commit = self.order_leaders(leader, state);
+        let mut leaders_to_commit = self.order_leaders(leader, state)?;
 
         while let Some(leader) = leaders_to_commit.pop_front() {
             let sub_dag_index = leader.nonce();
@@ -235,7 +244,7 @@ impl Bullshark {
             debug!(min_round, "Subdag has {} certificates", num_certificates);
 
             // We resolve the reputation score that should be stored alongside with this sub dag.
-            let reputation_score = self.resolve_reputation_score(state, &sequence, sub_dag_index);
+            let reputation_score = self.resolve_reputation_score(state, &sequence, sub_dag_index)?;
 
             let sub_dag: CommittedSubDag = CommittedSubDag::new(
                 sequence,
@@ -281,12 +290,23 @@ impl Bullshark {
     /// Order the past leaders that we didn't already commit. It orders the leaders from the one
     /// of the older (smaller) round to the newest round.
     #[instrument(level = "debug", skip_all, fields(leader_round = leader.round()))]
-    fn order_leaders(&self, leader: &Certificate, state: &ConsensusState) -> VecDeque<Certificate> {
+    fn order_leaders(
+        &self,
+        leader: &Certificate,
+        state: &ConsensusState,
+    ) -> Result<VecDeque<Certificate>, ConsensusError> {
         let mut to_commit = VecDeque::new();
         to_commit.push_front(leader.clone());
 
         let mut leader = leader;
-        assert_eq!(leader.round() % 2, 0);
+        // Leaders are elected only on even rounds. This is a construction invariant of the
+        // schedule; surface a typed error rather than asserting so a regression degrades to a
+        // clean shutdown instead of a bare `assert_eq!` backtrace on the consensus task.
+        leader
+            .round()
+            .is_multiple_of(2)
+            .then_some(())
+            .ok_or(ConsensusInvariant::LeaderRoundNotEven(leader.round()))?;
         for r in (state.last_round.committed_round + 2..=leader.round() - 2).rev().step_by(2) {
             // Get the certificate proposed by the previous leader.
             let (prev_leader, _authority) =
@@ -306,7 +326,7 @@ impl Bullshark {
             }
         }
 
-        to_commit
+        Ok(to_commit)
     }
 
     /// Checks if there is a path between two leaders.

--- a/crates/consensus/primary/src/consensus/mod.rs
+++ b/crates/consensus/primary/src/consensus/mod.rs
@@ -12,7 +12,7 @@ pub use crate::consensus::{
 };
 use thiserror::Error;
 use tn_storage::StoreError;
-use tn_types::{Certificate, HeaderDigest};
+use tn_types::{Certificate, HeaderDigest, Round};
 
 /// The default channel size used in the consensus and subscriber logic.
 pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
@@ -36,6 +36,54 @@ pub enum ConsensusError {
 
     #[error("Parent round not found in DAG for {0:?}!")]
     MissingParentRound(Box<Certificate>),
+
+    /// A Bullshark construction invariant (or a startup-recovery self-consistency
+    /// invariant) did not hold. None of these conditions is reachable under the `< f`
+    /// fault assumption on current `main`; converting the former always-active
+    /// `assert!`/`.expect` panics into this typed error turns a would-be node panic
+    /// (with a low-context backtrace) into a diagnosable, structured shutdown.
+    #[error("Consensus invariant violated: {0}")]
+    Invariant(#[from] ConsensusInvariant),
+}
+
+/// A violated internal construction invariant of the Bullshark commit hot path or of
+/// startup recovery.
+///
+/// Each variant records the operands that disagreed so a future regression is
+/// diagnosable from the error alone, rather than from a bare `assert_eq!` backtrace.
+/// These are defense-in-depth: on current `main` none is reachable under the standard
+/// `< f` Byzantine fault assumption.
+#[derive(Debug, Error)]
+pub enum ConsensusInvariant {
+    /// The reputation-score map did not carry exactly the committee's authorities.
+    #[error("reputation score authority count {actual} does not match committee size {expected}")]
+    ReputationAuthorityCount {
+        /// Number of authorities present in the reputation-score map.
+        actual: usize,
+        /// Number of authorities in the current committee.
+        expected: usize,
+    },
+
+    /// The child round of a committable leader was absent from the in-memory DAG, so
+    /// the leader's support could not be tallied.
+    #[error("missing round {0} in DAG while tallying leader support (expected full history)")]
+    MissingLeaderChildRound(Round),
+
+    /// A leader was elected on an odd round; leaders are only ever elected on even rounds.
+    #[error("leader round {0} is odd (leaders are elected only on even rounds)")]
+    LeaderRoundNotEven(Round),
+
+    /// On startup recovery, the recovered latest sub-dag's leader round did not equal the
+    /// recovered last committed round.
+    #[error(
+        "recovered sub-dag leader round {leader_round} does not equal last committed round {last_committed_round}"
+    )]
+    RecoveredLeaderRoundMismatch {
+        /// Leader round of the recovered latest sub-dag.
+        leader_round: Round,
+        /// Recovered last committed round.
+        last_committed_round: Round,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -1,7 +1,7 @@
 //! The state of consensus
 
 use crate::{
-    consensus::{bullshark::Bullshark, utils::gc_round, ConsensusError},
+    consensus::{bullshark::Bullshark, utils::gc_round, ConsensusError, ConsensusInvariant},
     ConsensusBus, NodeMode,
 };
 use std::{
@@ -305,13 +305,17 @@ impl<DB: Database> Consensus<DB> {
 
         debug!(target: "epoch-manager", ?latest_sub_dag, "recovered latest subdag:");
         if let Some(sub_dag) = &latest_sub_dag {
-            assert_eq!(
-                sub_dag.leader_round(),
-                last_committed_round,
-                "Last subdag leader round {} is not equal to the last committed round {}!",
-                sub_dag.leader_round(),
-                last_committed_round,
-            );
+            // Self-consistency tripwire for recovery. Both operands derive from the same
+            // append-only `ConsensusPack` (a torn tail is reconciled in lockstep at pack open),
+            // so an honest single-node crash cannot tear them apart; this can only fire on an
+            // internal sub-dag construction regression. Surface a typed, recoverable error
+            // instead of aborting recovery with an `assert_eq!` backtrace.
+            (sub_dag.leader_round() == last_committed_round).then_some(()).ok_or_else(|| {
+                ConsensusInvariant::RecoveredLeaderRoundMismatch {
+                    leader_round: sub_dag.leader_round(),
+                    last_committed_round,
+                }
+            })?;
         }
 
         // restore local dag
@@ -467,12 +471,29 @@ impl<DB: Database> Consensus<DB> {
                     .await
                     .map_err(|_| ConsensusError::ShuttingDown)?;
 
-                assert_eq!(self.state.last_round.committed_round, leader_commit_round);
-
-                self.consensus_bus
-                    .app()
-                    .committed_round_updates()
-                    .send_replace(self.state.last_round.committed_round);
+                // Commit-accounting invariant: the last committed round must equal the max
+                // header round we just sequenced. If it ever disagrees, mirror the bogus-sub-dag
+                // handling above (go inactive + shut down cleanly) instead of panicking on the
+                // single consensus task; the notified shutdown ends the run loop on the next
+                // select, so the trailing `Ok(())` is reached without further processing.
+                if self.state.last_round.committed_round == leader_commit_round {
+                    self.consensus_bus
+                        .app()
+                        .committed_round_updates()
+                        .send_replace(self.state.last_round.committed_round);
+                } else {
+                    tracing::error!(
+                        target: "telcoin::consensus_state",
+                        committed_round = self.state.last_round.committed_round,
+                        leader_commit_round,
+                        "commit-accounting invariant violated: last committed round does not match leader commit round; going inactive and shutting down",
+                    );
+                    self.consensus_bus
+                        .app()
+                        .node_mode()
+                        .send_modify(|v| *v = NodeMode::CvvInactive);
+                    self.consensus_config.shutdown().notify();
+                }
             }
         }
         Ok(())

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -55,7 +55,9 @@ async fn order_leaders() {
     let (_, leader) = schedule.leader_certificate(6, &state.dag);
 
     // WHEN
-    let mut ordered_leaders = bullshark.order_leaders(leader.unwrap(), &state);
+    let mut ordered_leaders = bullshark
+        .order_leaders(leader.unwrap(), &state)
+        .expect("order_leaders succeeds for a valid even-round leader");
 
     // THEN
     // we expect all the leaders to be returned in round ascending order
@@ -66,6 +68,54 @@ async fn order_leaders() {
 
     // we expect to have ordered all the 3 leaders
     assert!(expected_leader_rounds.is_empty());
+}
+
+#[tokio::test]
+async fn order_leaders_rejects_odd_round_leader() {
+    // GIVEN a populated DAG (rounds 1..=7) and a Bullshark instance.
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
+    let genesis =
+        Certificate::genesis(&committee).iter().map(|x| x.digest()).collect::<BTreeSet<_>>();
+    let (certificates, _next_parents) =
+        make_optimal_certificates(&committee, 1..=7, &genesis, &ids);
+
+    let gc_depth = 50;
+    let mut state = ConsensusState::new(gc_depth);
+    certificates.iter().for_each(|certificate| {
+        state.try_insert(certificate).unwrap();
+    });
+
+    let schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
+    let bullshark = Bullshark::new(
+        committee,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+        schedule,
+        DEFAULT_BAD_NODES_STAKE_THRESHOLD,
+    );
+
+    // AND an odd-round certificate standing in as a malformed leader. Leaders are only ever
+    // elected on even rounds, so round 5 violates the `order_leaders` construction invariant.
+    let odd_round_leader = state
+        .dag
+        .get(&5)
+        .and_then(|authorities| authorities.values().next())
+        .map(|(_digest, certificate)| certificate.clone())
+        .expect("round 5 certificate exists in the populated DAG");
+    assert_eq!(odd_round_leader.round() % 2, 1);
+
+    // WHEN / THEN the former `assert_eq!(leader.round() % 2, 0)` panic is now a diagnosable
+    // typed error, so the consensus task shuts down cleanly instead of aborting on a backtrace.
+    let err = bullshark.order_leaders(&odd_round_leader, &state).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            ConsensusError::Invariant(ConsensusInvariant::LeaderRoundNotEven(round))
+                if *round == odd_round_leader.round()
+        ),
+        "expected LeaderRoundNotEven typed error, got: {err}",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1043.

## Summary

The consensus commit path and startup recovery contain several always-active (not `debug_assert`) `assert_eq!` / `.expect` panics. Each encodes a genuine internal construction invariant, and under the standard `< f` Byzantine fault assumption none is reachable on current `main`. This PR converts them into structured, diagnosable handling as defense in depth: a would-be node panic (with a low-context backtrace) becomes a typed error and a clean, defined shutdown. There is **no security claim and no change to happy-path consensus behavior**.

## Problem

All of these sites run on the single consensus task, spawned via `spawn_critical_task`. Any resolution of a critical task takes the whole node down, so a panic there is already a node-level event — a panic buys nothing over a clean shutdown, it only costs an unwind and a backtrace that prints two integers and nothing else. A future refactor that breaks one of these construction invariants would turn a diagnosable condition into a hard panic with poor operator diagnostics. The codebase already handles the analogous "this should not happen" case gracefully (the bogus-sub-dag arm in `new_certificate`), so these panics are the inconsistent outliers.

Sites addressed (all on `main` @ `746d59cb`):

- `bullshark.rs` reputation map — `assert_eq!(reputation_score.total_authorities(), committee.size())`
- `bullshark.rs` leader support tally — `.expect("We should have the whole history by now")` on the child round
- `bullshark.rs` `order_leaders` — `assert_eq!(leader.round() % 2, 0)`
- `state.rs` commit accounting — `assert_eq!(last_round.committed_round, leader_commit_round)`
- `state.rs` startup recovery in `Consensus::spawn` — `assert_eq!(sub_dag.leader_round(), last_committed_round, ...)`

The two genuine DB-failure expects (`state.rs` DAG-recovery and database-available) are intentionally fatal and left out of scope per the issue.

## Fix

Two mechanisms, matched to each site's access:

- **`Bullshark` protocol sites** (no node-infra access) return a new typed `ConsensusError::Invariant(ConsensusInvariant::…)` and propagate through the existing `?` chain: `process_certificate → new_certificate → run` returns `Err`, and the `spawn_critical_task` supervisor performs the clean shutdown. The former `assert!`/`.expect` become combinator guards: `.then_some(_).ok_or_else(_)`, `.ok_or(_)?`, `.is_multiple_of(2).then_some(()).ok_or(_)?`.
- **`state.rs` commit-accounting site** sits inside `new_certificate` beside the existing bogus-sub-dag arm, so it mirrors that idiom exactly: on mismatch, `tracing::error!` with the operands, flip `NodeMode::CvvInactive`, `shutdown().notify()`, then fall through to the function's trailing `Ok(())` (the notified shutdown ends the run loop on the next `select`). The happy-path `committed_round_updates().send_replace(…)` moves into the match branch, unchanged.
- **`state.rs` startup site** (`spawn` already returns `Result`) becomes a typed `ConsensusInvariant::RecoveredLeaderRoundMismatch` returned via `?`. This is the weakest case for change (foreclosed on any honest crash — both operands derive from one append-only `ConsensusPack` reconciled in lockstep at pack open), included for completeness so a construction regression degrades to a clear startup error instead of an `assert_eq!` backtrace.

New error type (`mod.rs`), consistent with the existing `thiserror`-based `ConsensusError`:

```rust
pub enum ConsensusInvariant {
    ReputationAuthorityCount { actual: usize, expected: usize },
    MissingLeaderChildRound(Round),
    LeaderRoundNotEven(Round),
    RecoveredLeaderRoundMismatch { leader_round: Round, last_committed_round: Round },
}
```

wrapped by `ConsensusError::Invariant(#[from] ConsensusInvariant)`. Each variant records the disagreeing operands so a regression is diagnosable from the error alone. Doc comments on every new item; no new imperative loops or early `return`s (combinators + `?`); exhaustive matches preserved. `variantscan` confirms the additive variant breaks no existing `match` on `ConsensusError` workspace-wide.

To be explicit and avoid overselling: this does not keep the node running. The benefit is a clean, defined shutdown (`CvvInactive` for the commit site), a diagnosable log, and a typed error instead of a panic and unwind.

## Testing

- Added `order_leaders_rejects_odd_round_leader` (`bullshark_tests.rs`): feeds an odd-round certificate — the exact input the former `assert_eq!(leader.round() % 2, 0)` tripped on — and asserts `order_leaders` returns `ConsensusError::Invariant(ConsensusInvariant::LeaderRoundNotEven(_))`. Non-vacuous by construction: under the old code this input panics inside `order_leaders` (a failing test); under the new code it returns the typed error.
- The existing suite stays green: converting these sites to error-returns / graceful shutdown does not touch any happy-path assertion, and the recoverable `CertificateEquivocation` case is still asserted as a returned `Err`.
- `cargo +1.94 check -p tn-primary --tests` compiles clean (lib + test target); `cargo nextest run -p tn-primary order_leaders` → 2 passed (`order_leaders`, `order_leaders_rejects_odd_round_leader`), 0 failed.

The remaining converted sites (reputation count, missing child round, startup mismatch, and the commit-accounting `CvvInactive` flip) are left without dedicated regression tests: their invariants cannot be violated through the public API without contrived internal-state manipulation, and the sibling bogus-sub-dag graceful arm they mirror is itself untested — so this matches the codebase's existing posture rather than introducing brittle white-box tests.

## Non-goals

Not a security or exploitability claim; under `< f`, none of these panics is known to be reachable on current `main`. No change to happy-path consensus behavior. The two DB-failure expects are out of scope beyond message quality.
