### PR TITLE
test(e2e): cut state export fee test runtime by about 36%

### DIFF
--- a/crates/e2e-tests/tests/it/state_export_import.rs
+++ b/crates/e2e-tests/tests/it/state_export_import.rs
@@ -89,11 +89,14 @@ use crate::common::{
     wait_for_epoch_at_least, wait_for_mid_epoch, ProcessGuard,
 };
 
-/// Epoch duration (seconds) for this test. Held at 10s (matching the pack-import test in
-/// `sync.rs`) rather than the 5s epoch tests: the export runs a full plain-state walk on a
-/// background thread, then the bundle is copied and atomically renamed into place, so 10s keeps
-/// ample margin for a complete bundle to appear before the observer imports it.
-const EXPORT_EPOCH_DURATION: u64 = 10;
+/// Epoch duration (seconds) for this test. 6s sits a second above the 5s epoch tests' consensus
+/// minimum and still fits the whole per-epoch sequence: the measured mid-epoch landing window is
+/// `[1s, 4s]` and a transfer confirms well inside it. The export itself (a full plain-state walk
+/// on a background thread, then the bundle copied and atomically renamed into place) is gated by
+/// consensus certificate aggregation (`CERT_WAIT` in `close_epoch.rs`, a fixed 90s ceiling), which
+/// does not scale with the epoch duration; that margin lives in the 100s floor on every bundle
+/// wait below, not in a long epoch.
+const EXPORT_EPOCH_DURATION: u64 = 6;
 
 /// Epoch whose bundle the observer imports. Must be `>= 1`: an epoch-0 bundle restores state and
 /// records but writes no resume hint (rebuilding the epoch-0 consensus pack needs a pre-epoch-0
@@ -269,7 +272,10 @@ async fn test_state_export_import_bootstrap_inner() -> eyre::Result<()> {
         .join("state_exports")
         .join(format!("epoch-{IMPORT_EPOCH}"));
     wait_until(
-        Duration::from_secs(EXPORT_EPOCH_DURATION * 4),
+        // Floored at 100s: cert aggregation (`CERT_WAIT`, a fixed 90s that does not shrink with
+        // the epoch duration) gates the export, and this wait starts about one epoch after the
+        // close, so 100s covers the full certificate window plus bundle-copy margin.
+        Duration::from_secs((EXPORT_EPOCH_DURATION * 4).max(100)),
         &format!("exporter to write the epoch-{IMPORT_EPOCH} bundle"),
         || async { Ok(bundle_dir.is_dir()) },
     )
@@ -534,7 +540,10 @@ async fn test_state_export_import_idle_epoch_inner() -> eyre::Result<()> {
         .join("state_exports")
         .join(format!("epoch-{IMPORT_EPOCH}"));
     wait_until(
-        Duration::from_secs(EXPORT_EPOCH_DURATION * 4),
+        // Floored at 100s: cert aggregation (`CERT_WAIT`, a fixed 90s that does not shrink with
+        // the epoch duration) gates the export, and this wait starts about one epoch after the
+        // close, so 100s covers the full certificate window plus bundle-copy margin.
+        Duration::from_secs((EXPORT_EPOCH_DURATION * 4).max(100)),
         &format!("exporter to write the IDLE epoch-{IMPORT_EPOCH} bundle"),
         || async { Ok(bundle_dir.is_dir()) },
     )
@@ -795,7 +804,7 @@ async fn land_fee_warmup_tx(
         if Instant::now() >= deadline {
             eyre::bail!("warm-up transfer to {to} did not confirm within {budget}s");
         }
-        // Poll ~4x/sec: at a 10s epoch a 1s cadence is coarse relative to block confirmation.
+        // Poll ~4x/sec: at a 6s epoch a 1s cadence is coarse relative to block confirmation.
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
@@ -962,7 +971,10 @@ async fn test_state_export_import_recovers_recorded_fee_inner() -> eyre::Result<
         .join("state_exports")
         .join(format!("epoch-{import_epoch}"));
     wait_until(
-        Duration::from_secs(EXPORT_EPOCH_DURATION * 4),
+        // Floored at 100s: cert aggregation (`CERT_WAIT`, a fixed 90s that does not shrink with
+        // the epoch duration) gates the export, and this wait starts about one epoch after the
+        // close, so 100s covers the full certificate window plus bundle-copy margin.
+        Duration::from_secs((EXPORT_EPOCH_DURATION * 4).max(100)),
         &format!("exporter to write the epoch-{import_epoch} bundle"),
         || async { Ok(bundle_dir.is_dir()) },
     )


### PR DESCRIPTION
Closes #1125.

## Summary

The ignored e2e test `state_export_import::test_state_export_import_recovers_recorded_fee` runs about 74-77s solo.  Almost all of that time is idle waiting at wall-clock epoch boundaries.  The test crosses seven boundaries in sequence: the fee warm-up ladder covers epochs 1 through 4, the import epoch is 5, and the minimum lead epoch is 7.  Nothing the test does inside an epoch can move a boundary, so the epoch duration sets the runtime almost directly.  This change cuts the module epoch duration from 10s to 6s and raises the floor on the three bundle waits to 100s so the fixed certificate-aggregation window stays covered.  The measured runtime drops to about 47s (a cut of about 36%) with no assertion touched.

## Changes

All in `crates/e2e-tests/tests/it/state_export_import.rs`:

- [x] Set the module `EXPORT_EPOCH_DURATION` from 10 to 6 seconds and rewrite the const doc.  6s sits one second above the 5s consensus minimum that the shipping `basefee.rs` and `epochs.rs` tests already use.  The mid-epoch landing window becomes [1s, 4s], wider than the [1s, 3s] window of those 5s tests.
- [x] Floor all three bundle waits (bootstrap, idle, fee test) at 100 seconds: `(EXPORT_EPOCH_DURATION * 4).max(100)`.  The exporter is gated by consensus certificate aggregation (`CERT_WAIT` in `close_epoch.rs`, a fixed 90s ceiling that does not shrink with the epoch duration), and the bundle wait starts about one epoch after the close, so the old `EXPORT_EPOCH_DURATION * 4` budget gave the exporter only about 50s of that window.  #1125 proposed a 40s floor; 40s equals the old budget and cannot cover the certificate window, so this PR raises the floor to 100s instead.  The floor is a `wait_until` ceiling: passing runs never sleep on it, and a timeout stays a hard test failure, never a false pass.
- [x] Update the poll-cadence comment in `land_fee_warmup_tx` for the 6s epoch.

The const is module scoped, so the sibling tests `test_state_export_import_bootstrap` and `test_state_export_import_idle_epoch` get the same shorter epochs and the same floored bundle waits.

Coverage is unchanged.  Every wait stays condition-bound with a hard-fail timeout.  No assertion, fixture value, or epoch index changes.  The warm-up confirm budget scales with the duration (25s to 17s) against a 1-2s confirmation round, and the quiet-phase ceiling becomes 6 * 4 * 7 = 168s against 42s of wall-clock need.  The fee fixture guard is the coverage control: it hard-fails if the warm-up ladder shifts.  Alternatives that trade coverage for speed (a lower warm-up floor, a shorter minimum lead, a block-counted post-import wait) were considered and rejected in #1125.

## Acceptance criteria (from #1125)

- [x] Solo timed run drops from the measured ~74-77s band to ~47s with the prebuilt binary (measured 47.438s and 47.394s).
- [x] All existing asserts pass unchanged, and the fixture guard passes with the nominal ladder (expected 10 wei, stale 11 wei) across repeated solo runs.
- [x] A run under CPU load still passes (measured 49.023s with 6 busy-loop processes).
- [x] The sibling tests `test_state_export_import_bootstrap` and `test_state_export_import_idle_epoch` still pass with the shared 6s duration and the floored bundle waits.

## Verification

Measured at `7891daa5` (12 cores, prebuilt node binary handed to the suite via `TN_BIN_PATH`, `cargo nextest` timer, solo runs):

| Run | Time | Result |
| --- | --- | --- |
| baseline solo | 77.389s | PASS |
| baseline, the reported run motivating #1125 | 73.776s | PASS (reported) |
| patched solo x2 | 47.438s / 47.394s | PASS |
| patched + 6 CPU-hog processes | 49.023s | PASS |

The worst patched run (49.023s under load) against the fastest baseline (73.776s) is still a 33.6% cut, so the 25% target does not depend on which baseline is typical.  Command:

```
TN_BIN_PATH=<prebuilt telcoin-network binary> cargo nextest run -p e2e-tests --run-ignored all \
  -E 'test(=state_export_import::test_state_export_import_recovers_recorded_fee)'
```

`make attest` (nightly fmt + nightly clippy default and all-features + workspace tests on the pinned 1.94 toolchain) gates the push.
