### PR TITLE
tn-reth: make TNExecution's never-driven validator impls fail loudly (#1048)

### DIFF
--- a/crates/tn-reth/src/traits.rs
+++ b/crates/tn-reth/src/traits.rs
@@ -39,17 +39,38 @@ impl NodeTypesWithDB for TelcoinNode {
     type DB = Arc<DatabaseEnv>;
 }
 
-/// Compatibility type to easily integrate with reth.
+/// Compatibility type that stands in for reth's beacon-engine consensus and payload machinery.
 ///
-/// This type is used to noop verify all data. It is not used by Telcoin Network, but is required to
-/// integrate with reth for convenience. TN is mostly EVM/Ethereum types, but with a different
-/// consensus. The traits impl on this type are only used beacon engine, which is not used by TN.
+/// Telcoin Network never drives this machinery: TN runs its own consensus and canonicalizes blocks
+/// directly (see `finish_executing_output` in `lib.rs`), so no header, body, or payload ever flows
+/// through the trait methods below. The impls exist only to satisfy reth's trait bounds when wiring
+/// the RPC stack; they are not part of any driven code path on current `main`.
+///
+/// For that reason every method fails loudly instead of silently accepting (or, for the payload
+/// methods, fabricating) data. None is reachable today, so a call means reth's engine or
+/// validation machinery has been wired to TN by mistake (for example by registering the flashbots
+/// `ValidationApi`, building an auth/engine server, or constructing the engine tree handler).
+/// Returning a descriptive error surfaces that regression at the first call, rather than letting a
+/// skipped check or a fabricated empty block propagate undetected. See issue #1048.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct TNExecution;
 
+/// Build the message for the error every [`TNExecution`] validation method returns.
+///
+/// `method` names the trait method that was reached. The message is wrapped in
+/// [`ConsensusError::Other`] or [`NewPayloadError::Other`] at the call site, so both the consensus
+/// and payload paths share one wording for the "this should never run on TN" invariant.
+fn unreachable_validation(method: &str) -> String {
+    format!(
+        "TNExecution::{method} was called: Telcoin Network never drives reth's beacon-engine \
+         validation or payload conversion, so reaching this path means that machinery was wired to \
+         TN by mistake (see issue #1048)"
+    )
+}
+
 impl<H> HeaderValidator<H> for TNExecution {
     fn validate_header(&self, _header: &SealedHeader<H>) -> Result<(), ConsensusError> {
-        Ok(())
+        Err(ConsensusError::Other(unreachable_validation("validate_header")))
     }
 
     fn validate_header_against_parent(
@@ -57,7 +78,7 @@ impl<H> HeaderValidator<H> for TNExecution {
         _header: &SealedHeader<H>,
         _parent: &SealedHeader<H>,
     ) -> Result<(), ConsensusError> {
-        Ok(())
+        Err(ConsensusError::Other(unreachable_validation("validate_header_against_parent")))
     }
 }
 
@@ -67,11 +88,11 @@ impl<B: Block> Consensus<B> for TNExecution {
         _body: &B::Body,
         _header: &SealedHeader<B::Header>,
     ) -> Result<(), ConsensusError> {
-        Ok(())
+        Err(ConsensusError::Other(unreachable_validation("validate_body_against_header")))
     }
 
     fn validate_block_pre_execution(&self, _block: &SealedBlock<B>) -> Result<(), ConsensusError> {
-        Ok(())
+        Err(ConsensusError::Other(unreachable_validation("validate_block_pre_execution")))
     }
 }
 
@@ -82,13 +103,16 @@ impl<N: NodePrimitives> FullConsensus<N> for TNExecution {
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
     ) -> Result<(), ConsensusError> {
-        Ok(())
+        Err(ConsensusError::Other(unreachable_validation("validate_block_post_execution")))
     }
 }
 
-// Compatibility noop trait impl.
-// This is for the reth rpc build method.
-// NOTE: this should never be called because there is no beacon API
+// Compatibility trait impl for the reth rpc build method.
+//
+// This is never called because TN wires no beacon/engine API. Rather than fabricate a default
+// (empty) block for every payload, `convert_payload_to_block` fails loudly; the trait's default
+// `ensure_well_formed_payload` delegates to it via `?`, so it inherits the same error and no
+// override is needed.
 impl<Types> PayloadValidator<Types> for TNExecution
 where
     Types: PayloadTypes<ExecutionData = ExecutionData>,
@@ -99,14 +123,7 @@ where
         &self,
         _payload: ExecutionData,
     ) -> Result<SealedBlock<Self::Block>, NewPayloadError> {
-        Ok(Default::default())
-    }
-
-    fn ensure_well_formed_payload(
-        &self,
-        _payload: ExecutionData,
-    ) -> Result<RecoveredBlock<Self::Block>, NewPayloadError> {
-        Ok(Default::default())
+        Err(NewPayloadError::Other(unreachable_validation("convert_payload_to_block").into()))
     }
 }
 
@@ -132,5 +149,116 @@ impl PayloadTypes for DefaultEthPayloadTypes {
         let (payload, sidecar) =
             ExecutionPayload::from_block_unchecked(block.hash(), &block.into_block());
         ExecutionData { payload, sidecar }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Each test pins the fail-loud contract of one `TNExecution` validation method: the method
+    //! must return `Err`, and the error must name the method, so a test cannot pass on some
+    //! unrelated error. Confirm-by-mutation: reverting a body to its old `Ok(..)` form reds its
+    //! test; because the deleted `ensure_well_formed_payload` override now delegates to
+    //! `convert_payload_to_block`, reverting that one body reds both payload tests. The tests
+    //! were observed to fail under that reversion, so they pin the property rather than passing
+    //! vacuously.
+    use super::*;
+
+    /// Concrete block type used to source header/body/block fixtures for the generic trait methods.
+    type TestBlock = tn_types::Block;
+
+    /// A default (empty) sealed block; the methods ignore their arguments, so an empty fixture is
+    /// enough to exercise the error path.
+    fn default_block() -> SealedBlock<TestBlock> {
+        SealedBlock::default()
+    }
+
+    /// A minimal [`ExecutionData`], built from an empty block via the crate's own conversion.
+    fn execution_data() -> ExecutionData {
+        DefaultEthPayloadTypes::block_to_payload(default_block())
+    }
+
+    /// Assert that `result` is the fail-loud `Err` whose message names `method`.
+    ///
+    /// Checking the message (not merely `is_err()`) pins each test to the specific error origin:
+    /// the delegation test can only pass on the error raised by `convert_payload_to_block`, not on
+    /// a decoy error from some other fallible leg of the trait default.
+    fn assert_fails_loudly<T, E: std::fmt::Display>(result: Result<T, E>, method: &str) {
+        let marker = format!("TNExecution::{method} was called");
+        assert!(
+            result.err().is_some_and(|error| error.to_string().contains(&marker)),
+            "expected a fail-loud error whose message contains `{marker}`",
+        );
+    }
+
+    #[test]
+    fn validate_header_fails_loudly() {
+        let block = default_block();
+        assert_fails_loudly(TNExecution.validate_header(block.sealed_header()), "validate_header");
+    }
+
+    #[test]
+    fn validate_header_against_parent_fails_loudly() {
+        let block = default_block();
+        let header = block.sealed_header();
+        assert_fails_loudly(
+            TNExecution.validate_header_against_parent(header, header),
+            "validate_header_against_parent",
+        );
+    }
+
+    #[test]
+    fn validate_body_against_header_fails_loudly() {
+        let block = default_block();
+        let result = <TNExecution as Consensus<TestBlock>>::validate_body_against_header(
+            &TNExecution,
+            block.body(),
+            block.sealed_header(),
+        );
+        assert_fails_loudly(result, "validate_body_against_header");
+    }
+
+    #[test]
+    fn validate_block_pre_execution_fails_loudly() {
+        let result = <TNExecution as Consensus<TestBlock>>::validate_block_pre_execution(
+            &TNExecution,
+            &default_block(),
+        );
+        assert_fails_loudly(result, "validate_block_pre_execution");
+    }
+
+    #[test]
+    fn validate_block_post_execution_fails_loudly() {
+        let recovered = RecoveredBlock::<TestBlock>::default();
+        let result = <TNExecution as FullConsensus<TNPrimitives>>::validate_block_post_execution(
+            &TNExecution,
+            &recovered,
+            &BlockExecutionResult::default(),
+            None,
+        );
+        assert_fails_loudly(result, "validate_block_post_execution");
+    }
+
+    #[test]
+    fn convert_payload_to_block_fails_loudly() {
+        let result =
+            <TNExecution as PayloadValidator<DefaultEthPayloadTypes>>::convert_payload_to_block(
+                &TNExecution,
+                execution_data(),
+            );
+        assert_fails_loudly(result, "convert_payload_to_block");
+    }
+
+    #[test]
+    fn ensure_well_formed_payload_inherits_the_error() {
+        // The override was deleted; the trait default delegates to `convert_payload_to_block` via
+        // `?`, so this must surface that method's error rather than a fabricated block. Asserting
+        // on the `convert_payload_to_block` marker (not `ensure_well_formed_payload`) is
+        // deliberate: it is the delegated-to method whose error must propagate.
+        let result =
+            <TNExecution as PayloadValidator<DefaultEthPayloadTypes>>::ensure_well_formed_payload(
+                &TNExecution,
+                execution_data(),
+            );
+        assert_fails_loudly(result, "convert_payload_to_block");
     }
 }


### PR DESCRIPTION
Closes #1048.

## Summary

`TNExecution` (`crates/tn-reth/src/traits.rs`) is a compatibility type that stands in for reth's beacon-engine consensus and payload machinery. Telcoin Network never drives that machinery, so its four trait impls were all no-ops: five `Ok(())` bodies plus a `PayloadValidator` pair that returned `Ok(Default::default())`. The payload pair was the sharp edge . . . it did not merely skip a check, it ignored the payload argument and *manufactured* a default (empty) `SealedBlock` / `RecoveredBlock` for every call, with no error and no log.

This change makes every one of those never-driven bodies fail loudly. There is no behavior change on any driven path (see the unreachability argument below); the point is that if reth's engine or validation machinery is ever wired to TN by mistake, the first call errors out immediately instead of silently accepting, and in one case fabricating, blocks.

## Why this is safe today (no behavior change)

Verified against `origin/main` at `746d59cb`. Nothing reaches these bodies on current `main`, so turning them into errors changes no driven path:

- **No engine-API driver exists.** `TnEngineApiTreeHandler` (`crates/tn-reth/src/lib.rs:217`) is a bare type alias with zero construction sites; there is no `BeaconConsensusEngine`, no forkchoice / `newPayload` handling.
- **The RPC path never calls the validator.** `get_rpc_server` builds `Arc::new(TNExecution)` and hands it to reth's `RpcModuleBuilder::with_consensus` (`lib.rs:1210`, `1217`). In the pinned reth (v1.11.3) that consensus value is consumed only by the flashbots `ValidationApi`, and TN cannot register it: the module whitelist is `{Eth, Net, Web3, Debug, Trace, Rpc}` and the engine namespace is auth-server-only, with no auth server ever built.
- **Canonicalization never consults a validator.** `finish_executing_output` (`lib.rs`) commits blocks and broadcasts canonical state by hand, bypassing reth's tree path.
- **`convert_payload_to_block` / `ensure_well_formed_payload` have zero call sites** repo-wide; a search for `TNExecution` finds only the type alias and the RPC construction, neither of which invokes a method.

The impls exist only to satisfy reth's trait bounds. Reth's own structurally identical `NoopConsensus` is doc-marked "Not for production use"; hardening these bodies gives the same guarantee here, enforced by the compiler and a test rather than by a comment.

## Changes

`crates/tn-reth/src/traits.rs` only:

- [x] All five consensus methods (`HeaderValidator::validate_header` / `validate_header_against_parent`, `Consensus::validate_body_against_header` / `validate_block_pre_execution`, `FullConsensus::validate_block_post_execution`) now return `Err(ConsensusError::Other(..))` with a message naming the method and the invariant it violated.
- [x] `PayloadValidator::convert_payload_to_block` now returns `Err(NewPayloadError::Other(..))` instead of fabricating `Ok(Default::default())`.
- [x] The `ensure_well_formed_payload` override is deleted. Reth's `PayloadValidator` provides a default that delegates to `convert_payload_to_block` via `?`, so it inherits the same error automatically . . . one fewer stub to keep honest.
- [x] One shared private helper, `unreachable_validation(method)`, builds the message so the consensus and payload paths share a single wording.
- [x] The type's doc comment is rewritten to state the fail-loud contract and why the paths are unreachable; the stale `PayloadValidator` block comment is updated.

Both error variants (`ConsensusError::Other(String)`, `NewPayloadError::Other(Box<dyn Error + Send + Sync>)`) already exist in the pinned reth, so there are no reth-side or dependency changes.

## Testing

`cargo test -p tn-reth --lib traits::tests` on the pinned 1.94 toolchain. Seven unit tests, one per method, construct `TNExecution`, call the method with a minimal empty-block fixture, and assert the returned error message names the method (not merely `is_err()`, so a test cannot pass on some unrelated error). The delegation test asserts on the `convert_payload_to_block` marker specifically, pinning that `ensure_well_formed_payload` propagates the delegated error rather than any other fallible leg of reth's trait default. They are plain trait-method calls (no node, no swarm), deterministic, and panic-free.

Each test was confirmed by mutation: reverting all six bodies to their old `Ok(..)` form (with the `ensure_well_formed_payload` override still removed) turned all seven tests red, including `ensure_well_formed_payload_inherits_the_error`, which fails when `convert_payload_to_block` is reverted . . . proving that test exercises the default-delegation rather than passing vacuously. Restoring the fix returns the suite to green.

The existing suite stays green by the unreachability argument above: no driven path calls these methods, so no prior test observed their return value.

## Non-goals

- No security or exploitability claim. Nothing reaches these bodies on current `main`, and this change does not alter that.
- No change to how blocks are actually validated or canonicalized on Telcoin Network. `finish_executing_output` and the consensus pipeline are untouched.
- The optional deeper cleanup (deleting the unused `TnEngineApiTreeHandler` alias, `DefaultEthPayloadTypes`, and the `PayloadValidator` impl outright, which the compiler would then allow) is deferred: the alias may be intentionally retained as integration documentation, and the fail-loud bodies stand on their own.
