### PR TITLE
fix(node): restrict stale temp-export sweep to epoch-{N}.tmp directories

### DIFF
--- a/crates/node/src/manager/node/close_epoch.rs
+++ b/crates/node/src/manager/node/close_epoch.rs
@@ -44,11 +44,23 @@ use tracing::{debug, error, info, info_span, warn, Instrument};
 /// elapsed by the time this wait begins, so the cert is normally present immediately.
 const CERT_WAIT: Duration = Duration::from_secs(90);
 
-/// Remove every `epoch-*.tmp` directory under the exports root — orphaned temp export dirs left by
-/// a crashed or interrupted prior run. Called ONCE at node startup, where it is safe because no
-/// export is in flight; the per-boundary path deliberately clears only its own epoch's temp so it
-/// can never delete another epoch's still-in-flight export working dir. Final `epoch-{N}` dirs have
-/// no extension, so they are never swept.
+/// True iff `name` is exactly the temp-dir name the export path writes for some epoch, i.e.
+/// `epoch-{N}.tmp` where `{N}` is a canonical (no sign, no leading zeros) [`Epoch`] rendering.
+/// [`sweep_stale_tmp_exports`] deletes only matches; anything else in the exports root was not
+/// written by the exporter and is not ours to remove.
+fn is_stale_tmp_export_name(name: &str) -> bool {
+    name.strip_prefix("epoch-").and_then(|rest| rest.strip_suffix(".tmp")).is_some_and(|digits| {
+        digits.parse::<Epoch>().is_ok_and(|epoch| epoch.to_string() == digits)
+    })
+}
+
+/// Remove every `epoch-{N}.tmp` directory under the exports root: orphaned temp export dirs left
+/// by a crashed or interrupted prior run. That exact shape is the only temp the export path ever
+/// writes, so nothing else is swept: final `epoch-{N}` dirs have no `.tmp` suffix, and stray
+/// entries (operator files or dirs that merely end in `.tmp`) never match. Called ONCE at node
+/// startup, where it is safe because no export is in flight; the per-boundary path deliberately
+/// clears only its own epoch's temp so it can never delete another epoch's still-in-flight export
+/// working dir.
 ///
 /// Best-effort: a missing exports root or a removal failure is logged at warn and otherwise
 /// ignored, since a failure here must never crash the node.
@@ -64,8 +76,14 @@ pub(super) fn sweep_stale_tmp_exports(export_root: &Path) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        // `epoch-{N}.tmp` (final dirs are `epoch-{N}` with no extension, so they are never swept).
-        if path.extension().and_then(|ext| ext.to_str()) == Some("tmp") {
+        // Exactly `epoch-{N}.tmp`, and a directory: the one shape the export path writes (final
+        // dirs are `epoch-{N}` with no `.tmp` suffix, so they never match). The directory check
+        // also keeps stray `*.tmp` regular files off the `remove_dir_all` failure path, which
+        // would otherwise warn on every export-enabled startup without ever removing them.
+        let is_stale_tmp_export =
+            path.file_name().and_then(|name| name.to_str()).is_some_and(is_stale_tmp_export_name)
+                && entry.file_type().is_ok_and(|file_type| file_type.is_dir());
+        if is_stale_tmp_export {
             if let Err(e) = std::fs::remove_dir_all(&path) {
                 warn!(target: "tn::snapshot", path = ?path, error = %e, "failed to remove stale temp export dir");
             }
@@ -74,7 +92,7 @@ pub(super) fn sweep_stale_tmp_exports(export_root: &Path) {
 }
 
 /// Best-effort removal of an export temp dir, logging at warn on failure so a leftover temp is
-/// observable (the next boundary's [`sweep_stale_tmp_exports`] will retry it). Replaces the silent
+/// observable (the next startup's [`sweep_stale_tmp_exports`] will retry it). Replaces the silent
 /// `let _ = remove_dir_all(..)` cleanups on the export completion task's failure/skip paths.
 fn remove_tmp_export(tmp_dir: &Path, epoch: Epoch) {
     match std::fs::remove_dir_all(tmp_dir) {
@@ -788,8 +806,8 @@ mod tests {
 
     #[test]
     fn sweep_removes_only_temp_export_dirs() {
-        // Finding #13: the boundary sweep must clear every `epoch-*.tmp` (this epoch's and orphans
-        // from prior epochs) while leaving completed `epoch-{N}` dirs and unrelated files
+        // Finding #13: the startup sweep must clear every `epoch-{N}.tmp` orphaned by a prior run
+        // while leaving completed `epoch-{N}` dirs and everything the exporter did not write
         // untouched.
         let root = tempfile::tempdir().expect("temp dir");
         let export_root = root.path();
@@ -797,6 +815,13 @@ mod tests {
             std::fs::create_dir_all(export_root.join(name)).expect("mkdir");
         }
         std::fs::write(export_root.join("keep.txt"), b"x").expect("write file");
+        // Not exporter-written: a `.tmp` directory without the `epoch-{N}` stem, a directory whose
+        // epoch is not a canonical `Epoch` rendering, and a regular file that is name-shaped like
+        // a temp export. The sweep must leave all three (the file without even attempting the
+        // `remove_dir_all` that would warn on every export-enabled startup).
+        std::fs::create_dir_all(export_root.join("stray.tmp")).expect("mkdir");
+        std::fs::create_dir_all(export_root.join("epoch-x.tmp")).expect("mkdir");
+        std::fs::write(export_root.join("epoch-7.tmp"), b"x").expect("write file");
 
         sweep_stale_tmp_exports(export_root);
 
@@ -804,6 +829,9 @@ mod tests {
         assert!(!export_root.join("epoch-2.tmp").exists(), "orphaned temp dir must be swept");
         assert!(export_root.join("epoch-5").exists(), "completed export dir must survive");
         assert!(export_root.join("keep.txt").exists(), "unrelated file must survive");
+        assert!(export_root.join("stray.tmp").exists(), "non-epoch `.tmp` dir must survive");
+        assert!(export_root.join("epoch-x.tmp").exists(), "non-numeric `.tmp` dir must survive");
+        assert!(export_root.join("epoch-7.tmp").exists(), "`.tmp` regular file must survive");
 
         // A missing exports root is a no-op (must not panic).
         sweep_stale_tmp_exports(&export_root.join("does-not-exist"));


### PR DESCRIPTION
Closes #1084.

## Problem

`sweep_stale_tmp_exports` documents a narrow contract: at startup, remove the `epoch-{N}.tmp` directories a crashed or interrupted export left under the state-exports root.  The code enforced a much wider one.  Its predicate matched any entry whose name ended in `.tmp` (any stem, any file type), so an operator-placed `notes.tmp` directory would be deleted, and a stray `.tmp` regular file would hit the `remove_dir_all` failure path and warn on every export-enabled startup without ever being removed.  Two comments also promised a retry "at the next epoch boundary" that does not exist;  the sweep runs once, at node startup only.

Informational severity, no attacker required and none reachable: the exports root is node-managed and the only writer emits `epoch-{N}.tmp`, so nothing malicious can place entries there today.  The code and its documentation simply disagreed, and the existing test could not tell the two contracts apart.

## Root cause

The predicate checked only the `.tmp` extension, not the documented name shape or the entry type, and the retry comments described a per-boundary cadence the call graph never had (the only call site is node startup).

## Fix

- [x] New `is_stale_tmp_export_name` helper: exact `epoch-{N}.tmp` where `{N}` round-trips through `Epoch` parse and `Display`, so signs, leading zeros, and values a `u32` exporter cannot write are all rejected
- [x] The sweep additionally requires the entry to be a directory, keeping name-shaped regular files off the `remove_dir_all` failure path
- [x] Corrected both stale comments: a failed removal is retried by the next startup's sweep, not at the next boundary
- [x] `sweep_removes_only_temp_export_dirs` gains discriminating fixtures: a non-epoch `.tmp` directory (`stray.tmp`), a non-canonical stem (`epoch-x.tmp`), and a name-shaped regular file (`epoch-7.tmp`), each asserted to survive

## Testing

- `cargo +1.94 test -p tn-node --lib sweep_removes_only_temp_export_dirs` green in an isolated target dir
- Each new assertion confirmed by mutation: reverting the helper to the extension-only predicate fails the `stray.tmp` assertion, and dropping the canonical-parse check fails the `epoch-x.tmp` assertion (both mutants restored)
- Known gap, noted deliberately: the directory-type conjunct is not pinned by an fs-state assertion.  `std::fs::remove_dir_all` refuses regular files, so `epoch-7.tmp` survives with or without the check and only the absence of the startup warn distinguishes the arms;  the repo has no tracing-capture test idiom to assert on.  Recorded here so a future refactor does not silently drop the check.
- Nightly `fmt --check`, nightly `clippy --workspace -- -D warnings` and `--workspace --all-features -- -D warnings`, and `cargo +1.94 test --no-run --workspace`, all green locally
