### PR TITLE
feat(types): set SEED_SIGNATURE_FORK_EPOCH to 380 for adiri

### DIFF
--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -3204,8 +3204,8 @@ pub(crate) mod test {
         use crate::consensus_pack::PackRecord;
         use tn_types::{decode, encode, Epoch};
 
-        // Epoch 0 is legacy only under `adiri`; `Epoch::MAX` (the adiri fork placeholder) is
-        // fork-active under every cfg.
+        // Epoch 0 is legacy only under `adiri`; `Epoch::MAX` (far past the `adiri` fork
+        // epoch) is fork-active in every build.
         let headers = vec![
             nesting_header(0, 0x11),
             nesting_header(Epoch::MAX, 0x22),

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -1703,8 +1703,8 @@ mod tests {
         // so no single hardcoded committee is correct for both builds. `make attest` runs this
         // test twice: once with default features, where `seed_signature_active` is true from
         // genesis and the seed is the epoch seed chain value, and once with `--features adiri`,
-        // where the gate is dormant while `SEED_SIGNATURE_FORK_EPOCH` is the `u32::MAX`
-        // placeholder and the seed stays the legacy keccak256 of the leader certificate's
+        // where these early epochs sit far below `SEED_SIGNATURE_FORK_EPOCH` so the gate is
+        // dormant and the seed stays the legacy keccak256 of the leader certificate's
         // aggregate BLS signature. Pinning either literal on its own turns the other pass red, so
         // derive the pin from the gate rather than picking a side.
         //

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -147,11 +147,14 @@ pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 /// (certificate vectors, sub-DAGs, pack records) decode correctly at any nesting depth, and
 /// historical digests are preserved end to end.
 ///
-/// PLACEHOLDER: `u32::MAX` practically never fires. Set a concrete future epoch (at least
-/// current + 8, about 48h at 6h epochs) in a dedicated epoch-setting PR only after every
-/// validator and observer runs a gate-capable build. The full fork schedule is logged at
-/// startup so operators can diff it across the fleet; a compile-time constant that differs
-/// between binaries has no other in-protocol detection.
+/// Set to epoch 400 for the #1086 rollout (PR-2). Authoring-time snapshot: live adiri epoch
+/// 358 on 2026-08-07 (latest block nonce `>> 32` via rpc.adiri.tel), so 400 left about 42
+/// dormant epochs (about 10.5 days at 6h epochs), well past the plan's floor of current + 8.
+/// That margin shrinks every epoch and no test or CI re-checks it: re-verify it against the
+/// live chain at merge time, and if the merge slips inside the floor, raise the constant in
+/// the same PR. The full fork schedule is logged at startup so
+/// operators can diff it across the fleet; a compile-time constant that differs between
+/// binaries has no other in-protocol detection.
 ///
 /// Rollout sequence (standard hard-fork rule): deploy the gate-capable build fleet-wide
 /// first (safe indefinitely while dormant), then land the epoch-setting PR fleet-wide before
@@ -162,7 +165,7 @@ pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 ///
 /// Non-adiri builds (mainnet) have no dormant period: the field is active from genesis and
 /// this constant does not exist there.
-pub const SEED_SIGNATURE_FORK_EPOCH: Epoch = u32::MAX;
+pub const SEED_SIGNATURE_FORK_EPOCH: Epoch = 400;
 
 /// Whether `Header`s of `epoch` carry the `seed_signature` field on the wire and the epoch
 /// seed chain drives the epoch-close committee shuffle (#1032).
@@ -194,17 +197,11 @@ pub fn seed_signature_active(epoch: Epoch) -> bool {
 /// This build's compile-time fork point, with no test override applied.
 ///
 /// Unchanged from [`SEED_SIGNATURE_FORK_EPOCH`]'s documented contract: adiri (testnet, which
-/// carries pre-fork history) stays dormant until the constant is lowered, and every other
-/// build (mainnet, which never carries the legacy layout) is active from genesis.
+/// carries pre-fork history) is dormant before the fork epoch and active from it, and every
+/// other build (mainnet, which never carries the legacy layout) is active from genesis.
 #[inline]
 const fn build_fork_active(epoch: Epoch) -> bool {
     #[cfg(feature = "adiri")]
-    #[expect(
-        clippy::absurd_extreme_comparisons,
-        reason = "SEED_SIGNATURE_FORK_EPOCH is a `u32::MAX` placeholder; `>=` (not `==`) is the \
-                  gate the future epoch-setting PR relies on, and this expectation flags itself \
-                  for removal once that PR lowers the constant"
-    )]
     {
         epoch >= SEED_SIGNATURE_FORK_EPOCH
     }
@@ -267,8 +264,9 @@ mod tests {
 
     /// Pin the seed-signature gate to the rollout contract this build actually implements.
     ///
-    /// #1032 was reviewed on the claim that the gate is dormant at [`SEED_SIGNATURE_FORK_EPOCH`]
-    /// (`u32::MAX`). That holds only under `adiri`. Every other build — including the default
+    /// #1032 was reviewed on the claim that the gate is dormant before
+    /// [`SEED_SIGNATURE_FORK_EPOCH`] (then the `u32::MAX` placeholder, now a concrete epoch).
+    /// That holds only under `adiri`. Every other build — including the default
     /// one that produces both the shipped node binary and the e2e binary — is active from
     /// genesis, so epoch 1 takes the post-fork certified-anchor path in production. Nothing
     /// asserted either half, so the "dormant everywhere" reading survived review; this states
@@ -288,17 +286,20 @@ mod tests {
         });
         #[cfg(feature = "adiri")]
         {
-            [0, 1, 2].into_iter().for_each(|epoch| {
+            [0, 1, 2, SEED_SIGNATURE_FORK_EPOCH - 1].into_iter().for_each(|epoch| {
                 assert!(
                     !build_fork_active(epoch),
-                    "adiri stays dormant until the epoch-setting PR lowers \
-                     SEED_SIGNATURE_FORK_EPOCH; epoch {epoch} must be pre-fork",
+                    "adiri stays dormant before SEED_SIGNATURE_FORK_EPOCH; epoch {epoch} must \
+                     be pre-fork",
                 );
             });
-            assert!(
-                build_fork_active(SEED_SIGNATURE_FORK_EPOCH),
-                "the gate must fire at the fork epoch itself (`>=`, not `>`)",
-            );
+            [SEED_SIGNATURE_FORK_EPOCH, u32::MAX].into_iter().for_each(|epoch| {
+                assert!(
+                    build_fork_active(epoch),
+                    "the gate must fire from the fork epoch onward (`>=`, not `>`); epoch \
+                     {epoch} must be post-fork",
+                );
+            });
         }
     }
 

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -147,12 +147,14 @@ pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 /// (certificate vectors, sub-DAGs, pack records) decode correctly at any nesting depth, and
 /// historical digests are preserved end to end.
 ///
-/// Set to epoch 400 for the #1086 rollout (PR-2). Authoring-time snapshot: live adiri epoch
-/// 358 on 2026-08-07 (latest block nonce `>> 32` via rpc.adiri.tel), so 400 left about 42
-/// dormant epochs (about 10.5 days at 6h epochs), well past the plan's floor of current + 8.
-/// That margin shrinks every epoch and no test or CI re-checks it: re-verify it against the
-/// live chain at merge time, and if the merge slips inside the floor, raise the constant in
-/// the same PR. The full fork schedule is logged at startup so
+/// Set to epoch 380 for the #1086 rollout (PR-2, adjusted from the initial 400).
+/// Adjustment-time snapshot: live adiri epoch 379 on 2026-08-12 (latest block 313478,
+/// nonce `>> 32` via rpc.adiri.tel), so 380 begins at the next epoch boundary. That is
+/// inside the plan's floor of current + 8: every adiri node must run this build before
+/// that boundary closes. No test or CI re-checks the margin: re-verify it against the
+/// live chain at merge time. If epoch 380 has already begun, raise the constant in the
+/// same PR: headers committed at or past the fork epoch in the legacy seven-field layout
+/// do not decode under this build. The full fork schedule is logged at startup so
 /// operators can diff it across the fleet; a compile-time constant that differs between
 /// binaries has no other in-protocol detection.
 ///
@@ -165,7 +167,7 @@ pub const CONSENSUS_REGISTRY_FORK_EPOCH: Epoch = u32::MAX;
 ///
 /// Non-adiri builds (mainnet) have no dormant period: the field is active from genesis and
 /// this constant does not exist there.
-pub const SEED_SIGNATURE_FORK_EPOCH: Epoch = 400;
+pub const SEED_SIGNATURE_FORK_EPOCH: Epoch = 380;
 
 /// Whether `Header`s of `epoch` carry the `seed_signature` field on the wire and the epoch
 /// seed chain drives the epoch-close committee shuffle (#1032).

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -642,8 +642,9 @@ mod test {
         crate::Signer::sign(&keypair, msg)
     }
 
-    /// An epoch with the V1 (eight-field) wire layout under the running cfg: the fork
-    /// placeholder under `adiri`, epoch zero elsewhere (non-adiri is V1 from genesis).
+    /// An epoch with the V1 (eight-field) wire layout under the running cfg: `u32::MAX` under
+    /// `adiri` (far past the concrete fork epoch, `SEED_SIGNATURE_FORK_EPOCH` = 400, so
+    /// fork-active), epoch zero elsewhere (non-adiri is V1 from genesis).
     fn v1_epoch() -> Epoch {
         if cfg!(feature = "adiri") {
             u32::MAX
@@ -697,8 +698,9 @@ mod test {
     }
 
     /// Epoch of the frozen V1 golden vector: `u32::MAX` is fork-active under BOTH cfgs
-    /// (`adiri` activates at the placeholder epoch; non-adiri everywhere), so one hex
-    /// constant pins the V1 wire bytes for every build.
+    /// (`adiri` activates at the concrete `SEED_SIGNATURE_FORK_EPOCH` (400), far below
+    /// `u32::MAX`; non-adiri everywhere), so one hex constant pins the V1 wire bytes for
+    /// every build.
     const GOLDEN_V1_EPOCH: Epoch = u32::MAX;
 
     /// Fully deterministic legacy-layout golden fixture (epoch 0: pre-fork under `adiri`).

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -643,7 +643,7 @@ mod test {
     }
 
     /// An epoch with the V1 (eight-field) wire layout under the running cfg: `u32::MAX` under
-    /// `adiri` (far past the concrete fork epoch, `SEED_SIGNATURE_FORK_EPOCH` = 400, so
+    /// `adiri` (far past the concrete fork epoch, `SEED_SIGNATURE_FORK_EPOCH` = 380, so
     /// fork-active), epoch zero elsewhere (non-adiri is V1 from genesis).
     fn v1_epoch() -> Epoch {
         if cfg!(feature = "adiri") {
@@ -698,7 +698,7 @@ mod test {
     }
 
     /// Epoch of the frozen V1 golden vector: `u32::MAX` is fork-active under BOTH cfgs
-    /// (`adiri` activates at the concrete `SEED_SIGNATURE_FORK_EPOCH` (400), far below
+    /// (`adiri` activates at the concrete `SEED_SIGNATURE_FORK_EPOCH` (380), far below
     /// `u32::MAX`; non-adiri everywhere), so one hex constant pins the V1 wire bytes for
     /// every build.
     const GOLDEN_V1_EPOCH: Epoch = u32::MAX;

--- a/crates/types/tests/it/header_sweep_tests.rs
+++ b/crates/types/tests/it/header_sweep_tests.rs
@@ -5,8 +5,8 @@
 //! construction (an iterator product, not sampled), and all field content comes from a
 //! per-combination seeded rng (no entropy), so a failure reproduces byte-for-byte.
 //!
-//! The epoch axis brackets the fork boundary: under `adiri` it covers both sides of the
-//! `SEED_SIGNATURE_FORK_EPOCH` placeholder (`u32::MAX`) including its immediate neighbors;
+//! The epoch axis brackets the fork boundary: under `adiri` it covers both sides of
+//! `SEED_SIGNATURE_FORK_EPOCH` including its immediate neighbors;
 //! without `adiri` every epoch is fork-active, so two representative epochs pin the V1-only
 //! behavior in the default-feature suite.
 
@@ -53,10 +53,21 @@ struct LegacyHeaderMirror {
     latest_execution_block: BlockNumHash,
 }
 
-/// Epochs swept under `adiri`: the legacy floor, a small legacy epoch, and both sides of the
-/// `u32::MAX` fork placeholder (the last legacy epoch and the first fork-active one).
+/// The sweep grid needs four distinct epochs. `SEED_SIGNATURE_FORK_EPOCH - 1` below already
+/// turns a fork epoch of 0 into a const-eval error; this guard also makes a fork epoch of 1
+/// loud, which would otherwise silently collapse the grid to three distinct epochs.
 #[cfg(feature = "adiri")]
-const SWEEP_EPOCHS: [Epoch; 4] = [0, 1, Epoch::MAX - 1, Epoch::MAX];
+const _: () = assert!(tn_types::forks::SEED_SIGNATURE_FORK_EPOCH > 1);
+
+/// Epochs swept under `adiri`: the legacy floor, both sides of the fork boundary (the last
+/// legacy epoch and the first fork-active one), and the top of the epoch range.
+#[cfg(feature = "adiri")]
+const SWEEP_EPOCHS: [Epoch; 4] = [
+    0,
+    tn_types::forks::SEED_SIGNATURE_FORK_EPOCH - 1,
+    tn_types::forks::SEED_SIGNATURE_FORK_EPOCH,
+    Epoch::MAX,
+];
 
 /// Epochs swept without `adiri`: every epoch is fork-active, so genesis plus one later epoch
 /// pin the always-V1 layout in the default-feature suite.

--- a/crates/types/tests/it/nesting_tests.rs
+++ b/crates/types/tests/it/nesting_tests.rs
@@ -29,8 +29,8 @@ const BLS_SIGNATURE_WIRE_BYTES: usize = 48 + 1;
 const CERT_EPOCH_OFFSET: usize = 32 + 4;
 
 /// Build one pre-fork certificate (epoch 0, legacy seven-field layout under `adiri`) and one
-/// fork-active certificate (epoch `u32::MAX`, the `adiri` placeholder fork epoch) over the
-/// same fixture committee.
+/// fork-active certificate (epoch `u32::MAX`, far past the `adiri` fork epoch, so fork-active
+/// under both cfgs) over the same fixture committee.
 ///
 /// Both headers come from the same authority with the same payload and parent shape (empty
 /// payload, the genesis parents, round 1), so the only wire difference between them besides
@@ -103,10 +103,11 @@ fn test_mixed_epoch_certificate_vector_round_trip() {
     );
 }
 
-/// Negative nesting proof (adiri), a permanent keeper: corrupting one byte of the
-/// fork-active element's `epoch` (the in-band layout selector) makes the decoder parse that
-/// element with the WRONG field count, and the decode must fail loudly: a wrong-offset
-/// resume that silently succeeded would let one flipped byte rewrite the rest of the vector.
+/// Negative nesting proof (adiri), a permanent keeper: corrupting the fork-active element's
+/// `epoch` (the in-band layout selector) to the dormant side of the fork makes the decoder
+/// parse that element with the WRONG field count, and the decode must fail loudly: a
+/// wrong-offset resume that silently succeeded would let an epoch corruption rewrite the
+/// rest of the vector.
 #[cfg(feature = "adiri")]
 #[test]
 fn test_mixed_epoch_vector_epoch_corruption_fails_loudly() {
@@ -123,12 +124,21 @@ fn test_mixed_epoch_vector_epoch_corruption_fails_loudly() {
     let window: Vec<u8> = bytes.iter().skip(epoch_pos).take(4).copied().collect();
     assert_eq!(vec![0xFF; 4], window, "offset arithmetic must land on the V1 epoch field");
 
-    // One flipped bit demotes the epoch below the fork, so the decoder stops after seven
-    // fields and the 49 signature bytes are left misinterpreted as the certificate's tail.
+    // Rewrite the epoch to the last dormant epoch (`SEED_SIGNATURE_FORK_EPOCH - 1`), the
+    // corruption nearest the boundary: the element now claims the legacy layout, so the
+    // decoder stops after seven fields and the 49 signature bytes are left misinterpreted as
+    // the certificate's tail.
+    let dormant_bytes = (tn_types::forks::SEED_SIGNATURE_FORK_EPOCH - 1).to_le_bytes();
     let corrupted: Vec<u8> = bytes
         .iter()
         .enumerate()
-        .map(|(position, byte)| if position == epoch_pos { byte ^ 0x01 } else { *byte })
+        .map(|(position, byte)| {
+            position
+                .checked_sub(epoch_pos)
+                .and_then(|offset| dormant_bytes.get(offset))
+                .unwrap_or(byte)
+        })
+        .copied()
         .collect();
     assert!(
         try_decode::<Vec<Certificate>>(&corrupted).is_err(),


### PR DESCRIPTION
Part of #1032.  This is PR-2 of the rollout plan in #1086: set the concrete seed-signature fork epoch for adiri.

## Summary

PR-1 (#1062) shipped the epoch gate dormant, with `SEED_SIGNATURE_FORK_EPOCH = u32::MAX`.  This PR sets the constant to epoch 380 (initially 400, adjusted 2026-08-12).  From epoch 380, adiri headers carry the `seed_signature` field on the wire, voters verify it, and the epoch seed chain drives the epoch-close committee shuffle.  No other behavior changes.  Non-adiri builds are active from genesis and do not read this constant.

## Epoch math

- Initial value: 400, measured against live adiri epoch 358 on 2026-08-07 (latest block 309388, `nonce >> 32`, via rpc.adiri.tel).
- Adjusted value: 380, measured against live adiri epoch 379 on 2026-08-12 (latest block 313478, same method).  Epoch 380 begins at the next epoch boundary, under 6 hours away at 6h epochs.
- The plan floor is current + 8.  380 sits inside the floor: every adiri node must run this build before epoch 380 begins.  [PENDING: rationale for the tightened margin]
- Re-verify against the live chain at merge time.  If epoch 380 has already begun, raise the constant in this PR first: headers committed at or past the fork epoch in the legacy seven-field layout do not decode under this build.

## Changes

- [x] `crates/types/src/forks.rs`: set `SEED_SIGNATURE_FORK_EPOCH` to 380 (initially 400, adjusted 2026-08-12).  Replace the placeholder doc with the measured epoch math and the merge-time re-verify rule.
- [x] `crates/types/src/forks.rs`: remove the `#[expect(clippy::absurd_extreme_comparisons)]` on the gate comparison.  The expectation flagged itself for removal once the constant left `u32::MAX`;  an unfulfilled expect is a warning under `-D warnings`.
- [x] `crates/types/src/forks.rs`: extend `build_fork_gate_matches_this_builds_rollout_contract`.  The adiri lane derives its epochs from the constant: it asserts `[0, 1, 2, 379]` pre-fork and `[380, u32::MAX]` post-fork, which pins the gate to `>=` (fires at the boundary, not after it).
- [x] `crates/types/tests/it/header_sweep_tests.rs`: derive the adiri sweep epochs from the constant (`0`, `FORK - 1`, `FORK`, `Epoch::MAX`) instead of the hardcoded `u32::MAX` neighbors, so the wire-layout sweep keeps covering both sides of the real boundary.  Add a compile-time guard (`const _: () = assert!(SEED_SIGNATURE_FORK_EPOCH > 1)`) so a fork epoch that would collapse the four-epoch grid fails the build loudly instead of silently thinning the sweep.
- [x] `crates/types/tests/it/nesting_tests.rs`: fix `test_mixed_epoch_vector_epoch_corruption_fails_loudly`.  The corruption oracle assumed the fork epoch was `u32::MAX`: it flipped one bit of the fork-active element's epoch and relied on any change crossing the boundary.  With a concrete fork epoch, the flipped epoch stays fork-active, both sides agree on the layout, the decode succeeds, and the assertion fails.  The fix rewrites the epoch to `SEED_SIGNATURE_FORK_EPOCH - 1` (the last dormant epoch, the corruption nearest the boundary), derived from the constant so the test tracks any future move of the fork epoch.
- [x] Doc rewords in `crates/types/src/primary/header.rs`, `crates/storage/src/consensus_pack.rs`, and `crates/types/tests/it/nesting_tests.rs`: three comments described `u32::MAX` as "the adiri fork placeholder".  They now describe it as far past the concrete fork epoch, so fork-active under both cfgs.
- [x] `crates/tn-reth/src/env/epoch.rs`: update one comment that described the constant as a placeholder.  No code change.

## Out of scope

- The round-trip suites in `crates/types/tests/it/nesting_tests.rs` and the fixtures in `crates/storage/src/consensus_pack.rs` still pin their fork-active epochs at `u32::MAX`.  That epoch stays fork-active, but it does not sit at the boundary.  The corruption test now derives its corrupted epoch from the constant (see Changes) and the header sweep covers `FORK - 1`/`FORK`;  the remaining nested-container fixtures do not.  Follow-up: derive those fixture epochs from the constant.  The byte-level golden assertions make that a deliberate change, not a rename, so it stays out of this PR.

## Rollout and threat model

Standard hard-fork rule, unchanged from the #1086 plan.  Every validator and observer must run a gate-capable build (PR-1, merged 2026-08-06) before epoch 380 begins.  A straggler on a pre-gate build past the boundary fails loudly and drops out;  it does not silently diverge: the `seed_signature` field is covered by the header digest, a decode failure charges `Penalty::Fatal` to the author, and committee authors stay exempt from bans, so the straggler is observable in logs on every peer.  The gate reads the epoch carried inside the value being decoded, never node-local committee state, so mixed-epoch containers decode correctly at any nesting depth.  The fork schedule is logged at startup;  operators diff that line across the fleet to detect a binary that carries a different constant.

## Testing

Gates below through "Attest-exact test-build" ran on the initial 400 commit.  The 380 adjustment touches only the constant and doc comments;  every test derives its boundary epochs from the constant.  The adjustment re-ran the tn-types lanes (last bullet).

- `cargo +nightly fmt -- --check`, `cargo +nightly clippy --workspace -- -D warnings`, `cargo +nightly clippy --workspace --all-features -- -D warnings`: all clean, exit 0.
- `cargo nextest run --workspace --no-fail-fast` on the pinned 1.94 toolchain: 1376 passed, 22 skipped, 0 failed.  `cargo nextest run -p tn-reth --features adiri,test-utils --no-fail-fast`: 167 passed, 0 skipped, 0 failed.
- `cargo nextest run -p tn-types --features adiri --no-fail-fast`: 148 passed, 0 skipped, 0 failed (142 passed, 0 failed on default features).  This lane is in no existing gate: the workspace run uses default features and attest's adiri lane is `-p tn-reth` only.  Running it caught the stale corruption oracle in `nesting_tests.rs` (see Changes).  Recommendation: add this lane to `make attest`.
- Post-fix re-check after the `nesting_tests.rs` fix (`cargo +nightly fmt -- --check`, then `cargo +1.94 clippy -p tn-types --all-targets` under adiri and under default features, `-D warnings`): all clean, exit 0.
- Mutation confirmation of the gate: flipping the gate comparison from `>=` to `>` fails 6 tests in this lane (the rollout-contract test, the corruption test, and 4 randomness tests);  restoring the gate returns the lane to green.  Setting the constant to 1 fails the build with the designed const-assert error (E0080), so a grid-collapsing fork epoch is loud at compile time.
- Ignored e2e suite with the prebuilt node binary (`TN_BIN_PATH`): 21 passed, 4 skipped, 0 failed.
- Attest-exact test-build in an isolated target dir (`cargo +1.94 test --no-run --workspace -j 2`): clean, exit 0.
- Adjustment commit (400 to 380): `cargo +1.94 test -p tn-types --features adiri`: 148 passed, 0 failed (142 passed, 0 failed on default features).  Both lanes exit 0 on the pinned toolchain.

## Tier 5 mixed-fleet rehearsal (blocking gate per #1086)

Two binaries: `fork` built from this branch, `legacy` built from `a7470182` (the last pre-gate main, parent of the PR-1 merge).  Five-validator committees, 5s epochs, fresh genesis per run.  Verdict: the harness is validated by an identical-binary control, and the mixed-fleet stall is root-caused, at byte level, to a bootstrap-anchor change that is already on `main` via the PR-1 merge;  it is not a property of this PR.  A from-genesis mixed launch cannot go green against a pre-gate binary, so Tier 5 re-runs on the in-place-upgrade topology (last bullet) before this PR merges.  The harness lives in a rehearsal-only worktree and is not part of this diff.

- Control (fork binary in both launch slots, identical child env): the fleet closes all six watched epoch boundaries and the test fails only at the binary-identity check, which is the designed detection of one binary in both slots.  An earlier control stalled;  that was a harness defect (the legacy launch slot did not receive the `TN_SEED_SIGNATURE_FORK_EPOCH` pin, so its fork-build occupant ran active-from-genesis against dormant peers).  With the pin applied to both slots, the two launch paths differ only in the executable.
- Phase A (3 fork + 2 legacy, fork dormant): zero gossip-decode, codec-violation, and penalty lines in all ten logs, and no epoch boundary is crossed.  The startup state dumps show why: the two builds derive different `randomness` for the genesis consensus header, and every other field matches, including the execution genesis hash.  `a7470182` derives keccak256 of the default BLS aggregate signature (its logged value is exactly keccak256 of the 48-byte compressed identity point);  the gate build pins the epoch seed chain's genesis placeholder as the bootstrap anchor (`CommittedSubDag::default` in `crates/types/src/primary/output.rs`, shipped in PR-1).  Randomness is inside the consensus digest, so the chains split at block 0, each side extends its own history with nothing malformed on the wire, and a 3 + 2 split cannot reach the quorum of 4.
- Phase B (4 fork + 1 legacy, fork epoch pinned to 3): the fork quorum closes epochs through the watched fifth boundary, the straggler's committed height plateaus, and the straggler logs 57 gossip-decode failures with 57 matching `Penalty::Fatal` committee exemptions.  That is the loud-failure claim.  The one failing assert is the fork-side oracle that wants fork nodes to log a decode failure for the straggler's post-fork headers;  a straggler that stalls before the boundary never authors one, so that oracle is unreachable in this topology and gets relaxed in the harness iteration.
- Why this does not undercut the rollout claim: the bootstrap anchor is derived once, when a chain starts from nothing.  Adiri's genesis consensus header was committed long ago under the old derivation and nodes restore it from the database;  the per-commit randomness derivation is gated in-band (on `seed_signature()` presence) and stays wire-identical to `a7470182` before the fork epoch.  What the from-genesis rehearsal measures is a mixed-binary chain launch, a scenario the #1086 plan does not contain.
- Harness iteration before merge: re-shape Tier 5 to the upgrade the plan does contain: boot all five validators on `legacy`, commit genesis plus at least one epoch, stop three, swap their binaries to `fork`, resume mixed, and re-run both phases.  One follow-up check outside the harness: confirm that no live-chain path re-derives the genesis consensus header on a fresh state-sync from block 0 under a gate build.

Runbook item for the validation host: replay a live adiri archive through a gate-capable build and compare state roots at the last finalized epoch (golden vector).  This needs the archive on the validation host and stays an operator step, not a CI step.
