### PR TITLE
test(e2e): end the post-transfer idle wait in the eject tests

### DIFF
--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -599,7 +599,7 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
     // a normal transaction still confirms on the shrunken network
     let recipient = Address::from_slice(&[0x77; 20]);
     let transfer = governance_wallet.create_eip1559_encoded(
-        chain,
+        chain.clone(),
         None,
         100,
         Some(recipient),
@@ -611,8 +611,22 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
     let tx_block = get_tx_receipt_block(&rpc_url, &hash.to_string())?;
     info!(target: "eject-test", tx_block, "post-ejection transfer confirmed");
 
+    // under skip-empty-execution no block follows the transfer until the next epoch close, so
+    // give the observer probe below a prompt block
+    let follow_up = governance_wallet.create_eip1559_encoded(
+        chain,
+        None,
+        100,
+        Some(recipient),
+        parse_ether("1")?,
+        Bytes::default(),
+    );
+    let _pending = provider.send_raw_transaction(&follow_up).await?;
+
     // the ejected validator's node keeps following as an observer: its head advances past the
-    // transfer's block and it serves the shrunken epoch-E record with a verifying cert
+    // transfer's block (the follow-up's block arrives within ~1-2s; a dropped follow-up degrades
+    // to the next epoch close and the timeout stays as a hang ceiling) and it serves the
+    // shrunken epoch-E record with a verifying cert
     wait_for_head_at_least(&victim_url, tx_block + 1, EPOCH_DURATION * 3).await?;
     fetch_verified_epoch_record(&victim_url, e, EPOCH_DURATION * 3).await?;
 
@@ -911,7 +925,7 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
     // again, not merely its sync path.
     let recipient = Address::from_slice(&[0x77; 20]);
     let transfer = governance_wallet.create_eip1559_encoded(
-        chain,
+        chain.clone(),
         None,
         100,
         Some(recipient),
@@ -925,8 +939,21 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
     let tx_block = get_tx_receipt_block(&endpoints[1].http_url, &hash.to_string())?;
     info!(target: "eject-test", tx_block, "post-restart transfer confirmed via the restarted node");
 
+    // under skip-empty-execution no block follows the transfer until the next epoch close, so
+    // give the observer probe below a prompt block
+    let follow_up = governance_wallet.create_eip1559_encoded(
+        chain,
+        None,
+        100,
+        Some(recipient),
+        parse_ether("1")?,
+        Bytes::default(),
+    );
+    let _pending = restarted_provider.send_raw_transaction(&follow_up).await?;
+
     // the burned validator's node keeps following as an observer: its head advances past the
-    // transfer's block (the next block arrives at latest with the E+2 closing block)
+    // transfer's block (the follow-up's block arrives within ~1-2s; a dropped follow-up degrades
+    // to the next epoch close and the timeout stays as a hang ceiling)
     wait_for_head_at_least(&victim_url, tx_block + 1, RESTART_EPOCH_DURATION * 3).await?;
 
     Ok(())


### PR DESCRIPTION
Closes #1116.

## Summary

The e2e testnets run with skip-empty-execution.  The engine makes a block only when transactions exist or when an epoch closes.  In two eject tests, the last transfer is the last transaction in the run.  The final observer probe then waits for the next epoch-closing block.  In `test_committee_member_restarted_mid_epoch_after_ejection` this wait is ~38s of pure idle time (31.8% of the ~120s solo run).  This PR submits one follow-up transfer after the transfer confirms.  The probe then gets a prompt transaction-bearing block in under one second.

## Changes

- [x] `crates/e2e-tests/tests/it/eject.rs`: in `test_committee_member_restarted_mid_epoch_after_ejection`, build and submit one follow-up transfer after the post-restart transfer confirms.  Pass `chain.clone()` at the first call so the second call can consume `chain`.  The wallet holds its own nonce and bumps it per created transaction, so an identical second call is correct.
- [x] The same change in `test_validator_ejected_from_current_committee_mid_epoch`.  Its idle tail is up to ~10s at 10s epochs.
- [x] Comment updates where the old bound ("at latest with the E+2 closing block") no longer applies.

The test does not watch the follow-up receipt.  The probe is the wait.  If the network ever drops the follow-up, the probe still passes at the next epoch close, exactly as before this change.  Only the speedup would degrade.  The probe now accepts the follow-up's transaction block in place of the next epoch-closing block.  Epoch-boundary coverage stays in place: `assert_epoch_records_verify` and `assert_epoch_reached` still prove that every node executed each epoch-closing block.  The probe timeouts (`RESTART_EPOCH_DURATION * 3` and `EPOCH_DURATION * 3`) are unchanged and stay as hang ceilings.

## Acceptance criteria

- [x] The solo timed run drops from ~120s to ~84s.  Measured: 84.5s.
- [x] The probe returns in ~1-2s after the follow-up, not ~38s.  Measured: 0.5s.
- [x] Coverage check: a stalled victim still fails loudly.  In a scratch run the victim node was killed right after the follow-up submission.  The probe propagated the connection error and the test failed 5s after the kill.  A live but stuck victim still fails at the unchanged timeout ceiling.
- [x] All existing asserts pass on a solo run.

## Verification

Both tests ran solo with the prebuilt e2e binary and `TN_BIN_PATH` set:

```
cargo nextest run -p e2e-tests --run-ignored all -E 'test(<name>)'
```

| Test | Before (solo) | After (solo) | Probe segment |
| --- | --- | --- | --- |
| `test_committee_member_restarted_mid_epoch_after_ejection` | 120.0s | 84.5s | 38.2s before, 0.5s after |
| `test_validator_ejected_from_current_committee_mid_epoch` | idle tail up to ~10s | 44.0s | 0.7s after |

The instrumented timeline of the after-run matches the profile in #1116: boundary close at 80.0s, records verified at 80.4s, transfer confirmed at 81.5s, follow-up submitted at 81.5s, probe satisfied at 82.0s.

Lint gates on this branch: `cargo +nightly fmt -- --check` is clean for the crate.  `cargo +nightly clippy -p e2e-tests --all-targets --all-features` reports no warning in `eject.rs` (the preexisting warnings elsewhere in the `it` target are untouched).  `cargo check -p e2e-tests --all-targets` on the repo-pinned toolchain is green.
