### PR TITLE
fix(types): clamp current_base_fee before alloy's unchecked fee-increase add (#1108)

### DIFF
--- a/crates/types/src/gas_accumulator.rs
+++ b/crates/types/src/gas_accumulator.rs
@@ -437,6 +437,23 @@ impl GasAccumulator {
     }
 }
 
+/// The largest `current_base_fee` [`compute_next_base_fee_eip1559`] may hand to alloy.
+///
+/// alloy's [`calc_next_block_base_fee`] adds its delta to `base_fee` with a plain `+`. That
+/// addition is unchecked, so it panics under `overflow-checks` (the `dev`, `test` and `e2e`
+/// profiles) and wraps silently under `release`, where a wrapped fee is a consensus value every
+/// node agrees on and therefore validates cleanly instead of forking.
+///
+/// With `gas_used` already clamped to `gas_limit`, the delta alloy computes is at most
+/// `base_fee * (gas_limit - gas_target) / (gas_target * 8)`, and `gas_limit - gas_target` never
+/// exceeds `gas_target`, so the delta never exceeds `base_fee / 8`. Bounding `base_fee` by
+/// `u64::MAX - u64::MAX / 8` therefore keeps `base_fee + base_fee / 8` inside `u64`.
+///
+/// This bound holds in the saturating regime too. For a `target_gas > u64::MAX / 2` the synthetic
+/// `gas_limit` saturates at `u64::MAX`, alloy recovers `gas_target = u64::MAX / 2`, and
+/// `gas_limit - gas_target` still does not exceed `gas_target`, so the `/ 8` ceiling is unchanged.
+const SAFE_MAX_BASE_FEE: u64 = u64::MAX - u64::MAX / 8;
+
 /// EIP-1559-style base fee adjustment computed once per epoch.
 ///
 /// Compares `gas_used` (total gas consumed by a single worker during the epoch)
@@ -446,10 +463,13 @@ impl GasAccumulator {
 /// Delegates the formula to alloy's [`calc_next_block_base_fee`] using
 /// [`BaseFeeParams::ethereum`] (`elasticity_multiplier = 2`,
 /// `max_change_denominator = 8`). The synthetic `gas_limit` passed to alloy is
-/// `target_gas * 2` so alloy recovers the same `gas_target`. `gas_used` is
-/// clamped to `gas_limit` to enforce the EIP-1559 elasticity bound and avoid
-/// the unbounded delta arithmetic alloy would otherwise produce when callers
-/// pass `gas_used > gas_limit`.
+/// `target_gas * 2` so alloy recovers the same `gas_target`, except for a
+/// `target_gas > u64::MAX / 2`, where the multiply saturates and alloy instead
+/// recovers `u64::MAX / 2`. Both inputs into alloy's delta arithmetic are
+/// clamped so that arithmetic cannot leave `u64`: `gas_used` to `gas_limit`,
+/// enforcing the EIP-1559 elasticity bound, and `current_base_fee` to
+/// [`SAFE_MAX_BASE_FEE`], bounding the unchecked addition alloy performs on the
+/// fee-increase arm.
 ///
 /// The result is clamped to `[MIN_PROTOCOL_BASE_FEE, u64::MAX]`.
 pub fn compute_next_base_fee_eip1559(current_base_fee: u64, gas_used: u64, target_gas: u64) -> u64 {
@@ -460,6 +480,7 @@ pub fn compute_next_base_fee_eip1559(current_base_fee: u64, gas_used: u64, targe
     let params = BaseFeeParams::ethereum();
     let gas_limit = target_gas.saturating_mul(params.elasticity_multiplier as u64);
     let gas_used = gas_used.min(gas_limit);
+    let current_base_fee = current_base_fee.min(SAFE_MAX_BASE_FEE);
     let new_base_fee = calc_next_block_base_fee(gas_used, gas_limit, current_base_fee, params);
     new_base_fee.max(MIN_PROTOCOL_BASE_FEE)
 }
@@ -590,6 +611,56 @@ mod tests {
         let base = 1_000_000_000_000_000u64;
         let result = compute_next_base_fee_eip1559(base, u64::MAX, 1);
         assert_eq!(result, base + base / 8);
+    }
+
+    /// Mutation guard for the `.min(SAFE_MAX_BASE_FEE)` clamp: with the clamp removed, alloy's
+    /// unchecked `base_fee + delta` overflows on every case here: a panic under the test
+    /// profile's `overflow-checks`, and a wrapped (far lower) fee in a release build.
+    #[test]
+    fn ceiling_base_fee_never_overflows() {
+        let target = 15_000_000u64;
+
+        // the exact threshold: the unclamped sum is 2^64, which wraps to 0 and would surface as
+        // MIN_PROTOCOL_BASE_FEE after the floor
+        let threshold = 16_397_105_843_297_379_215u64;
+        let at_threshold = compute_next_base_fee_eip1559(threshold, target * 2, target);
+        assert!(
+            at_threshold >= SAFE_MAX_BASE_FEE,
+            "a fee increase must never collapse the fee: {at_threshold}"
+        );
+
+        // the widest word `entry_fee_for_worker` accepts, at the maximal +12.5% move
+        let at_max = compute_next_base_fee_eip1559(u64::MAX, target * 2, target);
+        assert_eq!(at_max, SAFE_MAX_BASE_FEE + SAFE_MAX_BASE_FEE / 8);
+
+        // the smallest over-target move still takes alloy's `max(1, ..)` floored delta
+        let barely_over = compute_next_base_fee_eip1559(u64::MAX, target + 1, target);
+        assert!(barely_over >= SAFE_MAX_BASE_FEE, "must not wrap: {barely_over}");
+    }
+
+    /// The clamp is a no-op for every fee the protocol can actually hold, so no epoch that did not
+    /// already overflow changes value. `SAFE_MAX_BASE_FEE` itself is the largest unaffected input.
+    #[test]
+    fn clamp_does_not_change_in_range_fees() {
+        let target = 15_000_000u64;
+        assert_eq!(compute_next_base_fee_eip1559(1000, target * 2, target), 1125);
+        assert_eq!(
+            compute_next_base_fee_eip1559(SAFE_MAX_BASE_FEE, target * 2, target),
+            SAFE_MAX_BASE_FEE + SAFE_MAX_BASE_FEE / 8
+        );
+        // one below the clamp still moves by the full 12.5%
+        let below = SAFE_MAX_BASE_FEE - 1;
+        assert_eq!(compute_next_base_fee_eip1559(below, target * 2, target), below + below / 8);
+    }
+
+    /// A saturating `target_gas` is the other axis into alloy's delta arithmetic; the clamp has to
+    /// hold there too, where `gas_target` is `u64::MAX / 2` rather than the configured target.
+    #[test]
+    fn ceiling_base_fee_never_overflows_with_saturating_target() {
+        [u64::MAX / 2 + 1, u64::MAX - 1, u64::MAX].iter().for_each(|&target| {
+            let out = compute_next_base_fee_eip1559(u64::MAX, u64::MAX, target);
+            assert!(out >= SAFE_MAX_BASE_FEE, "target {target} wrapped to {out}");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`compute_next_base_fee_eip1559` clamps `gas_used` from above and clamps its result from below, but never clamps `current_base_fee` from above.  It then hands that value to alloy's `calc_next_block_base_fee`, whose fee-increase arm performs a plain unchecked `u64` addition.  This adds the missing upper clamp, closing the overflow and restoring the `[MIN_PROTOCOL_BASE_FEE, u64::MAX]` guarantee the function's own doc comment already promised.

Fixes #1108.

## Problem

alloy's `calc_next_block_base_fee` (`alloy-eips` 1.8.3, `src/eip1559/helpers.rs`) increases a fee with `base_fee + delta`, unchecked:

```rust
core::cmp::Ordering::Greater => {
    base_fee
        + (core::cmp::max(
            1,
            base_fee as u128 * (gas_used - gas_target) as u128
                / (gas_target as u128 * base_fee_params.max_change_denominator),
        ) as u64)
}
```

The wrapper clamped one of the two inputs into that arithmetic and not the other.  `gas_used.min(gas_limit)` was already there, and the doc comment explains it exists to "avoid the unbounded delta arithmetic alloy would otherwise produce", but `current_base_fee` went in unbounded.  Once `current_base_fee` exceeds `u64::MAX * 8 / 9` and the epoch ran over its gas target, the addition overflows.  alloy's `max(1, ..)` delta floor means there is no escape hatch at the ceiling: even `u64::MAX` with `gas_used == target_gas + 1` overflows.

The two build profiles then disagree, which is the part that matters:

- `dev` / `test` / `e2e` set `overflow-checks = true`, so the node panics.
- `release` has no `[profile.release]` override, so it keeps Cargo's default of `false`, the addition wraps, and the function returns a base fee far *below* the one it was asked to increase.

Because the wrap is deterministic, every honest node computes the same collapsed fee, and `BatchValidator::validate_basefee` compares for equality only.  The bad value validates cleanly network-wide instead of forking: a silent consensus-value collapse with nothing signalled to the operator.

**Reachability.** The `WorkerConfigs` owner surface is `setWorkerConfig(uint16 workerId, uint8 strategy, uint64 value, uint184 data)`, which sets the strategy and the raw `data` word in a single call.  On epoch entry, `entry_fee_for_worker`'s `Eip1559` arm reads that word back as the worker's base fee, rejecting only words wider than `u64`:

```rust
let recorded = u64::try_from(entry.data).map_err(|_| { .. })?;
Ok(recorded.max(MIN_PROTOCOL_BASE_FEE))
```

Any word in `(u64::MAX * 8 / 9, u64::MAX]` passes that guard and becomes `current_base_fee`.  The repo's own `entry_fee_eip1559_accepts_u64_max_word` test pins exactly this: a `data` word of `u64::MAX` returns `Ok(u64::MAX)`.  So one owner transaction is enough to arm the overflow, and the next over-target epoch triggers it.  No congestion required.

(Issue #1108 proposed a different route: a `Static { fee }` value carried into `Eip1559` by a strategy switch.  That mechanism does not hold, because the `Eip1559` arm reads the recorded `data` word rather than the config's `value`.  The `data` argument above reaches the same place more directly, in one transaction rather than two.)

## Fix

One clamp, in the one shared fee formula, mirroring the `gas_used.min(gas_limit)` line directly above it:

```rust
let current_base_fee = current_base_fee.min(SAFE_MAX_BASE_FEE);
```

`SAFE_MAX_BASE_FEE` is `u64::MAX - u64::MAX / 8`, doc-commented with the bound's proof: with `gas_used` already clamped to `gas_limit`, `gas_limit - gas_target` never exceeds `gas_target`, so alloy's delta never exceeds `base_fee / 8`, and `base_fee + base_fee / 8` stays inside `u64`.  The bound holds in the saturating-`target_gas` regime too, where `gas_target` becomes `u64::MAX / 2` rather than the configured target.

The clamp lives at the point of use rather than at the entry points because both consensus seams that price a worker's next-epoch fee, `record_next_epoch_base_fees` (which writes the on-chain word inside the closing block) and `adjust_base_fees` (the live accumulator at close), route through this single function.  Clamping here fixes both symmetrically and keeps them byte-for-byte identical by construction.

**Safety.** For every `current_base_fee <= SAFE_MAX_BASE_FEE`, `.min(SAFE_MAX_BASE_FEE)` is a literal no-op, so the change cannot alter any value the network has ever computed or would compute for any in-range input.  It changes behaviour only on inputs that previously panicked or wrapped.

The doc comment's claim that the synthetic `gas_limit` makes "alloy recover the same `gas_target`" is also corrected in passing: for `target_gas > u64::MAX / 2` the multiply saturates and alloy recovers `u64::MAX / 2` instead.  That is a documentation accuracy fix, not a behaviour change.

## Testing

Three tests added to `crates/types/src/gas_accumulator.rs`, all pinned by mutation.  With the `.min(SAFE_MAX_BASE_FEE)` line removed they fail, and under the test profile's `overflow-checks` they fail by panicking rather than by asserting, which is precisely the profile difference that hid the defect:

- `ceiling_base_fee_never_overflows` is the mutation guard.  It covers the exact threshold (`16_397_105_843_297_379_215`, where the unclamped sum is `2^64` and wraps to `0`), `u64::MAX` at the maximal move, and the smallest over-target move that still takes alloy's floored delta.  It asserts that a fee increase never collapses the fee.
- `clamp_does_not_change_in_range_fees` pins the no-op argument, including `SAFE_MAX_BASE_FEE` itself as the largest unaffected input, and one below it still moving the full 12.5%.
- `ceiling_base_fee_never_overflows_with_saturating_target` covers the other axis into alloy's arithmetic, where `target_gas` saturates the synthetic `gas_limit`.

The bound was additionally verified out-of-tree against a verbatim copy of alloy 1.8.3's arithmetic with `checked_add` substituted for the unchecked `+`, over a boundary sweep (1,760 cases across both `target_gas` regimes) and a 3M-case random sweep: zero overflows with the clamp, 165 overflows without it, zero divergence below the threshold, and no case where an over-target epoch decreased the fee.

## Out of scope

Issue #1108 raises a second gap: the `Static` arms of `next_base_fee_for_config` and `entry_fee_for_worker` return the governance fee without the `MIN_PROTOCOL_BASE_FEE` floor their `Eip1559` siblings apply.  That is documented behaviour ("`Static` pins the fee to the governance-set value"), is unrelated to the overflow's causal chain, and changing it would alter a governance-visible value, so it is left for a separate decision rather than folded in here.
