### PR TITLE
cli: refuse a faucet-compiled binary on canonical Telcoin mainnet

### DIFF
--- a/crates/telcoin-network-cli/src/db.rs
+++ b/crates/telcoin-network-cli/src/db.rs
@@ -5,7 +5,10 @@
 //! `MissingBatches` check and classifying each missing batch as Absent (a real data gap) vs
 //! Misordered (present, but in the wrong consensus-header group).
 
-use crate::{node::NamedChain, version::SHORT_VERSION};
+use crate::{
+    node::{validate_faucet_build, NamedChain},
+    version::SHORT_VERSION,
+};
 use clap::{Args, Parser, Subcommand};
 use comfy_table::{Cell, Row, Table as ComfyTable};
 use eyre::{bail, eyre};
@@ -188,6 +191,10 @@ impl DbLoadStateArgs {
             Some(NamedChain::MainNet) => Config::load_mainnet(&datadir, false, SHORT_VERSION)?,
             None => Config::load(&datadir, false, SHORT_VERSION)?,
         };
+
+        // A faucet-compiled binary must not prepare mainnet chain data either: same guard as
+        // the node command, refused before any datadir mutation.
+        validate_faucet_build(tn_reth::FAUCET_ENABLED, tn_config.genesis())?;
 
         // Reject a non-resumable bundle BEFORE `restore_pack` mutates the datadir, so a refusal
         // leaves the target untouched.

--- a/crates/telcoin-network-cli/src/node.rs
+++ b/crates/telcoin-network-cli/src/node.rs
@@ -9,7 +9,8 @@ use rayon::ThreadPoolBuilder;
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, thread::available_parallelism};
 use tn_config::{Config, KeyConfig, TelcoinDirs as _};
 use tn_node::engine::TnBuilder;
-use tn_reth::{parse_socket_address, RethCommand, RethConfig};
+use tn_reth::{parse_socket_address, RethChainSpec, RethCommand, RethConfig, FAUCET_ENABLED};
+use tn_types::{Genesis, B256, MAINNET_GENESIS};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
@@ -171,6 +172,9 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
                 "Must NOT compile with adiri feature flag when connecting to non-adiri (testnet) networks!"
             ));
         }
+        // Runtime value, not a #[cfg], so the check holds no matter which crate in the
+        // build graph enabled the faucet feature.
+        validate_faucet_build(FAUCET_ENABLED, tn_config.genesis())?;
         debug!(target: "cli", validator = ?tn_config.node_info.name, "tn datadir for node command: {tn_datadir:?}");
         info!(target: "cli", validator = ?tn_config.node_info.name, "config loaded");
 
@@ -211,5 +215,115 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
         };
 
         Ok(launcher(builder, ext, tn_datadir, key_config, SHORT_VERSION))
+    }
+}
+
+/// Refuse to run a faucet-compiled binary against canonical Telcoin mainnet.
+///
+/// The `faucet` cargo feature swaps the TEL precompile's `mint` dispatch table (the
+/// instant, role-gated `mint(address,uint256)` replaces the timelocked, governance-only
+/// `mint(uint256)`), so a faucet build joining mainnet computes different state roots
+/// than the rest of the network for the same block: a consensus split, not a local
+/// misconfiguration. No attacker is required; cargo feature unification can enable the
+/// feature transitively without the operator ever typing it.
+///
+/// The check keys on the genesis block hash, the identity peers actually agree on,
+/// rather than either alternative:
+///
+/// - Chain id: the guard the issue literally proposed (refuse `chain_id != 2017` in faucet builds)
+///   would reject both supported faucet flows, the docker devnet scripts at chain id 487
+///   (`etc/genesis.sh`) and the e2e faucet test at the default 911329; keying on mainnet's own 487
+///   instead would still reject the devnet flow, which shares that id.
+/// - Struct equality on [`Genesis`]: the fork-config fields (`config`) sit outside the genesis
+///   header preimage, so a genesis differing from canonical mainnet only in such a field still
+///   computes mainnet's genesis block hash (and could join mainnet consensus) while comparing
+///   unequal.
+///
+/// Only the canonical embedded mainnet genesis is refused; adiri/testnet (2017) is
+/// faucet-intended and separately covered by the `adiri` feature guard at the call
+/// site in [`NodeCommand::execute`].
+pub(crate) fn validate_faucet_build(faucet_enabled: bool, genesis: &Genesis) -> eyre::Result<()> {
+    let joins_mainnet = faucet_enabled
+        .then(|| serde_yaml::from_str::<Genesis>(MAINNET_GENESIS))
+        .transpose()?
+        .is_some_and(|mainnet| genesis_block_hash(genesis.clone()) == genesis_block_hash(mainnet));
+    (!joins_mainnet).then_some(()).ok_or_else(|| {
+        eyre::eyre!("Must NOT compile with faucet feature flag when connecting to Telcoin mainnet!")
+    })
+}
+
+/// The genesis block hash of `genesis`: the hash of the sealed genesis header, covering
+/// the header fields plus the state root computed from `alloc`, built by the same
+/// chain-spec construction the node itself boots with.
+fn genesis_block_hash(genesis: Genesis) -> B256 {
+    RethChainSpec::from(genesis).sealed_genesis_header().hash()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tn_types::adiri_genesis;
+
+    /// A faucet build configured with the canonical mainnet genesis must refuse to start.
+    #[test]
+    fn faucet_build_rejects_canonical_mainnet_genesis() -> eyre::Result<()> {
+        let mainnet: Genesis = serde_yaml::from_str(MAINNET_GENESIS)?;
+        assert!(validate_faucet_build(true, &mainnet).is_err());
+        Ok(())
+    }
+
+    /// A default (non-faucet) build starts against the canonical mainnet genesis.
+    #[test]
+    fn default_build_accepts_mainnet_genesis() -> eyre::Result<()> {
+        let mainnet: Genesis = serde_yaml::from_str(MAINNET_GENESIS)?;
+        assert!(validate_faucet_build(false, &mainnet).is_ok());
+        Ok(())
+    }
+
+    /// A faucet build on the adiri/testnet genesis is allowed; that chain is
+    /// faucet-intended and separately covered by the `adiri` feature guard.
+    #[test]
+    fn faucet_build_accepts_testnet_genesis() -> eyre::Result<()> {
+        assert!(validate_faucet_build(true, &adiri_genesis()).is_ok());
+        Ok(())
+    }
+
+    /// A faucet build on a devnet genesis that reuses mainnet's chain id 487 (the
+    /// documented docker-devnet flow) must NOT be rejected: the guard keys on genesis
+    /// identity, not chain id.
+    #[test]
+    fn faucet_build_accepts_devnet_genesis_with_mainnet_chain_id() -> eyre::Result<()> {
+        let base: Genesis = serde_yaml::from_str(MAINNET_GENESIS)?;
+        let devnet = Genesis { timestamp: base.timestamp.wrapping_add(1), ..base };
+        assert_eq!(devnet.config.chain_id, 487);
+        assert!(validate_faucet_build(true, &devnet).is_ok());
+        Ok(())
+    }
+
+    /// A faucet build must be refused on a genesis whose fork config diverges from
+    /// canonical mainnet while header and alloc stay identical: such a genesis computes
+    /// mainnet's exact genesis block hash (the positive control below), so it could
+    /// still join mainnet consensus. Struct equality would wrongly admit it; hash
+    /// identity refuses it.
+    #[test]
+    fn faucet_build_rejects_config_only_divergence_from_mainnet() -> eyre::Result<()> {
+        let mainnet: Genesis = serde_yaml::from_str(MAINNET_GENESIS)?;
+        let mut divergent = mainnet.clone();
+        divergent.config.dao_fork_support = !divergent.config.dao_fork_support;
+        assert_ne!(divergent, mainnet);
+        assert_eq!(genesis_block_hash(divergent.clone()), genesis_block_hash(mainnet));
+        assert!(validate_faucet_build(true, &divergent).is_err());
+        Ok(())
+    }
+
+    /// The compiled feature set gates the canonical mainnet genesis exactly: refused
+    /// when the binary carries the faucet feature and accepted otherwise. This
+    /// exercises the same `FAUCET_ENABLED` value the [`NodeCommand::execute`] call site
+    /// wires in, under whichever feature set the test build resolved.
+    #[test]
+    fn compiled_feature_set_gates_canonical_mainnet_genesis() -> eyre::Result<()> {
+        let mainnet: Genesis = serde_yaml::from_str(MAINNET_GENESIS)?;
+        assert_eq!(validate_faucet_build(FAUCET_ENABLED, &mainnet).is_err(), FAUCET_ENABLED);
+        Ok(())
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -151,6 +151,21 @@ pub use types::*;
 #[cfg(any(feature = "test-utils", test))]
 pub mod test_utils;
 
+/// True when this binary was compiled with the `faucet` cargo feature.
+///
+/// The faucet feature replaces the TEL precompile's timelocked, governance-only
+/// `mint(uint256)` entry point with the instant, role-gated `mint(address,uint256)`
+/// faucet variant, so a faucet build and a default build compute different state roots
+/// for the same block once either mint selector is called. Startup code uses this
+/// constant to refuse to join networks where that divergence would split consensus.
+///
+/// # Invariant
+///
+/// A runtime constant (rather than a `#[cfg]` in the caller) is the ground truth for
+/// the whole binary: cargo feature unification means any crate in the build graph that
+/// enables `tn-reth/faucet` flips this value for every consumer of this crate.
+pub const FAUCET_ENABLED: bool = cfg!(feature = "faucet");
+
 /// Process-global holder of the chain's base-fee recipient address.
 ///
 /// It is a static [`OnceLock`] (rather than a `RethEnv` field) to work around the reth


### PR DESCRIPTION
Closes #1066.

## Problem

The node refuses to start when the compiled feature set does not match the chain being joined, but the check at `crates/telcoin-network-cli/src/node.rs` covers exactly one feature, `adiri`, against exactly one chain id, 2017.  The `faucet` feature is independently selectable (`tn-reth` defines `faucet = []`, and `bin/telcoin-network` propagates it through `tn-node/faucet` without touching the CLI crate), and it is not additive:  it swaps the TEL precompile's `mint` dispatch, replacing the timelocked, governance-only `mint(uint256)` with the instant, role-gated `mint(address,uint256)`.  The two signatures have different selectors, so a faucet build and a default build cannot agree on the result of any TEL `mint` transaction.  A faucet-enabled binary joining mainnet therefore computes different state roots than the rest of the network for the same block . . . a consensus split, not a local misconfiguration.  No attacker is required:  cargo feature unification can switch the feature on transitively without the operator ever typing it, and nothing at startup says so.

## Fix

- [x] `crates/tn-reth/src/lib.rs`:  export `pub const FAUCET_ENABLED: bool = cfg!(feature = "faucet")`.  The constant lives in the crate that owns the feature, so cargo feature unification makes it the ground truth for the whole binary no matter which crate in the build graph enabled `tn-reth/faucet`.  A `#[cfg]` in the CLI crate could not see this (the CLI crate has no `faucet` feature, and `bin/telcoin-network` routes the flag through `tn-node` only).
- [x] `crates/telcoin-network-cli/src/node.rs`:  add `validate_faucet_build(FAUCET_ENABLED, tn_config.genesis())` immediately after the existing `adiri` guard.  It errors iff the build is faucet-enabled and the loaded genesis computes the same genesis block hash as the canonical embedded `MAINNET_GENESIS`.
- [x] `crates/telcoin-network-cli/src/db.rs`:  run the same guard in `db load-state` before any datadir mutation;  it is the other CLI path that resolves a `--chain mainnet` config, and it should not prepare mainnet chain data under a faucet build either.

The check keys on the genesis block hash (the sealed genesis header:  header fields plus the state root computed from `alloc`, built by the same chain-spec construction the node boots with), which is the identity peers actually agree on.  The two plausible alternatives are both wrong:

- Chain id:  the guard the issue literally proposed (refuse `chain_id != 2017` in faucet builds) would reject both supported faucet flows.  The docker-devnet scripts generate their genesis with chain id 487 (`etc/genesis.sh`), which is also mainnet's id, and the e2e faucet test runs the default 911329;  keying on mainnet's own 487 instead would still reject the devnet flow.
- Struct equality on `Genesis`:  the fork-config fields (`config`) sit outside the genesis header preimage, so a genesis differing from canonical mainnet only in such a field still computes mainnet's exact genesis block hash (and could join mainnet consensus) while comparing unequal.  Hash identity refuses it;  a config-only-divergence regression test pins this.

The comparison is cheap-first and attacker-independent:  it runs once at startup, and the embedded-genesis parse and hash only happen in faucet builds.  Adiri/testnet (2017) needs no new handling:  it is faucet-intended, and the existing `adiri` guard already rejects any non-adiri build on 2017 in both directions.

Out of scope, noted for follow-up:  the pre-existing `adiri` guard is still a compile-time `#[cfg]` with the same transitive-unification exposure this PR closes for `faucet`, and the guard runs at the CLI entry points rather than inside the `tn_node::launch_node` library boundary (both of that function's current callers route through `NodeCommand::execute`).

## Testing

- [x] 6 deterministic unit tests in `node.rs`:  a faucet build rejects the canonical mainnet genesis;  a default build accepts it;  a faucet build accepts `adiri_genesis()`;  a faucet build accepts a devnet-style genesis that reuses chain id 487 but differs in content (the docker-devnet shape a bare chain-id check would have broken);  a faucet build rejects a genesis diverging from mainnet only in fork config (same genesis hash yet struct-unequal, with the hash equality asserted as a positive control . . . the case struct equality would have missed);  and the compiled feature set gates the canonical genesis exactly (`FAUCET_ENABLED` wired as at the call site).
- [x] Every regression test confirmed by mutation, each killed by a test failure (not a compile error) with the tree restored byte-identical:  disabling the comparison fails the reject-canonical test;  ignoring the `faucet_enabled` flag fails the default-accepts test;  reverting hash identity to struct equality fails the config-divergence test;  substituting a chain-id comparison fails the devnet test.
- [x] `cargo +nightly fmt -- --check`, `cargo +1.94 clippy --workspace --all-targets`, and `cargo +1.94 test --no-run --workspace` green on the pinned toolchain in an isolated target dir.
- [x] `cargo +1.94 test -p telcoin-network-cli --lib node::tests`:  6 passed.
