### PR TITLE
tn-reth: instrument the gas the epoch-boundary system calls spend

### DIFF
--- a/crates/tn-metrics/README.md
+++ b/crates/tn-metrics/README.md
@@ -41,6 +41,17 @@ become Prometheus `HELP` text.
 Rules:
 
 - No high-cardinality labels (no peer ids, digests, or epochs as label values).
+- A metric that needs a label has no derive field at all: the derive generates one unlabelled
+  series per field. Use the `metrics::gauge!` / `metrics::counter!` macros with the matching
+  `metrics::describe_*!`, which also resolve the recorder on every call. `tn-reth`'s
+  `tn_reth.epoch_close_system_call_gas_used` (`crates/tn-reth/src/metrics.rs`) is the in-repo
+  example — one series per epoch-boundary system call, keyed by a closed `call` label.
+- The derive's `Default::default()` caches the whole struct in a `static OnceLock`, so the first
+  construction in a process fixes which recorder every later handle records against.
+  `Metrics::new_with_labels` does not cache, so prefer it over `default()` wherever a second
+  recording in one process has to reach a different recorder — which is any test that installs a
+  local recorder. `tn-reth`'s `RethEnvMetrics` tests do exactly this. Production behaviour is
+  identical either way, since the node installs one recorder before the first metric exists.
 - Epoch / round / height are gauge **values**, not labels.
 - Histograms must end in `_seconds` or `_bytes`, or have explicit buckets registered in
   `recorder.rs` — otherwise they render as non-aggregatable quantile summaries.
@@ -64,7 +75,9 @@ use metrics_util::debugging::{DebugValue, DebuggingRecorder};
 let recorder = DebuggingRecorder::new();
 let snapshotter = recorder.snapshotter();
 metrics::with_local_recorder(&recorder, || {
-    let metrics = WorkerMetrics::default();
+    // `new_with_labels`, not `default()`: the latter caches in a `OnceLock` and would bind to
+    // whichever recorder was installed the first time this type was constructed in the process
+    let metrics = WorkerMetrics::new_with_labels(Vec::<metrics::Label>::new());
     metrics.batches_sealed_total.increment(1);
 });
 let snapshot = snapshotter.snapshot().into_vec();

--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -76,8 +76,13 @@ failure**:
 1. *(adiri builds only)* If the epoch being concluded satisfies
    `concluding_epoch + 1 == CONSENSUS_REGISTRY_FORK_EPOCH`, apply the registry fork
    (`apply_consensus_registry_fork`) — code swap plus one-time `migrateValidatorSets()` — so the
-   remaining steps in this same block already run on the upgraded code.
-2. The three boundary system calls (`apply_closing_epoch_contract_call`), in a client-enforced
+   remaining steps in this same block already run on the upgraded code, then the `WorkerConfigs`
+   fork (`apply_worker_configs_fork`), a code-only swap with no initializer call. The two ride the
+   same boundary, in that order, because the registry swap flips this very block's close onto the
+   post-fork sequence, whose fourth call needs the `setWorkerConfigsData` selector the pre-fork
+   `WorkerConfigs` deployment lacks — a build applying one swap but not the other aborts this
+   block.
+2. The four boundary system calls (`apply_closing_epoch_contract_call`), in a client-enforced
    order that is itself a consensus-safety obligation: `applyIncentives(RewardInfo[])` first
    (the reward infos carry each validator's consensus-leader count, weighted on pre-slash
    collateral), then `applySlashes(Slash[])` (the slashes carrier — the protocol passes an
@@ -89,11 +94,17 @@ failure**:
    obligation lives in the client** — the registry only enforces the outcome (it validates the
    committee against post-slash state and reverts `InvalidCommitteeSize` on a stale one). An
    undersized pool fails client-side with `TnRethError::UndersizedCommittee` instead of
-   submitting calldata that reverts on-chain. While the deployed registry still carries the
-   pre-fork adiri code, the close instead replays the legacy `applyIncentives` +
-   `concludeEpoch(address[])` pair through the same code-hash gate as the committee-pool read
-   (no interposed `applySlashes`; the shared selectors are byte-identical), keeping pre-fork
-   history re-executable.
+   submitting calldata that reverts on-chain. Finally `setWorkerConfigsData(uint16[],uint184[])`
+   (`record_next_epoch_base_fees`) writes each EIP-1559 worker's next-epoch base fee into its
+   `WorkerConfigs` `data` word, so a node entering the epoch reads the fee from one state slot
+   instead of rescanning the prior epoch's headers. It trails the registry calls because it
+   touches a different contract — nothing in the epoch transition reads what it writes — and it
+   is skipped entirely when no worker is EIP-1559 (an emptiness every node derives identically
+   from the same contract state, so skipping cannot diverge the fleet). While the deployed
+   registry still carries the pre-fork adiri code, the close instead replays the legacy
+   `applyIncentives` + `concludeEpoch(address[])` pair through the same code-hash gate as the
+   committee-pool read (no interposed `applySlashes` and no base-fee record; the shared selectors
+   are byte-identical), keeping pre-fork history re-executable.
 
 There is deliberately no in-`finish()` transition merge: reth's block-builder/executor wrappers
 merge once after `finish()` returns, and a second merge would push a phantom empty reverts entry
@@ -106,6 +117,83 @@ base-fee and nonce checks disabled (`transact_system_call` in `src/evm/mod.rs`);
 **Slashing is not live.** `applySlashes(Slash[])` is the slashes carrier and the registry
 implements it, but the client always passes an empty array (production builds);
 `concludeEpoch` takes only the new committee `address[]`.
+
+### Boundary gas
+
+The 100M budget is granted **per call**, not per block, and is independent of the block gas limit:
+a system call is submitted at `gas_price: 0`, so it neither pays for gas nor counts against the
+block. That also means its gas never enters the block's `gas_used`, and no block-level or
+engine-level gas metric can see it.
+
+Every step of the close is fatal on failure, and the revert is a pure function of committed state,
+so a `concludeEpoch` that outgrows its budget halts every node at the same boundary rather than
+degrading. Raising the limit changes block execution and is a lockstep fleet upgrade (see the
+`SYSTEM_CALL_GAS_LIMIT` doc in `src/evm/mod.rs`), so the headroom needs lead time. These gauges
+(`src/metrics.rs`) are where it comes from:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `tn_reth_epoch_close_system_call_gas_used{call="…"}` | gauge | Gas spent by one boundary system call. `call` is `apply_incentives`, `apply_slashes`, `conclude_epoch`, `record_base_fees`, or `registry_migration` (the one-shot registry fork migration, absent on every other close). A call that did not run publishes no series rather than a zero. |
+| `tn_reth_epoch_close_gas_used` | gauge | Gas spent by those calls together. Each has its own budget, so this is the boundary's total cost rather than the bounded figure. |
+| `tn_reth_epoch_close_system_call_gas_limit` | gauge | The compiled-in per-call budget, published so queries express headroom as a ratio instead of hardcoding 100000000. |
+
+These record gas **spent**, before EIP-3529 refunds, because the spend is what the budget bounds.
+That is deliberately not revm's `ExecutionResult::gas_used`, which is the spend net of the refund.
+The refund is computed after execution and capped at a fifth of the spend, so it never buys the
+call more room — publishing `gas_used` would slide the alert threshold with the refund: a call
+earning the full refund reports four fifths of what it spent, so an 80%-of-budget alert would not
+fire until the spend reached the whole 100M, which is the halt it exists to predict.
+
+Every node records these as it executes the closing block, so the series is fleet-wide rather than
+proposer-only, and it covers closing blocks re-executed during a sync — a replayed value is still a
+true observation of what that epoch cost.
+
+Dashboard — worst epoch close seen in the last 30 days, per call:
+
+```promql
+max_over_time(tn_reth_epoch_close_system_call_gas_used[30d])
+```
+
+The same figure as a fraction of the budget, which is the number to watch:
+
+```promql
+max_over_time(tn_reth_epoch_close_system_call_gas_used[30d])
+  / ignoring(call) group_left max_over_time(tn_reth_epoch_close_system_call_gas_limit[30d])
+```
+
+Alert — a node's epoch close crossed four fifths of its budget in the last 30 days, the same
+threshold that makes each close log a warning. `registry_migration` is excluded: it is the call the
+100M headroom exists for, and it is written once at the fork block and then latches forever, so it
+could never clear:
+
+```promql
+max_over_time(
+  tn_reth_epoch_close_system_call_gas_used{call!="registry_migration"}[30d]
+)
+  / ignoring(call) group_left max_over_time(tn_reth_epoch_close_system_call_gas_limit[30d])
+  > 0.8
+```
+
+Reading these correctly needs two properties of a once-per-epoch gauge:
+
+- **They latch, they do not lapse.** The exporter registers no idle timeout, so a gauge is
+  re-rendered with its last value on every scrape until the next close overwrites it. Short range
+  selectors are therefore legal, but a value can be an entire epoch old, and a node that has stopped
+  closing epochs keeps publishing its last figure as though it were current. Pair these with
+  `tn_epoch_current` when freshness matters.
+- **They are absent before the first close.** A restarted node publishes no
+  `tn_reth_epoch_close_*` series at all until it next executes a closing block, which for a node at
+  the start of an epoch is the whole epoch. Alerts must tolerate the absence rather than read it as
+  zero.
+
+What these do **not** cover: only the committed system calls above are instrumented. The closing
+block issues other calls under their own copy of the same budget, each equally fatal. The
+blockhashes (EIP-2935) and beacon-root (EIP-4788) pre-block calls are fixed-cost, so they need no
+watching. The reads are the gap — `shuffle_new_committee`'s committee-pool read scales with the
+eligible validator set and `record_next_epoch_base_fees`' `getAllWorkerConfigs` with the worker
+count, both inherit the same 100M ceiling (contract reads share the system-call plumbing; see the
+`SYSTEM_CALL_GAS_LIMIT` doc), and neither is instrumented. A boundary can still fail on a call
+these gauges never showed.
 
 ## ConsensusRegistry fork gate (adiri)
 
@@ -290,7 +378,7 @@ Block production must be a pure function of certified consensus output. Concrete
 | `src/evm/tel_precompile/` | Native TEL issuance at `0x…07e1` (see its README). |
 | `src/evm/bls_precompile/` | BLS12-381 signature verification at `0x…b151`. |
 | `src/forward.rs` | `WorkerRpcForwarder`: observer → committee transaction forwarding. |
-| `src/metrics.rs` | Block-building drop counters (`unrecoverable` alertable, `invalid` expected). |
+| `src/metrics.rs` | Block-building drop counters (`unrecoverable` alertable, `invalid` expected) and the epoch-close system-call gas gauges. |
 | `src/payload.rs` | `TNPayload` and `BuildArguments`: consensus data shaped for execution. |
 | `src/rpc_server_args.rs` | RPC CLI argument subset and transport-limit defaults. |
 | `src/snapshot.rs` | State-pack export (`PinnedStateView`) and verified restore (`SnapshotRestorer`). |

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -1310,6 +1310,130 @@ mod tests {
         Ok(())
     }
 
+    /// An epoch-closing block publishes what each of its system calls spent.
+    ///
+    /// The boundary calls are submitted at `gas_price: 0`, so their gas never enters the block's
+    /// `gas_used` and no other metric can see it (#1031) — while #1012 raised the per-call budget
+    /// to 100M without any measurement of what the calls actually consume. This drives a real
+    /// close through the production path and asserts the gauges observe it: each of the four
+    /// post-fork calls reports nonzero gas inside the budget it was granted, the total is their
+    /// sum, and the one-shot `registry_migration` series is absent away from the fork boundary.
+    ///
+    /// The local recorder is why `record_epoch_close_gas` resolves its handles on every close
+    /// instead of caching them: a cached handle binds to whichever recorder was installed first in
+    /// the process, which would make this assertion depend on test ordering (`crate::metrics`).
+    #[tokio::test]
+    async fn test_epoch_close_records_system_call_gas() -> eyre::Result<()> {
+        use crate::evm::SYSTEM_CALL_GAS_LIMIT;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        /// Read one gauge out of the snapshot, selecting by `call` label when one is given.
+        ///
+        /// Generic over the description slot so the recorder's own string type never has to be
+        /// named here.
+        fn gauge<D>(
+            snapshot: &[(metrics_util::CompositeKey, Option<metrics::Unit>, D, DebugValue)],
+            name: &str,
+            call: Option<&str>,
+        ) -> Option<f64> {
+            snapshot
+                .iter()
+                .find(|(key, ..)| {
+                    key.key().name() == name
+                        && call.is_none_or(|call| {
+                            key.key().labels().any(|l| l.key() == "call" && l.value() == call)
+                        })
+                })
+                .and_then(|(.., value)| match value {
+                    DebugValue::Gauge(g) => Some(g.0),
+                    DebugValue::Counter(_) | DebugValue::Histogram(_) => None,
+                })
+        }
+
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis_with_consensus_registry(5).into());
+        let tmp = TempDir::new().unwrap();
+        let tm = TaskManager::new("epoch close gas metrics");
+        let env = RethEnv::new_for_temp_chain(chain.clone(), tmp.path(), &tm, None)?;
+
+        let output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &output);
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        // block execution is inline on this thread, so the thread-local recorder observes it
+        metrics::with_local_recorder(&recorder, || {
+            execute_payload_and_update_canonical_chain(&env, payload, vec![])
+        })?;
+        let snapshot = snapshotter.snapshot().into_vec();
+
+        const PER_CALL: &str = "tn_reth.epoch_close_system_call_gas_used";
+        let budget = SYSTEM_CALL_GAS_LIMIT as f64;
+
+        // the four calls a post-fork close makes, each real work inside the budget it was granted
+        let spent: Vec<f64> =
+            ["apply_incentives", "apply_slashes", "conclude_epoch", "record_base_fees"]
+                .into_iter()
+                .map(|call| {
+                    let gas = gauge(&snapshot, PER_CALL, Some(call))
+                        .unwrap_or_else(|| panic!("{call} gas must be recorded: {snapshot:?}"));
+                    assert!(gas > 0.0, "{call} must report the gas it spent, got {gas}");
+                    assert!(gas < budget, "{call} spent {gas}, at or over its {budget} budget");
+                    gas
+                })
+                .collect();
+
+        assert_eq!(
+            gauge(&snapshot, "tn_reth.epoch_close_gas_used", None),
+            Some(spent.iter().sum::<f64>()),
+            "the total gauge must sum exactly the calls that ran"
+        );
+        assert_eq!(
+            gauge(&snapshot, "tn_reth.epoch_close_system_call_gas_limit", None),
+            Some(budget),
+            "the budget gauge must publish the compiled-in limit"
+        );
+
+        // epoch 0 is not the registry fork boundary, so no migration ran
+        assert!(
+            gauge(&snapshot, PER_CALL, Some("registry_migration")).is_none(),
+            "no registry migration away from the fork boundary: {snapshot:?}"
+        );
+
+        Ok(())
+    }
+
+    /// A block that closes no epoch publishes no epoch-close gas at all.
+    ///
+    /// Absent rather than zero. Ordinary blocks vastly outnumber closing ones, so publishing a
+    /// zero for each would overwrite the last real close's figures within seconds and leave the
+    /// gauges reading as though concluding an epoch were free.
+    #[tokio::test]
+    async fn test_block_without_epoch_close_records_no_gas() -> eyre::Result<()> {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis_with_consensus_registry(5).into());
+        let tmp = TempDir::new().unwrap();
+        let tm = TaskManager::new("epoch close gas metrics (no close)");
+        let env = RethEnv::new_for_temp_chain(chain.clone(), tmp.path(), &tm, None)?;
+
+        let output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &output);
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            execute_payload_and_update_canonical_chain(&env, payload, vec![])
+        })?;
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert!(
+            !snapshot.iter().any(|(key, ..)| key.key().name().starts_with("tn_reth.epoch_close")),
+            "a block that closes no epoch must record no epoch-close gas: {snapshot:?}"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_close_epochs() -> eyre::Result<()> {
         let validator_1 = Address::from_slice(&[0x11; 20]);

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -87,6 +87,7 @@
 
 use crate::{
     error::{TnRethError, TnRethResult},
+    metrics::{gas_spent, EpochCloseGas},
     system_calls::{
         decode_worker_fee_configs,
         ConsensusRegistry::{self, RewardInfo, ValidatorStatus},
@@ -236,6 +237,13 @@ pub(crate) struct TNBlockExecutor<Evm, Spec, R: ReceiptBuilder> {
     receipts: Vec<R::Receipt>,
     /// Total gas used by transactions in this block.
     gas_used: u64,
+    /// Gas spent by the epoch-boundary system calls this block issued, accumulated as they run
+    /// and published once by [`Self::finish`] (`crate::metrics::record_epoch_close_gas`).
+    ///
+    /// Every caller of [`Self::transact_and_commit_system_call`] is an epoch-boundary call, so
+    /// this stays empty on the overwhelming majority of blocks — and an empty `Vec` does not
+    /// allocate, so a non-closing block pays nothing for the instrumentation.
+    epoch_close_gas: EpochCloseGas,
 }
 
 // alloy-evm
@@ -252,7 +260,15 @@ where
 {
     /// Creates a new [`TNBlockExecutor`]
     pub(crate) fn new(evm: Evm, ctx: TNBlockExecutionCtx, spec: Spec, receipt_builder: R) -> Self {
-        Self { evm, ctx, receipts: Vec::new(), gas_used: 0, spec, receipt_builder }
+        Self {
+            evm,
+            ctx,
+            receipts: Vec::new(),
+            gas_used: 0,
+            spec,
+            receipt_builder,
+            epoch_close_gas: EpochCloseGas::default(),
+        }
     }
 
     /// Execute a system call from [`SYSTEM_ADDRESS`] to `contract` and commit its state changes.
@@ -269,11 +285,18 @@ where
     /// spurious account into the bundle and diverge the state root. Every commit of a
     /// system-call result must uphold this invariant; the EIP-4788/EIP-2935 pre-block calls do
     /// so with a `retain` of their target contract, which also drops the touched beneficiary.
+    ///
+    /// On success the gas the call SPENT (see [`gas_spent`]) is accumulated under `label` for
+    /// [`Self::finish`] to publish. `label` is the `call` label value the gauge carries, so it is
+    /// a stable machine-readable name rather than the human `description`: the two are separate
+    /// because renaming a log line must not silently rename a metric series. Only the success arm
+    /// records — a revert or halt aborts the block, leaving no epoch close to report gas for.
     fn transact_and_commit_system_call(
         &mut self,
         contract: Address,
         calldata: Bytes,
         description: &str,
+        label: &'static str,
     ) -> TnRethResult<()> {
         let mut res = match self.evm.transact_system_call(SYSTEM_ADDRESS, contract, calldata) {
             Ok(res) => res,
@@ -287,7 +310,9 @@ where
         // return error if the call executed but did not succeed, keeping Revert (decoded
         // reason + selector) distinguishable from Halt
         match &res.result {
-            ExecutionResult::Success { .. } => {}
+            ExecutionResult::Success { gas_used, gas_refunded, .. } => {
+                self.epoch_close_gas.push(label, gas_spent(*gas_used, *gas_refunded));
+            }
             ExecutionResult::Revert { output, gas_used } => {
                 let reason = alloy::sol_types::decode_revert_reason(output)
                     .unwrap_or_else(|| "<undecodable revert reason>".to_string());
@@ -376,6 +401,7 @@ where
             CONSENSUS_REGISTRY_ADDRESS,
             calldata,
             "applying incentives",
+            "apply_incentives",
         )?;
 
         // 2. slashes, landing before the committee is read
@@ -385,6 +411,7 @@ where
             CONSENSUS_REGISTRY_ADDRESS,
             calldata,
             "applying slashes",
+            "apply_slashes",
         )?;
 
         // 3. assemble the committee from the post-slash eligible pool, then conclude
@@ -394,6 +421,7 @@ where
             CONSENSUS_REGISTRY_ADDRESS,
             calldata,
             "closing epoch",
+            "conclude_epoch",
         )?;
 
         // 4. publish the next epoch's per-worker base fees for the epoch that just began
@@ -508,6 +536,7 @@ where
             WORKER_CONFIGS_ADDRESS,
             calldata,
             "recording next-epoch base fees",
+            "record_base_fees",
         )
     }
 
@@ -574,6 +603,7 @@ where
             CONSENSUS_REGISTRY_ADDRESS,
             calldata,
             "applying consensus block rewards",
+            "apply_incentives",
         )?;
 
         let mut new_committee = self.shuffle_new_committee(randomness)?;
@@ -582,7 +612,12 @@ where
         let calldata = LegacyConsensusRegistry::concludeEpochCall { newCommittee: new_committee }
             .abi_encode()
             .into();
-        self.transact_and_commit_system_call(CONSENSUS_REGISTRY_ADDRESS, calldata, "closing epoch")
+        self.transact_and_commit_system_call(
+            CONSENSUS_REGISTRY_ADDRESS,
+            calldata,
+            "closing epoch",
+            "conclude_epoch",
+        )
     }
 
     /// The upgraded `ConsensusRegistry` runtime bytecode and its code hash, sourced from the same
@@ -746,6 +781,7 @@ where
             CONSENSUS_REGISTRY_ADDRESS,
             calldata,
             "consensus registry migration",
+            "registry_migration",
         )?;
 
         // Read back the rebuilt eligible count for an operational confirmation log. Best-effort and
@@ -1291,6 +1327,13 @@ where
             // deliberately NO merge_transitions here: both reth wrappers merge after finish()
             // returns, and revm pushes a reverts entry per merge — merging in here too gives
             // every epoch-closing block a phantom empty bundle.reverts entry (len 2 vs 1)
+
+            // Publish what the boundary's system calls spent. Observation only — nothing below
+            // reads it and no state is touched. It lands here, after the calls have succeeded,
+            // because any failure above already aborted the block: there is no partial epoch
+            // close to report gas for. A system call runs at `gas_price: 0`, so this gas never
+            // enters `self.gas_used` and these gauges are the only place it is visible.
+            crate::metrics::record_epoch_close_gas(&self.epoch_close_gas);
         }
 
         Ok((

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -83,6 +83,10 @@ pub use utils::calculate_gas_penalty;
 ///
 /// Read-path note: contract reads that share the system-call plumbing (including RPC reads via
 /// `read_contract_at_block`) inherit this ceiling — an accepted consequence of the raise.
+///
+/// Observability: the `tn_reth.epoch_close_*` gauges (`crate::metrics`) publish what each
+/// epoch-boundary call spends against this budget, and the budget itself, so consumption is a
+/// ratio a dashboard can watch rather than something discovered when a close halts the fleet.
 pub(crate) const SYSTEM_CALL_GAS_LIMIT: u64 = 100_000_000;
 
 /// Gas budget for a single pre-genesis constructor CREATE

--- a/crates/tn-reth/src/metrics.rs
+++ b/crates/tn-reth/src/metrics.rs
@@ -8,6 +8,28 @@
 //! [`RethEnvMetrics`] for per-series semantics. [`report_db_metrics`] additionally samples reth
 //! database metrics as a pre-scrape hook.
 //!
+//! Three gauges under the same scope report what the epoch-boundary system calls spend against
+//! the budget they run under: [`EPOCH_CLOSE_SYSTEM_CALL_GAS_USED`] (labelled by `call`),
+//! [`EPOCH_CLOSE_GAS_USED`], and [`EPOCH_CLOSE_SYSTEM_CALL_GAS_LIMIT`]. Nothing else can see that
+//! gas — a system call is submitted with `gas_price: 0`, so it neither pays for gas nor enters
+//! the block's `gas_used`. See [`record_epoch_close_gas`] and `crates/tn-reth/README.md` for the
+//! dashboard and alert queries they are meant to be read with, and for what they do not cover.
+//!
+//! # Two mechanisms in one module
+//!
+//! The counters use the `reth_metrics::Metrics` derive; the epoch-close gauges use the
+//! `metrics::gauge!` / `metrics::describe_gauge!` macros. The split is not stylistic:
+//!
+//! 1. The per-call gauge carries a `call` label, which a derive field cannot express — the derive
+//!    generates one unlabelled series per field.
+//! 2. The macros re-resolve the recorder on every call, whereas the derive's `Default::default()`
+//!    caches the whole struct in a `static OnceLock` (`metrics-derive` `expand.rs`), fixing which
+//!    recorder every later handle records against. That is invisible in production, where one
+//!    recorder is installed before any metric exists, but it makes a test that installs a local
+//!    recorder pass or fail on test ordering. The counter tests below work around it with
+//!    `new_with_labels`; the gauges get the property for free, which is what lets a real epoch
+//!    close be asserted on (`env/epoch.rs`).
+//!
 //! Everything here binds to the process-global `metrics` recorder, so
 //! `tn_metrics::install_recorder` must run first — the node installs it before opening the
 //! database (`RethEnv::new_database`), and [`init`] (called from `RethEnv::new`) then forces
@@ -15,8 +37,9 @@
 
 use reth_metrics::{metrics::Counter, Metrics};
 use std::sync::LazyLock;
+use tracing::warn;
 
-use crate::RethDb;
+use crate::{evm::SYSTEM_CALL_GAS_LIMIT, RethDb};
 
 /// Process-wide metrics for [`crate::RethEnv`].
 ///
@@ -82,10 +105,158 @@ pub fn report_db_metrics(db: &RethDb) {
     db.report_metrics();
 }
 
+/// Gas spent by the epoch-boundary system calls together.
+///
+/// The committed calls the closing block issues to conclude the epoch, NOT every system call it
+/// makes — see the README for what is excluded and why. Each call gets its own budget, so this
+/// total is not the figure [`SYSTEM_CALL_GAS_LIMIT`] bounds; [`EPOCH_CLOSE_SYSTEM_CALL_GAS_USED`]
+/// is.
+const EPOCH_CLOSE_GAS_USED: &str = "tn_reth.epoch_close_gas_used";
+
+/// Gas spent by one epoch-boundary system call, labelled by `call`.
+///
+/// The `call` label is closed over the calls an epoch-closing block can make
+/// (`registry_migration`, `apply_incentives`, `apply_slashes`, `conclude_epoch`,
+/// `record_base_fees`), so it adds no cardinality that grows with the chain.
+const EPOCH_CLOSE_SYSTEM_CALL_GAS_USED: &str = "tn_reth.epoch_close_system_call_gas_used";
+
+/// The per-call gas budget every epoch-boundary system call runs under.
+///
+/// A constant, published so a dashboard or alert expresses headroom as a ratio against the budget
+/// the node actually compiled in rather than against a hardcoded 100000000.
+const EPOCH_CLOSE_SYSTEM_CALL_GAS_LIMIT: &str = "tn_reth.epoch_close_system_call_gas_limit";
+
+/// Gas one epoch-boundary system call may spend before the close logs a warning: four fifths of
+/// [`SYSTEM_CALL_GAS_LIMIT`], or 80M gas.
+///
+/// A warning here is not an incident, it is lead time. [`SYSTEM_CALL_GAS_LIMIT`] participates in
+/// consensus, so raising it is a lockstep fleet upgrade that has to be scheduled; a threshold
+/// that only fired once the budget was gone would provide none.
+///
+/// `registry_migration` is the call the 100M headroom exists for — it walks every validator in one
+/// shot — so it is the one that may legitimately trip this threshold, once, at the fork boundary.
+/// The README's alert query excludes it for that reason.
+const EPOCH_CLOSE_GAS_WARN_THRESHOLD: u64 = SYSTEM_CALL_GAS_LIMIT / 5 * 4;
+
+/// The warning must land strictly before the halt it predicts, or it is not a warning.
+///
+/// A build error rather than a test: the threshold is derived from [`SYSTEM_CALL_GAS_LIMIT`], so
+/// the only way to break the ordering is to edit this arithmetic, and that should not compile.
+const _: () = assert!(EPOCH_CLOSE_GAS_WARN_THRESHOLD < SYSTEM_CALL_GAS_LIMIT);
+
+/// Whether one call has crossed [`EPOCH_CLOSE_GAS_WARN_THRESHOLD`].
+///
+/// Split out from the recording so the boundary is testable without capturing a log line.
+const fn is_thin_headroom(gas: u64) -> bool {
+    gas >= EPOCH_CLOSE_GAS_WARN_THRESHOLD
+}
+
+/// The gas a call SPENT, before EIP-3529 refunds.
+///
+/// This is the quantity a gas limit bounds, and it is not what `ExecutionResult::gas_used`
+/// carries. revm distinguishes `Gas::spent()` (`limit - remaining`) from `Gas::used()`
+/// (`spent - refunded`), and `gas_used` is the latter. The refund is computed after execution and
+/// capped at a fifth of the spend, so it never buys the call more room: a call that exhausts its
+/// limit still halts, while reporting up to a fifth less than it spent.
+///
+/// Publishing `gas_used` would therefore slide the warning threshold with the refund. A call
+/// earning the full refund reports four fifths of its spend, so the 80%-of-budget warning would
+/// not fire until the spend reached the whole 100M — the halt the warning exists to predict. The
+/// refundless case is just as wrong in the other direction: a `conclude_epoch` that exhausted its
+/// budget would be published as 80M, the figure a dashboard reads as a fifth still to spare.
+///
+/// Saturating: two EVM gas figures cannot approach `u64::MAX`, but this runs on a path that is
+/// fatal to the block, so a metric must not be a panic site there.
+pub(crate) const fn gas_spent(gas_used: u64, gas_refunded: u64) -> u64 {
+    gas_used.saturating_add(gas_refunded)
+}
+
+/// What each epoch-boundary system call spent, in the order the closing block issued them.
+///
+/// A list, not a field per call. The boundary's call set is not stable — two calls, then three
+/// (#1012), then four (#1101), plus the legacy pre-fork pair and the one-shot fork migration — and
+/// a fixed struct has to be re-typed for every change. A list absorbs a call that was added, one
+/// that was skipped (`record_base_fees` issues nothing when no worker is EIP-1559), and the legacy
+/// path's shorter sequence, with no type churn.
+///
+/// A call that did not run pushes nothing, so it leaves its series untouched rather than
+/// publishing a zero that reads as "ran, and was free".
+#[derive(Debug, Default)]
+pub(crate) struct EpochCloseGas(Vec<(&'static str, u64)>);
+
+impl EpochCloseGas {
+    /// Record what one system call spent, under the `call` label it is published with.
+    pub(crate) fn push(&mut self, call: &'static str, gas: u64) {
+        self.0.push((call, gas));
+    }
+
+    /// Gas spent by every call that ran.
+    ///
+    /// Saturating: a handful of EVM gas figures cannot sum to anywhere near `u64::MAX`, but the
+    /// total is a metric and must not be a panic site on a path that is fatal to the block.
+    fn total(&self) -> u64 {
+        self.0.iter().fold(0u64, |total, (_, gas)| total.saturating_add(*gas))
+    }
+
+    /// Whether no epoch-boundary system call was recorded.
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Record the gas an epoch-closing block's system calls spent, and warn on thin headroom.
+///
+/// Called once per epoch close from `TNBlockExecutor::finish`, after the boundary calls have
+/// succeeded: a failed call aborts the block, so there is no partial epoch close to report gas
+/// for. Every node runs that closing block, so the series is fleet-wide rather than
+/// proposer-only, and it covers closing blocks re-executed while syncing — a replayed value is
+/// still a true observation of what that epoch cost, which is what makes a `max_over_time` query
+/// over these gauges meaningful.
+///
+/// Publishes nothing at all when no call was recorded, rather than a zero total that would read
+/// as a free boundary — the same rule the per-call series follows.
+pub(crate) fn record_epoch_close_gas(gas: &EpochCloseGas) {
+    if gas.is_empty() {
+        return;
+    }
+
+    metrics::describe_gauge!(
+        EPOCH_CLOSE_GAS_USED,
+        "Gas spent by the epoch-boundary system calls together (not every system call of the \
+         closing block)"
+    );
+    metrics::describe_gauge!(
+        EPOCH_CLOSE_SYSTEM_CALL_GAS_USED,
+        "Gas spent by each epoch-boundary system call, before EIP-3529 refunds"
+    );
+    metrics::describe_gauge!(
+        EPOCH_CLOSE_SYSTEM_CALL_GAS_LIMIT,
+        "Gas budget each epoch-boundary system call runs under"
+    );
+
+    metrics::gauge!(EPOCH_CLOSE_GAS_USED).set(gas.total() as f64);
+    metrics::gauge!(EPOCH_CLOSE_SYSTEM_CALL_GAS_LIMIT).set(SYSTEM_CALL_GAS_LIMIT as f64);
+
+    for &(call, spent) in &gas.0 {
+        metrics::gauge!(EPOCH_CLOSE_SYSTEM_CALL_GAS_USED, "call" => call).set(spent as f64);
+
+        if is_thin_headroom(spent) {
+            warn!(
+                target: "engine",
+                call,
+                gas_spent = spent,
+                gas_limit = SYSTEM_CALL_GAS_LIMIT,
+                "epoch-boundary system call is approaching its gas budget — exhausting it halts \
+                 the chain at an epoch boundary",
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshot};
 
     #[test]
     fn test_metrics_register_and_update() {
@@ -143,5 +314,162 @@ mod tests {
         assert!(matches!(value, DebugValue::Counter(0)));
         let (_, _, _, value) = find("tn_reth.invalid_txs_skipped_total");
         assert!(matches!(value, DebugValue::Counter(0)));
+    }
+
+    /// Read one gauge out of a snapshot, selecting by `call` label when one is given.
+    ///
+    /// Generic over the description slot so the recorder's own string type never has to be named
+    /// here.
+    fn gauge<D>(
+        snapshot: &[(metrics_util::CompositeKey, Option<metrics::Unit>, D, DebugValue)],
+        name: &str,
+        call: Option<&str>,
+    ) -> Option<f64> {
+        snapshot
+            .iter()
+            .find(|(key, ..)| {
+                key.key().name() == name
+                    && call.is_none_or(|call| {
+                        key.key().labels().any(|l| l.key() == "call" && l.value() == call)
+                    })
+            })
+            .and_then(|(.., value)| match value {
+                DebugValue::Gauge(g) => Some(g.0),
+                DebugValue::Counter(_) | DebugValue::Histogram(_) => None,
+            })
+    }
+
+    /// Record the given calls under a local recorder and return the snapshot.
+    fn record(calls: &[(&'static str, u64)]) -> Snapshot {
+        let mut gas = EpochCloseGas::default();
+        for &(call, spent) in calls {
+            gas.push(call, spent);
+        }
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || record_epoch_close_gas(&gas));
+        snapshotter.snapshot()
+    }
+
+    /// A successful call's spend is its `gas_used` plus the refund it earned.
+    ///
+    /// The whole point of [`gas_spent`]: `ExecutionResult::gas_used` is already net of the refund,
+    /// and these gauges have to publish the figure the budget bounds. Returning `gas_used` here
+    /// would understate a call's budget consumption by up to a fifth.
+    #[test]
+    fn test_gas_spent_adds_the_refund_back() {
+        // the worst case: a full EIP-3529 refund on a call that exhausted its budget
+        assert_eq!(
+            gas_spent(80_000_000, 20_000_000),
+            SYSTEM_CALL_GAS_LIMIT,
+            "spend is used + refunded"
+        );
+        assert_eq!(gas_spent(21_000, 0), 21_000, "no refund leaves the figure unchanged");
+    }
+
+    #[test]
+    fn test_records_a_series_per_call_plus_the_total_and_the_budget() {
+        let snapshot = record(&[
+            ("apply_incentives", 1_000),
+            ("apply_slashes", 2_000),
+            ("conclude_epoch", 3_000),
+            ("record_base_fees", 4_000),
+        ])
+        .into_vec();
+
+        assert_eq!(
+            gauge(&snapshot, EPOCH_CLOSE_GAS_USED, None),
+            Some(10_000.0),
+            "the total gauge must sum every call that ran"
+        );
+        assert_eq!(
+            gauge(&snapshot, EPOCH_CLOSE_SYSTEM_CALL_GAS_LIMIT, None),
+            Some(SYSTEM_CALL_GAS_LIMIT as f64),
+            "the budget gauge must publish the compiled-in limit"
+        );
+
+        for (call, expected) in [
+            ("apply_incentives", 1_000.0),
+            ("apply_slashes", 2_000.0),
+            ("conclude_epoch", 3_000.0),
+            ("record_base_fees", 4_000.0),
+        ] {
+            assert_eq!(
+                gauge(&snapshot, EPOCH_CLOSE_SYSTEM_CALL_GAS_USED, Some(call)),
+                Some(expected),
+                "call={call} gas"
+            );
+        }
+    }
+
+    /// A skipped call must leave its series absent, not publish a zero.
+    ///
+    /// `record_base_fees` is the live case: a closing block with no EIP-1559 worker issues no
+    /// system call at all. `registry_migration` is the other, on every close but one.
+    #[test]
+    fn test_a_call_that_did_not_run_publishes_no_series() {
+        let snapshot = record(&[("apply_incentives", 2_000), ("conclude_epoch", 3_000)]).into_vec();
+
+        for absent in ["registry_migration", "apply_slashes", "record_base_fees"] {
+            assert!(
+                gauge(&snapshot, EPOCH_CLOSE_SYSTEM_CALL_GAS_USED, Some(absent)).is_none(),
+                "a skipped call ({absent}) must not publish a zero"
+            );
+        }
+        assert_eq!(
+            gauge(&snapshot, EPOCH_CLOSE_SYSTEM_CALL_GAS_USED, Some("conclude_epoch")),
+            Some(3_000.0),
+            "the calls that ran must still be recorded"
+        );
+    }
+
+    /// The same rule applied to the aggregate gauges: no observation, no series.
+    ///
+    /// A zero total would read as an epoch boundary that concluded for free, which is exactly the
+    /// misreading the per-call rule above exists to prevent.
+    #[test]
+    fn test_a_close_that_recorded_nothing_publishes_nothing() {
+        let snapshot = record(&[]).into_vec();
+        assert!(snapshot.is_empty(), "an empty close must publish no series at all: {snapshot:?}");
+    }
+
+    /// Pin the warning boundary itself, not just the constant's arithmetic.
+    ///
+    /// The warning is the only signal that fires without a dashboard, so an inverted or deleted
+    /// comparison has to fail a test. Asserting on the constant alone would catch neither. (That
+    /// the threshold sits below the budget at all is a build-time assertion, not a test.)
+    ///
+    /// The literal is deliberate: raising [`SYSTEM_CALL_GAS_LIMIT`] should break this test, since
+    /// the README quotes both figures in its alert query.
+    #[test]
+    fn test_warn_fires_at_four_fifths_of_the_budget_and_not_below() {
+        assert_eq!(EPOCH_CLOSE_GAS_WARN_THRESHOLD, 80_000_000);
+
+        assert!(!is_thin_headroom(0), "an idle boundary must not warn");
+        assert!(
+            !is_thin_headroom(EPOCH_CLOSE_GAS_WARN_THRESHOLD - 1),
+            "one gas below the threshold must not warn"
+        );
+        assert!(is_thin_headroom(EPOCH_CLOSE_GAS_WARN_THRESHOLD), "the threshold itself must warn");
+        assert!(is_thin_headroom(SYSTEM_CALL_GAS_LIMIT), "an exhausted budget must warn");
+    }
+
+    /// Recording twice in one process must reach the recorder installed for the second close.
+    ///
+    /// This is the ordering hazard that rules out the `Metrics` derive for these gauges: handles
+    /// cached by `Default::default()` bind to whichever recorder ran first, so the second close
+    /// would land in the first recorder and this snapshot would come back empty.
+    #[test]
+    fn test_a_second_close_binds_to_the_live_recorder() {
+        let first = record(&[("apply_incentives", 1), ("conclude_epoch", 1)]).into_vec();
+        let second = record(&[("apply_incentives", 2_000), ("conclude_epoch", 3_000)]).into_vec();
+
+        assert_eq!(gauge(&first, EPOCH_CLOSE_GAS_USED, None), Some(2.0));
+        assert_eq!(
+            gauge(&second, EPOCH_CLOSE_GAS_USED, None),
+            Some(5_000.0),
+            "the second close must be recorded against the recorder installed for it"
+        );
     }
 }


### PR DESCRIPTION
Closes #1031.

## Problem

The epoch boundary concludes on a system call, and a system call gets a fixed 30M gas budget with nothing watching it.  `applyIncentives` credits the closing epoch's rewards and `concludeEpoch` rotates the epoch and seats the new committee, and both scale with the validator set.  There was no way to answer "how close are we?" from a running node.

Nothing existing can answer it either, which is the part worth naming.  A system call is submitted with `gas_price: 0`, so it neither pays for gas nor counts against the block gas limit, and its gas never enters the block's `gas_used`.  `tn_engine.block_gas_used` therefore reports the epoch-closing block as if the epoch conclusion were free.  The budget is also per call rather than per block, so each of the boundary's calls receives its own full 30M.

The failure mode is not degradation.  Both calls are fatal on failure, and the revert is a pure function of committed state, so a `concludeEpoch` that outgrows its budget aborts the closing block on every node at the same boundary.  Raising the limit changes block execution, so it needs scheduling, which means the headroom needs a long lead time rather than a discovery at a boundary.

## Fix

- [x] `crates/tn-reth/src/system_calls.rs`: add `SYSTEM_CALL_GAS_LIMIT` (30M), documenting that the budget is per call, is independent of the block gas limit, and that exhausting it halts the boundary.
- [x] `crates/tn-reth/src/evm/mod.rs`: both `gas_limit: 30_000_000` literals now read the constant (`transact_system_call` and `transact_pre_genesis_create`), so the value the gauges publish is the value execution actually uses.
- [x] `crates/tn-reth/src/evm/block.rs`: `apply_consensus_block_rewards`, `apply_closing_epoch_contract_call` and `apply_consensus_registry_fork` return the gas their system call spent instead of `()`.  `BlockExecutor::finish` collects the three figures and records them after the calls have succeeded and transitions are merged.
- [x] `crates/tn-reth/src/evm/block.rs`: `gas_spent`, because `ExecutionResult::gas_used` is the wrong quantity here.  revm separates `Gas::spent()` (`limit - remaining`) from `Gas::used()` (`spent - refunded`), and `gas_used` carries the latter.  The refund is computed after execution and capped at a fifth of the spend (EIP-3529), so it never buys the call more room: a call that exhausts its budget still reverts while `gas_used` reports up to 20% less than it spent.  A `concludeEpoch` that consumed its whole 30M would have published 24M — exactly the value the 80% warning treats as still having headroom, so the alert could never fire before a halt.  The gauges publish `gas_used + gas_refunded` instead.
- [x] `crates/tn-reth/src/metrics.rs` (new): `EpochCloseGas` plus `record_epoch_close_gas`, publishing three gauges under a new `tn_execution` scope, and logging a warning when any single call crosses four fifths of its budget.
- [x] `crates/tn-reth/README.md`: the metric catalog and the dashboard / alert PromQL, with the epoch-cadence caveat on the range selector.
- [x] `crates/tn-metrics/README.md`: the one convention this change had to deviate from, and when the next crate will have to as well.

### The metrics

| Metric | Type | Meaning |
| --- | --- | --- |
| `tn_execution_epoch_close_system_call_gas_used{call="..."}` | gauge | Gas spent by one epoch-boundary system call.  `call` is `apply_incentives`, `conclude_epoch`, or `registry_migration`. |
| `tn_execution_epoch_close_gas_used` | gauge | Gas spent by those calls together. |
| `tn_execution_epoch_close_system_call_gas_limit` | gauge | The compiled-in per-call budget. |

The per-call series is the one the budget bounds today, and it is labelled rather than split into three metric names so a single query covers the boundary.  The `call` label is closed over the three calls an epoch-closing block can make, so it adds no cardinality that grows with the chain.  The registry-migration series is absent rather than zero on every block except the one fork boundary, so a skipped call cannot be read as "ran, and was free".

The budget is published as its own gauge so a query expresses headroom as a ratio against what the node compiled in, instead of hardcoding 30000000 into a dashboard that then has to be found and edited when the limit moves.

The total is included for the epoch after #1012: once the boundary is a single `concludeEpoch` call, the total *is* the budget-bounded figure.  Today it is the total cost of the boundary rather than a headroom number, and the README says so, because summing figures that each hold an independent budget would otherwise read as a utilisation.

Every node records these when it executes the closing block, so the series is fleet-wide rather than proposer-only.  That includes closing blocks re-executed during a sync, which is deliberate: a replayed value is a true observation of what that epoch cost, and it is what makes `max_over_time(...[30d])` meaningful on a node that has not been up for 30 days.

What the gauges deliberately do not cover is stated in the README rather than left implied.  The closing block makes further system calls, each under its own copy of the same budget and each equally fatal: the EIP-2935 and EIP-4788 calls, which are fixed-cost, and the committee-pool reads `shuffle_new_committee` issues while assembling the `concludeEpoch` calldata, which are **not** — they scale with the eligible validator set, the same input that drives `concludeEpoch`.  Instrumenting those is follow-up work;  the README says so plainly, since a boundary can fail on a call these gauges never showed.

Two properties of a once-per-epoch gauge are documented with the queries, because getting either wrong makes an alert lie.  The exporter registers no idle timeout, so these gauges latch their last value on every scrape rather than lapsing — short ranges are legal, but a value can be a whole epoch old, so freshness has to come from pairing with `tn_epoch_current`.  And a restarted node publishes no `tn_execution_` series at all until its next close, so alerts must tolerate absence rather than read it as zero.  The one-shot `registry_migration` series is excluded from the alert for the same reason in reverse: written once at the fork block, it holds that value forever and could never clear.

### The one convention this deviates from

Every other instrumented crate declares metrics with the `reth_metrics::Metrics` derive.  This module records through the `metrics` macros and describes itself explicitly instead.

The reason is two-part, and the weightier half is simply that the per-call gauge carries a `call` label, which a derive field cannot express.  Recording the two unlabelled gauges through the derive as well would put two mechanisms and two sources of HELP text in one function.

The second half is a hazard worth recording for the next crate.  `metrics-derive` generates a `Default::default()` that caches the whole struct in a `static OnceLock` (`metrics-derive-0.1.2/src/expand.rs:114-133`), so the *first* construction in a process fixes which recorder every later handle records against.  `new_with_labels` does not cache.  This was not theoretical: the first version of this change used `default()`, and its own unit tests failed under `cargo test` (all tests in one process, even at `--test-threads=1`) while passing under `cargo nextest` (a process per test) — the second recording landed in the first test's recorder.  `crates/tn-reth/src/metrics.rs` now carries `a_second_close_in_the_same_process_binds_to_the_live_recorder` as a regression guard, and `crates/tn-metrics/README.md` states the `default()`-versus-`new_with_labels` rule — its own testing example used `default()`, which this corrects.  Production behaviour is identical either way, since the node installs one recorder before the first metric exists.

### Not addressed here, deliberately

- The 30M limit itself is untouched.  The issue asks for benchmarks in `tn-contracts` and a theoretical maximum before that number moves;  this PR is the instrument those need, not the change.
- The warning threshold does not fail or throttle anything.  A close near its budget is still a valid close, and making it fatal earlier would trade a future halt for a present one.
- Benchmarks in `tn-contracts` are a separate repository and out of scope for this PR.
- The other system calls (`applyConsensusRoot`, blockhashes) are not instrumented.  They are fixed-cost and not the thing that grows with the validator set.

## Testing

Worktree `1031-conclude-epoch-gas-metric` off `origin/main` 746d59cb.

- `cargo +nightly-2026-03-20 fmt -- --check` . . . clean.
- `cargo clippy -p tn-reth` on default features and `--all-features` . . . 0 errors, 0 warnings.  This matches attest's clippy scope (no `--all-targets`).
- `cargo test -p tn-reth --lib` . . . 72 passed, 0 failed.  With `--features adiri,test-utils` . . . 83 passed, 0 failed, which covers the restructured fork-boundary branch and the `registry_migration` arm.
- `cargo check -p telcoin-network` . . . clean, so the added constant and the new crate-root `metrics` module do not disturb any dependent.

New tests:

- `crates/tn-reth/src/lib.rs`, `epoch_close_records_system_call_gas`: executes a real epoch-closing block off a `test_genesis_with_consensus_registry(5)` chain under a local recorder and asserts `applyIncentives` and `concludeEpoch` each report nonzero gas *inside* the budget, that the total is their sum, that the budget gauge publishes the compiled-in limit, and that the migration series is absent away from the fork boundary.  It first executes a non-closing block and asserts no `tn_execution.` series exists at all, so the instrument cannot be recording on every block.
- `crates/tn-reth/src/metrics.rs`: five unit tests over `EpochCloseGas` and `record_epoch_close_gas` — the saturating total, the three labelled series plus total and budget, a skipped call publishing nothing, the second-close recorder binding described above, and the warning boundary at threshold-1 / threshold / exhausted.
- `crates/tn-reth/src/evm/block.rs`: two unit tests over `gas_spent` — that a success adds the refund back, and that a revert or an out-of-gas halt passes its figure through unchanged.

Each was confirmed by mutation, seen to fail before being restored:

1. Zeroing `conclude_epoch_gas` in `finish` failed `epoch_close_records_system_call_gas` with `concludeEpoch gas: 0`.
2. Publishing a skipped call as `Some(0)` instead of `None` failed `a_call_that_did_not_run_publishes_no_series`.
3. Setting the total gauge to only `conclude_epoch`'s gas failed three tests at once — `records_a_series_per_call_plus_the_total_and_the_budget` (`left: Some(3000.0), right: Some(6000.0)`), `a_second_close_in_the_same_process_binds_to_the_live_recorder`, and the end-to-end test.
4. Dropping the refund from `gas_spent` (i.e. reverting to `gas_used`) failed `gas_spent_adds_the_refund_back_on_success` with `left: 24000000, right: 30000000` — the exact 30M-reported-as-24M case.
5. Weakening `is_thin_headroom` to `>` failed `warn_fires_at_four_fifths_of_the_budget_and_not_below` at "the threshold itself must warn".  The previous version of that test asserted only the constant's arithmetic, so deleting the whole warning branch passed it.

`make attest` was not run end to end, since it requires a clean tree and submits an on-chain transaction.  Its local gates are green as listed above.
