### PR TITLE
fix(tn-reth): refuse non-public dial targets in observer transaction forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11939,6 +11939,7 @@ dependencies = [
  "tn-worker",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -280,6 +280,21 @@ pub struct Parameters {
     /// certificates.
     #[serde(default = "Parameters::default_parallel_fetch_request_delay_interval")]
     pub parallel_fetch_request_delay_interval: Duration,
+
+    /// Allow observer transaction forwarding to dial advertised JSON-RPC endpoints whose host is
+    /// not a public internet address.
+    ///
+    /// An observer forwards each transaction it seals to the endpoint the owning validator
+    /// advertised on its node record, so the dial target is chosen by a committee member rather
+    /// than by this node. Default `false`: an endpoint on a loopback, private, link-local,
+    /// unique-local, shared-address-space or unspecified address is refused, so a committee member
+    /// cannot aim this node's outbound HTTP at hosts inside its own perimeter (issue #1092).
+    ///
+    /// Set `true` only where every committee member is under the same operator as this node --
+    /// single-host and docker-compose deployments, where validators legitimately advertise
+    /// `127.0.0.1` -- since it restores dialing of arbitrary internal addresses.
+    #[serde(default = "Parameters::default_allow_private_forward_targets")]
+    pub allow_private_forward_targets: bool,
 }
 
 impl Parameters {
@@ -327,6 +342,11 @@ impl Parameters {
     fn default_parallel_fetch_request_delay_interval() -> Duration {
         Duration::from_secs(5)
     }
+
+    /// Refuse non-public forwarding targets unless the operator opts in.
+    fn default_allow_private_forward_targets() -> bool {
+        false
+    }
 }
 
 /// Admin server settings.
@@ -366,6 +386,7 @@ impl Default for Parameters {
             basefee_address: None,
             parallel_fetch_request_delay_interval:
                 Parameters::default_parallel_fetch_request_delay_interval(),
+            allow_private_forward_targets: Parameters::default_allow_private_forward_targets(),
         }
     }
 }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
     sync::OnceLock,
 };
 use telcoin_network_cli::{genesis::GenesisArgs, keytool::KeyArgs, node::NodeCommand, NoArgs};
-use tn_config::{Config, ConfigFmt, ConfigTrait, KeyConfig};
+use tn_config::{Config, ConfigFmt, ConfigTrait, KeyConfig, Parameters};
 use tn_node::launch_node;
 use tn_reth::init_txpool_defaults;
 use tn_types::{test_utils::CommandParser, Address, Genesis, GenesisAccount};
@@ -242,6 +242,16 @@ fn config_local_testnet_inner(
     }
     let create_committee_command = CommandParser::<GenesisArgs>::parse_from(genesis_args);
     create_committee_command.args.execute(shared_genesis_dir.clone())?;
+
+    // Every node in this harness runs on one host and advertises `http://127.0.0.1:<port>`, which
+    // the observer's transaction forwarder refuses by default (issue #1092). This is the
+    // single-host deployment the opt-in exists for, so enable it on the shared parameters before
+    // they are distributed, rather than leaving observer forwarding silently dead in e2e tests.
+    let parameters_path = shared_genesis_dir.join("parameters.yaml");
+    let mut parameters: Parameters = Config::load_from_path(&parameters_path, ConfigFmt::YAML)?;
+    parameters.allow_private_forward_targets = true;
+    Config::write_to_path(&parameters_path, &parameters, ConfigFmt::YAML)?;
+
     // If provided optional accounts then hack them into genesis now...
     if let Some(accounts) = accounts {
         let data_dir = shared_genesis_dir.join("genesis/genesis.yaml");

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -46,7 +46,7 @@ use tn_reth::{
         ConsensusRegistry::{self, EpochInfo},
         EpochState,
     },
-    WorkerRpcForwarder,
+    ForwardTargetPolicy, WorkerRpcForwarder,
 };
 use tn_rpc::RpcNodeInfo;
 use tn_types::{
@@ -503,9 +503,15 @@ where
 
         // Observer transaction forwarding: a non-committee worker forwards each transaction it
         // accepts to the JSON-RPC endpoint of the validator that owns it, discovered over
-        // kademlia (issue #804).
-        let forwarder =
-            Arc::new(WorkerRpcForwarder::new(network_handle.get_task_spawner().clone()));
+        // kademlia (issue #804). The endpoint is chosen by a committee member, so the policy
+        // decides which advertised hosts this node is willing to dial (issue #1092); it refuses
+        // non-public hosts unless the operator opted in for a single-host deployment.
+        let forwarder = Arc::new(WorkerRpcForwarder::new(
+            network_handle.get_task_spawner().clone(),
+            ForwardTargetPolicy::from_allow_private(
+                consensus_config.parameters().allow_private_forward_targets,
+            ),
+        ));
 
         let worker = WorkerNode::new(
             worker_id,

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -479,6 +479,15 @@ The `parameters.yaml` file controls consensus timing and behavior. If the file i
 | `batch_vote_timeout`                    | `10s`    | Timeout for batch voting requests                   |
 | `basefee_address`                       | none     | Address that receives transaction base fees         |
 | `parallel_fetch_request_delay_interval` | `5s`     | Delay between parallel certificate fetch requests   |
+| `allow_private_forward_targets`         | `false`  | Let observer forwarding dial non-public RPC hosts   |
+
+### `allow_private_forward_targets`
+
+An observer forwards each transaction it accepts to the JSON-RPC endpoint the owning validator advertised on its node record, so the dial target is chosen by a committee member rather than by this node. Left at the default `false`, an advertised endpoint on a loopback, private (RFC 1918), link-local, unique-local, shared-address-space or unspecified address is refused and logged once at `warn` with the advertising validator's BLS key, so a committee member cannot direct this node's outbound HTTP at hosts inside its own perimeter.
+
+The check reads the host as written and never resolves DNS. It refuses IP literals in every spelling (dotted-quad, decimal, octal, hex, IPv4-mapped and NAT64/6to4 IPv6) and the names reserved to resolve locally (`localhost`, `*.localhost`, `*.local`), but a hostname that merely resolves to a private address is still dialed. Treat this as a guard against an advertised internal address, not as complete egress filtering. Operators who need the stronger property should restrict outbound traffic from observer nodes at the network layer.
+
+Set it to `true` only when every committee member is under the same operator as this node - single-host and docker-compose deployments, where validators legitimately advertise `127.0.0.1`. On a public network it re-enables dialing arbitrary internal addresses.
 
 Example (testnet configuration):
 

--- a/crates/tn-reth/Cargo.toml
+++ b/crates/tn-reth/Cargo.toml
@@ -66,6 +66,7 @@ alloy = { workspace = true, features = ["genesis"] }
 alloy-evm = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time"] }
 reth-ethereum-primitives = { workspace = true }
 secp256k1 = { workspace = true, optional = true }

--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -310,6 +310,14 @@ no other validator is tried. The advertised endpoint may be `http` or `https`
 transit plaintext HTTP if a validator advertises it; TN adds no authentication or encryption of
 its own on this path.
 
+The dial target is likewise chosen by a committee member rather than by this node, so
+`ForwardTargetPolicy` gates it at the point an advertised URL becomes a provider. `PublicOnly`
+(the default) refuses loopback, private, link-local, unique-local, shared-address-space and
+unspecified IP literals in every spelling, plus the names reserved to resolve locally, and logs
+each refusal once at `warn` with the advertising validator's BLS key. Operators of single-host
+deployments opt back in with the `allow_private_forward_targets` parameter. The check never
+resolves DNS, so a hostname that resolves to an internal address is still dialed.
+
 ### `SYSTEM_ADDRESS` is unreachable by users
 
 `SYSTEM_ADDRESS` (`0xff…fe`, `src/system_calls.rs`) is crate-private and has no known private

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -9,7 +9,7 @@
 //! not advertised an endpoint (or is momentarily unreachable) is skipped in favor of one that
 //! has.
 //!
-//! Two properties worth knowing at this boundary:
+//! Three properties worth knowing at this boundary:
 //!
 //! - Transport security is whatever the validator advertised. Endpoint validation accepts both `https://`
 //!   and plain `http://` URLs, and the forwarder adds no encryption of its own, so a plain-HTTP
@@ -21,6 +21,12 @@
 //!   share consensus state, so the rejection would repeat everywhere. Only endpoint-local failures
 //!   (timeout, transport error, full pool, internal error) fall through to the next advertised
 //!   validator, and "already known" counts as delivered.
+//! - The dial target is chosen by a committee member, not by this node. The endpoint arrives inside
+//!   a BLS-signed node record, so an arbitrary network peer cannot inject one, but a committee
+//!   member can still advertise any host it likes and every observer will dial it unattended.
+//!   [`ForwardTargetPolicy`] therefore refuses non-public hosts at the dial site by default, so a
+//!   committee member cannot aim an observer's outbound HTTP at hosts inside that observer's own
+//!   perimeter (issue #1092).
 //!
 //! [`submit_txn_if_mine`]: tn_types::BatchValidation::submit_txn_if_mine
 
@@ -31,12 +37,14 @@ use alloy::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
+    net::{Ipv4Addr, Ipv6Addr},
     sync::{Arc, Mutex},
     time::Duration,
 };
 use tn_types::{BlsPublicKey, RpcInfo, TaskSpawner, TxnForwarder};
 use tokio::time::timeout;
 use tracing::{debug, warn};
+use url::{Host, Url};
 
 /// Bounds a single validator's `eth_sendRawTransaction` round-trip so one unresponsive endpoint
 /// cannot stall the fallback chain; on timeout the forward tries the next validator.
@@ -58,16 +66,232 @@ const TRANSIENT_RPC_CODES: [i64; 2] = [-32003, -32603];
 /// validator's pool (`code -32000`). Treated as a successful delivery, not a failure to retry.
 const ALREADY_KNOWN_MESSAGE: &str = "already known";
 
+/// Whether the forwarder may dial an advertised endpoint whose host is not a public internet
+/// address.
+///
+/// The endpoint is chosen by a committee member and dialed by an unattended observer process, so
+/// an unconstrained target lets a committee member direct an observer's outbound HTTP at hosts
+/// only that observer can reach. Production deployments run [`Self::PublicOnly`]; single-host and
+/// docker-compose deployments, where validators legitimately advertise `127.0.0.1`, opt in to
+/// [`Self::AllowPrivate`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForwardTargetPolicy {
+    /// Dial only hosts that could be a public internet peer. Refuses loopback, private-use,
+    /// link-local, unique-local, shared-address-space, unspecified and non-unicast literals, and
+    /// the reserved `localhost`/`.local` names. This is the default.
+    PublicOnly,
+    /// Dial whatever a committee member advertised, including addresses inside this node's own
+    /// network. Only appropriate where every committee member is under the same operator.
+    AllowPrivate,
+}
+
+impl ForwardTargetPolicy {
+    /// Build the policy from the operator's `allow_private_forward_targets` setting, which is
+    /// `false` (that is, [`Self::PublicOnly`]) unless the operator sets it.
+    pub fn from_allow_private(allow_private: bool) -> Self {
+        if allow_private {
+            Self::AllowPrivate
+        } else {
+            Self::PublicOnly
+        }
+    }
+
+    /// Decide whether `url` may be dialed under this policy.
+    fn check(&self, url: &Url) -> Result<(), RefusedTarget> {
+        match self {
+            Self::AllowPrivate => Ok(()),
+            Self::PublicOnly => check_public_host(url),
+        }
+    }
+}
+
+/// Why [`ForwardTargetPolicy::PublicOnly`] refused an advertised endpoint as a dial target.
+///
+/// Carried instead of a message string so the refusal reason is a closed set the log line and the
+/// tests agree on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RefusedTarget {
+    /// The URL has no host component at all, so there is nothing to dial.
+    MissingHost,
+    /// Loopback: `127.0.0.0/8`, `::1`, or a name reserved to loopback by RFC 6761 (`localhost`,
+    /// `*.localhost`).
+    Loopback,
+    /// RFC 1918 private-use: `10/8`, `172.16/12`, `192.168/16`.
+    PrivateUse,
+    /// Link-local: RFC 3927 `169.254.0.0/16` (which carries cloud instance metadata), RFC 4291
+    /// `fe80::/10`, or an RFC 6762 multicast-DNS name (`*.local`).
+    LinkLocal,
+    /// RFC 4193 unique-local: `fc00::/7`.
+    UniqueLocal,
+    /// RFC 6598 shared address space: `100.64.0.0/10`, used for carrier-grade NAT and by several
+    /// container networks.
+    SharedAddressSpace,
+    /// "This network": `0.0.0.0/8` (RFC 1122) or the unspecified address `::`.
+    Unspecified,
+    /// Multicast, broadcast or reserved: never a valid unicast dial target.
+    NotUnicast,
+}
+
+impl std::fmt::Display for RefusedTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::MissingHost => "no host",
+            Self::Loopback => "loopback",
+            Self::PrivateUse => "private-use (RFC 1918)",
+            Self::LinkLocal => "link-local",
+            Self::UniqueLocal => "unique-local (RFC 4193)",
+            Self::SharedAddressSpace => "shared address space (RFC 6598)",
+            Self::Unspecified => "unspecified",
+            Self::NotUnicast => "not a unicast address",
+        })
+    }
+}
+
+/// Refuse `url` unless its host could be a public internet peer.
+///
+/// This is a literal check on the host as written: it never resolves DNS, so it costs nothing on
+/// the cache-miss path and cannot be steered by a resolver the advertiser controls. The cost is
+/// that a hostname resolving to a private address still passes, which is why the two reserved
+/// name suffixes that are *defined* to be local ([`RefusedTarget::Loopback`] for `localhost`,
+/// [`RefusedTarget::LinkLocal`] for `.local`) are refused by name. Refusing an arbitrary hostname
+/// that merely happens to resolve inside the perimeter needs resolution plus address pinning in
+/// the connector (otherwise a rebinding resolver defeats it) and is tracked separately.
+///
+/// URL host parsing normalizes the alternative IPv4 spellings (`http://2130706433/`,
+/// `http://0177.0.0.1/`) into [`Host::Ipv4`] before this sees them, so those reach the same
+/// predicate as dotted-quad.
+fn check_public_host(url: &Url) -> Result<(), RefusedTarget> {
+    url.host().ok_or(RefusedTarget::MissingHost).and_then(|host| match host {
+        Host::Ipv4(addr) => check_public_ipv4(addr),
+        Host::Ipv6(addr) => check_public_ipv6(addr),
+        Host::Domain(name) => check_public_domain(name),
+    })
+}
+
+/// Refuse an IPv4 literal that is not globally reachable.
+fn check_public_ipv4(addr: Ipv4Addr) -> Result<(), RefusedTarget> {
+    let [first, second, _, _] = addr.octets();
+    if addr.is_loopback() {
+        Err(RefusedTarget::Loopback)
+    } else if addr.is_private() {
+        Err(RefusedTarget::PrivateUse)
+    } else if addr.is_link_local() {
+        Err(RefusedTarget::LinkLocal)
+    } else if first == 0 {
+        // 0.0.0.0/8 "this network"; `is_unspecified` covers only 0.0.0.0 itself.
+        Err(RefusedTarget::Unspecified)
+    } else if first == 100 && (64..128).contains(&second) {
+        // 100.64.0.0/10.
+        Err(RefusedTarget::SharedAddressSpace)
+    } else if first >= 224 {
+        // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved, and 255.255.255.255 broadcast.
+        Err(RefusedTarget::NotUnicast)
+    } else {
+        Ok(())
+    }
+}
+
+/// Refuse an IPv6 literal that is not globally reachable.
+///
+/// The IPv6-specific blocks are checked before the embedded-IPv4 fallback so `::1` is reported as
+/// loopback rather than as the `0.0.0.1` it maps to. The fallback itself is what closes the
+/// `http://[::ffff:127.0.0.1]/` spelling of a loopback address, which no IPv6 predicate catches.
+fn check_public_ipv6(addr: Ipv6Addr) -> Result<(), RefusedTarget> {
+    let [first, ..] = addr.segments();
+    if addr.is_loopback() {
+        Err(RefusedTarget::Loopback)
+    } else if addr.is_unspecified() {
+        Err(RefusedTarget::Unspecified)
+    } else if first & 0xfe00 == 0xfc00 {
+        // fc00::/7.
+        Err(RefusedTarget::UniqueLocal)
+    } else if first & 0xffc0 == 0xfe80 {
+        // fe80::/10.
+        Err(RefusedTarget::LinkLocal)
+    } else if addr.is_multicast() {
+        // ff00::/8.
+        Err(RefusedTarget::NotUnicast)
+    } else {
+        embedded_ipv4(addr).map_or(Ok(()), check_public_ipv4)
+    }
+}
+
+/// Extract the IPv4 address an IPv6 literal embeds, for the prefixes a translating gateway routes
+/// back to that IPv4 destination.
+///
+/// Covers the two forms [`Ipv6Addr::to_ipv4`] recognizes, IPv4-compatible `::a.b.c.d` and
+/// IPv4-mapped `::ffff:a.b.c.d`, plus two it does not:
+///
+/// - the RFC 6052 NAT64 well-known prefix `64:ff9b::/96`, which a NAT64 gateway translates to the
+///   embedded address. This is the default egress path for IPv6-only cloud and container subnets,
+///   so without it `http://[64:ff9b::a9fe:a9fe]/` reaches `169.254.169.254` on exactly the
+///   deployments where `http://169.254.169.254/` is correctly refused.
+/// - the RFC 3056 6to4 prefix `2002::/16`, which carries the IPv4 address in its next 32 bits.
+///
+/// RFC 6052 also allows network-specific prefixes at other lengths. Those use an operator's own
+/// prefix and cannot be enumerated statically, so they are out of reach of a literal check; only
+/// the well-known prefix is fixed enough to match.
+fn embedded_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
+    let [first, second, third, fourth, fifth, sixth, seventh, eighth] = addr.segments();
+    addr.to_ipv4().or_else(|| {
+        ((first, second, third, fourth, fifth, sixth) == (0x0064, 0xff9b, 0, 0, 0, 0))
+            .then(|| ipv4_from_segments(seventh, eighth))
+            .or_else(|| (first == 0x2002).then(|| ipv4_from_segments(second, third)))
+    })
+}
+
+/// Rebuild an IPv4 address from the two 16-bit segments that carry it inside an IPv6 literal.
+fn ipv4_from_segments(high: u16, low: u16) -> Ipv4Addr {
+    let [a, b] = high.to_be_bytes();
+    let [c, d] = low.to_be_bytes();
+    Ipv4Addr::new(a, b, c, d)
+}
+
+/// Refuse the two name suffixes that are reserved to resolve locally.
+///
+/// Every other hostname passes: see [`check_public_host`] for why resolution is out of scope here.
+fn check_public_domain(name: &str) -> Result<(), RefusedTarget> {
+    // The absolute form (`localhost.`) resolves identically to the relative one.
+    let name = name.trim_end_matches('.').to_ascii_lowercase();
+    if name == "localhost" || name.ends_with(".localhost") {
+        // RFC 6761 section 6.3: reserved, resolves to loopback.
+        Err(RefusedTarget::Loopback)
+    } else if name == "local" || name.ends_with(".local") {
+        // RFC 6762: multicast DNS, resolves only on the local link.
+        Err(RefusedTarget::LinkLocal)
+    } else {
+        Ok(())
+    }
+}
+
+/// Per-endpoint state the forwarder keeps across batch seals, behind one lock.
+#[derive(Default)]
+struct EndpointCache {
+    /// HTTP providers cached per advertised endpoint so consecutive batch seals reuse the
+    /// underlying connection pool instead of paying a fresh TCP+TLS handshake per validator
+    /// per seal. Entries for endpoints that are no longer advertised are evicted on each
+    /// forward, so the cache stays bounded by the current committee's advertisement set.
+    providers: BTreeMap<String, RootProvider>,
+    /// Endpoints already refused by [`ForwardTargetPolicy`], so the refusal is logged once per
+    /// advertisement instead of once per batch seal. Evicted alongside `providers`, so a
+    /// committee member that re-advertises a refused endpoint is logged again.
+    ///
+    /// Evicting is the deliberate side of the trade: it bounds this set by the current committee's
+    /// advertisement set, at the cost of letting a member that toggles its advertisement re-arm
+    /// the warning. Never evicting would silence that, but would let a member rotating through
+    /// fresh URLs grow the set without bound, which is the worse failure for an unattended node.
+    refused: BTreeSet<String>,
+}
+
 /// Forwards observer transactions to validators over their advertised JSON-RPC endpoints.
 #[derive(Clone)]
 pub struct WorkerRpcForwarder {
     /// Spawner used to run the (best-effort, non-blocking) forward on a background task.
     task_spawner: TaskSpawner,
-    /// HTTP providers cached per advertised endpoint so consecutive batch seals reuse the
-    /// underlying connection pool instead of paying a fresh TCP+TLS handshake per validator
-    /// per seal. Entries for endpoints that are no longer advertised are evicted on each
-    /// forward, so the cache stays bounded by the current committee's advertisement set.
-    providers: Arc<Mutex<BTreeMap<String, RootProvider>>>,
+    /// Which advertised hosts this node is willing to dial.
+    policy: ForwardTargetPolicy,
+    /// Providers and refusals for the currently advertised endpoints.
+    cache: Arc<Mutex<EndpointCache>>,
 }
 
 impl std::fmt::Debug for WorkerRpcForwarder {
@@ -77,46 +301,74 @@ impl std::fmt::Debug for WorkerRpcForwarder {
 }
 
 impl WorkerRpcForwarder {
-    /// Create a new forwarder that runs forwards on `task_spawner`.
-    pub fn new(task_spawner: TaskSpawner) -> Self {
-        Self { task_spawner, providers: Arc::new(Mutex::new(BTreeMap::new())) }
+    /// Create a new forwarder that runs forwards on `task_spawner` and dials only the advertised
+    /// hosts `policy` admits.
+    pub fn new(task_spawner: TaskSpawner, policy: ForwardTargetPolicy) -> Self {
+        Self { task_spawner, policy, cache: Arc::new(Mutex::new(EndpointCache::default())) }
     }
 
     /// Resolve the advertised endpoints to providers, reusing cached ones where the endpoint
-    /// is unchanged. A malformed URL is dropped here so the per-transaction loop only sees
-    /// usable endpoints. The endpoint string is reparsed into the exact URL type the provider
-    /// expects. `RootProvider` needs no fillers: the transactions are already signed raw
-    /// bytes, and `send_raw_transaction` submits them as-is.
+    /// is unchanged. An endpoint the policy refuses, or a malformed URL, is dropped here so the
+    /// per-transaction loop only sees usable endpoints. The endpoint string is reparsed into the
+    /// exact URL type the provider expects. `RootProvider` needs no fillers: the transactions are
+    /// already signed raw bytes, and `send_raw_transaction` submits them as-is.
+    ///
+    /// The policy is applied on the cache-miss path only, which is where the dial target is turned
+    /// into a live provider: a refused endpoint is never inserted, so it can never be served from
+    /// the cache on a later seal.
     fn cached_providers(
         &self,
         validator_rpcs: &[(BlsPublicKey, RpcInfo)],
     ) -> BTreeMap<BlsPublicKey, RootProvider> {
-        let mut cache = self.providers.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut cache = self.cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let advertised: BTreeSet<String> =
             validator_rpcs.iter().map(|(_, rpc)| rpc.http.to_string()).collect();
-        cache.retain(|url, _| advertised.contains(url));
+        cache.providers.retain(|url, _| advertised.contains(url));
+        cache.refused.retain(|url| advertised.contains(url));
         validator_rpcs
             .iter()
             .filter_map(|(key, rpc)| {
                 let url = rpc.http.to_string();
                 cache
+                    .providers
                     .get(&url)
                     .cloned()
-                    .or_else(|| match url.parse() {
-                        Ok(parsed) => {
-                            let provider = RootProvider::new_http(parsed);
-                            cache.insert(url, provider.clone());
-                            Some(provider)
-                        }
-                        Err(err) => {
-                            debug!(
-                                target: "worker::forward",
-                                endpoint = %rpc.http,
-                                %err,
-                                "skipping validator with an unparseable RPC endpoint"
-                            );
-                            None
-                        }
+                    .or_else(|| {
+                        self.policy
+                            .check(&rpc.http)
+                            .map_err(|reason| {
+                                // Log once per advertisement, not once per seal, so an operator
+                                // can tell a refused endpoint from an unreachable one without the
+                                // line repeating on every batch.
+                                if cache.refused.insert(url.clone()) {
+                                    warn!(
+                                        target: "worker::forward",
+                                        validator = %key,
+                                        endpoint = %rpc.http,
+                                        %reason,
+                                        "refusing to forward to a non-public advertised RPC \
+                                         endpoint; set `allow_private_forward_targets` to permit it"
+                                    );
+                                }
+                            })
+                            .ok()
+                            .and_then(|()| {
+                                url.parse()
+                                    .map_err(|err| {
+                                        debug!(
+                                            target: "worker::forward",
+                                            endpoint = %rpc.http,
+                                            %err,
+                                            "skipping validator with an unparseable RPC endpoint"
+                                        );
+                                    })
+                                    .ok()
+                            })
+                            .map(|parsed| {
+                                let provider = RootProvider::new_http(parsed);
+                                cache.providers.insert(url.clone(), provider.clone());
+                                provider
+                            })
                     })
                     .map(|provider| (*key, provider))
             })
@@ -294,8 +546,13 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
     use tn_types::{BlsKeypair, TaskManager};
 
+    /// A forwarder under the shipped default: only public hosts may be dialed.
     fn test_forwarder() -> WorkerRpcForwarder {
-        WorkerRpcForwarder::new(TaskManager::default().get_spawner())
+        test_forwarder_with(ForwardTargetPolicy::PublicOnly)
+    }
+
+    fn test_forwarder_with(policy: ForwardTargetPolicy) -> WorkerRpcForwarder {
+        WorkerRpcForwarder::new(TaskManager::default().get_spawner(), policy)
     }
 
     fn test_key(seed: u8) -> BlsPublicKey {
@@ -307,15 +564,38 @@ mod tests {
     }
 
     fn cached_urls(forwarder: &WorkerRpcForwarder) -> Vec<String> {
-        forwarder.providers.lock().map(|cache| cache.keys().cloned().collect()).unwrap_or_default()
+        forwarder
+            .cache
+            .lock()
+            .map(|cache| cache.providers.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn refused_urls(forwarder: &WorkerRpcForwarder) -> Vec<String> {
+        forwarder
+            .cache
+            .lock()
+            .map(|cache| cache.refused.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Refuse `url` under the default policy, or fail with the URL that slipped through.
+    fn refusal(url: &str) -> eyre::Result<RefusedTarget> {
+        let parsed: Url = url.parse()?;
+        ForwardTargetPolicy::PublicOnly
+            .check(&parsed)
+            .err()
+            .ok_or_else(|| eyre::eyre!("{url} was accepted as a dial target but must be refused"))
     }
 
     #[test]
     fn cached_providers_resolves_every_advertised_endpoint() -> eyre::Result<()> {
+        // Public hosts: the loopback fixtures this test used before are refused by the default
+        // policy, and cache mechanics are what is under test here.
         let forwarder = test_forwarder();
         let rpcs = vec![
-            (test_key(1), test_rpc("http://127.0.0.1:8545")?),
-            (test_key(2), test_rpc("http://127.0.0.1:8546")?),
+            (test_key(1), test_rpc("http://validator-one.example.com:8545")?),
+            (test_key(2), test_rpc("http://validator-two.example.com:8546")?),
         ];
 
         let resolved = forwarder.cached_providers(&rpcs);
@@ -328,8 +608,8 @@ mod tests {
     #[test]
     fn cached_providers_reuses_cache_and_evicts_stale_endpoints() -> eyre::Result<()> {
         let forwarder = test_forwarder();
-        let live = (test_key(1), test_rpc("http://127.0.0.1:8545")?);
-        let stale = (test_key(2), test_rpc("http://127.0.0.1:8546")?);
+        let live = (test_key(1), test_rpc("http://validator-one.example.com:8545")?);
+        let stale = (test_key(2), test_rpc("http://validator-two.example.com:8546")?);
         let first = forwarder.cached_providers(&[live.clone(), stale]);
         assert_eq!(first.len(), 2);
 
@@ -338,8 +618,168 @@ mod tests {
         let second = forwarder.cached_providers(&[live]);
 
         assert_eq!(second.len(), 1);
-        assert_eq!(cached_urls(&forwarder), vec!["http://127.0.0.1:8545/".to_string()]);
+        assert_eq!(
+            cached_urls(&forwarder),
+            vec!["http://validator-one.example.com:8545/".to_string()]
+        );
         Ok(())
+    }
+
+    #[test]
+    fn cached_providers_refuses_non_public_endpoints_but_keeps_public_ones() -> eyre::Result<()> {
+        let forwarder = test_forwarder();
+        // The public endpoint shares the slice with the refused ones, so a reject-everything
+        // regression cannot pass this assertion.
+        let public = (test_key(1), test_rpc("http://validator.example.com:8545")?);
+        let rpcs = vec![
+            public.clone(),
+            (test_key(2), test_rpc("http://169.254.169.254/latest/meta-data/")?),
+            (test_key(3), test_rpc("http://127.0.0.1:8545")?),
+            (test_key(4), test_rpc("http://10.0.0.1:8545")?),
+            (test_key(5), test_rpc("http://192.168.1.1:8545")?),
+        ];
+
+        let resolved = forwarder.cached_providers(&rpcs);
+
+        // Only the public validator has a provider, and only its URL is cached.
+        assert_eq!(resolved.keys().cloned().collect::<Vec<_>>(), vec![public.0]);
+        assert_eq!(cached_urls(&forwarder), vec!["http://validator.example.com:8545/".to_string()]);
+        // Every refused endpoint is recorded once so its warning is not repeated per seal.
+        assert_eq!(refused_urls(&forwarder).len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_providers_never_caches_a_refused_endpoint() -> eyre::Result<()> {
+        let forwarder = test_forwarder();
+        let rpcs = vec![(test_key(1), test_rpc("http://10.0.0.1:8545")?)];
+
+        // A refused endpoint is never cached, so a later seal re-runs the check rather than
+        // serving a provider the policy already rejected.
+        assert!(forwarder.cached_providers(&rpcs).is_empty());
+        assert!(forwarder.cached_providers(&rpcs).is_empty());
+        assert!(cached_urls(&forwarder).is_empty());
+        // ... and the refusal is remembered once, so the operator warning does not repeat.
+        assert_eq!(refused_urls(&forwarder), vec!["http://10.0.0.1:8545/".to_string()]);
+
+        // Dropping the advertisement clears the record, so a re-advertisement warns again.
+        assert!(forwarder.cached_providers(&[]).is_empty());
+        assert!(refused_urls(&forwarder).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn cached_providers_dials_private_endpoints_under_the_local_opt_in() -> eyre::Result<()> {
+        // Single-host and docker-compose deployments advertise loopback legitimately.
+        let forwarder = test_forwarder_with(ForwardTargetPolicy::AllowPrivate);
+        let rpcs = vec![
+            (test_key(1), test_rpc("http://127.0.0.1:8545")?),
+            (test_key(2), test_rpc("http://10.0.0.1:8545")?),
+        ];
+
+        let resolved = forwarder.cached_providers(&rpcs);
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(cached_urls(&forwarder).len(), 2);
+        assert!(refused_urls(&forwarder).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn public_only_refuses_every_non_global_host_form() -> eyre::Result<()> {
+        // IPv4 special-purpose blocks.
+        assert_eq!(refusal("http://127.0.0.1:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://127.255.255.254/")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://10.0.0.1:8545")?, RefusedTarget::PrivateUse);
+        assert_eq!(refusal("http://172.16.0.1/")?, RefusedTarget::PrivateUse);
+        assert_eq!(refusal("http://192.168.1.1:8545")?, RefusedTarget::PrivateUse);
+        assert_eq!(refusal("http://169.254.169.254/latest/meta-data/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://0.0.0.0:8545")?, RefusedTarget::Unspecified);
+        assert_eq!(refusal("http://0.1.2.3/")?, RefusedTarget::Unspecified);
+        assert_eq!(refusal("http://100.64.0.1/")?, RefusedTarget::SharedAddressSpace);
+        assert_eq!(refusal("http://100.127.255.255/")?, RefusedTarget::SharedAddressSpace);
+        assert_eq!(refusal("http://224.0.0.1/")?, RefusedTarget::NotUnicast);
+        assert_eq!(refusal("http://255.255.255.255/")?, RefusedTarget::NotUnicast);
+
+        // Alternative IPv4 spellings the URL host parser normalizes before the check sees them.
+        assert_eq!(refusal("http://2130706433/")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://0177.0.0.1/")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://0x7f.0.0.1/")?, RefusedTarget::Loopback);
+
+        // IPv6 special-purpose blocks, including the IPv4-mapped spelling of a loopback address
+        // that no IPv6 predicate catches.
+        assert_eq!(refusal("http://[::1]:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://[::ffff:127.0.0.1]:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://[::ffff:10.0.0.1]/")?, RefusedTarget::PrivateUse);
+        assert_eq!(refusal("http://[::ffff:169.254.169.254]/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://[::]/")?, RefusedTarget::Unspecified);
+        assert_eq!(refusal("http://[fc00::1]/")?, RefusedTarget::UniqueLocal);
+        assert_eq!(refusal("http://[fd12:3456::1]:8545")?, RefusedTarget::UniqueLocal);
+        assert_eq!(refusal("http://[fe80::1]/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://[febf::1]/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://[ff02::1]/")?, RefusedTarget::NotUnicast);
+
+        // Prefixes a translating gateway routes back to an embedded IPv4 destination, which
+        // `Ipv6Addr::to_ipv4` does not recognize. `64:ff9b::a9fe:a9fe` is the cloud
+        // instance-metadata address reached over NAT64.
+        assert_eq!(refusal("http://[64:ff9b::a9fe:a9fe]/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://[64:ff9b::7f00:1]:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://[64:ff9b::a00:1]/")?, RefusedTarget::PrivateUse);
+        assert_eq!(refusal("http://[2002:a9fe:a9fe::1]/")?, RefusedTarget::LinkLocal);
+        assert_eq!(refusal("http://[2002:7f00:1::1]/")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://[2002:c0a8:101::1]/")?, RefusedTarget::PrivateUse);
+
+        // Names reserved to resolve locally, in relative, absolute and subdomain form.
+        assert_eq!(refusal("http://localhost:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://LocalHost:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://localhost./")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://validator.localhost:8545")?, RefusedTarget::Loopback);
+        assert_eq!(refusal("http://validator.local:8545")?, RefusedTarget::LinkLocal);
+        Ok(())
+    }
+
+    #[test]
+    fn public_only_admits_public_hosts() -> eyre::Result<()> {
+        // Public literals and hostnames must still resolve, or the filter is a blanket reject.
+        // Each entry sits just outside a refused block, so an off-by-one in a mask shows up here.
+        [
+            "http://8.8.8.8:8545",
+            "https://1.1.1.1/",
+            "http://172.32.0.1/",      // just above the 172.16/12 private block
+            "http://100.128.0.1/",     // just above the 100.64/10 shared block
+            "http://169.253.0.1/",     // just below the 169.254/16 link-local block
+            "http://126.255.255.255/", // just below 127/8
+            "http://223.255.255.255/", // just below the 224/4 multicast block
+            "https://validator.example.com:8545/",
+            "http://[2001:4860:4860::8888]/",
+            "http://[::ffff:8.8.8.8]/", // IPv4-mapped, but the mapped address is public
+            "http://[64:ff9b::808:808]/", // NAT64, but the embedded address is public
+            "http://[2002:808:808::1]/", // 6to4, but the embedded address is public
+            "http://[64:ff9c::a9fe:a9fe]/", // not the NAT64 well-known prefix: not unmapped
+            "http://[fbff::1]/",        // just below fc00::/7
+            "http://[fe7f::1]/",        // just below fe80::/10
+            "http://not-localhost.example.com/",
+            "http://localhosting.example.com/",
+        ]
+        .into_iter()
+        .try_for_each(|url| {
+            let parsed: Url = url.parse()?;
+            assert_eq!(
+                ForwardTargetPolicy::PublicOnly.check(&parsed),
+                Ok(()),
+                "{url} must be accepted as a dial target"
+            );
+            eyre::Ok(())
+        })
+    }
+
+    #[test]
+    fn from_allow_private_defaults_to_public_only() {
+        assert_eq!(ForwardTargetPolicy::from_allow_private(false), ForwardTargetPolicy::PublicOnly);
+        assert_eq!(
+            ForwardTargetPolicy::from_allow_private(true),
+            ForwardTargetPolicy::AllowPrivate
+        );
     }
 
     #[test]

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -147,7 +147,7 @@ pub use evm::{
     grantMintRoleCall, hasMintRoleCall, mintCall, revokeMintRoleCall, totalSupplyCall,
     BLS_G1_PRECOMPILE_ADDRESS, TELCOIN_PRECOMPILE_ADDRESS,
 };
-pub use forward::WorkerRpcForwarder;
+pub use forward::{ForwardTargetPolicy, WorkerRpcForwarder};
 pub use metrics::report_db_metrics;
 pub use types::*;
 


### PR DESCRIPTION
Closes #1092.  (Cantina #11)

## Problem

An observer (a worker that is not an active committee validator) forwards every transaction it seals to the JSON-RPC endpoint the owning validator advertised on its worker record. The dial target is therefore chosen by a committee member, not by the observer, and `cached_providers` turned any advertised URL into a live `RootProvider` with no check on the host at all.

A committee member that advertises `http://169.254.169.254/latest/meta-data/`, a Kubernetes API server, or any host reachable only from inside an observer operator's network gets every observer to POST a JSON-RPC body at that target from a source address inside that perimeter. The attacker picks scheme, host, port and path, and can rotate the target on each node-record republish. Because routing is by sender slot, submitting a transaction whose sender maps to the attacker's own committee slot puts the attacker's URL first in the order rather than leaving it as a fallback.

Threat model. The advertisement rides inside a BLS-signed `NodeRecord` whose signature is verified at record ingest, so an arbitrary network peer cannot inject one and kademlia record poisoning is already closed off. The attacker is a current-committee validator, or anyone holding a current-committee validator's BLS key. There is no consensus impact: no halt, no fork, no state divergence, and the response body is never returned to the advertiser, so this is blind SSRF (a probe and side-effect trigger, not an exfiltration channel). Both entry points are gated the same way: `WorkerNode::seal` routes to `disburse_txns` when the node has no `quorum_waiter`, and epoch close re-disburses orphaned batches when `is_active_cvv()` is false.

## Root cause

The only gate an advertised endpoint passed before becoming a dial target was `RpcInfo::validate`, applied at record ingest in the peer manager. It checks URL byte length and the `http` / `https` scheme and never inspects the host. Its own call site says as much: "signature verification proves authenticity but not scheme correctness".

`crates/tn-reth/src/forward.rs` already reasoned explicitly about one security property of these attacker-chosen URLs (that a plain-`http://` advertisement carries the raw transaction in cleartext). The dial target itself was not reasoned about anywhere.

## Fix

The check lives at the dial site rather than in `RpcInfo::validate`. `validate` is a type-level well-formedness check in `tn-types` with no operator configuration in scope, and it runs at record ingest, where a local dev deployment legitimately advertises `127.0.0.1`. Putting the policy where the node is about to act on the URL keeps `validate` a pure syntactic check.

- **`crates/tn-reth/src/forward.rs`**: new `ForwardTargetPolicy` (`PublicOnly` default, `AllowPrivate` opt-in), applied in `cached_providers` immediately before `RootProvider::new_http`. `PublicOnly` refuses loopback, RFC 1918 private-use, link-local (RFC 3927 `169.254.0.0/16` and RFC 4291 `fe80::/10`), RFC 4193 unique-local `fc00::/7`, RFC 6598 shared address space `100.64.0.0/10`, `0.0.0.0/8`, and multicast / broadcast / reserved. The refusal reason is a closed `RefusedTarget` sum type rather than a message string, so the log line and the tests agree on it.
- **Bypass closure.** Four spellings of an internal address that an IP-literal check can miss are unmapped and re-checked against the IPv4 predicate: IPv4-compatible `::a.b.c.d`, IPv4-mapped `::ffff:a.b.c.d`, the RFC 6052 NAT64 well-known prefix `64:ff9b::/96`, and the RFC 3056 6to4 prefix `2002::/16`. The first two are what `Ipv6Addr::to_ipv4` recognizes; the last two it does not, yet a NAT64 gateway (the default egress path for IPv6-only cloud and container subnets) translates `http://[64:ff9b::a9fe:a9fe]/` straight back to `169.254.169.254`, so without this the literal `http://169.254.169.254/` is refused while its NAT64 spelling is dialed. RFC 6052 network-specific prefixes use an operator's own prefix and cannot be enumerated statically, which is stated at the function. The IPv6-specific blocks are tested before the fallback so `::1` reports as loopback rather than as the `0.0.0.1` it maps to. The alternative IPv4 spellings (`http://2130706433/`, `http://0177.0.0.1/`) are normalized to `Host::Ipv4` by URL host parsing before the predicate sees them, and are covered by test.
- **Reserved names.** `localhost`, `*.localhost` (RFC 6761 section 6.3) and `*.local` (RFC 6762) are refused by name, in relative, absolute and subdomain form. Without this, `http://localhost:8545/` walks straight past an IP-literal-only filter. The check is deliberately DNS-free: it costs nothing on the cache-miss path and cannot be steered by a resolver the advertiser controls. Refusing an arbitrary hostname that merely resolves inside the perimeter needs resolution plus address pinning in the connector (a re-resolving check is raceable by a rebinding resolver), which changes the connector and is left to a follow-up, as the issue recommends.
- **`crates/tn-reth/src/forward.rs`**: `EndpointCache` now holds the provider map plus a `refused` set. Both are evicted against the current advertisement set on every forward, so the refusal warning fires once per advertisement instead of once per batch seal, and a re-advertised endpoint warns again. A refused endpoint is never inserted into the provider cache, so it can never be served from cache on a later seal.
- **`crates/config/src/node.rs`**: new `Parameters::allow_private_forward_targets`, `#[serde(default)]` to `false`. Absent from a `parameters.yaml` it deserializes to the refusing policy, so the secure value is the one an un-migrated operator gets.
- **`crates/node/src/manager/node/start_epoch.rs`**: reads the parameter and passes the policy into `WorkerRpcForwarder::new`.
- **`crates/e2e-tests/src/lib.rs`**: the local test network enables the opt-in on the shared parameters before they are distributed. Every node in that harness advertises `http://127.0.0.1:<port>`, which is exactly the single-host case the opt-in exists for. Without this the observer forwarding tests would go silently dead rather than fail loudly.
- **`crates/telcoin-network-cli/README.md`**: parameter table row plus a section stating the default, what it refuses, and the narrow condition under which an operator should turn it on.
- **`crates/tn-reth/README.md`**: the transaction-forwarding section already reasoned about one security property of these advertised URLs (that a plain-`http://` advertisement carries the raw transaction in cleartext) and said nothing about the dial target. It now states the policy, the default, the opt-in, and the DNS limitation alongside it.

Each suppressed endpoint is logged once at `warn` with the advertising validator's BLS key, the URL, and the refusal reason, mirroring the existing unparseable-URL `debug!`, so an operator can tell a filtered endpoint from an unreachable one.

## Testing

Pinned toolchain throughout (`rust-toolchain.toml` = 1.94; rustfmt on the pinned nightly, since `rustfmt.toml` sets `wrap_comments` which stable `cargo fmt` skips).

- `cargo +nightly-2026-03-20 fmt --all -- --check`: clean.
- `cargo +1.94 clippy --workspace --all-targets`: exit 0, zero warnings attributed to any file in this diff.
- `cargo +1.94 test --no-run --workspace`: exit 0.
- `cargo +1.94 test -p tn-reth --lib forward::`: 9 passed, 0 failed.

New coverage in `crates/tn-reth/src/forward.rs`:

- `cached_providers_refuses_non_public_endpoints_but_keeps_public_ones` puts `169.254.169.254`, `127.0.0.1`, `10.0.0.1` and `192.168.1.1` in the same slice as a public host and asserts only the public one becomes a provider and only its URL is cached. The public entry is the guard against a vacuous pass: a reject-everything regression would otherwise look identical to a correct filter.
- `public_only_refuses_every_non_global_host_form` covers each refused block with its expected `RefusedTarget`, including the IPv4-mapped, NAT64 and 6to4 IPv6 spellings and the reserved names.
- `public_only_admits_public_hosts` walks the address just outside each refused block (`172.32.0.1`, `100.128.0.1`, `169.253.0.1`, `126.255.255.255`, `223.255.255.255`, `[fbff::1]`, `[fe7f::1]`), so an off-by-one in a mask fails here rather than silently over-rejecting operators. It also carries a NAT64 and a 6to4 address whose *embedded* address is public, plus `[64:ff9c::a9fe:a9fe]` (one bit off the NAT64 well-known prefix), so the unmapping is shown to be an exact prefix match rather than a wildcard that swallows public IPv6.
- `cached_providers_never_caches_a_refused_endpoint` asserts a refused endpoint stays out of the provider cache across seals, is memoized once for the warning, and is forgotten when it stops being advertised.
- `cached_providers_dials_private_endpoints_under_the_local_opt_in` covers the dev deployment explicitly rather than by the absence of a test.
- The two pre-existing `cached_providers` tests moved off `127.0.0.1` fixtures onto public hosts. They pinned the old behavior (that loopback endpoints resolve with zero host filtering), so they had to be updated alongside the filter; they still test cache reuse and stale-endpoint eviction.

Confirmed by mutation. Each mutant was applied to a byte-exact copy, the suite was watched going red, and the file was restored and re-verified by SHA-256:

| Mutant | Result |
| --- | --- |
| `PublicOnly` arm returns `Ok(())` (host check removed) | killed, 3 failed |
| IPv4-mapped IPv6 unmapping removed | killed, 1 failed |
| `localhost` / `*.localhost` arm disabled | killed, 1 failed |
| refusal memo always re-warns | killed, 2 failed |
| `refused` set not evicted with the advertisement | killed, 1 failed |
| NAT64 well-known prefix not unmapped | killed, 1 failed |
| 6to4 prefix not unmapped | killed, 1 failed |
| `embedded_ipv4` result discarded entirely | killed, 1 failed |

Eight mutants, eight kills, no survivors.

## Scope notes

- The resolving version of the check (resolve a hostname and apply the same predicate to every resolved address, with the address pinned into the connector so a rebinding resolver cannot race it) is deliberately not in this PR. It changes the HTTP connector, whereas the literal check is self-contained. The issue recommends the same split. The practical consequence is worth stating plainly rather than leaving for a reviewer to find: a committee member that advertises `http://evil.example.com/` with an A record pointing at `169.254.169.254` still gets dialed. This change raises the cost of the attack from "advertise a literal" to "control a domain", and closes the literal-address case completely; it is not complete egress filtering, and the README now says so.
- RFC 6052 permits NAT64 network-specific prefixes at `/32`, `/40`, `/48`, `/56`, `/64` and `/96`. Those use an operator's own prefix, which a static check cannot enumerate, so only the well-known `64:ff9b::/96` is matched.
- `RpcInfo::validate` is unchanged, so record ingest still accepts a loopback advertisement. That is intentional: a validator on a local network legitimately advertises one, and the consumer decides whether to dial it.
- The `ws` field of `RpcInfo` is not covered, because the forwarder never dials it. If a future consumer dials `RpcInfo::ws`, it needs the same gate.
- `chain-configs/mainnet/parameters.yaml` and `chain-configs/testnet/parameters.yaml` are unchanged. Both omit the key and therefore get the refusing default, matching how `parallel_fetch_request_delay_interval` is already handled in the mainnet file.
