### PR TITLE
Write next-epoch worker base fees to WorkerConfigs at epoch close

### DIFF
--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -126,7 +126,7 @@ async fn test_empty_output_skips_execution() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // update rewards counter so execution address is visible
     let committee =
@@ -231,7 +231,7 @@ async fn test_queued_outputs_bounded_with_backpressure() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     let committee =
         create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
@@ -341,7 +341,7 @@ async fn test_empty_output_with_close_epoch_still_executes() -> eyre::Result<()>
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // update rewards counter so execution address is visible
     let committee =
@@ -753,7 +753,7 @@ async fn test_empty_output_increments_leader_count() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // update rewards counter so execution address is visible
     let committee =
@@ -933,7 +933,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
         Some(chain.clone()),
         None,
         &tmp_dir.path().join("exc-node"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // create committee from genesis state
@@ -1422,7 +1422,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
         Some(chain.clone()),
         None,
         &tmp_dir.path().join("exc-node"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // create committee from genesis state
@@ -2123,7 +2123,7 @@ async fn test_simple_basefee_penalty() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &tmp_dir.path().join("exc-node"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // create committee from genesis state
@@ -2477,7 +2477,7 @@ async fn test_gas_refund_does_not_inflate_penalty() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &tmp_dir.path().join("exc-node"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // create committee
@@ -2665,7 +2665,7 @@ async fn test_partial_output_failure_rolls_back_in_memory_state() -> eyre::Resul
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     let committee =
         create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -529,7 +529,7 @@ async fn test_empty_close_epoch_unknown_leader_fail_stops() -> eyre::Result<()> 
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // install a real committee so the miss comes from the leader, not an unset committee
     let committee =
@@ -645,7 +645,7 @@ async fn test_empty_close_epoch_without_committee_fail_stops() -> eyre::Result<(
         Some(chain.clone()),
         None,
         tmp_dir.path(),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // build the committee to obtain a legitimate member id, but never call `set_committee`:
     // the rewards counter's committee stays `None` (the delta from the happy-path test above)

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -176,6 +176,11 @@ pub(crate) struct EpochManager<P, DB> {
 /// count and every worker's base fee for the entered epoch, deriving them from the previous
 /// epoch's closing-block state on every entry.
 ///
+/// The restored per-worker gas totals and worker count are consensus-critical, not merely local
+/// fee inputs: the next epoch close feeds them into the closing block's on-chain base-fee record
+/// (`record_next_epoch_base_fees` in `tn-reth`), so an inaccurate restore here diverges that
+/// block's hash from the rest of the fleet.
+///
 /// Every chain-derived input (the block scan range's start and end, the worker-count read block,
 /// and the epoch used to bound leader counting) is pinned to the single finalized
 /// [`SealedHeader`]. Startup heals the finalized marker to the persisted canonical tip

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -1258,8 +1258,9 @@ where
 
     /// Build the execution engine and its underlying reth environment.
     ///
-    /// The reth env is wired to the shared `reth_db`, the configured base-fee address, and the
-    /// accumulator's rewards counter so execution and reward accounting stay consistent.
+    /// The reth env is wired to the shared `reth_db`, the configured base-fee address, and a clone
+    /// of the live gas accumulator so execution, gas/fee accounting, and reward accounting all
+    /// observe the same shared state.
     fn create_engine(
         &self,
         engine_task_manager: &TaskManager,
@@ -1272,7 +1273,7 @@ where
             engine_task_manager,
             self.reth_db.clone(),
             basefee_address,
-            gas_accumulator.rewards_counter(),
+            gas_accumulator.clone(),
         )?;
         let engine = ExecutionNode::new(&self.builder, reth_env)?;
 

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -29,7 +29,7 @@ use tn_reth::{system_calls::EpochState, RethDb, RethEnv};
 use tn_storage::{consensus::ConsensusChain, open_db, DatabaseType};
 use tn_types::{
     deconstruct_nonce,
-    gas_accumulator::{GasAccumulator, WorkerFeeConfig},
+    gas_accumulator::{next_base_fee_for_config, GasAccumulator, WorkerFeeConfig},
     BlsPublicKey, BootstrapServer, Committee, ConsensusHeader, ConsensusHeaderDigest,
     ConsensusNumHash, ConsensusOutput, Database as TNDatabase, EngineUpdate, Epoch, Notifier,
     SealedHeader, TaskError, TaskManager, TaskSpawner, TimestampSec, WorkerId, DEFAULT_WORKER_ID,
@@ -372,7 +372,7 @@ pub(crate) fn gas_used_per_worker(headers: &[SealedHeader]) -> HashMap<WorkerId,
 /// during the epoch that just closed.
 ///
 /// One slot per entry in `configs` (the on-chain `WorkerConfigs` order, indexed by worker id).
-/// A worker present in `held_fees` folds through `next_base_fee_for_config` — the SAME formula
+/// A worker present in `held_fees` folds through [`next_base_fee_for_config`] — the SAME formula
 /// `adjust_base_fees` (in the `run_epoch` module) applies at a live epoch close, so entry
 /// derivation and close-time adjustment produce identical values from identical inputs. A worker
 /// absent from `held_fees` (no genuine block in the scanned range, so the chain does not reveal
@@ -389,7 +389,7 @@ pub fn fold_next_epoch_base_fees(
             let worker_id = worker_id as WorkerId;
             held_fees.get(&worker_id).map(|&held_fee| {
                 let gas_used = gas_totals.get(&worker_id).copied().unwrap_or_default();
-                run_epoch::next_base_fee_for_config(*config, held_fee, gas_used)
+                next_base_fee_for_config(*config, held_fee, gas_used)
             })
         })
         .collect()
@@ -521,7 +521,7 @@ pub fn derive_base_fees_for_entered_epoch(
 ///
 /// A step describes the boundary INTO some epoch `k`: the worker's strategy read at epoch
 /// `k - 1`'s closing block, plus what epoch `k - 1`'s genuine blocks reveal about the worker.
-/// Folding a step ([`fold_forward`]) reproduces the `next_base_fee_for_config` application the
+/// Folding a step ([`fold_forward`]) reproduces the [`next_base_fee_for_config`] application the
 /// live committee ran at that boundary's close.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct EpochFeeStep {
@@ -543,9 +543,9 @@ pub(crate) struct EpochFeeStep {
 /// the SAME formula a live `adjust_base_fees` ran at that boundary. The result is the fee the
 /// worker holds entering the epoch above the last step's boundary.
 pub(crate) fn fold_forward(anchor: u64, steps: &[EpochFeeStep]) -> u64 {
-    steps.iter().fold(anchor, |current, step| {
-        run_epoch::next_base_fee_for_config(step.config, current, step.gas_used)
-    })
+    steps
+        .iter()
+        .fold(anchor, |current, step| next_base_fee_for_config(step.config, current, step.gas_used))
 }
 
 /// Derive the base fee worker `worker_id` holds during `epoch` purely from on-chain state —
@@ -1516,7 +1516,7 @@ mod tests {
             );
             assert_eq!(
                 fees,
-                vec![Some(run_epoch::next_base_fee_for_config(config, held_fee, gas_used))],
+                vec![Some(next_base_fee_for_config(config, held_fee, gas_used))],
                 "fold diverged from next_base_fee_for_config for {config:?}",
             );
         }
@@ -1545,10 +1545,7 @@ mod tests {
         // the decay is real: three idle boundaries move a non-MIN fee down (and never below MIN)
         assert!((MIN_PROTOCOL_BASE_FEE..anchor).contains(&oracle));
         // and each boundary equals the one-formula seam
-        assert_eq!(
-            fold_forward(anchor, &steps[..1]),
-            run_epoch::next_base_fee_for_config(cfg, anchor, 0),
-        );
+        assert_eq!(fold_forward(anchor, &steps[..1]), next_base_fee_for_config(cfg, anchor, 0));
     }
 
     #[test]
@@ -1580,7 +1577,7 @@ mod tests {
         let creation_static = idle_step(WorkerFeeConfig::Static { fee: 800 });
         assert_eq!(
             fold_forward(MIN_PROTOCOL_BASE_FEE, &[creation_static]),
-            run_epoch::next_base_fee_for_config(
+            next_base_fee_for_config(
                 WorkerFeeConfig::Static { fee: 800 },
                 MIN_PROTOCOL_BASE_FEE,
                 0,
@@ -1594,11 +1591,7 @@ mod tests {
         // later boundaries fold from the creation-priced fee
         assert_eq!(
             fold_forward(MIN_PROTOCOL_BASE_FEE, &[creation_static, creation_eip]),
-            run_epoch::next_base_fee_for_config(
-                WorkerFeeConfig::Eip1559 { target_gas: 1_000_000 },
-                800,
-                0,
-            ),
+            next_base_fee_for_config(WorkerFeeConfig::Eip1559 { target_gas: 1_000_000 }, 800, 0),
         );
     }
 

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -988,12 +988,24 @@ fn check_output_continuity(last_forwarded: u64, number: u64) -> OutputContinuity
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manager::{derive_base_fees_for_entered_epoch, sync_num_workers_from_chain};
+    use rand::{rngs::StdRng, SeedableRng as _};
     use std::{cell::Cell, sync::Arc};
     use tempfile::TempDir;
     use tn_config::WORKER_CONFIGS_ADDRESS;
     use tn_reth::{
-        system_calls::CONSENSUS_REGISTRY_ADDRESS, test_utils::test_genesis_with_consensus_registry,
+        payload::TNPayload,
+        system_calls::CONSENSUS_REGISTRY_ADDRESS,
+        test_utils::{
+            consensus_output_for_tests, execute_payload_and_update_canonical_chain,
+            read_worker_config_entries_at, test_genesis_with_consensus_registry,
+            test_genesis_with_consensus_registry_and_workers, TransactionFactory,
+        },
         RethChainSpec,
+    };
+    use tn_types::{
+        gas_accumulator::WorkerFeeConfig, Address, GenesisAccount, WorkerId, B256,
+        MIN_PROTOCOL_BASE_FEE, U256,
     };
 
     #[tokio::test(start_paused = true)]
@@ -1145,6 +1157,299 @@ mod tests {
 
         // the guard trips before the config read, so fees stay untouched
         assert_eq!(acc.base_fee(0).base_fee(), 4_242, "worker 0 fee unchanged");
+
+        Ok(())
+    }
+
+    /// Build one worker block on `parent` carrying `base_fee` and `txs`, execute it (running
+    /// the epoch-closing system calls when `output` is flagged), commit it as the canonical +
+    /// finalized tip, and mirror the engine's post-execution accounting by folding the executed
+    /// header's gas into `acc`.
+    ///
+    /// The `inc_block` AFTER execution is the production ordering (`tn_engine`'s
+    /// payload builder): for an epoch-closing block it means the closing system calls read the
+    /// accumulator WITHOUT this block's own gas — the executor folds that gas in itself.
+    fn execute_worker_block(
+        reth_env: &RethEnv,
+        acc: &GasAccumulator,
+        parent: SealedHeader,
+        output: &ConsensusOutput,
+        base_fee: u64,
+        worker_id: WorkerId,
+        txs: Vec<Vec<u8>>,
+    ) -> eyre::Result<SealedHeader> {
+        let gas_limit = parent.gas_limit;
+        let payload = TNPayload::new(
+            parent,
+            Address::random(),
+            0,
+            B256::random(),
+            output,
+            B256::ZERO,
+            base_fee,
+            gas_limit,
+            B256::random(),
+            worker_id,
+        );
+        let block = execute_payload_and_update_canonical_chain(reth_env, payload, txs)?;
+        let header = block.recovered_block.clone_sealed_header();
+        acc.inc_block(worker_id, header.gas_used, header.gas_limit);
+        Ok(header)
+    }
+
+    /// CROSS-LAYER CAPSTONE: the three production computations of a worker's next-epoch base
+    /// fee agree bit-identically at every epoch close:
+    ///
+    ///  (a) the on-chain `WorkerConfigs.data` word the closing block's 4th system call records
+    ///      (`record_next_epoch_base_fees` in `tn-reth`), read back at the closing block's
+    ///      state through the production decode seam;
+    ///  (b) the epoch-entry derivation every node runs ([`derive_base_fees_for_entered_epoch`]);
+    ///  (c) the live producer's close-time accumulator update ([`adjust_base_fees`]);
+    ///
+    /// each pinned against an independent [`next_base_fee_for_config`] oracle computed from raw
+    /// header gas and the epoch's entry fee. This equality is a consensus invariant: the batch
+    /// validator snapshots one entry fee per epoch and compares for EXACT equality, so a
+    /// one-wei divergence between any two of these seams rejects every peer batch for a whole
+    /// epoch — and replacing (b) with a read of (a) is only safe while all three agree.
+    ///
+    /// Drives TWO real epoch closes over one chain (worker 0 `Eip1559 { target_gas: 1M }`,
+    /// worker 1 `Static` — a mixed strategy set), with genuine per-worker user-tx gas and real
+    /// transfers in BOTH closing blocks so the closing block's own-gas fold-in is exercised at
+    /// each boundary. Fixture guards pin that the eip1559 fee moves away from MIN, from the
+    /// epoch's entry fee, AND from the value computed without the closing block's own gas — a
+    /// wrong fee source, a dropped total, or an off-by-one-block gas fold all fail loudly.
+    ///
+    /// Epoch 0 runs at a preloaded `START_FEE` (accumulator slot and epoch-0 block headers
+    /// carry the same value — the input-consistency production guarantees by pricing batches
+    /// from the accumulator), standing in for any epoch N with a real fee so the ±12.5% moves
+    /// are exercised at full scale rather than degenerating to MIN±1. The second boundary is
+    /// fully organic: epoch 1 runs at the fee the FIRST close wrote on-chain, so boundary 2
+    /// starts from a written fee, not genesis defaults.
+    #[tokio::test]
+    async fn close_record_adjust_and_entry_derivation_agree_across_boundaries() -> eyre::Result<()>
+    {
+        const TARGET_GAS: u64 = 1_000_000;
+        const START_FEE: u64 = 1_000_000;
+        const STATIC_FEE: u64 = 12_345;
+        const TX_GAS_PRICE: u128 = 2_000_000;
+        let cfg0 = WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS };
+
+        // fund an EOA so every epoch (and both closing blocks) carries real user-tx gas
+        let mut sender = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(913));
+        let genesis = test_genesis_with_consensus_registry_and_workers(
+            4,
+            vec![(0u8, TARGET_GAS), (1u8, STATIC_FEE)],
+        )
+        .extend_accounts([(
+            sender.address(),
+            GenesisAccount::default().with_balance(U256::from(1_000_000_000_000_000_000_u64)),
+        )]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::with_prefix("cross_layer_fee_agreement")?;
+        let task_manager = TaskManager::new("cross layer fee agreement");
+        let recipient = Address::repeat_byte(0xab);
+        let mut transfer = |chain: &Arc<RethChainSpec>| {
+            sender.create_eip1559_encoded(
+                chain.clone(),
+                None,
+                TX_GAS_PRICE,
+                Some(recipient),
+                U256::from(1),
+                Default::default(),
+            )
+        };
+
+        // the LIVE accumulator, shared with the block executor (wired into the EVM config so
+        // the closing block's record reads exactly this state)
+        let acc = GasAccumulator::new(1);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // epoch-0 entry: size the accumulator from genesis WorkerConfigs state (the production
+        // epoch-0 entry seam), then preload worker 0's stand-in entry fee; worker 1 keeps MIN
+        sync_num_workers_from_chain(&reth_env, &acc, 0)?;
+        assert_eq!(acc.num_workers(), 2, "accumulator sized from the on-chain worker count");
+        acc.base_fee(0).set_base_fee(START_FEE);
+
+        // ceremony genesis deploys WorkerConfigs with every data word unwritten
+        let (_, entries) =
+            read_worker_config_entries_at(&reth_env, chain.sealed_genesis_header().hash())?;
+        assert!(entries[0].data.is_zero(), "no close has recorded a fee yet");
+        assert!(entries[1].data.is_zero(), "no close has recorded a fee yet");
+
+        // ----- epoch 0: worker 0 produces (fee START_FEE), worker 1 produces (fee MIN) -----
+        let out1 = consensus_output_for_tests(1, 0, 1, false);
+        let h1 = execute_worker_block(
+            &reth_env,
+            &acc,
+            chain.sealed_genesis_header(),
+            &out1,
+            START_FEE,
+            0,
+            vec![transfer(&chain), transfer(&chain)],
+        )?;
+        assert!(h1.gas_used > 0, "worker 0's epoch-0 block must carry real gas");
+
+        let out2 = consensus_output_for_tests(2, 0, 2, false);
+        let h2 = execute_worker_block(
+            &reth_env,
+            &acc,
+            h1.clone(),
+            &out2,
+            MIN_PROTOCOL_BASE_FEE,
+            1,
+            vec![transfer(&chain)],
+        )?;
+        assert!(h2.gas_used > 0, "worker 1's epoch-0 block must carry real gas");
+
+        // the closing block: worker 0, epoch-close flagged, with real transfers riding it
+        let out3 = consensus_output_for_tests(3, 0, 3, true);
+        let h3 = execute_worker_block(
+            &reth_env,
+            &acc,
+            h2.clone(),
+            &out3,
+            START_FEE,
+            0,
+            vec![transfer(&chain), transfer(&chain)],
+        )?;
+        assert!(h3.gas_used > 0, "the closing block must carry its own user-tx gas");
+        assert_eq!(reth_env.epoch_state_from_canonical_tip()?.epoch, 1, "epoch 0 closed");
+
+        // independent oracle for boundary 1: the ONE formula over the entry fee and the
+        // epoch's total worker-0 gas INCLUDING the closing block's own
+        let epoch0_gas_w0 = h1.gas_used + h3.gas_used;
+        let oracle_1 = next_base_fee_for_config(cfg0, START_FEE, epoch0_gas_w0);
+        // fixture guards: the value discriminates a MIN write, a no-op write, and a total
+        // that dropped the closing block's own gas
+        assert_ne!(oracle_1, MIN_PROTOCOL_BASE_FEE, "fixture: fee must move off MIN");
+        assert_ne!(oracle_1, START_FEE, "fixture: fee must move off the entry fee");
+        assert_ne!(
+            oracle_1,
+            next_base_fee_for_config(cfg0, START_FEE, h1.gas_used),
+            "fixture: the closing block's own gas must change the priced fee",
+        );
+
+        // live totals at the close (before clear): also the scan-equivalence reference
+        let (_, live_gas_w0, _) = acc.get_values(0);
+        let (_, live_gas_w1, _) = acc.get_values(1);
+        assert_eq!(live_gas_w0, epoch0_gas_w0, "inc_block total = header gas total");
+        assert_eq!(live_gas_w1, h2.gas_used);
+
+        // (c) the live producer's close-time update over the shared accumulator
+        adjust_base_fees(&reth_env, &acc).await?;
+        let close_time_w0 = acc.base_fee(0).base_fee();
+        let close_time_w1 = acc.base_fee(1).base_fee();
+
+        // (a) the on-chain record at the closing block's state
+        let (num_workers, entries) = read_worker_config_entries_at(&reth_env, h3.hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(entries[0].config, cfg0, "strategy survives the data write");
+        assert_eq!(entries[1].config, WorkerFeeConfig::Static { fee: STATIC_FEE });
+        assert!(entries[1].data.is_zero(), "a static worker's data word is never written");
+        let recorded_w0 = entries[0].data.to::<u64>();
+
+        // (b) the epoch-entry derivation every node runs, pinned to the same closing block
+        let derived_1 = derive_base_fees_for_entered_epoch(&reth_env, 1, &h3)?;
+        assert_eq!(derived_1.num_workers, 2);
+        // header scan ≡ the live accumulator's inc_block totals for the closed epoch
+        assert_eq!(derived_1.gas_totals.get(&0).copied().unwrap_or_default(), live_gas_w0);
+        assert_eq!(derived_1.gas_totals.get(&1).copied().unwrap_or_default(), live_gas_w1);
+
+        // THE EQUALITY at boundary 1: (a) == (b) == (c) == oracle, per worker
+        assert_eq!(recorded_w0, oracle_1, "(a) on-chain record != oracle");
+        assert_eq!(derived_1.fees[0], Some(oracle_1), "(b) entry derivation != oracle");
+        assert_eq!(close_time_w0, oracle_1, "(c) close-time accumulator != oracle");
+        assert_eq!(derived_1.fees[1], Some(STATIC_FEE), "(b) static worker != configured fee");
+        assert_eq!(close_time_w1, STATIC_FEE, "(c) static worker != configured fee");
+
+        // enter epoch 1 exactly as production: clear the epoch's gas, then derive+apply —
+        // which must rewrite the very fees the close-time update left in place
+        acc.clear();
+        derived_1.apply(&acc);
+        assert_eq!(acc.base_fee(0).base_fee(), oracle_1, "entry apply rewrites the close value");
+        assert_eq!(acc.base_fee(1).base_fee(), STATIC_FEE);
+
+        // ----- epoch 1: runs at the fee the first close WROTE (not genesis defaults) -----
+        let fee_epoch1 = acc.base_fee(0).base_fee();
+        let out4 = consensus_output_for_tests(1, 1, 4, false);
+        let h4 = execute_worker_block(
+            &reth_env,
+            &acc,
+            h3.clone(),
+            &out4,
+            fee_epoch1,
+            0,
+            vec![transfer(&chain), transfer(&chain)],
+        )?;
+        assert!(h4.gas_used > 0);
+
+        let out5 = consensus_output_for_tests(2, 1, 5, false);
+        let h5 = execute_worker_block(
+            &reth_env,
+            &acc,
+            h4.clone(),
+            &out5,
+            STATIC_FEE,
+            1,
+            vec![transfer(&chain)],
+        )?;
+        assert!(h5.gas_used > 0);
+
+        // epoch 1's closing block, again carrying real user-tx gas of its own
+        let out6 = consensus_output_for_tests(3, 1, 6, true);
+        let h6 = execute_worker_block(
+            &reth_env,
+            &acc,
+            h5.clone(),
+            &out6,
+            fee_epoch1,
+            0,
+            vec![transfer(&chain), transfer(&chain)],
+        )?;
+        assert!(h6.gas_used > 0, "the second closing block must carry its own user-tx gas");
+        assert_eq!(reth_env.epoch_state_from_canonical_tip()?.epoch, 2, "epoch 1 closed");
+
+        // independent oracle for boundary 2, folded from the WRITTEN boundary-1 fee
+        let epoch1_gas_w0 = h4.gas_used + h6.gas_used;
+        let oracle_2 = next_base_fee_for_config(cfg0, oracle_1, epoch1_gas_w0);
+        assert_ne!(oracle_2, oracle_1, "fixture: the second boundary must move the fee again");
+        assert_ne!(oracle_2, MIN_PROTOCOL_BASE_FEE);
+        assert_ne!(
+            oracle_2,
+            next_base_fee_for_config(cfg0, oracle_1, h4.gas_used),
+            "fixture: the second closing block's own gas must change the priced fee",
+        );
+
+        let (_, live_gas_w0_e1, _) = acc.get_values(0);
+        let (_, live_gas_w1_e1, _) = acc.get_values(1);
+        assert_eq!(live_gas_w0_e1, epoch1_gas_w0);
+        assert_eq!(live_gas_w1_e1, h5.gas_used);
+
+        // (c) at boundary 2
+        adjust_base_fees(&reth_env, &acc).await?;
+
+        // (a) at boundary 2
+        let (num_workers, entries) = read_worker_config_entries_at(&reth_env, h6.hash())?;
+        assert_eq!(num_workers, 2);
+        assert!(entries[1].data.is_zero(), "static worker still never written");
+
+        // (b) at boundary 2
+        let derived_2 = derive_base_fees_for_entered_epoch(&reth_env, 2, &h6)?;
+        assert_eq!(derived_2.num_workers, 2);
+        assert_eq!(derived_2.gas_totals.get(&0).copied().unwrap_or_default(), epoch1_gas_w0);
+        assert_eq!(derived_2.gas_totals.get(&1).copied().unwrap_or_default(), h5.gas_used);
+
+        // THE EQUALITY at boundary 2 — starting from a written fee, not genesis defaults
+        assert_eq!(entries[0].data.to::<u64>(), oracle_2, "(a) on-chain record != oracle");
+        assert_eq!(derived_2.fees[0], Some(oracle_2), "(b) entry derivation != oracle");
+        assert_eq!(acc.base_fee(0).base_fee(), oracle_2, "(c) close-time accumulator != oracle");
+        assert_eq!(derived_2.fees[1], Some(STATIC_FEE));
+        assert_eq!(acc.base_fee(1).base_fee(), STATIC_FEE);
 
         Ok(())
     }

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -33,7 +33,7 @@ use tn_storage::{certificate_pack::CertificatePack, tables::OurNodeBatchesCache}
 use tn_types::{
     gas_accumulator::{next_base_fee_for_config, GasAccumulator},
     BlsPublicKey, Committee, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase,
-    EpochRecord, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
+    EpochRecord, Notifier, SealedHeader, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -763,6 +763,11 @@ where
 /// Inert on existing chains: the genesis fee strategy is `Eip1559 { target_gas: u64::MAX }`, which
 /// floors every worker at `MIN_PROTOCOL_BASE_FEE`. Fees only move once governance sets a real
 /// per-worker target.
+///
+/// The identity check lives here and the per-worker fold in
+/// [`apply_close_time_fee_updates`]; the closing block itself records the same values on-chain
+/// (`record_next_epoch_base_fees` in `tn-reth`), computed from the same accumulator and the same
+/// pinned block, so all three seams agree bit-for-bit.
 async fn adjust_base_fees(
     reth_env: &RethEnv,
     gas_accumulator: &GasAccumulator,
@@ -835,6 +840,25 @@ async fn adjust_base_fees(
         ));
     }
 
+    apply_close_time_fee_updates(reth_env, gas_accumulator, &tip).await
+}
+
+/// The post-identity-check half of [`adjust_base_fees`]: read the worker fee configs at the
+/// closing block `tip` and fold each worker's next-epoch base fee into `gas_accumulator`.
+///
+/// Split out so the read-failure policy can be exercised at any pinned header without driving a
+/// real epoch-closing block. The closing block itself now records the same fees on-chain (see
+/// `record_next_epoch_base_fees` in `tn-reth`), which is fatal when the `WorkerConfigs` contract
+/// is unreadable — so a test that strips the contract from genesis can no longer produce a
+/// closing block to call the outer function against.
+///
+/// See [`adjust_base_fees`] for the identity check this assumes has already passed, and the
+/// read-failure classification both halves share.
+async fn apply_close_time_fee_updates(
+    reth_env: &RethEnv,
+    gas_accumulator: &GasAccumulator,
+    tip: &SealedHeader,
+) -> eyre::Result<()> {
     // FAIL-OPEN (CHAIN-GLOBAL FAILURES ONLY): a chain-global config-read failure must not abort
     // the epoch close. Keep the current per-worker base fees and worker count untouched -- both
     // are already consensus-consistent (seeded from the same chain at epoch entry, then held
@@ -968,12 +992,8 @@ mod tests {
     use tempfile::TempDir;
     use tn_config::WORKER_CONFIGS_ADDRESS;
     use tn_reth::{
-        payload::TNPayload, system_calls::CONSENSUS_REGISTRY_ADDRESS,
-        test_utils::test_genesis_with_consensus_registry, NewCanonicalChain, RethChainSpec,
-    };
-    use tn_types::{
-        BlsSignature, Certificate, CommittedSubDag, ConsensusHeader, ReputationScores,
-        SignatureVerificationState,
+        system_calls::CONSENSUS_REGISTRY_ADDRESS, test_utils::test_genesis_with_consensus_registry,
+        RethChainSpec,
     };
 
     #[tokio::test(start_paused = true)]
@@ -1026,56 +1046,19 @@ mod tests {
         assert_eq!(calls.get(), 1, "chain-global failures are never retried");
     }
 
-    /// Drive ONE epoch-closing block on `reth_env` (parent = genesis) outside the full engine:
-    /// build the block from a boundary [`ConsensusOutput`] (its payload runs `concludeEpoch`),
-    /// commit it as the canonical head, and finalize it. Afterwards the canonical tip IS an
-    /// epoch-0 closing block, so the close-time identity (`tip + 1 == entered blockHeight`)
-    /// holds for `adjust_base_fees`. Mirrors tn-reth's `execute_payload_and_update_canonical_chain`
-    /// test helper via the public [`RethEnv`] surface.
-    fn execute_epoch_closing_block(
-        reth_env: &RethEnv,
-        chain: &Arc<RethChainSpec>,
-    ) -> eyre::Result<()> {
-        let mut leader = Certificate::default();
-        leader.set_signature_verification_state(SignatureVerificationState::VerifiedDirectly(
-            BlsSignature::default(),
-        ));
-        leader.update_header_created_at_for_test(tn_types::now());
-        leader.update_header_round_for_test(2);
-        let sub_dag = CommittedSubDag::new(
-            vec![Certificate::default(), leader.clone()],
-            leader,
-            1,
-            ReputationScores::default(),
-            None,
-        );
-        let output = ConsensusOutput::new_closed_with_subdag(
-            sub_dag,
-            ConsensusHeader::default().digest(),
-            1,
-        );
-
-        let parent = chain.sealed_genesis_header();
-        let payload = TNPayload::new_for_test(parent.clone(), &output);
-        let block =
-            reth_env.build_block_from_batch_payload(payload, &Vec::new(), parent.hash(), &[])?;
-        let header = block.recovered_block.clone_sealed_header();
-        let canonical_state = reth_env.canonical_in_memory_state();
-        canonical_state.update_chain(NewCanonicalChain::Commit { new: vec![block.clone()] });
-        canonical_state.set_canonical_head(header.clone());
-        reth_env.finish_executing_output(vec![block], None)?;
-        reth_env.finalize_block(header)?;
-        Ok(())
-    }
-
-    /// Keep-current arm (first coverage of the close-time fail-open): a
-    /// CHAIN-GLOBAL config-read failure (WorkerConfigs contract absent, the alloc-stripped-genesis
-    /// trick) at a REAL closing block returns `Ok` and keeps the per-worker base fees, the worker
-    /// count, and the accumulated gas untouched. The identity read PASSES here (registry
-    /// present, `concludeEpoch` ran in the tip), isolating the failure to the config read's
-    /// fail-open arm.
+    /// Keep-current arm of the close-time fail-open: a CHAIN-GLOBAL config-read failure
+    /// (WorkerConfigs contract absent, the alloc-stripped-genesis trick) returns `Ok` and keeps
+    /// the per-worker base fees, the worker count, and the accumulated gas untouched.
+    ///
+    /// Calls the inner [`apply_close_time_fee_updates`] at a genesis tip rather than the outer
+    /// [`adjust_base_fees`] behind a real closing block: the closing block now records the same
+    /// fees on-chain and is FATAL when `WorkerConfigs` is unreadable, so this fixture (which
+    /// exists precisely to make that contract unreadable) can no longer produce one. Pinning the
+    /// inner function keeps the coverage that matters — the fail-open arm still preserves fees
+    /// and count — and it is also the shape a node whose tip predates this feature hits, where
+    /// the closing block carries no recorded fees at all.
     #[tokio::test]
-    async fn adjust_base_fees_keeps_fees_and_count_on_read_failure() -> eyre::Result<()> {
+    async fn close_time_fee_updates_keep_fees_and_count_on_read_failure() -> eyre::Result<()> {
         // registry genesis WITHOUT the WorkerConfigs account: the config read is guaranteed to
         // fail chain-globally (call to codeless address succeeds with empty data -> decode fails)
         let mut genesis = test_genesis_with_consensus_registry(4);
@@ -1085,13 +1068,7 @@ mod tests {
         let task_manager = TaskManager::new("adjust fees fail open");
         let reth_env =
             RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
-
-        // close epoch 0 so the canonical tip is a closing block and the identity gate passes
-        execute_epoch_closing_block(&reth_env, &chain)?;
         let tip = reth_env.canonical_tip();
-        let (entered_epoch, epoch_info) = reth_env.get_current_epoch_info_at_header(&tip)?;
-        assert_eq!(entered_epoch, 1, "registry state crossed to the entered epoch");
-        assert_eq!(tip.number + 1, epoch_info.blockHeight, "close-time identity holds at the tip");
 
         // non-default fees, gas, and count on the accumulator
         let acc = GasAccumulator::new(2);
@@ -1101,7 +1078,7 @@ mod tests {
         acc.inc_block(1, 2_000_000, 30_000_000);
 
         // chain-global failure -> keep-current fail-open: Ok, everything untouched
-        adjust_base_fees(&reth_env, &acc).await?;
+        apply_close_time_fee_updates(&reth_env, &acc, &tip).await?;
 
         assert_eq!(acc.num_workers(), 2, "worker count unchanged");
         assert_eq!(acc.base_fee(0).base_fee(), 4_242, "worker 0 fee unchanged");

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -31,7 +31,7 @@ use tn_primary::ConsensusBus;
 use tn_reth::{error::StateReadError, RethEnv};
 use tn_storage::{certificate_pack::CertificatePack, tables::OurNodeBatchesCache};
 use tn_types::{
-    gas_accumulator::{compute_next_base_fee_eip1559, GasAccumulator, WorkerFeeConfig},
+    gas_accumulator::{next_base_fee_for_config, GasAccumulator},
     BlsPublicKey, Committee, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase,
     EpochRecord, Notifier, TaskJoinError, TaskManager, TaskSpawner, TnReceiver,
 };
@@ -741,11 +741,11 @@ where
 /// Recompute each worker's next-epoch base fee from the gas it accumulated this epoch and the
 /// worker's fee strategy read from the `WorkerConfigs` contract.
 ///
-/// Reads one [`WorkerFeeConfig`] per worker at the canonical tip — which inside
-/// [`Self::close_epoch`] (after `wait_for_consensus_execution`) is exactly the epoch's closing
-/// block — then applies the strategy via [`next_base_fee_for_config`] and writes the result back to
-/// each worker's base-fee container. This is the deterministic seam every committee member runs
-/// identically at the boundary.
+/// Reads one [`WorkerFeeConfig`](tn_types::gas_accumulator::WorkerFeeConfig) per worker at the
+/// canonical tip — which inside [`Self::close_epoch`] (after `wait_for_consensus_execution`) is
+/// exactly the epoch's closing block — then applies the strategy via [`next_base_fee_for_config`]
+/// and writes the result back to each worker's base-fee container. This is the deterministic seam
+/// every committee member runs identically at the boundary.
 ///
 /// The read's config count is the on-chain `numWorkers()` at the closing block, i.e. the worker
 /// count for the NEXT epoch (a mid-epoch `setNumWorkers` only takes effect at the boundary by
@@ -934,29 +934,6 @@ where
     }
 }
 
-/// Apply a worker's [`WorkerFeeConfig`] to compute its next-epoch base fee.
-///
-/// `Eip1559 { target_gas }` nudges the fee toward the gas target via
-/// [`compute_next_base_fee_eip1559`] (floored at `MIN_PROTOCOL_BASE_FEE`); `Static { fee }` pins
-/// the fee to the governance-set value, ignoring gas usage.
-///
-/// This is the ONE fee formula: [`adjust_base_fees`] applies it at a live epoch close and
-/// `fold_next_epoch_base_fees` (in the parent module) applies it when deriving the entered
-/// epoch's fees from the previous epoch's chain state, so both seams produce identical values
-/// from identical inputs.
-pub(crate) fn next_base_fee_for_config(
-    config: WorkerFeeConfig,
-    current_base_fee: u64,
-    gas_used: u64,
-) -> u64 {
-    match config {
-        WorkerFeeConfig::Eip1559 { target_gas } => {
-            compute_next_base_fee_eip1559(current_base_fee, gas_used, target_gas)
-        }
-        WorkerFeeConfig::Static { fee } => fee,
-    }
-}
-
 /// How the next consensus output's number relates to the last one forwarded to the engine.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum OutputContinuity {
@@ -996,51 +973,8 @@ mod tests {
     };
     use tn_types::{
         BlsSignature, Certificate, CommittedSubDag, ConsensusHeader, ReputationScores,
-        SignatureVerificationState, MIN_PROTOCOL_BASE_FEE,
+        SignatureVerificationState,
     };
-
-    #[test]
-    fn eip1559_config_with_max_target_is_inert_at_min() {
-        // Genesis/default strategy: Eip1559 { target_gas: u64::MAX }. Against an unreachable target
-        // the fee can only ratchet down and floors at MIN, so a worker at MIN stays at MIN
-        // regardless of gas used -- the inert guarantee that keeps existing chains unchanged.
-        let cfg = WorkerFeeConfig::Eip1559 { target_gas: u64::MAX };
-        assert_eq!(
-            next_base_fee_for_config(cfg, MIN_PROTOCOL_BASE_FEE, 5_000_000),
-            MIN_PROTOCOL_BASE_FEE
-        );
-        // a non-MIN fee ratchets down (and never below MIN)
-        let down = next_base_fee_for_config(cfg, MIN_PROTOCOL_BASE_FEE * 1000, 0);
-        assert!((MIN_PROTOCOL_BASE_FEE..MIN_PROTOCOL_BASE_FEE * 1000).contains(&down));
-    }
-
-    #[test]
-    fn eip1559_config_moves_fee_with_gas_vs_target() {
-        let target = 1_000_000u64;
-        let current = 1_000_000u64;
-        let cfg = WorkerFeeConfig::Eip1559 { target_gas: target };
-        // gas above target -> fee increases; below -> decreases; at target -> unchanged.
-        assert!(next_base_fee_for_config(cfg, current, 2_000_000) > current);
-        assert!(next_base_fee_for_config(cfg, current, 0) < current);
-        assert_eq!(next_base_fee_for_config(cfg, current, target), current);
-    }
-
-    #[test]
-    fn static_config_pins_to_configured_fee() {
-        // Static ignores gas usage and the current fee, always returning the governance-set value.
-        assert_eq!(
-            next_base_fee_for_config(
-                WorkerFeeConfig::Static { fee: 12_345 },
-                MIN_PROTOCOL_BASE_FEE,
-                999_999
-            ),
-            12_345
-        );
-        assert_eq!(
-            next_base_fee_for_config(WorkerFeeConfig::Static { fee: 500 }, 1_000_000, 0),
-            500
-        );
-    }
 
     #[tokio::test(start_paused = true)]
     async fn retry_provider_faults_halts_after_exhausting_attempts() {

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -87,7 +87,7 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // manually create engine
@@ -336,7 +336,7 @@ async fn test_catchup_accumulator_with_empty_outputs() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &tmp.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(10);
@@ -505,7 +505,7 @@ async fn test_catchup_accumulator_partial_execution() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &tmp.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(10);
@@ -696,7 +696,7 @@ async fn test_sync_then_catchup_recovers_two_worker_accumulator() -> eyre::Resul
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // manually create engine
@@ -1400,7 +1400,7 @@ async fn test_derive_base_fees_recovers_committee_fee_at_boundary() -> eyre::Res
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     // manually create engine
@@ -1577,7 +1577,7 @@ async fn epoch_block_height_is_closing_block_plus_one() -> eyre::Result<()> {
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(10);
@@ -1740,7 +1740,7 @@ async fn test_derive_base_fees_eip1559_variant_matches_oracle() -> eyre::Result<
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
 
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(10);
@@ -1854,7 +1854,7 @@ async fn test_derive_base_fees_excludes_synthetic_close_block() -> eyre::Result<
         Some(chain.clone()),
         None,
         &temp_dir.path().join("reth"),
-        Some(gas_accumulator.rewards_counter()),
+        Some(gas_accumulator.clone()),
     )?;
     // the empty-close path resolves the leader's execution address through the rewards
     // counter's committee, so build the committee from on-chain registry state

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -8,7 +8,7 @@ use tn_config::Config;
 use tn_node::engine::{ExecutionNode, TnBuilder};
 use tn_reth::{init_txpool_defaults, RethChainSpec, RethCommand, RethConfig, RethEnv};
 use tn_types::{
-    gas_accumulator::RewardsCounter, Address, TaskManager, TimestampSec, Withdrawals, B256,
+    gas_accumulator::GasAccumulator, Address, TaskManager, TimestampSec, Withdrawals, B256,
 };
 
 /// Convenience type for testing Execution Node.
@@ -23,7 +23,7 @@ pub fn default_test_execution_node(
     opt_chain: Option<Arc<RethChainSpec>>,
     opt_address: Option<Address>,
     tmp_dir: &Path,
-    rewards: Option<RewardsCounter>,
+    rewards: Option<GasAccumulator>,
 ) -> eyre::Result<TestExecutionNode> {
     let (builder, _) = execution_builder::<NoArgs>(
         opt_chain.clone(),

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -990,8 +990,9 @@ mod tests {
     use tempfile::TempDir;
     use tn_config::NodeInfo;
     use tn_types::{
-        gas_accumulator::RewardsCounter, generate_proof_of_possession_bls_for_test, BlsKeypair,
-        GenesisAccount, NodeP2pInfo, TaskManager, U256,
+        gas_accumulator::{GasAccumulator, RewardsCounter},
+        generate_proof_of_possession_bls_for_test, BlsKeypair, GenesisAccount, NodeP2pInfo,
+        TaskManager, U256,
     };
 
     /// In-protocol `ConsensusRegistry` fork over the PRE-fork testnet registry.
@@ -2322,7 +2323,7 @@ mod tests {
             chain.clone(),
             tmp_dir.path(),
             &task_manager,
-            Some(counter.clone()),
+            Some(GasAccumulator::new_with_rewards(1, counter.clone())),
         )?;
 
         // seed the counter exactly as run_epoch does at epoch entry: the genesis committee,

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -3483,6 +3483,154 @@ mod tests {
         Ok(())
     }
 
+    /// The closing block's own gas is folded into the PRODUCING worker's total only: with two
+    /// EIP-1559 workers and the closing block produced by worker 1 (not the worker-0 default
+    /// every other close test uses), worker 1's recorded fee is priced WITH the closing block's
+    /// user-tx gas while worker 0's is priced from its accumulator gas alone.
+    ///
+    /// This is the only test that discriminates the fold's TARGET selection
+    /// (`worker_id == own_worker` over `ctx.worker_id()` in `record_next_epoch_base_fees`):
+    /// with a worker-0 closing block, a `worker_id()` that always answers 0 and a fold applied
+    /// to every worker are both indistinguishable from the correct close. The fixture guards
+    /// pin both discriminations at runtime — the fold must move worker 1's oracle, and a leak
+    /// of the closing block's gas into worker 0 must move worker 0's.
+    #[tokio::test]
+    async fn test_close_folds_own_gas_into_producing_worker_only() -> eyre::Result<()> {
+        use crate::snapshot::worker_id_from_header;
+        use tn_types::{Hash as _, WorkerId};
+
+        const TARGET_GAS_0: u64 = 2_000_000;
+        const START_FEE_0: u64 = 2_000_000;
+        const EPOCH_GAS_0: u64 = 1_100_000;
+        const TARGET_GAS_1: u64 = 1_000_000;
+        const START_FEE_1: u64 = 1_000_000;
+        const EPOCH_GAS_1: u64 = 1_500_000;
+        const CLOSING_WORKER: WorkerId = 1;
+
+        let mut sender = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(79));
+        let genesis = test_genesis_with_consensus_registry_and_workers(
+            5,
+            vec![(0u8, TARGET_GAS_0), (0u8, TARGET_GAS_1)],
+        )
+        .extend_accounts([(
+            sender.address(),
+            GenesisAccount::default().with_balance(U256::from(parse_ether("1")?)),
+        )]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Own Gas Producer Attribution Test");
+
+        // both workers carry moved fees and non-zero mid-epoch gas, so either slot would show a
+        // misattributed fold at full magnitude
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(START_FEE_0);
+        acc.inc_block(0, EPOCH_GAS_0, 30_000_000);
+        acc.base_fee(1).set_base_fee(START_FEE_1);
+        acc.inc_block(1, EPOCH_GAS_1, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // two real transfers ride the closing block
+        let recipient = Address::from_slice(&[0xef; 20]);
+        let txs = vec![
+            sender.create_eip1559_encoded(
+                chain.clone(),
+                None,
+                100,
+                Some(recipient),
+                U256::from(1),
+                Bytes::new(),
+            ),
+            sender.create_eip1559_encoded(
+                chain.clone(),
+                None,
+                100,
+                Some(recipient),
+                U256::from(1),
+                Bytes::new(),
+            ),
+        ];
+
+        // close epoch 0 from CLOSING_WORKER: `new_for_test` hardcodes worker 0, so build the
+        // payload through the production constructor with the same test inputs
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let parent = chain.sealed_genesis_header();
+        let payload = TNPayload::new(
+            parent.clone(),
+            Address::random(),
+            0, // batch_index
+            B256::random(),
+            &consensus_output,
+            consensus_output.digest().into(),
+            parent.base_fee_per_gas.unwrap_or(MIN_PROTOCOL_BASE_FEE),
+            parent.gas_limit,
+            B256::random(),
+            CLOSING_WORKER,
+        );
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, txs)?;
+        let closing_header = block.recovered_block.clone_sealed_header();
+
+        // the sealed header attributes the closing block to worker 1 through the production
+        // mask (the same low-16-bits read the executor's own-gas fold keys on)
+        assert_eq!(
+            worker_id_from_header(&closing_header),
+            CLOSING_WORKER,
+            "closing block must be attributed to worker 1"
+        );
+        let own_gas = closing_header.gas_used;
+        assert!(own_gas > 0, "closing block must carry user-tx gas");
+
+        let config_0 = WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS_0 };
+        let config_1 = WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS_1 };
+        // producing worker: accumulator gas plus the closing block's own gas
+        let expected_1 = next_base_fee_for_config(config_1, START_FEE_1, EPOCH_GAS_1 + own_gas);
+        // non-producing worker: accumulator gas alone
+        let expected_0 = next_base_fee_for_config(config_0, START_FEE_0, EPOCH_GAS_0);
+
+        // fixture guards: the fold must matter for worker 1 (an unfolded worker 1 prices
+        // differently), a leak into worker 0 must be visible (worker 0 with the closing gas
+        // prices differently), and every value sits away from MIN and the start fees
+        let unfolded_1 = next_base_fee_for_config(config_1, START_FEE_1, EPOCH_GAS_1);
+        assert_ne!(
+            expected_1, unfolded_1,
+            "fixture must discriminate the fold on the producing worker"
+        );
+        let leaked_0 = next_base_fee_for_config(config_0, START_FEE_0, EPOCH_GAS_0 + own_gas);
+        assert_ne!(
+            expected_0, leaked_0,
+            "fixture must discriminate own-gas leakage into the non-producing worker"
+        );
+        for fee in [expected_0, expected_1, unfolded_1, leaked_0] {
+            assert_ne!(fee, MIN_PROTOCOL_BASE_FEE, "fixture fees must not pin at MIN");
+        }
+        assert_ne!(expected_0, START_FEE_0);
+        assert_ne!(expected_1, START_FEE_1);
+        assert_ne!(expected_0, expected_1, "a swapped write must not alias the two workers");
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(
+            entries[1].data,
+            U184::from(expected_1),
+            "producing worker's record must fold the closing block's own gas"
+        );
+        assert_eq!(
+            entries[0].data,
+            U184::from(expected_0),
+            "non-producing worker's record must be priced from its accumulator gas alone"
+        );
+        // the data writes preserve both workers' strategies
+        assert_eq!(entries[0].config, config_0);
+        assert_eq!(entries[1].config, config_1);
+
+        Ok(())
+    }
+
     /// A worker governance adds MID-epoch (contract `numWorkers` 1 -> 2 while the shared
     /// accumulator still has 1 slot) is priced at the close from the CONTRACT's count with the
     /// fresh-slot anchor `next_base_fee_for_config(config, MIN_PROTOCOL_BASE_FEE, 0)`; the

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -964,18 +964,26 @@ mod tests {
         TaskManager, MIN_PROTOCOL_BASE_FEE, U256,
     };
 
-    /// In-protocol `ConsensusRegistry` fork over the PRE-fork testnet registry.
+    /// In-protocol `ConsensusRegistry` + `WorkerConfigs` fork over the PRE-fork testnet genesis.
     ///
     /// `test_genesis()` embeds the committed testnet `genesis.yaml`, whose `ConsensusRegistry`
     /// account carries the pre-fork runtime code and validator storage with NO per-status sets —
-    /// the exact on-chain shape the fork upgrades in place. The epoch-closing block that
-    /// concludes `FORK_EPOCH - 1` swaps in the new runtime and runs `migrateValidatorSets()`
-    /// FIRST, then the rewards + conclude calls run on the new code over the byte-identical
-    /// preserved storage.
+    /// the exact on-chain shape the fork upgrades in place — and whose `WorkerConfigs` account
+    /// carries the old uint128-data build without the `setWorkerConfigsData` selector. The
+    /// epoch-closing block that concludes `FORK_EPOCH - 1` swaps in the new registry runtime and
+    /// runs `migrateValidatorSets()` FIRST, then swaps the `WorkerConfigs` runtime (code only),
+    /// then the rewards + conclude + base-fee-record calls run on the new code over the
+    /// byte-identical preserved storage.
     ///
     /// Asserts: the pre-fork code does not answer the new-ABI eligible-count call; post-fork the
     /// new code is live and the migration populated a non-empty eligible set; a preserved BLS
-    /// pubkey survives the swap as 96-byte compressed; and the fork block's `state_root` is
+    /// pubkey survives the swap as 96-byte compressed; the `WorkerConfigs` code hash equals the
+    /// current artifact's (and not the pre-fork pin) with storage preserved (`numWorkers` still
+    /// 1, worker 0 still EIP-1559 with the genesis `u64::MAX` gas target); the SAME closing
+    /// block's fourth system call wrote worker 0's next-epoch base fee through the swapped-in
+    /// code (exactly `MIN_PROTOCOL_BASE_FEE` for the untouched genesis config); `MAX_STRATEGY()`
+    /// flips from the old build's hard-coded `1` to `0` (the appended, unset slot — the
+    /// documented post-swap governance-runbook state); and the fork block's `state_root` is
     /// identical across two independent executions (determinism — every node re-derives the
     /// same root).
     ///
@@ -1026,6 +1034,14 @@ mod tests {
             );
         }
 
+        // pre-fork WorkerConfigs fixture guard: the live old build hard-codes MAX_STRATEGY() = 1
+        // (a readable failure here means the committed genesis fixture was regenerated)
+        assert_eq!(
+            max_strategy_at_block(&env1, genesis_header.hash())?,
+            1,
+            "pre-fork WorkerConfigs must answer MAX_STRATEGY() with its hard-coded 1"
+        );
+
         // --- produce the fork boundary block on the production path ---
         let block = execute_payload_and_update_canonical_chain(&env1, payload.clone(), vec![])?;
         let header = block.recovered_block.clone_sealed_header();
@@ -1075,6 +1091,67 @@ mod tests {
             assert_eq!(bls.len(), 96, "preserved BLS pubkey must remain 96-byte compressed");
         }
 
+        // --- the WorkerConfigs swap landed in the same closing block ---
+        {
+            use reth_provider::StateProvider as _;
+
+            // (a) code hash == the embedded current artifact's, and off the pre-fork pin
+            let code = env1
+                .latest()?
+                .account_code(&WORKER_CONFIGS_ADDRESS)?
+                .expect("worker configs account must have code");
+            let artifact = RethEnv::fetch_value_from_json_str(
+                tn_config::WORKER_CONFIGS_JSON,
+                Some("deployedBytecode.object"),
+            )?;
+            let artifact_code = alloy::hex::decode(
+                artifact.as_str().expect("worker configs deployedBytecode.object is a string"),
+            )?;
+            assert_eq!(
+                code.0.hash_slow(),
+                alloy::primitives::keccak256(&artifact_code),
+                "post-fork WorkerConfigs code hash must match the embedded current artifact"
+            );
+            assert_ne!(
+                code.0.hash_slow(),
+                tn_types::forks::WORKER_CONFIGS_PRE_FORK_CODE_HASH,
+                "the swap must move the WorkerConfigs code hash off the pre-fork pin"
+            );
+        }
+
+        // (b) storage survived the code-only swap: numWorkers and worker 0's config semantics
+        // read back unchanged through the swapped-in code; (c) the SAME closing block's fourth
+        // system call recorded worker 0's next-epoch base fee in its data word
+        let (num_workers, entries) = worker_config_entries_at_block(&env1, header.hash())?;
+        assert_eq!(num_workers, 1, "preserved numWorkers must still read 1 post-swap");
+        assert_eq!(
+            entries[0].config,
+            WorkerFeeConfig::Eip1559 { target_gas: u64::MAX },
+            "preserved worker 0 config semantics must be unchanged post-swap"
+        );
+        // fee oracle: a default accumulator (MIN fee, zero gas) plus a closing block with no
+        // user transactions hold the untouched genesis config (u64::MAX gas target) at the floor
+        assert_eq!(header.gas_used, 0, "fork-boundary closing block carries no user-tx gas");
+        let expected_fee = next_base_fee_for_config(
+            WorkerFeeConfig::Eip1559 { target_gas: u64::MAX },
+            MIN_PROTOCOL_BASE_FEE,
+            header.gas_used,
+        );
+        assert_eq!(expected_fee, MIN_PROTOCOL_BASE_FEE, "oracle: u64::MAX target floors at MIN");
+        assert_eq!(
+            entries[0].data,
+            U184::from(expected_fee),
+            "the closing block must write worker 0's next-epoch base fee (== MIN_PROTOCOL_BASE_FEE)"
+        );
+
+        // (d) the appended maxStrategy slot reads 0 post-swap — the documented state governance
+        // clears with one setMaxStrategy(1) transaction after the fork
+        assert_eq!(
+            max_strategy_at_block(&env1, header.hash())?,
+            0,
+            "post-swap MAX_STRATEGY() must read the appended, unset slot as 0"
+        );
+
         // --- determinism: an independent execution of the identical block yields the same root ---
         let tmp2 = TempDir::new().unwrap();
         let tm2 = TaskManager::new("fork test env2");
@@ -1101,7 +1178,10 @@ mod tests {
     ///
     /// Asserts: the closing block executes; the registry code hash is untouched (no swap —
     /// epoch 3 is far from the fork boundary); the post-fork-only eligible-count call still
-    /// fails; and the block's `state_root` is identical across two independent executions.
+    /// fails; the `WorkerConfigs` code hash also stays at its pre-fork pin AND nothing was
+    /// written (the legacy close has no fourth system call, so the old build's uint128 data
+    /// words still decode as all-zero through the production seam); and the block's
+    /// `state_root` is identical across two independent executions.
     #[cfg(feature = "adiri")]
     #[tokio::test]
     async fn test_pre_fork_epoch_close_uses_legacy_registry_read() -> eyre::Result<()> {
@@ -1176,6 +1256,17 @@ mod tests {
                 "a normal pre-fork epoch close must not swap the registry code"
             );
 
+            // the WorkerConfigs code is equally untouched: only the fork boundary swaps it
+            let wc_code = env1
+                .latest()?
+                .account_code(&WORKER_CONFIGS_ADDRESS)?
+                .expect("worker configs account must have code");
+            assert_eq!(
+                wc_code.0.hash_slow(),
+                tn_types::forks::WORKER_CONFIGS_PRE_FORK_CODE_HASH,
+                "a normal pre-fork epoch close must not swap the worker configs code"
+            );
+
             let state = StateProviderDatabase::new(env1.latest()?);
             let mut cached = CachedReads::default();
             let mut db = State::builder()
@@ -1195,6 +1286,15 @@ mod tests {
                 "post-fork-only getEligibleValidatorCount must still fail on the pre-fork code"
             );
         }
+
+        // --- and the legacy close wrote nothing: it has no fourth system call, so the old
+        // build's uint128 data words still decode as all-zero through the production seam ---
+        let (num_workers, entries) = worker_config_entries_at_block(&env1, header.hash())?;
+        assert_eq!(num_workers, 1, "pre-fork genesis deploys a single worker");
+        assert!(
+            entries.iter().all(|entry| entry.data == U184::ZERO),
+            "a pre-fork close must leave every worker data word unwritten"
+        );
 
         // --- determinism: an independent execution of the identical block yields the same root ---
         let tmp2 = TempDir::new().unwrap();
@@ -3075,6 +3175,26 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    /// Execute `MAX_STRATEGY()` against the state of `block_hash` and decode the `uint8`.
+    ///
+    /// Both the live pre-fork `WorkerConfigs` build (which hard-codes the ceiling as the
+    /// constant `1`) and the current artifact (which reads the appended `maxStrategy` storage
+    /// slot) expose this selector, so one probe pins the documented value flip across the
+    /// fork's code-only swap: `1` before, `0` after (until governance's `setMaxStrategy(1)`).
+    #[cfg(feature = "adiri")]
+    fn max_strategy_at_block(reth_env: &RethEnv, block_hash: B256) -> eyre::Result<u8> {
+        let mut tn_evm = reth_env.tn_evm(block_hash)?;
+        let calldata = WorkerConfigs::MAX_STRATEGYCall {}.abi_encode().into();
+        let res = tn_evm.transact_system_call(SYSTEM_ADDRESS, WORKER_CONFIGS_ADDRESS, calldata)?;
+        let data = match res.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            other => eyre::bail!("MAX_STRATEGY failed at pinned block: {other:?}"),
+        };
+        Ok(<WorkerConfigs::MAX_STRATEGYCall as alloy::sol_types::SolCall>::abi_decode_returns(
+            &data,
+        )?)
     }
 
     /// Execute `getAllWorkerConfigs()` against the state of `block_hash` and decode the raw

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -97,7 +97,10 @@ use crate::{
         EvmReadError, EvmReadResult, StateReadError, StateReadResult, TnRethError, TnRethResult,
     },
     evm::TNEvm,
-    system_calls::{ConsensusRegistry, EpochState, WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS},
+    system_calls::{
+        decode_worker_fee_configs, ConsensusRegistry, EpochState, WorkerConfigs,
+        CONSENSUS_REGISTRY_ADDRESS,
+    },
     RethEnv, SYSTEM_ADDRESS,
 };
 
@@ -571,6 +574,11 @@ impl RethEnv {
     /// when a future contract version introduces one before this node is upgraded) is NOT an
     /// error — it falls back to [`WorkerFeeConfig::Eip1559`] with a warning, preserving liveness
     /// instead of halting all validators on the unrecognized id.
+    ///
+    /// The decode, arity check, and strategy mapping live in
+    /// [`decode_worker_fee_configs`](crate::system_calls::decode_worker_fee_configs), shared with
+    /// the epoch-closing block's base-fee recording so the two cannot drift. Callers of this
+    /// method want fee strategies only, so each row's `data` word is dropped here.
     pub(crate) fn worker_fee_configs_inner(
         &self,
         header: &SealedHeader,
@@ -593,54 +601,12 @@ impl RethEnv {
                 )))
             }
         };
-        let ret =
-            <WorkerConfigs::getAllWorkerConfigsCall as alloy::sol_types::SolCall>::abi_decode_returns(
-                &data,
-            )
-            .map_err(|e| {
-                StateReadError::ChainGlobal(format!(
-                    "worker configs return decode failed (contract absent at this block?): {e}"
-                ))
-            })?;
+        // decode/arity failures are deterministic products of the pinned block, so they land in
+        // ChainGlobal alongside the revert and absent-contract cases above
+        let (num_workers, entries) =
+            decode_worker_fee_configs(&data).map_err(StateReadError::ChainGlobal)?;
 
-        let num_workers = ret.count as usize;
-        if ret.strategies.len() != num_workers
-            || ret.values.len() != num_workers
-            || ret.datas.len() != num_workers
-        {
-            return Err(StateReadError::ChainGlobal(format!(
-                "worker config arity mismatch: count={num_workers}, strategies={}, values={}, datas={}",
-                ret.strategies.len(),
-                ret.values.len(),
-                ret.datas.len(),
-            )));
-        }
-
-        let mut configs = Vec::with_capacity(num_workers);
-        for (worker_id, (&strategy, &value)) in
-            ret.strategies.iter().zip(ret.values.iter()).enumerate()
-        {
-            let config = match strategy {
-                0 => WorkerFeeConfig::Eip1559 { target_gas: value },
-                1 => WorkerFeeConfig::Static { fee: value },
-                s => {
-                    // The contract rejects unknown strategies, so this branch only fires when a
-                    // future contract version introduces a strategy this node hasn't been
-                    // updated to understand. Fall back to EIP-1559 to preserve liveness instead
-                    // of halting all validators.
-                    tracing::warn!(
-                        target: "tn::reth",
-                        worker_id,
-                        strategy = s,
-                        "unknown fee strategy; falling back to strategy 0 (Eip1559)"
-                    );
-                    WorkerFeeConfig::Eip1559 { target_gas: value }
-                }
-            };
-            configs.push(config);
-        }
-
-        Ok((num_workers, configs))
+        Ok((num_workers as usize, entries.into_iter().map(|entry| entry.config).collect()))
     }
 
     /// Build an EVM at the canonical tip, execute a read-only [ConsensusRegistry] call, and
@@ -977,11 +943,12 @@ mod tests {
         test_utils::{
             consensus_output_for_tests, create_committee_from_state,
             execute_payload_and_update_canonical_chain, governance_burn_tx,
-            governance_owner_factory, test_genesis_with_consensus_registry, TransactionFactory,
+            governance_owner_factory, test_genesis_with_consensus_registry,
+            test_genesis_with_consensus_registry_and_workers, TransactionFactory,
         },
         RethChainSpec,
     };
-    use alloy::primitives::utils::parse_ether;
+    use alloy::primitives::{aliases::U184, utils::parse_ether};
     use rand::{rngs::StdRng, SeedableRng as _};
     use reth_revm::{
         cached::CachedReads, database::StateProviderDatabase, DatabaseCommit as _, State,
@@ -990,9 +957,11 @@ mod tests {
     use tempfile::TempDir;
     use tn_config::NodeInfo;
     use tn_types::{
-        gas_accumulator::{GasAccumulator, RewardsCounter},
+        gas_accumulator::{
+            next_base_fee_for_config, GasAccumulator, RewardsCounter, WorkerConfigEntry,
+        },
         generate_proof_of_possession_bls_for_test, BlsKeypair, GenesisAccount, NodeP2pInfo,
-        TaskManager, U256,
+        TaskManager, MIN_PROTOCOL_BASE_FEE, U256,
     };
 
     /// In-protocol `ConsensusRegistry` fork over the PRE-fork testnet registry.
@@ -3104,6 +3073,432 @@ mod tests {
             "batched committee read with an absent registry must classify as ChainGlobal, got: \
              {err}"
         );
+
+        Ok(())
+    }
+
+    /// Execute `getAllWorkerConfigs()` against the state of `block_hash` and decode the raw
+    /// return bytes through the production seam ([`decode_worker_fee_configs`]) — the exact
+    /// decode the closing block's `record_next_epoch_base_fees` uses, so these tests observe
+    /// the write through the same path that produced it.
+    fn worker_config_entries_at_block(
+        reth_env: &RethEnv,
+        block_hash: B256,
+    ) -> eyre::Result<(u16, Vec<WorkerConfigEntry>)> {
+        let mut tn_evm = reth_env.tn_evm(block_hash)?;
+        let calldata = WorkerConfigs::getAllWorkerConfigsCall {}.abi_encode().into();
+        let res = tn_evm.transact_system_call(SYSTEM_ADDRESS, WORKER_CONFIGS_ADDRESS, calldata)?;
+        let data = match res.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            other => eyre::bail!("getAllWorkerConfigs failed at pinned block: {other:?}"),
+        };
+        decode_worker_fee_configs(&data).map_err(|e| eyre::eyre!(e))
+    }
+
+    /// The closing block's 4th system call records an EIP-1559 worker's NEXT-epoch base fee in
+    /// its `WorkerConfigs.data` word, bit-identical to
+    /// `next_base_fee_for_config(config, accumulator fee at close, accumulator gas + the closing
+    /// block's own user-tx gas)` — the same value `adjust_base_fees` and the epoch-entry
+    /// derivation compute from the same inputs.
+    ///
+    /// The fixture is chosen so the expected value differs from `MIN_PROTOCOL_BASE_FEE`, from
+    /// the starting fee, AND from the value computed without the closing block's own gas — so a
+    /// wrong fee source, a dropped gas total, or an off-by-one-block gas fold all fail loudly.
+    #[tokio::test]
+    async fn test_close_records_eip1559_next_epoch_base_fee_in_worker_data() -> eyre::Result<()> {
+        const TARGET_GAS: u64 = 1_000_000;
+        const START_FEE: u64 = 1_000_000;
+        const EPOCH_GAS: u64 = 1_500_000;
+
+        // fund an EOA so the closing block carries real user-tx gas
+        let mut sender = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(77));
+        let genesis = test_genesis_with_consensus_registry_and_workers(5, vec![(0u8, TARGET_GAS)])
+            .extend_accounts([(
+                sender.address(),
+                GenesisAccount::default().with_balance(U256::from(parse_ether("1")?)),
+            )]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Base Fee Record Test");
+
+        // the shared accumulator the block executor reads: a moved fee and mid-epoch gas
+        let acc = GasAccumulator::new(1);
+        acc.base_fee(0).set_base_fee(START_FEE);
+        acc.inc_block(0, EPOCH_GAS, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // ceremony genesis deploys the current WorkerConfigs with data == 0 (never written)
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, chain.sealed_genesis_header().hash())?;
+        assert_eq!(num_workers, 1);
+        assert_eq!(entries[0].data, U184::ZERO, "genesis data word starts unwritten");
+
+        // close epoch 0 with a real user transaction in the closing block
+        let tx = sender.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(Address::from_slice(&[0xab; 20])),
+            U256::from(1),
+            Bytes::new(),
+        );
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![tx])?;
+        let closing_header = block.recovered_block.clone_sealed_header();
+
+        // independent oracle: the ONE fee formula over the accumulator fee and the total epoch
+        // gas INCLUDING the closing block's own user-tx gas
+        let own_gas = closing_header.gas_used;
+        assert!(own_gas > 0, "closing block must carry user-tx gas");
+        let expected = next_base_fee_for_config(
+            WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS },
+            START_FEE,
+            EPOCH_GAS + own_gas,
+        );
+        // fixture guards: the expected value discriminates against a MIN write, a no-op write,
+        // and a total that dropped the closing block's own gas
+        assert_ne!(expected, MIN_PROTOCOL_BASE_FEE);
+        assert_ne!(expected, START_FEE);
+        assert_ne!(
+            expected,
+            next_base_fee_for_config(
+                WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS },
+                START_FEE,
+                EPOCH_GAS,
+            ),
+        );
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 1);
+        assert_eq!(
+            entries[0].data,
+            U184::from(expected),
+            "recorded next-epoch base fee must equal the independent oracle"
+        );
+        // the data write preserves the worker's strategy and value
+        assert_eq!(entries[0].config, WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS });
+
+        Ok(())
+    }
+
+    /// Mixed strategies at the close: the EIP-1559 worker's `data` word gets its oracle fee
+    /// while the Static worker is skipped entirely — its `data` stays 0 (the fee already lives
+    /// in the config's `value`) no matter what fee or gas its accumulator slot carries.
+    #[tokio::test]
+    async fn test_close_records_eip1559_worker_and_skips_static_worker() -> eyre::Result<()> {
+        const TARGET_GAS: u64 = 1_000_000;
+        const START_FEE: u64 = 1_000_000;
+        const EPOCH_GAS: u64 = 500_000;
+        const STATIC_FEE: u64 = 777;
+
+        let genesis = test_genesis_with_consensus_registry_and_workers(
+            5,
+            vec![(0u8, TARGET_GAS), (1u8, STATIC_FEE)],
+        );
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Mixed Strategy Record Test");
+
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(START_FEE);
+        acc.inc_block(0, EPOCH_GAS, 30_000_000);
+        // distinctive state on the static worker's slot: none of it may reach the chain
+        acc.base_fee(1).set_base_fee(5_555);
+        acc.inc_block(1, 123_456, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let closing_header = block.recovered_block.clone_sealed_header();
+
+        let expected = next_base_fee_for_config(
+            WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS },
+            START_FEE,
+            EPOCH_GAS,
+        );
+        assert_ne!(expected, MIN_PROTOCOL_BASE_FEE);
+        assert_ne!(expected, START_FEE);
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(entries[0].data, U184::from(expected), "eip1559 worker records its oracle");
+        assert_eq!(entries[1].data, U184::ZERO, "static worker is never written");
+        assert_eq!(entries[1].config, WorkerFeeConfig::Static { fee: STATIC_FEE });
+
+        Ok(())
+    }
+
+    /// An all-Static worker set produces an empty write set: the close succeeds while issuing
+    /// no `setWorkerConfigsData` call at all — every worker's `data` word is still 0 at the
+    /// closing block.
+    #[tokio::test]
+    async fn test_close_with_all_static_workers_records_nothing() -> eyre::Result<()> {
+        let genesis =
+            test_genesis_with_consensus_registry_and_workers(5, vec![(1u8, 500), (1u8, 900)]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("All Static Record Test");
+
+        // populated slots prove the skip is strategy-driven, not empty-accumulator-driven
+        let acc = GasAccumulator::new(2);
+        acc.base_fee(0).set_base_fee(4_242);
+        acc.inc_block(0, 1_000_000, 30_000_000);
+        acc.base_fee(1).set_base_fee(9_099);
+        acc.inc_block(1, 2_000_000, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // the close must succeed without any base-fee write
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let closing_header = block.recovered_block.clone_sealed_header();
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 2);
+        assert_eq!(entries[0].data, U184::ZERO, "static worker 0 stays unwritten");
+        assert_eq!(entries[1].data, U184::ZERO, "static worker 1 stays unwritten");
+        assert_eq!(entries[0].config, WorkerFeeConfig::Static { fee: 500 });
+        assert_eq!(entries[1].config, WorkerFeeConfig::Static { fee: 900 });
+
+        Ok(())
+    }
+
+    /// The closing block's OWN user-tx gas is folded into its worker's epoch total before
+    /// pricing: the recorded fee equals the oracle computed WITH the closing block's gas and
+    /// differs from the oracle computed WITHOUT it (the accumulator alone — `inc_block` for
+    /// this block only runs after the payload executes).
+    #[tokio::test]
+    async fn test_close_folds_closing_block_gas_into_recorded_fee() -> eyre::Result<()> {
+        const TARGET_GAS: u64 = 1_000_000;
+        const START_FEE: u64 = 1_000_000;
+        const EPOCH_GAS: u64 = 1_200_000;
+
+        let mut sender = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(78));
+        let genesis = test_genesis_with_consensus_registry_and_workers(5, vec![(0u8, TARGET_GAS)])
+            .extend_accounts([(
+                sender.address(),
+                GenesisAccount::default().with_balance(U256::from(parse_ether("1")?)),
+            )]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Own Gas Fold Test");
+
+        let acc = GasAccumulator::new(1);
+        acc.base_fee(0).set_base_fee(START_FEE);
+        acc.inc_block(0, EPOCH_GAS, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // two real transfers ride the closing block
+        let recipient = Address::from_slice(&[0xcd; 20]);
+        let txs = vec![
+            sender.create_eip1559_encoded(
+                chain.clone(),
+                None,
+                100,
+                Some(recipient),
+                U256::from(1),
+                Bytes::new(),
+            ),
+            sender.create_eip1559_encoded(
+                chain.clone(),
+                None,
+                100,
+                Some(recipient),
+                U256::from(1),
+                Bytes::new(),
+            ),
+        ];
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, txs)?;
+        let closing_header = block.recovered_block.clone_sealed_header();
+
+        let own_gas = closing_header.gas_used;
+        assert!(own_gas > 0, "closing block must carry user-tx gas");
+        let config = WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS };
+        let including = next_base_fee_for_config(config, START_FEE, EPOCH_GAS + own_gas);
+        let excluding = next_base_fee_for_config(config, START_FEE, EPOCH_GAS);
+        // fixture guard: the target makes the two totals price differently
+        assert_ne!(including, excluding, "fixture must discriminate the own-gas fold");
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 1);
+        assert_eq!(
+            entries[0].data,
+            U184::from(including),
+            "recorded fee must include the closing block's own gas"
+        );
+        assert_ne!(
+            entries[0].data,
+            U184::from(excluding),
+            "recorded fee must not be priced from the accumulator alone"
+        );
+
+        Ok(())
+    }
+
+    /// A worker governance adds MID-epoch (contract `numWorkers` 1 -> 2 while the shared
+    /// accumulator still has 1 slot) is priced at the close from the CONTRACT's count with the
+    /// fresh-slot anchor `next_base_fee_for_config(config, MIN_PROTOCOL_BASE_FEE, 0)`; the
+    /// pre-existing worker still gets its normal oracle, and the close only READS the shared
+    /// accumulator — it must not resize it (entry logic owns that).
+    #[tokio::test]
+    async fn test_close_prices_mid_epoch_added_worker_without_resizing_accumulator(
+    ) -> eyre::Result<()> {
+        const TARGET_GAS_0: u64 = 2_000_000;
+        const START_FEE_0: u64 = 2_000_000;
+        const EPOCH_GAS_0: u64 = 2_500_000;
+        const TARGET_GAS_1: u64 = 1_000_000;
+
+        let genesis =
+            test_genesis_with_consensus_registry_and_workers(5, vec![(0u8, TARGET_GAS_0)]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Mid Epoch Worker Add Test");
+
+        let acc = GasAccumulator::new(1);
+        acc.base_fee(0).set_base_fee(START_FEE_0);
+        acc.inc_block(0, EPOCH_GAS_0, 30_000_000);
+        let reth_env = RethEnv::new_for_temp_chain(
+            chain.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            Some(acc.clone()),
+        )?;
+
+        // block 1 (mid-epoch-0): the owner configures worker 1 then grows the count
+        // (setWorkerConfig must precede setNumWorkers per the contract)
+        let mut governance = governance_owner_factory();
+        let set_config_tx = governance.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(WORKER_CONFIGS_ADDRESS),
+            U256::ZERO,
+            WorkerConfigs::setWorkerConfigCall {
+                workerId: 1,
+                strategy: 0,
+                value: TARGET_GAS_1,
+                data: U184::ZERO,
+            }
+            .abi_encode()
+            .into(),
+        );
+        let set_num_workers_tx = governance.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(WORKER_CONFIGS_ADDRESS),
+            U256::ZERO,
+            WorkerConfigs::setNumWorkersCall { numWorkers_: 2 }.abi_encode().into(),
+        );
+        let consensus_output = consensus_output_for_tests(2, 0, 1, false);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(
+            &reth_env,
+            payload,
+            vec![set_config_tx, set_num_workers_tx],
+        )?;
+        let canonical_header = block1.recovered_block.clone_sealed_header();
+
+        // sanity: the governance txs landed (a silent revert would fake a 1-worker close)
+        assert_eq!(reth_env.get_worker_fee_configs()?.len(), 2);
+        assert_eq!(acc.num_workers(), 1, "accumulator untouched by governance txs");
+
+        // block 2: close epoch 0 over the 2-worker contract / 1-worker accumulator split
+        let consensus_output = consensus_output_for_tests(2, 1, 2, true);
+        let payload = TNPayload::new_for_test(canonical_header, &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let closing_header = block2.recovered_block.clone_sealed_header();
+
+        // the close must not resize the live accumulator shared with the batch validator
+        assert_eq!(acc.num_workers(), 1, "close must only READ the accumulator, never resize it");
+
+        let expected_0 = next_base_fee_for_config(
+            WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS_0 },
+            START_FEE_0,
+            EPOCH_GAS_0,
+        );
+        assert_ne!(expected_0, MIN_PROTOCOL_BASE_FEE);
+        assert_ne!(expected_0, START_FEE_0);
+        // fresh-slot anchor: a worker with no accumulator slot prices from (MIN, 0 gas) —
+        // exactly what adjust_base_fees' resize-then-compute and the entry walk produce
+        let expected_1 = next_base_fee_for_config(
+            WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS_1 },
+            MIN_PROTOCOL_BASE_FEE,
+            0,
+        );
+
+        let (num_workers, entries) =
+            worker_config_entries_at_block(&reth_env, closing_header.hash())?;
+        assert_eq!(num_workers, 2, "contract count grew at the boundary");
+        assert_eq!(entries[0].data, U184::from(expected_0), "worker 0 records its normal oracle");
+        assert_eq!(
+            entries[1].data,
+            U184::from(expected_1),
+            "governance-added worker records the fresh-slot anchor"
+        );
+        assert_ne!(entries[1].data, U184::ZERO, "the added worker WAS written");
+        assert_eq!(entries[1].config, WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS_1 });
+
+        Ok(())
+    }
+
+    /// A closing block over a chain whose `WorkerConfigs` account is absent must ABORT with an
+    /// error naming the base-fee recording — the close is fatal on an unreadable contract, it
+    /// must not silently skip the 4th system call and commit a diverging block.
+    #[tokio::test]
+    async fn test_close_fatal_when_worker_configs_unreadable() -> eyre::Result<()> {
+        // registry genesis WITHOUT the WorkerConfigs account: the three registry calls succeed,
+        // then the base-fee record's read decodes empty return data and fails deterministically
+        let mut genesis = test_genesis_with_consensus_registry(5);
+        genesis.alloc.remove(&WORKER_CONFIGS_ADDRESS);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Fatal Without Contract Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let err = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])
+            .expect_err("closing block without WorkerConfigs must abort");
+
+        // the error chain names the recording step (alternate format walks the full chain)
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("recording next-epoch base fees"),
+            "close failure must name the base-fee recording step, got: {msg}"
+        );
+
+        // the abort happened before anything committed: the canonical tip is still genesis
+        assert_eq!(reth_env.canonical_tip().number, 0, "no closing block may commit");
 
         Ok(())
     }

--- a/crates/tn-reth/src/env/genesis.rs
+++ b/crates/tn-reth/src/env/genesis.rs
@@ -70,7 +70,7 @@ use tn_config::{
     WORKER_CONFIGS_JSON,
 };
 use tn_types::{
-    gas_accumulator::RewardsCounter, Address, Genesis, GenesisAccount, TaskManager, B256, U256,
+    gas_accumulator::GasAccumulator, Address, Genesis, GenesisAccount, TaskManager, B256, U256,
 };
 use tracing::debug;
 
@@ -88,7 +88,7 @@ impl RethEnv {
         chain: Arc<RethChainSpec>,
         db_path: P,
         task_manager: &TaskManager,
-        rewards: Option<RewardsCounter>,
+        rewards: Option<GasAccumulator>,
     ) -> eyre::Result<Self> {
         /// MDBX map-size ceiling for throwaway temp-chain envs. reth defaults to 8 TB per
         /// environment; `cargo test` runs a test binary as threads in ONE process, so N

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -27,7 +27,7 @@ use reth_provider::{
 };
 use reth_revm::{database::StateProviderDatabase, State};
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_types::{gas_accumulator::RewardsCounter, Address, TaskManager, TaskSpawner, B256};
+use tn_types::{gas_accumulator::GasAccumulator, Address, TaskManager, TaskSpawner, B256};
 use tracing::{debug, info};
 
 use crate::{
@@ -109,10 +109,10 @@ impl RethEnv {
         task_manager: &TaskManager,
         database: RethDb,
         basefee_address: Option<Address>,
-        rewards_counter: RewardsCounter,
+        gas_accumulator: GasAccumulator,
     ) -> eyre::Result<Self> {
         let node_config = reth_config.0.clone();
-        let evm_config = TnEvmConfig::new(reth_config.0.chain.clone(), rewards_counter);
+        let evm_config = TnEvmConfig::new(reth_config.0.chain.clone(), gas_accumulator);
         let provider_factory = Self::init_provider_factory(&node_config, database)?;
         let blockchain_provider = BlockchainProvider::new(provider_factory)?;
         let task_spawner = task_manager.get_spawner();
@@ -200,7 +200,7 @@ impl RethEnv {
     }
 
     /// Return the EVM config used to build and execute TN blocks: the chain spec plus
-    /// the rewards counter, wiring the TN handler (base-fee redirection, gas-limit
+    /// the shared gas accumulator, wiring the TN handler (base-fee redirection, gas-limit
     /// penalty) and the TN precompiles.
     pub(crate) fn evm_config(&self) -> &TnEvmConfig {
         &self.inner.evm_config

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -25,19 +25,26 @@
 //!    (`deconstruct_nonce(ctx.nonce).0`) satisfies `concluding_epoch + 1 ==
 //!    CONSENSUS_REGISTRY_FORK_EPOCH` (checked addition): swaps the registry's runtime bytecode in
 //!    place, then runs the one-time `migrateValidatorSets()`.
-//! 2. `apply_closing_epoch_contract_call` - the three boundary system calls in order:
-//!    `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, then `concludeEpoch(address[])`.
-//!    The reward infos carry the leader counts from `ctx.gas_accumulator`'s rewards counter;
-//!    committee membership is drawn by the `randomness`-seeded Fisher-Yates shuffle (sorted by
-//!    address before encoding), run AFTER `applySlashes` commits so the eligible-pool read and the
-//!    committee reflect any slash-to-zero ejections. The ordering is a consensus-safety obligation
-//!    the protocol owns: incentives weight on pre-slash collateral, slashes land before the
-//!    committee is assembled, and `concludeEpoch` settles queued stake version changes from
-//!    post-slash balances. While the deployed registry still carries the pre-fork adiri code, the
-//!    close instead replays the legacy `applyIncentives` + `concludeEpoch(address[])` pair (same
-//!    code-hash gate as the committee-pool read), keeping pre-fork history re-executable; the
-//!    post-fork sequence differs only by the interposed `applySlashes` call, and both share
+//! 2. `apply_closing_epoch_contract_call` - the four boundary system calls in order:
+//!    `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, `concludeEpoch(address[])`, then
+//!    `setWorkerConfigsData(uint16[],uint184[])`. The reward infos carry the leader counts from
+//!    `ctx.gas_accumulator`'s rewards counter; committee membership is drawn by the
+//!    `randomness`-seeded Fisher-Yates shuffle (sorted by address before encoding), run AFTER
+//!    `applySlashes` commits so the eligible-pool read and the committee reflect any slash-to-zero
+//!    ejections. The ordering is a consensus-safety obligation the protocol owns: incentives weight
+//!    on pre-slash collateral, slashes land before the committee is assembled, and `concludeEpoch`
+//!    settles queued stake version changes from post-slash balances. While the deployed registry
+//!    still carries the pre-fork adiri code, the close instead replays the legacy pair
+//!    `applyIncentives` then `concludeEpoch(address[])` (same code-hash gate as the committee-pool
+//!    read), keeping pre-fork history re-executable; the post-fork sequence differs by the
+//!    interposed `applySlashes` call and the trailing worker-config write, and both share
 //!    byte-identical `applyIncentives` and `concludeEpoch(address[])` selectors.
+//!
+//! The fourth call (`record_next_epoch_base_fees`) writes each EIP-1559 worker's next-epoch base
+//! fee into its `WorkerConfigs` `data` word: an epoch-boundary snapshot that lets a node entering
+//! the epoch read the fee from one state slot instead of scanning the whole prior epoch's headers
+//! to recompute it. It runs last because it is the only step that reads no registry state and
+//! writes to no registry state, so nothing in the epoch transition depends on its position.
 //!
 //! The order is load-bearing. The fork must lead: the code swap flips the code-hash gate in
 //! `read_committee_eligible_pool` so the shuffle's committee-pool reads use the post-fork ABI
@@ -76,8 +83,9 @@
 use crate::{
     error::{TnRethError, TnRethResult},
     system_calls::{
+        decode_worker_fee_configs,
         ConsensusRegistry::{self, RewardInfo, ValidatorStatus},
-        CONSENSUS_REGISTRY_ADDRESS,
+        WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS,
     },
     SYSTEM_ADDRESS,
 };
@@ -88,6 +96,7 @@ use alloy::{
         eip4788::BEACON_ROOTS_ADDRESS,
         eip7685::{Requests, EMPTY_REQUESTS_HASH},
     },
+    primitives::aliases::U184,
     sol_types::SolCall as _,
 };
 use alloy_evm::{Database, Evm};
@@ -113,9 +122,11 @@ use reth_revm::{
     DatabaseCommit as _, State,
 };
 use std::{collections::BTreeMap, sync::Arc};
+use tn_config::WORKER_CONFIGS_ADDRESS;
 use tn_types::{
-    gas_accumulator::GasAccumulator, Address, Bytes, Encodable2718, ExecHeader, Receipt,
-    TransactionSigned, Withdrawals, B256, EMPTY_WITHDRAWALS, U256,
+    gas_accumulator::{next_base_fee_for_config, GasAccumulator, WorkerFeeConfig},
+    Address, Bytes, Encodable2718, ExecHeader, Receipt, TransactionSigned, Withdrawals, WorkerId,
+    B256, EMPTY_WITHDRAWALS, MIN_PROTOCOL_BASE_FEE, U256,
 };
 use tracing::{debug, error, trace};
 
@@ -192,6 +203,15 @@ impl TNBlockExecutionCtx {
     /// to `BEACON_ROOTS` contract (eip4788).
     fn first_batch(&self) -> bool {
         self.difficulty < U256::from(65536)
+    }
+
+    /// The worker id packed into the low 16 bits of `difficulty`.
+    ///
+    /// Same mask the header-side [`crate::snapshot::worker_id_from_header`] applies, so a block's
+    /// worker attribution is identical whether it is read from the execution context or from the
+    /// sealed header afterwards (the gas accumulator's per-worker totals depend on that).
+    fn worker_id(&self) -> WorkerId {
+        (self.difficulty.into_limbs()[0] & 0xffff) as WorkerId
     }
 }
 
@@ -302,15 +322,18 @@ where
         Ok(())
     }
 
-    /// Close the epoch through the three boundary system calls, in order:
-    /// `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, `concludeEpoch(address[])`.
+    /// Close the epoch through the four boundary system calls, in order:
+    /// `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, `concludeEpoch(address[])`,
+    /// `setWorkerConfigsData(uint16[],uint184[])`.
     ///
     /// The order is a consensus-safety invariant. `applySlashes` commits before the committee is
     /// assembled, so the `nextCommitteeSize` read and the shuffle below both see any slash-to-zero
     /// ejections: the committee `concludeEpoch` validates cannot be stale, and an ejected
     /// validator is never seated in a future committee. Slashing is not live, so the slashes array
     /// is always empty (production builds) and `applySlashes` is a no-op today; the call is
-    /// issued regardless so the sequence is correct by construction when slashing ships.
+    /// issued regardless so the sequence is correct by construction when slashing ships. The
+    /// base-fee record trails the registry calls (see [`Self::record_next_epoch_base_fees`]): it
+    /// touches a different contract, so nothing in the epoch transition reads what it writes.
     fn apply_closing_epoch_contract_call(
         &mut self,
         randomness: B256,
@@ -362,7 +385,120 @@ where
         // 3. assemble the committee from the post-slash eligible pool, then conclude
         let calldata = self.generate_conclude_epoch_calldata(randomness)?;
         trace!(target: "engine", ?calldata, "close epoch calldata");
-        self.transact_and_commit_system_call(CONSENSUS_REGISTRY_ADDRESS, calldata, "closing epoch")
+        self.transact_and_commit_system_call(
+            CONSENSUS_REGISTRY_ADDRESS,
+            calldata,
+            "closing epoch",
+        )?;
+
+        // 4. publish the next epoch's per-worker base fees for the epoch that just began
+        self.record_next_epoch_base_fees()
+    }
+
+    /// Record every EIP-1559 worker's NEXT-epoch base fee in the `WorkerConfigs` contract's
+    /// per-worker `data` word.
+    ///
+    /// Fourth and last of the closing block's system calls, so the write lands in the same block
+    /// that seats the new committee: a node entering the epoch reads each worker's fee from one
+    /// state slot instead of scanning the whole prior epoch's headers to recompute it.
+    ///
+    /// The value written for a worker MUST equal what the live producer's post-close
+    /// `adjust_base_fees` (in `tn_node::manager`) and every node's epoch-entry header-scan
+    /// derivation (`derive_base_fees_for_entered_epoch`) compute for it — the batch validator
+    /// snapshots a plain `u64` per epoch and compares base fees for exact equality, so a
+    /// one-wei divergence makes peers reject each other's batches for a whole epoch. Three
+    /// details carry that equivalence:
+    ///
+    /// - The worker set comes from the CONTRACT's `numWorkers`, not the accumulator's. Governance
+    ///   may have grown the worker set mid-epoch (a `setNumWorkers` only takes effect at this
+    ///   boundary), and both other seams read the count at this same closing block. A worker with
+    ///   no accumulator slot yet prices from `(MIN_PROTOCOL_BASE_FEE, 0 gas)`, which is exactly
+    ///   what `adjust_base_fees`' resize-then-compute and the entry walk's slot-creation anchor
+    ///   produce for a fresh slot.
+    /// - This block's own gas is folded into its worker's total. The accumulator does not include
+    ///   it yet (`inc_block` runs after the payload executes), while the post-close adjustment and
+    ///   the header scan both count this block.
+    /// - The accumulator is only READ. It is shared live with the batch validator and the node
+    ///   manager, so resizing or clearing it here would corrupt state those readers depend on.
+    ///
+    /// `Static` workers are skipped: their fee is already on-chain in the config's `value` word,
+    /// so recording it would be redundant. A closing block with no EIP-1559 worker therefore
+    /// issues no system call at all — an emptiness every node computes identically from the same
+    /// contract state, so skipping cannot diverge the fleet.
+    ///
+    /// Fatal on any failure (read, decode, or a reverting/halting write), like every other step of
+    /// the close: the error aborts execution of the consensus output rather than committing a
+    /// block whose state diverges from the rest of the fleet.
+    fn record_next_epoch_base_fees(&mut self) -> TnRethResult<()> {
+        let calldata = WorkerConfigs::getAllWorkerConfigsCall {}.abi_encode().into();
+        let data = self.read_state_on_chain(SYSTEM_ADDRESS, WORKER_CONFIGS_ADDRESS, calldata)?;
+        let (num_workers, entries) = decode_worker_fee_configs(&data).map_err(|e| {
+            error!(target: "engine", "failed to decode worker configs at epoch close: {e}");
+            TnRethError::EVMCustom(format!(
+                "failed to decode worker configs while recording next-epoch base fees: {e}"
+            ))
+        })?;
+
+        let own_worker = self.ctx.worker_id();
+        let own_gas = self.gas_used;
+        let accumulator_workers = self.ctx.gas_accumulator.num_workers();
+
+        let mut worker_ids: Vec<WorkerId> = Vec::new();
+        let mut datas: Vec<U184> = Vec::new();
+        for (worker_id, entry) in entries.iter().enumerate() {
+            let worker_id = worker_id as WorkerId;
+            match entry.config {
+                WorkerFeeConfig::Eip1559 { .. } => {}
+                // a static worker's fee is the config's `value` on-chain already
+                WorkerFeeConfig::Static { .. } => continue,
+            }
+
+            let (current_fee, gas_used) = if (worker_id as usize) < accumulator_workers {
+                let (_blocks, gas_used, _gas_limit) =
+                    self.ctx.gas_accumulator.get_values(worker_id);
+                (self.ctx.gas_accumulator.base_fee(worker_id).base_fee(), gas_used)
+            } else {
+                // governance added this worker mid-epoch: it has no slot to read, and a fresh
+                // slot is created with the min fee and zero gas
+                (MIN_PROTOCOL_BASE_FEE, 0)
+            };
+            // this block's gas reaches the accumulator only after execution finishes
+            let gas_used =
+                if worker_id == own_worker { gas_used.saturating_add(own_gas) } else { gas_used };
+
+            worker_ids.push(worker_id);
+            datas.push(U184::from(next_base_fee_for_config(entry.config, current_fee, gas_used)));
+        }
+
+        if worker_ids.is_empty() {
+            debug!(
+                target: "engine",
+                num_workers,
+                own_worker,
+                own_gas,
+                "no eip1559 workers configured; skipping next-epoch base fee record"
+            );
+            return Ok(());
+        }
+
+        debug!(
+            target: "engine",
+            num_workers,
+            own_worker,
+            own_gas,
+            ?worker_ids,
+            ?datas,
+            "recording next-epoch base fees"
+        );
+
+        let calldata = WorkerConfigs::setWorkerConfigsDataCall { workerIds: worker_ids, datas }
+            .abi_encode()
+            .into();
+        self.transact_and_commit_system_call(
+            WORKER_CONFIGS_ADDRESS,
+            calldata,
+            "recording next-epoch base fees",
+        )
     }
 
     /// The slashes to submit at this epoch boundary.

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -21,10 +21,15 @@
 //! When `ctx.close_epoch` is `Some(randomness)`, `finish` closes the epoch with system calls in
 //! this exact order:
 //!
-//! 1. (`adiri` builds only) `apply_consensus_registry_fork` — fires only when the concluding epoch
-//!    (`deconstruct_nonce(ctx.nonce).0`) satisfies `concluding_epoch + 1 ==
-//!    CONSENSUS_REGISTRY_FORK_EPOCH` (checked addition): swaps the registry's runtime bytecode in
-//!    place, then runs the one-time `migrateValidatorSets()`.
+//! 1. (`adiri` builds only) `apply_consensus_registry_fork` then `apply_worker_configs_fork` — fire
+//!    only when the concluding epoch (`deconstruct_nonce(ctx.nonce).0`), plus one (checked), equals
+//!    `CONSENSUS_REGISTRY_FORK_EPOCH`. The registry swap replaces the registry's runtime bytecode
+//!    in place, then runs the one-time `migrateValidatorSets()`; the worker-configs swap then
+//!    replaces the `WorkerConfigs` runtime bytecode (code only, no initializer). The two ship at
+//!    the same boundary because the registry swap flips this very block's close onto the post-fork
+//!    sequence, whose fourth call needs the `setWorkerConfigsData` selector the pre-fork
+//!    `WorkerConfigs` deployment lacks — a build applying one swap but not the other aborts this
+//!    block.
 //! 2. `apply_closing_epoch_contract_call` - the four boundary system calls in order:
 //!    `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, `concludeEpoch(address[])`, then
 //!    `setWorkerConfigsData(uint16[],uint184[])`. The reward infos carry the leader counts from
@@ -605,6 +610,37 @@ where
         &CODE
     }
 
+    /// The upgraded `WorkerConfigs` runtime bytecode and its code hash, sourced from the same
+    /// embedded artifact genesis deploys (`WORKER_CONFIGS_JSON` `deployedBytecode.object`).
+    ///
+    /// Materialized once. The embedded artifact is a compile-time `include_str!` constant (the
+    /// same bytes genesis generation decodes, and exercised by the fork unit test), so a decode
+    /// failure here is a corrupt build — uniform across the fleet — not a live-node runtime
+    /// condition; hence `expect` rather than a fallible return.
+    #[cfg(feature = "adiri")]
+    fn worker_configs_runtime_code() -> &'static (reth_revm::bytecode::Bytecode, B256) {
+        use reth_revm::bytecode::Bytecode;
+        use std::sync::LazyLock;
+        use tn_config::WORKER_CONFIGS_JSON;
+
+        static CODE: LazyLock<(Bytecode, B256)> = LazyLock::new(|| {
+            let value = crate::RethEnv::fetch_value_from_json_str(
+                WORKER_CONFIGS_JSON,
+                Some("deployedBytecode.object"),
+            )
+            .expect("embedded worker configs artifact json is valid");
+            let hex_str =
+                value.as_str().expect("worker configs deployedBytecode.object is a string");
+            let raw = alloy::hex::decode(hex_str)
+                .expect("worker configs deployedBytecode.object is valid hex");
+            let bytecode = Bytecode::new_raw(raw.into());
+            let code_hash = bytecode.hash_slow();
+            (bytecode, code_hash)
+        });
+
+        &CODE
+    }
+
     /// Apply the in-protocol `ConsensusRegistry` fork.
     ///
     /// Swaps the deployed registry runtime bytecode to the upgraded version — preserving the
@@ -731,6 +767,113 @@ where
             });
 
         tracing::info!(target: "engine", ?eligible, %code_hash, "consensus registry fork applied");
+        Ok(())
+    }
+
+    /// Apply the in-protocol `WorkerConfigs` fork.
+    ///
+    /// Swaps the deployed worker-configs runtime bytecode to the current artifact's — preserving
+    /// the account's balance, nonce, and **all** existing storage (slots 0-3: `_owner`, the
+    /// `_pendingOwner` + `numWorkers` packing, the `_workerConfigs` mapping, and
+    /// `_workerConfigSet`), so the swap rewrites only the account-code leaf.
+    ///
+    /// Ships at the SAME fork boundary as [`Self::apply_consensus_registry_fork`] (the
+    /// epoch-closing block of `CONSENSUS_REGISTRY_FORK_EPOCH - 1`, registry first) because the
+    /// two are coupled through this very block's close: the registry swap flips the code-hash
+    /// gate in `apply_closing_epoch_contract_call` onto the post-fork sequence, whose fourth
+    /// call ([`Self::record_next_epoch_base_fees`]) invokes the `setWorkerConfigsData` selector
+    /// — absent from the live pre-fork `WorkerConfigs` deployment (an old build whose
+    /// `WorkerConfig.data` is a `uint128` and which exposes no protocol write path at all). A
+    /// build applying one swap but not the other therefore diverges from fork-capable peers: its
+    /// own fourth system call reverts and aborts this block.
+    ///
+    /// Unlike the registry fork there is NO migrate-style initializer call: the pre-fork
+    /// deployment already holds `_workerConfigSet[0] = true` and `numWorkers = 1`, so
+    /// `getAllWorkerConfigs` (and the `_workerConfigSet` guard inside `setWorkerConfigsData`)
+    /// work immediately post-swap. The appended `maxStrategy` slot (slot 4) deliberately reads 0
+    /// after the code-only swap: a documented governance runbook item — one owner
+    /// `setMaxStrategy(1)` transaction after the fork (see
+    /// `tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH`). The protocol write path never reads
+    /// `maxStrategy`, so the zeroed ceiling gates future governance actions only.
+    ///
+    /// Fail-closed gate: the swap proceeds only if the worker-configs account's current code
+    /// hash equals the pinned `WORKER_CONFIGS_PRE_FORK_CODE_HASH`; any other deployment aborts
+    /// the block. Aborting cannot split the network: the check is a pure function of committed
+    /// state, so every fork-capable node evaluates it identically and fails (or passes) in
+    /// lockstep.
+    ///
+    /// Fatal on failure — a partial swap diverges state across the fleet.
+    #[cfg(feature = "adiri")]
+    fn apply_worker_configs_fork(&mut self) -> TnRethResult<()> {
+        // revm `Database` trait provides `basic`; imported anonymously to avoid clashing with the
+        // `alloy_evm::Database` already in module scope.
+        use reth_revm::{
+            state::{Account, AccountInfo, AccountStatus, EvmState},
+            Database as _,
+        };
+
+        let (code, code_hash) = Self::worker_configs_runtime_code().clone();
+
+        // Preserve the worker-configs account's balance + nonce; only the code changes. Reading
+        // via `basic` also loads the account into the `State` cache so the code-only commit below
+        // takes the `change` path (info updated, storage left intact) rather than creating a new
+        // account.
+        let current = self
+            .evm
+            .db_mut()
+            .basic(WORKER_CONFIGS_ADDRESS)
+            .map_err(|e| {
+                TnRethError::EVMCustom(format!("worker configs account read failed: {e}"))
+            })?
+            .unwrap_or_default();
+
+        // Fail closed on an unexpected pre-fork deployment. The code-only swap assumes the exact
+        // storage layout of the pinned pre-fork worker-configs code (on the live chain this is
+        // the fixed genesis code hash); swapping over anything else risks silent state
+        // corruption. Abort the block instead — the check is a pure function of committed state,
+        // so every fork-capable node fails uniformly rather than diverging.
+        if current.code_hash != tn_types::forks::WORKER_CONFIGS_PRE_FORK_CODE_HASH {
+            error!(
+                target: "engine",
+                pre_swap_code_hash = %current.code_hash,
+                expected = %tn_types::forks::WORKER_CONFIGS_PRE_FORK_CODE_HASH,
+                "worker configs fork failing closed: unexpected pre-fork worker configs code",
+            );
+            return Err(TnRethError::EVMCustom(format!(
+                "worker configs fork failing closed: pre-swap code hash {} does not match the \
+                 pinned pre-fork deployment {}",
+                current.code_hash,
+                tn_types::forks::WORKER_CONFIGS_PRE_FORK_CODE_HASH,
+            )));
+        }
+
+        debug!(
+            target: "engine",
+            pre_swap_code_hash = %current.code_hash,
+            new_code_hash = %code_hash,
+            "applying worker configs fork",
+        );
+
+        // Commit a code-only override: an empty storage map and a plain `Touched` status (never
+        // `Created`/`SelfDestructed`) so no storage slot enters the bundle and the existing
+        // storage root is preserved — only the single account-code leaf changes. The new bytecode
+        // is carried inline on the account info, so it is registered in the bundle's contracts
+        // (for post-restart `code_by_hash`) and is immediately callable by the fourth system call
+        // of this same block's close.
+        let account = Account {
+            info: AccountInfo {
+                balance: current.balance,
+                nonce: current.nonce,
+                code_hash,
+                code: Some(code),
+                ..Default::default()
+            },
+            status: AccountStatus::Touched,
+            ..Default::default()
+        };
+        self.evm.db_mut().commit(EvmState::from_iter([(WORKER_CONFIGS_ADDRESS, account)]));
+
+        tracing::info!(target: "engine", %code_hash, "worker configs fork applied");
         Ok(())
     }
 
@@ -1120,6 +1263,16 @@ where
                 self.apply_consensus_registry_fork().map_err(|e| {
                     BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
                 })?;
+
+                // The `WorkerConfigs` swap rides the same boundary, AFTER the registry swap:
+                // the registry swap just flipped this block's close onto the post-fork
+                // sequence, whose fourth call (`record_next_epoch_base_fees`) needs the
+                // `setWorkerConfigsData` selector the pre-fork deployment lacks. Code-only —
+                // no migrate-style call — see `apply_worker_configs_fork` for the storage
+                // preservation and `maxStrategy` runbook notes.
+                self.apply_worker_configs_fork().map_err(|e| {
+                    BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+                })?;
             }
 
             self.apply_closing_epoch_contract_call(
@@ -1415,7 +1568,7 @@ mod tests {
     use tempfile::TempDir;
     use tn_config::NodeInfo;
     #[cfg(feature = "adiri")]
-    use tn_config::CONSENSUS_REGISTRY_JSON;
+    use tn_config::{CONSENSUS_REGISTRY_JSON, WORKER_CONFIGS_JSON};
     use tn_types::{
         generate_proof_of_possession_bls_for_test, BlsKeypair, GenesisAccount, NodeP2pInfo,
         TaskManager,
@@ -1567,6 +1720,55 @@ mod tests {
         assert!(
             format!("{err:#}").contains("failing closed"),
             "abort must come from the fail-closed code-hash gate, got: {err:#}"
+        );
+
+        Ok(())
+    }
+
+    /// The `WorkerConfigs` fork must fail closed over an unexpected pre-fork deployment.
+    ///
+    /// Mirrors the registry's fail-closed test above: the genesis fixture's worker-configs
+    /// account is overwritten with the post-fork artifact bytes (any hash other than
+    /// `WORKER_CONFIGS_PRE_FORK_CODE_HASH` — a stand-in for an unknown deployment) while the
+    /// registry account keeps its pinned pre-fork code, so the registry swap that leads the
+    /// fork boundary succeeds and the abort is attributable to the WorkerConfigs gate alone.
+    /// (Without the gate this block would execute: the code-only swap is a no-op over the
+    /// current artifact, making this test the discriminating check.)
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_worker_configs_fork_fails_closed_on_unexpected_code() -> eyre::Result<()> {
+        // overwrite the worker-configs code (keeping balance + storage) with the post-fork
+        // artifact
+        let mut genesis = tn_types::test_genesis();
+        let v2_value = RethEnv::fetch_value_from_json_str(
+            WORKER_CONFIGS_JSON,
+            Some("deployedBytecode.object"),
+        )?;
+        let v2_code: Bytes =
+            alloy::hex::decode(v2_value.as_str().expect("deployedBytecode.object is a string"))?
+                .into();
+        genesis
+            .alloc
+            .get_mut(&WORKER_CONFIGS_ADDRESS)
+            .expect("testnet genesis must allocate the WorkerConfigs account")
+            .code = Some(v2_code);
+
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let genesis_header = chain.sealed_genesis_header();
+
+        // drive the fork boundary: the concluding epoch + 1 == CONSENSUS_REGISTRY_FORK_EPOCH
+        let concluding_epoch = tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH - 1;
+        let output = consensus_output_for_tests(2, concluding_epoch, 1, true);
+        let payload = TNPayload::new_for_test(genesis_header.clone(), &output);
+
+        let tmp = TempDir::new().unwrap();
+        let tm = TaskManager::new("worker configs fail closed test");
+        let env = RethEnv::new_for_temp_chain(chain.clone(), tmp.path(), &tm, None).unwrap();
+        let err = execute_payload_and_update_canonical_chain(&env, payload, vec![])
+            .expect_err("fork over an unexpected worker-configs deployment must abort the block");
+        assert!(
+            format!("{err:#}").contains("worker configs fork failing closed"),
+            "abort must come from the WorkerConfigs fail-closed code-hash gate, got: {err:#}"
         );
 
         Ok(())

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -433,7 +433,12 @@ where
     ///
     /// Fatal on any failure (read, decode, or a reverting/halting write), like every other step of
     /// the close: the error aborts execution of the consensus output rather than committing a
-    /// block whose state diverges from the rest of the fleet.
+    /// block whose state diverges from the rest of the fleet. That is deliberately the opposite
+    /// of the manager-side close-time update (`apply_close_time_fee_updates` in `tn-node`), which
+    /// fails OPEN on a chain-global `WorkerConfigs` read failure — keeping the current fees is
+    /// safe there because every node deterministically computes the same keep. A silently skipped
+    /// write here would instead leave a stale `data` word for the entry-time read of the recorded
+    /// fee to trust later, so fatal-and-halt beats silently-wrong state.
     fn record_next_epoch_base_fees(&mut self) -> TnRethResult<()> {
         let calldata = WorkerConfigs::getAllWorkerConfigsCall {}.abi_encode().into();
         let data = self.read_state_on_chain(SYSTEM_ADDRESS, WORKER_CONFIGS_ADDRESS, calldata)?;

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -27,17 +27,17 @@
 //!    place, then runs the one-time `migrateValidatorSets()`.
 //! 2. `apply_closing_epoch_contract_call` - the three boundary system calls in order:
 //!    `applyIncentives(RewardInfo[])`, `applySlashes(Slash[])`, then `concludeEpoch(address[])`.
-//!    The reward infos carry the leader counts from `ctx.rewards_counter`; committee membership is
-//!    drawn by the `randomness`-seeded Fisher-Yates shuffle (sorted by address before encoding),
-//!    run AFTER `applySlashes` commits so the eligible-pool read and the committee reflect any
-//!    slash-to-zero ejections. The ordering is a consensus-safety obligation the protocol owns:
-//!    incentives weight on pre-slash collateral, slashes land before the committee is assembled,
-//!    and `concludeEpoch` settles queued stake version changes from post-slash balances. While the
-//!    deployed registry still carries the pre-fork adiri code, the close instead replays the legacy
-//!    `applyIncentives` + `concludeEpoch(address[])` pair (same code-hash gate as the
-//!    committee-pool read), keeping pre-fork history re-executable; the post-fork sequence differs
-//!    only by the interposed `applySlashes` call, and both share byte-identical `applyIncentives`
-//!    and `concludeEpoch(address[])` selectors.
+//!    The reward infos carry the leader counts from `ctx.gas_accumulator`'s rewards counter;
+//!    committee membership is drawn by the `randomness`-seeded Fisher-Yates shuffle (sorted by
+//!    address before encoding), run AFTER `applySlashes` commits so the eligible-pool read and the
+//!    committee reflect any slash-to-zero ejections. The ordering is a consensus-safety obligation
+//!    the protocol owns: incentives weight on pre-slash collateral, slashes land before the
+//!    committee is assembled, and `concludeEpoch` settles queued stake version changes from
+//!    post-slash balances. While the deployed registry still carries the pre-fork adiri code, the
+//!    close instead replays the legacy `applyIncentives` + `concludeEpoch(address[])` pair (same
+//!    code-hash gate as the committee-pool read), keeping pre-fork history re-executable; the
+//!    post-fork sequence differs only by the interposed `applySlashes` call, and both share
+//!    byte-identical `applyIncentives` and `concludeEpoch(address[])` selectors.
 //!
 //! The order is load-bearing. The fork must lead: the code swap flips the code-hash gate in
 //! `read_committee_eligible_pool` so the shuffle's committee-pool reads use the post-fork ABI
@@ -68,7 +68,7 @@
 //! certificate's aggregate BLS signature, computed in `CommittedSubDag::new` and carried through
 //! the payload. It seeds the deterministic committee shuffle AND is stored as the block's
 //! `extra_data`, which is how the replay path (`context_for_block`) rebuilds the ctx from the
-//! sealed header — identical up to `rewards_counter`, which is the live shared counter rather
+//! sealed header — identical up to `gas_accumulator`, which is the live shared accumulator rather
 //! than header-derived (see the `evm/config.rs` module docs for the replay caveat and the
 //! `block.body.withdrawals` reconstruction follow-up). The RNG draw order inside the shuffle
 //! is consensus-critical: any refactor that reorders the draws selects a different committee.
@@ -114,7 +114,7 @@ use reth_revm::{
 };
 use std::{collections::BTreeMap, sync::Arc};
 use tn_types::{
-    gas_accumulator::RewardsCounter, Address, Bytes, Encodable2718, ExecHeader, Receipt,
+    gas_accumulator::GasAccumulator, Address, Bytes, Encodable2718, ExecHeader, Receipt,
     TransactionSigned, Withdrawals, B256, EMPTY_WITHDRAWALS, U256,
 };
 use tracing::{debug, error, trace};
@@ -146,8 +146,14 @@ pub struct TNBlockExecutionCtx {
     /// Difficulty- this contains the worker id and batch index:
     /// `U256::from(payload.batch_index << 16 | payload.worker_id as usize)`
     pub difficulty: U256,
-    /// Counter used to allocate rewards for block leaders.
-    pub rewards_counter: RewardsCounter,
+    /// Live shared accumulator for the current epoch: per-worker gas totals, current base fees,
+    /// worker count, and the leader counts used to allocate block rewards.
+    ///
+    /// Cloned from the EVM config by both context builders, so it is the same object every other
+    /// component holds rather than a header-derived snapshot (see the `evm/config.rs` module docs
+    /// for the replay caveat that follows from that). Execution reads only the rewards counter
+    /// today — the gas and fee data is carried so the epoch-closing block executor can reach it.
+    pub gas_accumulator: GasAccumulator,
     /// Test-only slash injection for the epoch boundary, copied from the payload
     /// (`context_for_next_block`). Feeds the executor's `epoch_boundary_slashes` seam so a test
     /// can drive a non-empty slash list through the production close path. Production builds have
@@ -982,7 +988,7 @@ where
 
             self.apply_closing_epoch_contract_call(
                 randomness,
-                self.ctx.rewards_counter.get_address_counts(),
+                self.ctx.gas_accumulator.rewards_counter().get_address_counts(),
             )
             .map_err(|e| {
                 BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
@@ -1140,7 +1146,7 @@ where
         let extra_data = ctx.close_epoch.map(|hash| hash.to_vec().into()).unwrap_or_default();
         let (withdrawals, withdrawals_root) = if ctx.close_epoch.is_some() {
             // closing epoch so include rewards info
-            let withdrawals = ctx.rewards_counter.generate_withdrawals();
+            let withdrawals = ctx.gas_accumulator.rewards_counter().generate_withdrawals();
             let withdrawals_root = calculate_withdrawals_root(withdrawals.as_ref());
             (Some(withdrawals), Some(withdrawals_root))
         } else {

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -5,8 +5,9 @@
 //! [`TnEvmConfig`] is TN's `ConfigureEvm` implementation. It wires three pieces together: the
 //! `TNEvmFactory` (every EVM instance, with TN precompiles installed), the
 //! `TNBlockExecutorFactory` (block-level execution, including the epoch-closing system calls),
-//! and the `TNBlockAssembler` (header assembly), plus the shared `RewardsCounter` threaded into
-//! each block's execution context for leader-reward attribution.
+//! and the `TNBlockAssembler` (header assembly), plus the shared `GasAccumulator` threaded into
+//! each block's execution context — per-worker gas totals, current base fees, worker count, and
+//! the rewards counter that drives leader-reward attribution.
 //!
 //! The epoch-close digest flows through here in both directions. Building a new block,
 //! `context_for_next_block` copies `TNPayload::close_epoch` into the execution context, and the
@@ -14,13 +15,18 @@
 //! `context_for_block` recovers the same value by decoding `extra_data` (empty = normal block,
 //! 32 bytes = the closing-epoch digest, any other length = malformed-header error).
 //!
-//! Replay caveat: `rewards_counter` is NOT header-derived — both context builders clone the
-//! config's live shared counter. Re-executing an epoch-closing block outside its original
-//! epoch context (e.g. `debug_executionWitness`) therefore runs `applyIncentives` with
-//! whatever the counter holds at that moment, not the amounts the historical block
-//! distributed. Reconstructing the historical counts from `block.body.withdrawals` (which
-//! records them) is a known follow-up; the canonical sync path is unaffected because the
-//! epoch manager seeds the counter before replaying an epoch's outputs.
+//! Replay caveat: `gas_accumulator` is NOT header-derived — both context builders clone the
+//! config's live shared accumulator, so the ctx carries whatever gas totals, base fees, and
+//! leader counts it holds at execution time. Every canonical path is seeded before it executes:
+//! `catchup_accumulator` (in `tn-node`) rebuilds the accumulator from chain state at startup, and
+//! the epoch manager seeds the rewards counter's committee before replaying an epoch's outputs —
+//! so a block built or re-executed through the payload builder always sees correct live values.
+//! Ad-hoc re-execution that rebuilds the ctx from a sealed header alone (e.g.
+//! `debug_executionWitness`) gets no such seeding and stays degraded: it runs `applyIncentives`
+//! with whatever the counter holds at that moment, not the amounts the historical block
+//! distributed. Reconstructing the historical counts from `block.body.withdrawals` (which records
+//! them) is a known follow-up. Widening this from the rewards counter to the whole accumulator
+//! extends the same accepted limitation to the gas and fee data.
 
 use super::{TNBlockAssembler, TNBlockExecutionCtx, TNBlockExecutorFactory, TNEvmFactory};
 use crate::{error::TnRethError, payload::TNPayload, TNPrimitives};
@@ -34,7 +40,7 @@ use reth_revm::{
 };
 use std::sync::Arc;
 use tn_types::{
-    gas_accumulator::RewardsCounter, BlockHeader as _, SealedBlock, SealedHeader, B256, U256,
+    gas_accumulator::GasAccumulator, BlockHeader as _, SealedBlock, SealedHeader, B256, U256,
 };
 
 /// TN-related EVM configuration.
@@ -44,13 +50,17 @@ pub struct TnEvmConfig {
     pub executor_factory: TNBlockExecutorFactory<RethReceiptBuilder, Arc<ChainSpec>, TNEvmFactory>,
     /// Ethereum block assembler.
     pub block_assembler: TNBlockAssembler<ChainSpec>,
-    /// Counter used to allocate rewards for block leaders.
-    pub rewards_counter: RewardsCounter,
+    /// Live shared accumulator for the current epoch: per-worker gas totals, current base fees,
+    /// worker count, and the leader counts used to allocate block rewards.
+    ///
+    /// Cloned into every block's execution context. Execution reads only the rewards counter
+    /// today — the gas and fee data is carried so the epoch-closing block executor can reach it.
+    pub gas_accumulator: GasAccumulator,
 }
 
 impl TnEvmConfig {
     /// Creates a new TN EVM configuration with the given chain spec.
-    pub fn new(chain_spec: Arc<ChainSpec>, rewards_counter: RewardsCounter) -> Self {
+    pub fn new(chain_spec: Arc<ChainSpec>, gas_accumulator: GasAccumulator) -> Self {
         Self {
             block_assembler: TNBlockAssembler::new(chain_spec.clone()),
             executor_factory: TNBlockExecutorFactory::new(
@@ -58,7 +68,7 @@ impl TnEvmConfig {
                 chain_spec,
                 TNEvmFactory::default(),
             ),
-            rewards_counter,
+            gas_accumulator,
         }
     }
 
@@ -195,7 +205,7 @@ impl ConfigureEvm for TnEvmConfig {
             ommers_hash: block.ommers_hash,
             close_epoch,
             difficulty: block.difficulty,
-            rewards_counter: self.rewards_counter.clone(),
+            gas_accumulator: self.gas_accumulator.clone(),
             // the header carries no slash list: a replayed block cannot reproduce a
             // test-injected slash (and does not need to — production lists are always empty)
             #[cfg(test)]
@@ -215,7 +225,7 @@ impl ConfigureEvm for TnEvmConfig {
             ommers_hash: payload.batch_digest,
             close_epoch: payload.close_epoch,
             difficulty: U256::from(payload.batch_index << 16 | payload.worker_id as usize),
-            rewards_counter: self.rewards_counter.clone(),
+            gas_accumulator: self.gas_accumulator.clone(),
             #[cfg(test)]
             epoch_boundary_slashes: payload.epoch_boundary_slashes,
         })
@@ -232,7 +242,7 @@ mod tests {
     #[test]
     fn test_context_for_block_extra_data_lengths() {
         let chain: ChainSpec = tn_types::test_genesis().into();
-        let config = TnEvmConfig::new(Arc::new(chain), RewardsCounter::default());
+        let config = TnEvmConfig::new(Arc::new(chain), GasAccumulator::default());
         let block_with_extra = |extra_data: Bytes| {
             SealedBlock::seal_slow(Block {
                 header: ExecHeader { extra_data, ..Default::default() },

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -27,6 +27,13 @@
 //! distributed. Reconstructing the historical counts from `block.body.withdrawals` (which records
 //! them) is a known follow-up. Widening this from the rewards counter to the whole accumulator
 //! extends the same accepted limitation to the gas and fee data.
+//!
+//! Callers that construct a `RethEnv` with a defaulted accumulator (e.g. the snapshot machinery,
+//! `new_for_temp_chain`) must never drive block EXECUTION through it. The accumulator now backs
+//! an EVM state write — `record_next_epoch_base_fees`' `setWorkerConfigsData` — so re-executing
+//! an epoch-closing block there would price every EIP-1559 worker from one empty slot (zero gas,
+//! `MIN_PROTOCOL_BASE_FEE`) and produce a divergent state root, not merely degraded reward
+//! accounting.
 
 use super::{TNBlockAssembler, TNBlockExecutionCtx, TNBlockExecutorFactory, TNEvmFactory};
 use crate::{error::TnRethError, payload::TNPayload, TNPrimitives};

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -90,7 +90,7 @@ use tn_storage::exec_state_pack::{
     ExecStateStats, StateEntry,
 };
 use tn_types::{
-    gas_accumulator::{RewardsCounter, WorkerFeeConfig},
+    gas_accumulator::{GasAccumulator, WorkerFeeConfig},
     Address, BlockBody, BlockNumHash, Bytes, Epoch, ExecHeader, GenesisAccount, SealedBlock,
     SealedHeader, TaskManager, WorkerId, B256, U256,
 };
@@ -348,7 +348,7 @@ impl SnapshotRestorer {
         task_manager: &TaskManager,
     ) -> eyre::Result<Self> {
         let reth_env =
-            RethEnv::new(reth_config, task_manager, db, None, RewardsCounter::default())?;
+            RethEnv::new(reth_config, task_manager, db, None, GasAccumulator::default())?;
 
         // a fresh or genesis-only datadir sits at block 0; any higher tip means the datadir
         // already holds chain data that restore must not clobber.
@@ -1008,7 +1008,7 @@ mod tests {
     use tempfile::TempDir;
     use tn_storage::exec_state_pack::{ExecStateAccount, ExecStatePackReader, ExecStatePackWriter};
     use tn_types::{
-        gas_accumulator::RewardsCounter, keccak256, test_genesis, Address, BlockNumHash, Bytes,
+        gas_accumulator::GasAccumulator, keccak256, test_genesis, Address, BlockNumHash, Bytes,
         ExecHeader, GenesisAccount, SealedHeader, TaskManager, B256, U256,
     };
 
@@ -1333,7 +1333,7 @@ mod tests {
         restorer.finish(final_state)?;
 
         // read the restored state back through a fresh env over the destination datadir
-        let reader = RethEnv::new(&reth_config, &dst_tm, db, None, RewardsCounter::default())?;
+        let reader = RethEnv::new(&reth_config, &dst_tm, db, None, GasAccumulator::default())?;
         assert_eq!(reader.last_block_number()?, b);
         assert_eq!(
             reader.sealed_header_by_number(b)?.expect("tip header").hash(),
@@ -1417,7 +1417,7 @@ mod tests {
         assert_eq!(root, root_without_s);
         restorer.finish(final_state)?;
 
-        let reader = RethEnv::new(&reth_config, &dst_tm, db, None, RewardsCounter::default())?;
+        let reader = RethEnv::new(&reth_config, &dst_tm, db, None, GasAccumulator::default())?;
         let state = reader.latest()?;
         assert!(
             state.storage(contract, slot_s)?.unwrap_or_default().is_zero(),
@@ -1863,7 +1863,7 @@ mod tests {
         // open a fresh env over the restored datadir for both the table-level assertions and the
         // state readback
         let reader =
-            RethEnv::new(&dst_config, &dst_tm, dst_db.clone(), None, RewardsCounter::default())?;
+            RethEnv::new(&dst_config, &dst_tm, dst_db.clone(), None, GasAccumulator::default())?;
 
         // change sets at block B MUST be empty: the skip is what lets storage stream per chunk.
         // genesis (block 0) legitimately keeps its own change sets (init_genesis wrote them and the

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -9,7 +9,10 @@
 //!   closing block: `applyIncentives`, then `applySlashes`, then `concludeEpoch`.
 //! - `LegacyConsensusRegistry` — the pre-fork registry's epoch-close surface, frozen so pre-fork
 //!   epoch closes replay byte-identically (see the code-hash gate in `evm/block.rs`).
-//! - `WorkerConfigs` — per-worker base-fee strategy used for base fee adjustment.
+//! - `WorkerConfigs` — per-worker base-fee strategy used for base fee adjustment, plus the
+//!   `setWorkerConfigsData` mutator the epoch-closing block invokes to record each EIP-1559
+//!   worker's next-epoch base fee. Its `getAllWorkerConfigs` return is decoded in exactly one
+//!   place, [`decode_worker_fee_configs`], shared by the pinned read path and the closing block.
 //!
 //! Two pinned addresses live here: `SYSTEM_ADDRESS` (0xfff...fffe), the reserved caller the EVM
 //! uses for system transactions (the custom handler exempts it from fee/beneficiary
@@ -19,7 +22,10 @@
 //! assume validators can currently be slashed in-protocol.
 
 use alloy::{primitives::address, sol};
-use tn_types::{Address, Epoch};
+use tn_types::{
+    gas_accumulator::{WorkerConfigEntry, WorkerFeeConfig},
+    Address, Epoch,
+};
 
 /// The system address.
 pub(super) const SYSTEM_ADDRESS: Address = address!("fffffffffffffffffffffffffffffffffffffffe");
@@ -340,6 +346,74 @@ pub struct EpochState {
     /// This time plus the `EpochInfo::epochDuration` creates the timestamp for the next epoch
     /// boundary.
     pub epoch_start: u64,
+}
+
+/// Decode a `getAllWorkerConfigs()` return payload into the on-chain worker count and one
+/// [`WorkerConfigEntry`] per worker.
+///
+/// The single decode seam for the `WorkerConfigs` table: the pinned read path
+/// (`RethEnv::worker_fee_configs_inner`) and the epoch-closing block's base-fee recording both
+/// route through here, so the strategy mapping and the arity check cannot drift between the node
+/// that reads a worker's fee strategy and the block that prices its next-epoch fee.
+///
+/// Errors are returned as strings for the caller to classify: every failure here is a
+/// deterministic product of the return payload (identical on every node reading the same block),
+/// so callers map them into their chain-global error variant.
+///
+/// Fail-open on unknown strategy ids: a strategy this node does not recognize (only possible when
+/// a future contract version introduces one before this node is upgraded) is NOT an error — it
+/// falls back to [`WorkerFeeConfig::Eip1559`] with a warning, preserving liveness instead of
+/// halting all validators on the unrecognized id. The fallback is deterministic, so every node on
+/// this build lands on the same config.
+pub(crate) fn decode_worker_fee_configs(
+    bytes: &[u8],
+) -> Result<(u16, Vec<WorkerConfigEntry>), String> {
+    let ret =
+        <WorkerConfigs::getAllWorkerConfigsCall as alloy::sol_types::SolCall>::abi_decode_returns(
+            bytes,
+        )
+        .map_err(|e| {
+            format!("worker configs return decode failed (contract absent at this block?): {e}")
+        })?;
+
+    let num_workers = ret.count as usize;
+    if ret.strategies.len() != num_workers
+        || ret.values.len() != num_workers
+        || ret.datas.len() != num_workers
+    {
+        return Err(format!(
+            "worker config arity mismatch: count={num_workers}, strategies={}, values={}, datas={}",
+            ret.strategies.len(),
+            ret.values.len(),
+            ret.datas.len(),
+        ));
+    }
+
+    let mut entries = Vec::with_capacity(num_workers);
+    for (worker_id, ((&strategy, &value), &data)) in
+        ret.strategies.iter().zip(ret.values.iter()).zip(ret.datas.iter()).enumerate()
+    {
+        let config = match strategy {
+            0 => WorkerFeeConfig::Eip1559 { target_gas: value },
+            1 => WorkerFeeConfig::Static { fee: value },
+            s => {
+                // The contract rejects unknown strategies, so this branch only fires when a
+                // future contract version introduces a strategy this node hasn't been
+                // updated to understand. Fall back to EIP-1559 to preserve liveness instead
+                // of halting all validators.
+                tracing::warn!(
+                    target: "tn::reth",
+                    worker_id,
+                    strategy = s,
+                    "unknown fee strategy; falling back to strategy 0 (Eip1559)"
+                );
+                WorkerFeeConfig::Eip1559 { target_gas: value }
+            }
+        };
+        entries.push(WorkerConfigEntry { config, data });
+    }
+
+    Ok((ret.count, entries))
 }
 
 #[cfg(test)]

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -295,7 +295,9 @@ sol!(
         /// updated.
         function setWorkerConfigsValue(uint16[] calldata workerIds, uint64[] calldata values) external;
         /// Raise the highest strategy id the contract accepts. Owner only and strictly
-        /// increasing, in lockstep with the protocol release that ships the new strategy.
+        /// increasing, in lockstep with the protocol release that ships the new strategy —
+        /// and only after every validator is confirmed running it (see
+        /// [`decode_worker_fee_configs`] for why a mixed fleet diverges).
         function setMaxStrategy(uint8 newMaxStrategy) external;
         /// The highest strategy id the contract currently accepts.
         function MAX_STRATEGY() external view returns (uint8);
@@ -363,8 +365,19 @@ pub struct EpochState {
 /// Fail-open on unknown strategy ids: a strategy this node does not recognize (only possible when
 /// a future contract version introduces one before this node is upgraded) is NOT an error — it
 /// falls back to [`WorkerFeeConfig::Eip1559`] with a warning, preserving liveness instead of
-/// halting all validators on the unrecognized id. The fallback is deterministic, so every node on
-/// this build lands on the same config.
+/// halting all validators on the unrecognized id.
+///
+/// The fallback is deterministic per BUILD, not across builds — and this seam feeds a state
+/// WRITE, not just the read path: the closing block's `setWorkerConfigsData` takes both its
+/// membership (an unknown id maps to `Eip1559` and is therefore written; `Static` rows are
+/// skipped) and its `data` values from these entries, so two builds that disagree about a
+/// strategy id produce different closing-block state roots — and that block's hash is the
+/// quorum-signed `EpochRecord::final_state`. LOCKSTEP FLEET-UPGRADE REQUIREMENT (same discipline
+/// as `SYSTEM_CALL_GAS_LIMIT` in `evm/mod.rs` and the fork rollout in `tn_types::forks`): every
+/// validator must be confirmed running the release that ships a new strategy id BEFORE governance
+/// sends `setMaxStrategy(N)` and assigns it. A uniform old-build fleet does not split, but is not
+/// benign either — every node identically reinterprets the row's `value` as a 1559 `target_gas`
+/// and writes a silently wrong fee into consensus state.
 pub(crate) fn decode_worker_fee_configs(
     bytes: &[u8],
 ) -> Result<(u16, Vec<WorkerConfigEntry>), String> {
@@ -419,7 +432,10 @@ pub(crate) fn decode_worker_fee_configs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{primitives::keccak256, sol_types::SolCall};
+    use alloy::{
+        primitives::{aliases::U184, keccak256},
+        sol_types::SolCall,
+    };
 
     /// The hand-written `delegationDigest` binding must track the on-chain 4-argument selector. If
     /// the contract selector changes and this binding does not, `tn_delegationDigest` reverts
@@ -429,5 +445,36 @@ mod tests {
         let expected: [u8; 4] =
             keccak256("delegationDigest(bytes,address,address,uint256)")[..4].try_into().unwrap();
         assert_eq!(ConsensusRegistry::delegationDigestCall::SELECTOR, expected);
+    }
+
+    /// An unknown strategy id must decode fail-open to `Eip1559` (deterministic per build), never
+    /// `Err`: this seam feeds both the entry-time config read and the closing block's
+    /// `setWorkerConfigsData` write set, so erroring here would halt every validator the moment a
+    /// newer contract version introduces a strategy id this build predates. Pins the fallback arm
+    /// (previously untested) alongside a known-strategy row to prove the mapping is per-row.
+    #[test]
+    fn unknown_strategy_decodes_fail_open_to_eip1559() {
+        use tn_types::gas_accumulator::WorkerFeeConfig;
+
+        let encoded = WorkerConfigs::getAllWorkerConfigsCall::abi_encode_returns(
+            &WorkerConfigs::getAllWorkerConfigsReturn {
+                count: 2,
+                strategies: vec![2, 1],
+                values: vec![777, 42],
+                datas: vec![U184::from(5u64), U184::ZERO],
+            },
+        );
+
+        let (count, entries) =
+            decode_worker_fee_configs(&encoded).expect("unknown strategy is fail-open, not Err");
+        assert_eq!(count, 2);
+        assert_eq!(
+            entries[0].config,
+            WorkerFeeConfig::Eip1559 { target_gas: 777 },
+            "unknown id 2 must fall back to Eip1559 over the row's value"
+        );
+        assert_eq!(entries[0].data, U184::from(5u64), "the row's data word rides along");
+        assert_eq!(entries[1].config, WorkerFeeConfig::Static { fee: 42 });
+        assert_eq!(entries[1].data, U184::ZERO);
     }
 }

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -63,7 +63,7 @@ use std::{
 use tn_config::NodeInfo;
 use tn_types::{
     address, calculate_transaction_root,
-    gas_accumulator::{RewardsCounter, WorkerFeeConfig},
+    gas_accumulator::{GasAccumulator, WorkerFeeConfig},
     generate_proof_of_possession_bls_for_test, keccak256, now, test_chain_spec_arc, test_genesis,
     AccessList, Address, Batch, BlobTransactionSidecar, Block, BlockBody, BlockHash, BlsKeypair,
     BlsPublicKey, BlsSignature, Bytes, Certificate, CommittedSubDag, Committee, CommitteeBuilder,
@@ -90,7 +90,7 @@ impl RethEnv {
     pub fn new_for_test<P: AsRef<Path>>(
         db_path: P,
         task_manager: &TaskManager,
-        rewards: Option<RewardsCounter>,
+        rewards: Option<GasAccumulator>,
     ) -> eyre::Result<Self> {
         Self::new_for_temp_chain(test_chain_spec_arc(), db_path, task_manager, rewards)
     }

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -7,7 +7,8 @@
 //! - `RethEnv` test constructors and read helpers: `new_for_test`, `state_by_block_hash`, `tn_evm`,
 //!   `execution_outcome_for_tests`, and `ConsensusRegistry` reads (`get_validator_rewards`,
 //!   `get_bls_pubkey`, `get_validator_info`, `validators_for_epoch_at_block`,
-//!   `get_worker_fee_configs`).
+//!   `get_worker_fee_configs`), plus the pinned `WorkerConfigs` table read
+//!   [`read_worker_config_entries_at`].
 //! - Batch fixtures: `transaction`, `batch`, `batches`, `fixture_batch_with_transactions`,
 //!   `batch_with_transactions`.
 //! - Genesis builders: `seeded_genesis_from_random_batch(es)`, and the
@@ -26,8 +27,11 @@ use crate::{
     evm::TNEvm,
     payload::TNPayload,
     recover_raw_transaction,
-    system_calls::{ConsensusRegistry, EpochState, CONSENSUS_REGISTRY_ADDRESS},
-    ExecutedBlock, NewCanonicalChain, RethEnv, WorkerTxPool,
+    system_calls::{
+        decode_worker_fee_configs, ConsensusRegistry, EpochState, WorkerConfigs,
+        CONSENSUS_REGISTRY_ADDRESS,
+    },
+    ExecutedBlock, NewCanonicalChain, RethEnv, WorkerTxPool, SYSTEM_ADDRESS,
 };
 use alloy::{
     consensus::{SignableTransaction as _, TxEip4844, TxEip4844Variant, TxLegacy},
@@ -41,14 +45,16 @@ use alloy::{
     sol_types::SolCall as _,
 };
 use reth_chainspec::{ChainSpec as RethChainSpec, EthChainSpec};
-use reth_evm::{execute::Executor as _, ConfigureEvm, EvmFactory as _};
+use reth_evm::{execute::Executor as _, ConfigureEvm, Evm as _, EvmFactory as _};
 use reth_primitives::sign_message;
 use reth_primitives_traits::SignerRecoverable;
 use reth_provider::{
     CanonChainTracker as _, ChainStateBlockWriter as _, DBProvider as _,
     DatabaseProviderFactory as _, StateProviderBox, StateProviderFactory,
 };
-use reth_revm::{database::StateProviderDatabase, db::BundleState, State};
+use reth_revm::{
+    context::result::ExecutionResult, database::StateProviderDatabase, db::BundleState, State,
+};
 use reth_transaction_pool::{EthPoolTransaction, EthPooledTransaction, PoolTransaction};
 use secp256k1::{
     rand::{rngs::StdRng, Rng, SeedableRng as _},
@@ -60,10 +66,10 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-use tn_config::NodeInfo;
+use tn_config::{NodeInfo, WORKER_CONFIGS_ADDRESS};
 use tn_types::{
     address, calculate_transaction_root,
-    gas_accumulator::{GasAccumulator, WorkerFeeConfig},
+    gas_accumulator::{GasAccumulator, WorkerConfigEntry, WorkerFeeConfig},
     generate_proof_of_possession_bls_for_test, keccak256, now, test_chain_spec_arc, test_genesis,
     AccessList, Address, Batch, BlobTransactionSidecar, Block, BlockBody, BlockHash, BlsKeypair,
     BlsPublicKey, BlsSignature, Bytes, Certificate, CommittedSubDag, Committee, CommitteeBuilder,
@@ -814,6 +820,28 @@ pub fn plant_finalized_marker(reth_env: &RethEnv, header: SealedHeader) -> eyre:
     reth_env.blockchain_provider().set_finalized(header.clone());
     reth_env.blockchain_provider().set_safe(header);
     Ok(())
+}
+
+/// Execute `getAllWorkerConfigs()` against the state of `block` and decode the raw return bytes
+/// through the production seam (`decode_worker_fee_configs`) — the exact decode the closing
+/// block's `record_next_epoch_base_fees` uses — returning the on-chain worker count and one
+/// [`WorkerConfigEntry`] per worker (fee strategy plus the raw `data` word).
+///
+/// Cross-crate epoch-close tests use this to read the next-epoch base fee a closing block
+/// recorded in an EIP-1559 worker's `data` word, pinned at that block's state and observed
+/// through the same system-call + decode path that produced the write.
+pub fn read_worker_config_entries_at(
+    env: &RethEnv,
+    block: B256,
+) -> eyre::Result<(u16, Vec<WorkerConfigEntry>)> {
+    let mut tn_evm = env.tn_evm(block)?;
+    let calldata = WorkerConfigs::getAllWorkerConfigsCall {}.abi_encode().into();
+    let res = tn_evm.transact_system_call(SYSTEM_ADDRESS, WORKER_CONFIGS_ADDRESS, calldata)?;
+    let data = match res.result {
+        ExecutionResult::Success { output, .. } => output.into_data(),
+        other => eyre::bail!("getAllWorkerConfigs failed at pinned block {block}: {other:?}"),
+    };
+    decode_worker_fee_configs(&data).map_err(|e| eyre::eyre!(e))
 }
 
 /// Build a test genesis whose `ConsensusRegistry` is freshly deployed from the current artifact

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -92,6 +92,14 @@ pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
 ///   pre-fork code, with pin tests against the embedded `ConsensusRegistry.json` and
 ///   `WorkerConfigs.json` artifacts: after the fork runs live, a tn-contracts artifact bump would
 ///   otherwise change the bytes re-execution swaps in and break historical state roots;
+/// - read the LIVE deployed `WorkerConfigs` and confirm `numWorkers()` and, for every `i <
+///   numWorkers`, `_workerConfigSet[i] == true` (a storage probe — the mapping is internal): the
+///   first post-fork closing block's `setWorkerConfigsData` system call reverts
+///   `MissingWorkerConfig` on any unset row, aborting the one-shot fork-boundary close. Do this
+///   alongside the post-fork hash re-pinning above, since an artifact rebuild silently moves those
+///   hashes. Informational reference only, NOT a compiled constant: at the time of writing, the
+///   embedded artifact's post-fork `WorkerConfigs` splice hashes to
+///   `0x58304c00bbfaa7e348220efb95843614756207311245abc4949f91bb3ddb2ff7`;
 /// - the `WorkerConfigs` bytecode swap ships at this same fork epoch (see
 ///   [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`]) — both swaps land in the epoch-closing block of
 ///   `CONSENSUS_REGISTRY_FORK_EPOCH - 1`, so a build applying one but not the other diverges;

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -23,6 +23,24 @@ use alloy::primitives::{b256, B256};
 pub const CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH: B256 =
     b256!("0x5318ebc5cd8123cfb0808fac0f3c0b95ed6f45f67c0853fea0766b52035fea53");
 
+/// Keccak-256 hash of the pre-fork `WorkerConfigs` runtime bytecode deployed on the live adiri
+/// testnet (the worker-configs account's `code` in the committed
+/// `chain-configs/testnet/genesis.yaml`).
+///
+/// The live deployment is an old, pre-#161 tn-contracts build: its `WorkerConfig.data` field is a
+/// `uint128`, and it exposes none of the `setWorkerConfigsData`, `setWorkerConfigsValue`, or
+/// `setMaxStrategy` selectors the current artifact defines. The protocol therefore has no way to
+/// write worker fee state back to the deployed contract, which is why the fork splices the current
+/// artifact's runtime code over it at [`CONSENSUS_REGISTRY_FORK_EPOCH`], alongside the registry
+/// swap.
+///
+/// That splice is gated fail-closed on this hash: if the on-chain `WorkerConfigs` code hashes to
+/// anything else, the block aborts rather than upgrading over an unknown storage layout.
+///
+/// Unconditional (not `adiri`-gated) so the pin test guarding it runs in default-feature CI.
+pub const WORKER_CONFIGS_PRE_FORK_CODE_HASH: B256 =
+    b256!("0x5e8a93f4eb1b5d645f32e5b8615463a996aaf4d8af2a90a444378a2d4b4b3bf2");
+
 #[cfg(feature = "adiri")]
 /// The epoch below which Adiri testnet may have had duplicate batches.
 pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
@@ -69,16 +87,27 @@ pub const ADIRI_DUP_BATCH_EPOCH: Epoch = 160;
 /// confirmed by the operator dry-run below, not promised here.
 ///
 /// Pre-deploy checklist for the epoch-setting PR:
-/// - pin the swapped-in (post-fork) runtime code hash the same way
-///   [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`] pins the pre-fork code, with a pin test against the
-///   embedded `ConsensusRegistry.json` artifact: after the fork runs live, a tn-contracts artifact
-///   bump would otherwise change the bytes re-execution swaps in and break historical state roots;
+/// - pin the swapped-in (post-fork) runtime code hashes of **both** contracts the same way
+///   [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`] and [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`] pin the
+///   pre-fork code, with pin tests against the embedded `ConsensusRegistry.json` and
+///   `WorkerConfigs.json` artifacts: after the fork runs live, a tn-contracts artifact bump would
+///   otherwise change the bytes re-execution swaps in and break historical state roots;
+/// - the `WorkerConfigs` bytecode swap ships at this same fork epoch (see
+///   [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`]) — both swaps land in the epoch-closing block of
+///   `CONSENSUS_REGISTRY_FORK_EPOCH - 1`, so a build applying one but not the other diverges;
 /// - confirm the live validator/ConsensusNFT count leaves headroom under the 100M system-call gas
 ///   cap that bounds the one-shot `migrateValidatorSets()` walk;
 /// - operator dry-run: resync a fork-build node against a live adiri archive across the fork
 ///   boundary and confirm matching state roots (also measures the live migration gas);
-/// - the swap fails closed on [`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`]: an unexpected on-chain
-///   deployment aborts the block (fatal error) rather than migrating over an incompatible layout.
+/// - both swaps fail closed on their pre-fork pin ([`CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH`],
+///   [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`]): an unexpected on-chain deployment aborts the block
+///   (fatal error) rather than migrating over an incompatible layout;
+/// - post-fork governance runbook: the `WorkerConfigs` swap replaces code only, so the appended
+///   `maxStrategy` slot (slot 4) stays `0` and every owner call assigning `Static` (strategy id 1)
+///   reverts `InvalidStrategy`. The owner must send one `setMaxStrategy(1)` transaction after the
+///   fork before any Static assignment. This is not urgent: neither the protocol write path
+///   (`setWorkerConfigsData` / `setWorkerConfigsValue`) nor the epoch-boundary read path consults
+///   `maxStrategy`, so a zeroed ceiling gates future governance actions only.
 pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 
 #[cfg(test)]
@@ -106,6 +135,31 @@ mod tests {
             keccak256(code),
             CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH,
             "CONSENSUS_REGISTRY_PRE_FORK_CODE_HASH mirrors the LIVE adiri deployment — do not \
+             blindly update this constant to make the test pass; if genesis.yaml was regenerated, \
+             reassess the fork plan and `CONSENSUS_REGISTRY_FORK_EPOCH` first",
+        );
+    }
+
+    /// Pin [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`] to the worker-configs code committed in
+    /// `chain-configs/testnet/genesis.yaml`.
+    ///
+    /// Unconditional (not `adiri`-gated) so it runs in default-feature CI even though the fork
+    /// machinery consuming the constant is `adiri`-only.
+    #[test]
+    fn test_pre_fork_worker_configs_code_hash_pinned() {
+        let genesis = crate::adiri_genesis();
+        // `tn-config::WORKER_CONFIGS_ADDRESS`, hardcoded because tn-config depends on tn-types
+        // and the reverse edge would be circular.
+        let worker_configs = address!("0xFee0FEe0fee0fEE0FEe0fee0FEE0fEe0feE0FEe0");
+        let code = genesis
+            .alloc
+            .get(&worker_configs)
+            .and_then(|account| account.code.as_ref())
+            .expect("testnet genesis must allocate WorkerConfigs runtime code");
+        assert_eq!(
+            keccak256(code),
+            WORKER_CONFIGS_PRE_FORK_CODE_HASH,
+            "WORKER_CONFIGS_PRE_FORK_CODE_HASH mirrors the LIVE adiri deployment — do not \
              blindly update this constant to make the test pass; if genesis.yaml was regenerated, \
              reassess the fork plan and `CONSENSUS_REGISTRY_FORK_EPOCH` first",
         );

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -116,11 +116,16 @@ pub fn is_worker_batch_block(header: &SealedHeader) -> bool {
 /// The contract documents `data` as reserved space for the protocol. As of the epoch-close
 /// base-fee snapshot it carries an [`WorkerFeeConfig::Eip1559`] worker's NEXT-epoch base fee,
 /// written by the closing block's `setWorkerConfigsData` system call, so a node entering an epoch
-/// can read the fee from one state slot instead of scanning the previous epoch's headers. A zero
-/// `data` means the word was never written — no epoch has closed since the worker was configured,
-/// or the worker is [`WorkerFeeConfig::Static`] and its fee already lives in the config's `value`.
-/// Zero is unambiguous for the workers that do get written, because a recorded fee is never below
-/// `MIN_PROTOCOL_BASE_FEE`.
+/// can read the fee from one state slot instead of scanning the previous epoch's headers.
+///
+/// `data` is authoritative ONLY for a row whose config reads [`WorkerFeeConfig::Eip1559`] at an
+/// epoch-closing block after the write path activated. A zero word means it was never written —
+/// no epoch has closed since the worker was configured, or the row is [`WorkerFeeConfig::Static`]
+/// and its fee already lives in the config's `value` (Static rows are never written). Non-zero
+/// does NOT imply current: a row governance switches Eip1559 -> Static keeps its last recorded
+/// word forever, and the owner setters can store an arbitrary `uint184`. Readers must gate on the
+/// row's strategy, never on `data` alone. Zero stays unambiguous for the rows that do get
+/// written, because a recorded fee is never below `MIN_PROTOCOL_BASE_FEE`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WorkerConfigEntry {
     /// The worker's fee strategy for the next epoch.
@@ -329,6 +334,11 @@ impl GasAccumulator {
     /// Increment the block count, gas used, and gas limit for `worker_id`.
     ///
     /// Blocks with zero `gas_used` are silently skipped to avoid inflating counts on restarts.
+    ///
+    /// The totals recorded here are consensus-critical: at epoch close the block executor reads
+    /// them to price next-epoch base fees and writes the result into EVM state
+    /// (`record_next_epoch_base_fees` in `tn-reth`), so a missed or double-counted block
+    /// diverges the closing block's hash across the fleet, not just a local fee.
     ///
     /// # Panics
     ///

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -54,7 +54,7 @@ use crate::{AuthorityIdentifier, Committee, SealedHeader, WorkerId, B256};
 
 /// Fee strategy for a worker, read from the WorkerConfigs contract each epoch.
 /// Adding a new strategy = new contract constant + new enum variant + match arm in
-/// adjust_base_fees.
+/// [`next_base_fee_for_config`] below.
 ///
 /// NOTE: these are mapped in `tn-reth/src/env/epoch.rs:worker_fee_configs_inner`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -453,6 +453,30 @@ pub fn compute_next_base_fee_eip1559(current_base_fee: u64, gas_used: u64, targe
     new_base_fee.max(MIN_PROTOCOL_BASE_FEE)
 }
 
+/// Apply a worker's [`WorkerFeeConfig`] to compute its next-epoch base fee.
+///
+/// `Eip1559 { target_gas }` nudges the fee toward the gas target via
+/// [`compute_next_base_fee_eip1559`] (floored at `MIN_PROTOCOL_BASE_FEE`); `Static { fee }` pins
+/// the fee to the governance-set value, ignoring gas usage.
+///
+/// This is the ONE fee formula, and it lives here so every seam that prices a worker's next-epoch
+/// fee dispatches through the same strategy match: `adjust_base_fees` (in `node::manager`) applies
+/// it at a live epoch close and `fold_next_epoch_base_fees` (also in `node::manager`) applies it
+/// when deriving the entered epoch's fees from the previous epoch's chain state, so both seams
+/// produce identical values from identical inputs.
+pub fn next_base_fee_for_config(
+    config: WorkerFeeConfig,
+    current_base_fee: u64,
+    gas_used: u64,
+) -> u64 {
+    match config {
+        WorkerFeeConfig::Eip1559 { target_gas } => {
+            compute_next_base_fee_eip1559(current_base_fee, gas_used, target_gas)
+        }
+        WorkerFeeConfig::Static { fee } => fee,
+    }
+}
+
 impl Default for GasAccumulator {
     fn default() -> Self {
         Self::new(1)
@@ -576,6 +600,49 @@ mod tests {
         assert_eq!(
             compute_next_base_fee_eip1559(MIN_PROTOCOL_BASE_FEE, 200, 100),
             MIN_PROTOCOL_BASE_FEE + 1
+        );
+    }
+
+    #[test]
+    fn eip1559_config_with_max_target_is_inert_at_min() {
+        // Genesis/default strategy: Eip1559 { target_gas: u64::MAX }. Against an unreachable target
+        // the fee can only ratchet down and floors at MIN, so a worker at MIN stays at MIN
+        // regardless of gas used -- the inert guarantee that keeps existing chains unchanged.
+        let cfg = WorkerFeeConfig::Eip1559 { target_gas: u64::MAX };
+        assert_eq!(
+            next_base_fee_for_config(cfg, MIN_PROTOCOL_BASE_FEE, 5_000_000),
+            MIN_PROTOCOL_BASE_FEE
+        );
+        // a non-MIN fee ratchets down (and never below MIN)
+        let down = next_base_fee_for_config(cfg, MIN_PROTOCOL_BASE_FEE * 1000, 0);
+        assert!((MIN_PROTOCOL_BASE_FEE..MIN_PROTOCOL_BASE_FEE * 1000).contains(&down));
+    }
+
+    #[test]
+    fn eip1559_config_moves_fee_with_gas_vs_target() {
+        let target = 1_000_000u64;
+        let current = 1_000_000u64;
+        let cfg = WorkerFeeConfig::Eip1559 { target_gas: target };
+        // gas above target -> fee increases; below -> decreases; at target -> unchanged.
+        assert!(next_base_fee_for_config(cfg, current, 2_000_000) > current);
+        assert!(next_base_fee_for_config(cfg, current, 0) < current);
+        assert_eq!(next_base_fee_for_config(cfg, current, target), current);
+    }
+
+    #[test]
+    fn static_config_pins_to_configured_fee() {
+        // Static ignores gas usage and the current fee, always returning the governance-set value.
+        assert_eq!(
+            next_base_fee_for_config(
+                WorkerFeeConfig::Static { fee: 12_345 },
+                MIN_PROTOCOL_BASE_FEE,
+                999_999
+            ),
+            12_345
+        );
+        assert_eq!(
+            next_base_fee_for_config(WorkerFeeConfig::Static { fee: 500 }, 1_000_000, 0),
+            500
         );
     }
 

--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -52,11 +52,26 @@
 
 use crate::{AuthorityIdentifier, Committee, SealedHeader, WorkerId, B256};
 
+use alloy::{
+    eips::eip1559::{calc_next_block_base_fee, BaseFeeParams, MIN_PROTOCOL_BASE_FEE},
+    primitives::{aliases::U184, Address},
+    rpc::types::{Withdrawal, Withdrawals},
+};
+use parking_lot::{Mutex, RwLock};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+use tracing::warn;
+
 /// Fee strategy for a worker, read from the WorkerConfigs contract each epoch.
 /// Adding a new strategy = new contract constant + new enum variant + match arm in
 /// [`next_base_fee_for_config`] below.
 ///
-/// NOTE: these are mapped in `tn-reth/src/env/epoch.rs:worker_fee_configs_inner`
+/// NOTE: these are mapped in `tn-reth/src/system_calls.rs:decode_worker_fee_configs`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkerFeeConfig {
     /// Adjust fee +/-12.5% per epoch based on gas utilization vs target.
@@ -95,20 +110,24 @@ pub fn is_worker_batch_block(header: &SealedHeader) -> bool {
     header.number != 0 && header.ommers_hash != B256::ZERO
 }
 
-use alloy::{
-    eips::eip1559::{calc_next_block_base_fee, BaseFeeParams, MIN_PROTOCOL_BASE_FEE},
-    primitives::Address,
-    rpc::types::{Withdrawal, Withdrawals},
-};
-use parking_lot::{Mutex, RwLock};
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
-use tracing::warn;
+/// One row of the on-chain `WorkerConfigs` table: a worker's fee strategy plus the raw `uint184`
+/// `data` word stored alongside it.
+///
+/// The contract documents `data` as reserved space for the protocol. As of the epoch-close
+/// base-fee snapshot it carries an [`WorkerFeeConfig::Eip1559`] worker's NEXT-epoch base fee,
+/// written by the closing block's `setWorkerConfigsData` system call, so a node entering an epoch
+/// can read the fee from one state slot instead of scanning the previous epoch's headers. A zero
+/// `data` means the word was never written — no epoch has closed since the worker was configured,
+/// or the worker is [`WorkerFeeConfig::Static`] and its fee already lives in the config's `value`.
+/// Zero is unambiguous for the workers that do get written, because a recorded fee is never below
+/// `MIN_PROTOCOL_BASE_FEE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerConfigEntry {
+    /// The worker's fee strategy for the next epoch.
+    pub config: WorkerFeeConfig,
+    /// The raw `uint184` word stored with the config.
+    pub data: U184,
+}
 
 /// Tracks how many blocks each leader committed during an epoch for reward distribution.
 ///


### PR DESCRIPTION
- Adds a fourth epoch-closing system call, `setWorkerConfigsData`, run after `applyIncentives` / `applySlashes` / `concludeEpoch` since it reads and writes no registry state. For every `Eip1559`-strategy worker it prices the next epoch from that epoch's final gas accumulator totals and stores the result in the row's `data` word; `Static` rows are left alone.
- Swaps the `WorkerConfigs` runtime bytecode at the same `CONSENSUS_REGISTRY_FORK_EPOCH` boundary as the existing registry swap — the live deployment predates the setter selectors and has an incompatible `uint128` `data` field. Gated fail-closed on `WORKER_CONFIGS_PRE_FORK_CODE_HASH`, mirroring the registry's pre-fork pin. Pre-fork closes keep replaying the legacy `applyIncentives` + `concludeEpoch` pair unchanged.
- Consolidates the fee-strategy formula into `next_base_fee_for_config` in `gas_accumulator.rs` so the new write path and the existing `adjust_base_fees` / `fold_next_epoch_base_fees` seams all derive from one function instead of duplicated match arms.
- Threads `GasAccumulator` through `RethEnv` into the block-execution context (replacing the narrower `RewardsCounter`) so the executor can reach gas totals and current fees, not just leader counts, at close.
- Distinguishes `Revert` (decoded reason + selector) from `Halt` in the shared system-call error path, so a reverted closing call is diagnosable from the error/log alone instead of a generic failure message.
- Test coverage: 3-way cross-layer equality pinning the write against `adjust_base_fees` and the entry-derivation formula, mutant-verified scoping of the own-gas fold to the closing worker, a pinned decode fallback for unknown strategy ids, and e2e coverage across basefee, epoch-boundary, and restart scenarios.

closes #1100 
blocked by #1072 