### PR TITLE
fix(engine): roll back the in-memory advance and classify provider faults when the output persist fails

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -13,7 +13,7 @@ use crate::metrics::ENGINE_METRICS;
 use error::EngineResult;
 pub use error::TnEngineError;
 use futures::{future::OptionFuture, StreamExt};
-pub use payload_builder::execute_consensus_output;
+pub use payload_builder::{execute_consensus_output, PERSIST_OUTPUT_ATTEMPTS};
 use std::collections::VecDeque;
 use tn_reth::{payload::BuildArguments, RethEnv};
 use tn_types::{

--- a/crates/engine/src/metrics.rs
+++ b/crates/engine/src/metrics.rs
@@ -32,6 +32,12 @@ pub(crate) struct EngineMetrics {
     pub(crate) block_gas_used: Histogram,
     /// Empty non-epoch-closing outputs skipped without producing a block.
     pub(crate) empty_outputs_skipped_total: Counter,
+    /// Bounded retries of the durable output persist after a node-local provider fault
+    /// (the engine halts only once the attempt budget is exhausted).
+    pub(crate) persist_provider_fault_retries_total: Counter,
+    /// Consensus outputs whose durable persist failed after every attempt, rolling back
+    /// the speculative in-memory advance and escalating out of the engine task.
+    pub(crate) persist_failures_total: Counter,
 }
 
 #[cfg(test)]
@@ -54,6 +60,8 @@ mod tests {
             metrics.blocks_executed_total.increment(3);
             metrics.block_gas_used.record(21_000.0);
             metrics.empty_outputs_skipped_total.increment(1);
+            metrics.persist_provider_fault_retries_total.increment(2);
+            metrics.persist_failures_total.increment(1);
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
@@ -73,5 +81,9 @@ mod tests {
         find("tn_engine.execution_duration_seconds");
         find("tn_engine.block_gas_used");
         find("tn_engine.empty_outputs_skipped_total");
+        let (_, _, _, value) = find("tn_engine.persist_provider_fault_retries_total");
+        assert!(matches!(value, DebugValue::Counter(2)));
+        let (_, _, _, value) = find("tn_engine.persist_failures_total");
+        assert!(matches!(value, DebugValue::Counter(1)));
     }
 }

--- a/crates/engine/src/payload_builder.rs
+++ b/crates/engine/src/payload_builder.rs
@@ -4,14 +4,16 @@
 
 use crate::error::{EngineResult, TnEngineError};
 use tn_reth::{
+    error::TnRethError,
     payload::{BuildArguments, TNPayload},
-    CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, NewCanonicalChain, RethEnv,
+    CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, NewCanonicalChain, ProviderError,
+    RethEnv,
 };
 use tn_types::{
     gas_accumulator::GasAccumulator, max_batch_gas, EngineUpdate, Hash as _, SealedHeader, B256,
 };
 use tokio::sync::mpsc;
-use tracing::{debug, error, field, info, info_span};
+use tracing::{debug, error, field, info, info_span, warn};
 
 /// Execute output from consensus to extend the canonical chain.
 ///
@@ -244,7 +246,25 @@ pub fn execute_consensus_output(
 
     span.record("executed_blocks", executed_blocks.len().to_string());
 
-    reth_env.finish_executing_output(
+    // Durably commit the output, then announce it. The two halves are called separately
+    // (rather than through `finish_executing_output`) because their failure contracts
+    // differ: a persist error leaves the database transaction uncommitted, so the
+    // speculative in-memory advance must be compensated exactly as the in-loop error exits
+    // above do, and a node-local provider fault is worth a bounded retry first. An announce
+    // error is post-commit: the blocks are canonical for real and must NOT be rolled back. The
+    // reward accounting stays in place on every path; see the note at the top of this
+    // function.
+    persist_output_with_retry(&reth_env, &executed_blocks).inspect_err(|e| {
+        error!(
+            target: "engine",
+            ?e,
+            attempts = PERSIST_OUTPUT_ATTEMPTS,
+            "persisting executed consensus output failed - rolling back in-memory advance"
+        );
+        crate::metrics::ENGINE_METRICS.persist_failures_total.increment(1);
+        rollback_in_memory_output(&canonical_in_memory_state, &anchor_header, &executed_blocks)
+    })?;
+    reth_env.announce_executed_output(
         executed_blocks,
         Some((leader_round, consensus_num_hash, engine_update_tx)),
     )?;
@@ -292,13 +312,82 @@ fn execute_payload(
     Ok(canonical_header)
 }
 
+/// Total attempts (first try + retries) for the durable output persist in
+/// [`execute_consensus_output`] before a node-local provider fault escalates out of the engine
+/// task (a halt). Mirrors the epoch seam's classified read policy (`CLOSE_READ_ATTEMPTS` in
+/// `tn-node`), which settled the treatment for this fault class on the read side (#1025).
+/// Public so operators interpreting `tn_engine.persist_failures_total` and the fault-seam
+/// integration tests reference the same attempt budget.
+pub const PERSIST_OUTPUT_ATTEMPTS: u32 = 3;
+
+/// Pause between persist retries in [`persist_output_with_retry`].
+const PERSIST_OUTPUT_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Run [`RethEnv::persist_executed_output`] up to [`PERSIST_OUTPUT_ATTEMPTS`] times, sleeping
+/// [`PERSIST_OUTPUT_RETRY_BACKOFF`] between tries, retrying ONLY on a retryable
+/// [`TnRethError::Provider`] fault (see [`retryable_persist_fault`]).
+///
+/// Provider faults on the durable write are node-local (disk pressure, an MDBX I/O error) and
+/// often transient, so a bounded retry preserves liveness before the caller escalates to a halt
+/// of the engine's critical task (issue #1090). Re-running the whole call is safe only while the
+/// failed attempt made no static-file progress: `save_blocks` appends to the process-wide
+/// static-file writers outside the database transaction, and once an attempt fsyncs such
+/// progress the repeat attempt surfaces [`ProviderError::UnexpectedStaticFileBlockNumber`],
+/// which [`retryable_persist_fault`] classifies terminal so the engine fails fast to a restart,
+/// where reth's startup consistency check reconciles static files with the database. Any other
+/// error class returns immediately for the caller's compensate-then-propagate arm. Sleeping
+/// blocks the thread, which is correct here: `execute_consensus_output` already runs on a
+/// dedicated blocking task.
+///
+/// Shape: the first `PERSIST_OUTPUT_ATTEMPTS - 1` attempts form the retry window (`find_map`
+/// short-circuits on any non-retryable outcome); if every one of them hit a provider fault, the
+/// final attempt's result is returned as-is.
+///
+/// Every retry is logged and counted (`tn_engine.persist_provider_fault_retries_total`) so a
+/// node quietly surviving storage faults stays observable before the fault stops being
+/// survivable.
+fn persist_output_with_retry(
+    reth_env: &RethEnv,
+    blocks: &[ExecutedBlock],
+) -> Result<(), TnRethError> {
+    (1..PERSIST_OUTPUT_ATTEMPTS)
+        .find_map(|attempt| match reth_env.persist_executed_output(blocks) {
+            Err(TnRethError::Provider(err)) if retryable_persist_fault(&err) => {
+                warn!(
+                    target: "engine",
+                    attempt,
+                    max_attempts = PERSIST_OUTPUT_ATTEMPTS,
+                    %err,
+                    "node-local provider fault persisting executed consensus output - retrying"
+                );
+                crate::metrics::ENGINE_METRICS.persist_provider_fault_retries_total.increment(1);
+                std::thread::sleep(PERSIST_OUTPUT_RETRY_BACKOFF);
+                None
+            }
+            other => Some(other),
+        })
+        .unwrap_or_else(|| reth_env.persist_executed_output(blocks))
+}
+
+/// Whether an attempt of [`RethEnv::persist_executed_output`] that failed with this
+/// node-local provider fault may be healed by re-running the call in-process.
+///
+/// A repeat attempt re-runs `save_blocks`, and any static-file progress the failed
+/// attempt already fsynced makes the repeat trip over the advanced writer with
+/// [`ProviderError::UnexpectedStaticFileBlockNumber`]. That class can never succeed
+/// in-process (the writer stays advanced until reth's startup consistency check
+/// reconciles it on restart), so it is terminal and must not burn further attempts.
+fn retryable_persist_fault(err: &ProviderError) -> bool {
+    !matches!(err, ProviderError::UnexpectedStaticFileBlockNumber(..))
+}
+
 /// Roll back the eager per-block in-memory canonical advance for a consensus output whose batch
-/// loop failed partway through.
+/// loop failed partway through, or whose post-loop durable persist failed.
 ///
 /// `execute_payload` advances the shared `CanonicalInMemoryState` (pending block, in-memory chain
 /// segment, and canonical head) for every block it builds, because a later block in the same output
 /// resolves its parent state from that advance. The durable commit and the finalized/safe markers
-/// are written only once the whole output has built (`RethEnv::finish_executing_output` then
+/// are written only once the whole output has built (`RethEnv::persist_executed_output` then
 /// `RethEnv::finalize_block`). So when a block after the first fails to build,
 /// `execute_consensus_output` propagates the error before any durable write, leaving the earlier
 /// blocks advanced in memory but absent from the database: a transient "phantom" canonical head
@@ -311,10 +400,13 @@ fn execute_payload(
 /// tip. It is a no-op when nothing advanced: an empty `advanced` slice reorgs no blocks and resets
 /// the head to the value it already holds, so it is safe to call on every error exit of the loop.
 ///
-/// Scope: this compensates only the pre-durable-commit advance inside the batch loop. Once
-/// `finish_executing_output` commits the blocks they are canonical for real and must not be
-/// reverted; the durable two-transaction commit/finalize window is a separate concern handled by
-/// `RethEnv::heal_finalized_to_persisted_tip`.
+/// Scope: this compensates only the pre-durable-commit advance: a failure inside the batch loop,
+/// or a failure of the durable persist itself (`RethEnv::persist_executed_output`, every error
+/// return of which leaves the database transaction uncommitted; issue #1090). Once the persist
+/// commits, the blocks
+/// are canonical for real and must not be reverted; an `announce_executed_output` failure
+/// propagates WITHOUT compensation; the durable two-transaction commit/finalize window is a
+/// separate concern handled by `RethEnv::heal_finalized_to_persisted_tip`.
 fn rollback_in_memory_output(
     canonical_in_memory_state: &CanonicalInMemoryState,
     anchor_header: &SealedHeader,
@@ -323,4 +415,27 @@ fn rollback_in_memory_output(
     canonical_in_memory_state
         .update_chain(NewCanonicalChain::Reorg { new: Vec::new(), old: advanced.to_vec() });
     canonical_in_memory_state.set_canonical_head(anchor_header.clone());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tn_reth::StaticFileSegment;
+
+    /// The static-file mismatch a repeat persist attempt raises over the failed attempt's
+    /// fsynced progress can never heal in-process, so it must be classified terminal.
+    #[test]
+    fn test_static_file_mismatch_is_not_retryable() {
+        assert!(!retryable_persist_fault(&ProviderError::UnexpectedStaticFileBlockNumber(
+            StaticFileSegment::Headers,
+            2,
+            1,
+        )));
+    }
+
+    /// An ordinary node-local provider fault stays inside the bounded retry budget.
+    #[test]
+    fn test_ordinary_provider_fault_is_retryable() {
+        assert!(retryable_persist_fault(&ProviderError::HeaderNotFound(0u64.into())));
+    }
 }

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -13,9 +13,13 @@ use std::{
 use tempfile::TempDir;
 use tn_batch_builder::test_utils::execute_test_batch;
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_engine::{execute_consensus_output, ExecutorEngine, TnEngineError, MAX_QUEUED_OUTPUTS};
+use tn_engine::{
+    execute_consensus_output, ExecutorEngine, TnEngineError, MAX_QUEUED_OUTPUTS,
+    PERSIST_OUTPUT_ATTEMPTS,
+};
 use tn_reth::{
     calculate_gas_penalty,
+    error::TnRethError,
     payload::BuildArguments,
     recover_signed_transaction,
     system_calls::EpochState,
@@ -24,7 +28,7 @@ use tn_reth::{
         seeded_genesis_from_random_batches, test_genesis_with_consensus_registry,
         TransactionFactory, BEACON_ROOTS_ADDRESS, EMPTY_REQUESTS_HASH, HISTORY_STORAGE_ADDRESS,
     },
-    FixedBytes, RethChainSpec, RethEnv,
+    FixedBytes, ProviderError, RethChainSpec, RethEnv,
 };
 use tn_test_utils::default_test_execution_node;
 use tn_types::{
@@ -2741,6 +2745,630 @@ async fn test_partial_output_failure_rolls_back_in_memory_state() -> eyre::Resul
         "a failed output must not broadcast a canon-state notification"
     );
     assert!(engine_update_rx.try_recv().is_err(), "a failed output must not send an engine update");
+
+    Ok(())
+}
+
+/// Regression test for issue #1090 defect (a): a pre-commit failure of the durable persist
+/// (`RethEnv::persist_executed_output`) after every block of the output built successfully must
+/// not leave the eager in-memory canonical advance standing (a "phantom" canonical head that RPC
+/// `latest`/`pending` reads would observe until the node restarts).
+///
+/// Drives `execute_consensus_output` with a two-batch output where both blocks build and advance
+/// the in-memory state, then fails every persist attempt via the injected provider fault
+/// (`PERSIST_OUTPUT_ATTEMPTS` armed faults, so the bounded retry exhausts too). Asserts the
+/// output errors with the provider fault, the in-memory canonical state is back at the
+/// pre-output (genesis) tip, nothing was committed durably, and no canon-state notification or
+/// engine update was emitted.
+///
+/// Confirm-by-mutation: with the `rollback_in_memory_output` compensation removed from the
+/// persist error path in `execute_consensus_output`, the two blocks' advance survives and the
+/// `canonical_chain().count() == 0` / `canonical_tip == genesis` assertions below fail.
+#[tokio::test]
+async fn test_persist_output_failure_rolls_back_in_memory_state() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two valid batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let batches = tn_reth::test_utils::batches(chain.clone(), 2);
+    let genesis = test_genesis_with_consensus_registry(4);
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // pre-conditions: nothing has advanced yet
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    // arm the injector: every persist attempt (first try + retries) hits a provider fault, so
+    // the bounded retry exhausts and the failure escalates
+    reth_env.inject_persist_provider_faults(PERSIST_OUTPUT_ATTEMPTS);
+
+    // subscribe before execution to prove no canon-state notification is emitted for the failure
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // run the output on a blocking task, mirroring the production execution task
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    // the persist fault escalates as a provider error once the retry budget is exhausted
+    assert_matches!(
+        result,
+        Err(TnEngineError::Reth(TnRethError::Provider(_))),
+        "an exhausted persist retry must escalate the provider fault"
+    );
+
+    // the whole budget was spent: a fault raised before `save_blocks` leaves nothing behind for
+    // the next attempt to trip over, so this is the one ordering a retry can actually work on
+    assert_eq!(
+        reth_env.persist_attempt_count(),
+        PERSIST_OUTPUT_ATTEMPTS,
+        "an early-seam fault must be retried until the budget is exhausted"
+    );
+
+    //=== the phantom head must not survive: in-memory state is rolled back to genesis
+    assert_eq!(
+        canonical_in_memory_state.canonical_chain().count(),
+        0,
+        "the blocks' in-memory advance must be rolled back after the persist failed"
+    );
+    assert_eq!(
+        reth_env.canonical_tip().hash(),
+        genesis_header.hash(),
+        "the canonical head must be reset to the pre-output (genesis) tip"
+    );
+
+    // no durable write: persisted tip and finalized marker stay at genesis
+    assert_eq!(reth_env.last_block_number()?, 0, "no block was committed durably");
+    assert_eq!(reth_env.last_finalized_block_number()?, 0, "no block was finalized");
+
+    // no external observer saw the phantom advance
+    assert!(
+        canon_rx.try_recv().is_err(),
+        "a failed output must not broadcast a canon-state notification"
+    );
+    assert!(engine_update_rx.try_recv().is_err(), "a failed output must not send an engine update");
+
+    Ok(())
+}
+
+/// Issue #1090, late-stage variant of the persist rollback: a provider fault raised AFTER
+/// `save_blocks` has advanced the process-wide static-file writers still compensates the
+/// speculative in-memory advance, so the phantom canonical head cannot survive a late-stage
+/// persist failure.
+///
+/// Mirrors `test_persist_output_failure_rolls_back_in_memory_state` exactly, changing only the
+/// fault seam: `inject_late_persist_provider_faults` fires after `save_blocks` and the
+/// finalized/safe marker writes, immediately before `provider_rw.commit()`, rather than at the
+/// top of `RethEnv::persist_executed_output`. The database transaction is still uncommitted on
+/// that path, so the post-conditions are identical: the in-memory chain segment is empty, the
+/// canonical head is back at the anchor, nothing is durable, and no canon-state or engine-update
+/// notification fired.
+///
+/// Unlike the early-seam case this ordering CANNOT exhaust the retry budget: attempt 1 leaves the
+/// static-file writers advanced, so attempt 2 fails terminally on the mismatch before it reaches
+/// the seam at all. The attempt-count assertion pins that, so the test cannot quietly start
+/// passing for a different reason than the one documented here.
+#[tokio::test]
+async fn test_late_persist_failure_rolls_back_in_memory_state() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two valid batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let batches = tn_reth::test_utils::batches(chain.clone(), 2);
+    let genesis = test_genesis_with_consensus_registry(4);
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // pre-conditions: nothing has advanced yet
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    // arm the LATE injector with the full budget: only the first fault is ever consumed, because
+    // attempt 2 trips over attempt 1's static-file progress before it reaches the seam
+    reth_env.inject_late_persist_provider_faults(PERSIST_OUTPUT_ATTEMPTS);
+
+    // subscribe before execution to prove no canon-state notification is emitted for the failure
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // run the output on a blocking task, mirroring the production execution task
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    // the persist fault escalates as a provider error
+    assert_matches!(
+        result,
+        Err(TnEngineError::Reth(TnRethError::Provider(_))),
+        "a failed persist must escalate the provider fault"
+    );
+
+    // this ordering cannot exhaust the budget: attempt 1 leaves the static-file writers advanced,
+    // so attempt 2 fails terminally on the mismatch before it ever reaches the seam
+    assert_eq!(
+        reth_env.persist_attempt_count(),
+        2,
+        "a late-seam fault must stop at the terminal repeat attempt, not spend the whole budget"
+    );
+
+    //=== the phantom head must not survive: in-memory state is rolled back to genesis
+    assert_eq!(
+        canonical_in_memory_state.canonical_chain().count(),
+        0,
+        "the blocks' in-memory advance must be rolled back after the late persist failed"
+    );
+    assert_eq!(
+        reth_env.canonical_tip().hash(),
+        genesis_header.hash(),
+        "the canonical head must be reset to the pre-output (genesis) tip"
+    );
+
+    // no durable write: persisted tip and finalized marker stay at genesis
+    assert_eq!(reth_env.last_block_number()?, 0, "no block was committed durably");
+    assert_eq!(reth_env.last_finalized_block_number()?, 0, "no block was finalized");
+
+    // no external observer saw the phantom advance
+    assert!(
+        canon_rx.try_recv().is_err(),
+        "a failed output must not broadcast a canon-state notification"
+    );
+    assert!(engine_update_rx.try_recv().is_err(), "a failed output must not send an engine update");
+
+    Ok(())
+}
+
+/// Issue #1090: once an attempt of `RethEnv::persist_executed_output` has failed AFTER
+/// `save_blocks` fsynced its static-file progress, re-running the call in-process can never
+/// succeed, so the bounded retry must abandon the budget rather than burn it.
+///
+/// Arms exactly ONE late fault: attempt 1 dies immediately before `provider_rw.commit()` with
+/// the static-file writers already advanced past this output's blocks, so attempt 2 re-runs
+/// `save_blocks` for real and trips over that progress. Empirically (three identical runs)
+/// attempt 2 fails with `ProviderError::UnexpectedStaticFileBlockNumber(Headers, 1, 3)`, reth's
+/// "trying to append data to Headers as block #1 but expected block #3", which
+/// `retryable_persist_fault` classifies terminal.
+///
+/// Pins three things: the terminal class is what escalates, the engine stops at attempt 2 of
+/// `PERSIST_OUTPUT_ATTEMPTS` instead of burning the third (asserted on the attempt counter, never
+/// on elapsed time), and the speculative in-memory advance is still compensated on the way out
+/// even though a durable side effect (the static-file writers) survives for reth's startup
+/// consistency check to reconcile.
+#[tokio::test]
+async fn test_repeat_persist_after_static_file_progress_is_terminal() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two valid batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let batches = tn_reth::test_utils::batches(chain.clone(), 2);
+    let genesis = test_genesis_with_consensus_registry(4);
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // pre-conditions: nothing has advanced yet
+    assert_eq!(canonical_in_memory_state.canonical_chain().count(), 0);
+    assert_eq!(reth_env.canonical_tip().hash(), genesis_header.hash());
+
+    // exactly ONE late fault: attempt 1 dies after `save_blocks`, attempt 2 re-runs it for real
+    reth_env.inject_late_persist_provider_faults(1);
+
+    // subscribe before execution to prove no canon-state notification is emitted for the failure
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // run the output on a blocking task, mirroring the production execution task
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    // attempt 2 trips over attempt 1's fsynced static-file progress, and that class is terminal
+    assert_matches!(
+        result,
+        Err(TnEngineError::Reth(TnRethError::Provider(
+            ProviderError::UnexpectedStaticFileBlockNumber(..)
+        ))),
+        "a repeat persist over the failed attempt's fsynced static-file progress must surface \
+         the static-file mismatch, not a retryable fault"
+    );
+
+    // the terminal class abandons the budget at attempt 2 instead of burning the third attempt
+    assert_eq!(
+        reth_env.persist_attempt_count(),
+        2,
+        "the static-file mismatch is terminal, so the retry must stop at attempt 2 of \
+         {PERSIST_OUTPUT_ATTEMPTS}"
+    );
+
+    //=== the phantom head must not survive: in-memory state is rolled back to genesis
+    assert_eq!(
+        canonical_in_memory_state.canonical_chain().count(),
+        0,
+        "the blocks' in-memory advance must be rolled back after the terminal persist failure"
+    );
+    assert_eq!(
+        reth_env.canonical_tip().hash(),
+        genesis_header.hash(),
+        "the canonical head must be reset to the pre-output (genesis) tip"
+    );
+
+    // no durable write: both attempts left the database transaction uncommitted
+    assert_eq!(reth_env.last_block_number()?, 0, "no block was committed durably");
+    assert_eq!(reth_env.last_finalized_block_number()?, 0, "no block was finalized");
+
+    // no external observer saw the phantom advance
+    assert!(
+        canon_rx.try_recv().is_err(),
+        "a failed output must not broadcast a canon-state notification"
+    );
+    assert!(engine_update_rx.try_recv().is_err(), "a failed output must not send an engine update");
+
+    Ok(())
+}
+
+/// Issue #1090 defect (b): a transient node-local provider fault on the durable persist is
+/// retried within the bounded budget instead of halting the engine.
+///
+/// Arms `PERSIST_OUTPUT_ATTEMPTS - 1` injected faults, so every attempt in the retry window
+/// fails and the final attempt succeeds. Asserts the output executes to completion exactly as on
+/// the fault-free path: both blocks durably committed with the finalized marker advanced, the
+/// in-memory head naming the committed tip, and the engine update and canon-state notification
+/// emitted.
+#[tokio::test]
+async fn test_persist_provider_fault_retry_recovers() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two valid batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let batches = tn_reth::test_utils::batches(chain.clone(), 2);
+    let genesis = test_genesis_with_consensus_registry(4);
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // arm the injector: the whole retry window faults, then the final attempt succeeds
+    reth_env.inject_persist_provider_faults(PERSIST_OUTPUT_ATTEMPTS - 1);
+
+    // subscribe before execution to observe the success-path notification
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // run the output on a blocking task, mirroring the production execution task
+    let (engine_update_tx, mut engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    // the transient faults are absorbed by the bounded retry
+    let executed_tip = result?;
+    assert_eq!(executed_tip.number, 2, "both blocks executed");
+
+    // the injector really fired: without this the test passes just as well when the seam fails to
+    // arm and the very first attempt succeeds, leaving the retry window itself untested
+    assert_eq!(
+        reth_env.persist_attempt_count(),
+        PERSIST_OUTPUT_ATTEMPTS,
+        "every attempt in the retry window must run before the final one succeeds"
+    );
+
+    // the output is durably committed and announced exactly as on the fault-free path
+    assert_eq!(reth_env.last_block_number()?, 2, "both blocks committed durably");
+    assert_eq!(reth_env.last_finalized_block_number()?, 2, "finalized marker advanced");
+    assert_eq!(
+        reth_env.canonical_tip().hash(),
+        executed_tip.hash(),
+        "the in-memory head names the committed tip"
+    );
+    assert!(
+        canon_rx.try_recv().is_ok(),
+        "a committed output broadcasts a canon-state notification"
+    );
+    let (_, _, header) =
+        engine_update_rx.try_recv().expect("a committed output sends an engine update");
+    assert_eq!(
+        header.map(|h| h.hash()),
+        Some(executed_tip.hash()),
+        "the engine update names the committed tip"
+    );
+
+    Ok(())
+}
+
+/// Issue #1090 mirror case: a failure AFTER the durable commit (a closed engine-update channel
+/// yields `TnRethError::EngineUpdateChannelClosed` from `RethEnv::announce_executed_output`) must
+/// NOT roll back the in-memory advance. The blocks are canonical for real, and reverting durably
+/// committed blocks would be a worse defect than the phantom head this issue fixes; this pins the
+/// compensator's pre-commit-only scope.
+///
+/// Confirm-by-mutation: with the rollback widened to fire on the announce failure too, the
+/// canonical-head assertions below fail.
+#[tokio::test]
+async fn test_post_commit_failure_preserves_committed_head() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+
+    // Two valid batches -> two blocks in one output.
+    let chain = test_chain_spec_arc();
+    let batches = tn_reth::test_utils::batches(chain.clone(), 2);
+    let genesis = test_genesis_with_consensus_registry(4);
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // create execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let leader_id = committee.authorities().first().expect("first authority").id();
+    let batch_producer =
+        committee.authority(&leader_id).expect("authority in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    //=== Consensus: one output containing both batches
+    let mut leader = Certificate::default();
+    leader.update_header_author_for_test(leader_id);
+    let sub_dag_index = 1;
+    leader.update_header_round_for_test(sub_dag_index as u32);
+    let batch_digests: VecDeque<BlockHash> = batches.iter().map(|b| b.digest()).collect();
+    let sub_dag = CommittedSubDag::new(
+        vec![Certificate::default(), leader.clone()],
+        leader,
+        sub_dag_index,
+        ReputationScores::default(),
+        None,
+    );
+    let consensus_output = ConsensusOutput::new(
+        sub_dag,
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests,
+        vec![CertifiedBatch { address: batch_producer, batches }],
+    );
+
+    //=== drive execution
+    let reth_env = execution_node.get_reth_env().await;
+    let genesis_header = chain.sealed_genesis_header();
+    let canonical_in_memory_state = reth_env.canonical_in_memory_state();
+
+    // subscribe before execution: the announce fails at the engine-update send, BEFORE the
+    // canon-state broadcast, so no notification may be observed either
+    let mut canon_rx = canonical_in_memory_state.subscribe_canon_state();
+
+    // close the engine-update channel BEFORE execution: the POST-commit blocking_send fails
+    let (engine_update_tx, engine_update_rx) = tokio::sync::mpsc::channel(64);
+    drop(engine_update_rx);
+
+    // run the output on a blocking task, mirroring the production execution task
+    let args = BuildArguments::new(reth_env.clone(), consensus_output, genesis_header.clone());
+    let result = tokio::task::spawn_blocking(move || {
+        execute_consensus_output(args, gas_accumulator, engine_update_tx)
+    })
+    .await?;
+
+    assert_matches!(
+        result,
+        Err(TnEngineError::Reth(TnRethError::EngineUpdateChannelClosed)),
+        "a closed engine-update channel fails the output post-commit"
+    );
+
+    // the blocks are durably canonical: committed tip and markers advanced
+    assert_eq!(
+        reth_env.last_block_number()?,
+        2,
+        "both blocks committed durably before the failure"
+    );
+    assert_eq!(
+        reth_env.last_finalized_block_number()?,
+        2,
+        "finalized marker advanced with the blocks"
+    );
+
+    // and the in-memory head still names the committed tip: NO rollback fired
+    assert_eq!(
+        reth_env.canonical_tip().number,
+        2,
+        "the in-memory canonical head must keep naming the committed tip"
+    );
+    assert_eq!(
+        canonical_in_memory_state.canonical_chain().count(),
+        2,
+        "the committed blocks stay in the in-memory chain (finalize_block never ran)"
+    );
+
+    // ordering: the announce failed before the canon-state broadcast
+    assert!(
+        canon_rx.try_recv().is_err(),
+        "the canon-state broadcast happens after the engine-update send, which failed"
+    );
 
     Ok(())
 }

--- a/crates/tn-reth/src/env/execution.rs
+++ b/crates/tn-reth/src/env/execution.rs
@@ -26,14 +26,22 @@
 //!
 //! # Atomicity contract
 //!
-//! [`RethEnv::finish_executing_output`] persists the blocks and the finalized/safe
+//! [`RethEnv::persist_executed_output`] persists the blocks and the finalized/safe
 //! block-number markers in ONE `provider_rw` transaction with a single commit — a
-//! crash can never leave the persisted tip and the markers out of sync. Only after
-//! that commit does it report the new tip over the engine update channel
-//! (`blocking_send`) and then broadcast the canonical-state notification
-//! (`notify_canon_state`). [`RethEnv::finalize_block`] is in-memory only (the
-//! finalized/safe watches plus pruning persisted blocks from the in-memory state);
-//! its database half happens inside the atomic commit above.
+//! crash can never leave the persisted tip and the markers out of sync, and every
+//! error it returns leaves that transaction uncommitted, so no block became canonical
+//! in the database. Durability is NOT all-or-nothing, though: `save_blocks` also
+//! appends to the process-wide static-file writers, and that progress is fsynced
+//! outside the transaction, so a fault after the append leaves the writers advanced
+//! for reth's startup consistency check to reconcile on restart. Read that method's
+//! error contract before retrying it. Only after that commit
+//! does [`RethEnv::announce_executed_output`] report the new tip over the engine
+//! update channel (`blocking_send`) and then broadcast the canonical-state
+//! notification (`notify_canon_state`); its errors are post-commit and must never
+//! trigger a rollback. [`RethEnv::finish_executing_output`] composes the two for
+//! callers that do not need the commit boundary. [`RethEnv::finalize_block`] is
+//! in-memory only (the finalized/safe watches plus pruning persisted blocks from
+//! the in-memory state); its database half happens inside the atomic commit above.
 
 use std::sync::Arc;
 
@@ -216,8 +224,7 @@ impl RethEnv {
         Ok(())
     }
 
-    /// Atomically persist an executed round of consensus output and announce the new
-    /// canonical tip.
+    /// Atomically persist an executed round of consensus output.
     ///
     /// The blocks AND the finalized/safe markers commit in the same database
     /// transaction (one `provider_rw` commit), so a crash can never leave the
@@ -225,23 +232,29 @@ impl RethEnv {
     /// committed consensus output and is final by construction. The in-memory
     /// finalized/safe watches are updated afterwards by [`Self::finalize_block`].
     ///
-    /// Ordering after the commit: first the new tip is reported over the engine
-    /// update channel (`blocking_send`, feeding the consensus layer's `recent_blocks`
-    /// watch — so this method must run on a blocking thread, and a closed channel
-    /// errors out before any broadcast); only then is the canonical-state
-    /// notification broadcast via `notify_canon_state` to in-process subscribers such
-    /// as the worker's pool maintenance task.
-    pub fn finish_executing_output(
-        &self,
-        blocks: Vec<ExecutedBlock>,
-        engine_update: Option<(Round, ConsensusNumHash, tokio::sync::mpsc::Sender<EngineUpdate>)>,
-    ) -> TnRethResult<()> {
-        // NOTE: this makes all blocks canonical, commits them to the database,
-        // and broadcasts new chain on `canon_state_notification_sender`
-        //
-        // the canon_state_notifications include every block executed in this round
-        //
-        // the worker's pool maintenance task subcribes to these events
+    /// # Error contract
+    ///
+    /// Every error return leaves the DATABASE transaction uncommitted: the last fallible
+    /// step is `provider_rw.commit()`, so on any `Err` no block became canonical in the
+    /// database and the caller must compensate the speculative in-memory advance.
+    ///
+    /// Durability is NOT all-or-nothing, though: `save_blocks` also appends to the
+    /// process-wide static-file writers, and that progress is fsynced outside the
+    /// database transaction. A fault after that append (marker writes, the commit
+    /// itself) aborts the database transaction but leaves the static-file writer
+    /// advanced, so a repeat call trips over it with
+    /// `ProviderError::UnexpectedStaticFileBlockNumber`; reth's startup consistency
+    /// check reconciles the divergence on restart. Callers retrying this method must
+    /// treat that error as terminal (see the engine's `persist_output_with_retry`).
+    /// Post-commit reporting lives in [`Self::announce_executed_output`] so the commit
+    /// boundary is a function boundary rather than an error-classification exercise
+    /// (issue #1090).
+    pub fn persist_executed_output(&self, blocks: &[ExecutedBlock]) -> TnRethResult<()> {
+        #[cfg(any(feature = "test-utils", test))]
+        self.inner.persist_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        #[cfg(any(feature = "test-utils", test))]
+        self.consume_injected_persist_fault()?;
+
         debug!(
             target: "engine",
             first=?blocks.first().map(|b| b.recovered_block.num_hash()),
@@ -251,7 +264,7 @@ impl RethEnv {
 
         // insert blocks to db
         let provider_rw = self.inner.blockchain_provider.database_provider_rw()?;
-        provider_rw.save_blocks(blocks.clone(), reth_provider::SaveBlocksMode::Full)?;
+        provider_rw.save_blocks(blocks.to_vec(), reth_provider::SaveBlocksMode::Full)?;
         // advance the finalized/safe markers in the same transaction as the blocks: every
         // canonical block comes from committed consensus output, so the last saved block is
         // final by construction, and the single commit leaves no crash window where the
@@ -261,9 +274,37 @@ impl RethEnv {
             provider_rw.save_finalized_block_number(last_number)?;
             provider_rw.save_safe_block_number(last_number)?;
         }
-        provider_rw.commit()?;
+        #[cfg(any(feature = "test-utils", test))]
+        self.consume_injected_late_persist_fault()?;
 
+        provider_rw.commit()?;
+        Ok(())
+    }
+
+    /// Announce a durably committed round of consensus output: report the new tip over
+    /// the engine update channel, then broadcast the canonical-state notification.
+    ///
+    /// POST-commit half of the split (issue #1090): by the time this runs the blocks
+    /// are canonical for real, so a failure here (e.g.
+    /// [`TnRethError::EngineUpdateChannelClosed`]) must NOT trigger any rollback of the
+    /// in-memory advance; the in-memory state correctly names the committed tip.
+    ///
+    /// Ordering: first the new tip is reported over the engine update channel
+    /// (`blocking_send`, feeding the consensus layer's `recent_blocks` watch, so this
+    /// method must run on a blocking thread, and a closed channel errors out before any
+    /// broadcast); only then is the canonical-state notification broadcast via
+    /// `notify_canon_state` to in-process subscribers such as the worker's pool
+    /// maintenance task.
+    pub fn announce_executed_output(
+        &self,
+        blocks: Vec<ExecutedBlock>,
+        engine_update: Option<(Round, ConsensusNumHash, tokio::sync::mpsc::Sender<EngineUpdate>)>,
+    ) -> TnRethResult<()> {
         // process update
+        //
+        // the canon_state_notifications include every block executed in this round
+        //
+        // the worker's pool maintenance task subcribes to these events
         //
         // see reth::EngineApiTreeHandler::on_canonical_chain_update
         let chain_update = NewCanonicalChain::Commit { new: blocks };
@@ -297,5 +338,98 @@ impl RethEnv {
         self.canonical_in_memory_state().notify_canon_state(notification);
 
         Ok(())
+    }
+
+    /// Atomically persist an executed round of consensus output and announce the new
+    /// canonical tip.
+    ///
+    /// Composes [`Self::persist_executed_output`] (the atomic durable write; every
+    /// error leaves the database transaction uncommitted) and
+    /// [`Self::announce_executed_output`] (post-commit reporting). Callers that must
+    /// distinguish the commit boundary (to compensate or retry only the durable
+    /// write, as the engine's `execute_consensus_output` does) call the two halves
+    /// directly.
+    pub fn finish_executing_output(
+        &self,
+        blocks: Vec<ExecutedBlock>,
+        engine_update: Option<(Round, ConsensusNumHash, tokio::sync::mpsc::Sender<EngineUpdate>)>,
+    ) -> TnRethResult<()> {
+        self.persist_executed_output(&blocks)?;
+        self.announce_executed_output(blocks, engine_update)
+    }
+
+    /// TEST-ONLY: arm `count` injected pre-commit persist faults.
+    ///
+    /// The next `count` calls to [`Self::persist_executed_output`] fail with a
+    /// [`TnRethError::Provider`] before touching the database, simulating a node-local
+    /// storage fault (disk full, an MDBX write error) on the durable write. Lets
+    /// integration tests exercise the engine's bounded persist retry and its
+    /// pre-commit rollback without a real storage fault (issue #1090).
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn inject_persist_provider_faults(&self, count: u32) {
+        self.inner.persist_fault_injections.store(count, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// TEST-ONLY: consume one armed injected persist fault, if any.
+    ///
+    /// Returns the injected [`TnRethError::Provider`] while a fault is armed and `Ok`
+    /// otherwise. The inner variant (`HeaderNotFound(0)`) is a stand-in: the engine's
+    /// retry policy classifies on the `Provider` class alone, never on the variant.
+    #[cfg(any(feature = "test-utils", test))]
+    fn consume_injected_persist_fault(&self) -> TnRethResult<()> {
+        use std::sync::atomic::Ordering;
+        self.inner
+            .persist_fault_injections
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| armed.checked_sub(1))
+            .map_or(Ok(()), |_| {
+                Err(TnRethError::Provider(reth_provider::ProviderError::HeaderNotFound(
+                    0u64.into(),
+                )))
+            })
+    }
+
+    /// TEST-ONLY: arm `count` injected LATE persist faults.
+    ///
+    /// The next `count` calls to [`Self::persist_executed_output`] fail with a
+    /// [`TnRethError::Provider`] AFTER `save_blocks` has advanced the process-wide
+    /// static-file writers, immediately before `provider_rw.commit()`, simulating a
+    /// node-local fault on the finalized/safe marker writes or the commit itself.
+    /// That ordering is the one that makes an in-process retry impossible: the failed
+    /// attempt's static-file progress is already fsynced, so a repeat call trips
+    /// `ProviderError::UnexpectedStaticFileBlockNumber` (issue #1090).
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn inject_late_persist_provider_faults(&self, count: u32) {
+        self.inner.persist_late_fault_injections.store(count, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// TEST-ONLY: consume one armed injected LATE persist fault, if any.
+    ///
+    /// Returns the injected [`TnRethError::Provider`] while a fault is armed and `Ok`
+    /// otherwise. The inner variant (`HeaderNotFound(0)`) is a stand-in for the marker
+    /// write or commit failing; the defining property is the POSITION (after
+    /// `save_blocks` advanced the static-file writers), not the variant.
+    #[cfg(any(feature = "test-utils", test))]
+    fn consume_injected_late_persist_fault(&self) -> TnRethResult<()> {
+        use std::sync::atomic::Ordering;
+        self.inner
+            .persist_late_fault_injections
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| armed.checked_sub(1))
+            .map_or(Ok(()), |_| {
+                Err(TnRethError::Provider(reth_provider::ProviderError::HeaderNotFound(
+                    0u64.into(),
+                )))
+            })
+    }
+
+    /// TEST-ONLY: how many times [`Self::persist_executed_output`] has been entered.
+    ///
+    /// Counts ATTEMPTS, not failures: the counter increments on entry, before any injected
+    /// fault is consumed, so a test can pin exactly how much of the engine's bounded retry
+    /// budget a given fault ordering spent. Telling "failed fast at attempt 2" apart from
+    /// "burned the whole budget" otherwise takes a wall-clock measurement of the retry
+    /// backoff, which is not a sound assertion (issue #1090).
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn persist_attempt_count(&self) -> u32 {
+        self.inner.persist_attempts.load(std::sync::atomic::Ordering::SeqCst)
     }
 }

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -69,6 +69,30 @@ struct RethEnvInner {
     evm_config: TnEvmConfig,
     /// The type to spawn tasks.
     task_spawner: TaskSpawner,
+    /// TEST-ONLY: number of pending injected pre-commit persist faults.
+    ///
+    /// While non-zero, each call to `RethEnv::persist_executed_output` consumes one count
+    /// and fails with a `TnRethError::Provider` before touching the database, simulating a
+    /// node-local storage fault on the durable write. Armed via
+    /// `RethEnv::inject_persist_provider_faults` (see `env/execution.rs`).
+    #[cfg(any(feature = "test-utils", test))]
+    persist_fault_injections: std::sync::atomic::AtomicU32,
+    /// TEST-ONLY: number of pending injected LATE (post-`save_blocks`) persist faults.
+    ///
+    /// While non-zero, each call to `RethEnv::persist_executed_output` consumes one count
+    /// and fails with a `TnRethError::Provider` AFTER `save_blocks` has advanced the
+    /// process-wide static-file writers, immediately before the database commit, simulating
+    /// a node-local fault on the marker writes or the commit itself. Armed via
+    /// `RethEnv::inject_late_persist_provider_faults` (see `env/execution.rs`).
+    #[cfg(any(feature = "test-utils", test))]
+    persist_late_fault_injections: std::sync::atomic::AtomicU32,
+    /// TEST-ONLY: how many times `RethEnv::persist_executed_output` has been entered.
+    ///
+    /// Incremented on entry, before any injected fault is consumed, so the value is the
+    /// number of persist ATTEMPTS the engine's bounded retry actually made. Read through
+    /// `RethEnv::persist_attempt_count` (see `env/execution.rs`).
+    #[cfg(any(feature = "test-utils", test))]
+    persist_attempts: std::sync::atomic::AtomicU32,
 }
 
 impl std::fmt::Debug for RethEnv {
@@ -127,6 +151,12 @@ impl RethEnv {
                 blockchain_provider,
                 evm_config,
                 task_spawner,
+                #[cfg(any(feature = "test-utils", test))]
+                persist_fault_injections: std::sync::atomic::AtomicU32::new(0),
+                #[cfg(any(feature = "test-utils", test))]
+                persist_late_fault_injections: std::sync::atomic::AtomicU32::new(0),
+                #[cfg(any(feature = "test-utils", test))]
+                persist_attempts: std::sync::atomic::AtomicU32::new(0),
             }),
         })
     }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -104,6 +104,9 @@ pub use reth_node_core::{
     node_config::DEFAULT_PERSISTENCE_THRESHOLD,
 };
 pub use reth_primitives_traits::crypto::secp256k1::sign_message;
+/// Test-only re-export so engine tests can construct static-file provider errors.
+#[cfg(feature = "test-utils")]
+pub use reth_provider::StaticFileSegment;
 pub use reth_provider::{
     providers::StaticFileProvider, CanonStateNotificationStream, ChangedAccount,
 };


### PR DESCRIPTION
Closes #1090.

## Problem

`execute_consensus_output` advances the shared `CanonicalInMemoryState` eagerly, block by block, while it builds a consensus output.  Both in-loop error exits compensate that speculative advance with `rollback_in_memory_output`, but the post-loop durable write did not: `finish_executing_output` was called with a bare `?`, so a failure of the durable write left the phantom canonical head standing.  RPC and every other reader of the in-memory state kept naming blocks that never became canonical in the database, while the engine's critical task died and took the node down around them.

Independently, `TnRethError::Provider` was never matched anywhere on the write path, so a transient node-local storage fault was unclassified: no retry, immediate engine death.  The read side already classifies and retries exactly this fault class (#1025, `retry_provider_faults`).  No attacker is required for either defect;  a single node-local storage hiccup at the wrong instant is enough, which makes this an availability and state-coherence hardening rather than an attack-surface change.

## Fix

- [x] `crates/tn-reth/src/env/execution.rs`: split `finish_executing_output` at the commit boundary.  `persist_executed_output` is the durable write (blocks plus the finalized and safe markers in one `provider_rw` transaction, with `commit()` as the last fallible step);  every error return leaves the database transaction uncommitted, so no block became canonical in the database and the caller must compensate the speculative in-memory advance.  Durability is not all-or-nothing, though, and the doc comment now says so explicitly because the retry policy depends on it:  `save_blocks` also appends to the process-wide static-file writers, and that progress is fsynced outside the database transaction, so a fault after the append leaves the writers advanced until reth's startup consistency check reconciles them on restart.  `announce_executed_output` is the post-commit half (engine-update send, then canon-state broadcast);  its errors must never trigger a rollback.  `finish_executing_output` remains as the composition, so its four other call sites, all of them test helpers (`tn-reth/src/test_utils.rs`, `tn-reth/tests/it/pipeline_helpers.rs`, `node/tests/it/main.rs`, `e2e-tests/tests/it/staking.rs`), are behaviorally untouched.
- [x] `crates/engine/src/payload_builder.rs`: the engine calls the two halves directly.  The persist runs through `persist_output_with_retry`: up to `PERSIST_OUTPUT_ATTEMPTS` (3) attempts with a 100ms pause, retrying only a `TnRethError::Provider` that `retryable_persist_fault` classifies as healable in process, mirroring the #1025 read-side policy (the pause is fine here;  this code already runs on its own blocking task).  `ProviderError::UnexpectedStaticFileBlockNumber` is classified terminal, because it is exactly what a repeat attempt raises over the failed attempt's already-fsynced static-file progress: retrying it can only burn the remaining budget and report a misleading error instead of failing fast to the restart that heals it.  An exhausted or terminal persist failure logs, increments `tn_engine.persist_failures_total`, rolls back the in-memory advance with the same compensator the in-loop error exits use, and then propagates.  Announce and finalize failures propagate with no rollback, because once the commit lands the blocks are canonical for real.
- [x] `crates/tn-reth/src/env/mod.rs` and `crates/tn-reth/src/lib.rs`: test-only fault seams.  Two `#[cfg(any(feature = "test-utils", test))] AtomicU32` counters on `RethEnvInner` arm injected provider faults at the two positions that behave differently: early, before any provider is acquired, and late, after `save_blocks` and the marker writes and immediately before the commit.  The late seam is the one the retry contract turns on, because it is the ordering in which the failed attempt has already advanced the static-file writers.  A third counter records every entry into `persist_executed_output`, so a test asserts how many attempts the bounded retry actually spent rather than inferring it from elapsed wall-clock time.  `StaticFileSegment` is re-exported under the same feature so the engine's classifier tests can construct the terminal error.  All of it compiles away outside test builds.
- [x] `crates/engine/src/metrics.rs`: two new counters, `tn_engine.persist_provider_fault_retries_total` and `tn_engine.persist_failures_total`, so a node quietly surviving storage faults stays observable before the fault stops being survivable.
- [x] `crates/engine/tests/it/main.rs`: tests mirroring the existing in-loop rollback regression test.  An exhausted early-seam persist failure rolls back to the anchor (in-memory chain empty, tip back to genesis, nothing durable, no canon or engine-update notification);  the same holds for a late-seam failure raised after `save_blocks`;  a repeat persist over the failed attempt's fsynced static-file progress fails terminally at attempt 2 of 3 instead of burning the budget;  a transient fault recovers inside the retry budget;  and the post-commit mirror (closed engine-update channel) preserves the committed head with no rollback.  Each of those asserts the attempt count directly, which is also what stops the retry-recovery test from passing vacuously if the seam ever fails to arm.  Two unit tests in `payload_builder` pin the classifier on both sides.

## Testing

- `cargo +1.94 test -p tn-engine --lib -- --exact tests::test_metrics_register_and_update` (green)
- `cargo +1.94 test -p tn-engine --lib -- payload_builder::tests` (green): the static-file mismatch is terminal, an ordinary provider fault is retryable
- `cargo +1.94 test -p tn-engine --test it -- --exact <test>` for `test_persist_output_failure_rolls_back_in_memory_state`, `test_late_persist_failure_rolls_back_in_memory_state`, `test_repeat_persist_after_static_file_progress_is_terminal`, `test_persist_provider_fault_retry_recovers`, `test_post_commit_failure_preserves_committed_head`, and the pre-existing `test_partial_output_failure_rolls_back_in_memory_state` (all green, run one at a time)
- Each new test confirmed by mutation: removing the persist-path rollback fails the rollback test;  widening the rollback to fire on the post-commit announce failure fails the preserved-head test;  emptying the retry window fails the recovery test;  and inverting the classifier so the static-file mismatch counts as retryable fails the terminal-fault test at its attempt-count assertion (3 attempts against the expected 2).  Every mutant died at its assertion, not at build time, and the tree was restored to the tested bytes.
- The `make attest` gates on the pinned 1.94 toolchain, all green against current `main`: `cargo +nightly fmt -- --check`, then `cargo +1.94 clippy --workspace --all-targets -j 2` (exit 0), then `cargo +1.94 test --no-run --workspace -j 2` (exit 0, all 37 test executables built).  Both cargo passes ran against an isolated target dir rather than the shared one, so no sibling worktree's artifact could stand in for a crate this branch changed;  the cold pass compiled all 901 crates in 15m35s.  Clippy raises no diagnostic in any file this branch adds or touches (the warnings it still reports under `--all-targets` are pre-existing, in test code this branch leaves alone, and `--all-targets` is stricter than the clippy invocation attest itself runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
