### PR TITLE
fix(config): refuse an unset basefee_address at the production entry points

### DIFF
--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -282,14 +282,18 @@ pub struct Parameters {
     /// build different state roots from the same committed output and the network splits. See the
     /// `BASEFEE_ADDRESS` documentation in `tn-reth` for the execution-side detail.
     ///
-    /// An absent key deserializes to `None`. That is declared here rather than left to serde's
-    /// implicit handling of `Option`, because the fallback it selects is three crates away.
-    /// `None` stays legal for test fixtures, but [`Parameters::validate_operational_floors`]
-    /// refuses it at the production entry points, so an operator must state the address. The
-    /// chain presets set it from their embedded parameters, so `--chain mainnet` and
-    /// `--chain adiri` never reach this path.
-    #[serde(default)]
-    pub basefee_address: Option<Address>,
+    /// The key is required: a parameters file that omits it fails to deserialize with an error
+    /// that names the field, wherever that file is parsed. (The one adjacent gap is a missing
+    /// FILE under [`Config::load_or_default`], which substitutes the complete
+    /// [`Parameters::default`] and writes it back to disk; its only caller today is a test
+    /// helper, and the production node start loads through `Config::load`, which errors on a
+    /// missing file.) This field deliberately declares no serde default. A default here would fill
+    /// a fallback on a missing key in silence, which is the exact failure mode of issue #1113
+    /// moved one layer up. Test fixtures obtain an address through [`Parameters::default`],
+    /// which supplies `GOVERNANCE_SAFE_ADDRESS`. The chain presets and the genesis ceremony
+    /// both write the key, so `--chain mainnet`, `--chain adiri`, and ceremony-founded
+    /// networks all parse.
+    pub basefee_address: Address,
     /// The default duration between parallel/fallback fetch requests to peers for missing
     /// certificates.
     #[serde(default = "Parameters::default_parallel_fetch_request_delay_interval")]
@@ -377,11 +381,11 @@ impl Default for Parameters {
             max_batch_delay: Parameters::default_max_batch_delay(),
             max_concurrent_requests: Parameters::default_max_concurrent_requests(),
             batch_vote_timeout: Parameters::default_batch_vote_timeout(),
-            // Explicit, and identical in effect to the previous `None`: an unset address already
-            // resolved to `GOVERNANCE_SAFE_ADDRESS` inside `set_basefee_address`. Stating it here
-            // keeps the default satisfying `validate_operational_floors`, which now refuses
-            // `None`.
-            basefee_address: Some(GOVERNANCE_SAFE_ADDRESS),
+            // The test-fixture path. Production reads a parameters file, and a file without the
+            // key fails to deserialize, so this value never reaches a production node. The
+            // governance safe is the address an unset `Option` historically resolved to inside
+            // `set_basefee_address`, so fixtures keep their old effective value.
+            basefee_address: GOVERNANCE_SAFE_ADDRESS,
             parallel_fetch_request_delay_interval:
                 Parameters::default_parallel_fetch_request_delay_interval(),
         }
@@ -440,13 +444,10 @@ impl Parameters {
     ///   but includes at most `max_header_num_of_batches` of them, so a zero threshold seals empty
     ///   headers on the fast path and a threshold above the max makes the two conditions mutually
     ///   inconsistent.
-    /// - `basefee_address` must be set. The EVM credits this account on every transaction, so its
-    ///   balance enters the state root and every node on the network must agree on it. A
-    ///   `parameters.yaml` that omits the key parses without error, deserializes to `None`, and
-    ///   silently selects `GOVERNANCE_SAFE_ADDRESS`, which splits state roots against every peer
-    ///   holding a different value. Refusing `None` here converts that silent split into a startup
-    ///   error that names the field. The chain presets and the genesis ceremony both write the key,
-    ///   so this rejects a file that lost it, not a supported configuration.
+    ///
+    /// `basefee_address` needs no floor here: the field is a required key with no serde default,
+    /// so a `parameters.yaml` that omits it already fails to deserialize, before any constructor
+    /// runs, with an error that names the field.
     pub fn validate_operational_floors(&self) -> eyre::Result<()> {
         eyre::ensure!(
             self.gc_depth > tn_types::GC_ACTIVITY_BUFFER,
@@ -470,11 +471,6 @@ impl Parameters {
             self.header_num_of_batches_threshold,
             self.max_header_num_of_batches,
         );
-        eyre::ensure!(
-            self.basefee_address.is_some(),
-            "basefee_address must be set explicitly: it receives every transaction's base fee, so \
-             its balance enters the state root and all nodes on the network must agree on it",
-        );
         Ok(())
     }
 
@@ -494,7 +490,7 @@ impl Parameters {
         // reading each other's files.
         info!(
             "Basefee address set to {} (consensus-critical: all nodes must agree)",
-            self.basefee_address.unwrap_or(GOVERNANCE_SAFE_ADDRESS)
+            self.basefee_address
         );
     }
 }
@@ -608,28 +604,32 @@ mod test {
         );
     }
 
-    /// A parameters file that omits `basefee_address` parses without error and yields `None`.
+    /// A parameters file that omits `basefee_address` must fail to deserialize.
     ///
-    /// This asserts the concrete value rather than `is_some()`, which would pass under either
-    /// behavior and pin nothing.
+    /// Every other key in the file carries a serde default, so this partial file isolates the one
+    /// required key. Without this pin, a `#[serde(default)]` reintroduced on the field would fill
+    /// a fallback on a missing key in silence, which is the failure mode of issue #1113.
     #[test]
-    fn absent_basefee_address_key_deserializes_to_none() {
-        let params: Parameters =
-            serde_yaml::from_str("gc_depth: 50").expect("a partial parameters file parses");
-        assert_eq!(
-            params.basefee_address, None,
-            "an omitted key must stay observable as None so the floors can refuse it"
+    fn absent_basefee_address_key_fails_to_deserialize() {
+        let err = serde_yaml::from_str::<Parameters>("gc_depth: 50")
+            .expect_err("a parameters file without basefee_address must not parse");
+        assert!(
+            err.to_string().contains("basefee_address"),
+            "the error must name the field an operator has to fix: {err}"
         );
     }
 
-    /// A production node must not start on a file that lost the key. Without this check the node
-    /// starts, credits the fallback address, and splits state roots against its peers in silence.
+    /// A parameters file with an explicit `basefee_address: null` must also fail to deserialize.
+    ///
+    /// This is the upgrade shape, not a hypothetical: before this change `Parameters::default()`
+    /// held `None`, and `load_from_path_or_default` writes the default back to disk when the file
+    /// is absent, so a datadir created under the old code can hold `basefee_address: null`. That
+    /// file takes serde's type-error path, not the missing-field path the previous test pins, so
+    /// it needs its own pin.
     #[test]
-    fn operational_floors_reject_absent_basefee_address() {
-        let params = Parameters { basefee_address: None, ..Default::default() };
-        let err = params
-            .validate_operational_floors()
-            .expect_err("a production node must not start without an explicit basefee address");
+    fn null_basefee_address_key_fails_to_deserialize() {
+        let err = serde_yaml::from_str::<Parameters>("gc_depth: 50\nbasefee_address: null")
+            .expect_err("a parameters file with a null basefee_address must not parse");
         assert!(
             err.to_string().contains("basefee_address"),
             "the error must name the field an operator has to fix: {err}"
@@ -648,12 +648,11 @@ mod test {
             serde_yaml::from_str(TESTNET_PARAMETERS).expect("adiri parameters parse");
         assert_eq!(
             mainnet.basefee_address,
-            Some(address!("0x9999999999999999999999999999999999999999")),
+            address!("0x9999999999999999999999999999999999999999"),
             "mainnet's committed basefee address changed"
         );
         assert_eq!(
-            adiri.basefee_address,
-            Some(GOVERNANCE_SAFE_ADDRESS),
+            adiri.basefee_address, GOVERNANCE_SAFE_ADDRESS,
             "adiri's committed basefee address changed"
         );
         mainnet

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -1,6 +1,6 @@
 //! Configurations for the Telcoin Network.
 
-use crate::{ConfigFmt, ConfigTrait, NodeInfo, TelcoinDirs};
+use crate::{ConfigFmt, ConfigTrait, NodeInfo, TelcoinDirs, GOVERNANCE_SAFE_ADDRESS};
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Write, time::Duration};
@@ -274,7 +274,21 @@ pub struct Parameters {
     /// Worker timeout when request vote from peers.
     #[serde(default = "Parameters::default_batch_vote_timeout")]
     pub batch_vote_timeout: Duration,
-    /// If set the Address that will recieve basefees.
+    /// The address that receives the base-fee portion of every transaction's gas payment.
+    ///
+    /// CONSENSUS-CRITICAL. The EVM credits this account on every transaction, so its balance
+    /// enters the state root. All nodes on a network must hold the same value. If two nodes
+    /// disagree, they still agree on the batch, the certificate, and the commit order, but they
+    /// build different state roots from the same committed output and the network splits. See the
+    /// `BASEFEE_ADDRESS` documentation in `tn-reth` for the execution-side detail.
+    ///
+    /// An absent key deserializes to `None`. That is declared here rather than left to serde's
+    /// implicit handling of `Option`, because the fallback it selects is three crates away.
+    /// `None` stays legal for test fixtures, but [`Parameters::validate_operational_floors`]
+    /// refuses it at the production entry points, so an operator must state the address. The
+    /// chain presets set it from their embedded parameters, so `--chain mainnet` and
+    /// `--chain adiri` never reach this path.
+    #[serde(default)]
     pub basefee_address: Option<Address>,
     /// The default duration between parallel/fallback fetch requests to peers for missing
     /// certificates.
@@ -363,7 +377,11 @@ impl Default for Parameters {
             max_batch_delay: Parameters::default_max_batch_delay(),
             max_concurrent_requests: Parameters::default_max_concurrent_requests(),
             batch_vote_timeout: Parameters::default_batch_vote_timeout(),
-            basefee_address: None,
+            // Explicit, and identical in effect to the previous `None`: an unset address already
+            // resolved to `GOVERNANCE_SAFE_ADDRESS` inside `set_basefee_address`. Stating it here
+            // keeps the default satisfying `validate_operational_floors`, which now refuses
+            // `None`.
+            basefee_address: Some(GOVERNANCE_SAFE_ADDRESS),
             parallel_fetch_request_delay_interval:
                 Parameters::default_parallel_fetch_request_delay_interval(),
         }
@@ -422,6 +440,13 @@ impl Parameters {
     ///   but includes at most `max_header_num_of_batches` of them, so a zero threshold seals empty
     ///   headers on the fast path and a threshold above the max makes the two conditions mutually
     ///   inconsistent.
+    /// - `basefee_address` must be set. The EVM credits this account on every transaction, so its
+    ///   balance enters the state root and every node on the network must agree on it. A
+    ///   `parameters.yaml` that omits the key parses without error, deserializes to `None`, and
+    ///   silently selects `GOVERNANCE_SAFE_ADDRESS`, which splits state roots against every peer
+    ///   holding a different value. Refusing `None` here converts that silent split into a startup
+    ///   error that names the field. The chain presets and the genesis ceremony both write the key,
+    ///   so this rejects a file that lost it, not a supported configuration.
     pub fn validate_operational_floors(&self) -> eyre::Result<()> {
         eyre::ensure!(
             self.gc_depth > tn_types::GC_ACTIVITY_BUFFER,
@@ -445,6 +470,11 @@ impl Parameters {
             self.header_num_of_batches_threshold,
             self.max_header_num_of_batches,
         );
+        eyre::ensure!(
+            self.basefee_address.is_some(),
+            "basefee_address must be set explicitly: it receives every transaction's base fee, so \
+             its balance enters the state root and all nodes on the network must agree on it",
+        );
         Ok(())
     }
 
@@ -459,12 +489,21 @@ impl Parameters {
         info!("Sync retry nodes set to {} nodes", self.sync_retry_nodes);
         info!("Max batch delay set to {} ms", self.max_batch_delay.as_millis());
         info!("Max concurrent requests set to {}", self.max_concurrent_requests);
+        // Consensus-critical, and the only parameter here whose value enters the state root. Two
+        // operators debugging a state-root split have no other way to compare this value without
+        // reading each other's files.
+        info!(
+            "Basefee address set to {} (consensus-critical: all nodes must agree)",
+            self.basefee_address.unwrap_or(GOVERNANCE_SAFE_ADDRESS)
+        );
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::Parameters;
+    use crate::GOVERNANCE_SAFE_ADDRESS;
+    use tn_types::{address, MAINNET_PARAMETERS, TESTNET_PARAMETERS};
 
     #[test]
     fn default_parameters_are_within_protocol_ceilings() {
@@ -567,5 +606,61 @@ mod test {
             params.validate_operational_floors().is_ok(),
             "threshold == max == 1 is the minimal consistent batch configuration and must be accepted"
         );
+    }
+
+    /// A parameters file that omits `basefee_address` parses without error and yields `None`.
+    ///
+    /// This asserts the concrete value rather than `is_some()`, which would pass under either
+    /// behavior and pin nothing.
+    #[test]
+    fn absent_basefee_address_key_deserializes_to_none() {
+        let params: Parameters =
+            serde_yaml::from_str("gc_depth: 50").expect("a partial parameters file parses");
+        assert_eq!(
+            params.basefee_address, None,
+            "an omitted key must stay observable as None so the floors can refuse it"
+        );
+    }
+
+    /// A production node must not start on a file that lost the key. Without this check the node
+    /// starts, credits the fallback address, and splits state roots against its peers in silence.
+    #[test]
+    fn operational_floors_reject_absent_basefee_address() {
+        let params = Parameters { basefee_address: None, ..Default::default() };
+        let err = params
+            .validate_operational_floors()
+            .expect_err("a production node must not start without an explicit basefee address");
+        assert!(
+            err.to_string().contains("basefee_address"),
+            "the error must name the field an operator has to fix: {err}"
+        );
+    }
+
+    /// Both shipped presets must keep an explicit, correct address.
+    ///
+    /// The addresses are pinned by value. They are consensus-critical, so a change to either is a
+    /// hard fork for that chain and updating this test is the intended cost of making one.
+    #[test]
+    fn shipped_chain_presets_pin_their_basefee_address() {
+        let mainnet: Parameters =
+            serde_yaml::from_str(MAINNET_PARAMETERS).expect("mainnet parameters parse");
+        let adiri: Parameters =
+            serde_yaml::from_str(TESTNET_PARAMETERS).expect("adiri parameters parse");
+        assert_eq!(
+            mainnet.basefee_address,
+            Some(address!("0x9999999999999999999999999999999999999999")),
+            "mainnet's committed basefee address changed"
+        );
+        assert_eq!(
+            adiri.basefee_address,
+            Some(GOVERNANCE_SAFE_ADDRESS),
+            "adiri's committed basefee address changed"
+        );
+        mainnet
+            .validate_operational_floors()
+            .expect("the mainnet preset must satisfy the operational floors");
+        adiri
+            .validate_operational_floors()
+            .expect("the adiri preset must satisfy the operational floors");
     }
 }

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -1102,12 +1102,16 @@ where
         gas_accumulator: &GasAccumulator,
     ) -> eyre::Result<ExecutionNode> {
         // create execution components (ie - reth env)
+        // `parameters.basefee_address` is a required key with no serde default, so this path
+        // always carries an explicit address; the `Option` below exists for the temp-chain and
+        // snapshot-restore constructors (genesis tooling, `db load-state`, and tests), which pin
+        // the governance default.
         let basefee_address = self.builder.tn_config.parameters.basefee_address;
         let reth_env = RethEnv::new(
             &self.builder.node_config,
             engine_task_manager,
             self.reth_db.clone(),
-            basefee_address,
+            Some(basefee_address),
             gas_accumulator.clone(),
         )?;
         // Give the consensus bus a canonical-DB fallback for `wait_for_execution` (issue #1036):

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -477,8 +477,14 @@ The `parameters.yaml` file controls consensus timing and behavior. If the file i
 | `max_batch_delay`                       | `1s`     | Worker timeout before sealing a batch               |
 | `max_concurrent_requests`               | `500000` | Max concurrent requests from untrusted entities     |
 | `batch_vote_timeout`                    | `10s`    | Timeout for batch voting requests                   |
-| `basefee_address`                       | none     | Address that receives transaction base fees         |
+| `basefee_address`                       | required | Base-fee recipient; must match every peer           |
 | `parallel_fetch_request_delay_interval` | `5s`     | Delay between parallel certificate fetch requests   |
+
+`basefee_address` is the one field here without a usable default. It is consensus-critical: the
+EVM credits this account on every transaction, so its balance enters the state root and every node
+on the network must hold the same value. A node started with this key missing is refused at
+startup rather than falling back in silence. The `genesis` commands write the key for you, and the
+`mainnet` and `adiri` chain presets carry their own value.
 
 Example (testnet configuration):
 

--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -463,7 +463,7 @@ Outbound: Unrestricted UDP for QUIC connections to peers.
 
 ## Consensus parameters
 
-The `parameters.yaml` file controls consensus timing and behavior. If the file is absent, defaults are used. Duration values accept human-readable strings (e.g. `3s`, `500ms`).
+The `parameters.yaml` file controls consensus timing and behavior. The node reads it at startup and refuses to start when the file is missing or fails to parse. Duration values accept human-readable strings (e.g. `3s`, `500ms`).
 
 | Field                                   | Default  | Description                                         |
 | --------------------------------------- | -------- | --------------------------------------------------- |
@@ -480,11 +480,11 @@ The `parameters.yaml` file controls consensus timing and behavior. If the file i
 | `basefee_address`                       | required | Base-fee recipient; must match every peer           |
 | `parallel_fetch_request_delay_interval` | `5s`     | Delay between parallel certificate fetch requests   |
 
-`basefee_address` is the one field here without a usable default. It is consensus-critical: the
+`basefee_address` is the one field here without a default. It is consensus-critical: the
 EVM credits this account on every transaction, so its balance enters the state root and every node
-on the network must hold the same value. A node started with this key missing is refused at
-startup rather than falling back in silence. The `genesis` commands write the key for you, and the
-`mainnet` and `adiri` chain presets carry their own value.
+on the network must hold the same value. A parameters file that omits the key fails to parse, so
+the node refuses to start rather than falling back in silence. The `genesis` commands write the
+key for you, and the `mainnet` and `adiri` chain presets carry their own value.
 
 Example (testnet configuration):
 

--- a/crates/telcoin-network-cli/src/genesis/mod.rs
+++ b/crates/telcoin-network-cli/src/genesis/mod.rs
@@ -318,7 +318,7 @@ impl GenesisArgs {
         if let Some(gc_depth) = self.gc_depth {
             parameters.gc_depth = gc_depth;
         }
-        parameters.basefee_address = Some(self.basefee_address);
+        parameters.basefee_address = self.basefee_address;
 
         // write genesis and config to file
         Config::write_to_path(

--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -237,6 +237,9 @@ All fee handling lives in `TNEvmHandler` (`src/evm/handler.rs`); system calls by
   set, `basefee_address()` falls back to `GOVERNANCE_SAFE_ADDRESS`. Every node in the fleet must
   agree on this value — a node with a different base-fee address computes different state roots
   and forks off (the doc comment on `set_basefee_address` says exactly this).
+  `Parameters::validate_operational_floors` (`tn-config`) refuses an unset `basefee_address` at
+  the production entry points, so a node whose `parameters.yaml` lost the key fails to start with
+  an error instead of reaching this fallback in silence.
 
 ## Precompiles
 

--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -237,9 +237,9 @@ All fee handling lives in `TNEvmHandler` (`src/evm/handler.rs`); system calls by
   set, `basefee_address()` falls back to `GOVERNANCE_SAFE_ADDRESS`. Every node in the fleet must
   agree on this value — a node with a different base-fee address computes different state roots
   and forks off (the doc comment on `set_basefee_address` says exactly this).
-  `Parameters::validate_operational_floors` (`tn-config`) refuses an unset `basefee_address` at
-  the production entry points, so a node whose `parameters.yaml` lost the key fails to start with
-  an error instead of reaching this fallback in silence.
+  `Parameters` (`tn-config`) declares `basefee_address` as a required key with no serde default,
+  so a `parameters.yaml` that lost the key fails at parse time with an error that names the field
+  instead of reaching this fallback in silence.
 
 ## Precompiles
 

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -104,6 +104,12 @@ impl std::fmt::Debug for RethEnv {
 /// Set the basefee address.  This will only work on the first call and should be during program
 /// initialization. Calling more than once will do nothing, not calling early can lead to an unset
 /// basefee address and a chain fork.
+///
+/// `None` pins the `GOVERNANCE_SAFE_ADDRESS` default. It is passed by the temp-chain and
+/// snapshot-restore constructors (genesis tooling, `db load-state`, and tests) — see the
+/// `BASEFEE_ADDRESS` docs in `lib.rs` for the first-write-wins hazard. The production node start
+/// (`crates/node/src/manager/node.rs`) always supplies a configured address, because the config
+/// layer declares `parameters.basefee_address` as a required key.
 fn set_basefee_address(address: Option<Address>) {
     // Ignore the error. Should probably panic on error but this will break some test environments.
     let _ = BASEFEE_ADDRESS.set(address.unwrap_or(GOVERNANCE_SAFE_ADDRESS));

--- a/crates/tn-reth/src/evm/handler.rs
+++ b/crates/tn-reth/src/evm/handler.rs
@@ -313,8 +313,8 @@ mod tests {
     /// of the state, so the two runs produce two different state roots.
     ///
     /// This pins the claim the `BASEFEE_ADDRESS` documentation in `lib.rs` makes, and it is the
-    /// reason [`Parameters::validate_operational_floors`](tn_config::Parameters) refuses an unset
-    /// `basefee_address`: two honest nodes that disagree on this one value still agree on the
+    /// reason `tn-config` declares [`basefee_address`](tn_config::Parameters) as a required key
+    /// with no serde default: two honest nodes that disagree on this one value still agree on the
     /// batch, the certificate, and the commit order, and disagree only on the resulting state.
     /// Without this test a later change could treat the field as cosmetic and nothing would fail.
     #[test]

--- a/crates/tn-reth/src/evm/handler.rs
+++ b/crates/tn-reth/src/evm/handler.rs
@@ -227,6 +227,10 @@ mod tests {
     /// Governance collector credited with the basefee portion of gas payments.
     const BASEFEE_ADDR: Address = address!("4444444000000000000000000000000000000004");
 
+    /// A second, equally valid collector. Used only to show that the configured address is what
+    /// decides which account the base fee lands in.
+    const ALT_BASEFEE_ADDR: Address = address!("5555555000000000000000000000000000000005");
+
     /// Basefee (in wei per gas) used by both reward tests.
     const BASEFEE: u64 = 7;
 
@@ -245,8 +249,10 @@ mod tests {
 
     /// Run [`TNEvmHandler::reward_beneficiary`] against a fresh [`TestEnv`]
     /// for a legacy transaction with the given gas price, spending `gas_limit`
-    /// in full, and return the credited (beneficiary, basefee) balances.
-    fn reward_with(gas_price: u128, gas_limit: u64) -> (U256, U256) {
+    /// in full and crediting base fees to `collector`. Return the balances of
+    /// the beneficiary and of both candidate collectors, so a caller can see
+    /// which account the configured address selected.
+    fn reward_crediting(collector: Address, gas_price: u128, gas_limit: u64) -> (U256, U256, U256) {
         let mut env = TestEnv::new();
         env.evm.ctx.set_block(BlockEnv {
             beneficiary: BENEFICIARY,
@@ -263,10 +269,21 @@ mod tests {
                 .expect("valid test tx env"),
         );
         let mut frame = spent_frame(gas_limit);
-        TNEvmHandler::new(BASEFEE_ADDR)
+        TNEvmHandler::new(collector)
             .reward_beneficiary(&mut env.evm, &mut frame)
             .expect("reward_beneficiary succeeds");
-        (env.get_balance(BENEFICIARY), env.get_balance(BASEFEE_ADDR))
+        (
+            env.get_balance(BENEFICIARY),
+            env.get_balance(BASEFEE_ADDR),
+            env.get_balance(ALT_BASEFEE_ADDR),
+        )
+    }
+
+    /// Credit base fees to [`BASEFEE_ADDR`] and return the (beneficiary, basefee) balances.
+    fn reward_with(gas_price: u128, gas_limit: u64) -> (U256, U256) {
+        let (beneficiary, basefee_collector, _alt) =
+            reward_crediting(BASEFEE_ADDR, gas_price, gas_limit);
+        (beneficiary, basefee_collector)
     }
 
     /// In-range fees split exactly: the beneficiary receives
@@ -289,5 +306,39 @@ mod tests {
         let (beneficiary, basefee_collector) = reward_with(u128::MAX, 2);
         assert_eq!(beneficiary, U256::from(u128::MAX));
         assert_eq!(basefee_collector, U256::from(u128::from(BASEFEE) * 2));
+    }
+
+    /// Two runs that agree on the block, the transaction, and the gas, and differ only in the
+    /// configured base-fee address, credit two different accounts. The credited balances are part
+    /// of the state, so the two runs produce two different state roots.
+    ///
+    /// This pins the claim the `BASEFEE_ADDRESS` documentation in `lib.rs` makes, and it is the
+    /// reason [`Parameters::validate_operational_floors`](tn_config::Parameters) refuses an unset
+    /// `basefee_address`: two honest nodes that disagree on this one value still agree on the
+    /// batch, the certificate, and the commit order, and disagree only on the resulting state.
+    /// Without this test a later change could treat the field as cosmetic and nothing would fail.
+    #[test]
+    fn differing_basefee_addresses_credit_different_accounts() {
+        let gas_used = 21_000u64;
+        let credited = U256::from(u128::from(BASEFEE) * u128::from(gas_used));
+
+        let (beneficiary_a, primary_a, alt_a) = reward_crediting(BASEFEE_ADDR, 10, gas_used);
+        let (beneficiary_b, primary_b, alt_b) = reward_crediting(ALT_BASEFEE_ADDR, 10, gas_used);
+
+        // the beneficiary is credited identically, so the collector address is the only difference
+        assert_eq!(beneficiary_a, beneficiary_b, "only the basefee address differs between runs");
+
+        assert_eq!((primary_a, alt_a), (credited, U256::ZERO), "run A must credit BASEFEE_ADDR");
+        assert_eq!(
+            (primary_b, alt_b),
+            (U256::ZERO, credited),
+            "run B must credit ALT_BASEFEE_ADDR"
+        );
+        assert_ne!(
+            (primary_a, alt_a),
+            (primary_b, alt_b),
+            "a different basefee address must produce a different account state, and therefore a \
+             different state root"
+        );
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -188,7 +188,9 @@ pub const FAUCET_ENABLED: bool = cfg!(feature = "faucet");
 /// default `GOVERNANCE_SAFE_ADDRESS`: `RethEnv::new_for_temp_chain` (`env/genesis.rs`,
 /// also reached through genesis tooling) and `SnapshotRestorer::open` (`snapshot.rs`).
 /// The production node passes the configured `parameters.basefee_address`
-/// (`crates/node/src/manager/node.rs`).
+/// (`crates/node/src/manager/node.rs`). That field is a required key with no serde
+/// default (`tn-config`), so a `parameters.yaml` that lost the key fails at parse
+/// time instead of reaching the default here.
 ///
 /// Consequence: if a `None` path runs first in a process that then starts a real node
 /// configured with a non-default basefee address, the configured address is silently


### PR DESCRIPTION
Closes #1113.

## Problem

`parameters.basefee_address` selects the account that the EVM credits with the base-fee portion of
every transaction.  That balance enters the state root, so the value is consensus-critical.  The
field was an `Option` with no serde default, and no validation step examined it.

A `parameters.yaml` that omits the key parsed without an error.  serde deserializes a missing
`Option<T>` to `None`, and `None` selects `GOVERNANCE_SAFE_ADDRESS` three crates away, inside
`set_basefee_address`.  Nothing logged the substitution and nothing reported the effective address.

Two operators on the same network can therefore run with two different fee recipients.  The nodes
agree on the batch, on the certificate, and on the commit order.  They disagree only on the
resulting state root, which is the most difficult class of split to diagnose from logs.

`--chain mainnet` and `--chain adiri` are not affected.  `Config::load_mainnet` and
`Config::load_adiri` build their `Parameters` from the embedded constants and never read the
operator's file.  The exposure is the path with no chain preset, which is the path that networks
founded through the genesis ceremony use.

## Root cause

The fallback was correct but invisible.  It lived in `tn-reth`, three crates away from the
declaration an operator reads, and no validation step connected the two.  An absent key and a
deliberate choice of the governance address produced the same result, so the configuration layer
could not tell a lost key from an intended value.

## Fix

Make the key required at the type, and log the effective value.

Per the review discussion, `basefee_address` is now a plain `Address` with no serde default.  A
`parameters.yaml` that omits the key fails to deserialize with an error that names the field.
That refusal holds for every constructor and entry point, not only the guarded production ones,
so the runtime floor check an earlier revision of this PR added is gone as dead code.

The field deliberately declares no `#[serde(default)]`.  A default would fill a fallback on a
missing key in silence, which is the exact failure mode of #1113 moved one layer up.

`Parameters::default()` states `Some`thing concrete: `GOVERNANCE_SAFE_ADDRESS`, the address an
unset `Option` historically resolved to.  `Default` is the test-fixture path;  production reads a
file, and a file without the key does not parse, so this value never reaches a production node.

The value stays data rather than a const: the two shipped presets commit two different addresses,
`telcoin-network genesis --basefee-address` sets a per-network value at the ceremony, and a preset
edit before genesis must not require a coordinated binary upgrade.

No behavior changes for `--chain mainnet`, for `--chain adiri`, or for any file that already
carries the key.  The genesis ceremony already writes the key, so it produces a valid file.

## Changes

- [x] `crates/config/src/node.rs`: `basefee_address` is a plain `Address` documented as
      consensus-critical, with no serde default, so an absent key is a hard deserialize error.
- [x] `crates/config/src/node.rs`: `Parameters::default()` states the governance address, which
      keeps every test fixture on its old effective value.
- [x] `crates/config/src/node.rs`: `Parameters::tracing()` logs the effective base-fee recipient at
      INFO, beside the other consensus parameters, so two operators can compare the value without
      reading each other's files.
- [x] `crates/node/src/manager/node.rs`: the production caller passes `Some(address)` to
      `RethEnv::new`, whose `Option<Address>` parameter remains for the test-facing constructors.
- [x] `crates/tn-reth/src/evm/handler.rs`: the reward test helper takes the collector address, so a
      test can execute the same transaction under two different addresses.
- [x] `crates/telcoin-network-cli/README.md` and `crates/tn-reth/README.md`: record that the key is
      required and that a file without it fails to parse, and fix a stale "if the file is absent,
      defaults are used" lead-in that contradicted the loader.
- [x] `crates/tn-reth/src/env/mod.rs` and `crates/tn-reth/src/lib.rs`: document exactly which
      constructors still pass `None` (genesis tooling, `db load-state`, and tests) and that the
      production node start always supplies the configured address.

## Testing

Four tests.  All of them fail if the change is reverted.

- `absent_basefee_address_key_fails_to_deserialize` pins the parse failure of a file that omits
  the key and requires the error to name the field.  Every other key carries a serde default, so
  the partial file isolates the one required key;  a `#[serde(default)]` reintroduced on the field
  turns this test red.
- `shipped_chain_presets_pin_their_basefee_address` pins both committed addresses by value and
  confirms both presets satisfy the operational floors.  The addresses are consensus-critical, so a
  change to either is a hard fork for that chain, and updating this test is the intended cost of
  making one.
- `differing_basefee_addresses_credit_different_accounts` executes one identical transaction under
  two different base-fee addresses and asserts that the two runs credit two different accounts.
  The credited balances are part of the state, so the two runs produce two different state roots.
  This pins the consensus-criticality claim that the `BASEFEE_ADDRESS` documentation makes, so a
  later change cannot treat the field as cosmetic without a test failure.
- `default_parameters_pass_operational_floors` keeps the fixture default valid against the floors.

## Alternative considered

Issue #1113 also proposes sourcing the address from genesis, which removes the failure mode
instead of reporting it.  That is the stronger fix, and `tn-reth` already documents the matching
model: "Per chain the address is fixed and only changes via a hard fork."  It changes the genesis
artifact and the ceremony, so it is a maintainer decision rather than something to fold into this
change.  This PR takes the smaller option and leaves that door open.  This PR does not stop two
operators from configuring two different addresses.  Only the genesis-sourced option closes that.

One adjacent gap stays open at the ceremony layer: `telcoin-network genesis` gives
`--basefee-address` a clap default of `GOVERNANCE_SAFE_ADDRESS`, so a founder who omits the flag
still writes the governance safe with no prompt.  The written file is explicit and every founder
gets the same value, so it is not a fork risk, but making the flag required would close the last
silent-choice path.  That is a CLI-behavior decision, so it is left out of this change.
