### PR TITLE
gateway: recover the JSON-RPC id without building a Value tree

### DIFF
--- a/bin/worker-gateway/src/error.rs
+++ b/bin/worker-gateway/src/error.rs
@@ -5,10 +5,16 @@
 //! object rather than a bare connection reset, so clients see a structured
 //! failure they can handle.
 
+use std::{borrow::Cow, fmt};
+
 use axum::{
     body::Body,
     http::{header, HeaderValue, StatusCode},
     response::Response,
+};
+use serde::{
+    de::{IgnoredAny, MapAccess, Visitor},
+    Deserialize, Deserializer,
 };
 use serde_json::{json, Value};
 
@@ -145,7 +151,17 @@ impl GatewayError {
 
 /// Render `err` as a JSON-RPC 2.0 error response, echoing the request `id`
 /// recovered from `request_body` when possible (otherwise `null`, per spec).
+///
+/// A caller that has already parsed the body for its own reasons should take
+/// the id from that parse and call [`error_response_with_id`] instead, rather
+/// than paying for a second parse of the same bytes here.
 pub(crate) fn error_response(err: &GatewayError, request_body: &[u8]) -> Response {
+    error_response_with_id(err, RequestId::recover(request_body))
+}
+
+/// Render `err` as a JSON-RPC 2.0 error response echoing an `id` the caller has
+/// already recovered.
+pub(crate) fn error_response_with_id(err: &GatewayError, id: RequestId) -> Response {
     // Every gateway-side rejection funnels through here, so this is the single
     // point that records the rejection metric (by reason, plus the `rejected`
     // arm of the request counter).
@@ -154,7 +170,7 @@ pub(crate) fn error_response(err: &GatewayError, request_body: &[u8]) -> Respons
     let body = json!({
         "jsonrpc": "2.0",
         "error": { "code": err.code(), "message": err.message() },
-        "id": recover_id(request_body),
+        "id": id.0,
     });
     // Serialization of this fixed shape cannot fail; keep a defensive fallback.
     let text = serde_json::to_string(&body).unwrap_or_else(|_| {
@@ -173,35 +189,224 @@ pub(crate) fn error_response(err: &GatewayError, request_body: &[u8]) -> Respons
     response
 }
 
-/// Best-effort recovery of the JSON-RPC request `id` for echoing in an error.
+/// The JSON-RPC request `id` echoed back on an error response.
 ///
-/// Only the top-level `id` is read; a batch, malformed, or id-less body yields
-/// `null`.
-fn recover_id(request_body: &[u8]) -> Value {
-    serde_json::from_slice::<Value>(request_body)
-        .ok()
-        .and_then(|value| value.get("id").cloned())
-        .unwrap_or(Value::Null)
+/// `null` is the "no id" case the spec mandates for a request whose id the
+/// server could not read: a batch, a malformed body, or an id-less call.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RequestId(Value);
+
+impl RequestId {
+    /// The top-level `id` of a request the caller has already parsed.
+    ///
+    /// The raw-transaction screen parses the body to decide whether to reject
+    /// it; taking the id from that parse is what keeps the screening reject
+    /// path to a single parse of the request.
+    pub(crate) fn from_request(request: &Value) -> Self {
+        Self(request.get("id").cloned().unwrap_or(Value::Null))
+    }
+
+    /// Best-effort recovery of the top-level `id` from an unparsed body.
+    ///
+    /// Only the `id` member is materialized: every other member deserializes
+    /// into serde's ignored-value sink, which skips it in place. A multi-megabyte
+    /// `params` therefore costs a scan of the bytes rather than a `Value` tree
+    /// several times the size of the request.
+    ///
+    /// The whole body is still scanned, deliberately. JSON-RPC does not fix
+    /// member order and clients routinely serialize `id` after a large
+    /// `params`, so recovering from a bounded leading slice would echo `null`
+    /// for well-formed large requests.
+    pub(crate) fn recover(request_body: &[u8]) -> Self {
+        serde_json::from_slice::<IdMember>(request_body)
+            .map(|parsed| Self(parsed.0))
+            .unwrap_or(Self(Value::Null))
+    }
+}
+
+/// Deserialization shim that materializes a request's `id` member and nothing
+/// else. See [`RequestId::recover`].
+struct IdMember(Value);
+
+impl<'de> Deserialize<'de> for IdMember {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(IdMemberVisitor)
+    }
+}
+
+/// Visitor behind [`IdMember`]: walks a request's members, keeps `id`, and
+/// discards the rest without materializing them.
+struct IdMemberVisitor;
+
+impl<'de> Visitor<'de> for IdMemberVisitor {
+    type Value = IdMember;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON-RPC request object")
+    }
+
+    /// Only a JSON object carries a top-level `id`, and this visitor accepts
+    /// nothing else, so a batch (a JSON array) is a type error here rather than
+    /// a body whose first element could masquerade as an `id`.
+    fn visit_map<A: MapAccess<'de>>(self, mut members: A) -> Result<Self::Value, A::Error> {
+        // Every non-`id` member deserializes into serde's ignored-value sink,
+        // which skips it in place: a multi-megabyte `params` costs a scan of the
+        // bytes rather than a `Value` tree several times the size of the input.
+        // A repeated `id` keeps the last occurrence, which is how a full parse
+        // into `Value` resolves a duplicated member.
+        std::iter::from_fn(|| {
+            members.next_key::<Cow<'_, str>>().transpose().map(|member| {
+                member.and_then(|member| match member.as_ref() {
+                    "id" => members.next_value::<Value>().map(Some),
+                    _ => members.next_value::<IgnoredAny>().map(|_| None),
+                })
+            })
+        })
+        .try_fold(Value::Null, |id, member| member.map(|found| found.unwrap_or(id)))
+        .map(IdMember)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The recovered id as a plain `Value`, for comparison against `json!`.
+    fn recovered(request_body: &[u8]) -> Value {
+        RequestId::recover(request_body).0
+    }
+
     #[test]
     fn recovers_numeric_id() {
-        assert_eq!(recover_id(br#"{"jsonrpc":"2.0","method":"eth_chainId","id":7}"#), json!(7));
+        assert_eq!(recovered(br#"{"jsonrpc":"2.0","method":"eth_chainId","id":7}"#), json!(7));
     }
 
     #[test]
     fn recovers_string_id() {
-        assert_eq!(recover_id(br#"{"id":"abc"}"#), json!("abc"));
+        assert_eq!(recovered(br#"{"id":"abc"}"#), json!("abc"));
     }
 
     #[test]
     fn missing_or_malformed_id_is_null() {
-        assert_eq!(recover_id(b"not json"), Value::Null);
-        assert_eq!(recover_id(br#"{"method":"eth_chainId"}"#), Value::Null);
+        assert_eq!(recovered(b"not json"), Value::Null);
+        assert_eq!(recovered(br#"{"method":"eth_chainId"}"#), Value::Null);
+    }
+
+    #[test]
+    fn recovers_an_id_that_trails_a_large_params() {
+        // JSON-RPC does not fix member order and raw-transaction clients
+        // routinely serialize `id` after the payload, so recovery must read
+        // past the whole `params` rather than a leading slice of the body.
+        let payload = "a".repeat(64 * 1024);
+        let body =
+            format!(r#"{{"method":"eth_sendRawTransaction","params":["{payload}"],"id":11}}"#);
+        assert_eq!(recovered(body.as_bytes()), json!(11));
+    }
+
+    #[test]
+    fn batch_body_recovers_null() {
+        // A batch has no top-level id. Gating on the object opener is what stops
+        // serde's struct-from-sequence accommodation from mapping the batch's
+        // first element onto `id`.
+        assert_eq!(recovered(br#"[{"method":"eth_chainId","id":3}]"#), Value::Null);
+    }
+
+    #[test]
+    fn duplicated_id_member_keeps_the_last() {
+        // Last-wins is how a full parse into `Value` resolves a duplicated
+        // member; recovery must not diverge from it on a malformed body.
+        assert_eq!(recovered(br#"{"id":1,"id":2}"#), json!(2));
+    }
+
+    #[test]
+    fn leading_whitespace_does_not_hide_the_id() {
+        assert_eq!(recovered(b"  \n\t{\"id\":4}"), json!(4));
+    }
+
+    #[test]
+    fn trailing_bytes_recover_null() {
+        // The body must be exactly one JSON value; garbage after it is not a
+        // request whose id we can trust.
+        assert_eq!(recovered(br#"{"id":4} trailing"#), Value::Null);
+    }
+
+    #[test]
+    fn parsed_request_yields_its_id() {
+        assert_eq!(RequestId::from_request(&json!({"id": 9, "method": "eth_chainId"})).0, json!(9));
+        assert_eq!(RequestId::from_request(&json!({"method": "eth_chainId"})).0, Value::Null);
+        assert_eq!(RequestId::from_request(&json!([{"id": 9}])).0, Value::Null);
+    }
+
+    #[test]
+    fn recovery_matches_a_full_parse_of_the_body() {
+        // The whole point of the shim is to cost less, not to answer
+        // differently. This pins it against the full-`Value` parse it replaced,
+        // over the shapes where a cheaper reader could plausibly drift:
+        // member order, duplicates, non-object bodies, and malformed input.
+        fn full_parse(request_body: &[u8]) -> Value {
+            serde_json::from_slice::<Value>(request_body)
+                .ok()
+                .and_then(|value| value.get("id").cloned())
+                .unwrap_or(Value::Null)
+        }
+
+        let bodies: [&[u8]; 18] = [
+            br#"{"jsonrpc":"2.0","method":"eth_chainId","id":7}"#,
+            br#"{"id":7,"jsonrpc":"2.0","method":"eth_chainId"}"#,
+            br#"{"method":"eth_sendRawTransaction","params":["0x00"],"id":"tx-1"}"#,
+            br#"{"id":"abc"}"#,
+            br#"{"id":0}"#,
+            br#"{"id":-1}"#,
+            br#"{"id":1.5}"#,
+            br#"{"id":null}"#,
+            br#"{"id":{"nested":[1,2,3]}}"#,
+            br#"{"id":[1,2]}"#,
+            br#"{"id":1,"id":2}"#,
+            br#"{"method":"eth_chainId"}"#,
+            br#"{}"#,
+            br#"[{"method":"eth_chainId","id":3}]"#,
+            b"7",
+            b"\"bare string\"",
+            b"not json",
+            b"",
+        ];
+        bodies.iter().for_each(|body| {
+            assert_eq!(
+                RequestId::recover(body).0,
+                full_parse(body),
+                "{}",
+                String::from_utf8_lossy(body)
+            );
+        });
+    }
+
+    #[test]
+    fn recovering_and_reusing_a_parse_agree() {
+        // The two entry points must not drift: a reject path that reuses its own
+        // parse has to echo exactly what a re-parse of the body would echo.
+        let bodies: [&[u8]; 5] = [
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x00"],"id":"tx-1"}"#,
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x00"],"id":0}"#,
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x00"]}"#,
+            br#"{"id":null}"#,
+            br#"{"id":{"nested":[1,2,3]}}"#,
+        ];
+        bodies.iter().for_each(|body| {
+            let parsed: Value = serde_json::from_slice(body).expect("body parses");
+            assert_eq!(RequestId::recover(body), RequestId::from_request(&parsed), "{body:?}");
+        });
+    }
+
+    #[tokio::test]
+    async fn error_response_with_id_echoes_the_supplied_id() {
+        let response =
+            error_response_with_id(&GatewayError::InvalidTransaction, RequestId(json!("tx-1")));
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.expect("body");
+        let body: Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(body["id"], json!("tx-1"));
+        assert_eq!(body["error"]["code"], json!(-32007));
     }
 
     #[test]

--- a/bin/worker-gateway/src/proxy.rs
+++ b/bin/worker-gateway/src/proxy.rs
@@ -29,7 +29,7 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
-    error::{error_response, GatewayError},
+    error::{error_response, error_response_with_id, GatewayError, RequestId},
     server::AppState,
     telemetry,
 };
@@ -90,10 +90,11 @@ pub(crate) async fn proxy(
 
     // Shallow pre-flight for raw-transaction submissions: reject a payload the
     // worker would also reject (undecodable, or an EIP-4844 blob) before paying
-    // for an upstream round-trip.
-    if let Some(err) = screen_raw_transaction(body.as_ref()) {
+    // for an upstream round-trip. The screen has already parsed the body, so it
+    // hands back the request id rather than leaving it to be re-parsed here.
+    if let Some((err, id)) = screen_raw_transaction(body.as_ref()) {
         warn!(target: "gateway::proxy", ?err, "rejecting eth_sendRawTransaction before forwarding");
-        return error_response(&err, body.as_ref());
+        return error_response_with_id(&err, id);
     }
 
     let Some(rpc_url) = state.readiness.first_ready_rpc_url() else {
@@ -197,17 +198,21 @@ fn classify_error(err: reqwest::Error) -> GatewayError {
 
 /// Shallow pre-flight for `eth_sendRawTransaction`.
 ///
-/// Returns `Some(error)` only when `body` is a single `eth_sendRawTransaction`
-/// call whose raw transaction cannot be decoded, or decodes to an EIP-4844 blob
-/// transaction (which the network does not accept). Every other request —
-/// including batches, other methods, and any structurally-off submission —
-/// returns `None` and is forwarded unchanged.
+/// Returns `Some((error, id))` only when `body` is a single
+/// `eth_sendRawTransaction` call whose raw transaction cannot be decoded, or
+/// decodes to an EIP-4844 blob transaction (which the network does not accept).
+/// Every other request — including batches, other methods, and any
+/// structurally-off submission — returns `None` and is forwarded unchanged.
+///
+/// The `id` rides along with the rejection because deciding it required parsing
+/// the body: returning it spares the response path a second parse of the same
+/// bytes.
 ///
 /// The decode uses the same pooled wire format the worker's RPC accepts and
 /// never recovers the signer, so it cannot reject a transaction the worker
 /// would have accepted (no false rejections); it only front-runs a rejection
 /// the worker would issue anyway.
-fn screen_raw_transaction(body: &[u8]) -> Option<GatewayError> {
+fn screen_raw_transaction(body: &[u8]) -> Option<(GatewayError, RequestId)> {
     // Fast path: skip JSON parsing entirely unless the method name is present.
     if !mentions_send_raw_transaction(body) {
         return None;
@@ -221,16 +226,19 @@ fn screen_raw_transaction(body: &[u8]) -> Option<GatewayError> {
     // A submission whose params are structurally off (missing / not a string)
     // is forwarded so the worker returns its own canonical parameter error.
     let raw_hex = request.get("params").and_then(|params| params.get(0)).and_then(Value::as_str)?;
+    // Read off the parse that got us here; a rejection below must not re-parse
+    // the body just to echo this back.
+    let id = RequestId::from_request(&request);
 
     // From here the payload is unambiguously a raw transaction, so a decode
     // failure is a real rejection rather than a reason to forward.
     let Some(raw) = decode_hex(raw_hex) else {
-        return Some(GatewayError::InvalidTransaction);
+        return Some((GatewayError::InvalidTransaction, id));
     };
     let mut buf = raw.as_slice();
     match PooledTransaction::decode_2718(&mut buf) {
-        Err(_) => Some(GatewayError::InvalidTransaction),
-        Ok(tx) if tx.is_eip4844() => Some(GatewayError::UnsupportedTransactionType),
+        Err(_) => Some((GatewayError::InvalidTransaction, id)),
+        Ok(tx) if tx.is_eip4844() => Some((GatewayError::UnsupportedTransactionType, id)),
         Ok(_) => None,
     }
 }
@@ -261,15 +269,20 @@ mod tests {
             .into_bytes()
     }
 
+    /// The screen's verdict alone, for the cases that do not assert on the id.
+    fn screen_err(body: &[u8]) -> Option<GatewayError> {
+        screen_raw_transaction(body).map(|(err, _)| err)
+    }
+
     #[test]
     fn valid_legacy_transaction_is_forwarded() {
-        assert!(screen_raw_transaction(&send_raw(&format!("[\"{EIP155_LEGACY_TX}\"]"))).is_none());
+        assert!(screen_err(&send_raw(&format!("[\"{EIP155_LEGACY_TX}\"]"))).is_none());
     }
 
     #[test]
     fn undecodable_transaction_is_rejected() {
         // Valid hex, but not a decodable transaction envelope.
-        let err = screen_raw_transaction(&send_raw(r#"["0xdeadbeef"]"#));
+        let err = screen_err(&send_raw(r#"["0xdeadbeef"]"#));
         assert!(matches!(err, Some(GatewayError::InvalidTransaction)));
     }
 
@@ -279,14 +292,46 @@ mod tests {
         // a pooled transaction, so it is rejected rather than forwarded. Real
         // blob submissions decode and hit the `is_eip4844` reject; either way a
         // blob-typed payload never reaches an upstream.
-        let err = screen_raw_transaction(&send_raw(r#"["0x03c0"]"#));
+        let err = screen_err(&send_raw(r#"["0x03c0"]"#));
         assert!(err.is_some());
     }
 
     #[test]
     fn non_hex_param_is_rejected() {
-        let err = screen_raw_transaction(&send_raw(r#"["not-hex"]"#));
+        let err = screen_err(&send_raw(r#"["not-hex"]"#));
         assert!(matches!(err, Some(GatewayError::InvalidTransaction)));
+    }
+
+    #[test]
+    fn rejection_carries_the_id_a_re_parse_would_have_recovered() {
+        // The point of threading the id out of the screen: the client must see
+        // exactly the id that re-parsing the body would have produced, across
+        // every id shape a submission can carry.
+        let bodies = [
+            send_raw(r#"["0xdeadbeef"]"#),
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["not-hex"],"id":"tx-7"}"#.to_vec(),
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xdeadbeef"]}"#
+                .to_vec(),
+            br#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xdeadbeef"],"id":null}"#.to_vec(),
+        ];
+        bodies.iter().for_each(|body| {
+            let (_, id) = screen_raw_transaction(body).expect("rejected");
+            assert_eq!(id, RequestId::recover(body), "{}", String::from_utf8_lossy(body));
+        });
+    }
+
+    #[test]
+    fn rejection_id_survives_a_payload_serialized_before_it() {
+        // `id` after a large `params` is the ordering that rules out recovering
+        // it from a bounded prefix of the body; the reused parse is unaffected.
+        let payload = format!("0xdead{}", "beef".repeat(16 * 1024));
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["{payload}"],"id":31}}"#
+        )
+        .into_bytes();
+        let (err, id) = screen_raw_transaction(&body).expect("rejected");
+        assert!(matches!(err, GatewayError::InvalidTransaction));
+        assert_eq!(id, RequestId::recover(&body));
     }
 
     #[test]

--- a/bin/worker-gateway/src/server.rs
+++ b/bin/worker-gateway/src/server.rs
@@ -479,6 +479,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn screened_transaction_is_rejected_with_the_request_id() {
+        // The screening reject answers from the id its own parse produced; end
+        // to end, the client must still get its id echoed back. The upstream is
+        // marked ready and points at a dead port, so a submission that reached
+        // forwarding would surface as a 502 rather than this 400.
+        let state = test_state(&[upstream("127.0.0.1:1".parse().expect("addr"))]);
+        state.readiness.set_ready(0, true);
+        let (gateway_addr, _shutdown) = spawn(test_router(state)).await;
+
+        let response = Client::new()
+            .post(format!("http://{gateway_addr}/"))
+            .body(
+                r#"{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xdeadbeef"],"id":"tx-77"}"#,
+            )
+            .send()
+            .await
+            .expect("send");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json().await.expect("json");
+        assert_eq!(body["error"]["code"], -32007);
+        assert_eq!(body["id"], "tx-77");
+    }
+
+    #[tokio::test]
     async fn oversized_body_gets_jsonrpc_error() {
         let state = test_state(&[upstream("127.0.0.1:1".parse().expect("addr"))]);
         // A tiny configured body limit so a small request trips the size guard


### PR DESCRIPTION
Closes #957.

## Problem

`error_response` recovered the JSON-RPC `id` by calling `recover_id`, which ran `serde_json::from_slice::<Value>` over the entire buffered body (bounded only by `--max-request-bytes`, default 25 MiB) and then plucked a single member off the resulting tree.

Two costs followed from that:

1. **A redundant second parse on the screening reject path.** `screen_raw_transaction` (`proxy.rs`) already parsed the body to decide whether to reject it. Every rejection it returned was handed straight back to `error_response(&err, body.as_ref())`, which parsed the same bytes again. The same request was JSON-parsed twice.
2. **A whole-tree allocation on every reject path**, including loop-detect, no-upstream-ready, and forward-failure, where a full `Value` was built solely to read one member off the top level.

The tree is the expensive part, not the scan. Measured on this branch with a counting global allocator, against a 25,493,509 byte body (a `params` array of small JSON numbers with `id` serialized last, sitting at the default size limit):

| | peak allocation | time |
| --- | --- | --- |
| `recover_id` (full `Value`) | 384 MiB | 121 ms to 206 ms |
| this PR | 7 bytes | 45 ms |

That is roughly 15x the request size held live, and the screening path paid it twice.

### Threat model

No attacker advantage is claimed here and none is needed to justify the change, so this is hardening rather than a fix. The parses sit behind the outermost rate limiter (`server.rs:112-114`, which sheds before the body is read), the `DefaultBodyLimit` extraction cap, the whole-request deadline, and the connection cap. What the change removes is the amplification factor available to input that has already cleared those guards: the rate limiter is optional (disabled at `0`, `cli.rs:112`), so a deployment that runs without it was leaning on the size and deadline caps alone while a 25 MiB request could pin 384 MiB per reject, twice on the screening path. The gateway is stateless, so there is no corruption or persistence angle either way.

## Fix

Recovery now materializes the `id` member and nothing else, and the one caller that had already parsed the body stops re-parsing it.

- [x] `bin/worker-gateway/src/error.rs`: new `RequestId` newtype wrapping the echoed `Value`. `RequestId::recover(&[u8])` deserializes through `IdMember`, a hand-written `Visitor` whose `visit_map` keeps `id` and feeds every other member to serde's `IgnoredAny` sink, which skips it in place instead of building it. A multi-megabyte `params` costs a scan of the bytes and no tree.
- [x] `bin/worker-gateway/src/error.rs`: `error_response` now delegates to a new `error_response_with_id`, which takes an already-recovered id. `record_rejection` moved into the shared tail, so every reject path still records exactly one rejection under an unchanged reason label.
- [x] `bin/worker-gateway/src/proxy.rs`: `screen_raw_transaction` returns `Option<(GatewayError, RequestId)>`, reading the id off the parse it already performed, and the screening reject branch calls `error_response_with_id`. The screening path is down to one parse of the request.
- [x] `RequestId::from_request(&Value)` is the entry point for a caller that holds a parsed request, so the two ways of obtaining an id cannot drift apart silently. A test pins them equal.

The whole body is still scanned, deliberately. Recovering from a bounded leading slice was rejected in the issue for the right reason: JSON-RPC does not fix member order, `eth_sendRawTransaction` clients routinely serialize `id` after a multi-megabyte `params`, and a truncated slice would echo `id: null` for well-formed large requests. Skipping members is free of that hazard because the parser still reads to the end of the body.

### Behavior is unchanged, including on malformed input

This is a cost change, not a semantics change, and the diff treats that as the binding constraint. Two shapes were easy to get wrong and are handled explicitly:

- **A batch (a JSON array) must recover `null`.** Only `visit_map` is implemented, so a sequence is a type error rather than a body whose first element could be mapped onto `id` by position. A derived `Deserialize` would have accepted the array, because serde's derived struct visitor also implements `visit_seq`.
- **A duplicated `id` member keeps the last occurrence**, which is how a full parse into `Value` resolves it. The obvious derive-based shim diverges here (it errors on a duplicate field, which would have silently turned an echoed id into `null`).

The issue also floated passing `b""` on the loop-detect path to skip the parse outright. Declining that: it would echo `null` to a legitimate client whose request happened to loop, and now that recovery no longer builds a tree the parse it was avoiding is just a scan. The observable behavior is worth more than the scan.

## Testing

Under the repo-pinned toolchains, in a worktree off `origin/main` at 746d59cb.

- `cargo +1.94 test -p tn-worker-gateway --all-targets`: 69 passed, 0 failed.
- `cargo +nightly-2026-03-20 fmt -- --check`: clean, no reformatting needed.
- `cargo +nightly-2026-03-20 clippy -p tn-worker-gateway --all-targets --all-features -- -D warnings`: clean.

New tests:

- `recovery_matches_a_full_parse_of_the_body` is the load-bearing one. It reimplements the deleted `recover_id` inline and asserts the new recovery agrees with it across 18 bodies: `id` first and last, string / numeric / zero / negative / float / null / object / array ids, a duplicated `id`, a missing `id`, `{}`, a batch, a bare number, a bare string, non-JSON, and an empty body.
- `recovering_and_reusing_a_parse_agree` pins `RequestId::recover` equal to `RequestId::from_request` so the reused-parse path cannot drift from the re-parse path.
- `recovers_an_id_that_trails_a_large_params` and `rejection_id_survives_a_payload_serialized_before_it` cover the member ordering that rules out the leading-slice approach.
- `batch_body_recovers_null`, `duplicated_id_member_keeps_the_last`, `leading_whitespace_does_not_hide_the_id`, `trailing_bytes_recover_null` cover the edge shapes above.
- `rejection_carries_the_id_a_re_parse_would_have_recovered` asserts the screening reject's threaded id equals what a re-parse would have produced, over four id shapes.
- `server::tests::screened_transaction_is_rejected_with_the_request_id` covers it end to end through the real router: a `0xdeadbeef` submission gets `-32007` with `"id": "tx-77"` echoed back, against a ready upstream pointed at a dead port so a request that reached forwarding would surface as a 502 instead.

Each new test was confirmed by mutation (applied, seen to fail, restored):

| mutation | tests that failed |
| --- | --- |
| `RequestId::from_request` returns `Null` | 5, including the end-to-end server test |
| drop the `id` when any member follows it | `recovery_matches_a_full_parse_of_the_body` |
| duplicate `id` keeps first instead of last | `duplicated_id_member_keeps_the_last`, differential |
| accept a sequence and take its first element as `id` | `batch_body_recovers_null`, differential |

### Not yet run

`make attest` has not been run on this branch. The workspace test-build is the remaining pre-push gate. `tn-worker-gateway` is a leaf binary crate with no reverse dependencies in the workspace (nothing else names it in a `Cargo.toml`), so the blast radius of this diff is the crate itself, but that is an argument about scope and not a substitute for the gate.
