### PR TITLE
tn-reth epoch-boundary hardening sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Check out the repo and update the submodules:
 
 ### Run an observer against testnet
 
-Build a release version of the node software:
-`cargo build -p telcoin-network --bin telcoin-network --release`
+Build a release version of the node software with the `adiri` feature (required to join the
+adiri testnet — the node refuses the `--chain adiri` flag at startup without it):
+`cargo build -p telcoin-network --bin telcoin-network --release --features adiri`
 
 Generate a config and keys for your observer node:
 `target/release/telcoin-network keytool generate observer --datadir DATADIR --address 0x4444444444444444444444444444444444444444 --bls-passphrase-source ask`

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -440,7 +440,10 @@ impl DerivedBaseFees {
 ///
 /// Steps:
 /// 1. `getEpochInfo(entered_epoch - 1)` at `closing_header` yields the previous epoch's first block
-///    (clamped to 1: constructor-seeded epochs report `blockHeight = 0`).
+///    (clamped to 1: epoch 0 is stamped by the registry's constructor at genesis and reports
+///    `blockHeight = 0` for the life of the chain). Every other epoch that has actually begun
+///    carries a real height — `RethEnv::get_epoch_info_at_block` rejects a `blockHeight = 0` for
+///    any epoch but 0 as a not-yet-begun record — so the `.max(1)` covers epoch 0 alone.
 /// 2. Scan the sealed headers `first..=closing`, keeping only genuine worker batch blocks
 ///    ([`is_worker_batch_block`] — excludes genesis and the synthetic empty-close block).
 /// 3. Extract each worker's last held fee ([`latest_base_fee_per_worker`]) and gas total
@@ -466,8 +469,10 @@ pub fn derive_base_fees_for_entered_epoch(
         .checked_sub(1)
         .ok_or_else(|| eyre!("cannot derive base fees for entered epoch 0: no prior epoch"))?;
 
-    // the previous epoch's block range, read from the registry AT the closing block (the ring
-    // buffer holds the four most recent epochs, so the prior epoch is always resolvable here)
+    // the previous epoch's block range, read from the registry AT the closing block.
+    // `getEpochInfo` resolves the window `[current - 3, current + 2]` (four recent slots plus two
+    // future ones); at this block the prior epoch is at most one behind `currentEpoch`, so it sits
+    // at the newest end of the past half — resolvable, and already stamped with its block height.
     let epoch_info = reth_env.get_epoch_info_at_block(prior_epoch, closing_header.hash())?;
     let range = epoch_info.blockHeight.max(1)..=closing_header.number;
     let range_len = range.end().saturating_sub(*range.start()).saturating_add(1);

--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -171,6 +171,11 @@ where
     /// is also stashed in `last_consensus_header` so the caller's close-and-write
     /// sequence (`close_epoch`, then `write_epoch_record`) can commit the epoch's
     /// record.
+    ///
+    /// A forwarding failure (the engine channel closed) also returns `None`: the
+    /// caller must not wait on execution of output the engine never received, and
+    /// the dead channel resurfaces as a hard error at the next forwarding attempt
+    /// after re-entry.
     pub(super) async fn send_leftover_consensus_output_to_engine(
         &mut self,
         consensus_output: &mut impl TnReceiver<ConsensusOutput>,
@@ -185,8 +190,13 @@ where
             } else {
                 None
             };
-            // only forward the output to the engine
-            let _ = self.process_output(to_engine, output).await;
+            // only forward the output to the engine; a send failure means the engine is gone,
+            // so stop draining and report no boundary rather than a hash the caller would
+            // block on forever in wait_for_consensus_execution
+            if let Err(e) = self.process_output(to_engine, output).await {
+                error!(target: "epoch-manager", "error sending leftover consensus output to engine: {}", e);
+                return None;
+            }
             if result.is_some() {
                 return result;
             }
@@ -209,7 +219,13 @@ where
                         } else {
                             None
                         };
-                        let _ = self.process_output(to_engine, output).await;
+                        // stop on a send failure: the engine is gone, and forwarding later
+                        // entries would leave a gap; report no boundary rather than a hash
+                        // the caller would block on forever in wait_for_consensus_execution
+                        if let Err(e) = self.process_output(to_engine, output).await {
+                            error!(target: "epoch-manager", number, "error sending leftover consensus output to engine: {}", e);
+                            return None;
+                        }
                         if result.is_some() {
                             return result;
                         }

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -264,6 +264,23 @@ Available named chains: `adiri` (alias: `testnet`), `mainnet`.
 
 The `--chain` flag overrides local genesis files with the embedded config for that network.
 
+#### Run an observer against testnet
+
+Build a release version of the node software with the `adiri` feature (required to join the
+adiri testnet — the node refuses the `--chain adiri` flag at startup without it):
+`cargo build -p telcoin-network --bin telcoin-network --release --features adiri`
+
+Generate a config and keys for your observer node:
+`target/release/telcoin-network keytool generate observer --datadir DATADIR --address 0x4444444444444444444444444444444444444444 --bls-passphrase-source ask`
+
+This will use DATADIR for storage and set your "execution" address to 0x4444444444444444444444444444444444444444. Note an observer does not recieve credit for execution but this option needs to be set anyway (at time of writing). Use an address you control or a dummy like above. This will also ask for the password for your nodes BLS key, this will need to be entered when started (or it can be put in an ENV var for injection).
+
+Start your observer node:
+`target/release/telcoin-network node -vvv --http --observer --chain adiri --bls-passphrase-source ask --datadir DATADIR`
+
+Make sure DATADIR matches the config command above and use the same password for reading the key.
+
+
 ### Using local config
 
 When running a private network or local testnet, omit `--chain` and point `--datadir` at a directory containing the genesis files:

--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -46,7 +46,7 @@ TN repurposes several Ethereum header fields for protocol data. Assembly happens
 | `beneficiary` | Execution address of the authority that produced the batch; receives priority fees (`src/payload.rs`, `src/evm/handler.rs`). |
 | `base_fee_per_gas` | Taken from the proposed batch; never recomputed or EIP-1559-adjusted during execution (`next_evm_env` in `src/evm/config.rs` uses `payload.base_fee_per_gas` as-is). Base fees are set per worker per epoch and validated at the worker/batch level, allowing parallel per-worker base fees. |
 | `gas_limit` | Taken from the worker's batch (`payload.gas_limit`). |
-| `withdrawals` / `withdrawals_root` | Empty list / `EMPTY_WITHDRAWALS` on normal blocks. On an epoch-closing block the body carries one `Withdrawal` per rewarded validator whose `amount` is the validator's **consensus-leader count, not wei** (`RewardsCounter::generate_withdrawals` in `tn-types` `gas_accumulator.rs`). This is a record only: the TN block executor never credits withdrawal amounts to balances — rewards move through the `concludeEpoch` system call. |
+| `withdrawals` / `withdrawals_root` | Empty list / `EMPTY_WITHDRAWALS` on normal blocks. On an epoch-closing block the body carries one `Withdrawal` per rewarded validator whose `amount` is the validator's **consensus-leader count, not wei** (`RewardsCounter::generate_withdrawals` in `tn-types` `gas_accumulator.rs`). This is a record only: the TN block executor never credits withdrawal amounts to balances — rewards move through the `applyIncentives` system call. |
 | `blob_gas_used` / `excess_blob_gas` | `Some(sum of tx blob gas)` (effectively 0, see blob handling below) and `Some(0)`. |
 | `requests_hash` | Always `EMPTY_REQUESTS_HASH`; the executor returns `Requests::default()` from `finish()` (`src/evm/block.rs`) — there are no EL-triggered requests (no deposit/withdrawal/consolidation request processing). |
 | `timestamp` | The sub-DAG commit timestamp from consensus, not wall clock at execution time. |
@@ -77,26 +77,35 @@ failure**:
    `concluding_epoch + 1 == CONSENSUS_REGISTRY_FORK_EPOCH`, apply the registry fork
    (`apply_consensus_registry_fork`) — code swap plus one-time `migrateValidatorSets()` — so the
    remaining steps in this same block already run on the upgraded code.
-2. The unified `concludeEpoch(newCommittee, rewardInfos, slashes)` system call
-   (`apply_closing_epoch_contract_call`): the eligible pool (union of `Active`,
-   `PendingActivation`, `PendingExit`) is read from the registry, shuffled by a Fisher-Yates over
-   an `StdRng` seeded with the epoch-close randomness, backfilled from pending-exit validators if
-   the active set is short, and truncated to `getNextCommitteeSize()`; the reward infos carry
-   each validator's consensus-leader count. The registry applies rewards, slashes, and queued
-   stake version settlement internally in that order, so the stage-ordering obligation lives
-   on-chain. An undersized pool fails client-side with `TnRethError::UndersizedCommittee`
-   instead of submitting calldata that reverts on-chain. While the deployed registry still
-   carries the pre-fork adiri code, the close instead replays the legacy `applyIncentives` +
-   `concludeEpoch(address[])` pair through the same code-hash gate as the committee-pool read,
-   keeping pre-fork history re-executable.
-3. `merge_transitions(BundleRetention::Reverts)` folds the system-call state into the bundle.
+2. The three boundary system calls (`apply_closing_epoch_contract_call`), in a client-enforced
+   order that is itself a consensus-safety obligation: `applyIncentives(RewardInfo[])` first
+   (the reward infos carry each validator's consensus-leader count, weighted on pre-slash
+   collateral), then `applySlashes(Slash[])` (the slashes carrier — the protocol passes an
+   empty array today), then `concludeEpoch(address[])` over a committee assembled AFTER the
+   slashes commit: the eligible pool (union of `Active`, `PendingActivation`, `PendingExit`)
+   is read from the registry, shuffled by a Fisher-Yates over an `StdRng` seeded with the
+   epoch-close randomness, backfilled from pending-exit validators if the active set is short,
+   truncated to `getNextCommitteeSize()`, and sorted by address. **The stage-ordering
+   obligation lives in the client** — the registry only enforces the outcome (it validates the
+   committee against post-slash state and reverts `InvalidCommitteeSize` on a stale one). An
+   undersized pool fails client-side with `TnRethError::UndersizedCommittee` instead of
+   submitting calldata that reverts on-chain. While the deployed registry still carries the
+   pre-fork adiri code, the close instead replays the legacy `applyIncentives` +
+   `concludeEpoch(address[])` pair through the same code-hash gate as the committee-pool read
+   (no interposed `applySlashes`; the shared selectors are byte-identical), keeping pre-fork
+   history re-executable.
+
+There is deliberately no in-`finish()` transition merge: reth's block-builder/executor wrappers
+merge once after `finish()` returns, and a second merge would push a phantom empty reverts entry
+for every epoch-closing block.
 
 System calls execute as `SYSTEM_ADDRESS` → contract with a fixed 100M gas limit, zero gas price,
 base-fee and nonce checks disabled (`transact_system_call` in `src/evm/mod.rs`);
 `SYSTEM_ADDRESS` is stripped from the changeset before commit so it never enters the state root.
 
-**Slashing is not live.** `concludeEpoch` accepts a `slashes` array and the registry implements
-it, but the client always passes an empty array.
+**Slashing is not live.** `applySlashes(Slash[])` is the slashes carrier and the registry
+implements it, but the client always passes an empty array (production builds);
+`concludeEpoch` takes only the new committee `address[]`.
 
 ## ConsensusRegistry fork gate (adiri)
 

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -2130,7 +2130,7 @@ mod tests {
                     "InvalidCommitteeSize(uint256,uint256)".as_bytes(),
                 )[..4];
                 assert_eq!(
-                    &output[..4],
+                    output.get(..4).expect("revert output carries at least a 4-byte selector"),
                     selector,
                     "stale committee must revert with InvalidCommitteeSize"
                 );
@@ -2154,6 +2154,7 @@ mod tests {
 
         let committee =
             reth_env.validators_for_epoch_at_block(0, reth_env.canonical_tip().hash())?;
+        assert_eq!(committee.len(), 5);
         let victim = committee[0].validatorAddress;
         let mut tn_evm = reth_env.tn_evm(chain.sealed_genesis_header().hash())?;
 

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -1430,6 +1430,32 @@ mod tests {
         let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
         let canonical_header = block2.recovered_block.clone_sealed_header();
 
+        // system-call state hygiene through the close: SYSTEM_ADDRESS is a caller convention
+        // and must never enter the bundle (the executor strips it before every commit), and the
+        // closing block carries exactly one reverts entry — the wrapper's single post-finish
+        // merge (an in-finish merge would push a phantom second entry)
+        assert!(
+            block2.execution_output.state.state.get(&SYSTEM_ADDRESS).is_none(),
+            "SYSTEM_ADDRESS must not enter the epoch-closing bundle"
+        );
+        assert_eq!(
+            block2.execution_output.state.reverts.len(),
+            1,
+            "one merged reverts entry per closing block"
+        );
+
+        // a default (empty) RewardsCounter close allocates nothing: the boundary's
+        // applyIncentives ran with an empty rewardInfos array, so every genesis committee
+        // member still reads zero rewards
+        for v in &validators {
+            let rewards = reth_env.read_consensus_registry::<U256>(
+                ConsensusRegistry::getRewardsCall { validatorAddress: v.execution_address }
+                    .abi_encode()
+                    .into(),
+            )?;
+            assert!(rewards.is_zero(), "empty-counter close must allocate no rewards");
+        }
+
         // now close the second epoch so the new validator is active
         expected_epoch += 1;
         let consensus_output = consensus_output_for_tests(2, expected_epoch, 3, true);
@@ -1464,6 +1490,11 @@ mod tests {
         let calldata = ConsensusRegistry::getEpochInfoCall { epoch: epoch + 1 }.abi_encode().into();
         let new_epoch_info = reth_env
             .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut tn_evm, calldata)?;
+
+        // replay-critical order normalization: the installed committee is address-sorted
+        // (generate_conclude_epoch_calldata sorts after the shuffle) — asserted as a property,
+        // independent of the exact-membership golden below
+        assert!(new_epoch_info.committee.is_sorted(), "installed committee must be address-sorted");
 
         // ensure validators in increasing order by address
         let expected_new_committee = vec![

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -1435,7 +1435,7 @@ mod tests {
         // closing block carries exactly one reverts entry — the wrapper's single post-finish
         // merge (an in-finish merge would push a phantom second entry)
         assert!(
-            block2.execution_output.state.state.get(&SYSTEM_ADDRESS).is_none(),
+            !block2.execution_output.state.state.contains_key(&SYSTEM_ADDRESS),
             "SYSTEM_ADDRESS must not enter the epoch-closing bundle"
         );
         assert_eq!(

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -2216,6 +2216,61 @@ mod tests {
         Ok(())
     }
 
+    /// Boundary-block determinism at default features: two independent executions of the
+    /// byte-identical epoch-closing payload derive the same `state_root` and install the same
+    /// next-epoch state.
+    ///
+    /// Every node must re-derive the identical boundary block or the fleet forks — the core
+    /// safety property of the epoch close. Until now it was pinned only inside two
+    /// `adiri`-gated tests that CI never compiles, so a default-build regression (e.g. a
+    /// nondeterministic iteration order feeding `applyIncentives`, or an RNG-draw reorder in
+    /// the committee shuffle) had no tripwire.
+    #[tokio::test]
+    async fn test_epoch_close_deterministic_across_envs() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+        // one payload, cloned across both executions: `new_for_test` randomizes
+        // beneficiary/mix_hash/digest per call, and mix_hash seeds the committee shuffle
+        let output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &output);
+
+        let tmp1 = TempDir::new().unwrap();
+        let tm1 = TaskManager::new("determinism env1");
+        let env1 = RethEnv::new_for_temp_chain(chain.clone(), tmp1.path(), &tm1, None)?;
+        let block1 = execute_payload_and_update_canonical_chain(&env1, payload.clone(), vec![])?;
+        let header1 = block1.recovered_block.clone_sealed_header();
+
+        let tmp2 = TempDir::new().unwrap();
+        let tm2 = TaskManager::new("determinism env2");
+        let env2 = RethEnv::new_for_temp_chain(chain.clone(), tmp2.path(), &tm2, None)?;
+        let block2 = execute_payload_and_update_canonical_chain(&env2, payload, vec![])?;
+        let header2 = block2.recovered_block.clone_sealed_header();
+
+        assert_eq!(
+            header1.state_root, header2.state_root,
+            "epoch-closing state_root must be identical across independent executions"
+        );
+
+        // the installed next-epoch state matches read-for-read: same epoch record, same
+        // shuffled committee (stored at newEpoch + 2), same keys
+        let state1 = env1.epoch_state_from_canonical_tip()?;
+        let state2 = env2.epoch_state_from_canonical_tip()?;
+        assert_eq!(state1.epoch, 1);
+        assert_eq!(state1.epoch, state2.epoch);
+        assert_eq!(state1.epoch_info, state2.epoch_info);
+        assert_eq!(
+            env1.validators_for_epoch_at_block(3, env1.canonical_tip().hash())?,
+            env2.validators_for_epoch_at_block(3, env2.canonical_tip().hash())?
+        );
+        assert_eq!(
+            env1.bls_pubkeys_for_epoch_at_block(3, env1.canonical_tip().hash())?,
+            env2.bls_pubkeys_for_epoch_at_block(3, env2.canonical_tip().hash())?
+        );
+
+        Ok(())
+    }
+
     /// Governance `burn` of a validator seated only in FUTURE committees leaves the current
     /// committee untouched.
     ///

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -474,13 +474,19 @@ impl RethEnv {
     /// the block identified by `block_hash`.
     ///
     /// Builds an EVM pinned to `block_hash`'s state and issues a single `getEpochInfo(uint32)`
-    /// call. The registry keeps a ring buffer of the four most recent epochs and reverts
-    /// (`InvalidEpoch`) for anything outside it, so a successful return is guaranteed to be the
-    /// requested epoch's record. Used by the epoch manager to recover the previous epoch's block
-    /// range from its closing block when deriving next-epoch base fees.
+    /// call. The registry serves the window `[current - 3, current + 2]` and reverts
+    /// (`InvalidEpoch`) outside it — but a FUTURE epoch inside the window does not revert: it
+    /// returns a synthesized projection whose `blockHeight` is 0 (the interface's "not yet
+    /// begun" sentinel) with config fields as they would be stamped if the epoch began now.
+    /// This method exists to recover a *begun* epoch's record (the epoch manager derives the
+    /// previous epoch's block range from its closing block when seeding next-epoch base fees),
+    /// so it rejects non-identity records rather than handing callers a sentinel `blockHeight`
+    /// they would use as a block-scan floor: the returned `epochId` must equal the request
+    /// (re-checked here so a binding drift cannot mislabel a record), and `blockHeight == 0` is
+    /// only legitimate for epoch 0, whose first block is genesis.
     ///
-    /// Fails with a descriptive error if `block_hash` does not resolve to a sealed header or the
-    /// registry call does not succeed.
+    /// Fails with a descriptive error if `block_hash` does not resolve to a sealed header, the
+    /// registry call does not succeed, or the returned record is synthesized/mismatched.
     pub fn get_epoch_info_at_block(
         &self,
         epoch: Epoch,
@@ -493,8 +499,23 @@ impl RethEnv {
         let mut tn_evm = self.inner.evm_config.evm_factory().create_evm(&mut db, evm_env);
 
         let calldata = ConsensusRegistry::getEpochInfoCall { epoch }.abi_encode().into();
-        self.call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut tn_evm, calldata)
-            .map_err(Into::into)
+        let info =
+            self.call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut tn_evm, calldata)?;
+
+        if info.epochId != epoch {
+            eyre::bail!(
+                "getEpochInfo({epoch}) at block {block_hash:?} returned a record for epoch {}",
+                info.epochId
+            );
+        }
+        if info.blockHeight == 0 && epoch != 0 {
+            eyre::bail!(
+                "getEpochInfo({epoch}) at block {block_hash:?} returned a not-yet-begun record \
+                 (blockHeight 0): epoch {epoch} had not started as of this block"
+            );
+        }
+
+        Ok(info)
     }
 
     /// Read worker fee configs from the [`WorkerConfigs`] contract at the block identified by

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -975,9 +975,9 @@ mod tests {
         payload::TNPayload,
         system_calls::ConsensusRegistry::ValidatorStatus,
         test_utils::{
-            consensus_output_for_tests, execute_payload_and_update_canonical_chain,
-            governance_burn_tx, governance_owner_factory, test_genesis_with_consensus_registry,
-            TransactionFactory,
+            consensus_output_for_tests, create_committee_from_state,
+            execute_payload_and_update_canonical_chain, governance_burn_tx,
+            governance_owner_factory, test_genesis_with_consensus_registry, TransactionFactory,
         },
         RethChainSpec,
     };
@@ -990,8 +990,8 @@ mod tests {
     use tempfile::TempDir;
     use tn_config::NodeInfo;
     use tn_types::{
-        generate_proof_of_possession_bls_for_test, BlsKeypair, GenesisAccount, NodeP2pInfo,
-        TaskManager, U256,
+        gas_accumulator::RewardsCounter, generate_proof_of_possession_bls_for_test, BlsKeypair,
+        GenesisAccount, NodeP2pInfo, TaskManager, U256,
     };
 
     /// In-protocol `ConsensusRegistry` fork over the PRE-fork testnet registry.
@@ -2298,6 +2298,78 @@ mod tests {
             env1.bls_pubkeys_for_epoch_at_block(3, env1.canonical_tip().hash())?,
             env2.bls_pubkeys_for_epoch_at_block(3, env2.canonical_tip().hash())?
         );
+
+        Ok(())
+    }
+
+    /// Reward accounting through the production close: seeded leader counts flow
+    /// `RewardsCounter` → `applyIncentives(RewardInfo[])` → on-chain balances, with the epoch
+    /// issuance split exactly between equal-count leaders.
+    ///
+    /// Pins the `BTreeMap<Address, u32>` → `RewardInfo[]` mapping in
+    /// `apply_closing_epoch_contract_call` with a NON-empty rewards array at unit level —
+    /// previously exercised only by the engine e2e suite. The fixture's `epochIssuance`
+    /// (25,806 TEL) is even, so two equal-weight leaders each collect exactly half
+    /// (`div_ceil(2)` matches the engine assertions and is exact here).
+    #[tokio::test]
+    async fn test_rewards_counter_flows_through_production_close() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Rewards Close Test");
+        let counter = RewardsCounter::default();
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(counter.clone()),
+        )?;
+
+        // seed the counter exactly as run_epoch does at epoch entry: the genesis committee,
+        // then equal leader tallies for two members
+        let epoch_state = reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch_state.validators.len(), 5);
+        let member_addresses: Vec<Address> =
+            epoch_state.validators.iter().map(|v| v.validatorAddress).collect();
+        let issuance = epoch_state.epoch_info.epochIssuance;
+        let committee = create_committee_from_state(epoch_state).await?;
+        counter.set_committee(committee.clone());
+        let authorities: Vec<_> = committee.authorities().into_iter().collect();
+        let (leader_a, leader_b) = (&authorities[0], &authorities[1]);
+        for _ in 0..3 {
+            counter.inc_leader_count(&leader_a.id());
+            counter.inc_leader_count(&leader_b.id());
+        }
+        assert_eq!(counter.get_address_counts().len(), 2);
+
+        // close epoch 0 through the production path; finish() drains the counter into
+        // applyIncentives(RewardInfo[]) with a two-entry array
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+
+        // equal weights split the (even) issuance exactly; non-leaders collect nothing
+        let expected_each = issuance.div_ceil(U256::from(2));
+        assert_eq!(expected_each * U256::from(2), issuance, "fixture issuance splits exactly");
+        for leader in [leader_a, leader_b] {
+            let rewards = reth_env.read_consensus_registry::<U256>(
+                ConsensusRegistry::getRewardsCall { validatorAddress: leader.execution_address() }
+                    .abi_encode()
+                    .into(),
+            )?;
+            assert_eq!(rewards, expected_each, "equal-count leader collects an exact half");
+        }
+        let non_leader = member_addresses
+            .iter()
+            .find(|address| {
+                **address != leader_a.execution_address()
+                    && **address != leader_b.execution_address()
+            })
+            .expect("five members, two leaders");
+        let rewards = reth_env.read_consensus_registry::<U256>(
+            ConsensusRegistry::getRewardsCall { validatorAddress: *non_leader }.abi_encode().into(),
+        )?;
+        assert!(rewards.is_zero(), "non-leader collects nothing");
 
         Ok(())
     }

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -1754,7 +1754,9 @@ mod tests {
 
         // applyIncentives with rewards for the burned + a surviving validator: the isRetired
         // branch skips the burned validator while the survivor accrues rewards. Then
-        // concludeEpoch over the shrunken committee, matching the protocol's boundary sequence.
+        // concludeEpoch over the shrunken committee. (A hand-rolled pair, not the protocol's
+        // boundary sequence - the executor issues three calls with applySlashes interposed; see
+        // test_epoch_boundary_slash_ejects_through_production_close.)
         let alive = committee[0].validatorAddress;
         let mut tn_evm = reth_env.tn_evm(canonical_header.hash())?;
         let mut new_committee: Vec<Address> =
@@ -1813,11 +1815,13 @@ mod tests {
     /// The epoch-boundary slashing sequence: a slash-to-zero ejection lands mid-sequence and the
     /// close still succeeds because the committee is assembled from post-slash state.
     ///
-    /// Drives the exact three-call order the block executor issues - `applyIncentives`, then
-    /// `applySlashes`, then `concludeEpoch` - with a slash that empties a validator's stake.
-    /// Pins the sequencing contract an automated slash producer must uphold: the committee size
-    /// and eligible pool are read AFTER `applySlashes` commits, so the ejection is reflected
-    /// before `concludeEpoch` validates the committee. Also pins the preserved reward economics:
+    /// Hand-rolls the three-call boundary order - `applyIncentives`, then `applySlashes`, then
+    /// `concludeEpoch` - on a raw `tn_evm`, with a slash that empties a validator's stake. Pins
+    /// the CONTRACT-side outcome an automated slash producer relies on: the committee size and
+    /// eligible pool reflect the ejection once `applySlashes` commits, so a post-slash committee
+    /// passes `concludeEpoch` validation. (The ordering as the block executor actually issues it
+    /// is pinned end-to-end by `test_epoch_boundary_slash_ejects_through_production_close`.)
+    /// Also pins the preserved reward economics:
     /// incentives run before slashes, so the closing epoch's rewards are weighted on pre-slash
     /// collateral and even the about-to-be-ejected validator collects its final epoch.
     #[tokio::test]
@@ -1938,6 +1942,107 @@ mod tests {
         Ok(())
     }
 
+    /// The production close path ejects a slash-to-zero validator: a slash injected through the
+    /// `TNPayload` seam rides `finish()`'s boundary sequence and the close succeeds because the
+    /// committee is assembled from post-slash state.
+    ///
+    /// This is the end-to-end pin for the executor's call ordering (`applyIncentives` →
+    /// `applySlashes` → committee reads → `concludeEpoch`), driving the real
+    /// `apply_closing_epoch_contract_call` rather than hand-rolling the sequence like the
+    /// siblings above. Each assertion kills a distinct mis-ordering:
+    /// - the block succeeding at all: the slash landed before the committee reads (a stale
+    ///   five-member committee would revert `InvalidCommitteeSize` on-chain and error the block);
+    /// - `exitEpoch == 1`: the slash landed BEFORE `concludeEpoch` rotated the epoch
+    ///   (`_consensusBurn` records the current epoch at slash time; a slash issued after the
+    ///   rotation would record 2, and close-success alone cannot discriminate that reorder);
+    /// - the shrunken current + shuffled committees: the ejection propagated into committee
+    ///   assembly.
+    ///
+    /// The inverted-order negative variant is deliberately absent: the fixed production path
+    /// cannot issue the calls out of order, and the contract half (stale committee ⇒
+    /// `InvalidCommitteeSize` revert) is already pinned by
+    /// `test_stale_pre_slash_committee_reverts_close`.
+    #[tokio::test]
+    async fn test_epoch_boundary_slash_ejects_through_production_close() -> eyre::Result<()> {
+        let genesis = test_genesis_with_consensus_registry(5);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::new("Seam Slash Ejection Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        // close epoch 0 through the production payload path so the seam-injected close below
+        // runs at a realistic mid-chain boundary rather than directly on genesis state
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let canonical_header = block1.recovered_block.clone_sealed_header();
+
+        let EpochState { epoch, validators: committee, .. } =
+            reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 1);
+        assert_eq!(committee.len(), 5);
+        let victim = committee[0].validatorAddress;
+
+        // slash sizing: the env runs a default (empty) RewardsCounter, so the boundary's
+        // `applyIncentives` credits nothing and the pre-boundary outstanding balance equals the
+        // balance `applySlashes` compares — a full-outstanding slash is a slash-to-zero
+        let (outstanding, _initial, _rewards) = reth_env
+            .read_consensus_registry::<(U256, U256, U256)>(
+                ConsensusRegistry::getBalanceBreakdownCall { validatorAddress: victim }
+                    .abi_encode()
+                    .into(),
+            )?;
+
+        // close epoch 1 through the PRODUCTION path with the slash injected through the seam:
+        // finish() must sequence it between applyIncentives and the committee reads
+        let consensus_output = consensus_output_for_tests(2, 1, 2, true);
+        let payload = TNPayload::new_for_test(canonical_header, &consensus_output)
+            .with_epoch_boundary_slashes(vec![ConsensusRegistry::Slash {
+                validatorAddress: victim,
+                amount: outstanding,
+            }]);
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+
+        // the slash landed: retired, ejected from the eligible pool, size clamped
+        let retired = reth_env.read_consensus_registry::<bool>(
+            ConsensusRegistry::isRetiredCall { validatorAddress: victim }.abi_encode().into(),
+        )?;
+        assert!(retired, "slash-to-zero through the production close retires the validator");
+        let eligible = reth_env.read_consensus_registry::<U256>(
+            ConsensusRegistry::getEligibleValidatorCountCall {}.abi_encode().into(),
+        )?;
+        assert_eq!(eligible, U256::from(4));
+        let next_size = reth_env.read_consensus_registry::<u16>(
+            ConsensusRegistry::getNextCommitteeSizeCall {}.abi_encode().into(),
+        )?;
+        assert_eq!(next_size, 4);
+
+        // ordering discriminator: `_consensusBurn` → `_exit(validator, currentEpoch)` records
+        // the epoch at slash time. The close rotated 1 → 2, so a slash issued after
+        // `concludeEpoch` would record 2; only the slash-before-conclude order records 1.
+        let victim_info = reth_env.read_consensus_registry::<ConsensusRegistry::ValidatorInfo>(
+            ConsensusRegistry::getValidatorCall { validatorAddress: victim }.abi_encode().into(),
+        )?;
+        assert_eq!(victim_info.exitEpoch, 1, "slash must land before the epoch rotates");
+
+        // the epoch rotated over a post-slash committee that excludes the victim
+        let EpochState { epoch, validators: committee, .. } =
+            reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 2);
+        assert_eq!(committee.len(), 4);
+        assert!(committee.iter().all(|v| v.validatorAddress != victim));
+
+        // the committee this concludeEpoch installed (stored at newEpoch + 2 = 4) was shuffled
+        // from the post-slash pool: four members, victim absent
+        let shuffled =
+            reth_env.validators_for_epoch_at_block(4, reth_env.canonical_tip().hash())?;
+        assert_eq!(shuffled.len(), 4);
+        assert!(shuffled.iter().all(|v| v.validatorAddress != victim));
+
+        Ok(())
+    }
+
     /// A committee sized from PRE-slash state makes `concludeEpoch` revert with
     /// `InvalidCommitteeSize` when a slash-to-zero ejection lands in between.
     ///
@@ -1945,7 +2050,9 @@ mod tests {
     /// `nextCommitteeSize`, so a slash producer that reads the size before `applySlashes`
     /// commits produces a fatal on-chain revert (a deterministic fleet halt), not a silent
     /// mis-seat. The block executor's read-after-slash sequencing exists to prevent exactly
-    /// this; the test pins the failure mode so it trips loudly if that ordering regresses.
+    /// this; this test pins the CONTRACT half (the revert and its selector), while the
+    /// executor's own ordering is pinned through the production close path by
+    /// `test_epoch_boundary_slash_ejects_through_production_close`.
     #[tokio::test]
     async fn test_stale_pre_slash_committee_reverts_close() -> eyre::Result<()> {
         use reth_revm::context::result::ExecutionResult;

--- a/crates/tn-reth/src/env/genesis.rs
+++ b/crates/tn-reth/src/env/genesis.rs
@@ -70,7 +70,7 @@ use tn_config::{
     WORKER_CONFIGS_JSON,
 };
 use tn_types::{
-    gas_accumulator::RewardsCounter, Address, Genesis, GenesisAccount, TaskManager, U256,
+    gas_accumulator::RewardsCounter, Address, Genesis, GenesisAccount, TaskManager, B256, U256,
 };
 use tracing::debug;
 
@@ -266,10 +266,24 @@ impl RethEnv {
         debug!(target: "engine", "state_size:{:#?}", state_size);
         debug!(target: "engine", "reverts_size:{:#?}", reverts_size);
 
-        // construct real genesis using known values & tmp chain storage result
-        let tmp_registry_storage = state.get(&tmp_registry_address).map(|account| {
-            account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
-        });
+        // construct real genesis using known values & tmp chain storage result. A missing
+        // account or empty storage map here means the ceremony's nonce-derived tmp address no
+        // longer matches where the constructor actually deployed (or the constructor wrote
+        // nothing); flowing that into `with_storage(None)` would ship a deployed-but-
+        // uninitialized contract — unownable, first epoch close reverts — so fail loud instead.
+        let tmp_registry_storage: std::collections::BTreeMap<B256, B256> = state
+            .get(&tmp_registry_address)
+            .map(|account| {
+                account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
+            })
+            .filter(|s: &std::collections::BTreeMap<B256, B256>| !s.is_empty())
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "pre-genesis ceremony harvested no ConsensusRegistry storage at tmp address \
+                     {tmp_registry_address}: constructor deployed elsewhere (nonce-derived \
+                     address drift?) or wrote no slots"
+                )
+            })?;
         let registry_runtimecode_binding = Self::fetch_value_from_json_str(
             CONSENSUS_REGISTRY_JSON,
             Some("deployedBytecode.object"),
@@ -278,9 +292,19 @@ impl RethEnv {
             registry_runtimecode_binding.as_str().ok_or_eyre("invalid registry json")?;
         let registry_runtimecode = hex::decode(registry_runtimecode_str)?;
 
-        let tmp_worker_configs_storage = state.get(&tmp_worker_configs_address).map(|account| {
-            account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
-        });
+        let tmp_worker_configs_storage: std::collections::BTreeMap<B256, B256> = state
+            .get(&tmp_worker_configs_address)
+            .map(|account| {
+                account.storage.iter().map(|(k, v)| ((*k).into(), v.present_value.into())).collect()
+            })
+            .filter(|s: &std::collections::BTreeMap<B256, B256>| !s.is_empty())
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "pre-genesis ceremony harvested no WorkerConfigs storage at tmp address \
+                     {tmp_worker_configs_address}: constructor deployed elsewhere (nonce-derived \
+                     address drift?) or wrote no slots"
+                )
+            })?;
         let worker_configs_runtimecode_binding =
             Self::fetch_value_from_json_str(WORKER_CONFIGS_JSON, Some("deployedBytecode.object"))?;
         let worker_configs_runtimecode = hex::decode(
@@ -307,7 +331,7 @@ impl RethEnv {
                 GenesisAccount::default()
                     .with_balance(U256::from(total_stake_balance))
                     .with_code(Some(registry_runtimecode.into()))
-                    .with_storage(tmp_registry_storage),
+                    .with_storage(Some(tmp_registry_storage)),
             ),
             (
                 ISSUANCE_ADDRESS,
@@ -317,7 +341,7 @@ impl RethEnv {
                 WORKER_CONFIGS_ADDRESS,
                 GenesisAccount::default()
                     .with_code(Some(worker_configs_runtimecode.into()))
-                    .with_storage(tmp_worker_configs_storage),
+                    .with_storage(Some(tmp_worker_configs_storage)),
             ),
         ]);
 

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -52,7 +52,8 @@
 //! block whose state diverges from the rest of the fleet.
 //!
 //! Note for auditors: protocol-side slashing is not live - the `slashes` array passed to
-//! `applySlashes` is always empty.
+//! `applySlashes` is always empty (production builds; tests may inject slashes through the
+//! `cfg(test)` seam on `TNPayload`).
 //!
 //! # System-call state hygiene
 //!
@@ -148,6 +149,12 @@ pub struct TNBlockExecutionCtx {
     pub difficulty: U256,
     /// Counter used to allocate rewards for block leaders.
     pub rewards_counter: RewardsCounter,
+    /// Test-only slash injection for the epoch boundary, copied from the payload
+    /// (`context_for_next_block`). Feeds the executor's `epoch_boundary_slashes` seam so a test
+    /// can drive a non-empty slash list through the production close path. Production builds have
+    /// no such field.
+    #[cfg(test)]
+    pub epoch_boundary_slashes: Vec<ConsensusRegistry::Slash>,
 }
 
 impl TNBlockExecutionCtx {
@@ -268,8 +275,8 @@ where
     /// assembled, so the `nextCommitteeSize` read and the shuffle below both see any slash-to-zero
     /// ejections: the committee `concludeEpoch` validates cannot be stale, and an ejected
     /// validator is never seated in a future committee. Slashing is not live, so the slashes array
-    /// is always empty and `applySlashes` is a no-op today; the call is issued regardless so the
-    /// sequence is correct by construction when slashing ships.
+    /// is always empty (production builds) and `applySlashes` is a no-op today; the call is
+    /// issued regardless so the sequence is correct by construction when slashing ships.
     fn apply_closing_epoch_contract_call(
         &mut self,
         randomness: B256,
@@ -326,18 +333,34 @@ where
 
     /// The slashes to submit at this epoch boundary.
     ///
-    /// Slashing is not live: this always returns an empty list and `applySlashes` runs as a
-    /// no-op. An automated slash producer plugs in here and nowhere else. The caller sequences
-    /// the returned slashes through `applySlashes` BEFORE the committee size and eligible pool
-    /// are read, so a slash-to-zero ejection is always reflected in the committee that
-    /// `concludeEpoch` validates. Submitting slashes through any other path, or after the
-    /// committee reads, reintroduces the stale-committee revert pinned by
-    /// `test_stale_pre_slash_committee_reverts_close` - a deterministic fleet halt.
+    /// Slashing is not live: this always returns an empty list (production builds) and
+    /// `applySlashes` runs as a no-op. An automated slash producer plugs in here and nowhere
+    /// else. The caller sequences the returned slashes through `applySlashes` BEFORE the
+    /// committee size and eligible pool are read, so a slash-to-zero ejection is always
+    /// reflected in the committee that `concludeEpoch` validates. That end-to-end ordering is
+    /// pinned by `test_epoch_boundary_slash_ejects_through_production_close`, which injects a
+    /// slash-to-zero through the test seam and drives it through this production close path.
+    ///
+    /// Sizing contract for a future slash producer: amounts must be computed against
+    /// POST-incentive balances. `applyIncentives` credits `balances[validator]` before
+    /// `applySlashes` runs, and the registry ejects only when `balance <= slash.amount`
+    /// (otherwise it decrements and keeps the validator seated) — so an amount sized from the
+    /// pre-boundary balance under-slashes: the validator keeps the incentive delta and is never
+    /// ejected.
     ///
     /// Determinism: every node must derive an identical list (content and order) from the same
     /// certified consensus output, or the boundary block diverges across the fleet.
+    #[cfg(not(test))]
     fn epoch_boundary_slashes(&self) -> Vec<ConsensusRegistry::Slash> {
         Vec::new()
+    }
+
+    /// Test-only body for the epoch-boundary slash seam: yields the slashes injected through
+    /// `TNPayload::with_epoch_boundary_slashes` (carried on the execution ctx). See the
+    /// production body above for the ordering, sizing, and determinism contract.
+    #[cfg(test)]
+    fn epoch_boundary_slashes(&self) -> Vec<ConsensusRegistry::Slash> {
+        self.ctx.epoch_boundary_slashes.clone()
     }
 
     /// Close the epoch via the PRE-fork registry ABI: `applyIncentives(RewardInfo[])` followed

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -38,8 +38,6 @@
 //!    committee-pool read), keeping pre-fork history re-executable; the post-fork sequence differs
 //!    only by the interposed `applySlashes` call, and both share byte-identical `applyIncentives`
 //!    and `concludeEpoch(address[])` selectors.
-//! 3. `merge_transitions(BundleRetention::Reverts)` - folds the transaction and system-call
-//!    transitions into the bundle state, retaining revert data.
 //!
 //! The order is load-bearing. The fork must lead: the code swap flips the code-hash gate in
 //! `read_committee_eligible_pool` so the shuffle's committee-pool reads use the post-fork ABI
@@ -110,7 +108,6 @@ use reth_revm::{
         result::{ExecutionResult, ResultAndState},
         Block as _,
     },
-    db::states::bundle_state::BundleRetention,
     DatabaseCommit as _, State,
 };
 use std::{collections::BTreeMap, sync::Arc};
@@ -980,8 +977,9 @@ where
                 BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
             })?;
 
-            // merge transitions into bundle state
-            self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
+            // deliberately NO merge_transitions here: both reth wrappers merge after finish()
+            // returns, and revm pushes a reverts entry per merge — merging in here too gives
+            // every epoch-closing block a phantom empty bundle.reverts entry (len 2 vs 1)
         }
 
         Ok((

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -227,10 +227,12 @@ where
 
     /// Execute a system call from [`SYSTEM_ADDRESS`] to `contract` and commit its state changes.
     ///
-    /// Shared implementation for the epoch system calls (`concludeEpoch`, its legacy pre-fork
-    /// pair, `migrateValidatorSets`). Any failure — the call itself erroring or the execution
-    /// result being unsuccessful — is fatal to the block; `description` names the call in the
-    /// log and error strings.
+    /// Shared implementation for the epoch system calls (`applyIncentives`, `applySlashes`,
+    /// `concludeEpoch`, the legacy pre-fork close pair, `migrateValidatorSets`). Any failure —
+    /// the call itself erroring or the execution result being unsuccessful — is fatal to the
+    /// block; `description` names the call in the log and error strings, and a revert's decoded
+    /// reason (with its selector and raw output in the log) rides along so the deterministic
+    /// fleet halt this causes is diagnosable from the error alone.
     ///
     /// [`SYSTEM_ADDRESS`] is removed from the result state before commit: it is only touched as
     /// the system caller, not a real state change — leaving it in the changeset would put a
@@ -252,11 +254,38 @@ where
             }
         };
 
-        // return error if the call executed but did not succeed
-        if !res.result.is_success() {
-            // execution failed
-            error!(target: "engine", "failed {description} call: {:?}", res.result);
-            return Err(TnRethError::EVMCustom(format!("failed {description}")));
+        // return error if the call executed but did not succeed, keeping Revert (decoded
+        // reason + selector) distinguishable from Halt
+        match &res.result {
+            ExecutionResult::Success { .. } => {}
+            ExecutionResult::Revert { output, gas_used } => {
+                let reason = alloy::sol_types::decode_revert_reason(output)
+                    .unwrap_or_else(|| "<undecodable revert reason>".to_string());
+                let selector = output
+                    .get(..4)
+                    .map(alloy::hex::encode_prefixed)
+                    .unwrap_or_else(|| format!("<{} bytes>", output.len()));
+                error!(
+                    target: "engine",
+                    %selector,
+                    raw_output = %output,
+                    gas_used,
+                    "failed {description} call: reverted: {reason}"
+                );
+                return Err(TnRethError::EVMCustom(format!(
+                    "failed {description}: reverted: {reason}"
+                )));
+            }
+            ExecutionResult::Halt { reason, gas_used } => {
+                error!(
+                    target: "engine",
+                    gas_used,
+                    "failed {description} call: halted: {reason:?}"
+                );
+                return Err(TnRethError::EVMCustom(format!(
+                    "failed {description}: halted: {reason:?} (gas used {gas_used})"
+                )));
+            }
         }
         trace!(target: "engine", ?res, "{description}");
 

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -67,9 +67,11 @@
 //! The epoch-close `randomness` (`ctx.close_epoch`) is the keccak256 of the leader
 //! certificate's aggregate BLS signature, computed in `CommittedSubDag::new` and carried through
 //! the payload. It seeds the deterministic committee shuffle AND is stored as the block's
-//! `extra_data`, which is how the replay path (`context_for_block`) rebuilds an identical ctx
-//! from the sealed header. The RNG draw order inside the shuffle is consensus-critical: any
-//! refactor that reorders the draws selects a different committee.
+//! `extra_data`, which is how the replay path (`context_for_block`) rebuilds the ctx from the
+//! sealed header — identical up to `rewards_counter`, which is the live shared counter rather
+//! than header-derived (see the `evm/config.rs` module docs for the replay caveat and the
+//! `block.body.withdrawals` reconstruction follow-up). The RNG draw order inside the shuffle
+//! is consensus-critical: any refactor that reorders the draws selects a different committee.
 
 use crate::{
     error::{TnRethError, TnRethResult},

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -575,7 +575,16 @@ where
                 debug!(target: "engine", "non-fatal eligible-count readback after migration failed: {e}");
             })
             .ok()
-            .and_then(|data| <U256 as alloy::sol_types::SolValue>::abi_decode(&data).ok());
+            .and_then(|data| {
+                <U256 as alloy::sol_types::SolValue>::abi_decode(&data)
+                    .inspect_err(|e| {
+                        debug!(
+                            target: "engine",
+                            "non-fatal eligible-count readback after migration returned undecodable data: {e}"
+                        );
+                    })
+                    .ok()
+            });
 
         tracing::info!(target: "engine", ?eligible, %code_hash, "consensus registry fork applied");
         Ok(())
@@ -1191,6 +1200,15 @@ fn assemble_new_committee(
     eligible_pool: Vec<ConsensusRegistry::ValidatorInfo>,
     rng: &mut StdRng,
 ) -> TnRethResult<Vec<Address>> {
+    // a zero target would sail through the final length check below (`0 == 0`) and forward
+    // `concludeEpoch([])` — an opaque on-chain revert; refuse it here with a distinct message
+    if new_committee_size == 0 {
+        return Err(TnRethError::EVMCustom(
+            "next committee size is zero: refusing to conclude the epoch with an empty committee"
+                .to_string(),
+        ));
+    }
+
     // 1) separate active and pending validators
     // 2) check if active length is sufficient
     // 3) if missing, randomly select from the pending validators

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -187,6 +187,10 @@ impl ConfigureEvm for TnEvmConfig {
             close_epoch,
             difficulty: block.difficulty,
             rewards_counter: self.rewards_counter.clone(),
+            // the header carries no slash list: a replayed block cannot reproduce a
+            // test-injected slash (and does not need to — production lists are always empty)
+            #[cfg(test)]
+            epoch_boundary_slashes: Vec::new(),
         })
     }
 
@@ -203,6 +207,8 @@ impl ConfigureEvm for TnEvmConfig {
             close_epoch: payload.close_epoch,
             difficulty: U256::from(payload.batch_index << 16 | payload.worker_id as usize),
             rewards_counter: self.rewards_counter.clone(),
+            #[cfg(test)]
+            epoch_boundary_slashes: payload.epoch_boundary_slashes,
         })
     }
 }

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -12,8 +12,15 @@
 //! `context_for_next_block` copies `TNPayload::close_epoch` into the execution context, and the
 //! assembler later records it as the header's `extra_data`. Re-executing a stored block,
 //! `context_for_block` recovers the same value by decoding `extra_data` (empty = normal block,
-//! 32 bytes = the closing-epoch digest, any other length = malformed-header error), so replay
-//! reproduces the identical epoch-boundary execution.
+//! 32 bytes = the closing-epoch digest, any other length = malformed-header error).
+//!
+//! Replay caveat: `rewards_counter` is NOT header-derived — both context builders clone the
+//! config's live shared counter. Re-executing an epoch-closing block outside its original
+//! epoch context (e.g. `debug_executionWitness`) therefore runs `applyIncentives` with
+//! whatever the counter holds at that moment, not the amounts the historical block
+//! distributed. Reconstructing the historical counts from `block.body.withdrawals` (which
+//! records them) is a known follow-up; the canonical sync path is unaffected because the
+//! epoch manager seeds the counter before replaying an epoch's outputs.
 
 use super::{TNBlockAssembler, TNBlockExecutionCtx, TNBlockExecutorFactory, TNEvmFactory};
 use crate::{error::TnRethError, payload::TNPayload, TNPrimitives};
@@ -145,7 +152,9 @@ impl ConfigureEvm for TnEvmConfig {
             number: U256::from(parent.number + 1),
             beneficiary: payload.beneficiary,
             timestamp: U256::from(payload.timestamp),
-            difficulty: U256::from(payload.batch_index), // stored in final execution
+            // unread post-merge; the header's difficulty comes from ctx.difficulty in the
+            // assembler (batch_index << 16 | worker_id), not from this block-env field
+            difficulty: U256::from(payload.batch_index),
             prevrandao: Some(payload.prev_randao()),
             gas_limit: payload.gas_limit,
             basefee: payload.base_fee_per_gas,

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -67,9 +67,22 @@ pub use utils::calculate_gas_penalty;
 /// Gas budget for a single protocol system call.
 ///
 /// System calls run at `gas_price: 0` and do not count toward the block gas limit, so this
-/// bound exists only to stop runaway execution. It is sized well above the block gas limit to
-/// give the epoch-closing `concludeEpoch` call headroom: that call applies rewards, slashes,
-/// and queued stake settlement across the full validator set in one transaction.
+/// bound exists only to stop runaway execution. The 100M headroom (vs the historical 30M
+/// budget) is for the one-shot `migrateValidatorSets()` walk at the ConsensusRegistry fork
+/// boundary (see `tn-types` `forks.rs`), which touches every validator in a single call; the
+/// regular boundary calls fit far below it.
+///
+/// LOCKSTEP FLEET-UPGRADE REQUIREMENT: this value participates in consensus.
+/// `transact_system_call` swaps `block.gas_limit` to this value for the call's duration, and a
+/// binary built with the old 30M diverges from a 100M binary on any system call needing more
+/// than 30M — exactly the calls the headroom exists for. Every validator must run a binary
+/// with the same value before any close can depend on it. (Relatedly, the epoch boundary is
+/// now three calls — `applyIncentives`, `applySlashes`, `concludeEpoch` — vs two on `main`;
+/// `applySlashes` is present in the deployed testnet and mainnet genesis bytecode and an
+/// empty-array call is a state-neutral no-op, so existing history replays unchanged.)
+///
+/// Read-path note: contract reads that share the system-call plumbing (including RPC reads via
+/// `read_contract_at_block`) inherit this ceiling — an accepted consequence of the raise.
 pub(crate) const SYSTEM_CALL_GAS_LIMIT: u64 = 100_000_000;
 
 /// Gas budget for a single pre-genesis constructor CREATE

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -72,6 +72,16 @@ pub use utils::calculate_gas_penalty;
 /// and queued stake settlement across the full validator set in one transaction.
 pub(crate) const SYSTEM_CALL_GAS_LIMIT: u64 = 100_000_000;
 
+/// Gas budget for a single pre-genesis constructor CREATE
+/// (`TNEvm::transact_pre_genesis_create`).
+///
+/// Deliberately 30M — the chain's block gas limit — as a deploy-size ceiling for the genesis
+/// ceremony, NOT a stale copy of the old 30M system-call budget (that constant is
+/// [`SYSTEM_CALL_GAS_LIMIT`] and moved to 100M for epoch-boundary headroom). Pre-genesis
+/// creates run at `gas_price: 0` with the block gas limit raised to match, so the bound exists
+/// to stop runaway constructor execution at the same scale a live block would allow.
+pub(crate) const PRE_GENESIS_CREATE_GAS_LIMIT: u64 = 30_000_000;
+
 /// TN EVM implementation.
 ///
 /// This is a wrapper type around the `revm` ethereum evm with optional [`Inspector`] (tracing)
@@ -317,9 +327,10 @@ where
     /// Deploy a contract during pre-genesis construction (a CREATE, not a call).
     ///
     /// Uses the same relaxed environment as `transact_system_call` — zero gas price and base fee,
-    /// nonce and chain-id checks disabled — under its own fixed 30M gas budget with the block gas
-    /// limit raised to match, but issues a `TxKind::Create` and returns the full result state for
-    /// the caller to commit (no `SYSTEM_ADDRESS` stripping convention here).
+    /// nonce and chain-id checks disabled — under its own [`PRE_GENESIS_CREATE_GAS_LIMIT`]
+    /// budget with the block gas limit raised to match, but issues a `TxKind::Create` and
+    /// returns the full result state for the caller to commit (no `SYSTEM_ADDRESS` stripping
+    /// convention here).
     pub(crate) fn transact_pre_genesis_create(
         &mut self,
         caller: Address,
@@ -330,7 +341,7 @@ where
             kind: TxKind::Create,
             // Explicitly set nonce to 0 so revm does not do any nonce checks
             nonce: 0,
-            gas_limit: 30_000_000,
+            gas_limit: PRE_GENESIS_CREATE_GAS_LIMIT,
             value: U256::ZERO,
             data,
             // Setting the gas price to zero enforces that no value is transferred as part of the

--- a/crates/tn-reth/src/evm/mod.rs
+++ b/crates/tn-reth/src/evm/mod.rs
@@ -77,7 +77,7 @@ pub use utils::calculate_gas_penalty;
 /// binary built with the old 30M diverges from a 100M binary on any system call needing more
 /// than 30M — exactly the calls the headroom exists for. Every validator must run a binary
 /// with the same value before any close can depend on it. (Relatedly, the epoch boundary is
-/// now three calls — `applyIncentives`, `applySlashes`, `concludeEpoch` — vs two on `main`;
+/// three calls — `applyIncentives`, `applySlashes`, `concludeEpoch` — vs two on `main`;
 /// `applySlashes` is present in the deployed testnet and mainnet genesis bytecode and an
 /// empty-array call is a state-neutral no-op, so existing history replays unchanged.)
 ///

--- a/crates/tn-reth/src/payload.rs
+++ b/crates/tn-reth/src/payload.rs
@@ -71,6 +71,15 @@ pub struct TNPayload {
     pub close_epoch: Option<B256>,
     /// Worker that created this payload.
     pub worker_id: WorkerId,
+    /// Test-only slash injection for the epoch boundary.
+    ///
+    /// Flows through `TNBlockExecutionCtx` into the executor's `epoch_boundary_slashes` seam so a
+    /// test can drive a non-empty slash list through the production close path. Production builds
+    /// have no such field: slashing is not live and the executor's production body always returns
+    /// an empty list. `serde(skip)` keeps the serialized payload byte-identical to production.
+    #[cfg(test)]
+    #[serde(skip)]
+    pub epoch_boundary_slashes: Vec<crate::system_calls::ConsensusRegistry::Slash>,
 }
 
 impl TNPayload {
@@ -107,6 +116,8 @@ impl TNPayload {
             mix_hash,
             close_epoch,
             worker_id,
+            #[cfg(test)]
+            epoch_boundary_slashes: Vec::new(),
         }
     }
 
@@ -151,6 +162,20 @@ impl TNPayload {
             0,
         )
     }
+
+    /// Inject slashes to submit at the epoch boundary this payload closes.
+    ///
+    /// Only meaningful on an epoch-closing payload: the executor reads the list in its
+    /// `epoch_boundary_slashes` seam and sequences it through `applySlashes` between
+    /// `applyIncentives` and `concludeEpoch`.
+    #[cfg(test)]
+    pub(crate) fn with_epoch_boundary_slashes(
+        mut self,
+        slashes: Vec<crate::system_calls::ConsensusRegistry::Slash>,
+    ) -> Self {
+        self.epoch_boundary_slashes = slashes;
+        self
+    }
 }
 
 impl BuildPendingEnv<ExecHeader> for TNPayload {
@@ -168,6 +193,8 @@ impl BuildPendingEnv<ExecHeader> for TNPayload {
             mix_hash: B256::ZERO,
             close_epoch: None,
             worker_id: 0,
+            #[cfg(test)]
+            epoch_boundary_slashes: Vec::new(),
         }
     }
 }

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -300,8 +300,9 @@ sol!(
 
 // The epoch-close surface of the PRE-fork `ConsensusRegistry` deployment. While the deployed
 // registry still carries the pre-fork code hash, epoch closes must replay this exact two-call
-// ABI (the unified three-argument `concludeEpoch` does not exist on-chain there); the code-hash
-// gate in `evm/block.rs` routes between the two. Frozen: these signatures must stay
+// sequence byte-for-byte — re-executed pre-fork blocks must derive identical state roots
+// without leaning on contract-semantics arguments about which extra calls would no-op; the
+// code-hash gate in `evm/block.rs` routes between the two. Frozen: these signatures must stay
 // byte-identical to the calls the historical chain executed.
 sol!(
     /// Pre-fork `ConsensusRegistry` epoch-close interface.

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -755,4 +755,60 @@ mod tests {
         assert_eq!(counts.len(), 4);
         assert_eq!(counts.get(&victim_address), Some(&VICTIM_LEADER_BLOCKS));
     }
+
+    /// Epoch-boundary invariant: `clear` resets every leader count so no rewards carry into the
+    /// next epoch's withdrawals, while the committee survives for the next epoch's tallies.
+    #[test]
+    fn clear_resets_leader_counts_but_preserves_committee() {
+        use crate::{BlsKeypair, CommitteeBuilder};
+        use rand::rng;
+
+        let mut rng = rng();
+        let keypairs: Vec<BlsKeypair> = (0..4).map(|_| BlsKeypair::generate(&mut rng)).collect();
+        let addresses: Vec<Address> = (0..4).map(|i| Address::repeat_byte(i as u8 + 1)).collect();
+
+        let mut builder = CommitteeBuilder::new(1);
+        for (keypair, address) in keypairs.iter().zip(addresses.iter()) {
+            builder.add_authority(*keypair.public(), *address);
+        }
+        let committee = builder.build();
+
+        let counter = RewardsCounter::default();
+        counter.set_committee(committee.clone());
+
+        let ids: Vec<AuthorityIdentifier> = keypairs
+            .iter()
+            .map(|keypair| {
+                committee
+                    .authority_by_key(keypair.public())
+                    .expect("keypair is a committee member")
+                    .id()
+            })
+            .collect();
+
+        // tally leader counts for two distinct addresses
+        for _ in 0..3 {
+            counter.inc_leader_count(&ids[0]);
+        }
+        counter.inc_leader_count(&ids[1]);
+
+        // sanity: the tallies are visible before the boundary
+        let counts = counter.get_address_counts();
+        assert_eq!(counts.len(), 2);
+        assert_eq!(counts.get(&addresses[0]), Some(&3));
+        assert_eq!(counts.get(&addresses[1]), Some(&1));
+        assert_eq!(counter.generate_withdrawals().len(), 2);
+
+        counter.clear();
+
+        // counts reset: nothing carries into the next epoch's incentives or withdrawals
+        assert!(counter.get_address_counts().is_empty());
+        assert!(counter.generate_withdrawals().is_empty());
+
+        // the committee survives clear: a fresh tally still resolves through it
+        counter.inc_leader_count(&ids[1]);
+        let counts = counter.get_address_counts();
+        assert_eq!(counts.len(), 1);
+        assert_eq!(counts.get(&addresses[1]), Some(&1));
+    }
 }


### PR DESCRIPTION
Hardening pass over the epoch-close execution path: fail-loud error surfaces, a bundle-hygiene fix, and default-feature tests for the boundary's consensus invariants.

- Boundary system-call failures now decode the revert reason and selector and distinguish reverts from halts, so a deterministic fleet halt is diagnosable from the error alone.
- `get_epoch_info_at_block` rejects synthesized future-epoch records (`blockHeight == 0` outside epoch 0) and epoch-id mismatches instead of handing callers a sentinel block-scan floor.
- Leftover consensus-output draining stops on a closed engine channel and reports no boundary instead of returning a hash the caller would wait on forever in `wait_for_consensus_execution`.
- The pre-genesis ceremony errors when the constructor storage harvest is empty rather than shipping a deployed-but-uninitialized registry.
- Dropped the in-`finish()` `merge_transitions`: both reth wrappers merge after `finish()` returns, so the old call gave every epoch-closing bundle a phantom empty reverts entry.
- Committee assembly refuses a zero `getNextCommitteeSize()` client-side instead of submitting `concludeEpoch([])`.
- New `cfg(test)` slash-injection seam on `TNPayload` feeds the executor's `epoch_boundary_slashes` hook; production builds keep the always-empty body.
- Tests: slash-to-zero ejection through the production close (with an `exitEpoch` ordering discriminator), boundary-block determinism across independent environments at default features (previously only adiri-gated), reward flow from `RewardsCounter` through `applyIncentives` to on-chain balances, bundle hygiene (no `SYSTEM_ADDRESS`, exactly one reverts entry), and `RewardsCounter::clear` semantics.
- Named the pre-genesis create gas ceiling (`PRE_GENESIS_CREATE_GAS_LIMIT`) and documented the lockstep fleet-upgrade requirement on `SYSTEM_CALL_GAS_LIMIT`.
- Docs: the epoch-boundary READMEs now describe the shipped three-call design, and the top-level README build command requires the `adiri` feature.

closes #1073 