### PR TITLE
fix(tn-rpc): run the proofOfPossessionMessage BLS decompress off the shared runtime

### DIFF
--- a/crates/execution/tn-rpc/Cargo.toml
+++ b/crates/execution/tn-rpc/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 alloy = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/execution/tn-rpc/src/error.rs
+++ b/crates/execution/tn-rpc/src/error.rs
@@ -31,8 +31,12 @@ pub enum TNRpcError {
         /// Raw ABI-encoded revert bytes, hex-encoded into the error `data` field.
         output: Bytes,
     },
-    /// Internal failure reading the registry. Detail logged server-side only.
-    #[error("consensus registry read failed")]
+    /// Internal failure serving the request. Detail logged server-side only.
+    ///
+    /// Deliberately says nothing about which endpoint or stage failed: it is returned for registry
+    /// reads and for the blocking-dispatch failures behind `proofOfPossessionMessage` alike, and
+    /// the cause is only ever logged server-side.
+    #[error("internal error")]
     Internal,
     /// Caller supplied an invalid parameter (e.g. a malformed BLS public key).
     #[error("{0}")]
@@ -101,7 +105,7 @@ mod tests {
     fn internal_maps_to_internal_error_without_detail() {
         let err: ErrorObject<'static> = TNRpcError::Internal.into();
         assert_eq!(err.code(), -32603);
-        assert_eq!(err.message(), "consensus registry read failed");
+        assert_eq!(err.message(), "internal error");
         assert!(err.data().is_none());
     }
 

--- a/crates/execution/tn-rpc/src/rpc_ext.rs
+++ b/crates/execution/tn-rpc/src/rpc_ext.rs
@@ -16,7 +16,7 @@ use tn_reth::{
 use tn_types::{
     construct_proof_of_possession_message, Address, BlsPublicKey, Bytes, ConsensusHeader, Epoch,
     EpochCertificate, EpochDigest, EpochRecord, Genesis, NodeMode, SolCall, SolType, SolValue,
-    B256, U256,
+    TaskSpawner, B256, U256,
 };
 use tokio::sync::{oneshot, Semaphore};
 
@@ -149,7 +149,8 @@ pub trait TelcoinNetworkRpcExtApi {
     /// Return the BLS12-381 proof-of-possession message a validator signs:
     /// `intentPrefix(3) || compressedBlsPubkey(96) || validatorAddress(20)`.
     ///
-    /// Expects the 96-byte compressed BLS public key.
+    /// Expects the 96-byte compressed BLS public key. The 192-byte uncompressed encoding is also
+    /// accepted and normalized to the compressed form, so both yield the same message.
     #[method(name = "proofOfPossessionMessage")]
     async fn proof_of_possession_message(
         &self,
@@ -167,19 +168,116 @@ pub trait TelcoinNetworkRpcExtApi {
     async fn undistributed_issuance(&self) -> TelcoinNetworkRpcResult<U256>;
 }
 
-/// Maximum number of concurrent blocking [`ConsensusRegistry`] reads served by the `tn`
-/// namespace.
+/// Maximum number of concurrent blocking tasks the `tn` namespace may have in flight.
 ///
-/// Each public read builds a fresh EVM and state snapshot at the canonical tip - synchronous
-/// database/CPU work on a blocking thread. A semaphore permit is held for the full lifetime of
-/// the blocking work, so this bounds true blocking-pool occupancy, not just in-flight requests.
+/// Covers both kinds of synchronous work this namespace dispatches off the async runtime:
+/// [`ConsensusRegistry`] reads, which build a fresh EVM and state snapshot at the canonical tip
+/// (database plus CPU), and the BLS12-381 G2 decompress behind `proofOfPossessionMessage` (pure
+/// CPU, tens of microseconds per call). A semaphore permit is held for the full lifetime of the
+/// blocking work, so this bounds true blocking-pool occupancy, not just in-flight requests.
+///
+/// One bound covers both deliberately. The budget below is a share of a pool the whole process
+/// contends for, so splitting it into a guard per endpoint would let their worst cases add up and
+/// silently double the occupancy this number is chosen to permit.
 ///
 /// Mirrors reth's `eth_call` guard (`DEFAULT_MAX_BLOCKING_IO_REQUEST` = 256): tokio's blocking
 /// pool defaults to 512 threads and grows unbounded under request load without a bound. Set
 /// below reth's 256 because reth's own eth namespace shares the same pool; 64 keeps headroom
 /// for BLS signing and engine blocking tasks. Lives at the RPC layer only, so consensus-critical
 /// reads (`epoch_state_from_canonical_tip`) are never throttled by RPC traffic.
-const MAX_CONCURRENT_REGISTRY_READS: usize = 64;
+const MAX_CONCURRENT_BLOCKING_RPC_WORK: usize = 64;
+
+/// Run `work` on `spawner`'s blocking pool under a `guard` permit, and await its value.
+///
+/// This is how every synchronous endpoint in this namespace runs its work. Handler bodies are
+/// polled on the shared runtime's worker threads, the same threads consensus tasks are scheduled
+/// on, so synchronous work that does not yield holds a worker for its entire duration and nothing
+/// else can be scheduled there until it returns. Dispatching it here keeps the worker free and puts
+/// the work on a pool whose occupancy `guard` bounds.
+///
+/// The permit is moved into the blocking task rather than held across the await, so it is released
+/// when the work actually finishes rather than when the caller stops waiting. A client that
+/// disconnects mid-call therefore cannot release capacity that is still in use.
+///
+/// At capacity this queues rather than rejecting, so a burst of legitimate callers is served late
+/// rather than failed.
+///
+/// `name` labels the task for the task manager's bookkeeping.
+async fn spawn_bounded_blocking<R, F>(
+    guard: &Arc<Semaphore>,
+    spawner: &TaskSpawner,
+    name: &'static str,
+    work: F,
+) -> TelcoinNetworkRpcResult<R>
+where
+    R: Send + 'static,
+    F: FnOnce() -> R + Send + 'static,
+{
+    // bound concurrent blocking work; queues (does not reject) at capacity, mirroring
+    // reth's eth_call guard. acquire only fails if the semaphore is closed, which never
+    // happens because it lives as long as the RPC server.
+    let permit = guard.clone().acquire_owned().await.map_err(|e| {
+        tracing::warn!(target: "tn::rpc", error = %e, task = name, "rpc blocking semaphore closed");
+        TNRpcError::Internal
+    })?;
+
+    let (tx, rx) = oneshot::channel();
+    spawner.spawn_blocking_task(name, move || {
+        // hold the permit across the work itself and release it before handing the result back, so
+        // capacity frees the moment the expensive part is done rather than after the handoff. The
+        // ordering also means a caller woken by the send always observes the permit as returned.
+        let value = {
+            let _permit = permit;
+            work()
+        };
+        if tx.send(value).is_err() {
+            tracing::debug!(target: "tn::rpc", task = name, "blocking rpc receiver dropped before result");
+        }
+        Ok(())
+    });
+
+    rx.await.map_err(|e| {
+        tracing::warn!(target: "tn::rpc", error = %e, task = name, "blocking rpc result channel closed");
+        TNRpcError::Internal
+    })
+}
+
+/// Build the proof-of-possession message `validator_address` signs with `bls_pubkey`.
+///
+/// Screening the encoding length happens here, on the async thread, because it is the one check
+/// that costs nothing and it settles every input that could never parse before a permit or a pool
+/// thread is committed to it. A flood of malformed keys therefore cannot occupy capacity that real
+/// work needs. Whatever survives the screen still has to decompress a BLS12-381 G2 point, which
+/// takes tens of microseconds and must not run where consensus tasks are scheduled, so it goes to
+/// the blocking pool under a permit.
+async fn proof_of_possession_message_bounded(
+    guard: &Arc<Semaphore>,
+    spawner: &TaskSpawner,
+    bls_pubkey: Bytes,
+    validator_address: Address,
+) -> TelcoinNetworkRpcResult<Bytes> {
+    BlsPublicKey::is_plausible_encoding(&bls_pubkey).then_some(()).ok_or_else(|| {
+        TNRpcError::InvalidParams(format!(
+            "invalid BLS pubkey: expected {} bytes (compressed) or {} bytes (uncompressed), got {}",
+            BlsPublicKey::COMPRESSED_BYTES,
+            BlsPublicKey::UNCOMPRESSED_BYTES,
+            bls_pubkey.len(),
+        ))
+    })?;
+
+    spawn_bounded_blocking(guard, spawner, "tn-rpc-proof-of-possession", move || {
+        // As of the compressed-bytes pivot the registry's `proofOfPossessionMessage` is an internal
+        // helper (not externally callable), so build the message natively from the same `tn_types`
+        // routine the validator signs and the registry reproduces on-chain byte-for-byte:
+        // `intent || compressed pubkey || address`.
+        BlsPublicKey::from_literal_bytes(&bls_pubkey)
+            .map(|pubkey| construct_proof_of_possession_message(&pubkey, &validator_address).into())
+            .map_err(|e| {
+                TNRpcError::InvalidParams(format!("invalid 96-byte compressed BLS pubkey: {e:?}"))
+            })
+    })
+    .await?
+}
 
 /// The type that implements `tn` namespace trait.
 #[derive(Debug)]
@@ -190,8 +288,8 @@ pub struct TelcoinNetworkRpcExt<N: EngineToPrimary> {
     ///
     /// The interface that handles primary <-> engine network communication.
     inner_node_network: N,
-    /// Bounds concurrent blocking [`ConsensusRegistry`] reads (see
-    /// [`MAX_CONCURRENT_REGISTRY_READS`]). Acquired before spawning the blocking read and held
+    /// Bounds the blocking work this namespace dispatches (see
+    /// [`MAX_CONCURRENT_BLOCKING_RPC_WORK`]). Acquired before spawning the blocking task and held
     /// until it completes, capping blocking-pool occupancy from RPC load.
     blocking_io_guard: Arc<Semaphore>,
 }
@@ -387,14 +485,13 @@ where
         bls_pubkey: Bytes,
         validator_address: Address,
     ) -> TelcoinNetworkRpcResult<Bytes> {
-        // As of the compressed-bytes pivot the registry's `proofOfPossessionMessage` is an internal
-        // helper (not externally callable), so build the message natively from the same `tn_types`
-        // routine the validator signs and the registry reproduces on-chain byte-for-byte:
-        // `intent || compressed pubkey || address`.
-        let pubkey = BlsPublicKey::from_literal_bytes(&bls_pubkey).map_err(|e| {
-            TNRpcError::InvalidParams(format!("invalid 96-byte compressed BLS pubkey: {e:?}"))
-        })?;
-        Ok(construct_proof_of_possession_message(&pubkey, &validator_address).into())
+        proof_of_possession_message_bounded(
+            &self.blocking_io_guard,
+            self.evm_state.get_task_spawner(),
+            bls_pubkey,
+            validator_address,
+        )
+        .await
     }
 
     async fn get_next_committee_size(&self) -> TelcoinNetworkRpcResult<u16> {
@@ -419,8 +516,30 @@ where
 impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
     /// Create new instance of the Telcoin Network RPC extension.
     pub fn new(evm_state: RethEnv, inner_node_network: N) -> Self {
-        let blocking_io_guard = Arc::new(Semaphore::new(MAX_CONCURRENT_REGISTRY_READS));
+        let blocking_io_guard = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOCKING_RPC_WORK));
         Self { evm_state, inner_node_network, blocking_io_guard }
+    }
+
+    /// Run `work` on the protocol blocking pool under a [`MAX_CONCURRENT_BLOCKING_RPC_WORK`]
+    /// permit, and await its value.
+    ///
+    /// Binds [`spawn_bounded_blocking`] to this instance's guard and task spawner.
+    async fn spawn_bounded_blocking<R, F>(
+        &self,
+        name: &'static str,
+        work: F,
+    ) -> TelcoinNetworkRpcResult<R>
+    where
+        R: Send + 'static,
+        F: FnOnce() -> R + Send + 'static,
+    {
+        spawn_bounded_blocking(
+            &self.blocking_io_guard,
+            self.evm_state.get_task_spawner(),
+            name,
+            work,
+        )
+        .await
     }
 
     /// Execute a read-only [`ConsensusRegistry`] call at the canonical tip and decode the result.
@@ -437,11 +556,9 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
     /// Run a read-only [`ConsensusRegistry`] closure on the blocking pool and map its result to
     /// an RPC response.
     ///
-    /// EVM reads are synchronous database/CPU work, so they run on the protocol [`TaskSpawner`]'s
-    /// blocking pool to avoid stalling the async runtime on a public endpoint. A
-    /// [`MAX_CONCURRENT_REGISTRY_READS`] permit is acquired before spawning and moved into the
-    /// blocking task, so it is released only when the work finishes — bounding blocking-pool
-    /// occupancy even if a client disconnects mid-read.
+    /// EVM reads are synchronous database/CPU work, so they go through
+    /// [`Self::spawn_bounded_blocking`] rather than running on the async runtime, under the shared
+    /// [`MAX_CONCURRENT_BLOCKING_RPC_WORK`] bound.
     ///
     /// The closure receives an owned [`RethEnv`] and may issue one read
     /// ([`RethEnv::read_consensus_registry`]) or several pinned reads
@@ -450,38 +567,14 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
     ///
     /// On-chain reverts surface to the client eth_call-style (code 3 with revert bytes in
     /// `data`); internal failures are logged server-side and return a generic error.
-    ///
-    /// [`TaskSpawner`]: tn_types::TaskSpawner
     async fn spawn_registry_read<R, F>(&self, read: F) -> TelcoinNetworkRpcResult<R>
     where
         R: Send + 'static,
         F: FnOnce(RethEnv) -> EvmReadResult<R> + Send + 'static,
     {
-        // bound concurrent blocking reads; queues (does not reject) at capacity, mirroring
-        // reth's eth_call guard. acquire only fails if the semaphore is closed, which never
-        // happens because it lives as long as the RPC server.
-        let permit = self.blocking_io_guard.clone().acquire_owned().await.map_err(|e| {
-            tracing::warn!(target: "tn::rpc", error = %e, "registry read semaphore closed");
-            TNRpcError::Internal
-        })?;
-
         let evm = self.evm_state.clone();
-        let (tx, rx) = oneshot::channel();
-        self.evm_state.get_task_spawner().spawn_blocking_task("tn-rpc-registry-read", move || {
-            // hold the permit until the blocking read completes
-            let _permit = permit;
-            if tx.send(read(evm)).is_err() {
-                tracing::debug!(target: "tn::rpc", "registry read receiver dropped before result");
-            }
-            Ok(())
-        });
-
-        rx.await
-            .map_err(|e| {
-                tracing::warn!(target: "tn::rpc", error = %e, "registry read result channel closed");
-                TNRpcError::Internal
-            })?
-            .map_err(|err| match &err {
+        self.spawn_bounded_blocking("tn-rpc-registry-read", move || read(evm)).await?.map_err(
+            |err| match &err {
                 EvmReadError::Revert { output, .. } => {
                     TNRpcError::Revert { message: err.to_string(), output: output.clone() }
                 }
@@ -493,6 +586,236 @@ impl<N: EngineToPrimary> TelcoinNetworkRpcExt<N> {
                     );
                     TNRpcError::Internal
                 }
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        future::Future as _,
+        pin::pin,
+        task::{Context, Poll, Waker},
+        thread,
+    };
+    use tn_types::{BlsKeypair, TaskManager};
+
+    /// Fixed keypair so nothing here depends on an RNG. `[7u8; 32]` is a valid BLS12-381 scalar
+    /// (well below the group order, whose first byte is `0x73`).
+    fn test_keypair() -> BlsKeypair {
+        BlsKeypair::from_bytes(&[7u8; 32]).expect("fixed test scalar is a valid bls private key")
+    }
+
+    /// A guard with every permit already taken, so any code path that acquires one cannot proceed.
+    async fn exhausted_guard() -> (Arc<Semaphore>, tokio::sync::OwnedSemaphorePermit) {
+        let guard = Arc::new(Semaphore::new(1));
+        let held = guard.clone().acquire_owned().await.expect("semaphore is open");
+        (guard, held)
+    }
+
+    /// Moving the decompress to the blocking pool must not change what callers receive: the
+    /// response is still the message `construct_proof_of_possession_message` builds, for both
+    /// encodings `from_literal_bytes` accepts.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pop_message_matches_direct_construction() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let guard = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOCKING_RPC_WORK));
+        let keypair = test_keypair();
+        let address = Address::repeat_byte(0x11);
+        let expected: Bytes =
+            construct_proof_of_possession_message(keypair.public(), &address).into();
+
+        let from_compressed = proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(keypair.public().to_bytes().to_vec()),
+            address,
+        )
+        .await
+        .expect("compressed key is accepted");
+        // `BlsPublicKey` implements `Serialize`, so reach the blst inherent `serialize` through the
+        // deref rather than letting serde's method win resolution
+        let uncompressed = (**keypair.public()).serialize().to_vec();
+        let from_uncompressed = proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(uncompressed),
+            address,
+        )
+        .await
+        .expect("uncompressed key is accepted");
+
+        assert_eq!(from_compressed, expected);
+        assert_eq!(
+            from_uncompressed, expected,
+            "uncompressed input normalizes to the same message"
+        );
+        assert_eq!(
+            guard.available_permits(),
+            MAX_CONCURRENT_BLOCKING_RPC_WORK,
+            "permits are returned once the work completes"
+        );
+    }
+
+    /// The length screen runs before any blocking capacity is committed. With every permit held,
+    /// a wrong-length key must still be answered on the very first poll: a flood of malformed keys
+    /// cannot queue behind, or displace, real work.
+    ///
+    /// Deleting the screen from `proof_of_possession_message_bounded` makes this poll return
+    /// `Pending` instead, because the call then waits on the exhausted semaphore.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn malformed_key_is_rejected_before_taking_a_permit() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let (guard, held) = exhausted_guard().await;
+
+        let mut call = pin!(proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(vec![0u8; BlsPublicKey::COMPRESSED_BYTES - 1]),
+            Address::repeat_byte(0x11),
+        ));
+        let first_poll = call.as_mut().poll(&mut Context::from_waker(Waker::noop()));
+
+        assert!(
+            matches!(first_poll, Poll::Ready(Err(TNRpcError::InvalidParams(_)))),
+            "a wrong-length key must be rejected on the first poll, before acquiring a permit"
+        );
+        drop(held);
+    }
+
+    /// Only the expensive path consults the guard, which is what makes the screen worth having.
+    ///
+    /// A closed semaphore fails every acquisition immediately, so it separates the two paths
+    /// without any timing: a well-formed key has to acquire, and surfaces `Internal`; a malformed
+    /// key is answered by the screen and still surfaces `InvalidParams`.
+    ///
+    /// Removing the permit acquisition from `spawn_bounded_blocking` makes the well-formed call
+    /// succeed here; removing the screen makes the malformed call return `Internal`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn only_the_expensive_path_consults_the_guard() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let guard = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOCKING_RPC_WORK));
+        guard.close();
+        let keypair = test_keypair();
+        let address = Address::repeat_byte(0x11);
+
+        let well_formed = proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(keypair.public().to_bytes().to_vec()),
+            address,
+        )
+        .await;
+        let malformed = proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(vec![0u8; BlsPublicKey::COMPRESSED_BYTES - 1]),
+            address,
+        )
+        .await;
+
+        assert!(
+            matches!(well_formed, Err(TNRpcError::Internal)),
+            "a well-formed key must acquire a permit, so a closed guard has to fail it"
+        );
+        assert!(
+            matches!(malformed, Err(TNRpcError::InvalidParams(_))),
+            "a malformed key is screened before the guard is ever consulted"
+        );
+    }
+
+    /// Capacity is a queue, not a rejection. With the only permit held, a well-formed key parks,
+    /// and it completes once capacity frees, so a burst of legitimate callers is served late rather
+    /// than failed.
+    ///
+    /// Swapping the `acquire_owned().await` in `spawn_bounded_blocking` for a `try_acquire_owned()`
+    /// makes the first poll return `Ready(Err(Internal))` here instead of `Pending`. Nothing else
+    /// in this module distinguishes those two, because every other test either has a free
+    /// permit or a closed semaphore, and a closed semaphore fails both forms identically.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn at_capacity_a_well_formed_key_queues_rather_than_failing() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let (guard, held) = exhausted_guard().await;
+        let keypair = test_keypair();
+        let address = Address::repeat_byte(0x11);
+        let expected: Bytes =
+            construct_proof_of_possession_message(keypair.public(), &address).into();
+
+        let mut call = pin!(proof_of_possession_message_bounded(
+            &guard,
+            &spawner,
+            Bytes::from(keypair.public().to_bytes().to_vec()),
+            address,
+        ));
+        let while_at_capacity = call.as_mut().poll(&mut Context::from_waker(Waker::noop()));
+        assert!(
+            matches!(while_at_capacity, Poll::Pending),
+            "at capacity a well-formed key must queue rather than be rejected"
+        );
+
+        drop(held);
+        let served = call.await.expect("the queued call is served once capacity frees");
+        assert_eq!(served, expected);
+    }
+
+    /// The work runs on the blocking pool, not on the async worker thread that polled the handler.
+    /// This is the property that keeps a request flood from holding worker threads that consensus
+    /// tasks are also scheduled on.
+    ///
+    /// Calling `work()` inline instead of dispatching it makes the two thread ids equal.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_work_runs_off_the_async_thread() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let guard = Arc::new(Semaphore::new(MAX_CONCURRENT_BLOCKING_RPC_WORK));
+        let caller = thread::current().id();
+
+        let worker =
+            spawn_bounded_blocking(&guard, &spawner, "tn-rpc-test", move || thread::current().id())
+                .await
+                .expect("blocking task delivers its result");
+
+        assert_ne!(caller, worker, "blocking work must not run on the polling thread");
+    }
+
+    /// The permit covers the whole blocking op, not just its dispatch. Capacity is only returned
+    /// once the work is actually finished, so a caller that gives up early cannot free a slot that
+    /// is still occupied.
+    ///
+    /// Dropping the permit at the await point instead of moving it into the task makes the
+    /// mid-flight assertion see a free permit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn permit_is_held_until_the_work_completes() {
+        let task_manager = TaskManager::new("pop-test");
+        let spawner = task_manager.get_spawner();
+        let guard = Arc::new(Semaphore::new(1));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
+        let call_guard = guard.clone();
+        let call_spawner = spawner.clone();
+        let call = tokio::spawn(async move {
+            spawn_bounded_blocking(&call_guard, &call_spawner, "tn-rpc-test", move || {
+                let _ = started_tx.send(());
+                // park until the test releases us, so "mid-flight" is a fact, not a race
+                let _ = release_rx.recv();
+                7u8
             })
+            .await
+        });
+
+        started_rx.await.expect("blocking work started");
+        assert_eq!(guard.available_permits(), 0, "the permit is held while the work runs");
+
+        release_tx.send(()).expect("release the blocking work");
+        let result = call.await.expect("task joins").expect("blocking work delivers its result");
+        assert_eq!(result, 7);
+        assert_eq!(guard.available_permits(), 1, "the permit is returned once the work completes");
     }
 }

--- a/crates/types/src/crypto/bls_public_key.rs
+++ b/crates/types/src/crypto/bls_public_key.rs
@@ -87,12 +87,41 @@ impl From<CorePublicKey> for BlsPublicKey {
 }
 
 impl BlsPublicKey {
+    /// Length of the compressed G2 encoding of a public key, in bytes.
+    ///
+    /// This is the wire form used everywhere in the protocol: the validator signs it, the
+    /// `ConsensusRegistry` stores it, and `to_bytes` produces it.
+    pub const COMPRESSED_BYTES: usize = 96;
+
+    /// Length of the uncompressed G2 encoding of a public key, in bytes.
+    ///
+    /// [`Self::from_literal_bytes`] accepts this form as well as [`Self::COMPRESSED_BYTES`],
+    /// normalizing it to the compressed form, but nothing in the protocol emits it.
+    pub const UNCOMPRESSED_BYTES: usize = 192;
+
     /// Encode the public key to base58. This is used for serialize/deserialize.
     pub fn encode_base58(&self) -> String {
         self.to_string()
     }
 
+    /// Whether `bytes` is long enough to be worth handing to [`Self::from_literal_bytes`].
+    ///
+    /// `blst` screens the length before it touches the curve, so this reproduces that screen for
+    /// callers that want to reject junk *before* paying to schedule the decompress. It is a
+    /// necessary condition only: a correct length still decompresses and can still fail. Any
+    /// length this accepts, `from_literal_bytes` may accept; any length it rejects,
+    /// `from_literal_bytes` rejects too, so screening on it never changes which inputs succeed.
+    pub fn is_plausible_encoding(bytes: &[u8]) -> bool {
+        matches!(bytes.len(), Self::COMPRESSED_BYTES | Self::UNCOMPRESSED_BYTES)
+    }
+
     /// Decode the public key from bytes on-chain and return result to caller.
+    ///
+    /// Accepts the [`Self::COMPRESSED_BYTES`] and [`Self::UNCOMPRESSED_BYTES`] G2 encodings.
+    ///
+    /// This decompresses a BLS12-381 G2 point, which costs tens of microseconds. Callers reachable
+    /// from an unauthenticated surface must keep it off the async runtime's worker threads and
+    /// bound how many run at once (see `tn-rpc`'s `proofOfPossessionMessage` handler).
     ///
     /// WARNING: do not use this method to deserialize bytes from filesystem.
     /// This method is only used to convert the literal bytes for the pubkey.
@@ -273,5 +302,80 @@ impl<'de> Deserialize<'de> for BlsPublicKey {
         D: serde::Deserializer<'de>,
     {
         Ok(BlsPublicKeyBytes::deserialize(deserializer)?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BlsKeypair;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    /// The two encoding lengths are the ones `blst` actually accepts, taken from a real key rather
+    /// than asserted from the constants alone. If `blst` ever changed either size, the constants
+    /// would silently start screening out keys the parser accepts, so pin them to observed
+    /// behaviour.
+    #[test]
+    fn encoding_length_constants_match_blst() {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([11u8; 32]));
+        let compressed = keypair.public().to_bytes();
+        // `BlsPublicKey` implements `Serialize`, so reach the blst inherent `serialize` through the
+        // deref rather than letting serde's method win resolution
+        let uncompressed = (**keypair.public()).serialize();
+
+        assert_eq!(compressed.len(), BlsPublicKey::COMPRESSED_BYTES);
+        assert_eq!(uncompressed.len(), BlsPublicKey::UNCOMPRESSED_BYTES);
+        assert!(BlsPublicKey::from_literal_bytes(&compressed).is_ok());
+        assert!(BlsPublicKey::from_literal_bytes(&uncompressed).is_ok());
+        assert!(BlsPublicKey::is_plausible_encoding(&compressed));
+        assert!(BlsPublicKey::is_plausible_encoding(&uncompressed));
+    }
+
+    /// The screen is a *necessary* condition for parsing, which is what makes it safe to run
+    /// before [`BlsPublicKey::from_literal_bytes`]: anything it rejects, the parser rejects too, so
+    /// screening first never changes which inputs succeed. Callers rely on this to reject
+    /// malformed input without paying to schedule a decompress.
+    #[test]
+    fn screen_rejects_only_what_the_parser_would_reject() {
+        let keypair = BlsKeypair::generate(&mut StdRng::from_seed([12u8; 32]));
+        let compressed = keypair.public().to_bytes();
+        // sweep past both accepted lengths, reusing real key bytes so the contents are as
+        // parseable as they can be and only the length is ever at fault
+        let sweep = 0..=BlsPublicKey::UNCOMPRESSED_BYTES + 8;
+
+        // pin which lengths survive, so a screen that accepted everything would fail here rather
+        // than emptying the set below and passing vacuously
+        let surviving: Vec<usize> = sweep
+            .clone()
+            .filter(|&len| BlsPublicKey::is_plausible_encoding(&vec![0u8; len]))
+            .collect();
+        assert_eq!(
+            surviving,
+            vec![BlsPublicKey::COMPRESSED_BYTES, BlsPublicKey::UNCOMPRESSED_BYTES],
+            "exactly the two lengths blst accepts may pass the screen"
+        );
+
+        let screened_out: Vec<Vec<u8>> = sweep
+            .map(|len| (0..len).map(|i| compressed[i % compressed.len()]).collect::<Vec<u8>>())
+            .filter(|candidate| !BlsPublicKey::is_plausible_encoding(candidate))
+            .collect();
+        assert!(
+            screened_out.iter().all(|c| BlsPublicKey::from_literal_bytes(c).is_err()),
+            "screen rejected a length that from_literal_bytes would have accepted"
+        );
+    }
+
+    /// The screen is necessary but not sufficient: a correct length still has to decompress, and
+    /// can still fail. Callers must keep handling the parse error rather than treating a passing
+    /// screen as validation.
+    #[test]
+    fn screen_alone_does_not_validate_the_point() {
+        let junk = vec![0xffu8; BlsPublicKey::COMPRESSED_BYTES];
+
+        assert!(BlsPublicKey::is_plausible_encoding(&junk));
+        assert!(
+            BlsPublicKey::from_literal_bytes(&junk).is_err(),
+            "a correctly sized non-point must still fail to parse"
+        );
     }
 }


### PR DESCRIPTION
Closes #976.

## Problem

`tn_proofOfPossessionMessage` is served from the unauthenticated `tn` namespace and decompresses a BLS12-381 G2 point inline in the handler body.  That body contains no `.await`, so once a runtime worker thread picks it up, nothing else scheduled on that thread runs until the crypto finishes . . . including consensus tasks, which share the same runtime.

Measured on this branch (blst 0.3.16, release, Apple M2 Pro performance core):

| operation | cost per call |
| --- | --- |
| decompress a 96-byte compressed key | 24.8 us |
| decompress 96 arbitrary bytes with the compression bit set | 24.8 us |
| decompress a 192-byte uncompressed key | 0.51 us |
| re-compress a parsed key | 0.10 us |
| reject a wrong-length input | 0.0012 us |

Two things follow from those numbers.  An attacker needs no key material at all: 96 bytes that are not on the curve cost the server exactly as much as a real validator key, because the square root runs before the on-curve check can fail.  And a wrong-length input is essentially free, because blst screens the length before it touches the curve, so the expensive case is specifically a correctly sized one.

The per-request cost understates the exposure, because a caller does not have to send one call per request.  jsonrpsee runs the entries of a JSON-RPC batch sequentially inside a single task (`jsonrpsee-server-0.26.0/src/middleware/rpc.rs:157-160`), and batching is unlimited: jsonrpsee defaults to `BatchRequestConfig::Unlimited` (`server.rs:366`) and reth never calls `set_batch_request_config`, so the only ceiling is the default 15 MB request body (`RPC_DEFAULT_MAX_REQUEST_SIZE_MB`).  At roughly 340 bytes per batch entry that is about 44,000 calls in one HTTP request, roughly 1.1 s of a single worker thread with no yield point anywhere inside it.  The default connection limit is 500.

Threat model: no privilege, no stake, no key material, no prior handshake.  Any anonymous client that can reach the general HTTP/WS/IPC transport.

## Root cause

This is the only handler in the namespace that does its work inline.  Every registry-backed `tn` method already goes through `spawn_registry_read`, which takes a permit and runs on the blocking pool specifically so that, in the words of its own doc comment, "consensus-critical reads are never throttled by RPC traffic".

`proof_of_possession_message` used to be one of those: it called the on-chain `ConsensusRegistry::proofOfPossessionMessageCall` through the guarded path.  #759 replaced that with native in-process construction, which is the right call for correctness and cost, but it also took the handler off the guarded path and nothing replaced the guard.  So this is not a regression of a check that once wrapped the BLS work.  That work has never had one;  the #736 guard only ever protected the EVM read.

The shared-runtime premise is confirmed rather than assumed.  The node builds exactly one `Builder::new_multi_thread()` (`telcoin-network-cli/src/cli.rs:153`) with no `worker_threads` override.  `RethEnv::start_rpc` never attaches a dedicated runtime, so jsonrpsee's `ServerConfig.tokio_runtime` stays at its `None` default and both the accept loop and every per-connection task are plain `tokio::spawn` on that runtime.  Consensus tasks reach the same runtime through the same `tokio::spawn` (`types/src/task_manager.rs:189`).  An async trait method is dispatched inline by `register_async_method`, with no offload, which is what lets a yield-free body hold a worker.

## Changes

- [x] `tn-rpc/src/rpc_ext.rs`: new `spawn_bounded_blocking` . . . acquire a permit, dispatch to the task spawner's blocking pool, and move the permit into the task so it is released when the work finishes rather than when the caller stops waiting.  `spawn_registry_read` is now expressed on top of it, so the two endpoints share one implementation of the permit-and-dispatch dance instead of keeping two copies in step.
- [x] `tn-rpc/src/rpc_ext.rs`: `proof_of_possession_message` dispatches the decompress through it.  Per-call latency goes from 24.8 us to 33.7 us;  the worker thread is free for all of it, and in the batch case the await between entries is what lets consensus interleave.
- [x] `tn-rpc/src/rpc_ext.rs`: cheap-first screen.  An impossible encoding length is rejected inline, before a permit or a pool thread is committed, so a flood of malformed keys cannot displace real work: 0.0012 us to reject against a 5.8 us round-trip to dispatch it.
- [x] `tn-rpc/src/rpc_ext.rs`: `MAX_CONCURRENT_REGISTRY_READS` becomes `MAX_CONCURRENT_BLOCKING_RPC_WORK`, one bound over both kinds of blocking work.  A second guard sized independently would let the two worst cases add up and quietly double the pool occupancy the existing 64 was chosen to permit.
- [x] `tn-types/src/crypto/bls_public_key.rs`: `COMPRESSED_BYTES`, `UNCOMPRESSED_BYTES` and `is_plausible_encoding`, so the screen and the parser agree by construction instead of the RPC layer hard-coding 96 and 192 next to a `blst` call that owns those numbers.
- [x] Doc fix: `proofOfPossessionMessage` also accepts the 192-byte uncompressed encoding and normalizes it to the compressed form.  The trait doc claimed 96 only.

Behaviour for a successful call is unchanged: both encodings still produce the same message bytes, and a bad point still returns `InvalidParams`.  Two error paths do change, both deliberately:

- A wrong-length key now returns an `InvalidParams` naming the expected lengths, instead of a bare blst code.
- The endpoint gains an `Internal` (-32603) failure class it did not have when it ran inline, reachable if the blocking dispatch cannot deliver (realistically only in a shutdown window, where the runtime drops a queued closure).  Nothing in the repo or in `crates/e2e-tests` asserts on either message.

`TNRpcError::Internal`'s text moves from "consensus registry read failed" to "internal error" for that reason: the variant is now returned by an endpoint that performs no registry read, and its whole design is to say nothing and log the cause server-side.

## On sharing one guard

This is the part most worth arguing with, so both directions, not just the flattering one.

The direction this PR creates is registry-read to PoP.  An EVM read holds its permit for milliseconds;  a PoP call holds one for tens of microseconds.  Since the semaphore is FIFO, a PoP call arriving behind a saturated queue of registry reads now waits where before it waited for nothing at all, and the wait queue itself has no depth cap.

The reverse direction, PoP to registry read, is the benign one: in-flight PoP calls are capped by the 500-connection limit because batch entries run sequentially per connection, permits turn over every ~30 us, and a registry read arriving behind a full queue waits on the order of a millisecond.

What makes the trade worth taking is that the status quo is not "registry reads keep their own 64 permits".  It is a flood that holds runtime worker threads, which stalls the registry endpoints, consensus, and the rest of the RPC surface at once.  Bounded queueing against a fair semaphore is a better failure mode than that, and a second independently sized guard would restore the unbounded-occupancy problem the first one exists to prevent.  If reviewers would rather keep the endpoints isolated, the alternative is two guards summing to 64 rather than two guards of 64.

## Testing

```
cargo +nightly-2026-03-20 fmt -- --check
cargo +nightly-2026-03-20 clippy --workspace -- -D warnings
cargo +nightly-2026-03-20 clippy --workspace --all-features -- -D warnings
cargo +1.94 test --no-run --workspace
cargo +1.94 test -p tn-rpc -p tn-types --lib
```

All green.  `tn-rpc` 10 passed, `tn-types` 91 passed.

Every new test was confirmed by mutation, meaning each was seen to fail against a deliberately broken build before being trusted:

| mutation applied | test that failed |
| --- | --- |
| length screen removed | `malformed_key_is_rejected_before_taking_a_permit` |
| permit acquired from a throwaway semaphore | `only_the_expensive_path_consults_the_guard`, `permit_is_held_until_the_work_completes` |
| work run inline instead of dispatched | `blocking_work_runs_off_the_async_thread` |
| permit released at dispatch instead of held | `permit_is_held_until_the_work_completes` |
| `acquire_owned().await` swapped for `try_acquire_owned()` | `at_capacity_a_well_formed_key_queues_rather_than_failing` |
| screen accepts every length | `screen_rejects_only_what_the_parser_would_reject` |
| screen drops the uncompressed length | `encoding_length_constants_match_blst`, `screen_rejects_only_what_the_parser_would_reject` |

The queue-not-reject case earns its place: under the `try_acquire_owned` mutation every other test stays green, because they all run with either a free permit or a closed semaphore, and a closed semaphore fails both forms identically.  Only an exhausted-but-open guard tells them apart.

No test asserts on wall-clock time.  The offload is pinned by comparing thread ids across the dispatch.  The two request paths are separated by closing the semaphore, which fails any acquisition immediately, so a well-formed key surfaces `Internal` while a malformed one is still answered by the screen;  that distinguishes them without waiting on anything.  `screen_rejects_only_what_the_parser_would_reject` asserts which lengths survive before asserting the implication over the rest, because a screen that accepted everything would otherwise empty the set and pass vacuously.

## Out of scope

The issue also lists rate limiting or authentication for the method, and a `worker_threads` floor.  Those are deliberately not here:

- Authenticating `tn_*` or removing it from the public transport is a decision about who may call the namespace, not a defect fix.
- A batch-size limit is the most valuable remaining hardening, since batching is what turns one request into 44,000 calls.  It is set on reth's `ServerConfigBuilder` and would apply to the whole node RPC surface, including `eth_*` where clients batch legitimately, so it deserves its own issue and its own default.  Happy to open one.
- A `worker_threads` floor changes process-wide scheduling for every deployment.

What this PR removes is the endpoint's ability to hold worker threads at all, which is the part that is unambiguously a defect.  The aggregate CPU a flood can consume is a rate-limiting concern and is unchanged.

One measurement noted for the record and deliberately not acted on: `construct_proof_of_possession_message` re-compresses the key through `to_bytes()` rather than reading the already-cached bytes, so the handler performs one decompress and two compresses.  At 0.10 us against 24.8 us that is 0.4% of the call and not the lever here, and the function is on consensus paths, so it does not belong in a DoS fix.
