### PR TITLE
fix(worker-gateway): bound response-body streaming against slow-reading clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12098,6 +12098,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "socket2 0.6.3",
  "tempfile",
  "tn-config",
  "tn-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ hyper-util = { version = "0.1", default-features = false, features = [
 tower-http = { version = "0.6", default-features = false, features = [
     "timeout",
 ] }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
 const-str = "0.5.6"
 opentelemetry = { version = "0.31.0", default-features = false }
 opentelemetry_sdk = { version = "0.31.0", default-features = false }

--- a/bin/worker-gateway/Cargo.toml
+++ b/bin/worker-gateway/Cargo.toml
@@ -51,6 +51,11 @@ tn-config = { workspace = true }
 tn-metrics = { workspace = true }
 tn-types = { workspace = true }
 
+# `TCP_USER_TIMEOUT` on accepted connections (see `server::set_tcp_user_timeout`);
+# the socket option is Linux-family only, so the dependency is too.
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
+socket2 = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/bin/worker-gateway/README.md
+++ b/bin/worker-gateway/README.md
@@ -103,6 +103,8 @@ Every flag has an environment-variable fallback.
 | `--upstream-request-timeout` | `WORKER_GATEWAY_UPSTREAM_REQUEST_TIMEOUT` | `30s` | Upstream per-request deadline. |
 | `--header-read-timeout` | `WORKER_GATEWAY_HEADER_READ_TIMEOUT` | `10s` | Inbound header read deadline (slow-loris guard). |
 | `--max-connections` | `WORKER_GATEWAY_MAX_CONNECTIONS` | `500` | Concurrent inbound connection cap. |
+| `--tcp-user-timeout` | `WORKER_GATEWAY_TCP_USER_TIMEOUT` | `30s` | Transport-stall deadline (`TCP_USER_TIMEOUT`, Linux; `0` disables). |
+| `--max-connection-duration` | `WORKER_GATEWAY_MAX_CONNECTION_DURATION` | `10m` | Hard cap on one connection's total lifetime (`0` disables). |
 | `--max-request-bytes` | `WORKER_GATEWAY_MAX_REQUEST_BYTES` | `26214400` | Max request body size, in bytes. |
 | `--rate-limit-per-ip` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP` | `100` | Per-IP requests/second (`0` disables). |
 | `--rate-limit-per-ip-burst` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP_BURST` | `0` | Per-IP burst (`0` derives 2×rate). |
@@ -125,8 +127,23 @@ and the upstream response headers, so a request body trickled in below the
 size limit cannot hold a slot indefinitely.
 
 Upstream response bodies are streamed through, never buffered whole, so
-response size does not translate into gateway memory; a stalled stream is
-bounded by the upstream request timeout.
+response size does not translate into gateway memory. A stalled *upstream* is
+bounded by the upstream request timeout; a stalled or slow-reading *client*
+(the response-side slow loris: that timeout is only observed while the body
+is being polled, which downstream backpressure prevents) is bounded by two
+write-path guards instead: `TCP_USER_TIMEOUT` (`--tcp-user-timeout`, Linux
+kernels) closes a connection whose peer stops acknowledging written data
+(note it replaces the kernel's default ~15min retransmit budget for that
+socket, so a peer black-holed past the deadline is dropped where stock TCP
+might have recovered), and a connection-lifetime cap
+(`--max-connection-duration`) closes any connection, keep-alive sessions
+included, that outlives it, catching a client that trickles reads too slowly
+to be worth a slot but fast enough to defeat the transport guard. The cap
+closes abruptly: an exchange in flight on a long-lived keep-alive session is
+cut off at the cap, so size it well above the longest legitimate transfer.
+It must be at least the gateway's single-request bound
+(`--header-read-timeout` + the whole-request deadline above) so the first
+request on a connection can never be cut off.
 
 Every forwarded request carries the `X-TN-Gateway` hop marker, and an inbound
 request that already carries it is rejected (HTTP `508`), so a misconfigured

--- a/bin/worker-gateway/src/app.rs
+++ b/bin/worker-gateway/src/app.rs
@@ -29,6 +29,8 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         upstream_request_timeout,
         header_read_timeout,
         max_connections,
+        tcp_user_timeout,
+        max_connection_duration,
         max_request_bytes,
         rate_limit_per_ip,
         rate_limit_global,
@@ -53,6 +55,8 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         target: "gateway",
         rate_limiting = rate_limiters.is_some(),
         max_request_bytes,
+        ?tcp_user_timeout,
+        ?max_connection_duration,
         "edge protections configured"
     );
 
@@ -125,9 +129,12 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         // One deadline must fit the body read plus the upstream response
         // headers: the upstream hop is bounded by its own request timeout, and
         // the body read gets a header-scale budget on top, so a trickled body
-        // cannot hold a request slot indefinitely.
+        // cannot hold a request slot indefinitely. (`into_settings` guarantees
+        // any connection-lifetime cap is at least this deadline.)
         request_deadline: upstream_request_timeout.saturating_add(header_read_timeout),
         max_connections,
+        tcp_user_timeout,
+        max_connection_duration,
         max_request_bytes,
     };
 

--- a/bin/worker-gateway/src/cli.rs
+++ b/bin/worker-gateway/src/cli.rs
@@ -99,6 +99,40 @@ pub(crate) struct Cli {
     #[arg(long, env = "WORKER_GATEWAY_MAX_CONNECTIONS", default_value = "500")]
     pub(crate) max_connections: NonZeroUsize,
 
+    /// Transport-stall deadline for inbound connections (`TCP_USER_TIMEOUT`):
+    /// a connection whose peer leaves written response data unacknowledged, or
+    /// its receive window closed, for this long is forcibly closed by the
+    /// kernel. This kills a fully stalled reader at the transport layer, at a
+    /// cost: the option replaces the kernel's default retransmit budget
+    /// (typically ~15min via `tcp_retries2`), so a peer whose path stays
+    /// black-holed past the deadline is dropped where stock TCP might have
+    /// recovered. Linux-family kernels only; elsewhere only
+    /// `--max-connection-duration` bounds a stalled reader. `0` disables.
+    #[arg(
+        long,
+        env = "WORKER_GATEWAY_TCP_USER_TIMEOUT",
+        default_value = "30s",
+        value_parser = humantime::parse_duration
+    )]
+    pub(crate) tcp_user_timeout: Duration,
+
+    /// Hard cap on a single inbound connection's total lifetime, keep-alive
+    /// sessions included. The cap fires independent of connection progress, so
+    /// it also bounds a client that trickles reads slowly enough to keep the
+    /// transport-stall guard from firing. The close is abrupt: an exchange
+    /// still in flight when a long-lived keep-alive session hits the cap is
+    /// cut off mid-stream, so size the cap well above the longest legitimate
+    /// transfer. Must be at least the gateway's own single-request bound
+    /// (`--header-read-timeout` plus the whole-request deadline) so the first
+    /// request on a connection can never be cut off. `0` disables.
+    #[arg(
+        long,
+        env = "WORKER_GATEWAY_MAX_CONNECTION_DURATION",
+        default_value = "10m",
+        value_parser = humantime::parse_duration
+    )]
+    pub(crate) max_connection_duration: Duration,
+
     /// Maximum request body the gateway will accept, in bytes. Requests whose
     /// body exceeds this are rejected with a JSON-RPC "request too large" error
     /// before being forwarded.
@@ -171,6 +205,12 @@ pub(crate) struct Settings {
     pub(crate) header_read_timeout: Duration,
     /// Maximum concurrently-open inbound connections.
     pub(crate) max_connections: NonZeroUsize,
+    /// Transport-stall deadline (`TCP_USER_TIMEOUT`) for inbound connections,
+    /// or `None` when disabled.
+    pub(crate) tcp_user_timeout: Option<Duration>,
+    /// Hard cap on a single inbound connection's total lifetime, or `None`
+    /// when uncapped.
+    pub(crate) max_connection_duration: Option<Duration>,
     /// Maximum accepted request body size, in bytes.
     pub(crate) max_request_bytes: usize,
     /// Per-client-IP rate limit, or `None` when disabled.
@@ -196,6 +236,28 @@ impl Cli {
             ensure_not_gateway(self.listen_addr, &upstream.rpc_url)?;
             ensure_not_gateway(self.listen_addr, &upstream.readiness_url)
         })?;
+        let max_connection_duration = resolve_optional_duration(self.max_connection_duration);
+        // The longest a single request stays live from the gateway's own point
+        // of view: up to `header_read_timeout` reading the head before the
+        // service's whole-request deadline (see [`crate::app`]) is even armed,
+        // plus that deadline itself. A connection cap below this bound could
+        // cut off a request the gateway still considers live, so reject the
+        // combination at startup.
+        let single_request_bound = self
+            .header_read_timeout
+            .saturating_add(self.upstream_request_timeout.saturating_add(self.header_read_timeout));
+        max_connection_duration.map_or(Ok(()), |cap| {
+            eyre::ensure!(
+                cap >= single_request_bound,
+                "--max-connection-duration ({}) is shorter than the gateway's own \
+                 single-request bound (--header-read-timeout plus the whole-request deadline \
+                 --upstream-request-timeout + --header-read-timeout = {}); raise the cap or \
+                 set it to 0 to disable it",
+                humantime::format_duration(cap),
+                humantime::format_duration(single_request_bound),
+            );
+            Ok(())
+        })?;
         Ok(Settings {
             listen_addr: self.listen_addr,
             upstreams,
@@ -205,6 +267,8 @@ impl Cli {
             upstream_request_timeout: self.upstream_request_timeout,
             header_read_timeout: self.header_read_timeout,
             max_connections: self.max_connections,
+            tcp_user_timeout: resolve_optional_duration(self.tcp_user_timeout),
+            max_connection_duration,
             max_request_bytes: self.max_request_bytes,
             rate_limit_per_ip: resolve_rate_limit(
                 self.rate_limit_per_ip,
@@ -242,6 +306,12 @@ impl Cli {
             }
         }
     }
+}
+
+/// Turn a duration flag into `Some(duration)`, or `None` when zero (the
+/// flag's disabled sentinel, mirroring the `0`-disables rate-limit flags).
+fn resolve_optional_duration(value: Duration) -> Option<Duration> {
+    (!value.is_zero()).then_some(value)
 }
 
 /// Turn a `(rate, burst)` flag pair into a [`RateLimit`], or `None` when the
@@ -334,6 +404,60 @@ mod tests {
         .into_settings()?;
         assert_eq!(settings.upstreams.len(), 1);
         Ok(())
+    }
+
+    #[test]
+    fn zero_disables_write_path_guards() -> eyre::Result<()> {
+        let settings = Cli::parse_from([
+            "worker-gateway",
+            "--upstream-rpc-url=http://127.0.0.1:8544",
+            "--upstream-readiness-url=http://127.0.0.1:8551/health/workers",
+            "--tcp-user-timeout=0s",
+            "--max-connection-duration=0",
+        ])
+        .into_settings()?;
+        assert_eq!(settings.tcp_user_timeout, None);
+        assert_eq!(settings.max_connection_duration, None);
+        Ok(())
+    }
+
+    #[test]
+    fn write_path_guards_default_on() -> eyre::Result<()> {
+        let settings = cli_with(
+            None,
+            Some("http://127.0.0.1:8544"),
+            Some("http://127.0.0.1:8551/health/workers"),
+        )
+        .into_settings()?;
+        assert_eq!(settings.tcp_user_timeout, Some(Duration::from_secs(30)));
+        assert_eq!(settings.max_connection_duration, Some(Duration::from_secs(600)));
+        Ok(())
+    }
+
+    #[test]
+    fn connection_cap_below_request_deadline_is_rejected() {
+        // Default single-request bound is 10s (header phase) + 30s + 10s
+        // (whole-request deadline) = 50s; a cap of the bare whole-request
+        // deadline (40s) could still cut off a request whose headers took the
+        // full header window to arrive.
+        let result = Cli::parse_from([
+            "worker-gateway",
+            "--upstream-rpc-url=http://127.0.0.1:8544",
+            "--upstream-readiness-url=http://127.0.0.1:8551/health/workers",
+            "--max-connection-duration=40s",
+        ])
+        .into_settings();
+        assert!(result.is_err(), "a cap below the single-request bound must be a startup error");
+
+        // The boundary itself is accepted.
+        let boundary = Cli::parse_from([
+            "worker-gateway",
+            "--upstream-rpc-url=http://127.0.0.1:8544",
+            "--upstream-readiness-url=http://127.0.0.1:8551/health/workers",
+            "--max-connection-duration=50s",
+        ])
+        .into_settings();
+        assert!(boundary.is_ok(), "a cap equal to the single-request bound must be accepted");
     }
 
     #[test]

--- a/bin/worker-gateway/src/proxy.rs
+++ b/bin/worker-gateway/src/proxy.rs
@@ -164,8 +164,12 @@ async fn forward(
     // sizes are client-controlled (`eth_getLogs`, `debug_*`, large batches can
     // reach the worker's ~160 MB response cap), so N concurrent buffered
     // responses would exhaust gateway memory. The proxy client's total request
-    // timeout keeps bounding the stream, so a stalled upstream or slow-reading
-    // client cannot hold the connection past the deadline.
+    // timeout bounds a stalled *upstream* (hyper keeps polling the body while
+    // its write buffer has room, so the timeout is observed) but not a
+    // slow-reading *client*: under downstream backpressure hyper stops polling
+    // the body and the poll-driven timeout never fires. That side is bounded
+    // at the connection layer instead: `TCP_USER_TIMEOUT` plus the
+    // connection-lifetime cap (see [`crate::server::accept_loop`]).
     let mut response = Response::new(Body::from_stream(upstream.bytes_stream()));
     *response.status_mut() = status;
     if let Some(content_type) = upstream_content_type {

--- a/bin/worker-gateway/src/server.rs
+++ b/bin/worker-gateway/src/server.rs
@@ -8,8 +8,11 @@
 //! rather than `axum::serve`: `axum::serve` never installs a hyper timer, so
 //! hyper's header read timeout is silently disabled and a slow-loris client
 //! could hold connections open forever. Here every connection gets a header
-//! read deadline, a whole-request deadline, `TCP_NODELAY`, and a global
-//! concurrent-connection cap.
+//! read deadline, a whole-request deadline, `TCP_NODELAY`, a global
+//! concurrent-connection cap, and two write-path guards for the response-side
+//! slow loris (a client that stops or trickles its reads while a response
+//! body streams to it): a transport-stall deadline (`TCP_USER_TIMEOUT`) and a
+//! hard cap on total connection lifetime.
 
 use std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration};
 
@@ -21,6 +24,7 @@ use axum::{
     routing::get,
     Extension, Json, Router,
 };
+use futures::future::{self, Either};
 use hyper_util::{
     rt::{TokioIo, TokioTimer},
     server::graceful::GracefulShutdown,
@@ -29,7 +33,10 @@ use hyper_util::{
 use reqwest::Client;
 use serde::Serialize;
 use tn_types::{Noticer, TaskError};
-use tokio::{net::TcpListener, sync::Semaphore};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Semaphore,
+};
 use tower_http::timeout::TimeoutLayer;
 use tracing::{debug, info, warn};
 
@@ -72,6 +79,18 @@ pub(crate) struct ServerLimits {
     /// Maximum concurrently-open inbound connections; further connections wait
     /// in the OS accept backlog.
     pub(crate) max_connections: NonZeroUsize,
+    /// Transport-stall deadline (`TCP_USER_TIMEOUT`) armed on every accepted
+    /// connection, or `None` when disabled. Closes a connection whose peer
+    /// leaves written data unacknowledged (or its receive window closed) this
+    /// long; Linux-family kernels only, best-effort elsewhere.
+    pub(crate) tcp_user_timeout: Option<Duration>,
+    /// Hard cap on a single connection's total lifetime (keep-alive sessions
+    /// included), or `None` when uncapped. Enforced by the runtime independent
+    /// of connection progress, so it fires even when hyper's write path is
+    /// backpressured by a slow-reading client and no future the connection
+    /// owns is being polled forward. The close is abrupt: an exchange still
+    /// in flight when a keep-alive session hits the cap is cut off mid-stream.
+    pub(crate) max_connection_duration: Option<Duration>,
     /// Maximum accepted request body size, in bytes.
     pub(crate) max_request_bytes: usize,
 }
@@ -88,9 +107,11 @@ struct ReadyBody {
 /// `request_deadline` bounds each whole request; the bare `408` the timeout
 /// layer produces is rewritten into the gateway's JSON-RPC error envelope so
 /// the "always a well-formed JSON-RPC error" contract holds. Streamed
-/// *response* bodies are written after the handler returns and are bounded by
-/// the upstream client's own total timeout instead. `max_request_bytes` caps
-/// the buffered request body.
+/// *response* bodies are written after the handler returns, outside this
+/// deadline; they are bounded by the accept loop's transport-stall deadline
+/// and connection-lifetime cap (the upstream client's total timeout is only
+/// checked when the body is polled, which a slow-reading client can prevent;
+/// see [`accept_loop`]). `max_request_bytes` caps the buffered request body.
 ///
 /// When `rate_limiters` is present it is installed as the outermost layer, so
 /// an over-limit request is shed with a JSON-RPC `429` before its body is
@@ -160,8 +181,19 @@ pub(crate) async fn serve(
 }
 
 /// Accept connections until `shutdown` fires, serving each on its own task
-/// with the configured header deadline, `TCP_NODELAY`, and connection cap,
-/// then drain within `graceful_timeout`.
+/// with the configured header deadline, `TCP_NODELAY`, transport-stall
+/// deadline, lifetime cap, and connection cap, then drain within
+/// `graceful_timeout`.
+///
+/// The two write-path guards close the response-side slow loris: the
+/// whole-request deadline stops covering a response once its head is produced,
+/// and the upstream client's total timeout is only observed when the streamed
+/// body is polled; under downstream backpressure hyper stops polling the body
+/// (its write loop parks on a full write buffer), so that timeout never fires.
+/// `TCP_USER_TIMEOUT` fires in the kernel when the peer stops acknowledging
+/// written data outright, and the connection-lifetime cap is a runtime timer
+/// polled independent of connection progress, so it fires even against a
+/// client trickling one byte per interval to keep the transport alive.
 async fn accept_loop(
     listener: TcpListener,
     app: Router,
@@ -208,15 +240,48 @@ async fn accept_loop(
             debug!(target: "gateway::server", %err, "failed to set TCP_NODELAY");
         }
 
+        // Best-effort: on an unsupported platform (or a setsockopt failure)
+        // the lifetime cap below still bounds a stalled reader.
+        if let Some(Err(err)) =
+            limits.tcp_user_timeout.map(|timeout| set_tcp_user_timeout(&stream, timeout))
+        {
+            debug!(target: "gateway::server", %err, "failed to set TCP_USER_TIMEOUT");
+        }
+
         // Hand handlers the real client address (`ConnectInfo`, consumed by the
         // proxy's `X-Forwarded-For`).
         let service =
             TowerToHyperService::new(app.clone().layer(Extension(ConnectInfo(peer_addr))));
         let connection =
             graceful.watch(connection_builder.serve_connection(TokioIo::new(stream), service));
+        // The lifetime cap is a runtime timer, deliberately NOT a timeout on
+        // any body future: the runtime polls it regardless of whether hyper's
+        // backpressured write path ever polls the connection forward again.
+        // Constructed here (not inside the task) so the deadline counts from
+        // accept even if the spawned task's first poll is delayed. `None` caps
+        // nothing (a never-ready future).
+        let lifetime_cap = limits.max_connection_duration.map_or_else(
+            || Either::Left(future::pending::<()>()),
+            |cap| Either::Right(tokio::time::sleep(cap)),
+        );
         tokio::spawn(async move {
-            if let Err(err) = connection.await {
-                debug!(target: "gateway::server", %err, "connection error");
+            // `biased` so a connection that finishes in the same poll as the
+            // cap expires is reported as what it was (completion or its real
+            // error), never mislabeled as cap-killed.
+            tokio::select! {
+                biased;
+                result = connection => {
+                    if let Err(err) = result {
+                        debug!(target: "gateway::server", %err, "connection error");
+                    }
+                }
+                () = lifetime_cap => {
+                    debug!(
+                        target: "gateway::server",
+                        %peer_addr,
+                        "connection exceeded max lifetime; closing"
+                    );
+                }
             }
             drop(permit);
         });
@@ -241,6 +306,25 @@ async fn accept_loop(
     Ok(())
 }
 
+/// Arm `TCP_USER_TIMEOUT` on an accepted connection: the kernel forcibly
+/// closes the connection when transmitted data stays unacknowledged, or
+/// buffered data stays untransmittable behind a closed receive window, longer
+/// than `timeout`, freeing the slot a fully stalled reader would otherwise
+/// hold.
+#[cfg(any(target_os = "android", target_os = "linux"))]
+fn set_tcp_user_timeout(stream: &TcpStream, timeout: Duration) -> std::io::Result<()> {
+    socket2::SockRef::from(stream).set_tcp_user_timeout(Some(timeout))
+}
+
+/// `TCP_USER_TIMEOUT` is Linux-family only; elsewhere report it unsupported so
+/// the caller's debug log tells the truth. Production gateways deploy on Linux
+/// (see the crate's `Dockerfile`); on other hosts the connection-lifetime cap
+/// still bounds a stalled reader.
+#[cfg(not(any(target_os = "android", target_os = "linux")))]
+fn set_tcp_user_timeout(_stream: &TcpStream, _timeout: Duration) -> std::io::Result<()> {
+    Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "TCP_USER_TIMEOUT requires Linux"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,6 +344,8 @@ mod tests {
             header_read_timeout: Duration::from_secs(5),
             request_deadline: Duration::from_secs(5),
             max_connections: NonZeroUsize::new(64).expect("nonzero"),
+            tcp_user_timeout: None,
+            max_connection_duration: None,
             max_request_bytes: MAX_REQUEST_BYTES,
         }
     }
@@ -627,5 +713,115 @@ mod tests {
                 .expect("send");
             assert_eq!(response.status(), StatusCode::OK);
         }
+    }
+
+    /// Upstream response body sized well above the sum of every buffer
+    /// between the mock upstream and the stalled client (gateway channel,
+    /// socket send/receive buffers, even generously tuned `tcp_wmem`/
+    /// `tcp_rmem` sysctls), so a client that stops reading provably parks the
+    /// stream mid-body.
+    const STALL_BODY_BYTES: usize = 32 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn slow_reader_is_closed_at_connection_lifetime_cap() {
+        // The issue #958 scenario: response streaming to a client that stops
+        // reading. The whole-request deadline no longer covers the response
+        // body, and the upstream client's total timeout is only observed when
+        // the body is polled (which the stall prevents), so only the lifetime
+        // cap bounds this connection.
+        let mock = Router::new().route("/", post(|| async { vec![0_u8; STALL_BODY_BYTES] }));
+        let (upstream_addr, _mock) = spawn(mock).await;
+
+        let state = test_state(&[upstream(upstream_addr)]);
+        state.readiness.set_ready(0, true);
+        // The cap is generous enough that the response head always arrives
+        // inside it, even on a loaded CI host where the whole 3-hop round
+        // trip shares one test runtime.
+        let limits =
+            ServerLimits { max_connection_duration: Some(Duration::from_secs(2)), ..test_limits() };
+        let (gateway_addr, _shutdown) = spawn_with_limits(test_router(state), limits).await;
+
+        let mut stream = TcpStream::connect(gateway_addr).await.expect("connect");
+        stream
+            .write_all(
+                b"POST / HTTP/1.1\r\nHost: gateway\r\nContent-Type: application/json\r\n\
+                  Content-Length: 47\r\n\r\n{\"jsonrpc\":\"2.0\",\"method\":\"eth_getLogs\",\"id\":1}",
+            )
+            .await
+            .expect("write");
+
+        // Read one chunk (the response head plus some body), then stall past
+        // the lifetime cap without reading further.
+        let mut first = [0_u8; 4096];
+        let read = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut first))
+            .await
+            .expect("response head should arrive well inside the lifetime cap")
+            .expect("first read");
+        assert!(read > 0, "expected the response head to arrive");
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+
+        // Drain what the socket still holds. The cap closed the connection
+        // mid-body, so the drain must end (EOF or reset both count) well short
+        // of the full body; pre-fix the stream resumes here and delivers all
+        // of it.
+        let mut rest = Vec::new();
+        let drained = tokio::time::timeout(Duration::from_secs(10), stream.read_to_end(&mut rest))
+            .await
+            .expect("connection should be closed by the lifetime cap");
+        drop(drained); // EOF is Ok, an RST is Err; either way `rest` holds what arrived.
+        assert!(
+            read + rest.len() < STALL_BODY_BYTES,
+            "expected a truncated body, got all {} bytes",
+            read + rest.len(),
+        );
+    }
+
+    #[tokio::test]
+    async fn lifetime_cap_closes_idle_connection_and_releases_permit() {
+        let state = test_state(&[upstream("127.0.0.1:1".parse().expect("addr"))]);
+        // One connection slot total, capped at 300ms; the header read deadline
+        // (5s) stays out of the way of both asserts below.
+        let limits = ServerLimits {
+            max_connections: NonZeroUsize::new(1).expect("nonzero"),
+            max_connection_duration: Some(Duration::from_millis(300)),
+            ..test_limits()
+        };
+        let (addr, _shutdown) = spawn_with_limits(test_router(state), limits).await;
+
+        // A connection that never sends a byte must be closed by the lifetime
+        // cap (well before the 5s header deadline, hence the 2s bound).
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        let mut buf = [0_u8; 16];
+        let read = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut buf))
+            .await
+            .expect("connection should be closed by the lifetime cap");
+        assert_eq!(read.expect("read"), 0, "expected EOF from the server");
+
+        // The capped connection's permit must be released: with a single slot,
+        // this probe only gets accepted (and answered) if it was.
+        let response = tokio::time::timeout(
+            Duration::from_secs(5),
+            Client::new().get(format!("http://{addr}/health")).send(),
+        )
+        .await
+        .expect("permit should be released after the cap fires")
+        .expect("send");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// The transport-stall guard actually arms the socket option (readable
+    /// back via `SO_TCP_USER_TIMEOUT`). Linux-family only, like the option.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[tokio::test]
+    async fn tcp_user_timeout_is_armed() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let (_client, accepted) =
+            tokio::join!(async { TcpStream::connect(addr).await.expect("connect") }, async {
+                listener.accept().await.expect("accept").0
+            });
+        set_tcp_user_timeout(&accepted, Duration::from_secs(7)).expect("set TCP_USER_TIMEOUT");
+        let armed = socket2::SockRef::from(&accepted).tcp_user_timeout().expect("read back");
+        assert_eq!(armed, Some(Duration::from_secs(7)));
     }
 }


### PR DESCRIPTION
Closes #958.

## Problem

The whole-request `TimeoutLayer` bounds a request only until the response head is produced;  the streamed response body is written to the client afterward with no inbound write or idle deadline.  The nominal bound, the upstream reqwest client's total `timeout`, is poll-driven:  reqwest's `TotalTimeoutBody` checks its `Sleep` only inside `poll_frame`.  Under downstream backpressure (a client that stops reading, or trickles reads) hyper's h1 write loop parks on a full write buffer and stops polling the response body, so that timeout is never observed and the connection is held open past any deadline.  `--max-connections` was the only backstop.  This is the response-side analog of the request-side slow loris the hand-rolled accept loop was purpose-built to close:  no attacker sophistication required, any client that requests a large response (`eth_getLogs`, `debug_*`, batches) and stops reading holds a slot until the cap starves out legitimate clients.

## Root cause

Every existing response-side bound is observed only while the connection future makes progress:  the timeout layer detaches at the response head, and the upstream total timeout requires the body to be polled.  Nothing fired at a layer independent of body polling.  (For a stalled *upstream* the old `proxy.rs` comment was correct:  hyper keeps polling the body while its write buffer has room, so the upstream timeout does fire.  For a slow-reading *client* it was wrong.)

## Fix

Two write-path guards in the accept loop, both firing independent of body polling, per the mechanism proposed in #958:

- [x] **`TCP_USER_TIMEOUT`** (`--tcp-user-timeout`, default `30s`, `0` disables), armed on every accepted socket via `socket2`:  the kernel forcibly closes a connection whose peer leaves transmitted data unacknowledged, or its receive window closed, past the deadline.  This drops a fully stalled reader at the transport layer, at a documented cost:  the option replaces the kernel's default retransmit budget (typically ~15min via `tcp_retries2`), so a peer black-holed past the deadline is dropped where stock TCP might have recovered.  Linux-family kernels only (the deployment target, see the crate `Dockerfile`);  the dependency is target-gated the same way and the setter reports unsupported elsewhere, where the lifetime cap below remains the bound.
- [x] **Connection-lifetime cap** (`--max-connection-duration`, default `10m`, `0` disables):  the connection task `select!`s (`biased`, completion first, so a finished connection is never mislabeled cap-killed) the hyper connection future against a runtime timer armed at accept.  The runtime polls that timer regardless of whether hyper's backpressured write path ever polls the connection forward, so it also bounds the trickle reader that acknowledges just enough to keep the transport guard from firing.  The close is deliberately abrupt (that unconditionality is the DoS bound):  an exchange still in flight when a long-lived keep-alive session hits the cap is cut off mid-stream, so the cap should sit well above the longest legitimate transfer.  The `--max-connections` permit is released on both `select!` branches.
- [x] **Bound symmetry, validated at startup**:  a configured cap must be at least the gateway's own single-request bound, `--header-read-timeout` (spent before the whole-request deadline is even armed) plus that whole-request deadline (`--upstream-request-timeout` + `--header-read-timeout`), 50s at defaults, so the first request on any connection can never be cut off.  Both defaults are derived, not guessed:  `30s` matches the upstream request timeout the issue showed being bypassed, `10m` is 12x the default single-request bound.
- [x] `bin/worker-gateway/src/proxy.rs`, `bin/worker-gateway/src/server.rs`:  corrected the doc comments that claimed the upstream total timeout bounds a slow-reading client;  `README.md` documents both flags and the guard semantics.

Idle keep-alive connections between requests were already bounded (hyper re-arms `header_read_timeout` per request), so the guards target exactly the write path.

## Testing

- `slow_reader_is_closed_at_connection_lifetime_cap`:  the issue scenario end-to-end through the real accept loop.  A 32 MiB upstream response (larger than every buffer between the mock upstream and the client) streams to a raw TCP client that reads one chunk and stalls;  the connection must terminate mid-body with a truncated stream.  Confirmed by mutation:  with the cap disabled the test fails after receiving all 33,555,359 bytes.
- `lifetime_cap_closes_idle_connection_and_releases_permit`:  a byte-silent connection is closed at the cap (well before the header deadline) and its permit is released:  a follow-up probe on a single-slot server succeeds.  Also seen to fail by mutation.
- `tcp_user_timeout_is_armed` (Linux-only, like the option):  the sockopt round-trips through the getter on a really-accepted socket.
- CLI:  defaults resolve both guards on, `0s` and bare `0` each disable, and a cap below the single-request bound is a startup error (a bare whole-request-deadline cap of `40s` rejected, the `50s` boundary accepted;  the floor was also confirmed by mutation, reverting it to `40s` fails the test).
- `cargo +nightly-2026-03-20 fmt --all -- --check`, `cargo +nightly-2026-03-20 clippy -p tn-worker-gateway --tests -- -D warnings`, crate suite green (62 passed) on the pinned 1.94 toolchain, and `cargo +1.94 test --no-run --workspace` in an isolated target dir.
