### PR TITLE
network: gate worker batch-digest gossip subscription on node mode

### DIFF
--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -137,8 +137,11 @@ where
 
     /// Process gossip from the committee.
     ///
-    /// Workers gossip the Batch Digests once accepted so that non-committee peers can request the
-    /// Batch.
+    /// Workers gossip a batch digest once it is accepted so that peers which consume individual
+    /// current-epoch batches — committee validators, including one catching up to rejoin — can
+    /// prefetch the body into `NodeBatchesCache` before the vote path needs it. Observers do not
+    /// subscribe to this topic (issue #960): they receive batch bodies inside the verified
+    /// consensus output and epoch packs they already download (`crates/state-sync`).
     pub(super) async fn process_gossip(&self, msg: &GossipMessage) -> WorkerNetworkResult<()> {
         // deconstruct message
         let GossipMessage { data, source: _, sequence_number: _, topic } = msg;
@@ -155,9 +158,10 @@ where
                     WorkerNetworkError::InvalidTopic
                 );
                 let my_epoch = self.consensus_config.epoch();
-                // We are probably behind.  Do not bother to fetch and store this Batch now, it will
-                // most likely be removed before we can use it and will be fetched
-                // later when needed.
+                // We are probably behind. Do not bother to fetch and store this Batch now: the
+                // cache is cleared at the epoch boundary, and a node that is behind receives the
+                // bodies for the epochs it is missing inside the epoch packs / consensus output
+                // it syncs (`crates/state-sync`), not through a later per-batch fetch.
                 ensure!(my_epoch == epoch, WorkerNetworkError::BatchEpochMismatch(epoch, my_epoch));
                 // Since we are precaching Batches for the current epoch we only need to check if it
                 // is in the local cache. There should not have been an opertunity
@@ -174,8 +178,9 @@ where
                     // and a concurrency permit for the whole fetch, releasing both on
                     // scope exit. When admission declines (a prefetch for this digest
                     // is already in flight, or the cap is reached) the prefetch is
-                    // skipped: it is a best-effort optimization and a genuinely needed
-                    // batch is fetched on demand later.
+                    // skipped: it is a best-effort optimization, and a genuinely needed
+                    // batch is still fetched by the vote path itself
+                    // (`PrimaryReceiverHandler::synchronize` -> `request_batches`).
                     let Some(_prefetch) = try_admit_prefetch(
                         &self.prefetch_semaphore,
                         &self.in_flight_prefetch,
@@ -183,14 +188,14 @@ where
                     ) else {
                         return Ok(());
                     };
-                    // If batch is missing from db, then request from peer.
-                    // If we are a CVV then we should already have it.
-                    // This allows non-CVVs to pre fetch batches they will soon need.
+                    // If batch is missing from db, then request from peer. Only committee
+                    // validators subscribe to this topic (issue #960), so this warms the cache
+                    // the vote path reads: an active CVV usually already has the body from the
+                    // normal worker path, while a CVV catching up to rejoin gets the most out of
+                    // the prefetch — the cache survives the mode-change re-entry that promotes it.
                     let mut missing = BTreeSet::from([batch_hash]);
                     match self.network_handle.request_batches(&mut missing).await {
                         Ok(batches) => {
-                            // Note: retrieving this batch for no reason is wasteful, it should
-                            // only effect nodes catching up old epochs though...
                             if let Some((digest, batch)) = batches.first() {
                                 self.validate_and_cache_prefetched_batch(digest, batch)?;
                             }

--- a/crates/consensus/worker/src/network/message.rs
+++ b/crates/consensus/worker/src/network/message.rs
@@ -8,7 +8,9 @@ use tn_types::{BlockHash, Epoch, SealedBatch};
 /// Worker messages on the gossip network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum WorkerGossip {
-    /// A new batch digest is available so non-committee peers can fetch it.
+    /// An accepted batch digest, announced so subscribed committee validators can prefetch the
+    /// body before the vote path needs it. Carries the epoch so a stale-epoch announcement is
+    /// rejected rather than prefetched.
     Batch(Epoch, BlockHash),
 }
 

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -58,10 +58,12 @@ pub const MAX_PENDING_REQUESTS_PER_PEER: usize = 2;
 
 /// Maximum number of concurrent gossip-triggered batch prefetches.
 ///
-/// When a committee worker gossips an accepted batch digest, a peer that is missing
-/// the batch prefetches it, and that fetch fans out to every connected peer (see
+/// When a committee worker gossips an accepted batch digest, a subscribed committee validator
+/// that is missing the batch prefetches it, and that fetch fans out to every connected peer (see
 /// [`handle::WorkerNetworkHandle::request_batches`]). Prefetching is a best-effort
-/// optimization: a genuinely needed batch is still fetched on demand later. Capping
+/// optimization: a genuinely needed batch is still fetched by the vote path itself
+/// (`PrimaryReceiverHandler::synchronize` -> `request_batches`), and observers never take this
+/// path at all — they receive batch bodies with the consensus output they follow. Capping
 /// the number in flight (and deduplicating by digest) stops a Byzantine author from
 /// amplifying bandwidth/connection load across the worker mesh by gossiping many
 /// distinct (possibly forged) digests. Load beyond the cap is shed, not queued.

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -313,8 +313,9 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
                             "batch sealed"
                         );
                         self.metrics.record_batch_sealed(batch.size(), batch.transactions.len());
-                        // Publish the digest for any nodes listening to this gossip (non-committee
-                        // members). Note, ignore error- this should not
+                        // Publish the digest for the nodes subscribed to this gossip, i.e. the
+                        // committee validators that consume individual current-epoch batches.
+                        // Note, ignore error- this should not
                         // happen and should not cause an issue (except the
                         // underlying p2p network may be in trouble but that will manifest quickly).
                         let _ = self.network_handle.publish_batch(digest).await;

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -829,6 +829,17 @@ where
                 self.authorized_publishers.insert(topic, publishers);
                 send_or_log_error!(reply, res, "Subscribe");
             }
+            NetworkCommand::Unsubscribe { topic, reply } => {
+                let sub: IdentTopic = Topic::new(&topic);
+                let was_subscribed = self.swarm.behaviour_mut().gossipsub.unsubscribe(&sub);
+                // Removing the entry is required, not hygiene: `verify_gossip` reads an absent
+                // entry as "topic not subscribed here" and rejects. Leaving a stale entry behind
+                // pins this topic to the allowlist of whichever committee was current when it was
+                // last subscribed, so a later committee's honest authors would be rejected as
+                // unauthorized.
+                self.authorized_publishers.remove(&topic);
+                send_or_log_error!(reply, was_subscribed, "Unsubscribe");
+            }
             NetworkCommand::ConnectedPeerIds { reply } => {
                 let res = self.swarm.behaviour().peer_manager.connected_or_dialing_peers();
                 debug!(target: "network", ?res, "peer manager connected peers:");

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -996,6 +996,100 @@ async fn test_publish_to_one_peer() -> eyre::Result<()> {
 }
 
 #[tokio::test]
+async fn test_unsubscribe_stops_gossip_delivery() -> eyre::Result<()> {
+    // start honest cvv network
+    let TestTypes { peer1, peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let NetworkPeer { config: config_1, network_handle: cvv, network, .. } = peer1;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    // start honest nvv network
+    let NetworkPeer {
+        config: config_2,
+        network_handle: nvv,
+        network_events: mut nvv_network_events,
+        network,
+    } = peer2;
+    tokio::spawn(async move {
+        network.run().await.expect("network run failed!");
+    });
+
+    // start swarm listening on default any address
+    cvv.start_listening(config_1.primary_address()).await?;
+    nvv.start_listening(config_2.primary_address()).await?;
+    let cvv_addr = cvv.listeners().await?.first().expect("peer2 listen addr").clone();
+
+    // unsubscribing a topic that was never subscribed is a benign no-op - the epoch-start
+    // gate calls this on every observer's first epoch
+    assert!(!nvv.unsubscribe(TEST_TOPIC.into()).await?, "never subscribed - nothing to drop");
+
+    // subscribe and dial
+    nvv.subscribe_with_publishers(TEST_TOPIC.into(), config_1.committee_pub_keys()).await?;
+    nvv.add_trusted_peer_and_dial(
+        config_1.key_config().primary_public_key(),
+        config_1.key_config().primary_network_public_key(),
+        cvv_addr,
+    )
+    .await?;
+
+    let random_block = fixture_batch_with_transactions(10);
+    let sealed_block = random_block.seal_slow();
+    let expected_result = Vec::from(&sealed_block);
+
+    // wait until the publisher has observed the subscriber before publishing
+    let topic_hash = TopicHash::from_raw(TEST_TOPIC);
+    let topic_ref = &topic_hash;
+    let handle = &cvv;
+    wait_until(
+        Duration::from_secs(5),
+        "publisher observes a TEST_TOPIC subscriber",
+        move || async move {
+            handle
+                .all_peers()
+                .await
+                .map_err(Into::into)
+                .map(|peers| peers.values().any(|topics| topics.contains(topic_ref)))
+        },
+    )
+    .await?;
+
+    // baseline: while subscribed, gossip is delivered
+    let _message_id = cvv.publish(TEST_TOPIC.into(), expected_result.clone()).await?;
+    let event =
+        timeout(Duration::from_secs(2), nvv_network_events.recv()).await?.expect("batch received");
+    assert!(
+        matches!(event, NetworkEvent::Gossip(gossip) if gossip.message.data == expected_result)
+    );
+
+    // drop the subscription - reports that it was subscribed
+    assert!(nvv.unsubscribe(TEST_TOPIC.into()).await?, "was subscribed - reports the drop");
+
+    // the unsubscribe propagates: the publisher stops seeing this peer on the topic
+    wait_until(
+        Duration::from_secs(5),
+        "publisher observes no TEST_TOPIC subscriber",
+        move || async move {
+            handle
+                .all_peers()
+                .await
+                .map_err(Into::into)
+                .map(|peers| !peers.values().any(|topics| topics.contains(topic_ref)))
+        },
+    )
+    .await?;
+
+    // with no subscriber left, publishing on the topic has nowhere to go
+    assert!(
+        cvv.publish(TEST_TOPIC.into(), expected_result).await.is_err(),
+        "no remaining subscribers for the topic"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_msg_verification_ignores_unauthorized_publisher() -> eyre::Result<()> {
     // start honest cvv network
     let TestTypes { peer1, peer2, .. } =

--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -404,6 +404,13 @@ where
         /// The reply to caller.
         reply: oneshot::Sender<Result<bool, SubscriptionError>>,
     },
+    /// Unsubscribe from a topic.
+    Unsubscribe {
+        /// The topic to unsubscribe from.
+        topic: String,
+        /// The reply to caller: true if this node was subscribed.
+        reply: oneshot::Sender<bool>,
+    },
     /// Publish a message to topic subscribers.
     Publish {
         /// The topic to publish the message on.
@@ -659,6 +666,20 @@ where
         self.sender.send(NetworkCommand::Subscribe { topic, publishers: None, reply }).await?;
         let res = already_subscribed.await?;
         res.map_err(Into::into)
+    }
+
+    /// Unsubscribe from a topic.
+    ///
+    /// Gossipsub subscriptions live on the process-lifetime swarm, so a topic subscribed for one
+    /// epoch stays subscribed until it is explicitly dropped. This also clears the topic's
+    /// authorized-publisher entry, restoring the "not subscribed here" state that
+    /// `verify_gossip` expects for an absent entry.
+    ///
+    /// Return `true` if this node was subscribed to the topic.
+    pub async fn unsubscribe(&self, topic: String) -> NetworkResult<bool> {
+        let (reply, was_subscribed) = oneshot::channel();
+        self.sender.send(NetworkCommand::Unsubscribe { topic, reply }).await?;
+        Ok(was_subscribed.await?)
     }
 
     /// Publish a message on a certain topic.

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -884,7 +884,9 @@ where
         // once here in the process-lifetime path. That makes the network layer drop non-committee
         // messages before re-propagation and refreshes the authorized set on every committee
         // rotation, rather than accepting any publisher once at node start. See issues #898 and
-        // #912.
+        // #912. `worker_batch_topic` follows the same per-epoch pattern in
+        // `spawn_worker_network_for_epoch`, and is additionally gated on node mode: only
+        // committee validators subscribe, observers unsubscribe (issue #960).
         state_sync::spawn_epoch_record_collector(
             self.consensus_chain.clone(),
             primary_network_handle.clone(),

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -708,9 +708,13 @@ where
     /// committee peers — the peer manager drops dials to peers already connected — then waits
     /// for peers before spawning the network on the epoch-scoped spawner.
     ///
-    /// The batch topic is subscribed, restricted to committee publishers so non-CVVs can
-    /// prefetch batches (harmless for CVVs). Non-CVVs push the transactions they accept to
-    /// the committee over RPC rather than gossiping them (issue #804).
+    /// The batch topic is subscribed only by committee validators, restricted to committee
+    /// publishers, so they can prefetch batch bodies into `NodeBatchesCache` ahead of the vote
+    /// path. Observers skip it and unsubscribe: they receive batch bodies inside the verified
+    /// consensus output and epoch packs they already download (`crates/state-sync`), so the
+    /// digest gossip would only fetch the same bytes a second time (issue #960). Non-CVVs push
+    /// the transactions they accept to the committee over RPC rather than gossiping them
+    /// (issue #804).
     #[allow(clippy::too_many_arguments)]
     async fn spawn_worker_network_for_epoch(
         &mut self,
@@ -780,15 +784,28 @@ where
 
         Self::wait_for_network_peers(network_handle.inner_handle(), "worker network").await?;
 
-        // Get gossip from committee members about batches every epoch.
-        // Useful for non-CVVs to prefetch and harmless for CVVs.
-        network_handle
-            .inner_handle()
-            .subscribe_with_publishers(
-                tn_config::LibP2pConfig::worker_batch_topic(consensus_config.chain_id()),
-                committee_keys.into_iter().collect(),
-            )
-            .await?;
+        // Decide the batch-digest gossip subscription for this epoch (issue #960). Committee
+        // validators subscribe to warm the vote path's batch cache; observers unsubscribe,
+        // because state-sync already delivers batch bodies with the consensus output they
+        // follow, so the prefetch would refetch bytes they are downloading anyway.
+        //
+        // The decision is two-sided rather than a bare skip because the worker swarm is
+        // process-lifetime: a validator that subscribed in one epoch stays subscribed into every
+        // later epoch unless the subscription is explicitly dropped. Skipping alone would also
+        // skip the only refresh of this topic's authorized-publisher allowlist, freezing it on
+        // the committee that was current when the node last subscribed.
+        let batch_topic = tn_config::LibP2pConfig::worker_batch_topic(consensus_config.chain_id());
+        let mode = self.consensus_bus.current_node_mode();
+        if should_subscribe_batch_topic(mode) {
+            debug!(target: "epoch-manager", ?mode, "subscribing to worker batch topic");
+            network_handle
+                .inner_handle()
+                .subscribe_with_publishers(batch_topic, committee_keys.into_iter().collect())
+                .await?;
+        } else {
+            debug!(target: "epoch-manager", ?mode, "skipping worker batch topic - follows consensus output");
+            network_handle.inner_handle().unsubscribe(batch_topic).await?;
+        }
 
         // spawn worker network
         WorkerNetwork::new(
@@ -960,5 +977,48 @@ impl ReplayResult {
     /// Take `Self::last_replayed_hash` if it exists.
     pub(super) fn take_last_replayed_hash(&mut self) -> Option<ConsensusHeaderDigest> {
         self.last_replayed_hash.take()
+    }
+}
+
+/// Whether a node in this [`NodeMode`] should subscribe to the worker batch-digest gossip topic.
+///
+/// Only nodes that consume individual current-epoch batches benefit: a committee validator
+/// prefetches the body into `NodeBatchesCache` so the vote path finds it locally instead of
+/// fetching it on demand. That includes `CvvInactive` — a validator catching up to rejoin warms
+/// the cache it will vote against, and a mode-change re-entry does not clear that cache, so the
+/// warm-up survives its promotion. An `Observer` never votes and receives batch bodies inside the
+/// verified consensus output and epoch packs it already downloads (`crates/state-sync`), so for it
+/// the prefetch is pure duplicate bandwidth.
+///
+/// Equivalent to [`ConsensusBus::is_cvv`], written as an exhaustive match so a new [`NodeMode`]
+/// variant fails to compile until this decision is made for it.
+fn should_subscribe_batch_topic(mode: NodeMode) -> bool {
+    match mode {
+        NodeMode::CvvActive | NodeMode::CvvInactive => true,
+        NodeMode::Observer => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_subscribe_batch_topic, NodeMode};
+
+    /// An active committee validator prefetches batches for the vote path.
+    #[test]
+    fn active_cvv_subscribes_to_batch_topic() {
+        assert!(should_subscribe_batch_topic(NodeMode::CvvActive));
+    }
+
+    /// A validator catching up to rejoin warms the cache it is about to vote against; the cache
+    /// survives the mode-change re-entry that promotes it.
+    #[test]
+    fn inactive_cvv_subscribes_to_batch_topic() {
+        assert!(should_subscribe_batch_topic(NodeMode::CvvInactive));
+    }
+
+    /// An observer follows consensus output and would only refetch bytes it already downloads.
+    #[test]
+    fn observer_does_not_subscribe_to_batch_topic() {
+        assert!(!should_subscribe_batch_topic(NodeMode::Observer));
     }
 }


### PR DESCRIPTION
Closes #960.

## Problem

Every node subscribes to `worker_batch_topic` every epoch, regardless of role.  `spawn_worker_network_for_epoch` restricted who may *publish* to the committee, but every node still *subscribed* and received every accepted batch digest.  For a node that only follows consensus, each received digest triggered a best-effort prefetch (`process_gossip` -> `request_batches` -> `validate_and_cache_prefetched_batch`) of a batch body it was already downloading: `crates/state-sync` delivers observers a verified consensus output (header plus batches) and epoch pack files, so the digest gossip fetched the same bytes a second time.  Harmless to correctness, real bandwidth on every follower.

## Root cause

The subscription decision was never gated on node mode, and the gate could not simply be added, because two properties of the current design make a one-sided "skip the subscribe call" fix both ineffective and actively harmful:

1. **The worker swarm is process-lifetime.**  It is built once in `spawn_node_networks` (`node.rs`), outside the `run_epochs` loop, and `spawn_worker_network_for_epoch` runs "over the shared swarm" every epoch.  Gossipsub subscription state therefore survives epoch boundaries and mode-change re-entries.  There was no unsubscribe anywhere in the repo: `NetworkCommand` had a `Subscribe` variant and no counterpart, and `consensus.rs` only ever called `gossipsub.subscribe`.  A validator that subscribed in epoch N and rotated out to `Observer` in N+1 would keep receiving digest gossip forever.

2. **The subscribe call is the only writer of the topic's publisher allowlist.**  `NetworkCommand::Subscribe` is the sole mutation of `authorized_publishers` (an `insert`, with no `remove` / `clear` / `retain` anywhere).  Skipping it would freeze the entry on whichever committee was current when the node last subscribed.  `verify_gossip` documents the entry semantics as absent => not subscribed => reject, so a stale entry does not fail open, it fails *closed against the wrong set*: the current committee's honest batch gossip is rejected as `UnauthorizedAuthor`, is no longer re-propagated to downstream peers, and feeds `RejectPenalty::FatalAuthor` into `process_penalty` against honest validators.  Today that harm is contained only by the peer manager's prev/current/next committee exemption, so a skip-only gate would have silently depended on an unrelated safety net.

## Fix

- [x] **`network-libp2p/src/types.rs`** . . . new `NetworkCommand::Unsubscribe { topic, reply }` and `NetworkHandle::unsubscribe(topic) -> NetworkResult<bool>`, reporting whether the node was subscribed.  The reply is a bare `bool` because `libp2p-gossipsub` 0.49.4 (the pinned version) returns `bool` from `unsubscribe`, so the only error paths are channel failures and unsubscribing a never-subscribed topic is a benign no-op, not an error.  That matters: the epoch-start gate calls it on every observer's first epoch and propagates with `?`.
- [x] **`network-libp2p/src/consensus.rs`** . . . the mirror arm in `process_command`'s exhaustive match calls `gossipsub.unsubscribe(&sub)` **and** `authorized_publishers.remove(&topic)`.  The removal is required for the invariant above, not hygiene, and the comment says so.
- [x] **`node/src/manager/node/start_epoch.rs`** . . . the batch-topic decision is now two-sided and re-made every epoch: committee validators subscribe (which also refreshes the publisher allowlist for the new committee), everyone else unsubscribes.  Never a bare skip, for reason 1 above.
- [x] **`should_subscribe_batch_topic(mode)`** . . . the predicate is extracted as a pure function with an exhaustive match over `NodeMode`, so a new variant fails to compile until the decision is made for it, and so all three modes are unit-testable without an `EpochManager` harness (this file previously had no test module).
- [x] **Comment pass** . . . `worker/src/network/handler.rs` (the `process_gossip` doc, the "fetched later when needed" and "fetched on demand later" fallbacks, the inverted "this allows non-CVVs to pre fetch" claim, and the stale "only effect nodes catching up old epochs" note, now deleted), `worker/src/network/message.rs`, `worker/src/worker.rs`, `worker/src/network/mod.rs` (the Byzantine fan-out cap rationale is kept, only the fallback framing is corrected), and the subscription-policy comment hub in `node/src/manager/node.rs` that already enumerates the #898 / #912 topic decisions.

### The two design points the issue asked to settle

**Which modes skip: gate on `is_cvv()`, not `is_active_cvv()`.**  The issue recommended `is_active_cvv()` unless there is a measured cache-warming benefit for the inactive-to-active transition.  There is one, and it is structural rather than measured.  A `ModeChange` re-entry does not clear `NodeBatchesCache`: `clear_tables_for_next_epoch` is set only on `run_epoch`'s boundary arm and its leftover-drain arm, never on the mode-change arm.  The prefetch admits current-epoch digests.  So a `CvvInactive` node catching up warms a cache that *survives its own promotion*, and the vote path (`PrimaryReceiverHandler::synchronize`) reads that cache local-first.  Gossipsub does not backfill, so under `is_active_cvv()` a promoted node would re-subscribe and hold a subscription with a cold cache at exactly the moment it resumes voting at the live tip.  `is_cvv()` also matches the existing precedent in this same file, where the primary network's dial decision already gates on `self.consensus_bus.is_cvv()`.

**Mode is dynamic, subscription is per-epoch: no reactive subscription is needed, and not merely because the epoch cadence is short.**  Under `is_cvv()` the gate value provably cannot change mid-epoch.  Every mid-epoch mutation site that notifies shutdown (`primary/src/network/handler.rs`, `executor/src/subscriber.rs`, `primary/src/consensus/state.rs`) moves only between `CvvActive` and `CvvInactive`, which `is_cvv()` scores identically.  The only mutation to `Observer` is the observer-config branch at `EpochManager` construction, which runs once at process start.  The transitions that *do* flip `is_cvv()` are committee-membership changes, and those are recomputed at epoch entry by `identify_node_mode` (`!in_committee || tn_config.observer`), which `create_consensus` awaits strictly before it reaches the subscription site.  A mode transition also tears the epoch down and re-enters it as `RunEpochMode::ModeChange`, re-running the decision.  So the per-epoch decision is never stale.

### Threat model

The gate is attacker-independent: it is a local read of this node's own mode, taken once per epoch before any peer input, so it cannot be influenced by a peer and adds no work to the message path.  It only narrows what this node accepts, so it cannot widen any trust boundary.  Rotation correctness is the load-bearing part and is explicit above: the subscribe branch re-authorizes the entering committee, and the unsubscribe branch removes the entry entirely rather than leaving the outgoing committee's allowlist installed, which is what would have turned a bandwidth optimization into a penalty against honest current-committee workers.  Removing the prefetch cannot affect liveness or safety in any mode: it is best-effort by construction (the existing admission gate already drops digests silently when the concurrency cap is reached), a genuinely needed batch is still fetched by the vote path itself, and observers receive bodies inside the consensus output they follow.

## Testing

Run on the pinned toolchain (`rust-toolchain.toml` = 1.94), with the `-j 2` OOM cap and an isolated target dir so a sibling worktree's artifacts cannot produce a false green:

```
cargo +nightly-2026-03-20 fmt -- --check
cargo +1.94 clippy --all-targets
CARGO_TARGET_DIR=/Users/oobi/Documents/.tn-960-iso cargo +1.94 test --no-run --workspace -j 2
cargo +1.94 nextest run -p tn-network-libp2p -p tn-node
```

New tests:

- `network-libp2p/src/tests/network_tests.rs::test_unsubscribe_stops_gossip_delivery` . . . asserts unsubscribing a never-subscribed topic returns `false` rather than erroring (the observer first-epoch path), establishes a delivery baseline while subscribed, then unsubscribes and asserts the drop is reported, that the publisher stops observing this peer on the topic, and that publishing then fails for want of a subscriber.  Convergence uses `wait_until`, never `sleep`.
- `node/src/manager/node/start_epoch.rs::tests` . . . `should_subscribe_batch_topic` over all three `NodeMode` variants.

Scope note on what the tests do and do not cover: `authorized_publishers.remove` in the unsubscribe arm is not observable through the network API in a black-box test, because once gossipsub has unsubscribed, no message on that topic reaches `verify_gossip` for the map to be consulted.  It is asserted by construction (the two-sided gate means the entry is either removed or overwritten with the entering committee's set) and by the comment at the call site, not by the new test.  Calling it out rather than implying coverage.
