### PR TITLE
test(e2e): run the eject mid-epoch test on 6 second epochs (#1121)

### DIFF
--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -70,6 +70,17 @@ const GENESIS_OBSERVER: &str = "genesis-observer";
 /// that test which scales with epoch length derives from this constant, not [`EPOCH_DURATION`].
 const RESTART_EPOCH_DURATION: u64 = 40;
 
+/// Per-test epoch duration (seconds) for the mid-epoch current-committee ejection test.
+///
+/// [`test_validator_ejected_from_current_committee_mid_epoch`] spends its runtime waiting at
+/// wall-clock epoch boundaries; its only in-epoch sequence is the mid-epoch burn submit and
+/// confirm (about 2s), so it does not need the module-wide [`EPOCH_DURATION`] (10s). 6s keeps
+/// the mid-epoch submission window at [1, 4], wider than the [1, 3] window of the 5s epochs
+/// already shipping in `basefee.rs` and `epochs.rs` ("5s is the consensus minimum epoch
+/// duration"). The test's timeout ceilings deliberately keep reading [`EPOCH_DURATION`]:
+/// relative to 6s epochs every ceiling only gets more generous, so none needs a `.max()` floor.
+const EJECT_EPOCH_DURATION: u64 = 6;
+
 /// Find the epoch that contains `block` by walking the epoch-info ring buffer down from the
 /// current epoch.
 ///
@@ -372,7 +383,7 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
         (GENESIS_OBSERVER, observer_wallet.address()),
         governance_wallet.address(),
         &nodes,
-        EPOCH_DURATION,
+        EJECT_EPOCH_DURATION,
     )?;
 
     // start nodes (committee + genesis observer); the observer never stakes, it only follows


### PR DESCRIPTION
Closes #1121 (this PR is change 1 of the issue;  change 2, the follow-up transfer, is already open as #1117 and closes #1116).  The two diffs touch disjoint hunks of `eject.rs` off the same base, so they merge cleanly in either order.

## Summary

`eject::test_validator_ejected_from_current_committee_mid_epoch` runs ~44-59s solo (the report that motivated #1121 timed it at 52.257s).  Nearly all of that time is idle waiting at wall-clock epoch boundaries: each boundary is fixed when its epoch is entered, so nothing the test does inside an epoch moves it.  The only in-epoch work on the critical path is the mid-epoch burn submit and confirm, about 2s.  This PR gives the test its own 6 second epoch duration (module default: 10s).  No assertion is added, removed, or weakened.

## Changes

- [x] `crates/e2e-tests/tests/it/eject.rs`: new `EJECT_EPOCH_DURATION: u64 = 6` with a doc comment.  This mirrors the existing per-test override precedent (`RESTART_EPOCH_DURATION = 40`) in the opposite direction.
- [x] `crates/e2e-tests/tests/it/eject.rs`: the test's `create_genesis_for_test` call passes `EJECT_EPOCH_DURATION` in place of `EPOCH_DURATION`.  This call is the only consumer;  no other test reads the new constant.

Why 6s is safe where 10s was the default:

- `wait_for_mid_epoch` gives a `[MIN_PHASE, epoch_duration - END_MARGIN]` landing window.  At 6s that is [1, 4], wider than the [1, 3] window the shipping 5s tests already use (`basefee.rs`, `epochs.rs`: "5s is the consensus minimum epoch duration").
- Every timeout ceiling in the test keeps reading the module `EPOCH_DURATION` (10s).  Relative to 6s epochs each ceiling only becomes more generous, so no ceiling needs a floor.
- The `[intended, intended + 2]` burn slide budget shrinks from 30s to 18s absolute, still 9x to 18x the burn confirm time.
- The module default's 10s rationale ("margin for parallel test execution and CI load variance") does not bind here: this test is `#[ignore = "only run independently from all other it tests"]`, so it never runs in parallel with the rest of the suite.
- Interplay with #1117: without the follow-up transfer, the final head check idles to the next 6s epoch close under skip-empty-execution, and the unchanged `EPOCH_DURATION * 3` ceiling covers it.  With #1117, the check resolves in about one batch round.  Neither ordering changes any assert.

## Acceptance criteria (from #1121)

- [x] All existing asserts pass unchanged.  The burn lands inside the verified `[intended, intended + 2]` window without new retry churn across repeated solo runs.
- [x] A run under CPU load passes (measured below with 6 busy-loop processes).
- [x] The full ~30-32s band of #1121 needs both changes: this PR alone measures 32.518s / 32.377s;  with #1117's follow-up transfer also applied, 30.1-32.4s.

## Verification

Timed with `cargo nextest run -p e2e-tests --run-ignored all -E 'test(=eject::test_validator_ejected_from_current_committee_mid_epoch)'` at 7891daa5, 12 cores, with `TN_BIN_PATH` pointing at a prebuilt node binary so the in-test build stays out of the timer:

| Configuration | Solo | Under load (6 busy cores) |
| --- | --- | --- |
| baseline (origin/main, 10s epochs) | 44.091s / 58.740s (52.257s reported) | not measured |
| this PR alone (6s epochs) | 32.518s / 32.377s | 32.641s |
| this PR + #1117's follow-up transfer | 32.352s / 30.586s / 30.142s | 30.392s |

Lint gates on this branch: `cargo +nightly fmt -- --check` is clean for the crate.  `cargo clippy -p e2e-tests --all-targets -- -D warnings` on the repo-pinned toolchain reports nothing in `eject.rs` (the 24 pre-existing lints elsewhere in the `it` target are untouched, the same set #1117 documents).  `make attest` runs on the pinned 1.94 toolchain before push.
