### PR TITLE
tn-reth: check parent-hash linkage across the snapshot header window

### DIFF
--- a/SYNC.md
+++ b/SYNC.md
@@ -88,9 +88,13 @@ The snapshot narrows what must be re-derived rather than replacing the trust mod
   from epoch 0. A tampered record chain is rejected.
 - The **consensus pack** for the snapshot epoch is rebuilt and its final header is checked against the
   (certificate-verified) epoch record's final consensus hash.
-- The **execution state** is taken from the bundle as a trusted starting point (its state root is
-  recomputed as it is stored). You trust whoever produced the bundle for the execution state; the
-  committee/consensus history remains self-verifying.
+- The **execution state** is rebuilt from the bundle and bound to the same certificate chain. Its state
+  root is recomputed from scratch as it is stored and must match both the root the pack declares and the
+  `state_root` of the snapshot block, whose hash comes from the (certificate-verified) epoch record's
+  final execution state. The ancestor headers shipped with it must be parent-hash linked up to that
+  block, so the same certificate pins them too. What the bundle's producer still picks unchecked is how
+  far back the header window reaches: a short window is accepted, and blocks below it are scaffolded
+  with zero hashes, so `BLOCKHASH` at those heights reads zero on the restored node.
 
 ### The export bundle
 

--- a/crates/telcoin-network-cli/src/db.rs
+++ b/crates/telcoin-network-cli/src/db.rs
@@ -363,7 +363,10 @@ fn reject_non_resumable_bundle(
 ///
 /// The record itself is cryptographically verified against its certificate later, in
 /// `verify_and_save_epoch_records`; pinning the exec pack to it here makes the super-quorum
-/// certificate over the record transitively cover the exec pack's identity.
+/// certificate over the record transitively cover the exec pack's identity. That coverage reaches
+/// the pack's ancestor headers too, not just its tip: `SnapshotRestorer::import_chain_scaffold`
+/// walks the parent-hash links across the whole window, and a header hash commits to every field
+/// of its header, so the certified tip hash pins each ancestor in turn.
 fn check_state_pack_matches_record(pack: &Path, record: &EpochRecord) -> eyre::Result<()> {
     let reader = ExecStatePackReader::open(pack)
         .map_err(|e| eyre!("failed to open state pack {}: {e}", pack.display()))?;

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -40,13 +40,16 @@
 //!
 //! Restore proves internal consistency, not provenance. It verifies that the pack's accounts
 //! rebuild from scratch to both the pack's declared state root and `header(B).state_root`, that
-//! the header window is contiguous by block number and its tip matches the claimed `final_state`
-//! number and hash, and (in [`SnapshotRestorer::finish`]) that the reconstructed tip matches
-//! `final_state`. It does NOT verify that the window headers or `final_state` belong to the
-//! canonical chain: no consensus provenance or signature check happens in this module, and
-//! parent-hash linkage between consecutive window headers is not re-checked here (the window is
-//! validated upstream). The operator-supplied header window and final block hash are therefore
-//! the trusted inputs — a restore against forged-but-self-consistent headers would succeed.
+//! the header window is contiguous by block number, hash-linked from each header to its
+//! predecessor, and tipped by a header matching the claimed `final_state` number and hash, and
+//! (in [`SnapshotRestorer::finish`]) that the reconstructed tip matches `final_state`. It does
+//! NOT verify that `final_state` itself belongs to the canonical chain: no consensus provenance
+//! or signature check happens in this module, so `final_state` is the trusted input here: a
+//! restore against a forged window that is internally consistent and tipped by the claimed final
+//! block would succeed. Callers are expected to supply a `final_state` they have verified: `tn db
+//! load-state` pins it to an epoch record checked against that epoch's super-quorum certificate.
+//! Because a header hash commits to every field of its header, including `parent_hash`, the
+//! linkage walk carries such a caller's guarantee from the tip down through the whole window.
 //! Genesis is never taken from the snapshot; it always comes from the local chain spec, which
 //! remains the trust root.
 
@@ -362,9 +365,10 @@ impl SnapshotRestorer {
 
     /// Write a header-only chain scaffold up to the snapshot's final block `B`.
     ///
-    /// `window` is a contiguous, ascending run of the real headers that end at `final_state`
-    /// (block `B`); it must not include genesis. This method, run once before
-    /// [`import_state`](Self::import_state):
+    /// `window` is a contiguous, ascending, parent-hash-linked run of the real headers that end at
+    /// `final_state` (block `B`); it must not include genesis. Those properties are re-checked
+    /// here rather than assumed, so every caller of this `pub` API gets them. This method, run
+    /// once before [`import_state`](Self::import_state):
     ///
     /// - Clears the genesis alloc from `PlainAccountState`, `PlainStorageState`, `HashedAccounts`,
     ///   `HashedStorages`, `AccountsTrie`, and `StoragesTrie`. `init_genesis` (run in
@@ -395,8 +399,9 @@ impl SnapshotRestorer {
             .ok_or_else(|| eyre!("snapshot restore: cannot scaffold an empty header window"))?;
         let b = final_state.number;
 
-        // cheap invariant checks (the window is validated upstream, but a mis-shaped window here
-        // would silently corrupt the scaffold)
+        // cheap invariant checks. nothing upstream re-checks the window's shape or its linkage
+        // (`scaffold_window` only normalizes, and the pack-vs-record check sees the tip alone), so
+        // these run here or nowhere, and a mis-shaped window would silently corrupt the scaffold
         if b == 0 {
             return Err(eyre!("snapshot restore: cannot scaffold at genesis (block 0)"));
         }
@@ -422,6 +427,24 @@ impl SnapshotRestorer {
                 ));
             }
         }
+        // parent-hash linkage. `final_state.hash` is pinned upstream to the certificate-verified
+        // `EpochRecord.final_state`, and a header hash commits to every field of that header,
+        // including its `parent_hash`. Walking the links therefore carries the certificate's
+        // coverage from the tip down through every ancestor this scaffold writes, instead of
+        // trusting the bundle's producer for them. Number contiguity alone accepts a header that
+        // sits at the right height with arbitrary ancestry.
+        window.iter().zip(window.iter().skip(1)).try_for_each(|(parent, child)| {
+            (child.parent_hash == parent.hash()).then_some(()).ok_or_else(|| {
+                eyre!(
+                    "snapshot restore: window is not hash-linked at block {}: parent_hash {} does \
+                     not match block {}'s hash {}",
+                    child.number,
+                    child.parent_hash,
+                    parent.number,
+                    parent.hash()
+                )
+            })
+        })?;
 
         info!(
             target: "tn::reth",
@@ -1528,6 +1551,48 @@ mod tests {
         let err = SnapshotRestorer::open(&reth_config, db, &tm)
             .expect_err("open must refuse a datadir that already holds chain data");
         assert!(err.to_string().contains("non-empty"), "unexpected error: {err}");
+
+        Ok(())
+    }
+
+    /// Block-number contiguity alone accepts a window whose headers carry the right heights but
+    /// descend from different ancestors, so the scaffold also walks the parent-hash links. The
+    /// break sits in the middle of the window and the header above it re-links to the mutated
+    /// header, so only a per-pair walk catches it; checking the ends of the window would not.
+    #[tokio::test]
+    async fn import_rejects_a_window_that_is_not_hash_linked() -> eyre::Result<()> {
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let genesis_header = chain.sealed_genesis_header();
+        let state_root = genesis_header.state_root;
+
+        // scaffold a 3-block window into a fresh datadir; `linked` decides whether block 2
+        // descends from block 1 or from a stranger. every other check the scaffold makes
+        // (non-empty, non-genesis, number contiguity, tip vs `final_state`) passes either way, so
+        // the two runs differ in the parent-hash link and nothing else.
+        let run = |linked: bool| -> eyre::Result<()> {
+            let h1 = synthetic_header(1, genesis_header.hash(), state_root, 0, true);
+            let h2_parent = if linked { h1.hash() } else { B256::repeat_byte(0xee) };
+            let h2 = synthetic_header(2, h2_parent, state_root, 0, true);
+            let h3 = synthetic_header(3, h2.hash(), state_root, 0, true);
+            let window = vec![h1, h2, h3.clone()];
+            let final_state = BlockNumHash::new(3, h3.hash());
+
+            let dir = TempDir::new()?;
+            let tm = TaskManager::new("Window Linkage");
+            let (reth_config, db) = temp_config_and_db(chain.clone(), dir.path())?;
+            let restorer = SnapshotRestorer::open(&reth_config, db, &tm)?;
+            restorer.import_chain_scaffold(&window, final_state)
+        };
+
+        // positive control: the same fixture, honestly linked, is accepted, so the rejection
+        // below is attributable to the broken link rather than to the synthetic headers
+        run(true)?;
+
+        let err = run(false).expect_err("a window that is not hash-linked must be rejected");
+        assert!(
+            err.to_string().contains("not hash-linked at block 2"),
+            "expected a parent-hash linkage rejection, got: {err:?}"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Closes #1074.

## Problem

`SnapshotRestorer::import_chain_scaffold` validated the exec-state pack's header window by block-number contiguity only. The loop read `header.number` and nothing else, so it never checked that consecutive headers are hash-linked (`window[i].parent_hash == window[i - 1].hash()`). Every ancestor header in an export bundle was written into `Headers` and `HeaderNumbers` with no tie to any certified value.

Those headers are not inert. The module says plainly why the real hashes are there: they keep `BLOCKHASH` and the per-worker base-fee walk resolvable. A divergent `BLOCKHASH` is not a local read anomaly. Any contract consuming it produces different state on the restored node than on the rest of the network, which is a permanent execution fork from the first block that touches it.

The threat model is what makes this worth closing rather than documenting:

- **No forgery is required.** Pack record integrity is an unkeyed CRC-32 written beside the record it covers, and `scaffold_window` re-seals every header with `SealedHeader::seal_slow`, so a mutated ancestor is re-sealed to the hash its mutated contents imply. The pipeline recomputes the "correct" hash on the tampered bytes.
- **The guard meant to police the window reads the window.** `check_resumable_fees` walks every window header through `is_worker_batch_block`, which is a pure header-field test (`number != 0 && ommers_hash != B256::ZERO`). A header edited to carry a non-zero `ommers_hash` presents as a genuine worker batch block, so the precondition can be walked past by editing the very data it inspects.
- **The certificate already covered these headers.** `EpochRecord.final_state` is documented as a signed checkpoint of execution state, and `check_state_pack_matches_record` pins the pack's tip to it. Since a header hash commits to every field of that header, the certified `hash(B)` already commits to `parent_hash(B)`, which commits to `hash(B - 1)`, and so on down the window. The commitment existed; only the loop that checks it was missing.

Reachability is bounded and stated honestly: `tn db load-state` is a manual operator CLI run against a local bundle directory, with no automatic network path feeding it. Exploitation needs an operator to load a bundle from a producer who tampered with it. The argument for fixing it anyway is the cost asymmetry. Every other component of the bundle is self-verifying, so operators can reasonably read the whole bundle as trustless, and closing the gap is a comparison inside a loop that already existed.

## Root cause

The module doc was candid that linkage was unchecked, but it named an upstream that does not exist:

> parent-hash linkage between consecutive window headers is not re-checked here (the window is validated upstream)

"Re-checked" and "validated upstream" both imply a first check somewhere. The only upstream steps on this path are `scaffold_window` (sort plus drop-genesis, a normalization step) and `check_state_pack_matches_record` (the tip only). Neither inspects linkage. `ExecStatePackReader::verify` does exist, but it is dead on this path: all three of its call sites are inside `#[cfg(test)]`, and it compares `headers[0]` against the pack meta without ever inspecting `headers[1..]`.

## Fix

- **`crates/tn-reth/src/snapshot.rs`** . . . `import_chain_scaffold` now walks the parent-hash links across the window after the existing contiguity check, failing with the offending block number and both hashes. Placing it here rather than in `restore_pack` covers every caller of the `pub` API, not just the CLI one. Ordering it after contiguity keeps a duplicate block number failing at the contiguity check first. The walk pairs each header with its successor via iterator combinators, so there is no index arithmetic to get wrong, and the cost is roughly 257 comparisons rather than 257 hashes: `SealedHeader::hash()` reads a `OnceLock` that `scaffold_window`'s `seal_slow` already populated.
- **`crates/tn-reth/src/snapshot.rs`** . . . the module's "Trust boundary" doc no longer claims linkage is validated upstream. It now states what is actually true: the window is checked contiguous, hash-linked, and tipped by `final_state`, and `final_state` itself is the trusted input that callers are expected to supply verified. It says explicitly that a header hash commits to `parent_hash`, so the linkage walk carries such a caller's guarantee from the tip down through the whole window.
- **`crates/tn-reth/src/snapshot.rs`** . . . `import_chain_scaffold`'s own doc states the window contract as contiguous, ascending, and parent-hash-linked, and notes those properties are re-checked rather than assumed. The local comment above the checks carried the same "validated upstream" claim as the module doc and would have contradicted both the new walk and the corrected doc, so it now says these checks run here or nowhere, and why.
- **`crates/telcoin-network-cli/src/db.rs`** . . . the `check_state_pack_matches_record` doc said pinning the pack to the record makes the certificate "transitively cover the exec pack's identity". That was true of the tip and the state but not the ancestors. It now says why the coverage reaches the ancestors too.
- **`SYNC.md`** . . . the operator-facing trust model said "You trust whoever produced the bundle for the execution state (its state root is recomputed as it is stored)". That understated the code even before this change: the recomputed root is checked against the certified `header(B).state_root`. It now describes the execution state and its ancestor headers as bound to the same certificate chain, and names the one thing still left to the producer, which is how far back the window reaches.

## Testing

`cargo +1.94 test -p tn-reth --lib snapshot::` on the pinned toolchain.

New test `import_rejects_a_window_that_is_not_hash_linked` builds a three-block window that satisfies every check the scaffold already made (non-empty, non-genesis, contiguous by number, tip matching `final_state`) and differs only in the parent-hash link, so the rejection is attributable to linkage and nothing else. Two details are deliberate:

- **The break sits in the middle.** Block 3 re-links to the mutated block 2, so only a per-pair walk catches it. Checking the ends of the window would pass.
- **A positive control shares the fixture.** The same closure runs first with the link intact and asserts the scaffold accepts it, so the negative case cannot pass vacuously on a fixture that was broken for some other reason.

The test was confirmed by mutation: with the linkage walk reverted it fails (the broken window is accepted), and it passes with the walk restored.

## Scope notes

- **Coverage, stated plainly.** Seven of the eight existing `import_chain_scaffold` call sites pass single-header windows, where the new walk has no pairs to examine and is vacuous. The one pre-existing multi-header window (`restore_roundtrips_state_from_export`) is genuinely hash-linked and passes unchanged. That thin coverage of the multi-header path is why this was never caught, so please do not read eight green call sites as eight exercises of the new check. The new test above and that roundtrip are the real ones.
- **This adds no provenance.** A forged window that is internally consistent and tipped by the claimed final block still restores. What the change buys is that the certificate a caller already verifies now reaches the whole window instead of only its tip. The module doc says this in those terms.
- **Minimum window length is deliberately out of scope.** #1074 also notes that a one-header bundle passes every check and silently gets zero-hash dummies where honest nodes hold real ancestor hashes, within `BLOCKHASH` range. Fixing that is not a free comparison: `BLOCKHASH_ANCESTORS = 256` is a private non-`pub` const in `crates/node/src/manager/export_exec.rs`, and `tn-node` depends on `tn-reth` rather than the reverse, so `snapshot.rs` cannot name it even if it were made `pub`. Hoisting it into `tn-types` (the treatment already given to the worker-attribution helpers) is a precondition, and the minimum-length check would then require real windows at the seven single-header call sites above. It is a test-fixture change as much as a validation change, so it is better as its own PR. The `SYNC.md` rewrite names this remaining gap rather than papering over it.
- **`scaffold_window` does not dedup.** Duplicate block numbers are already rejected by the contiguity check (a sorted non-decreasing sequence must diverge from a strictly increasing `expected`), and placing the linkage walk after it does not change that.
