### PR TITLE
fix(tn-reth): reject state-mutating TEL precompile selectors under STATICCALL

### DIFF
--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -8,7 +8,10 @@
 //!
 //! The precompile is registered as a [`DynPrecompile`] inside a [`PrecompilesMap`] at
 //! [`TELCOIN_PRECOMPILE_ADDRESS`] (`0x7e1`). Any `CALL`/`STATICCALL` targeting that address is
-//! intercepted and routed to [`telcoin_precompile`] instead of executing bytecode.
+//! intercepted and routed to [`telcoin_precompile`] instead of executing bytecode. Bypassing
+//! bytecode execution also bypasses the interpreter's static-call write protection, so
+//! [`telcoin_precompile`] enforces that itself: inside a `STATICCALL` frame it serves the
+//! read-only selectors and refuses every state-mutating one.
 //!
 //! # Module structure
 //!
@@ -37,6 +40,8 @@
 //!   `claim`, `burn`, and (with faucet) `grantMintRole`/`revokeMintRole`.
 //! - **Mint-role holders** (faucet only): can call the faucet `mint(address, uint256)`.
 //! - **Any account**: can call `totalSupply()` (read-only).
+//! - **Static frames**: regardless of caller, only the read-only selectors (`totalSupply()`, plus
+//!   `hasMintRole` with the faucet feature) are served inside a `STATICCALL`.
 //!
 //! # Feature flags
 //!
@@ -114,9 +119,30 @@ pub fn add_telcoin_precompile(map: &mut PrecompilesMap) {
     });
 }
 
+/// Rejection emitted when a state-mutating selector is reached inside a `STATICCALL` frame.
+const STATIC_CALL_MUTATION: &str = "static call: state mutation not permitted";
+
 /// Top-level dispatcher for the Telcoin precompile.
 ///
 /// Extracts the 4-byte selector from calldata and routes to the matching handler.
+///
+/// # Static-call write protection
+///
+/// [`totalSupplyCall`] and (with the `faucet` feature) [`hasMintRoleCall`] only read state, so they
+/// stay callable inside a `STATICCALL` frame. Every other selector dispatched below writes storage,
+/// native balances, or logs, and is refused when [`PrecompileInput::is_static`] is set.
+///
+/// Enforcing this here is not redundant with the interpreter. Registering this address as a
+/// precompile short-circuits bytecode execution, so the `require_non_staticcall!` check that
+/// `SSTORE` and `LOG` expand through never runs for calls routed to [`telcoin_precompile`], and the
+/// journal beneath it carries no static-context flag to catch the writes either. Write protection
+/// for a precompile is the precompile's own responsibility.
+///
+/// Classifying by *read-only* rather than by *mutating* selector is deliberate: a selector added to
+/// the dispatcher later is guarded unless it is explicitly named read-only here, so the failure
+/// direction is a refused read rather than an unguarded write. One consequence is that an
+/// unrecognised selector inside a static frame reports [`STATIC_CALL_MUTATION`] rather than
+/// `"Unknown function selector"`; both are [`PrecompileError::Other`] and both revert the frame.
 fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
     if input.data.len() < 4 {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
@@ -124,6 +150,15 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
 
     let selector: [u8; 4] = input.data[0..4].try_into().unwrap();
     let calldata = &input.data[4..];
+
+    // Selectors that touch no state. Everything else the `match` below recognises mutates.
+    // `hasMintRole` is dispatched only under the `faucet` feature, so it counts as read-only only
+    // there: this list mirrors the read-only arms of that `match` exactly, under both feature sets.
+    let read_only = matches!(selector, burnable::totalSupplyCall::SELECTOR)
+        || (cfg!(feature = "faucet") && matches!(selector, hasMintRoleCall::SELECTOR));
+    (read_only || !input.is_static)
+        .then_some(())
+        .ok_or_else(|| PrecompileError::Other(STATIC_CALL_MUTATION.into()))?;
 
     match selector {
         // State-mutating functions

--- a/crates/tn-reth/tests/it/main.rs
+++ b/crates/tn-reth/tests/it/main.rs
@@ -5,6 +5,7 @@
 mod bls_precompile_props;
 mod economics_props;
 mod pipeline_helpers;
+mod precompile_relays;
 mod recover_drop_props;
 
 // testnet

--- a/crates/tn-reth/tests/it/precompile_relays.rs
+++ b/crates/tn-reth/tests/it/precompile_relays.rs
@@ -1,0 +1,65 @@
+//! Hand-assembled relay contracts for reaching the TEL precompile from a nested call frame.
+//!
+//! A top-level transaction frame is never static and `TxEnv` carries no `is_static` to set, so a
+//! `STATICCALL` into `0x7e1` can only be expressed by routing through deployed bytecode. These
+//! relays are shared by the mainnet and `faucet` precompile test modules so the two builds exercise
+//! byte-identical call paths.
+//!
+//! Both relays end by storing the inner call's success flag at memory word 0 and returning it, so a
+//! test can tell "the precompile accepted this" from "the precompile refused it". The
+//! `DELEGATECALL` relay in `tel_precompile_props.rs` instead `POP`s that flag and forwards the
+//! precompile's returndata, which cannot express this distinction: an accepted mutation and a
+//! refused one both return empty bytes, and the outer transaction succeeds either way because the
+//! relay always `RETURN`s.
+//!
+//! # Hosting address
+//!
+//! `STATICCALL` does not preserve `msg.sender`, so the precompile authorizes against the relay's
+//! own address. A relay at a fresh address is rejected with `"unauthorized"` whether or not any
+//! static guard exists, which would make a write-protection test pass vacuously. Deploy these at an
+//! address the precompile already trusts and drive the outer transaction from a different sender,
+//! since revm rejects a transaction whose sender has code (EIP-3607).
+
+/// Runtime bytecode forwarding calldata to `0x7e1` with `CALL`, returning the inner success flag.
+///
+/// The positive control for the `STATICCALL` write-protection tests: it differs from
+/// [`STATICCALL_RELAY_BYTECODE`] only in pushing a zero `value` operand (`CALL` takes seven stack
+/// operands, `STATICCALL` six) and in the call opcode itself, `0xf1` against `0xfa`.
+///
+/// Disassembly:
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize, argsOffset
+///   PUSH1 0; PUSH2 0x07e1; GAS; CALL               // value, address, gas
+///   PUSH1 0; MSTORE                                // mem[0..32] = success flag
+///   PUSH1 32; PUSH1 0; RETURN                      // return that word
+/// ```
+pub(crate) const CALL_RELAY_BYTECODE: &[u8] = &[
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // retSize, retOffset, argsSize, argsOffset
+    0x60, 0x00, // value = 0
+    0x61, 0x07, 0xe1, 0x5a, 0xf1, // PUSH2 0x07e1; GAS; CALL
+    0x60, 0x00, 0x52, // MSTORE(0, success)
+    0x60, 0x20, 0x60, 0x00, 0xf3, // RETURN(0, 32)
+];
+
+/// Runtime bytecode forwarding calldata to `0x7e1` with `STATICCALL`, returning the success flag.
+///
+/// Identical to [`CALL_RELAY_BYTECODE`] but for the dropped `value` operand and `0xfa` in place of
+/// `0xf1`.
+///
+/// Disassembly:
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize, argsOffset
+///   PUSH2 0x07e1; GAS; STATICCALL                  // address, gas
+///   PUSH1 0; MSTORE                                // mem[0..32] = success flag
+///   PUSH1 32; PUSH1 0; RETURN                      // return that word
+/// ```
+pub(crate) const STATICCALL_RELAY_BYTECODE: &[u8] = &[
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // retSize, retOffset, argsSize, argsOffset
+    0x61, 0x07, 0xe1, 0x5a, 0xfa, // PUSH2 0x07e1; GAS; STATICCALL
+    0x60, 0x00, 0x52, // MSTORE(0, success)
+    0x60, 0x20, 0x60, 0x00, 0xf3, // RETURN(0, 32)
+];

--- a/crates/tn-reth/tests/it/tel_precompile_faucet_props.rs
+++ b/crates/tn-reth/tests/it/tel_precompile_faucet_props.rs
@@ -5,17 +5,20 @@
 //! - Mint role grant/revoke semantics
 //! - Supply accounting with faucet mints
 
+use crate::precompile_relays::{CALL_RELAY_BYTECODE, STATICCALL_RELAY_BYTECODE};
 use alloy::sol_types::SolCall;
 use proptest::prelude::*;
 use reth_revm::primitives::{address, Address};
 use tn_config::GOVERNANCE_SAFE_ADDRESS as GOVERNANCE;
 use tn_reth::{
-    claimCall, grantMintRoleCall, mintCall, revokeMintRoleCall,
+    claimCall, faucet_mint_role_slot, grantMintRoleCall, hasMintRoleCall, mintCall,
+    revokeMintRoleCall,
     test_utils::precompile_test_utils::{
-        assert_not_success, assert_success, TestEnv, RECIPIENT, USER,
+        assert_not_success, assert_success, decode_bool, TestEnv, RECIPIENT, USER,
     },
+    TELCOIN_PRECOMPILE_ADDRESS,
 };
-use tn_types::U256;
+use tn_types::{Bytes, U256};
 
 const FAUCET: Address = address!("0000000000000000000000000000000000000F00");
 
@@ -167,4 +170,82 @@ proptest! {
         );
         assert_not_success(&result);
     }
+}
+
+// ==============================
+// `STATICCALL` write protection (faucet selectors)
+// ==============================
+
+/// A `STATICCALL` reaching a faucet role-management selector is refused, and writes nothing.
+///
+/// The mainnet counterparts of these tests live in `tel_precompile_props.rs`, which `main.rs`
+/// compiles only under `#[cfg(not(feature = "faucet"))]`. Without this test the faucet build's
+/// mutating selectors, and the dispatcher's faucet-only read-only classification, would carry no
+/// static-call coverage at all.
+///
+/// The relay is hosted at [`GOVERNANCE`] because `STATICCALL` does not preserve `msg.sender`: the
+/// precompile authorizes against the relay's own address, so a relay anywhere else would be
+/// rejected with `"unauthorized"` whether or not the guard exists, and the test would pass against
+/// unfixed code. The outer transaction is driven by [`USER`], since revm rejects a transaction
+/// whose sender has code (EIP-3607).
+///
+/// Each relay gets its own environment: within one env the journal caches account code across
+/// transactions while `deploy_code` writes to the database underneath it, so swapping the relay
+/// bytecode mid-test would silently re-run the first relay.
+#[test]
+fn test_staticcall_cannot_grant_mint_role() {
+    let role_slot = faucet_mint_role_slot(FAUCET);
+
+    // Positive control: the same relay frame under `CALL` grants the role.
+    let mut allowed_env = new_faucet_env();
+    allowed_env.deploy_code(GOVERNANCE, Bytes::from_static(CALL_RELAY_BYTECODE));
+    let allowed = allowed_env.exec_to(
+        USER,
+        GOVERNANCE,
+        grantMintRoleCall { addr: FAUCET }.abi_encode(),
+        200_000,
+    );
+    assert_success(&allowed);
+    assert!(decode_bool(&allowed), "CALL into grantMintRole must be accepted");
+    assert_eq!(
+        allowed_env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, role_slot),
+        U256::from(1),
+        "positive control failed: the CALL relay never reached the precompile, so the \
+         STATICCALL assertions below would be vacuous"
+    );
+
+    // Same caller, same calldata, same authorization - only the opcode changes.
+    let mut refused_env = new_faucet_env();
+    refused_env.deploy_code(GOVERNANCE, Bytes::from_static(STATICCALL_RELAY_BYTECODE));
+    let refused = refused_env.exec_to(
+        USER,
+        GOVERNANCE,
+        grantMintRoleCall { addr: FAUCET }.abi_encode(),
+        200_000,
+    );
+    assert_success(&refused);
+    assert!(!decode_bool(&refused), "STATICCALL into grantMintRole must be refused");
+    assert_eq!(
+        refused_env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, role_slot),
+        U256::ZERO,
+        "STATICCALL must not write the mint-role slot"
+    );
+}
+
+/// `hasMintRole` is read-only, so the guard must leave it reachable inside a `STATICCALL`.
+///
+/// This is the faucet-only half of the dispatcher's read-only classification, the arm gated behind
+/// `cfg!(feature = "faucet")`. The role is deliberately not granted first: the assertion is on the
+/// relay's returned success flag (did the precompile serve the call), not on `hasMintRole`'s own
+/// boolean answer, and granting it would require a transaction that loads `GOVERNANCE` into the
+/// journal before the relay is deployed there.
+#[test]
+fn test_staticcall_still_serves_has_mint_role() {
+    let mut env = new_faucet_env();
+    env.deploy_code(GOVERNANCE, Bytes::from_static(STATICCALL_RELAY_BYTECODE));
+
+    let result =
+        env.exec_to(USER, GOVERNANCE, hasMintRoleCall { addr: FAUCET }.abi_encode(), 200_000);
+    assert_success(&result);
+    assert!(decode_bool(&result), "hasMintRole must remain callable under STATICCALL");
 }

--- a/crates/tn-reth/tests/it/tel_precompile_props.rs
+++ b/crates/tn-reth/tests/it/tel_precompile_props.rs
@@ -11,7 +11,7 @@ use tn_config::GOVERNANCE_SAFE_ADDRESS;
 use tn_reth::{
     burnCall, claimCall, grantMintRoleCall, hasMintRoleCall, mintCall, revokeMintRoleCall,
     test_utils::precompile_test_utils::{
-        assert_not_success, assert_success, decode_u256, TestEnv, GENESIS_SUPPLY,
+        assert_not_success, assert_success, decode_bool, decode_u256, TestEnv, GENESIS_SUPPLY, USER,
     },
     totalSupplyCall, TELCOIN_PRECOMPILE_ADDRESS, TIMELOCK_DURATION,
 };
@@ -412,4 +412,103 @@ fn test_delegatecall_writes_target_precompile_storage() {
         U256::ZERO,
         "caller's storage must NOT be written by precompile under DELEGATECALL"
     );
+}
+
+// ==============================
+// `STATICCALL` write protection
+// ==============================
+
+use crate::precompile_relays::{CALL_RELAY_BYTECODE, STATICCALL_RELAY_BYTECODE};
+
+/// Pending-mint amount slot for governance: `keccak256(abi.encode(GOVERNANCE_SAFE_ADDRESS, 0))`.
+fn governance_pending_slot() -> U256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(GOVERNANCE_SAFE_ADDRESS.as_slice());
+    U256::from_be_bytes(keccak256(buf).0)
+}
+
+/// A `STATICCALL` reaching a state-mutating selector is refused, and writes nothing.
+///
+/// Registering `0x7e1` as a precompile short-circuits bytecode execution, so the interpreter's
+/// `require_non_staticcall!` write protection never runs on the `SSTORE`s and `LOG`s the handlers
+/// perform. Only the dispatcher's own check stands between a static frame and a real mutation.
+///
+/// The relay has to be hosted **at** [`GOVERNANCE_SAFE_ADDRESS`]. `STATICCALL` does not preserve
+/// `msg.sender` (unlike the `DELEGATECALL` case above), so the precompile authorizes against the
+/// relay's own address; a relay at a fresh address would be rejected with `"unauthorized"` whether
+/// or not the static guard exists, and the test would pass vacuously. The outer transaction is
+/// therefore driven by [`USER`], since revm rejects a transaction whose sender has code (EIP-3607).
+///
+/// Test plan:
+/// 1. Host a `CALL` relay at governance and `mint(1234)` through it. This is the positive control:
+///    it proves the authorization path and the write both work through a relay frame.
+/// 2. In a second environment, host the `STATICCALL` relay, identical but for the call opcode and
+///    the dropped `value` operand, and `mint(5678)` through it.
+/// 3. Assert the inner call reported failure and that nothing was written.
+#[test]
+#[cfg(not(feature = "faucet"))]
+fn test_staticcall_cannot_mutate_precompile_state() {
+    let pending_slot = governance_pending_slot();
+
+    // 1. Positive control: the same relay frame under `CALL` mints successfully.
+    //
+    // This uses its own `TestEnv`. Within one env the journal caches account code across
+    // transactions, while `deploy_code` writes to the database underneath it, so redeploying over
+    // a contract that has already executed does not take effect and the second transaction would
+    // silently re-run the first relay.
+    let mut allowed_env = TestEnv::new();
+    allowed_env.deploy_code(GOVERNANCE_SAFE_ADDRESS, Bytes::from_static(CALL_RELAY_BYTECODE));
+    let allowed = allowed_env.exec_to(
+        USER,
+        GOVERNANCE_SAFE_ADDRESS,
+        mintCall { amount: U256::from(1234) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&allowed);
+    assert!(decode_bool(&allowed), "CALL into a mutating selector must be accepted");
+    assert_eq!(
+        allowed_env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, pending_slot),
+        U256::from(1234),
+        "positive control failed: the CALL relay never reached the precompile, so the \
+         STATICCALL assertions below would be vacuous"
+    );
+
+    // 2. Same caller, same calldata shape, same authorization - only the opcode changes.
+    let mut refused_env = TestEnv::new();
+    refused_env.deploy_code(GOVERNANCE_SAFE_ADDRESS, Bytes::from_static(STATICCALL_RELAY_BYTECODE));
+    let refused = refused_env.exec_to(
+        USER,
+        GOVERNANCE_SAFE_ADDRESS,
+        mintCall { amount: U256::from(5678) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&refused);
+
+    // 3. The precompile must have refused, and nothing may have been written.
+    assert!(
+        !decode_bool(&refused),
+        "STATICCALL into a mutating selector must be refused by the precompile"
+    );
+    assert_eq!(
+        refused_env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, pending_slot),
+        U256::ZERO,
+        "STATICCALL must not write the pending-mint slot"
+    );
+}
+
+/// The static guard rejects mutation only: read-only selectors stay callable under `STATICCALL`.
+///
+/// Guards this fix against over-reach. `totalSupply()` is exactly the kind of call a static frame
+/// is supposed to be able to make, and the relay used here is the same one that is refused a
+/// `mint` in [`test_staticcall_cannot_mutate_precompile_state`], so the selector is the only
+/// variable between the two outcomes.
+#[test]
+fn test_staticcall_still_serves_read_only_selectors() {
+    let mut env = TestEnv::new();
+    env.deploy_code(GOVERNANCE_SAFE_ADDRESS, Bytes::from_static(STATICCALL_RELAY_BYTECODE));
+
+    let result =
+        env.exec_to(USER, GOVERNANCE_SAFE_ADDRESS, totalSupplyCall {}.abi_encode(), 200_000);
+    assert_success(&result);
+    assert!(decode_bool(&result), "totalSupply() must remain callable under STATICCALL");
 }


### PR DESCRIPTION
Closes #1089.

## Problem

`0x7e1` is registered as a stateful precompile, so any `CALL` or `STATICCALL` targeting it is intercepted and routed to `telcoin_precompile` instead of executing bytecode.  Short-circuiting bytecode execution also short-circuits the EVM's static-call write protection: `require_non_staticcall!` lives in the interpreter's instruction path (the macro `SSTORE` and `LOG` expand through), and the journal beneath it carries no static-context flag.  For a precompile there is no second line of defence, so enforcement is the precompile's own responsibility.

It was not being done.  The dispatcher branched on the 4-byte selector alone and never read `input.is_static`, and neither did any handler . . . `rg -n "is_static" crates/tn-reth/src/evm/` returned zero matches across the whole tree.  `PrecompileInput` carries the flag (`alloy-evm` 0.27.3 populates `is_static` from revm's `CallInputs` and exposes `is_static_call()`), so it was delivered and dropped.  Every mutating selector (`mint`, `claim`, `burn`, and with the `faucet` feature `mint`, `grantMintRole`, `revokeMintRole`) would perform its full set of `sstore`, balance, and log side effects inside a frame where the EVM promises a revert.

**Threat model.** This is not an unauthorized-issuance path, and no attacker is required for it to matter.  Authorization still gates every mutating selector before any write, and `STATICCALL` (unlike `DELEGATECALL`) does not preserve `msg.sender`, so the precompile authorizes against the immediate caller.  A wrapper that staticcalls `0x7e1` on governance's behalf is itself the caller and still gets `"unauthorized"`.  The reachable shape is narrower and entirely honest: a read-only probe issued from an authorized address's own execution context, which is the ordinary "simulate the action first" pattern in Safe module and guard code.  Such a caller gets the real mint/claim/burn side effects where it expected a revert.  There is also no consensus-divergence exposure here . . . one client, one dispatcher, so every node takes the same branch and the mutation is deterministic.  The damage is to the semantics integrators compose against.

The gap was in coverage, not just in code.  `DELEGATECALL` into `0x7e1` is already pinned by a regression test, so the call-context question had been asked for one of the two non-`CALL` entry paths.  `STATICCALL` was the one that was not, and no test could express it: `TestEnv` drives top-level transactions, a top-level frame is never static, and `TxEnv` carries no `is_static` to set.  Reaching a static frame at all requires routing through a deployed relay contract.

## Fix

`crates/tn-reth/src/evm/tel_precompile/mod.rs` . . . classify the selector, then refuse mutation in a static frame before dispatch:

- [x] Read-only selectors (`totalSupply()`, plus `hasMintRole` under the `faucet` feature) are named explicitly and stay callable inside a `STATICCALL`.  Both were confirmed write-free: each only `sload`s.
- [x] Everything else the dispatcher recognises is refused when `input.is_static` is set, via a single `?` guard placed before the existing `match`.  The guard runs ahead of any gas accounting or storage read, matching how the existing length check already behaves.
- [x] The classification is by **read-only**, not by **mutating**, so the failure direction is safe by construction: a selector added to the dispatcher later is guarded unless it is explicitly named read-only.  Forgetting to classify a new mutating selector cannot produce an unguarded write.
- [x] Rejection uses `PrecompileError::Other`, consistent with every other rejection this precompile emits.  Documented consequence: an unrecognised selector inside a static frame now reports the static-call message rather than `"Unknown function selector"`.  Both are `PrecompileError::Other` and both revert the frame, so only the text differs.
- [x] Module and dispatcher docs record the invariant and why the check cannot live in the interpreter.

The guard is hoisted rather than duplicated across the three (or, with `faucet`, six) handlers: it keeps handler signatures unchanged, avoids threading a fourth argument through six functions, and keeps one condition in one place.

No caller is broken by this.  The only in-tree Solidity path that reaches a mutating selector is `StablecoinManager::_drip`, which uses a low-level `.call(...)` (`tn-contracts/src/testnet/StablecoinManager.sol:211`), not a staticcall.

## Testing

`crates/tn-reth/tests/it/tel_precompile_props.rs` . . . two tests built on the relay pattern already proven twice in this repo (the `DELEGATECALL` relay for `0x7e1`, and the `STATICCALL` relay for `0xb151`).

- [x] `test_staticcall_cannot_mutate_precompile_state` . . . `mint` through a `STATICCALL` relay is refused, and the pending-mint slot stays zero.
- [x] `test_staticcall_still_serves_read_only_selectors` . . . `totalSupply()` through the same relay still succeeds, so the guard is not over-broad.

Three details decide whether these tests mean anything, and the obvious version of the test gets all three wrong:

1. **The relay is hosted at `GOVERNANCE_SAFE_ADDRESS`.** `STATICCALL` does not preserve `msg.sender`, so a relay at a fresh address is itself the caller and every mutating selector would be rejected with `"unauthorized"` whether or not the guard exists . . . the test would pass against unfixed code. The outer transaction is driven by `USER` instead, since revm rejects a transaction whose sender has code (EIP-3607).
2. **The relay returns the inner call's success flag** rather than `POP`ping it. The existing `DELEGATECALL` relay discards that flag and forwards the precompile's returndata, which cannot express this distinction: a successful `mint` and a rejected one both return empty bytes, and the outer transaction succeeds either way because the relay always `RETURN`s. Asserting on outer transaction success would have been vacuous.
3. **Each relay gets its own `TestEnv`.** Within one env the journal caches account code across transactions while `deploy_code` writes to the database underneath it, so swapping the relay bytecode mid-test does not take effect and the second transaction silently re-runs the first relay. The first draft of this test did exactly that and reported the `STATICCALL` as succeeding; the failure was the harness, not the guard.

The mutating test carries its own positive control: the identical relay under `CALL` (differing only in the zero `value` operand and `0xf1` against `0xfa`) mints successfully and writes `1234`, so authorization and the write path are proven live before the `STATICCALL` case asserts they do not fire. Its assertion message says so explicitly, so a future regression that breaks the control reports itself rather than passing quietly.

Commands run, `cargo fmt` on the pinned nightly and the rest on the repo-pinned 1.94:

```
cargo +nightly-2026-03-20 fmt -- --check                          # clean
cargo +1.94 clippy -p tn-reth --all-targets                       # clean, 0 warnings
cargo +1.94 clippy -p tn-reth --features faucet --all-targets     # clean, 0 warnings
cargo +1.94 test -p tn-reth --test it                             # 49 passed, 0 failed
cargo +1.94 test -p tn-reth --features faucet --test it           # 37 passed, 0 failed
```

Confirmed by mutation, not just by passing: with the guard reverted to `(read_only || true)`, `test_staticcall_cannot_mutate_precompile_state` fails on its "must be refused by the precompile" assertion while the read-only test and the pre-existing `DELEGATECALL` test keep passing. This was then confirmed a second time by accident, which is the stronger evidence: a stale `libtn_reth` built *without* the guard got linked into the test binary, and the test failed with exactly that assertion and no other. It detects a missing guard.

This also settles empirically what the issue could only reason about statically: revm does propagate `is_static` through `alloy-evm` into `PrecompileInput` for a stateful custom precompile, so the flag was genuinely available and unread.

Not run here: the full `make attest` workspace gate. A concurrent build held the shared target-dir lock throughout, so the numbers above required forcing a rebuild of `tn-reth` from this worktree to avoid linking a sibling branch's artifacts. That is exactly why `-p <crate>` against the shared target is not a valid attest proxy, and the isolated `--workspace` build is still owed before pushing.
