### PR TITLE
fix(node): import PrimaryNode in close_epoch

### DIFF
--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -14,7 +14,7 @@
 //! next epoch starts from a clean slate. Historic data survives in the
 //! `ConsensusChain` store; only the per-epoch working tables are cleared.
 
-use crate::{engine::ExecutionNode, manager::EpochManager};
+use crate::{engine::ExecutionNode, manager::EpochManager, primary::PrimaryNode};
 use eyre::eyre;
 use std::collections::BTreeSet;
 use tn_config::TelcoinDirs;


### PR DESCRIPTION
main does not compile: export_epoch_state (added in #973) takes &PrimaryNode<DB>, but close_epoch.rs never imports the type, so cargo check -p tn-node fails with E0425/E0282 on both default and all-features builds. One-line import fix; verified green on both feature sets.

Note: #1012 was re-merged with main today and inherits this breakage until this lands; it needs no change of its own.