### PR TITLE
docs: correct stale epoch, base-fee and hash references; drop dead topic constants

### DIFF
--- a/crates/network-libp2p/src/types.rs
+++ b/crates/network-libp2p/src/types.rs
@@ -52,13 +52,6 @@ pub trait IntoRpcError<E> {
     fn into_error(error: E) -> Self;
 }
 
-/// The topic for NVVs to subscribe to for published worker batches.
-pub const WORKER_BATCH_TOPIC: &str = "tn_batches";
-/// The topic for NVVs to subscribe to for published primary certificates.
-pub const PRIMARY_CERT_TOPIC: &str = "tn_certificates";
-/// The topic for NVVs to subscribe to for published consensus chain.
-pub const CONSENSUS_HEADER_TOPIC: &str = "tn_consensus_headers";
-
 /// The role of a consensus network instance: primary or worker.
 ///
 /// A node runs both as fully isolated libp2p swarms in one process. This is the

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -190,20 +190,20 @@ telcoin-network genesis \
     --consensus-registry-owner 0xGOVERNANCE_MULTISIG \
     --basefee-address 0xBASEFEE_RECIPIENT \
     --initial-stake-per-validator 1000000 \
-    --epoch-duration-in-secs 86400
+    --epoch-duration-in-secs 28800
 ```
 
 ### genesis flags
 
 | Flag                                                 | Default        | Description                                                                               |
 | ---------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------- |
-| `--chain-id`                                         | `2017` (0x7e1) | Numeric chain ID. Accepts decimal or `0x`-prefixed hex                                    |
+| `--chain-id`                                         | `911329` (0xde7e1) | Numeric chain ID. Accepts decimal or `0x`-prefixed hex                                |
 | `--consensus-registry-owner`                         | `0x...07a0`    | Owner address for the ConsensusRegistry contract. Use a governance multisig in production |
 | `--basefee-address`                                  | `0x...07a0`    | Address that receives all transaction base fees                                           |
 | `--initial-stake-per-validator`, `--stake`           | `1000000`      | TEL staked per validator at genesis (input in whole TEL, stored as wei)                   |
 | `--min-withdraw-amount`, `--min_withdraw`            | `1000`         | Minimum TEL withdrawal amount                                                             |
 | `--epoch-block-rewards`, `--block_rewards_per_epoch` | `25806`        | Total block rewards per epoch in TEL                                                      |
-| `--epoch-duration-in-secs`, `--epoch_length`         | `86400`        | Epoch duration in seconds (default: 24 hours)                                             |
+| `--epoch-duration-in-secs`, `--epoch_length`         | `28800`        | Epoch duration in seconds (default: 8 hours)                                              |
 | `--max-header-delay-ms`                              | none           | Max delay between header proposals (milliseconds)                                         |
 | `--min-header-delay-ms`                              | none           | Min delay between header proposals (milliseconds)                                         |
 | `--max-batch-delay-ms`                               | none           | Max delay before a worker seals a batch of pending transactions (milliseconds)            |

--- a/crates/types/src/primary/block.rs
+++ b/crates/types/src/primary/block.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 /// Header for the consensus chain.
 ///
 /// The consensus chain records consensus output used to extend the execution chain.
-/// All hashes are Keccak 256.
+///
+/// Consensus-layer digests are BLAKE3 ([`crypto::DefaultHashFunction`]), not Keccak-256.
+/// Keccak-256 is used at the execution layer and for the committee-shuffle seed.
 #[derive(PartialEq, Serialize, Deserialize, Clone, Debug)]
 pub struct ConsensusHeader {
     /// The hash of the previous ConsesusHeader in the chain.

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -68,12 +68,17 @@ pub struct Batch {
     /// The 160-bit address to which all fees collected from the successful mining of this batch
     /// be transferred; formally Hc.
     pub beneficiary: Address,
-    /// A scalar representing EIP1559 base fee which can move up or down each batch according
-    /// to a formula which is a function of gas used in parent batch and gas target
-    /// (batch gas limit divided by elasticity multiplier) of parent batch.
-    /// The algorithm results in the base fee per gas increasing when batchs are
-    /// above the gas target, and decreasing when batchs are below the gas target. The base fee per
-    /// gas is sent to governance address.
+    /// The EIP-1559 base fee in effect for this batch.
+    ///
+    /// Unlike Ethereum, this does not move from batch to batch. The value is keyed by `worker_id`
+    /// and is constant for the whole epoch, so every validator's worker N carries the same base
+    /// fee until the epoch closes; a batch carrying any other value is rejected as
+    /// `InvalidBaseFee`.
+    ///
+    /// It is recomputed only at the epoch boundary, from that worker's gas accumulated over the
+    /// epoch against its target: either by the EIP-1559 formula (floored at
+    /// `MIN_PROTOCOL_BASE_FEE`) or pinned to a fixed value, according to the worker's on-chain fee
+    /// strategy. Collected base fees go to the configured base fee recipient.
     pub base_fee_per_gas: u64,
     /// The worker id for the worker that orginated this batch.
     /// Worker ids will be consistent accross validators (i.e. worker 0 talks to othere worker 0s,


### PR DESCRIPTION
## Summary

Four places in the tree describe behaviour the code no longer has.  Each one is independently
checkable against the source, and each currently sends a reader to the wrong conclusion about a
protocol parameter.  This is a documentation-only change apart from item 4, which deletes three
constants that nothing references.

No issue is linked: these surfaced while cross-checking prose descriptions of the protocol against
the implementation.

## Changes

- [x] `crates/telcoin-network-cli/README.md` . . . the genesis flag table advertised
  `--epoch-duration-in-secs` as defaulting to `86400` ("default: 24 hours").  The actual default is
  `default_value_t = 60 * 60 * 8` (`crates/telcoin-network-cli/src/genesis/mod.rs:93`), so the
  documented value was 3x the real one.  Corrected the table to `28800` / 8 hours, and updated the
  worked example above it so the file no longer contradicts itself.

- [x] `crates/telcoin-network-cli/README.md` . . . the same table gave `--chain-id` as `2017`
  (`0x7e1`).  The real default is `default_value_t = 911329` (`genesis/mod.rs:121`), whose own doc
  comment on the line above says "Default is 0xde7e1 (911329)".  `0x7e1` is 2017 and `0xde7e1` is
  911329, so both the decimal and the hex were wrong.  Corroborated by the e2e fixture
  (`crates/e2e-tests/tests/it/common.rs:670`, `chain: 0xde7e1`);  `2017` appears in the tree only as
  a `maybe_hex` unit-test vector and a genesis test fixture, never as a clap default.  The remaining
  defaults in that table (`0x...07a0` twice, `1_000_000`, `1_000`, `25_806`, and the `Option` flags
  below, which correctly show `none`) were each checked against the same source file and are right.

  Not fixed here, to keep the diff to incorrect statements rather than incomplete ones: the table
  omits rows for `--gc-depth` and `--worker-fee-config`.  Happy to add them if you would rather have
  it in one pass.

- [x] `crates/types/src/worker/sealed_batch.rs` . . . the `base_fee_per_gas` doc described
  Ethereum's per-block EIP-1559 dynamics ("can move up or down each batch . . . function of gas used
  in parent batch and gas target . . . of parent batch").  That is not what this protocol does.  The
  value is keyed by `worker_id`, is constant for the whole epoch (`crates/batch-builder/src/lib.rs`:
  "The base fee for this epoch.  Constant for the batch builder's lifetime"), and is recomputed only
  at the epoch boundary from that worker's accumulated gas against target.  A batch carrying any
  other value is rejected as `InvalidBaseFee` by `BatchValidator::validate_basefee`.  Rewrote the
  doc to say that, and to name the epoch-boundary recomputation and the `MIN_PROTOCOL_BASE_FEE`
  floor.

- [x] `crates/types/src/primary/block.rs` . . . the `ConsensusHeader` doc asserted "All hashes are
  Keccak 256".  Consensus-layer digests are BLAKE3: `crypto::DefaultHashFunction` is
  `blake3::Hasher` (`crates/types/src/crypto/mod.rs`), and `block.rs` itself calls it in four
  places.  Keccak-256 is the execution-layer hash and the committee-shuffle seed.  This one matters
  beyond tidiness: anyone writing an independent verifier against the consensus chain would derive
  the wrong digest from this comment.

- [x] `crates/network-libp2p/src/types.rs` . . . deleted `WORKER_BATCH_TOPIC` (`"tn_batches"`),
  `PRIMARY_CERT_TOPIC` (`"tn_certificates"`) and `CONSENSUS_HEADER_TOPIC` (`"tn_consensus_headers"`).
  The live topics are built by `LibP2pConfig::{primary,consensus_output,epoch_vote,worker_batch}_topic`
  and are chain-id namespaced (`tn-primary-<chain_id>` and friends), so these three name topics that
  no longer exist in any form.  That namespacing is pinned by the `gossip_topics_are_chain_namespaced`
  test (`crates/config/src/network.rs:665-674`).  Nothing in the working tree references either the
  identifiers or their string values: a fixed-string sweep across all 5456 files, including tests,
  benches, examples, `bin/`, `etc/` and non-Rust files, returns zero hits.

  To be precise about the surface: `types` is a public module (`crates/network-libp2p/src/lib.rs:27`,
  `pub mod types;`) that other crates do import through directly (for example
  `crates/consensus/primary/src/certificate_fetcher.rs:20`), so removing a `pub const` from it is
  technically a public-API change.  It is safe here only because nothing references these three,
  and the crate is workspace-internal rather than published.

This is the only item that is not a comment change.  It is separable if you would rather keep the
constants: dropping that hunk leaves the other three corrections intact.

## Testing

Verified against `origin/main` at `deee7a10`, on the pinned toolchains.

- `cargo +nightly-2026-03-20 fmt -- --check` . . . clean.  Worth noting the repo's `rustfmt.toml`
  sets `wrap_comments = true` and `comment_width = 100`, which stable `cargo fmt` silently skips;
  the rewritten doc comments were re-wrapped by the nightly formatter, not by hand.
- `cargo +1.94 check -p tn-types -p tn-network-libp2p` . . . clean, re-checking `tn-types`,
  `tn-network-types`, `tn-storage`, `tn-config` and `tn-network-libp2p` from this worktree with no
  errors and no warnings.

Every factual claim above was read out of the source at `deee7a10` rather than taken from a prior
description, and the three deleted constants were confirmed unreferenced by an exhaustive search of
the tree, not by a spot check.
