### PR TITLE
fix(worker-gateway): key per-IP rate limit buckets on a network prefix (#956)

### DIFF
--- a/bin/worker-gateway/README.md
+++ b/bin/worker-gateway/README.md
@@ -108,6 +108,8 @@ Every flag has an environment-variable fallback.
 | `--max-request-bytes` | `WORKER_GATEWAY_MAX_REQUEST_BYTES` | `26214400` | Max request body size, in bytes. |
 | `--rate-limit-per-ip` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP` | `100` | Per-IP requests/second (`0` disables). |
 | `--rate-limit-per-ip-burst` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP_BURST` | `0` | Per-IP burst (`0` derives 2×rate). |
+| `--rate-limit-per-ip-v6-prefix` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP_V6_PREFIX` | `64` | IPv6 prefix (bits) the client address is masked to before it keys its bucket. |
+| `--rate-limit-per-ip-v4-prefix` | `WORKER_GATEWAY_RATE_LIMIT_PER_IP_V4_PREFIX` | `32` | IPv4 prefix (bits) the client address is masked to before it keys its bucket. |
 | `--rate-limit-global` | `WORKER_GATEWAY_RATE_LIMIT_GLOBAL` | `3000` | Gateway-wide requests/second (`0` disables). |
 | `--rate-limit-global-burst` | `WORKER_GATEWAY_RATE_LIMIT_GLOBAL_BURST` | `0` | Global burst (`0` derives 2×rate). |
 | `--graceful-shutdown-timeout` | `WORKER_GATEWAY_GRACEFUL_SHUTDOWN_TIMEOUT` | `30s` | Drain deadline on SIGTERM. |
@@ -156,14 +158,44 @@ revisit instead of exhausting file descriptors.
 
 Two token-bucket limiters shed load before a request is buffered or forwarded:
 
-- A **per-client-IP** limiter (`--rate-limit-per-ip`, requests/second, with
-  `--rate-limit-per-ip-burst`) stops any single source monopolizing the workers.
+- A **per-client** limiter (`--rate-limit-per-ip`, requests/second, with
+  `--rate-limit-per-ip-burst`) caps what one source can take of that budget.
 - A **global** limiter (`--rate-limit-global` / `--rate-limit-global-burst`)
   caps aggregate throughput to roughly what the upstream workers can absorb.
 
 Either limiter is disabled by setting its rate to `0`; a `0` burst derives twice
 the sustained rate. An over-limit request receives a JSON-RPC `429` (see below),
 never a bare reset.
+
+#### Prefix keying
+
+The per-client bucket is keyed on the client's **network prefix**, not its bare
+address: the peer address has its host bits cleared before the bucket is looked
+up. Keyed on the bare address, a client that rotates its source address gets a
+fresh, full bucket per address and never accumulates spent budget, so only the
+global limit applies to it; a single IPv6 `/64` makes that trivial.
+
+- `--rate-limit-per-ip-v6-prefix` (default `64`) is the IPv6 prefix. A `/64` is
+  the smallest subnet routed to one customer, so every address a client can pick
+  inside its own allocation shares one bucket.
+- `--rate-limit-per-ip-v4-prefix` (default `32`) is the IPv4 prefix. A `/32` is
+  a single address, so the IPv4 path behaves exactly as it did before prefix
+  keying and unrelated customers behind one carrier-grade NAT are never grouped
+  onto a shared bucket. Narrow it only if your clients genuinely map to larger
+  IPv4 allocations.
+
+A prefix wider than its address family allows (`/33` for IPv4, `/129` for IPv6)
+is rejected at startup rather than clamped. On a dual-stack listener an IPv4
+peer is reported in the mapped `::ffff:a.b.c.d` form; those are unmapped and
+keyed by the **IPv4** prefix, so they are metered per address rather than all
+landing in one `/64`.
+
+> **Residual limitation.** Prefix keying bounds rotation *within* one allocation,
+> not across allocations. An attacker holding many distinct allocations (several
+> `/64`s, a spread of unrelated IPv4 addresses, or a botnet) still earns one
+> bucket per allocation, and only the global limiter caps their total. Prefix
+> keying raises the cost of the attack from free to the price of address space;
+> it does not eliminate it. Size `--rate-limit-global` accordingly.
 
 The client identity is the immediate TCP peer. Run the gateway **edge-facing**:
 behind an untrusted L7 proxy the peer is that proxy, so per-IP limiting would

--- a/bin/worker-gateway/src/app.rs
+++ b/bin/worker-gateway/src/app.rs
@@ -33,6 +33,7 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
         max_connection_duration,
         max_request_bytes,
         rate_limit_per_ip,
+        rate_limit_prefix,
         rate_limit_global,
         graceful_shutdown_timeout,
         metrics_addr,
@@ -49,8 +50,12 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
 
     // Edge rate limiters (per-IP and/or global), or `None` when both are
     // disabled; in that case no rate-limit layer or sweep task is installed.
-    let rate_limiters =
-        RateLimiters::new(rate_limit_per_ip, rate_limit_global, DEFAULT_MAX_PER_IP_ENTRIES);
+    let rate_limiters = RateLimiters::new(
+        rate_limit_per_ip,
+        rate_limit_global,
+        DEFAULT_MAX_PER_IP_ENTRIES,
+        rate_limit_prefix,
+    );
     info!(
         target: "gateway",
         rate_limiting = rate_limiters.is_some(),

--- a/bin/worker-gateway/src/cli.rs
+++ b/bin/worker-gateway/src/cli.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::{
     config::{GatewayConfig, UpstreamWorker},
-    ratelimit::RateLimit,
+    ratelimit::{PrefixLen, PrefixPolicy, RateLimit},
 };
 
 /// Stateless reverse proxy in front of Telcoin Network worker JSON-RPC.
@@ -155,6 +155,30 @@ pub(crate) struct Cli {
     #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_PER_IP_BURST", default_value_t = 0)]
     pub(crate) rate_limit_per_ip_burst: u32,
 
+    /// IPv6 network prefix, in bits, that a client address is masked to before
+    /// it keys its per-IP bucket. The default `/64` is the smallest subnet
+    /// routed to one customer, so a client rotating addresses inside its own
+    /// allocation keeps spending one bucket instead of minting a fresh one per
+    /// address. Widen it (up to `/128`) only to meter individual addresses.
+    #[arg(
+        long,
+        env = "WORKER_GATEWAY_RATE_LIMIT_PER_IP_V6_PREFIX",
+        default_value_t = crate::ratelimit::DEFAULT_V6_PREFIX
+    )]
+    pub(crate) rate_limit_per_ip_v6_prefix: u8,
+
+    /// IPv4 network prefix, in bits, that a client address is masked to before
+    /// it keys its per-IP bucket. The default `/32` is a single address: it
+    /// preserves the gateway's per-address behaviour and never groups unrelated
+    /// customers that share one carrier-grade NAT. Narrow it only for a
+    /// deployment whose clients genuinely map to larger IPv4 allocations.
+    #[arg(
+        long,
+        env = "WORKER_GATEWAY_RATE_LIMIT_PER_IP_V4_PREFIX",
+        default_value_t = crate::ratelimit::DEFAULT_V4_PREFIX
+    )]
+    pub(crate) rate_limit_per_ip_v4_prefix: u8,
+
     /// Sustained gateway-wide request rate across all clients, in requests per
     /// second (`0` disables the global rate limit).
     #[arg(long, env = "WORKER_GATEWAY_RATE_LIMIT_GLOBAL", default_value_t = 3_000)]
@@ -215,6 +239,9 @@ pub(crate) struct Settings {
     pub(crate) max_request_bytes: usize,
     /// Per-client-IP rate limit, or `None` when disabled.
     pub(crate) rate_limit_per_ip: Option<RateLimit>,
+    /// Network prefix each client address is masked to before it keys a
+    /// per-client bucket.
+    pub(crate) rate_limit_prefix: PrefixPolicy,
     /// Gateway-wide rate limit, or `None` when disabled.
     pub(crate) rate_limit_global: Option<RateLimit>,
     /// Graceful-shutdown drain deadline.
@@ -258,6 +285,10 @@ impl Cli {
             );
             Ok(())
         })?;
+        let rate_limit_prefix = resolve_prefix_policy(
+            self.rate_limit_per_ip_v4_prefix,
+            self.rate_limit_per_ip_v6_prefix,
+        )?;
         Ok(Settings {
             listen_addr: self.listen_addr,
             upstreams,
@@ -274,6 +305,7 @@ impl Cli {
                 self.rate_limit_per_ip,
                 self.rate_limit_per_ip_burst,
             ),
+            rate_limit_prefix,
             rate_limit_global: resolve_rate_limit(
                 self.rate_limit_global,
                 self.rate_limit_global_burst,
@@ -324,6 +356,20 @@ fn resolve_rate_limit(rate: u32, burst: u32) -> Option<RateLimit> {
         // the (non-zero) rate rather than panic if that ever fails to hold.
         RateLimit::new(rate, NonZeroU32::new(burst).unwrap_or(rate))
     })
+}
+
+/// Validate the two per-IP prefix flags into a [`PrefixPolicy`]. A length wider
+/// than its address family allows is a startup error rather than a silently
+/// clamped value: a `/200` in a deployment's config is a typo, and quietly
+/// meaning `/32` would hide it.
+fn resolve_prefix_policy(v4: u8, v6: u8) -> eyre::Result<PrefixPolicy> {
+    PrefixLen::v4(v4)
+        .map_err(|err| eyre::eyre!("invalid --rate-limit-per-ip-v4-prefix: {err}"))
+        .and_then(|v4| {
+            PrefixLen::v6(v6)
+                .map_err(|err| eyre::eyre!("invalid --rate-limit-per-ip-v6-prefix: {err}"))
+                .map(|v6| PrefixPolicy::new(v4, v6))
+        })
 }
 
 /// Reject non-`http` upstream URLs at startup. The gateway is HTTP-only (the
@@ -553,6 +599,36 @@ mod tests {
         assert_eq!(per_ip.rate().get(), 40);
         assert_eq!(per_ip.burst().get(), 50);
         Ok(())
+    }
+
+    #[test]
+    fn per_ip_prefix_defaults_are_v4_32_and_v6_64() -> eyre::Result<()> {
+        let settings = cli_with_flags(&[]).into_settings()?;
+        // /32 keeps IPv4 metering per address; /64 collapses an IPv6
+        // allocation's rotating addresses onto one bucket.
+        assert_eq!(settings.rate_limit_prefix.v4_bits(), 32);
+        assert_eq!(settings.rate_limit_prefix.v6_bits(), 64);
+        Ok(())
+    }
+
+    #[test]
+    fn per_ip_prefixes_are_configurable() -> eyre::Result<()> {
+        let settings = cli_with_flags(&[
+            "--rate-limit-per-ip-v4-prefix=24",
+            "--rate-limit-per-ip-v6-prefix=48",
+        ])
+        .into_settings()?;
+        assert_eq!(settings.rate_limit_prefix.v4_bits(), 24);
+        assert_eq!(settings.rate_limit_prefix.v6_bits(), 48);
+        Ok(())
+    }
+
+    #[test]
+    fn out_of_range_per_ip_prefix_is_rejected() {
+        let v4 = cli_with_flags(&["--rate-limit-per-ip-v4-prefix=33"]).into_settings();
+        assert!(v4.is_err(), "a /33 IPv4 prefix must fail startup, not be clamped");
+        let v6 = cli_with_flags(&["--rate-limit-per-ip-v6-prefix=129"]).into_settings();
+        assert!(v6.is_err(), "a /129 IPv6 prefix must fail startup, not be clamped");
     }
 
     #[test]

--- a/bin/worker-gateway/src/ratelimit.rs
+++ b/bin/worker-gateway/src/ratelimit.rs
@@ -2,10 +2,21 @@
 //!
 //! Two token-bucket limiters shed load before a request reaches the proxy or
 //! has its body buffered: a gateway-wide bucket caps aggregate throughput to
-//! roughly what the upstream workers can absorb, and a per-client-IP bucket
-//! stops any single source monopolizing that budget. An over-limit request
-//! receives the gateway's JSON-RPC "rate limit exceeded" envelope (HTTP `429`),
-//! never a bare connection reset.
+//! roughly what the upstream workers can absorb, and a per-client bucket keyed
+//! on the client's *network prefix* caps what one source can take of that
+//! budget. An over-limit request receives the gateway's JSON-RPC "rate limit
+//! exceeded" envelope (HTTP `429`), never a bare connection reset.
+//!
+//! The per-client key is the peer address masked to a configurable prefix
+//! ([`PrefixPolicy`]), not the bare address. Keyed on the bare address, a client
+//! that rotates its source address gets a fresh, full bucket per address and so
+//! never accumulates spent budget, which a single IPv6 `/64` makes trivial;
+//! masking collapses one allocation onto one bucket. The defaults are `/64` for
+//! IPv6 and `/32` for IPv4, so IPv4 behaviour is unchanged and unrelated
+//! customers behind one carrier NAT are never grouped. This bounds rotation
+//! *within* an allocation, not across them: a client holding many distinct
+//! allocations still earns a bucket per allocation, and only the gateway-wide
+//! bucket caps their total.
 //!
 //! The client identity is the immediate TCP peer address (`ConnectInfo`,
 //! injected per connection by the accept loop). The gateway is meant to run
@@ -16,7 +27,8 @@
 
 use std::{
     collections::HashMap,
-    net::{IpAddr, SocketAddr},
+    fmt,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     num::NonZeroU32,
     sync::{Arc, Mutex, MutexGuard, PoisonError},
     time::{Duration, Instant},
@@ -141,31 +153,195 @@ struct GlobalLimiter {
     bucket: Mutex<Bucket>,
 }
 
-/// Per-client-IP buckets, bounded in cardinality; idle buckets are reclaimed by
-/// [`RateLimiters::gc`].
+/// Width of an IPv4 address, in bits.
+const V4_BITS: u8 = 32;
+
+/// Width of an IPv6 address, in bits.
+const V6_BITS: u8 = 128;
+
+/// Default IPv6 prefix the client address is masked to before it keys a bucket.
+/// A `/64` is the smallest subnet routed to a single customer in practice, so it
+/// is the smallest unit a rotating client cannot escape by picking another
+/// address.
+pub(crate) const DEFAULT_V6_PREFIX: u8 = 64;
+
+/// Default IPv4 prefix the client address is masked to before it keys a bucket.
+/// A `/32` is a single address, so it preserves the gateway's historical
+/// per-address behaviour exactly and cannot group unrelated customers that share
+/// one carrier-grade NAT onto a single bucket. IPv4 addresses are scarce enough
+/// that rotation inside one allocation is not the cheap attack it is on IPv6.
+pub(crate) const DEFAULT_V4_PREFIX: u8 = 32;
+
+/// Why a prefix length was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrefixLenError {
+    /// The requested length is wider than its address family allows.
+    TooLong {
+        /// The length that was requested, in bits.
+        requested: u8,
+        /// The widest length the family permits, in bits.
+        max: u8,
+    },
+}
+
+impl fmt::Display for PrefixLenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLong { requested, max } => {
+                write!(f, "prefix length /{requested} exceeds the maximum /{max} for this family")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PrefixLenError {}
+
+/// A network prefix length in bits, validated against its address family so it
+/// can never exceed the address width. Only [`PrefixLen::v4`] and
+/// [`PrefixLen::v6`] construct one, so masking can never shift past the width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PrefixLen(u8);
+
+impl PrefixLen {
+    /// An IPv4 prefix length, rejecting anything wider than `/32`.
+    pub(crate) fn v4(bits: u8) -> Result<Self, PrefixLenError> {
+        Self::checked(bits, V4_BITS)
+    }
+
+    /// An IPv6 prefix length, rejecting anything wider than `/128`.
+    pub(crate) fn v6(bits: u8) -> Result<Self, PrefixLenError> {
+        Self::checked(bits, V6_BITS)
+    }
+
+    /// The shared range check: `bits` must fit within the family's `max` width.
+    fn checked(bits: u8, max: u8) -> Result<Self, PrefixLenError> {
+        (bits <= max).then_some(Self(bits)).ok_or(PrefixLenError::TooLong { requested: bits, max })
+    }
+
+    /// The prefix width, in bits.
+    fn bits(&self) -> u8 {
+        self.0
+    }
+}
+
+/// The network prefix each address family is masked to before it keys a per-IP
+/// bucket, so a client rotating addresses inside one allocation shares a single
+/// bucket instead of minting a fresh one per address.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PrefixPolicy {
+    /// Prefix applied to IPv4 client addresses.
+    v4: PrefixLen,
+    /// Prefix applied to IPv6 client addresses.
+    v6: PrefixLen,
+}
+
+impl PrefixPolicy {
+    /// Build a policy from a validated length per address family.
+    pub(crate) fn new(v4: PrefixLen, v6: PrefixLen) -> Self {
+        Self { v4, v6 }
+    }
+
+    /// The IPv4 prefix width, in bits.
+    #[cfg(test)]
+    pub(crate) fn v4_bits(&self) -> u8 {
+        self.v4.bits()
+    }
+
+    /// The IPv6 prefix width, in bits.
+    #[cfg(test)]
+    pub(crate) fn v6_bits(&self) -> u8 {
+        self.v6.bits()
+    }
+
+    /// The bucket key for `ip`: the address with its host bits cleared, per this
+    /// policy's prefix for the address's family.
+    ///
+    /// A dual-stack listener reports an IPv4 peer as the mapped `::ffff:a.b.c.d`
+    /// form. Every such address shares the same fixed top 96 bits, so masking
+    /// them as IPv6 would collapse *all* IPv4 clients onto one bucket; they are
+    /// unmapped first and keyed by the IPv4 prefix, exactly as an IPv4-only
+    /// listener would key them.
+    fn key(&self, ip: IpAddr) -> IpAddr {
+        match ip {
+            IpAddr::V4(addr) => IpAddr::V4(mask_v4(addr, self.v4)),
+            IpAddr::V6(addr) => addr.to_ipv4_mapped().map_or_else(
+                || IpAddr::V6(mask_v6(addr, self.v6)),
+                |unmapped| IpAddr::V4(mask_v4(unmapped, self.v4)),
+            ),
+        }
+    }
+}
+
+impl Default for PrefixPolicy {
+    /// The shipped defaults: [`DEFAULT_V4_PREFIX`] and [`DEFAULT_V6_PREFIX`].
+    fn default() -> Self {
+        // Both constants are within their family's width, so neither checked
+        // constructor can fail; fall back to the widest (identity) prefix rather
+        // than panic if that ever stops holding.
+        Self {
+            v4: PrefixLen::v4(DEFAULT_V4_PREFIX).unwrap_or(PrefixLen(V4_BITS)),
+            v6: PrefixLen::v6(DEFAULT_V6_PREFIX).unwrap_or(PrefixLen(V6_BITS)),
+        }
+    }
+}
+
+/// Clear the host bits of an IPv4 address below `prefix`.
+///
+/// The host-bit count is `32 - prefix`, which is a full-width shift at
+/// `prefix == 0` and so an arithmetic overflow (a panic in debug builds);
+/// `checked_shl` returns `None` there and the `unwrap_or(0)` yields the all-zero
+/// mask that a `/0` means. At `/32` the shift is zero and the mask is all-ones,
+/// i.e. the identity.
+fn mask_v4(addr: Ipv4Addr, prefix: PrefixLen) -> Ipv4Addr {
+    let host_bits = u32::from(V4_BITS.saturating_sub(prefix.bits()));
+    let mask = u32::MAX.checked_shl(host_bits).unwrap_or(0);
+    Ipv4Addr::from(u32::from(addr) & mask)
+}
+
+/// Clear the host bits of an IPv6 address below `prefix`. Same full-width shift
+/// guard as [`mask_v4`]: `/0` masks to `::`, `/128` is the identity.
+fn mask_v6(addr: Ipv6Addr, prefix: PrefixLen) -> Ipv6Addr {
+    let host_bits = u32::from(V6_BITS.saturating_sub(prefix.bits()));
+    let mask = u128::MAX.checked_shl(host_bits).unwrap_or(0);
+    Ipv6Addr::from(u128::from(addr) & mask)
+}
+
+/// Per-client-prefix buckets, bounded in cardinality; idle buckets are reclaimed
+/// by [`RateLimiters::gc`]. The map is keyed on the *masked* client address (see
+/// [`PrefixPolicy`]), so address rotation inside one allocation shares a bucket.
 #[derive(Debug)]
 struct PerIpLimiter {
+    /// The rate and burst every per-client bucket is built with.
     limit: RateLimit,
+    /// Ceiling on tracked buckets; beyond it new clients are admitted untracked.
     max_entries: usize,
+    /// Live buckets, keyed on the prefix-masked client address.
     buckets: Mutex<HashMap<IpAddr, Bucket>>,
+    /// How a client address is masked down to its bucket key.
+    prefix: PrefixPolicy,
 }
 
 impl PerIpLimiter {
-    /// Admit or reject a request from `ip`, creating its bucket on first sight.
+    /// Admit or reject a request from `ip`, creating the bucket for its network
+    /// prefix on first sight.
     fn admit(&self, now: Instant, ip: IpAddr) -> bool {
         let rate = self.limit.tokens_per_sec();
         let capacity = self.limit.capacity();
+        // Every address in one allocation collapses onto this key, so a rotating
+        // client keeps spending the same budget.
+        let key = self.prefix.key(ip);
         let mut buckets = lock(&self.buckets);
         // Bind the existing-bucket outcome first so its borrow of `buckets` ends
         // before the new-IP path takes `&mut buckets`.
-        let existing = buckets.get_mut(&ip).map(|bucket| bucket.try_admit(now, rate, capacity));
+        let existing = buckets.get_mut(&key).map(|bucket| bucket.try_admit(now, rate, capacity));
         existing.unwrap_or_else(|| {
-            admit_new_ip(&mut buckets, self.max_entries, now, ip, rate, capacity)
+            admit_new_ip(&mut buckets, self.max_entries, now, key, rate, capacity)
         })
     }
 }
 
-/// Admit a first-seen `ip`, tracking it unless the table is at capacity.
+/// Admit a first-seen `ip` (already masked to its network prefix by the
+/// caller), tracking it unless the table is at capacity.
 ///
 /// A new IP with the table already full is admitted *untracked* rather than
 /// evicting a live bucket or rejecting a fresh client: the global limit still
@@ -205,17 +381,22 @@ impl RateLimiters<SystemClock> {
         per_ip: Option<RateLimit>,
         global: Option<RateLimit>,
         max_per_ip_entries: usize,
+        prefix: PrefixPolicy,
     ) -> Option<Arc<Self>> {
-        Self::with_clock(SystemClock, per_ip, global, max_per_ip_entries).map(Arc::new)
+        Self::with_clock(SystemClock, per_ip, global, max_per_ip_entries, prefix).map(Arc::new)
     }
 }
 
 impl<C: Clock> RateLimiters<C> {
+    /// Build the limiters over an injected clock. `prefix` decides how a client
+    /// address is masked before it keys a per-IP bucket; it is inert when the
+    /// per-IP limiter is disabled.
     fn with_clock(
         clock: C,
         per_ip: Option<RateLimit>,
         global: Option<RateLimit>,
         max_per_ip_entries: usize,
+        prefix: PrefixPolicy,
     ) -> Option<Self> {
         if per_ip.is_none() && global.is_none() {
             return None;
@@ -229,6 +410,7 @@ impl<C: Clock> RateLimiters<C> {
             limit,
             max_entries: max_per_ip_entries.max(1),
             buckets: Mutex::new(HashMap::new()),
+            prefix,
         });
         Some(Self { clock, global, per_ip })
     }
@@ -354,19 +536,45 @@ mod tests {
         IpAddr::from([10, 0, 0, last])
     }
 
+    /// An address in `2001:db8::/32`: `subnet` picks the `/64`, `host` the
+    /// address within it.
+    fn ip6(subnet: u16, host: u16) -> IpAddr {
+        IpAddr::from([0x2001, 0x0db8, 0, subnet, 0, 0, 0, host])
+    }
+
+    fn prefixes(v4: u8, v6: u8) -> PrefixPolicy {
+        PrefixPolicy::new(
+            PrefixLen::v4(v4).expect("v4 prefix in range"),
+            PrefixLen::v6(v6).expect("v6 prefix in range"),
+        )
+    }
+
     impl<C: Clock> RateLimiters<C> {
         fn per_ip_len(&self) -> usize {
             self.per_ip.as_ref().map(|per_ip| lock(&per_ip.buckets).len()).unwrap_or(0)
         }
     }
 
+    /// Limiters under the shipped prefix policy (`/32` v4, `/64` v6).
     fn limiters<C: Clock>(
         clock: C,
         per_ip: Option<RateLimit>,
         global: Option<RateLimit>,
         max_entries: usize,
     ) -> RateLimiters<C> {
-        RateLimiters::with_clock(clock, per_ip, global, max_entries).expect("some limiter enabled")
+        limiters_with_prefix(clock, per_ip, global, max_entries, PrefixPolicy::default())
+    }
+
+    /// Limiters under an explicit prefix policy.
+    fn limiters_with_prefix<C: Clock>(
+        clock: C,
+        per_ip: Option<RateLimit>,
+        global: Option<RateLimit>,
+        max_entries: usize,
+        prefix: PrefixPolicy,
+    ) -> RateLimiters<C> {
+        RateLimiters::with_clock(clock, per_ip, global, max_entries, prefix)
+            .expect("some limiter enabled")
     }
 
     #[test]
@@ -447,6 +655,125 @@ mod tests {
 
     #[test]
     fn both_disabled_yields_no_limiters() {
-        assert!(RateLimiters::with_clock(SystemClock, None, None, 16).is_none());
+        assert!(RateLimiters::with_clock(SystemClock, None, None, 16, PrefixPolicy::default())
+            .is_none());
+    }
+
+    #[test]
+    fn rotation_inside_one_v6_prefix_shares_a_bucket() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 2)), None, 16);
+        // Three requests, each from a different address inside one /64. Keyed on
+        // the bare address they would be three fresh, full buckets and all three
+        // would be admitted; keyed on the /64 they share one burst of 2.
+        assert!(limiters.check(Some(ip6(1, 1))).is_ok());
+        assert!(limiters.check(Some(ip6(1, 2))).is_ok());
+        assert!(
+            matches!(limiters.check(Some(ip6(1, 3))), Err(GatewayError::RateLimited)),
+            "address rotation inside one /64 must not mint a fresh bucket"
+        );
+        assert_eq!(limiters.per_ip_len(), 1, "one /64 is one bucket");
+    }
+
+    #[test]
+    fn rotation_across_v6_prefixes_uses_separate_buckets() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 2)), None, 16);
+        // Exhaust the first /64.
+        assert!(limiters.check(Some(ip6(1, 1))).is_ok());
+        assert!(limiters.check(Some(ip6(1, 2))).is_ok());
+        assert!(limiters.check(Some(ip6(1, 3))).is_err());
+        // A different /64 is a different customer, so it gets its own bucket.
+        // This is the residual limit: prefix keying bounds rotation within an
+        // allocation, not across allocations.
+        assert!(limiters.check(Some(ip6(2, 1))).is_ok());
+        assert_eq!(limiters.per_ip_len(), 2);
+    }
+
+    #[test]
+    fn ipv4_default_prefix_preserves_per_address_buckets() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 1)), None, 16);
+        // The default IPv4 prefix is /32, so neighbouring addresses stay
+        // independent exactly as before prefix keying.
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert!(limiters.check(Some(ip(1))).is_err());
+        assert!(limiters.check(Some(ip(2))).is_ok());
+        assert_eq!(limiters.per_ip_len(), 2);
+    }
+
+    #[test]
+    fn ipv4_mapped_peers_key_as_ipv4() {
+        let limiters = limiters(ManualClock::new(), Some(limit(1, 1)), None, 16);
+        let mapped = |last: u8| IpAddr::V6(Ipv4Addr::new(10, 0, 0, last).to_ipv6_mapped());
+        // A dual-stack listener sees IPv4 peers as `::ffff:a.b.c.d`, which all
+        // share their top 96 bits: masked as IPv6 under the /64 default they
+        // would become one bucket for every IPv4 client on earth.
+        assert!(limiters.check(Some(mapped(1))).is_ok());
+        assert!(limiters.check(Some(mapped(2))).is_ok(), "mapped peers must not share a bucket");
+        // The mapped form keys to the same bucket as the bare IPv4 address,
+        // whose single token the first request already spent.
+        assert!(limiters.check(Some(ip(1))).is_err());
+        assert_eq!(limiters.per_ip_len(), 2);
+    }
+
+    #[test]
+    fn prefix_zero_collapses_every_address_to_one_bucket() {
+        let limiters =
+            limiters_with_prefix(ManualClock::new(), Some(limit(1, 1)), None, 16, prefixes(0, 0));
+        // A /0 is the degenerate policy: every address in a family shares one
+        // bucket, and the full-width shift it implies must not panic.
+        assert!(limiters.check(Some(ip(1))).is_ok());
+        assert!(limiters.check(Some(ip(2))).is_err(), "a /0 keys all of IPv4 to one bucket");
+        assert!(limiters.check(Some(ip6(1, 1))).is_ok());
+        assert!(limiters.check(Some(ip6(2, 9))).is_err(), "a /0 keys all of IPv6 to one bucket");
+        assert_eq!(limiters.per_ip_len(), 2, "one bucket per address family");
+    }
+
+    #[test]
+    fn prefix_zero_masks_to_the_unspecified_address() {
+        let v4 = PrefixLen::v4(0).expect("/0 is in range");
+        let v6 = PrefixLen::v6(0).expect("/0 is in range");
+        assert_eq!(mask_v4(Ipv4Addr::new(203, 0, 113, 7), v4), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(
+            mask_v6(Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 9), v6),
+            Ipv6Addr::UNSPECIFIED
+        );
+    }
+
+    #[test]
+    fn max_prefix_masking_is_identity() {
+        let v4 = PrefixLen::v4(32).expect("/32 is in range");
+        let v6 = PrefixLen::v6(128).expect("/128 is in range");
+        let addr4 = Ipv4Addr::new(203, 0, 113, 7);
+        let addr6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 9);
+        assert_eq!(mask_v4(addr4, v4), addr4);
+        assert_eq!(mask_v6(addr6, v6), addr6);
+    }
+
+    #[test]
+    fn masking_clears_only_the_host_bits() {
+        let v4 = PrefixLen::v4(24).expect("/24 is in range");
+        let v6 = PrefixLen::v6(64).expect("/64 is in range");
+        assert_eq!(mask_v4(Ipv4Addr::new(203, 0, 113, 7), v4), Ipv4Addr::new(203, 0, 113, 0));
+        assert_eq!(
+            mask_v6(Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0xdead, 0xbeef, 0, 9), v6),
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 1, 0, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn out_of_range_prefix_is_rejected() {
+        assert_eq!(
+            PrefixLen::v4(33),
+            Err(PrefixLenError::TooLong { requested: 33, max: 32 }),
+            "a /33 is not an IPv4 prefix"
+        );
+        assert_eq!(
+            PrefixLen::v6(129),
+            Err(PrefixLenError::TooLong { requested: 129, max: 128 }),
+            "a /129 is not an IPv6 prefix"
+        );
+        assert!(PrefixLen::v4(32).is_ok());
+        assert!(PrefixLen::v6(128).is_ok());
+        assert!(PrefixLen::v4(0).is_ok());
+        assert!(PrefixLen::v6(0).is_ok());
     }
 }

--- a/bin/worker-gateway/src/ratelimit.rs
+++ b/bin/worker-gateway/src/ratelimit.rs
@@ -542,6 +542,7 @@ mod tests {
         IpAddr::from([0x2001, 0x0db8, 0, subnet, 0, 0, 0, host])
     }
 
+    /// A `PrefixPolicy` from raw v4/v6 prefix lengths, which must be in range.
     fn prefixes(v4: u8, v6: u8) -> PrefixPolicy {
         PrefixPolicy::new(
             PrefixLen::v4(v4).expect("v4 prefix in range"),

--- a/bin/worker-gateway/src/server.rs
+++ b/bin/worker-gateway/src/server.rs
@@ -328,7 +328,11 @@ fn set_tcp_user_timeout(_stream: &TcpStream, _timeout: Duration) -> std::io::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::UpstreamWorker, proxy::MAX_REQUEST_BYTES, ratelimit::RateLimit};
+    use crate::{
+        config::UpstreamWorker,
+        proxy::MAX_REQUEST_BYTES,
+        ratelimit::{PrefixPolicy, RateLimit},
+    };
     use axum::{http::HeaderMap, routing::post};
     use std::num::NonZeroU32;
     use tn_types::Notifier;
@@ -618,8 +622,13 @@ mod tests {
         state.readiness.set_ready(0, true);
         // Global limit of one request with no burst headroom: the first request
         // passes, the second (same instant, no refill) is rejected with 429.
-        let limiters =
-            RateLimiters::new(None, Some(RateLimit::new(nz(1), nz(1))), 16).expect("limiters");
+        let limiters = RateLimiters::new(
+            None,
+            Some(RateLimit::new(nz(1), nz(1))),
+            16,
+            PrefixPolicy::default(),
+        )
+        .expect("limiters");
         let (addr, _shutdown) =
             spawn(router(state, Duration::from_secs(5), MAX_REQUEST_BYTES, Some(limiters))).await;
 
@@ -649,8 +658,13 @@ mod tests {
         // A maximally strict global limit (burst 1). If probes were rate-limited,
         // the second `/health` hit would be 429; they must stay 200 so an
         // orchestrator does not kill the pod under load.
-        let limiters =
-            RateLimiters::new(None, Some(RateLimit::new(nz(1), nz(1))), 16).expect("limiters");
+        let limiters = RateLimiters::new(
+            None,
+            Some(RateLimit::new(nz(1), nz(1))),
+            16,
+            PrefixPolicy::default(),
+        )
+        .expect("limiters");
         let (addr, _shutdown) =
             spawn(router(state, Duration::from_secs(5), MAX_REQUEST_BYTES, Some(limiters))).await;
 


### PR DESCRIPTION
Closes #956.

## Problem

The per-IP token bucket keyed on the full client address, so rotating the source address defeated it entirely.

`PerIpLimiter` stored `HashMap<IpAddr, Bucket>` and took its key straight from the connection's peer address.  A first-seen address takes the `admit_new_ip` path, which builds `Bucket::full(..)` and spends one of its `capacity` tokens, so the very first request from any address is always admitted.  A client that never reuses an address therefore never accumulates *spent* per-IP budget: each address gets its own fresh full bucket, and any bucket it abandons refills and is reclaimed by the GC sweep, so no bucket it touches ever reaches its limit.

The per-IP limiter was the only thing standing between one source and the whole gateway budget, so the sustained ceiling collapsed to the global limit.  At the shipped defaults (per-IP 100/s, global 3000/s) roughly 30 distinct addresses consume the entire global budget while every per-IP bucket stays healthy.  A single IPv6 /64 holds 2^64 addresses, which makes single-use-per-address rotation trivial and invisible to any per-address detection.  Legitimate clients then take the `429` from the global limiter while the module's stated goal, "stops any single source monopolizing that budget", is not met for any normal IPv6 client.

No attacker sophistication is required and nothing needs to be malformed: this is ordinary traffic from many addresses in one allocation.

## Root cause

The guard existed and was structurally correct.  Only its key was wrong.  Nothing masked the address between the peer lookup and the map key, so an allocation the operator thinks of as one client presented as up to 2^64 independent clients.

## Fix

Mask the client address to a network prefix before it becomes the bucket key, so rotation inside one allocation collapses onto a single bucket.

- `PrefixLen` is a validated newtype whose only constructors (`PrefixLen::v4` / `PrefixLen::v6`) return `Result`, so an out-of-range prefix cannot be built.
- `PrefixPolicy` holds the v4 and v6 lengths and exposes `key(IpAddr) -> IpAddr`.  It matches `IpAddr` exhaustively with no wildcard arm.
- `mask_v4` / `mask_v6` clear the host bits via `checked_shl(host_bits).unwrap_or(0)`.  The `checked_shl` is load-bearing rather than defensive: a prefix of 0 shifts by the full type width, which is an arithmetic overflow that panics in debug builds.  Conversions go through `u32::from` / `u128::from` / `Ipv4Addr::from` / `Ipv6Addr::from`, so there is no naked `as`.
- `Bucket`, `try_admit`, the `check` short-circuit and `gc` are logically unchanged.  The only behavioural change is which key the bucket hangs on.

Defaults are IPv6 `/64` and IPv4 `/32`, both settable with `--rate-limit-per-ip-v6-prefix` / `--rate-limit-per-ip-v4-prefix` (and the matching `WORKER_GATEWAY_*` env vars).

The IPv4 default of `/32` is deliberate and conservative.  It preserves today's exact IPv4 behaviour, so this change cannot newly group unrelated customers sitting behind one carrier NAT.  Operators who want `/24` aggregation opt into it.  IPv6 is where the bypass is actually cheap, and `/64` is the smallest block normally routed to a single customer, so that is where the default does the work.

An IPv4-mapped peer (`::ffff:a.b.c.d`) is unmapped and keyed under the IPv4 prefix.  Masking it as IPv6 would have been actively harmful: all mapped addresses share their top 96 bits, so under the `/64` default a dual-stack listener would have collapsed every IPv4 client onto the single key `::`, which is a self-inflicted denial of service strictly worse than the bug being fixed.

Residual limitation, stated in the README rather than left implicit: an attacker holding many distinct allocations can still rotate across them.  Prefix keying raises the cost from "one /64" to "one allocation per bucket", it does not make rotation free of cost or impossible.

## Changes

- [x] `bin/worker-gateway/src/ratelimit.rs` . . . `PrefixLen`, `PrefixLenError`, `PrefixPolicy`, `mask_v4` / `mask_v6`;  `PerIpLimiter` gains a `prefix` field and masks in `admit`;  module doc corrected to describe prefix keying instead of per-address keying
- [x] `bin/worker-gateway/src/cli.rs` . . . the two prefix flags, `Settings.rate_limit_prefix`, and `resolve_prefix_policy`, which mirrors the existing `resolve_rate_limit` shape and surfaces an out-of-range prefix as a startup error
- [x] `bin/worker-gateway/src/app.rs` . . . thread the policy through to `RateLimiters::new`
- [x] `bin/worker-gateway/src/server.rs` . . . two test call sites updated for the new argument
- [x] `bin/worker-gateway/README.md` . . . document both flags and the residual limitation

## Testing

`cargo +1.94 check -p tn-worker-gateway --all-targets` is clean with zero warnings, and `cargo +nightly fmt -- --check` passes.

Nine new tests in `ratelimit.rs` and three in `cli.rs`, all using the existing `ManualClock` and helper shapes with no wall-clock assumptions:

- `rotation_inside_one_v6_prefix_shares_a_bucket` (the regression test)
- `rotation_across_v6_prefixes_uses_separate_buckets` (pins the residual limit honestly)
- `ipv4_default_prefix_preserves_per_address_buckets`
- `ipv4_mapped_peers_key_as_ipv4`
- `prefix_zero_collapses_every_address_to_one_bucket`, `prefix_zero_masks_to_the_unspecified_address`
- `max_prefix_masking_is_identity` (/32 and /128), `masking_clears_only_the_host_bits` (/24 and /64)
- `out_of_range_prefix_is_rejected`
- `per_ip_prefix_defaults_are_v4_32_and_v6_64`, `per_ip_prefixes_are_configurable`, `out_of_range_per_ip_prefix_is_rejected`

**The regression test was confirmed by mutation, not assumed.**  Reverting the one line in `PerIpLimiter::admit` back to the unmasked key:

```diff
-        let key = self.prefix.key(ip);
+        let key = ip;
```

takes the suite from `17 passed; 0 failed` to `13 passed; 4 failed`, and `rotation_inside_one_v6_prefix_shares_a_bucket` fails on its own assertion ("address rotation inside one /64 must not mint a fresh bucket"), not on a build error or a timeout.  Restoring the line returns the suite to `17 passed; 0 failed`.
