### PR TITLE
fix(storage): report a queued write failure from EpochRecordDb::persist (#1065)

### DIFF
--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -67,7 +67,10 @@ enum EpochDbMessage {
 /// Handle to the epoch records database.
 ///
 /// Operations are dispatched to a background thread that owns the file handles.
-/// Errors from background writes are surfaced on the next call via [`get_error`].
+/// Errors from background writes are surfaced on the next call via [`get_error`], which clears
+/// the slot as it reads, so exactly one subsequent caller observes a given failure. Use
+/// [`peek_error`] to check without consuming. [`persist`] is the durability barrier: it reports
+/// any earlier write failure even if that write was still queued when the flush was requested.
 #[derive(Debug, Clone)]
 pub struct EpochRecordDb {
     /// Channel to send commands to the background thread.
@@ -131,7 +134,13 @@ fn run_db_loop(
                 let _ = tx.send(inner.latest_record());
             }
             EpochDbMessage::Persist(tx) => {
-                let _ = tx.send(inner.persist());
+                // Fold a write that failed while this persist was queued into the reply.
+                // `persist()` samples the error slot before enqueueing, and writes are
+                // fire-and-forget, so a save that fails after that sample but before this arm
+                // would otherwise be acknowledged as a successful flush.
+                let pending = tx_error.send_replace(None);
+                let flushed = inner.persist();
+                let _ = tx.send(pending.map_or(flushed, Err));
             }
             EpochDbMessage::Shutdown => {
                 let _ = inner.persist();
@@ -465,6 +474,12 @@ impl EpochRecordDb {
     }
 
     /// Flush all pending writes to disk.
+    ///
+    /// Returns `Err` if any background write queued before this call failed, including one that
+    /// was still queued when this call sampled the error slot: the actor drains a single FIFO
+    /// channel, so every earlier write is processed before the flush and its failure is folded
+    /// into the reply. Callers that treat a successful `persist()` as proof of durability, such
+    /// as the epoch-close path, depend on that guarantee.
     pub async fn persist(&self) -> Result<(), EpochDbError> {
         self.get_error()?;
         let (tx, rx) = oneshot::channel();
@@ -1178,6 +1193,36 @@ mod test {
 
         // `get_error` is the acknowledger, so the slot is cleared only after it is read there.
         db.get_error().expect("slot cleared after acknowledgement");
+    }
+
+    #[tokio::test]
+    async fn persist_reports_a_write_that_failed_while_the_flush_was_queued() {
+        // Regression test for #1065: `persist()` samples the error slot before it enqueues, and
+        // writes are fire-and-forget, so a save that fails while the `Persist` message is still
+        // queued behind it must be folded into the persist reply. Otherwise the epoch-close path
+        // treats `Ok(())` as proof of durability for a record that never reached disk.
+        let temp_dir = TempDir::with_prefix("persist_queued_write_error").expect("temp dir");
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+
+        // Queue a save the actor will reject — epoch 5 is out of order on an empty db — and a
+        // persist behind it. Both go straight to the channel: the handle-side guards would reject
+        // this record before it ever reached the actor, and the point of the test is the actor's
+        // ordering. A single consumer draining a FIFO channel guarantees the save fails before
+        // the persist is dequeued, so this is deterministic rather than a race.
+        let record = EpochRecord { epoch: 5, ..Default::default() };
+        db.tx.send(super::EpochDbMessage::SaveRecord(record)).await.expect("queue failing save");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        db.tx.send(super::EpochDbMessage::Persist(tx)).await.expect("queue persist");
+
+        let err = rx
+            .await
+            .expect("actor replied to the persist")
+            .expect_err("persist must report the write that failed while it was queued");
+        assert!(matches!(err, EpochDbError::EpochOutOfOrder(0, 5)), "unexpected error: {err:?}");
+
+        // The flush consumed the failure, so it is not left behind to be misattributed to an
+        // unrelated later caller.
+        db.get_error().expect("persist acknowledged the error");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`EpochRecordDb::persist()` could return `Ok(())` after a background write had failed, so the epoch-close path could complete and report success for an epoch record that never reached disk.  This makes the flush report that failure.  Fixes the first defect in #1065.

## Problem

`EpochRecordDb` is a handle in front of an actor thread.  Writes are fire-and-forget: `save_record` (`epoch_records.rs:323-330`) enqueues and returns, so a write that fails on disk cannot be reported to the caller that made it.  The compensating mechanism is documented on the handle: "Errors from background writes are surfaced on the next call via `get_error`."

`persist()` is the call that is supposed to make a write durable, and it did not provide that.  It samples the error slot with `get_error()?` *before* enqueueing, and the `Persist` arm forwarded `Inner::persist()` (`:929-937`), which only commits and syncs the tables and never consults the error watch.  So:

1.  A caller runs `save_record(record)`.  It finds no error, enqueues `SaveRecord`, returns `Ok(())`.
2.  The caller runs `persist()`.  The actor has not drained `SaveRecord` yet, so the entry `get_error()?` finds nothing and `Persist` queues behind it.
3.  The actor processes `SaveRecord`, `inner.save_record` fails, the error goes into the watch.
4.  The actor processes `Persist`, commits tables the record was never appended to, and replies `Ok(())`.

The `self.error.borrow()` in `persist` does not cover this: it sits inside the `map_err` closure, so it runs only if the oneshot receive itself fails, meaning the actor died.  On the ordinary path the watch is never read.

This is not schedule-dependent.  The actor drains a single FIFO `mpsc::channel(1000)` (`:208`, `:89`), so a save queued ahead of a flush is *guaranteed* to be processed first.

The epoch-close path issues exactly that pair back to back, and documents that it depends on the flush:

```rust
// close_epoch.rs:343-347
self.consensus_chain.epochs().save_record(epoch_rec.clone()).await?;
// the cert-quorum path persists asynchronously; a crash before that flush would lose
// the record just saved — fatal for epoch 0, which has no peer-fetch anchor — so
// flush it durably here before publishing
self.consensus_chain.epochs().persist().await?;
```

Its doc comment (`:228-233`) states the guarantee directly: "The record is flushed durably to disk before returning ... fatal for epoch 0, which has no peer-fetch anchor to heal from."

The always-on epoch-record collector (`state-sync/epoch.rs:150`, 5s cadence, rescans from epoch 0) will usually back-fill a lost record from peers, so this is a silently violated durability contract and a peer-dependent recovery window rather than guaranteed permanent loss.  Epoch 0 is the case with no peer anchor.

## Fix

The `Persist` arm takes the pending error and folds it into its reply:

```rust
EpochDbMessage::Persist(tx) => {
    let pending = tx_error.send_replace(None);
    let flushed = inner.persist();
    let _ = tx.send(pending.map_or(flushed, Err));
}
```

The flush still runs, so the only behavioural change is that a previously silent failure reaches the caller that asked for durability.  Every caller already propagates the error with `?` or logs it.

Taking the error here also gives it an owner: the flush is the call that wanted the guarantee, so it consumes the failure rather than leaving it to be misattributed to an arbitrary later caller.

I also documented the clear-on-read semantics of `get_error` on the handle itself, and pointed at `peek_error` (added in #985) for the non-consuming check.

## Scope

This addresses defect 1 of #1065 only.  Defect 2 — `get_error` clearing on read, so a failure can be consumed by an unrelated write-side caller on the shared handle — is left alone deliberately.  Fixing it properly means either giving the save messages their own `oneshot<Result>` replies, as `ConsensusPack::save_consensus_output` (`consensus_pack.rs:351`) already does, or a sticky latch like the #975 fix in `layered_db.rs`.  Both change observable behaviour for existing callers, so that looks like a maintainer call rather than something to fold into this PR.

Worth noting separately: `CertificatePack::persist` (`certificate_pack.rs:188-196`) has the identical sample-before-enqueue shape and would need the same treatment.

## Testing

New regression test `persist_reports_a_write_that_failed_while_the_flush_was_queued`.  It queues a save the actor rejects (epoch 5 on an empty db is out of order) and a flush behind it, both sent straight to the channel so the handle-side guards do not reject the record before it reaches the actor, then asserts the flush reports the earlier failure.  Single-consumer FIFO ordering makes this deterministic rather than timing-dependent.

`cargo test -p tn-storage --lib` is green: 178 passed, 0 failed.

Confirmed by mutation: reverting the arm to `let _ = tx.send(inner.persist());` gives 177 passed, 1 failed, and the single failure is the new test.  So it is bound to this change rather than passing vacuously.
