### PR TITLE
tn-reth: seed reth's txpool defaults so an explicit --txpool.max-account-slots 16 is honored

### DIFF
--- a/bin/telcoin-network/src/main.rs
+++ b/bin/telcoin-network/src/main.rs
@@ -1,13 +1,15 @@
 //! Main binary for TN CLI
 
-use telcoin_network_cli::{cli::Cli, passphrase::get_bls_passphrase_from_env};
+use telcoin_network_cli::{cli::Cli, passphrase::get_bls_passphrase_from_env, NoArgs};
 use tn_node::launch_node;
 
 fn main() {
     // Must be the first statement of main: reads and clears TN_BLS_PASSPHRASE
     // before any threads exist (see `get_bls_passphrase_from_env`).
     let preloaded = get_bls_passphrase_from_env();
-    let cli = Cli::parse_args(); // = Cli::<NoArgs>::parse(), cli.rs:77-79
+    // Seeds reth's transaction pool defaults, then parses (see `Cli::parse_args`). The seeding
+    // has to precede the parse: clap resolves `--txpool.max-account-slots` against those defaults.
+    let cli = Cli::<NoArgs>::parse_args();
 
     let passphrase = cli.resolve_bls_passphrase(preloaded).unwrap_or_else(|err| {
         eprintln!("{err}");

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -16,6 +16,8 @@ clap = { workspace = true, features = ["derive", "env"] }
 eyre = { workspace = true }
 tn-config = { workspace = true }
 tn-node = { workspace = true }
+# not dev-only: `src/lib.rs` seeds reth's transaction pool defaults before it parses a node command
+tn-reth = { workspace = true, features = ["test-utils"] }
 tn-types = { workspace = true, features = ["test-utils"] }
 tracing = { workspace = true }
 jsonrpsee = { workspace = true }
@@ -31,7 +33,6 @@ alloy = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
-tn-reth = { workspace = true, features = ["test-utils"] }
 tn-test-utils = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
 use telcoin_network_cli::{genesis::GenesisArgs, keytool::KeyArgs, node::NodeCommand, NoArgs};
 use tn_config::{Config, ConfigFmt, ConfigTrait, KeyConfig};
 use tn_node::launch_node;
+use tn_reth::init_txpool_defaults;
 use tn_types::{test_utils::CommandParser, Address, Genesis, GenesisAccount};
 use tracing::{error, info};
 // unused deps warnings
@@ -294,6 +295,8 @@ pub fn spawn_local_testnet(
             ipc_path: ipc_path_str.clone(),
         });
 
+        // seed reth's pool defaults before the parse resolves `--txpool.max-account-slots`
+        init_txpool_defaults();
         let command = NodeCommand::parse_from([
             "tn",
             "--http",

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -383,7 +383,7 @@ The `admin` and `txpool` modules are not available at this time.
 
 | Flag                         | Default | Description                                                                                |
 | ---------------------------- | ------- | ------------------------------------------------------------------------------------------ |
-| `--txpool.max-account-slots` | `256`   | Max pending transactions per sender (Reth default is 16; Telcoin Network overrides to 256) |
+| `--txpool.max-account-slots` | `256`   | Max pending transactions per sender. Telcoin Network raises Reth's default of 16 to 256; any explicit value is honored, including 16 |
 
 ## Networking
 

--- a/crates/telcoin-network-cli/src/cli.rs
+++ b/crates/telcoin-network-cli/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 use std::{ffi::OsString, fmt, path::PathBuf, str::FromStr};
 use tn_config::KeyConfig;
 use tn_node::engine::TnBuilder;
-use tn_reth::{dirs::DEFAULT_ROOT_DIR, LogArgs};
+use tn_reth::{dirs::DEFAULT_ROOT_DIR, init_txpool_defaults, LogArgs};
 use tokio::{runtime::Builder, task::JoinHandle};
 use tracing::info_span;
 
@@ -72,23 +72,30 @@ pub struct Cli<Ext: clap::Args + fmt::Debug = NoArgs> {
     pub logs: LogArgs,
 }
 
-impl Cli {
+impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     /// Parsers only the default CLI arguments
+    ///
+    /// Seeds reth's transaction pool defaults first: the clap default for
+    /// `--txpool.max-account-slots` is resolved while the command is built, so seeding after the
+    /// parse would be too late. Prefer this over [`clap::Parser::parse`] for that reason, and note
+    /// that it is generic over `Ext` so an extended binary gets the same defaults as `tn` itself.
     pub fn parse_args() -> Self {
+        init_txpool_defaults();
         Self::parse()
     }
 
     /// Parsers only the default CLI arguments from the given iterator
+    ///
+    /// Seeds reth's transaction pool defaults first, for the same reason as [`Self::parse_args`].
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        Cli::try_parse_from(itr)
+        init_txpool_defaults();
+        Self::try_parse_from(itr)
     }
-}
 
-impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     /// Execute the configured cli command.
     ///
     /// This accepts a closure that is used to launch the node via the
@@ -100,7 +107,6 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     /// Parse additional CLI arguments for the node command and use it to configure the node.
     ///
     /// ```no_run
-    /// use clap::Parser;
     /// use telcoin_network_cli::{cli::Cli, passphrase::get_bls_passphrase_from_env};
     /// use tn_node::launch_node;
     ///
@@ -114,7 +120,9 @@ impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     ///
     /// // 1. Read (and clear) TN_BLS_PASSPHRASE before any threads exist.
     /// let preloaded = get_bls_passphrase_from_env();
-    /// let cli = Cli::<MyArgs>::parse();
+    /// // `parse_args` rather than `clap::Parser::parse`: it seeds reth's transaction pool
+    /// // defaults, which must happen before the clap command resolves its own defaults.
+    /// let cli = Cli::<MyArgs>::parse_args();
     /// // 2. Resolve the passphrase for the parsed subcommand.
     /// let passphrase = cli.resolve_bls_passphrase(preloaded)?;
     /// // 3. Run, installing ExExes on the builder before launching the node.
@@ -225,7 +233,7 @@ mod tests {
 
     #[test]
     fn parse_color_mode() {
-        let tn = Cli::try_parse_args_from(["tn", "node", "--color", "always"]).unwrap();
+        let tn = Cli::<NoArgs>::try_parse_args_from(["tn", "node", "--color", "always"]).unwrap();
         assert_eq!(tn.logs.color, ColorMode::Always);
     }
 
@@ -241,7 +249,7 @@ mod tests {
     fn test_parse_help_all_subcommands() {
         let tn = Cli::<NoArgs>::command();
         for sub_command in tn.get_subcommands() {
-            let err = Cli::try_parse_args_from(["tn", sub_command.get_name(), "--help"])
+            let err = Cli::<NoArgs>::try_parse_args_from(["tn", sub_command.get_name(), "--help"])
                 .err()
                 .unwrap_or_else(|| {
                     panic!("Failed to parse help message {}", sub_command.get_name())
@@ -256,7 +264,7 @@ mod tests {
     /// Tests that the log directory is parsed correctly.
     #[test]
     fn parse_logs_path() {
-        let tn = Cli::try_parse_args_from(["tn", "node"]).unwrap();
+        let tn = Cli::<NoArgs>::try_parse_args_from(["tn", "node"]).unwrap();
         let log_dir = tn.logs.log_file_directory;
 
         // let end = format!("{}/logs", DEFAULT_ROOT_DIR);
@@ -290,7 +298,7 @@ mod tests {
         // Create config files or the run() below will fail.
         Config::load_or_default(&temp_dir.path().to_path_buf(), true, "test").unwrap();
         std::env::set_var("RUST_LOG", "info,evm=debug");
-        let tn = Cli::try_parse_args_from([
+        let tn = Cli::<NoArgs>::try_parse_args_from([
             "tn",
             "node",
             "--datadir",

--- a/crates/telcoin-network-cli/tests/txpool_defaults.rs
+++ b/crates/telcoin-network-cli/tests/txpool_defaults.rs
@@ -1,0 +1,82 @@
+//! Pins how `--txpool.max-account-slots` resolves.
+//!
+//! Reth reads the clap default for that flag out of a process-wide `OnceLock` whose first read
+//! fixes it for the life of the process, so these assertions only mean something in a process
+//! where nothing built a clap command before the seeding call. That is why they live in their own
+//! integration test binary rather than beside the other CLI tests: every test here seeds the same
+//! value before it parses, so any interleaving of these tests yields the same lock contents, while
+//! a sibling in the library test binary (`Cli::command()` in `test_parse_help_all_subcommands`,
+//! for one) could take the lock first and make the default-value assertion vacuous.
+
+#![allow(unused_crate_dependencies)]
+
+use telcoin_network_cli::{
+    cli::{Cli, Commands},
+    NoArgs,
+};
+use tn_reth::TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER;
+
+/// Reth's own per-sender slot default, which TN's default replaces.
+///
+/// Hard-coded rather than imported so the test still fails if TN's default is ever changed to
+/// coincide with reth's, which would silently make the "explicit 16" case indistinguishable from
+/// an unset flag again.
+const RETH_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
+
+/// Parse a node command and report the per-sender slot limit it resolved to.
+///
+/// Goes through the crate's own parse entry point rather than seeding the defaults directly, so
+/// these tests also fail if that entry point ever stops seeding them.
+fn resolved_max_account_slots(args: &[&str]) -> Option<usize> {
+    let cli = Cli::<NoArgs>::try_parse_args_from(args).ok()?;
+    match cli.command {
+        Commands::Node(node) => Some(node.reth.txpool.max_account_slots),
+        Commands::Db(_) | Commands::Genesis(_) | Commands::Keytool(_) => None,
+    }
+}
+
+/// With the flag absent, the operator gets Telcoin Network's raised default.
+#[test]
+fn absent_flag_resolves_to_tn_default() {
+    assert_eq!(
+        resolved_max_account_slots(&["tn", "node"]),
+        Some(TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)
+    );
+}
+
+/// An explicit reth-standard 16 is honored rather than promoted to the TN default.
+///
+/// This is the case that regressed: while the TN default was applied by comparing the parsed value
+/// against reth's default constant, an operator-supplied 16 was indistinguishable from an unset
+/// flag and was silently rewritten to 256.
+#[test]
+fn explicit_reth_default_is_honored() {
+    assert_eq!(
+        resolved_max_account_slots(&["tn", "node", "--txpool.max-account-slots", "16"]),
+        Some(RETH_MAX_ACCOUNT_SLOTS_PER_SENDER)
+    );
+}
+
+/// The underscore alias reaches the same value as the dashed form.
+#[test]
+fn explicit_reth_default_is_honored_via_alias() {
+    assert_eq!(
+        resolved_max_account_slots(&["tn", "node", "--txpool.max_account_slots", "16"]),
+        Some(RETH_MAX_ACCOUNT_SLOTS_PER_SENDER)
+    );
+}
+
+/// A value that never collided with either default keeps working.
+#[test]
+fn explicit_other_value_is_honored() {
+    assert_eq!(
+        resolved_max_account_slots(&["tn", "node", "--txpool.max-account-slots", "32"]),
+        Some(32)
+    );
+}
+
+/// The two defaults must stay distinct, or the flag cannot express reth's value.
+#[test]
+fn tn_default_differs_from_reth_default() {
+    assert_ne!(TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, RETH_MAX_ACCOUNT_SLOTS_PER_SENDER);
+}

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -6,7 +6,7 @@ use std::{path::Path, str::FromStr, sync::Arc};
 use telcoin_network_cli::{node::NodeCommand, NoArgs};
 use tn_config::Config;
 use tn_node::engine::{ExecutionNode, TnBuilder};
-use tn_reth::{RethChainSpec, RethCommand, RethConfig, RethEnv};
+use tn_reth::{init_txpool_defaults, RethChainSpec, RethCommand, RethConfig, RethEnv};
 use tn_types::{
     gas_accumulator::RewardsCounter, Address, TaskManager, TimestampSec, Withdrawals, B256,
 };
@@ -64,7 +64,9 @@ fn execution_builder<CliExt: clap::Args + fmt::Debug>(
         default_args.to_vec()
     };
 
-    // use same approach as telcoin-network binary
+    // use same approach as telcoin-network binary, including seeding reth's pool defaults before
+    // the parse resolves `--txpool.max-account-slots`
+    init_txpool_defaults();
     let command = NodeCommand::<CliExt>::try_parse_from(cli_args)?;
 
     let NodeCommand { instance, ext, reth, healthcheck, .. } = command;

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -46,9 +46,9 @@ use jsonrpsee::Methods;
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use reth::{
     args::{
-        DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, DiscoveryArgs, EngineArgs, EraArgs,
-        EraSourceArgs, MetricArgs, NetworkArgs, PayloadBuilderArgs, PruningArgs, StaticFilesArgs,
-        StorageArgs, TxPoolArgs,
+        DatabaseArgs, DatadirArgs, DebugArgs, DefaultTxPoolValues, DevArgs, DiscoveryArgs,
+        EngineArgs, EraArgs, EraSourceArgs, MetricArgs, NetworkArgs, PayloadBuilderArgs,
+        PruningArgs, StaticFilesArgs, StorageArgs, TxPoolArgs,
     },
     builder::NodeConfig,
     network::transactions::{
@@ -98,9 +98,7 @@ use reth_revm::{
     db::{states::bundle_state::BundleRetention, BundleState},
     DatabaseCommit, State,
 };
-use reth_transaction_pool::{
-    blobstore::DiskFileBlobStore, EthTransactionPool, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-};
+use reth_transaction_pool::{blobstore::DiskFileBlobStore, EthTransactionPool};
 use rpc_server_args::RpcServerArgs;
 use serde_json::Value;
 use std::{
@@ -274,6 +272,50 @@ pub struct RethCommand {
     pub db: DatabaseArgs,
 }
 
+/// Telcoin Network's per-sender transaction pool slot default.
+///
+/// Reth's own default is 16 (`TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`). The limit is an
+/// admission-time anti-spam gate: once a sender already holds this many slots pool-wide, reth
+/// rejects further externally-submitted transactions from it. TN raises the default because
+/// its expected traffic is dominated by a small number of high-volume senders.
+///
+/// This is a default, not a floor. Operators override it with `--txpool.max-account-slots`,
+/// including back down to reth's 16.
+pub const TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 256;
+
+/// Seed reth's global transaction pool defaults with [`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`].
+///
+/// Must run before any [`TxPoolArgs`] is parsed or default-constructed. Reth resolves the
+/// `--txpool.max-account-slots` clap default out of a process-wide `OnceLock`, and the first
+/// read of that lock fixes it for the life of the process, so a late call cannot take effect.
+/// Both the clap default and `TxPoolArgs::default()` read it.
+///
+/// Seeding is what makes an explicit `--txpool.max-account-slots 16` reachable: the value clap
+/// injects when the flag is absent becomes 256, so an operator-supplied 16 is no longer
+/// indistinguishable from an unset flag and needs no sentinel to detect.
+///
+/// Idempotent, and safe to call from more than one entry point. A call that loses the race, or
+/// that arrives after some other code has already read the lock, warns only when the effective
+/// default actually differs from TN's, so repeat calls are silent.
+pub fn init_txpool_defaults() {
+    if DefaultTxPoolValues::default()
+        .with_max_account_slots(TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)
+        .try_init()
+        .is_err()
+    {
+        // The lock is already taken, so reading it back cannot change the outcome.
+        let effective = TxPoolArgs::default().max_account_slots;
+        if effective != TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER {
+            warn!(
+                target: "tn::reth",
+                effective,
+                expected = TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+                "reth transaction pool defaults already initialized; TN per-sender slot default not applied"
+            );
+        }
+    }
+}
+
 /// A wrapper abstraction around a Reth node config.
 #[derive(Clone, Debug)]
 pub struct RethConfig(NodeConfig<RethChainSpec>);
@@ -329,13 +371,10 @@ impl RethConfig {
     ) -> Self {
         // create a reth DatadirArgs from tn datadir
         let datadir = path_to_datadir(datadir.as_ref());
-        let RethCommand { mut rpc, mut txpool, db } = reth_config;
-
-        // TN default: 256 slots per sender (Reth default is 16).
-        // Only apply if user hasn't explicitly set a custom value via --txpool.max-account-slots.
-        if txpool.max_account_slots == TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER {
-            txpool.max_account_slots = 256;
-        }
+        // TN's per-sender slot default is seeded into reth's global pool defaults by
+        // `init_txpool_defaults` before parsing, so `txpool` already carries either that default
+        // or the operator's explicit value. Nothing to override here.
+        let RethCommand { mut rpc, txpool, db } = reth_config;
 
         Self::validate_rpc_modules(&mut rpc.http_api);
         Self::validate_rpc_modules(&mut rpc.ws_api);
@@ -1446,6 +1485,12 @@ impl RethEnv {
         /// (reth pairs its 8 TB default with a 4 GiB step; mirror reth's `test()` 4 MiB step).
         const TEMP_CHAIN_DB_GROWTH_STEP: usize = 4 * 1024 * 1024; // 4 MiB
 
+        // `NodeConfig::default` reads reth's process-wide pool defaults through
+        // `TxPoolArgs::default`, which locks them. Seed first so a temp chain built before any
+        // command is parsed does not fix the per-sender slot default at reth's 16 for the rest of
+        // the process, which would then also apply to every node parsed later.
+        init_txpool_defaults();
+
         let node_config = NodeConfig {
             datadir: DatadirArgs {
                 datadir: MaybePlatformPath::from(db_path.as_ref().to_path_buf()),
@@ -2480,6 +2525,40 @@ mod tests {
         BlsSignature, Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput,
         Encodable2718 as _, NodeP2pInfo, ReputationScores, SignatureVerificationState,
     };
+
+    /// Reth's own per-sender slot default, spelled out rather than imported.
+    ///
+    /// Hard-coding it keeps the assertion below honest if TN's default is ever changed to
+    /// coincide with reth's, which is the condition that made 16 unreachable in the first place.
+    const RETH_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 16;
+
+    /// An operator-supplied per-sender slot limit must reach the node config untouched.
+    ///
+    /// [`RethConfig::new`] used to raise reth's default to TN's by sentinel equality against
+    /// reth's constant, so an explicit `--txpool.max-account-slots 16` was indistinguishable from
+    /// an absent flag and was silently rewritten to 256. The default now arrives through
+    /// [`init_txpool_defaults`], leaving nothing for this function to override. Restoring that
+    /// guard fails this test.
+    ///
+    /// Only the explicit case is asserted here. What an *absent* flag resolves to depends on
+    /// which test in this binary reached reth's process-wide `OnceLock` first, so it is pinned in
+    /// the `telcoin-network-cli` integration test that owns its process instead.
+    #[test]
+    fn explicit_max_account_slots_survives_reth_config_new() {
+        assert_ne!(TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER, RETH_MAX_ACCOUNT_SLOTS_PER_SENDER);
+
+        let tmp_dir = TempDir::new().expect("tempdir created");
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let reth_command = RethCommand::parse_from([
+            "tn",
+            "--txpool.max-account-slots",
+            &RETH_MAX_ACCOUNT_SLOTS_PER_SENDER.to_string(),
+        ]);
+
+        let config = RethConfig::new(reth_command, None, tmp_dir.path(), true, chain);
+
+        assert_eq!(config.0.txpool.max_account_slots, RETH_MAX_ACCOUNT_SLOTS_PER_SENDER);
+    }
 
     /// Helper function for creating a consensus output for tests.
     fn consensus_output_for_tests(


### PR DESCRIPTION
Closes #1050.

## Problem

`--txpool.max-account-slots 16` was silently promoted to 256, so reth's own per-sender slot value was unreachable from the CLI.  No input produced an effective limit of 16, while 15 and 17 both worked, and the operator got no warning and no way to observe the substitution.

`max_account_slots` is not cosmetic.  It is reth's admission-time per-sender spam gate, enforced in `AllTransactions::ensure_valid`, which rejects an incoming external transaction once its sender already holds that many slots pool-wide.  The delta an operator silently lost is 16x: roughly 40 senders saturate the 10,000 transaction pending subpool at 256 slots, against roughly 625 at 16.  This is operator-facing only.  It is not remotely triggerable and it is not an unbounded-growth issue, since the global subpool caps bound the pool regardless.

## Root cause

`RethConfig::new` decided "the operator did not set this flag" by comparing the parsed value against reth's default constant:

```rust
if txpool.max_account_slots == TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER {
    txpool.max_account_slots = 256;
}
```

That constant is exactly what clap injects when the flag is absent (`default_value_t = DefaultTxPoolValues::get_global().max_account_slots`, reth `crates/node/core/src/args/txpool.rs:330`).  `TxPoolArgs::max_account_slots` is a bare `usize`, not an `Option`, so the parsed struct carries no "was this set" bit, and `RethConfig::new` receives only the already-parsed struct.  The predicate the comment promised was not recoverable at that point.

## Fix

Move the override from after the parse to before it, so the default reth injects is already TN's and an explicit value never has to be distinguished from an absent one.

- [x] `crates/tn-reth/src/lib.rs`: add `TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER` (256) and `init_txpool_defaults`, which seeds reth's process-wide `OnceLock` via `DefaultTxPoolValues::try_init`.  `try_init` consumes `self` and returns `Result<(), Self>`, so the late-init path is logged rather than unwrapped, per the no-`unwrap`/`expect` convention.  The warning fires only on an actual mismatch, so repeat calls are silent.
- [x] `crates/tn-reth/src/lib.rs`: delete the sentinel block in `RethConfig::new`.  Without this the seeding is inert, because the sentinel would then rewrite an explicit 16 and nothing else.
- [x] `crates/tn-reth/src/lib.rs`: seed in `RethEnv::new_for_temp_chain`.  Its `..NodeConfig::default()` reaches the same `OnceLock` through `TxPoolArgs::default`, so a temp chain built first (the genesis ceremony does exactly this) would otherwise lock the default at 16 for the rest of the process and make every later seeding call a no-op.  This is the one part of the change that is load-bearing but not obvious from the flag's name.
- [x] `crates/telcoin-network-cli/src/cli.rs`: seed in `parse_args` and `try_parse_args_from`, and move both onto the generic `impl<Ext> Cli<Ext>`.  On `impl Cli` they covered only `Cli<NoArgs>`, which would have left the crate's own documented ExEx extension path (`Cli::<MyArgs>::parse()`) resolving to 16 once the sentinel was gone.  The doc example now uses `parse_args`.  In-tree callers gain a `::<NoArgs>` turbofish.
- [x] `crates/test-utils/src/execution.rs`, `crates/e2e-tests/src/lib.rs`: seed before each harness parses a `NodeCommand`, so tests configure nodes the way the binary does.  `tn-reth` moves from dev-dependencies to dependencies in `e2e-tests` because `src/lib.rs` now needs it.
- [x] `crates/telcoin-network-cli/README.md`: the documented row now says an explicit value is honored, including 16.

Side effect worth naming in review: `RethEnv::new_for_temp_chain` previously ran with reth's 16 while the CLI path ran with 256, because it never reached the sentinel.  Seeding makes the two agree at 256.

Not addressed here, and deliberately so: this does not contest the 256 default itself, which is a design decision.  It contests only that the flag documented to override it could not express one of its values.

## Testing

Worktree `1050-txpool-seed-reth-pool-defaults` off `origin/main` 746d59cb.

- `cargo +nightly-2026-03-20 fmt -- --check` . . . clean.
- `cargo +nightly-2026-03-20 clippy -p telcoin-network -p telcoin-network-cli -p tn-reth -p tn-test-utils -p e2e-tests -- -D warnings`, default features and `--all-features` . . . 0 errors, 0 warnings.  This matches attest's clippy scope (no `--all-targets`).
- `cargo test -p telcoin-network-cli` . . . 53 passed, 0 failed.  `cargo test -p tn-reth --lib` . . . 65 passed, 0 failed.  `cargo test -p telcoin-network-cli --doc` . . . 1 passed, which compile-checks the edited `Cli::run` example.

New tests:

- `crates/telcoin-network-cli/tests/txpool_defaults.rs` pins all four rows of the table in the issue: absent flag resolves to 256, explicit `16` resolves to 16, the `--txpool.max_account_slots` alias form resolves to 16, and `32` resolves to 32.  It gets its own integration test binary on purpose.  The seeding is a process-wide `OnceLock`, and a sibling in the library test binary (`Cli::command()` in `test_parse_help_all_subcommands`) would take the lock first and make the default-value assertion vacuous.  Every test in this binary seeds the same value, so any interleaving yields the same lock contents under both `cargo test` and `nextest`.
- `crates/tn-reth/src/lib.rs` pins that `RethConfig::new` passes an explicit value through untouched.  This one asserts only the explicit case, which is independent of who reached the `OnceLock` first, so it is order-safe in a shared test binary.

Each was confirmed by mutation, seen to fail before being restored:

1. Restoring the sentinel block in `RethConfig::new` failed `explicit_max_account_slots_survives_reth_config_new` with `left: 256, right: 16`.
2. Removing `init_txpool_defaults()` from `Cli::try_parse_args_from` failed `absent_flag_resolves_to_tn_default` with `left: Some(16), right: Some(256)`.
3. Removing `#![allow(unused_crate_dependencies)]` from the new test root raised 29 `unused_crate_dependencies` errors under `-D warnings`, confirming the attribute (which every other test root in the repo carries) is required rather than decorative.

`make attest` was not run end to end here, since it requires a clean tree and submits an on-chain transaction.  Its local gates are green as listed above.
