### PR TITLE
worker: enforce a batch transaction-type allowlist symmetrically across gateway, builder, and validator

### DIFF
--- a/bin/worker-gateway/src/proxy.rs
+++ b/bin/worker-gateway/src/proxy.rs
@@ -242,7 +242,9 @@ fn screen_raw_transaction(body: &[u8]) -> Option<(GatewayError, RequestId)> {
     let mut buf = raw.as_slice();
     match PooledTransaction::decode_2718(&mut buf) {
         Err(_) => Some((GatewayError::InvalidTransaction, id)),
-        Ok(tx) if tx.is_eip4844() => Some((GatewayError::UnsupportedTransactionType, id)),
+        Ok(tx) if !tn_types::batch_allowlisted_tx_type(&tx) => {
+            Some((GatewayError::UnsupportedTransactionType, id))
+        }
         Ok(_) => None,
     }
 }

--- a/crates/batch-builder/src/batch.rs
+++ b/crates/batch-builder/src/batch.rs
@@ -64,6 +64,7 @@ pub fn build_batch<P: TxPool>(
     let mut transactions = Vec::new();
     let mut mined_transactions = Vec::new();
     let mut blob_transactions = Vec::new();
+    let mut unsupported_transactions = Vec::new();
     let mut sender_nonces: HashMap<Address, u64> = HashMap::new();
 
     // begin loop through sorted "best" transactions in pending pool
@@ -85,11 +86,19 @@ pub fn build_batch<P: TxPool>(
         // NOTE: `ValidPoolTransaction::size()` is private
         let tx = pool_tx.to_consensus();
 
-        // ignore blob transactions EIP-4844
-        if tx.is_eip4844() {
-            best_txs.ignore_eip4844(&pool_tx);
-            debug!(target: "worker::batch_builder", ?pool_tx, "marking eip4844 tx invalid");
-            blob_transactions.push(*tx.hash());
+        // ignore any transaction type outside the executable allowlist (EIP-4844
+        // blobs and EIP-7702 today): the batch validator rejects such batches, so
+        // packing one would cost this node a peer penalty on every vote request
+        if !tn_types::batch_allowlisted_tx_type(&tx) {
+            if tx.is_eip4844() {
+                best_txs.ignore_eip4844(&pool_tx);
+                debug!(target: "worker::batch_builder", ?pool_tx, "marking eip4844 tx invalid");
+                blob_transactions.push(*tx.hash());
+            } else {
+                best_txs.ignore_eip7702(&pool_tx);
+                debug!(target: "worker::batch_builder", ?pool_tx, "marking non-allowlisted tx type invalid");
+                unsupported_transactions.push(*tx.hash());
+            }
             continue;
         }
 
@@ -124,6 +133,9 @@ pub fn build_batch<P: TxPool>(
 
     // remove any blob transactions that were submitted
     pool.remove_eip4844_txs(blob_transactions);
+
+    // remove any non-allowlisted transaction types that were submitted
+    pool.remove_unsupported_txs(unsupported_transactions);
 
     // construct changed_accounts for pool nonce updates
     //

--- a/crates/batch-builder/src/test_utils.rs
+++ b/crates/batch-builder/src/test_utils.rs
@@ -46,6 +46,11 @@ impl TxPool for TestPool {
         self.transactions.retain(|tx| !tx.is_eip4844());
         self.by_id.retain(|_, tx| !tx.is_eip4844());
     }
+    fn remove_unsupported_txs(&mut self, _txs: Vec<TxHash>) {
+        // remove non-allowlisted transaction types from the transactions vec and btreemap
+        self.transactions.retain(|tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
+        self.by_id.retain(|_, tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
+    }
 }
 
 impl TestPool {

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -3,8 +3,9 @@
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use tn_reth::{recover_raw_transaction, recover_signed_transaction, RethEnv, WorkerTxPool};
 use tn_types::{
-    max_batch_gas, max_batch_size, BatchValidation, BatchValidationError, BlockHash, Epoch,
-    SealedBatch, TransactionSigned, TransactionTrait as _, WorkerId,
+    batch_allowlisted_tx_type, max_batch_gas, max_batch_size, BatchValidation,
+    BatchValidationError, BlockHash, Epoch, SealedBatch, TransactionSigned, TransactionTrait as _,
+    Typed2718 as _, WorkerId,
 };
 
 /// Type convenience for implementing block validation errors.
@@ -69,8 +70,8 @@ impl BatchValidation for BatchValidator {
         // validate txs decode
         let decoded_txs = self.decode_transactions(transactions, digest)?;
 
-        // validate no txs are eip4844
-        self.validate_no_blob_txs(&decoded_txs)?;
+        // validate every tx type is on the executable allowlist
+        self.validate_tx_type_allowlist(&decoded_txs)?;
 
         // validate gas limit
         // Use the parent timestamp for consistency with the batch builder.
@@ -194,15 +195,26 @@ impl BatchValidator {
         }
     }
 
-    /// Validate the block's basefee
-    fn validate_no_blob_txs(
+    /// Validate every transaction's EIP-2718 type is on the executable allowlist.
+    ///
+    /// The protocol admits only legacy, EIP-2930, and EIP-1559 envelopes in batches,
+    /// uniformly across chain configurations; the batch builder and the worker gateway
+    /// enforce the same `batch_allowlisted_tx_type` predicate on the producing side.
+    /// EIP-4844 keeps its dedicated error for continuity with existing peer penalties;
+    /// any other decodable type (EIP-7702 today) maps to `UnsupportedTxType`. A type
+    /// byte outside the envelope's decodable set never reaches this check: it fails
+    /// transaction decode first and surfaces as `RecoverTransaction`.
+    fn validate_tx_type_allowlist(
         &self,
         transactions: &[TransactionSigned],
     ) -> BatchValidationResult<()> {
-        if let Some(blob_tx) = transactions.iter().find(|tx| tx.is_eip4844()) {
-            return Err(BatchValidationError::InvalidTx4844(*blob_tx.hash()));
-        }
-        Ok(())
+        transactions.iter().find(|tx| !batch_allowlisted_tx_type(*tx)).map_or(Ok(()), |tx| {
+            if tx.is_eip4844() {
+                Err(BatchValidationError::InvalidTx4844(*tx.hash()))
+            } else {
+                Err(BatchValidationError::UnsupportedTxType { tx_type: tx.ty(), hash: *tx.hash() })
+            }
+        })
     }
 
     /// Helper function for decoding and recovering transactions.
@@ -664,6 +676,58 @@ mod tests {
             validator.validate_batch(batch.clone().seal_slow()),
             Err(BatchValidationError::InvalidTx4844(_))
         );
+    }
+
+    #[tokio::test]
+    async fn test_invalid_tx_eip7702() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let TestTools { valid_batch, validator, .. } =
+            test_tools(tmp_dir.path(), &task_manager).await;
+        let (mut batch, _) = valid_batch.split();
+
+        // eip7702 set-code transaction carrying a signed authorization, so the
+        // only invalid thing about the envelope is its type byte
+        let mut tx_factory = TransactionFactory::new_random();
+        let signed_tx =
+            tx_factory.create_eip7702(validator.reth_env.chainspec().chain_id(), None, 7);
+
+        // test batch with eip7702 tx
+        batch.transactions = vec![signed_tx.encoded_2718()];
+
+        assert_matches!(
+            validator.validate_batch(batch.clone().seal_slow()),
+            Err(BatchValidationError::UnsupportedTxType { tx_type: 4, hash: _ })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_valid_batch_legacy_and_eip2930() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let TestTools { valid_batch, validator, .. } =
+            test_tools(tmp_dir.path(), &task_manager).await;
+        let (mut batch, _) = valid_batch.split();
+
+        // positive control for the admit direction of the allowlist: the valid
+        // fixture already proves EIP-1559, so cover legacy and EIP-2930
+        let mut tx_factory = TransactionFactory::new_random();
+        let chain_id = validator.reth_env.chainspec().chain_id();
+        let legacy_tx = tx_factory
+            .create_explicit_legacy_tx(
+                Some(chain_id),
+                None,
+                None,
+                None,
+                Some(Address::ZERO),
+                None,
+                None,
+            )
+            .encoded_2718();
+        let eip2930_tx = tx_factory.create_eip2930(chain_id, None, 7, Address::ZERO).encoded_2718();
+        batch.transactions = vec![legacy_tx, eip2930_tx];
+
+        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
     }
 
     /// Compute the committee slot a sender address would be routed to.

--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -86,7 +86,8 @@ impl WorkerNetworkError {
                     BatchValidationError::CanonicalChain { .. } => Some(Penalty::Mild),
                     // medium
                     BatchValidationError::InvalidEpoch { .. }
-                    | BatchValidationError::InvalidTx4844(_) => Some(Penalty::Medium),
+                    | BatchValidationError::InvalidTx4844(_)
+                    | BatchValidationError::UnsupportedTxType { .. } => Some(Penalty::Medium),
                     // severe
                     BatchValidationError::RecoverTransaction(_, _) => Some(Penalty::Severe),
                     // fatal

--- a/crates/network-libp2p/src/peers/penalty.md
+++ b/crates/network-libp2p/src/peers/penalty.md
@@ -96,39 +96,40 @@ ban itself was applied elsewhere.
 
 ### 4.2 `WorkerNetworkError::penalty()` mapping
 
-Source: `crates/consensus/worker/src/network/error.rs:76-138`.
+Source: `crates/consensus/worker/src/network/error.rs:76-139`.
 
 | Error variant                                                                       | Severity | Source                                                 |
 | ----------------------------------------------------------------------------------- | -------- | ------------------------------------------------------ |
 | `BatchValidation(CanonicalChain { .. })`                                            | `Mild`   | `crates/consensus/worker/src/network/error.rs:86`      |
-| `BatchValidation(InvalidEpoch { .. })`                                              | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`   |
-| `BatchValidation(InvalidTx4844(_))`                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:88-89`   |
-| `BatchValidation(RecoverTransaction(..))`                                           | `Severe` | `crates/consensus/worker/src/network/error.rs:91`      |
-| `BatchValidation(EmptyBatch)`                                                       | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(InvalidBaseFee { .. })`                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(InvalidWorkerId { .. })`                                           | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(InvalidDigest)`                                                    | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(GasOverflow)`                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(CalculateMaxPossibleGas)`                                          | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(HeaderMaxGasExceedsGasLimit { .. })`                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `BatchValidation(HeaderTransactionBytesExceedsMax(_))`                              | `Fatal`  | `crates/consensus/worker/src/network/error.rs:93-101`  |
-| `InvalidRequest(_)`                                                                 | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106` |
-| `UnknownStreamRequest(_)`                                                           | `Mild`   | `crates/consensus/worker/src/network/error.rs:105-106` |
-| `StdIo(io_err)` kind `ConnectionReset`/`ConnectionAborted`/`TimedOut`/`Interrupted` | `Mild`   | `crates/consensus/worker/src/network/error.rs:108-114` |
-| `StdIo(io_err)` other kinds                                                         | `Medium` | `crates/consensus/worker/src/network/error.rs:115`     |
-| `NonCommitteeBatch`                                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:119`     |
-| `InvalidTopic`                                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `Bcs(_)`                                                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `TooManyBatches { .. }`                                                             | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `UnexpectedBatch(_)`                                                                | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `DuplicateBatch(_)`                                                                 | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `RequestHashMismatch`                                                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:121-126` |
-| `Timeout(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
-| `DBInsert(_)` / `DBCommit(_)` / `DBRead(_)`                                         | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
-| `StreamClosed`                                                                      | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
-| `Network(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
-| `BatchEpochMismatch(_, _)`                                                          | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
-| `Internal(_)`                                                                       | None     | `crates/consensus/worker/src/network/error.rs:128-135` |
+| `BatchValidation(InvalidEpoch { .. })`                                              | `Medium` | `crates/consensus/worker/src/network/error.rs:88-90`   |
+| `BatchValidation(InvalidTx4844(_))`                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:88-90`   |
+| `BatchValidation(UnsupportedTxType { .. })`                                         | `Medium` | `crates/consensus/worker/src/network/error.rs:88-90`   |
+| `BatchValidation(RecoverTransaction(..))`                                           | `Severe` | `crates/consensus/worker/src/network/error.rs:92`      |
+| `BatchValidation(EmptyBatch)`                                                       | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(InvalidBaseFee { .. })`                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(InvalidWorkerId { .. })`                                           | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(InvalidDigest)`                                                    | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(GasOverflow)`                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(CalculateMaxPossibleGas)`                                          | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(HeaderMaxGasExceedsGasLimit { .. })`                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `BatchValidation(HeaderTransactionBytesExceedsMax(_))`                              | `Fatal`  | `crates/consensus/worker/src/network/error.rs:94-102`  |
+| `InvalidRequest(_)`                                                                 | `Mild`   | `crates/consensus/worker/src/network/error.rs:106-107` |
+| `UnknownStreamRequest(_)`                                                           | `Mild`   | `crates/consensus/worker/src/network/error.rs:106-107` |
+| `StdIo(io_err)` kind `ConnectionReset`/`ConnectionAborted`/`TimedOut`/`Interrupted` | `Mild`   | `crates/consensus/worker/src/network/error.rs:109-115` |
+| `StdIo(io_err)` other kinds                                                         | `Medium` | `crates/consensus/worker/src/network/error.rs:116`     |
+| `NonCommitteeBatch`                                                                 | `Medium` | `crates/consensus/worker/src/network/error.rs:120`     |
+| `InvalidTopic`                                                                      | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `Bcs(_)`                                                                            | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `TooManyBatches { .. }`                                                             | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `UnexpectedBatch(_)`                                                                | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `DuplicateBatch(_)`                                                                 | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `RequestHashMismatch`                                                               | `Fatal`  | `crates/consensus/worker/src/network/error.rs:122-127` |
+| `Timeout(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
+| `DBInsert(_)` / `DBCommit(_)` / `DBRead(_)`                                         | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
+| `StreamClosed`                                                                      | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
+| `Network(_)`                                                                        | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
+| `BatchEpochMismatch(_, _)`                                                          | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
+| `Internal(_)`                                                                       | None     | `crates/consensus/worker/src/network/error.rs:129-136` |
 
 ## 5. Penalty Application Sites — Primary Layer
 
@@ -240,7 +241,7 @@ These are deliberate tolerances for benign failures. Changing any of these from
 
 - `InboundFailure::ResponseOmission` — local error, no peer fault. `crates/network-libp2p/src/consensus.rs:981`.
 - PX-disconnect outbound failures — `pending_px_disconnects` short-circuit before penalty. `crates/network-libp2p/src/consensus.rs:940-943`.
-- `WorkerNetworkError::Timeout` / `DBInsert` / `DBCommit` / `DBRead` / `StreamClosed` / `Network` / `BatchEpochMismatch` / `Internal` — local failures or epoch-boundary races. `crates/consensus/worker/src/network/error.rs:128-135`.
+- `WorkerNetworkError::Timeout` / `DBInsert` / `DBCommit` / `DBRead` / `StreamClosed` / `Network` / `BatchEpochMismatch` / `Internal` — local failures or epoch-boundary races. `crates/consensus/worker/src/network/error.rs:129-136`.
 - `PrimaryNetworkError::UnavailableEpoch` / `UnavailableEpochDigest` — a peer "might not have this yet" during sync. `crates/consensus/primary/src/error/network.rs:123-124`.
 - `PrimaryNetworkError::PeerNotInCommittee` — left to `None` to avoid penalizing during epoch transitions. `crates/consensus/primary/src/error/network.rs:125`.
 - `PrimaryNetworkError::Storage` / `Timeout` / `StreamUnavailable` / `Internal` — local failures. `crates/consensus/primary/src/error/network.rs:126-129`.

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -3,7 +3,7 @@
 //! Grouped by role:
 //!
 //! - [`TransactionFactory`]: deterministic keypair plus nonce tracking to create, sign, and submit
-//!   EIP-1559, legacy, and EIP-4844 transactions.
+//!   EIP-1559, legacy, EIP-4844, and EIP-7702 transactions.
 //! - `RethEnv` test constructors and read helpers: `new_for_test`, `state_by_block_hash`, `tn_evm`,
 //!   `execution_outcome_for_tests`, and `ConsensusRegistry` reads (`get_validator_rewards`,
 //!   `get_bls_pubkey`, `get_validator_info`, `validators_for_epoch_at_block`,
@@ -30,8 +30,10 @@ use crate::{
     ExecutedBlock, NewCanonicalChain, RethEnv, WorkerTxPool,
 };
 use alloy::{
-    consensus::{SignableTransaction as _, TxEip4844, TxEip4844Variant, TxLegacy},
-    eips::eip7594::BlobTransactionSidecarVariant,
+    consensus::{
+        SignableTransaction as _, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+    },
+    eips::{eip7594::BlobTransactionSidecarVariant, eip7702::Authorization},
     hex,
     primitives::{utils::parse_ether, ChainId},
     signers::{
@@ -413,6 +415,84 @@ impl TransactionFactory {
         self.inc_nonce();
 
         TransactionSigned::new_unhashed(variant.into(), signature)
+    }
+
+    /// Create a signed EIP-2930 access-list transaction.
+    pub fn create_eip2930(
+        &mut self,
+        chain_id: ChainId,
+        gas_limit: Option<u64>,
+        gas_price: u128,
+        to: Address,
+    ) -> TransactionSigned {
+        let gas_limit = gas_limit.unwrap_or(1_000_000);
+
+        // access-list transaction
+        let tx = TxEip2930 {
+            chain_id,
+            nonce: self.nonce,
+            gas_price,
+            gas_limit,
+            to: TxKind::Call(to),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Bytes::new(),
+        };
+        let tx_signature_hash = tx.signature_hash();
+
+        // construct transaction and sign
+        let signature = self.sign_hash(tx_signature_hash);
+
+        // increase nonce for next tx
+        self.inc_nonce();
+
+        TransactionSigned::new_unhashed(tx.into(), signature)
+    }
+
+    /// Create a signed EIP-7702 set-code transaction carrying one authorization
+    /// signed by this factory's key, so the envelope is well-formed and its type
+    /// byte is the only reason a fork-blind validator could reject it.
+    pub fn create_eip7702(
+        &mut self,
+        chain_id: ChainId,
+        gas_limit: Option<u64>,
+        gas_price: u128,
+    ) -> TransactionSigned {
+        let gas_limit = gas_limit.unwrap_or(1_000_000);
+
+        // authorization signed by this factory's key; for a self-sponsored delegation
+        // the account nonce at authorization check time is the tx nonce + 1 (the
+        // sender's nonce increments before the authorization list is processed)
+        let authorization = Authorization {
+            chain_id: U256::from(chain_id),
+            address: Address::ZERO,
+            nonce: self.nonce + 1,
+        };
+        let auth_signature = self.sign_hash(authorization.signature_hash());
+        let signed_authorization = authorization.into_signed(auth_signature);
+
+        // set-code transaction
+        let tx = TxEip7702 {
+            chain_id,
+            nonce: self.nonce,
+            gas_limit,
+            max_fee_per_gas: gas_price,
+            max_priority_fee_per_gas: 0,
+            to: address!("a8cb082a5a689e0d594d7da1e2d72a3d63adc1bd"),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            authorization_list: vec![signed_authorization],
+            input: Bytes::new(),
+        };
+        let tx_signature_hash = tx.signature_hash();
+
+        // construct transaction and sign
+        let signature = self.sign_hash(tx_signature_hash);
+
+        // increase nonce for next tx
+        self.inc_nonce();
+
+        TransactionSigned::new_unhashed(tx.into(), signature)
     }
 
     /// Create and sign an EIP4844 transaction.

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -37,7 +37,10 @@ use reth_provider::{
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction as reth_recover_raw_transaction;
 use reth_transaction_pool::{
-    error::{Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError},
+    error::{
+        Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
+        PoolError,
+    },
     AddedTransactionOutcome, BestTransactions, CanonicalStateUpdate, EthPooledTransaction,
     PoolSize, PoolTransaction, PoolUpdateKind, TransactionEvents, TransactionOrigin,
     TransactionPool as _, TransactionPoolExt as _, ValidPoolTransaction,
@@ -77,6 +80,9 @@ pub trait TxPool {
     fn get_pending_base_fee(&self) -> u64;
     /// Remove EIP-4844 blob transactions from the pool and delete the sidecars from blob store.
     fn remove_eip4844_txs(&mut self, blobs: Vec<TxHash>);
+    /// Remove transactions whose EIP-2718 type is outside the executable allowlist from the
+    /// pool, along with their descendants.
+    fn remove_unsupported_txs(&mut self, txs: Vec<TxHash>);
 }
 
 /// A telcoin network transaction pool.
@@ -329,6 +335,10 @@ impl TxPool for WorkerTxPool {
         self.0.remove_transactions_and_descendants(blobs.clone());
         self.0.delete_blobs(blobs);
     }
+
+    fn remove_unsupported_txs(&mut self, txs: Vec<TxHash>) {
+        self.0.remove_transactions_and_descendants(txs);
+    }
 }
 
 /// An iterator that produces the best transactions from a pool.
@@ -371,6 +381,19 @@ impl BestTxns {
         self.inner.mark_invalid(
             pool_tx,
             &InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::NoEip4844Blobs),
+        );
+    }
+
+    /// Mark a transaction outside the executable type allowlist as invalid.
+    ///
+    /// Mirrors [`Self::ignore_eip4844`]: the nearest upstream error kind stands in for a
+    /// type the batch allowlist refuses (only EIP-7702 decodes today).
+    pub fn ignore_eip7702(&mut self, pool_tx: &Arc<PoolTxn>) {
+        self.inner.mark_invalid(
+            pool_tx,
+            &InvalidPoolTransactionError::Eip7702(
+                Eip7702PoolTransactionError::MissingEip7702AuthorizationList,
+            ),
         );
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -54,7 +54,7 @@ pub use alloy::{
     },
     eips::{
         eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
-        eip2718::{Decodable2718, Encodable2718},
+        eip2718::{Decodable2718, Encodable2718, Typed2718},
         eip4844::{env_settings::EnvKzgSettings, BlobAndProofV1, BlobTransactionSidecar},
         BlockHashOrNumber, BlockNumHash,
     },
@@ -70,6 +70,16 @@ pub use alloy::{
     sol_types::{SolCall, SolType, SolValue},
 };
 pub use libp2p::{multiaddr::Protocol, Multiaddr};
+
+/// Whether a transaction's EIP-2718 type is on the batch executable allowlist
+/// (legacy, EIP-2930, EIP-1559).
+///
+/// One predicate shared by the batch validator, the batch builder, and the
+/// worker gateway so producers and validators can never disagree on the set.
+/// Deliberately fork-blind: uniform across chain configurations.
+pub fn batch_allowlisted_tx_type<T: Typed2718>(tx: &T) -> bool {
+    tx.is_legacy() || tx.is_eip2930() || tx.is_eip1559()
+}
 pub use reth_primitives::{
     Account, Block, BlockBody, EthPrimitives, NodePrimitives, PooledTransaction, Receipt,
     Recovered, RecoveredBlock, SealedBlock, SealedHeader, Transaction, TransactionSigned,

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -305,6 +305,15 @@ pub enum BatchValidationError {
     /// The batch contains blob transactions EIP-4844.
     #[error("Proposed batch contains blob transaction. Tx hash: {0}")]
     InvalidTx4844(BlockHash),
+    /// The batch contains a transaction whose EIP-2718 type byte is outside the
+    /// executable allowlist (legacy, EIP-2930, EIP-1559).
+    #[error("Proposed batch contains unsupported transaction type {tx_type}. Tx hash: {hash}")]
+    UnsupportedTxType {
+        /// The EIP-2718 type byte of the offending transaction.
+        tx_type: u8,
+        /// Hash of the offending transaction.
+        hash: BlockHash,
+    },
     /// The total allowable gas in the batch exceeds `u64::MAX`.
     #[error("Overflow calculating max possible gas.")]
     GasOverflow,


### PR DESCRIPTION
Closes #1067.

## Problem

`BatchValidator::validate_batch` never consults the chain spec or the fork schedule, and its only transaction-type discriminator is `tx.is_eip4844()`.  On mainnet (chainId 487, `shanghaiTime: 0`, no `cancunTime`/`pragueTime`), EIP-7702 is inactive, yet a batch carrying a type-0x04 transaction passes all eight validator checks, is voted on, and is certified.  Execution then rejects it (`Eip7702NotSupported`) and the executor's skip-and-continue arm drops it, incrementing `invalid_txs_skipped_total` . . . a counter documented as "Not an error signal, and not alertable", so a certified spec-invalid transaction is indistinguishable from routine duplicate traffic.

The attacker model is narrow (no unprivileged route exists): the RPC/pool path is Prague-gated by stock reth, and `process_report_batch` rejects non-committee reporters.  Only a Byzantine or key-compromised committee member can produce such a batch.  The failure is benign today, but the benign outcome rests on a third-party error-classification detail in `alloy-evm`, not on anything this repo enforces: an upstream reclassification (or a future tx type failing before `transact`) sends the same certified bytes to the fatal arm, and since consensus replays certified bytes on restart, that would be a crash loop.  The batch validator is the layer whose job is to make that unreachable.

## Fix

One allowlist predicate, `tn_types::batch_allowlisted_tx_type` (legacy, EIP-2930, EIP-1559), enforced symmetrically on the validating side and on both producing sides.  Symmetry is load-bearing: testnet and every CLI-generated genesis activate Prague from block 0, so their stock reth pool admits type-0x04 transactions;  a validator-only check would make honest proposers there pack pool-admitted transactions that every peer rejects, at `Penalty::Medium` per vote request.  With this change a non-allowlisted type is rejected at the gateway, never packed by the builder, and rejected by the validator, uniformly across chain configurations, so a future transaction type is excluded by default rather than silently certified and dropped at execution.

- [x] `crates/types/src/lib.rs`: the shared `batch_allowlisted_tx_type` predicate (plus the `Typed2718` re-export it rides on), so producers and validators can never disagree on the set.
- [x] `crates/batch-validator/src/validator.rs`: replace `validate_no_blob_txs` with `validate_tx_type_allowlist`, keeping the same `transactions.iter().find(..)` shape and the same seam in `validate_batch`.  EIP-4844 keeps its dedicated `InvalidTx4844` error for continuity with existing peer penalties;  any other decodable type (EIP-7702 today) maps to the new error.  A type byte outside the envelope's decodable set still fails earlier at decode as `RecoverTransaction` (Severe).  (Also fixes the copy-pasted "Validate the block's basefee" doc comment.)
- [x] `crates/types/src/worker/sealed_batch.rs`: new `BatchValidationError::UnsupportedTxType { tx_type, hash }` variant beside `InvalidTx4844`.  The enum has no serde derive and never crosses the wire (peers see only a vote refusal plus a local penalty), so variant position is not a compatibility surface.
- [x] `crates/consensus/worker/src/network/error.rs`: map `UnsupportedTxType` to `Penalty::Medium` beside `InvalidTx4844`, the consistent tier for a batch a correct peer cannot have produced.
- [x] `crates/batch-builder/src/batch.rs`: the builder now skips any non-allowlisted type the pool hands it (mirroring the existing EIP-4844 arm) and evicts those transactions and their descendants after sealing, so a proposer never builds a batch its peers will refuse.
- [x] `crates/tn-reth/src/txn_pool.rs`: `BestTxns::ignore_eip7702` (mirrors `ignore_eip4844`) and `TxPool::remove_unsupported_txs` backing the builder's skip-and-evict;  the test pool in `batch-builder` implements the same trait method.
- [x] `bin/worker-gateway/src/proxy.rs`: the ingress screen generalizes from `is_eip4844()` to the shared predicate, returning the existing `UnsupportedTransactionType` rejection.
- [x] `crates/network-libp2p/src/peers/penalty.md`: new table row, and every downstream `error.rs` line citation shifted by the one-line insertion.
- [x] `crates/tn-reth/src/test_utils.rs`: new `TransactionFactory::create_eip7702` (type-0x04 envelope carrying an authorization signed by the factory key at the correct self-sponsored nonce, so decode and signer recovery succeed and the type byte is the only thing a validator can object to) and `create_eip2930` for positive allowlist coverage.

Scope note: the stock reth pool still admits type-0x04 transactions where Prague is active (testnet), since pool policy is upstream code;  they now sit inert until the builder evicts them, and the gateway refuses them at ingress.  Batches never carry them on any chain configuration.

## Testing

- `cargo +1.94 test -p tn-batch-validator -p tn-batch-builder -p tn-worker-gateway`: all green (15 batch-validator tests, builder and gateway suites).  New coverage: `test_invalid_tx_eip7702` asserts `UnsupportedTxType { tx_type: 4, .. }` (the batch clears digest/worker/epoch/size/decode first, so the allowlist arm is what fires), and `test_valid_batch_legacy_and_eip2930` is the positive control for the admit direction (EIP-1559 was already covered by the valid-batch fixture).  The pre-existing `test_invalid_tx_eip4844` assertion is unchanged, so 4844 behavior and its penalty are preserved.
- Both new tests were confirmed by mutation.  Reverting the allowlist to the old `is_eip4844()` denylist makes `test_invalid_tx_eip7702` fail with `Ok(())` (the exact silent acceptance from the issue).  Dropping `is_eip2930` from the shared predicate makes `test_valid_batch_legacy_and_eip2930` fail with `UnsupportedTxType { tx_type: 1, .. }` (the honest-batch rejection the symmetry guards against).  Both restored to green.
- `cargo +nightly fmt -- --check`, `cargo +1.94 clippy --workspace --all-targets`, and attest's `cargo +1.94 test --no-run --workspace` in an isolated target dir: green on the pinned toolchain.

The repo's e2e suite cannot exhibit the original bug because `set_genesis_defaults` makes every test chain Prague-active;  the new unit tests are chain-config-independent because the allowlist is deliberately fork-blind on both sides.
