### PR TITLE
feat(engine): bind the WorkerConfigs runtime-update ABI

### DIFF
--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -1647,7 +1647,7 @@ impl RethEnv {
             );
 
             let (strategies, values): (Vec<u8>, Vec<u64>) = worker_configs.iter().copied().unzip();
-            let datas = vec![0u128; strategies.len()];
+            let datas = vec![alloy::primitives::aliases::U184::ZERO; strategies.len()];
             let constructor_args =
                 WorkerConfigs::constructorCall { strategies, values, datas, owner_: owner_address }
                     .abi_encode();
@@ -4459,9 +4459,14 @@ mod tests {
             100,
             Some(WORKER_CONFIGS_ADDRESS),
             U256::ZERO,
-            WorkerConfigs::setWorkerConfigCall { workerId: 1, strategy: 1, value: 500, data: 0 }
-                .abi_encode()
-                .into(),
+            WorkerConfigs::setWorkerConfigCall {
+                workerId: 1,
+                strategy: 1,
+                value: 500,
+                data: alloy::primitives::aliases::U184::ZERO,
+            }
+            .abi_encode()
+            .into(),
         );
         let set_num_workers_tx = governance_multisig.create_eip1559_encoded(
             chain.clone(),

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -236,13 +236,13 @@ sol!(
         constructor(
             uint8[] memory strategies,
             uint64[] memory values,
-            uint128[] memory datas,
+            uint184[] memory datas,
             address owner_,
         );
         /// Get the stored fee config for a worker.
         function getWorkerConfig(uint16 workerId)
             external view
-            returns (uint8 strategy, uint64 value, uint128 data);
+            returns (uint8 strategy, uint64 value, uint184 data);
         /// Get every worker's config in a single call.
         function getAllWorkerConfigs()
             external view
@@ -250,13 +250,26 @@ sol!(
                 uint16 count,
                 uint8[] memory strategies,
                 uint64[] memory values,
-                uint128[] memory datas,
+                uint184[] memory datas,
             );
         /// Set the number of workers for the next epoch.
         function setNumWorkers(uint16 numWorkers_) external;
         /// Set the config for a worker by worker id.
         /// NOTE: this must be called before calling `setNumWorkers`.
-        function setWorkerConfig(uint16 workerId, uint8 strategy, uint64 value, uint128 data) external;
+        function setWorkerConfig(uint16 workerId, uint8 strategy, uint64 value, uint184 data) external;
+        /// Update strategy-specific packed data for multiple workers. System call only;
+        /// each worker's strategy and value are preserved, and only previously configured
+        /// workers may be updated.
+        function setWorkerConfigsData(uint16[] calldata workerIds, uint184[] calldata datas) external;
+        /// Update config values for multiple workers. System call only; each worker's
+        /// strategy and data are preserved, and only previously configured workers may be
+        /// updated.
+        function setWorkerConfigsValue(uint16[] calldata workerIds, uint64[] calldata values) external;
+        /// Raise the highest strategy id the contract accepts. Owner only and strictly
+        /// increasing, in lockstep with the protocol release that ships the new strategy.
+        function setMaxStrategy(uint8 newMaxStrategy) external;
+        /// The highest strategy id the contract currently accepts.
+        function MAX_STRATEGY() external view returns (uint8);
         /// Retrieve the number of workers for the protocol.
         function numWorkers() external view returns (uint16);
     }


### PR DESCRIPTION
## Summary

Companion to Telcoin-Association/tn-contracts#161. Updates the `WorkerConfigs` `sol!` bindings for the widened `uint184` data fields and declares the contract's new runtime-update surface.

## Changes

- `system_calls.rs`: `uint128` data widens to `uint184` across the constructor, `getWorkerConfig`, `getAllWorkerConfigs`, and `setWorkerConfig`; new declarations for the system-call batch mutators `setWorkerConfigsData` / `setWorkerConfigsValue` (strategy and sibling fields preserved, only previously configured workers accepted), the owner-only strictly-increasing `setMaxStrategy`, and the `MAX_STRATEGY` view (now a storage-backed getter on the contract side).
- `lib.rs`: the pre-genesis deploy zero-fills `datas` with `U184::ZERO`, and the governance worker-config test encodes its `setWorkerConfig` data with the widened type. The per-epoch fee read is behaviorally unaffected: only `strategies` and `values` are consumed today, and the `datas` arity check is type-agnostic.

No caller emits the new system calls yet; that wiring lands with whichever protocol feature drives runtime fee updates. This PR keeps the bindings in lockstep so the ABI surface is ready.

## Lockstep

Rust tests that deploy `WorkerConfigs` pre-genesis encode constructor args against the vendored artifact bytecode, so this stays draft until the `tn-contracts` submodule pin and artifacts advance past tn-contracts#161 (artifacts already regenerated there). Folds into the same pin sequence as #1012/#909.

`cargo check -p tn-reth` passes.
