### PR TITLE
tn-storage: propagate non-NotFound remove_file failures in  write_bounded_pack

### DIFF
--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -1008,17 +1008,21 @@ impl From<io::Error> for EpochDbError {
 ///
 /// Removes any pre-existing file at `path` first, so a re-run overwrites rather than appends —
 /// `Pack::open` opens read-write in append mode, so writing over a leftover file would otherwise
-/// prepend prior-attempt records. Then opens the pack (which creates the file and writes its
-/// header), appends every value in order, and commits so the file is complete on disk. Keeps the
-/// sentinel tags and codec inside this crate so the export bundle stays readable by
-/// `read_records_from_pack` / `read_certs_from_pack`.
+/// prepend prior-attempt records. A removal failure other than `NotFound` is surfaced as
+/// [`EpochDbError::IO`] rather than ignored, since the stale file would otherwise survive and be
+/// appended onto. Then opens the pack (which creates the file and writes its header), appends
+/// every value in order, and commits so the file is complete on disk. Keeps the sentinel tags and
+/// codec inside this crate so the export bundle stays readable by `read_records_from_pack` /
+/// `read_certs_from_pack`.
 fn write_bounded_pack<V>(path: &Path, uid_idx: u64, values: &[V]) -> Result<(), EpochDbError>
 where
     V: std::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned,
 {
     // Enforce the "fresh" contract: a leftover file (e.g. from a prior failed export attempt) would
-    // be appended to, not replaced. NotFound is the normal case and is ignored.
-    let _ = std::fs::remove_file(path);
+    // be appended to, not replaced. NotFound is the normal case; any other removal failure means
+    // the stale file may survive, so surface it instead of appending a doubled pack.
+    std::fs::remove_file(path)
+        .or_else(|e| (e.kind() == io::ErrorKind::NotFound).then_some(()).ok_or(e))?;
     let mut pack =
         Pack::<V>::open(path, uid_idx, false, PackCompression::ZStd, EPOCH_PACK_VERSION)?;
     for value in values {
@@ -1205,6 +1209,54 @@ mod test {
             got.len()
         );
         assert_eq!(got.iter().map(|r| r.epoch).collect::<Vec<_>>(), vec![0, 1]);
+    }
+
+    /// Issue #1080: a non-`NotFound` `remove_file` failure must surface as an error instead of
+    /// being swallowed. A stale file surviving a failed removal would be appended onto, silently
+    /// doubling the pack.
+    #[test]
+    #[cfg(unix)]
+    fn write_bounded_pack_surfaces_remove_file_failure() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = TempDir::with_prefix("write_bounded_remove_err").expect("temp dir");
+        let path = dir.path().join("epoch_records");
+        let first: Vec<EpochRecord> =
+            (0..3).map(|epoch| EpochRecord { epoch, ..Default::default() }).collect();
+        super::write_bounded_pack(&path, super::Inner::PACK_EPOCH, &first).expect("first write");
+        let stale_bytes = std::fs::read(&path).expect("read stale pack");
+
+        // A probe file distinguishes root (directory permissions are bypassed, removal succeeds)
+        // from a genuine `PermissionDenied` environment.
+        let probe = dir.path().join("root-probe");
+        std::fs::write(&probe, b"probe").expect("write probe");
+
+        // Read-only directory: `remove_file` on its entries now fails with `PermissionDenied`.
+        let writable = std::fs::metadata(dir.path()).expect("dir metadata").permissions();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
+            .expect("make dir read-only");
+        if std::fs::remove_file(&probe).is_ok() {
+            // Running as root (directory permissions are bypassed): the error branch is
+            // unreachable, so the regression is untestable here. Say so loudly rather than
+            // report a silently vacuous pass, then restore cleanup permissions.
+            eprintln!(
+                "write_bounded_pack_surfaces_remove_file_failure: SKIPPED (root bypasses \
+                 directory permissions, so nothing was tested)"
+            );
+            std::fs::set_permissions(dir.path(), writable).expect("restore permissions");
+        } else {
+            let second: Vec<EpochRecord> =
+                (0..2).map(|epoch| EpochRecord { epoch, ..Default::default() }).collect();
+            let result = super::write_bounded_pack(&path, super::Inner::PACK_EPOCH, &second);
+
+            // Restore before asserting so `TempDir` cleanup works even if an assertion fails.
+            std::fs::set_permissions(dir.path(), writable).expect("restore permissions");
+
+            let err = result.expect_err("removal failure must surface, not append");
+            assert!(matches!(err, super::EpochDbError::IO(_)), "unexpected error: {err:?}");
+            // The stale pack is byte-identical: nothing was appended.
+            assert_eq!(std::fs::read(&path).expect("re-read pack"), stale_bytes);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1080.

## Problem

`write_bounded_pack` in `crates/storage/src/epoch_records.rs` promises a fresh pack file (its doc comment: a leftover file "would be appended to, not replaced"), but enforces that contract with a discarded-result removal:

```rust
let _ = std::fs::remove_file(path);
```

`NotFound` is the normal case and is rightly ignored, but every other failure (for example `PermissionDenied` on the export directory) is swallowed too. When removal fails and the stale file survives, the subsequent `Pack::open(.., ro: false, ..)` opens in append mode, sees a non-empty file, and loads the existing header instead of writing a fresh one. A stale pack from a prior export attempt carries the same `uid_idx`, so it passes every header check (magic, CRC32, uid, version, appnum), and the new records land after the old ones: a silently doubled pack, from a code path whose comment and doc comment both state the file must be fresh.

No attacker required: the trigger is operator-side filesystem state (a permissions problem on the export directory), and the blast radius is a doubled export bundle, not consensus state. The path is also not reachable through current in-tree callers . . . the epoch snapshot export in `close_epoch.rs` pre-clears its `epoch-{N}.tmp` target (tolerating only `NotFound`) before `export_bounded_bundle` runs, and the CLI importer rejects a doubled records pack up front (records must be contiguous from epoch 0). But both of those are caller-side and consumer-side guards for what is a local invariant of `write_bounded_pack`; a future caller that does not pre-clear its target directory inherits the doubled-pack hazard silently. Hence Low severity, and the value of the fix is making the function's own invariant self-contained.

## Fix

- [x] `crates/storage/src/epoch_records.rs`: propagate non-`NotFound` removal failures instead of discarding them:

  ```rust
  std::fs::remove_file(path)
      .or_else(|e| (e.kind() == io::ErrorKind::NotFound).then_some(()).ok_or(e))?;
  ```

  The `?` lands on the existing `From<io::Error>` conversion into `EpochDbError::IO`, so no new error plumbing is needed.
- [x] The doc comment on `write_bounded_pack` now states the error contract: a removal failure other than `NotFound` surfaces as `EpochDbError::IO` rather than being ignored.

## Testing

- New regression test `write_bounded_pack_surfaces_remove_file_failure` (`#[cfg(unix)]`): writes a stale pack, sets the parent directory to mode `0o555` so `remove_file` fails with `PermissionDenied`, and asserts both `Err(EpochDbError::IO(_))` and that the stale pack's bytes are untouched. A probe file created before the chmod detects root (directory permissions are bypassed there, so the error branch is unreachable); in that case the test prints a loud SKIPPED marker instead of passing vacuously. On this repo's CI (hosted `ubuntu-latest` runners, non-root) the error branch is exercised for real.
- Mutation-confirmed: reverting the fix to `let _ = std::fs::remove_file(path);` makes the new test fail on `removal failure must surface, not append`; the restored fix passes. `Pack::open` failures map to the distinct `EpochDbError::Open` variant, so the `IO` assertion cannot pass vacuously off an unrelated open error.
- Existing regression test `write_bounded_pack_overwrites_stale_file` (the successful-removal path) stays green.
- `cargo +1.94 test -p tn-storage --lib`: full crate suite green (one unrelated `composite_db::test::test_compositedb_clear` flake under a parallel full-suite run re-ran green in isolation; that module is untouched here).
- `cargo +nightly-2026-03-20 fmt -- --check` and `clippy -p tn-storage --all-features` green; attest-shape test-build `cargo +1.94 test --no-run --workspace -j 2` in an isolated target dir green.
