### PR TITLE
test(e2e): speed up basefee boundary-kill test by ~30% (#1119)

### DIFF
--- a/crates/e2e-tests/tests/it/basefee.rs
+++ b/crates/e2e-tests/tests/it/basefee.rs
@@ -64,10 +64,10 @@ use tokio::time::Instant;
 use tracing::info;
 
 use crate::common::{
-    address_from_word, current_epoch, get_balance, get_block_number, get_key,
+    address_from_word, current_epoch, force_kill_and_reap, get_balance, get_block_number, get_key,
     get_latest_consensus_header_number, get_tx_receipt_block, kill_child, network_advancing,
-    read_base_fee, send_tel, start_validator, wait_for_epoch_at_least, wait_for_mid_epoch,
-    wait_for_rpc, EpochSnapshot, ProcessGuard,
+    read_base_fee, send_tel, send_term, start_validator, wait_for_epoch_at_least,
+    wait_for_mid_epoch, wait_for_rpc, EpochSnapshot, ProcessGuard,
 };
 
 /// Epoch duration (seconds) for the base-fee tests. 5s is the consensus minimum epoch duration;
@@ -109,23 +109,26 @@ const TRANSFER_AMOUNT: u128 = 1_000_000_000_000_000;
 /// only place this module departs from [`EPOCH_DURATION`].
 ///
 /// That test has to fit a whole sequence inside ONE epoch: reap the node killed at the boundary
-/// (SIGTERM plus [`kill_child`]'s poll-for-exit, ~1-2.5s), then submit and confirm the new epoch's
-/// first transaction (~1-2s). At the 5s cadence that sequence can spill past the next boundary and
-/// land the control transaction in the epoch AFTER the one the oracle prices, where the fee has
-/// moved again — a timing flake that would read as a fee mismatch. 10s (the cadence `common.rs`'s
-/// epoch helpers are calibrated to) leaves the sequence ~6s of slack, at the cost of one extra
-/// epoch of warm-up.
-const BOUNDARY_EPOCH_DURATION: u64 = 10;
+/// (SIGTERM plus [`fast_kill`]'s 300ms poll-for-exit; the node's real shutdown takes ~2.3s), then
+/// submit and confirm the new epoch's first transaction (~1-2s). At the 5s cadence that sequence
+/// can spill past the next boundary and land the control transaction in the epoch AFTER the one
+/// the oracle prices, where the fee has moved again: a timing flake that would read as a fee
+/// mismatch. 8s keeps ~3s of worst-case slack for the sequence, at one wall-clock second saved per
+/// boundary the test crosses; [`fast_kill`] exists so the reap costs its true ~2.3s instead of
+/// [`kill_child`]'s 1.2s-quantized poll (up to 3.6s), which is where that slack comes from.
+const BOUNDARY_EPOCH_DURATION: u64 = 8;
 
 /// Consecutive epochs [`test_boundary_kill_restart_recovers_next_epoch_fee`] lands one transaction
 /// in before the boundary kill.
 ///
 /// Each such epoch raises worker 0's fee by one EIP-1559 step (+12.5%, minimum +1 against
-/// `target_gas = 1`), so three of them lift it from [`MIN_PROTOCOL_BASE_FEE`] (7) to ~9 and make
-/// the expected next-epoch fee ~10. That is far enough above MIN, and above the closed epoch's own
-/// fee, that neither a node which defaulted to MIN nor one which kept the previous epoch's value
-/// can satisfy the assertions by coincidence.
-const BOUNDARY_WARMUP_EPOCHS: usize = 3;
+/// `target_gas = 1`), so two of them lift it from [`MIN_PROTOCOL_BASE_FEE`] (7) to 8 and make the
+/// expected next-epoch fee 9. That is enough separation: at every assertion, 9 is distinct from a
+/// node which defaulted to MIN (7) and from one which kept the closed epoch's value (8), so
+/// neither failure mode can satisfy the assertions by coincidence. The decay/readmission
+/// arithmetic in steps 3-4 also stays exact on this band (`decay(step(x)) = x` for every fee in
+/// 7..12, because each step is the +1 minimum and decay is its -1 mirror above MIN).
+const BOUNDARY_WARMUP_EPOCHS: usize = 2;
 
 // ---------------------------------------------------------------------------------------------
 // Test 2 (written first because it is the robust, deterministic core): Static fee at boundary.
@@ -634,7 +637,7 @@ async fn test_boundary_kill_restart_recovers_next_epoch_fee() -> eyre::Result<()
     // One RPC call, taken before the signal: the node's tip at the kill instant.
     let head_at_kill = get_block_number(&client_urls[kill_idx])?;
     if let Some(mut taken) = guard.take(kill_idx) {
-        kill_child(&mut taken);
+        fast_kill(&mut taken);
     }
     info!(
         target: "basefee-test",
@@ -854,6 +857,24 @@ fn start_testnet(temp_path: &Path, test: &str) -> (ProcessGuard, [String; NUM_VA
     network_advancing(&client_urls).expect("network failed to start serving RPC");
 
     (guard, client_urls)
+}
+
+/// Boundary-kill reap: SIGTERM, then poll for exit every 300ms (up to 6s), then SIGKILL + wait.
+///
+/// [`kill_child`]'s shared reap (`common.rs`'s `wait_or_kill`) polls in 1.2s slots, which
+/// quantizes the node's real ~2.3s shutdown up to 3.6s. This reap runs INSIDE the one epoch that
+/// must also fit the control transaction (see [`BOUNDARY_EPOCH_DURATION`]), so the finer poll buys
+/// back over a second of in-epoch slack. The SIGKILL escalation grace (6s) is unchanged; only the
+/// poll cadence differs, and only at this call site: every other kill keeps [`kill_child`].
+fn fast_kill(child: &mut std::process::Child) {
+    send_term(child);
+    let exited = (0..20).any(|_| {
+        std::thread::sleep(Duration::from_millis(300));
+        child.try_wait().ok().flatten().is_some()
+    });
+    if !exited {
+        force_kill_and_reap(child);
+    }
 }
 
 /// Wait out a killed node's downtime, then proceed once a live peer's consensus chain has advanced.

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -156,17 +156,37 @@ impl ProcessGuard {
 
     /// Send SIGTERM to all, wait for each to exit (SIGKILL if needed), then clear all slots.
     /// Safe to call multiple times.
+    ///
+    /// The exit wait polls EVERY child against one shared 6s deadline (the same shape as
+    /// [`Self::wait_for_natural_exits`]) instead of giving each child its own [`wait_or_kill`]
+    /// window: a 10ms poll reaps the common case (all children already dying from the parallel
+    /// SIGTERM) as soon as the last one exits, instead of rounding each child up to its next
+    /// 1.2s poll slot in sequence.
     pub(crate) fn kill_all(&mut self) {
         // Phase 1: SIGTERM all in parallel for fast graceful shutdown
         self.send_term_all();
 
-        // Phase 2: wait for each to exit, escalate to SIGKILL if needed
-        for slot in self.children.iter_mut() {
-            if let Some(ref mut child) = slot {
-                wait_or_kill(child);
-            }
-            *slot = None;
+        // Phase 2: one shared deadline for every child to exit, polled at 10ms.
+        let deadline = std::time::Instant::now() + Duration::from_secs(6);
+        let all_exited =
+            std::iter::repeat(()).take_while(|()| std::time::Instant::now() < deadline).any(|()| {
+                std::thread::sleep(Duration::from_millis(10));
+                self.children
+                    .iter_mut()
+                    .flatten()
+                    .all(|child| child.try_wait().ok().flatten().is_some())
+            });
+
+        // Phase 3: escalate whatever is still running, then clear every slot. `try_wait` on an
+        // already-reaped child returns its stored status, so exited children are never signaled.
+        if !all_exited {
+            self.children.iter_mut().flatten().for_each(|child| {
+                if child.try_wait().ok().flatten().is_none() {
+                    force_kill_and_reap(child);
+                }
+            });
         }
+        self.children.iter_mut().for_each(|slot| *slot = None);
     }
 
     /// Wait (bounded) for every child at `indices` to exit on its own, without signaling any of
@@ -265,12 +285,20 @@ fn wait_or_kill(child: &mut Child) {
         }
         std::thread::sleep(Duration::from_millis(1200));
     }
-    if let Err(e) = child.kill() {
-        error!(target: "e2e-test", ?e, "error sending SIGKILL");
-    }
-    if let Err(e) = child.wait() {
-        error!(target: "e2e-test", ?e, "error waiting for child after SIGKILL");
-    }
+    force_kill_and_reap(child);
+}
+
+/// SIGKILL a child that did not exit within its SIGTERM grace, then reap it.
+///
+/// The shared tail of every kill path ([`wait_or_kill`], [`ProcessGuard::kill_all`], and
+/// `basefee.rs`'s boundary-kill helper). Failures are logged, not propagated: teardown has no
+/// recovery path, and signaling a child that already exited is harmless (`kill` on a reaped
+/// child returns `InvalidInput` without touching any pid).
+pub(crate) fn force_kill_and_reap(child: &mut Child) {
+    child.kill().unwrap_or_else(|e| error!(target: "e2e-test", ?e, "error sending SIGKILL"));
+    child.wait().map(drop).unwrap_or_else(
+        |e| error!(target: "e2e-test", ?e, "error waiting for child after SIGKILL"),
+    );
 }
 
 /// Get the block for block_number or latest block if None for node.


### PR DESCRIPTION
Closes #1119.

## Summary

`basefee::test_boundary_kill_restart_recovers_next_epoch_fee` runs in ~73.5s.  Almost all of that time is epoch waiting, not work: the test crosses 7 wall-clock epoch boundaries at `BOUNDARY_EPOCH_DURATION = 10`, which is 70s.  This PR removes one warm-up epoch, sizes the boundary epoch to the reap's true cost, and removes poll quantization from the two kill paths.  The test now runs in ~52s (about 29% less).  No assertion is removed or weakened.

## Changes

- [x] `crates/e2e-tests/tests/it/basefee.rs`: `BOUNDARY_WARMUP_EPOCHS` 3 -> 2.  The fee chain becomes 7 -> 8 with expected next-epoch fee 9.  Every assertion still separates the three outcomes it must separate: a node that defaulted to MIN (7), a node that kept the closed epoch's fee (8), and a correct node (9).  The decay arithmetic stays exact on this band: each step is the +1 minimum and each decay is its -1 mirror, so `decay(step(x)) = x` for every fee the test touches.
- [x] `crates/e2e-tests/tests/it/basefee.rs`: `BOUNDARY_EPOCH_DURATION` 10 -> 8, paired with a new call-site-local `fast_kill` helper (SIGTERM, then a 300ms exit poll up to 6s, then SIGKILL).  The node's real shutdown takes ~2.3s; `kill_child`'s 1.2s poll slots round it up to 3.6s.  With the finer poll, the kill-plus-control sequence keeps ~3s of worst-case slack inside the 8s epoch.  Every other call site keeps `kill_child`.
- [x] `crates/e2e-tests/tests/it/common.rs`: `ProcessGuard::kill_all` reaps with one shared 6s deadline and a 10ms poll instead of sequential per-child 1.2s slots.  The SIGTERM then SIGKILL escalation sequence and its 6s grace are unchanged.  This phase runs after the last assertion, so it changes no coverage.
- [x] `crates/e2e-tests/tests/it/common.rs`: the SIGKILL escalation (kill, reap, error logs) is one shared `force_kill_and_reap` helper used by `wait_or_kill`, `kill_all`, and `fast_kill`, instead of three copies.
- [x] The doc comments on both constants are rewritten in the same diff.  They justified the old values.

## Acceptance criteria

- [x] No assertion is removed or weakened.  The warm-up cut keeps three distinct observable outcomes at every assert.
- [x] The idle-epoch wait before step 3 stays.  That epoch is the only point where the restarted node exercises the fee-decrease branch;  a transaction there would make every fee transition an increase and hide a decay regression.
- [x] The kill-path changes alter poll cadence only, not the SIGTERM/SIGKILL sequence or its 6s grace.
- [x] Behavior for every other caller is unchanged: `kill_child` and `wait_or_kill` keep their semantics, and `fast_kill` is local to `basefee.rs`.

## Verification

Timed with `cargo nextest run -p e2e-tests --run-ignored all -E 'test(=basefee::test_boundary_kill_restart_recovers_next_epoch_fee)'` at 7891daa5, 12 cores, with `TN_BIN_PATH` pointing at a prebuilt node binary so the in-test build stays out of the timer:

- baseline (origin/main): 74.0s, 73.6s
- patched: 52.2s, 51.9s (about 29% less)
- patched under CPU load (6 busy cores): 51.5s, PASS

A margin failure is loud, not silent: the control-fee assert names the epoch and the fee.  The issue asks for 3 runs on a loaded CI worker before the timing margin is trusted;  that validation ask stands.

`make attest` green on the pinned 1.94 toolchain (fmt + clippy + test-build).
