### PR TITLE
storage: end the epoch-record waits with a lookup at the deadline

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -46,8 +46,10 @@ tn-reth = { workspace = true }
 tn-test-utils = { workspace = true }
 rand = { workspace = true }
 roaring = { workspace = true }
-# Async barrier tests for the durable `persist` need a runtime + timers.
-tokio = { workspace = true, features = [ "macros", "rt", "time" ] }
+# Async barrier tests for the durable `persist` need a runtime + timers. `test-util` is for the
+# paused-clock tests of the bounded waits in `epoch_records`, which would otherwise depend on
+# another workspace member happening to enable it for the whole build.
+tokio = { workspace = true, features = [ "macros", "rt", "time", "test-util" ] }
 
 [features]
 redb = []

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -8,6 +8,7 @@
 use std::{
     error::Error,
     fmt::Display,
+    future::Future,
     hash::BuildHasherDefault,
     io,
     path::{Path, PathBuf},
@@ -36,6 +37,10 @@ use crate::archive::{
 
 /// Current version of the epoch pack file.
 const EPOCH_PACK_VERSION: u16 = 0;
+
+/// Interval between lookups in the bounded waits [`EpochRecordDb::record_by_epoch_with_timeout`]
+/// and [`EpochRecordDb::cert_by_digest_with_timeout`].
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 enum EpochDbMessage {
     /// Save a "dummy" epoch 0 [`EpochRecord`] without a certificate.
@@ -371,24 +376,51 @@ impl EpochRecordDb {
         }
     }
 
+    /// Poll `lookup` every [`POLL_INTERVAL`] until it yields a value or `timeout` elapses,
+    /// whichever happens first.
+    ///
+    /// The wait always ends with a lookup at the deadline rather than with a sleep: the deadline
+    /// is tested before sleeping, and each sleep is clamped to it. A value stored during the last
+    /// poll interval is therefore still observed, which is the case both callers exist to cover.
+    /// They bridge a known arrival race, so a wait that runs long is precisely a wait whose value
+    /// is likely to land near the deadline. Clamping also keeps a `timeout` shorter than
+    /// [`POLL_INTERVAL`] from being rounded up to a full interval.
+    ///
+    /// Every message is served on one background thread in enqueue order, so a save enqueued
+    /// strictly before the deadline is visible to that final lookup. The residual race is the
+    /// first lookup only: a `timeout` shorter than one round trip to that thread can expire while
+    /// the lookup is in flight, missing a save enqueued behind it. The wait still ends within one
+    /// round trip of the deadline.
+    async fn poll_until_deadline<T, F, Fut>(timeout: Duration, lookup: F) -> Option<T>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Option<T>>,
+    {
+        let deadline = tokio::time::Instant::now() + timeout;
+        // TODO issue 573, clean this up: an event-driven wait would replace this poll entirely.
+        loop {
+            if let Some(found) = lookup().await {
+                return Some(found);
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            tokio::time::sleep_until(deadline.min(now + POLL_INTERVAL)).await;
+        }
+    }
+
     /// Retrieve an [`EpochRecord`] by epoch number.
     /// This version will wait up to timeout time for the record to show up if not available.
+    ///
+    /// The wait ends with a lookup at the deadline, so a record saved during the last poll
+    /// interval is still returned (see `poll_until_deadline`).
     pub async fn record_by_epoch_with_timeout(
         &self,
         epoch: Epoch,
         timeout: Duration,
     ) -> Option<EpochRecord> {
-        let deadline = tokio::time::Instant::now() + timeout;
-        // TODO issue 573, clean this up.
-        loop {
-            if let Some(rec) = self.record_by_epoch(epoch).await {
-                return Some(rec);
-            }
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            if tokio::time::Instant::now() >= deadline {
-                return None;
-            }
-        }
+        Self::poll_until_deadline(timeout, || self.record_by_epoch(epoch)).await
     }
 
     /// Retrieve an [`EpochRecord`] by its digest.
@@ -417,21 +449,15 @@ impl EpochRecordDb {
     /// A just-closed epoch's certificate is only aggregated at the next epoch's start, so a caller
     /// that needs epoch N's cert immediately after N closes (e.g. the state exporter) must give the
     /// collector a bounded window to produce it.
+    ///
+    /// The wait ends with a lookup at the deadline, so a certificate saved during the last poll
+    /// interval is still returned (see `poll_until_deadline`).
     pub async fn cert_by_digest_with_timeout(
         &self,
         digest: EpochDigest,
         timeout: Duration,
     ) -> Option<EpochCertificate> {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            if let Some(cert) = self.cert_by_digest(digest).await {
-                return Some(cert);
-            }
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            if tokio::time::Instant::now() >= deadline {
-                return None;
-            }
-        }
+        Self::poll_until_deadline(timeout, || self.cert_by_digest(digest)).await
     }
 
     /// True if the database contains a record for the given epoch number.
@@ -1851,6 +1877,95 @@ mod test {
         assert!(got.is_none(), "expected a timeout with no cert stored");
         // Poll interval is 200ms, so the loop must have waited at least one interval.
         assert!(start.elapsed() >= std::time::Duration::from_millis(200));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cert_by_digest_with_timeout_sees_cert_saved_in_final_poll_interval() {
+        // The wait must end with a lookup at the deadline, not with a sleep. The certificate is
+        // saved 900ms in: after the last lookup a sleep-then-test loop would make (800ms) and
+        // before the 1s deadline, so only a loop that checks once more at the deadline returns it.
+        //
+        // Virtual time makes that ordering exact rather than merely likely. The db thread is a
+        // real thread, but a paused clock only advances to the next timer while the runtime is
+        // idle, so the save fires between the 800ms lookup and the deadline however slow the
+        // machine is, and the assertion below never turns into a timing race.
+        let temp_dir = TempDir::with_prefix("cert_timeout_final_interval").expect("temp dir");
+        let mut rng = StdRng::from_os_rng();
+        let signers: Vec<TestSigner> = (0..4).map(|_| TestSigner::new(&mut rng)).collect();
+
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+        // The record is stored up front, so only the delayed save below can satisfy the wait.
+        let (record, cert) = make_test_pair(0, &signers, EpochDigest::default());
+        db.save_record(record.clone()).await.expect("save record");
+
+        let saver = {
+            let db = db.clone();
+            let cert = cert.clone();
+            let digest = record.digest();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+                db.save_certificate(digest, cert).await.expect("save cert");
+            })
+        };
+
+        let got = db
+            .cert_by_digest_with_timeout(record.digest(), std::time::Duration::from_secs(1))
+            .await;
+        saver.await.expect("saver task");
+        let got = got.expect("a cert saved before the deadline must be returned");
+        assert_eq!(got.epoch_hash, cert.epoch_hash);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn record_by_epoch_with_timeout_sees_record_saved_in_final_poll_interval() {
+        // Same property on the record wait, which restart catch-up depends on: a record that lands
+        // in the last poll interval before the deadline is returned rather than turned into the
+        // error that ends the node. See the sibling cert test for why virtual time is exact here.
+        let temp_dir = TempDir::with_prefix("record_timeout_final_interval").expect("temp dir");
+        let mut rng = StdRng::from_os_rng();
+        let signers: Vec<TestSigner> = (0..4).map(|_| TestSigner::new(&mut rng)).collect();
+
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+        let (record, _cert) = make_test_pair(0, &signers, EpochDigest::default());
+
+        let saver = {
+            let db = db.clone();
+            let record = record.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+                db.save_record(record).await.expect("save record");
+            })
+        };
+
+        let got = db.record_by_epoch_with_timeout(0, std::time::Duration::from_secs(1)).await;
+        saver.await.expect("saver task");
+        let got = got.expect("a record saved before the deadline must be returned");
+        assert_eq!(got.digest(), record.digest());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cert_by_digest_with_timeout_ends_at_a_deadline_inside_one_poll_interval() {
+        // A timeout shorter than the 200ms poll interval is not rounded up to a full interval: the
+        // sleep is clamped to the deadline, so the wait ends there. A loop that sleeps first
+        // always spends a whole interval no matter how short the timeout is.
+        let temp_dir = TempDir::with_prefix("cert_timeout_short").expect("temp dir");
+        let mut rng = StdRng::from_os_rng();
+        let signers: Vec<TestSigner> = (0..4).map(|_| TestSigner::new(&mut rng)).collect();
+
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+        let (record, _cert) = make_test_pair(0, &signers, EpochDigest::default());
+        db.save_record(record.clone()).await.expect("save record");
+
+        let start = tokio::time::Instant::now();
+        let got = db
+            .cert_by_digest_with_timeout(record.digest(), std::time::Duration::from_millis(50))
+            .await;
+        let waited = start.elapsed();
+        assert!(got.is_none(), "expected a timeout with no cert stored");
+        assert!(
+            waited < std::time::Duration::from_millis(200),
+            "a 50ms timeout must not sleep a full poll interval, waited {waited:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1082.

## Problem

Both bounded waits in the epoch-records database polled in an order that cannot observe a value arriving in their final interval (`crates/storage/src/epoch_records.rs`, `record_by_epoch_with_timeout` and `cert_by_digest_with_timeout`):

```rust
loop {
    if let Some(cert) = self.cert_by_digest(digest).await {
        return Some(cert);
    }
    tokio::time::sleep(Duration::from_millis(200)).await;
    if tokio::time::Instant::now() >= deadline {
        return None;
    }
}
```

Check, then sleep, then test the deadline.  A value persisted during that last sleep is never looked for: the loop wakes, sees the deadline has passed, and gives up one round trip short of success.

The blind window sits exactly where these two helpers earn their keep.  Both exist to bridge a known arrival race, so a wait that runs long is precisely a wait whose value is likely to land near the deadline, and the last 200 ms before it were unobservable.

This is a loop-shape defect with a test gap, not an operational problem, which is why the issue is filed Informational.  Both call sites already accept the same outcome for a genuinely late value:

- The export path waits `CERT_WAIT` (90 s, `crates/node/src/manager/node/close_epoch.rs:45`) for the closing epoch's own certificate, and abandons the export when the wait returns `None` (`close_epoch.rs:456-465`).  The plain-state walk has already finished by then, because the completion task body only runs after `rx.await` resolves (`close_epoch.rs:427`, fed by the blocking `export_once` on the exporter thread, `crates/node/src/manager/export_exec.rs:175`), so a certificate landing in the final sleep discards a completed export.  What is lost is epoch N's own per-epoch bundle, permanently: `export_once` refuses to export a block that is no longer the persisted tip (`export_exec.rs:204`), and `export_epoch_state` runs once per boundary (`run_epoch.rs:418`).  The damage stops there.  The idempotency check keys on epoch N's own directory (`close_epoch.rs:355`), so the next boundary is not suppressed, and its historical-cert precheck scans `0..tip_epoch` (`epoch_records.rs:516`), which passes because the certificate did arrive.
- The record path waits 30 s for the previous epoch record during restart catch-up and turns `None` into an error (`crates/node/src/manager/node/run_epoch.rs:565-573`).  That error leaves epoch startup (`run_epoch.rs:230`) and reaches `run_epochs`, where any epoch error aborts the epoch loop (`crates/node/src/manager/node.rs:1234`) and ends the node.  The mitigation is that the record is durable by then, so the next process start finds it on the immediate lookup (`run_epoch.rs:508-509`) and proceeds without waiting.

A second, smaller consequence of the same ordering: a `timeout` below the poll interval was rounded up to a full interval.  A 50 ms wait slept 200 ms;  a 300 ms wait returned after about 400 ms.

## Fix

Test the deadline before sleeping, and clamp each sleep to it, so the wait always ends with a lookup rather than with a sleep.

- [x] `crates/storage/src/epoch_records.rs`: new private `EpochRecordDb::poll_until_deadline`, which polls a caller-supplied lookup every `POLL_INTERVAL` until it yields a value or the timeout expires.  The 200 ms interval, duplicated as a literal in both loops, is now the single `POLL_INTERVAL` constant.
- [x] Both `record_by_epoch_with_timeout` and `cert_by_digest_with_timeout` delegate to it, so the two waits cannot drift apart, and the `// TODO issue 573` refactor that replaces polling with an event-driven wait has one loop to delete instead of two.
- [x] `crates/storage/Cargo.toml`: `test-util` added to the dev-dependency `tokio` features.  The new tests drive a paused clock, and without this the crate compiles them only because another workspace member happens to enable the feature for the whole build.

The corrected shape:

```rust
let deadline = tokio::time::Instant::now() + timeout;
loop {
    if let Some(found) = lookup().await {
        return Some(found);
    }
    let now = tokio::time::Instant::now();
    if now >= deadline {
        return None;
    }
    tokio::time::sleep_until(deadline.min(now + POLL_INTERVAL)).await;
}
```

Why the final lookup is enough: `EpochRecordDb` dispatches every message over one mpsc channel to a single background thread that drains it with `blocking_recv` (`epoch_records.rs:84-142`), so reads and writes are served in enqueue order.  A save enqueued strictly before the deadline is therefore visible to a lookup enqueued at the deadline.

One residual race is left, and it is stated in the helper's doc comment rather than papered over: the very first lookup can be in flight when a short deadline passes, so a save enqueued behind it is missed.  That needs a `timeout` shorter than one round trip to the database thread;  the real call sites pass 30 s and 90 s.  The wait still ends within one round trip of the deadline.

Threat model: none of this is adversary-facing.  `cert_by_digest_with_timeout` and `record_by_epoch_with_timeout` are internal database reads with node-chosen timeouts, and the values they wait for are certificates and records that are verified elsewhere before they are stored.  The change alters when a wait gives up, not what it accepts.

## Testing

Three new tests in `crates/storage/src/epoch_records.rs`, all on a paused clock so the ordering they assert is exact rather than probable.  The database thread is a real thread, but a paused clock only advances to the next timer while the runtime is idle, so the delayed save lands between the last pre-deadline lookup and the deadline no matter how slow the machine is.  That is what lets these tests pin a 200 ms window without being timing races.

- [x] `cert_by_digest_with_timeout_sees_cert_saved_in_final_poll_interval`: the certificate is saved 900 ms into a 1 s wait, after the last lookup a sleep-then-test loop would make (800 ms) and before the deadline.
- [x] `record_by_epoch_with_timeout_sees_record_saved_in_final_poll_interval`: the same property on the wait restart catch-up depends on.
- [x] `cert_by_digest_with_timeout_ends_at_a_deadline_inside_one_poll_interval`: a 50 ms timeout must not spend a full 200 ms poll interval.

The two existing tests are unchanged and still pass, including the one that asserts a 200 ms floor on an absent-certificate wait (a 300 ms timeout still crosses one full interval before the clamped final sleep).

`cargo +1.94 test -p tn-storage --lib epoch_records`: 32 passed, 0 failed.

Both halves of the fix were then confirmed by mutation, and each mutation killed exactly the tests that pin the property it broke:

1. Putting the sleep back before the deadline test, the pre-fix shape, failed exactly the three new tests and nothing else: 29 passed, 3 failed.  All three failures are assertion panics rather than compile errors, and the two pre-existing timeout tests are among the passes, so the reordering is not something they could ever have caught.
2. Keeping the deadline test first but dropping the clamp on the sleep failed exactly one test, `cert_by_digest_with_timeout_ends_at_a_deadline_inside_one_poll_interval`: 31 passed, 1 failed.  The two save-in-the-final-interval tests still passed under it, which is the point . . . they pin the reordering and only the third pins the clamp, so neither property rides on the other's test.

## Scope notes

- The `// TODO issue 573, clean this up.` marker is kept, and moves onto the helper where the poll loop now lives, since the extraction would otherwise leave it sitting over a one-line delegation with nothing to clean up.  #573 asked for an event-driven wait to replace these sleep-polls;  that refactor subsumes this fix by deleting the loop, and until it lands this is the minimal correctness change to the loop as written.
- The poll interval stays 200 ms.  Nothing here changes how long a caller waits, only where the wait ends.
- Three other loops in the tree end on a sleep the same way, and are deliberately left alone.  `export_once` sleeps on its last pin attempt and then falls out of the `for` bound without re-testing `verify_tip` (`crates/node/src/manager/export_exec.rs:199-256`);  `consensus_output_bytes` refreshes `my_number` after its last sleep but discards it on the attempt count before the `while` head can re-test it (`crates/consensus/primary/src/network/handler.rs:1088-1096`);  `dial_peer_bls` gives up after a backoff without re-dialing (`crates/node/src/manager/node/start_epoch.rs:672-682`).  Each has a different caller and a different consequence, so each belongs in its own change rather than widening this one.  The house shape is the corrected one: `wait_until` in `crates/test-utils/src/wait.rs`, `wait_for_network_peers`, `retry_provider_faults`, and the state-sync fetch retry all re-check before giving up.
