### PR TITLE
build(e2e): derive the e2e --target-dir from CARGO_TARGET_DIR instead of hardcoding it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,25 @@ test-faucet:
 # rebuilding it through escargot (~3-10s of cargo overhead per test process). Built under the
 # optimized `e2e` profile (opt-level 2 with debug-assertions/overflow-checks kept on; see
 # `[profile.e2e]` in .cargo/config.toml) so the reused binary runs consensus and EVM at speed.
+# Target root for the e2e node-binary build and its consumers, honoring a developer's
+# CARGO_TARGET_DIR: the variable's value when set, cargo's default $(CURDIR)/target
+# otherwise. A relative value is anchored at $(CURDIR) so E2E_BIN stays absolute (nextest
+# runs each test from the package directory); the absolute test is $(filter /%,...) with
+# plain concatenation, not $(abspath), because make functions split on whitespace and
+# $(abspath) would corrupt a path containing spaces. The root is passed to the build as an
+# explicit --target-dir and reused for E2E_BIN, so the producing and the consuming path
+# come from one expression and cannot diverge through any other target-dir channel
+# (CARGO_BUILD_TARGET_DIR or a config.toml build.target-dir keep their pre-change behavior:
+# overridden by the flag).
+E2E_TARGET_ROOT := $(if $(CARGO_TARGET_DIR),$(if $(filter /%,$(CARGO_TARGET_DIR)),$(CARGO_TARGET_DIR),$(CURDIR)/$(CARGO_TARGET_DIR)),$(CURDIR)/target)
+
 .PHONY: build-e2e-bin
 build-e2e-bin:
-	cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir $(CURDIR)/target ;
+	cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir "$(E2E_TARGET_ROOT)" ;
 
 # Location of the binary built by build-e2e-bin, passed to the e2e tests via TN_BIN_PATH.
 # A named cargo profile emits into target/<profile>/, so the `e2e` profile binary lands here.
-E2E_BIN := $(CURDIR)/target/e2e/telcoin-network
+E2E_BIN := $(E2E_TARGET_ROOT)/e2e/telcoin-network
 
 # Seed-signature fork epoch for the e2e lanes (#1032). Defaults to u32::MAX so the default
 # lanes run the fork DORMANT (wire-identical to pre-fork mainnet); non-adiri builds are
@@ -134,11 +146,11 @@ TN_SEED_SIGNATURE_FORK_EPOCH ?= 4294967295
 
 # run restart integration tests
 test-restarts: build-e2e-bin
-	TN_BIN_PATH=$(E2E_BIN) TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # run e2e tests
 test-e2e: build-e2e-bin
-	TN_BIN_PATH=$(E2E_BIN) TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
 
 # run tests with coverage (using llvm-cov + nextest)
 coverage:
@@ -213,9 +225,9 @@ revert-submodule:
 
 # workspace tests that don't require faucet credentials
 public-tests: build-e2e-bin
-	TN_BIN_PATH=$(E2E_BIN) cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
-	TN_BIN_PATH=$(E2E_BIN) TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
-	TN_BIN_PATH=$(E2E_BIN) TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # local checks to ensure PR is ready
 pr:

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -15,16 +15,21 @@ Point the suite at a prebuilt binary to avoid the in-test build:
 make test-e2e          # builds the binary once, then runs the suite with TN_BIN_PATH set
 ```
 
-or run the raw command yourself (for example from an IDE test runner):
+or run the raw commands yourself from the workspace root (for example from an IDE test runner):
 
 ```
-cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils
-TN_BIN_PATH="$(pwd)/target/e2e/telcoin-network" \
+cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir "${CARGO_TARGET_DIR:-$(pwd)/target}"
+TN_BIN_PATH="$(cd "${CARGO_TARGET_DIR:-$(pwd)/target}" >/dev/null && pwd)/e2e/telcoin-network" \
   cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
 ```
 
 `TN_BIN_PATH` must be an absolute path: `nextest` runs each test with its working directory set
 to the package (`crates/e2e-tests`), not the workspace root, so a relative path would not resolve.
+The `$(cd ... && pwd)` above keeps it absolute even when `CARGO_TARGET_DIR` is a relative path,
+and the explicit `--target-dir` keeps the build and `TN_BIN_PATH` on one root.
+The workspace root matters for the same reason:  with `CARGO_TARGET_DIR` unset, `$(pwd)/target`
+follows the working directory, so a run from `crates/e2e-tests` would build into, and read from,
+a stray package-local `target` tree.
 If `TN_BIN_PATH` is left unset the suite still runs; add `--no-capture` to watch the one-time build
 instead of waiting on a silent first test.
 

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -442,9 +442,8 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
             "e2e: TN_BIN_PATH not set; building telcoin-network via cargo before the first test. \
              This can take several minutes (opt-level 2 under the `e2e` profile), and nextest \
              hides it until the build finishes (add `--no-capture` to watch it). To skip it, run \
-             `make test-e2e`, or prebuild with `cargo build --profile e2e --bin telcoin-network \
-             --features tn-storage/test-utils` and export \
-             TN_BIN_PATH=\"$(pwd)/target/e2e/telcoin-network\" from the workspace root."
+             `make test-e2e`, or prebuild once and point TN_BIN_PATH at the built binary \
+             (see crates/e2e-tests/README.md)."
         );
         info!("building main binary for e2e tests");
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -454,13 +453,13 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
 
         // Build under the `e2e` profile (opt-level 2, safety checks kept on; defined in
         // .cargo/config.toml) so this in-process build and `make build-e2e-bin` produce and
-        // share one set of artifacts under `target/e2e/`.
+        // share one set of artifacts under `<target root>/e2e/`.
         //
         // No `.current_target()`: passing `--target <triple>` would emit into
-        // `target/<triple>/e2e/`, a tree that shares no artifacts with the plain `target/e2e/`
-        // that `make build-e2e-bin` and ordinary `cargo build --profile e2e` populate, forcing a
-        // guaranteed cold rebuild. Building into `target/e2e/` lets escargot reuse an
-        // already-compiled binary (reported "Fresh" by cargo) instead.
+        // `<target root>/<triple>/e2e/`, a tree that shares no artifacts with the plain
+        // `<target root>/e2e/` that `make build-e2e-bin` and ordinary `cargo build --profile e2e`
+        // populate, forcing a guaranteed cold rebuild. Building into `<target root>/e2e/` lets
+        // escargot reuse an already-compiled binary (reported "Fresh" by cargo) instead.
         TestBinary::Cargo(
             CargoBuild::new()
                 .bin("telcoin-network")
@@ -469,7 +468,21 @@ pub fn get_telcoin_network_binary() -> &'static TestBinary {
                 // overflow-checks kept on (see `[profile.e2e]` in .cargo/config.toml).
                 .args(["--profile", "e2e"])
                 .manifest_path(workspace_root.join("Cargo.toml"))
-                .target_dir(workspace_root.join("target"))
+                // escargot's `.target_dir()` emits a `--target-dir` CLI flag, which outranks the
+                // `CARGO_TARGET_DIR` environment variable. Honor the developer's configured
+                // target root when set (matching `make build-e2e-bin` and `test-and-attest.sh`)
+                // and fall back to cargo's default `<workspace root>/target` otherwise. An empty
+                // value counts as unset (mirroring the shell `:-` fallback at the other two
+                // sites), and a relative value is anchored at the workspace root so this in-test
+                // build shares one tree with the root-invoked builds even though nextest sets
+                // the test cwd to the package directory (`Path::join` keeps an absolute value
+                // as-is).
+                .target_dir(
+                    std::env::var_os("CARGO_TARGET_DIR")
+                        .filter(|dir| !dir.is_empty())
+                        .map(|dir| workspace_root.join(dir))
+                        .unwrap_or_else(|| workspace_root.join("target")),
+                )
                 .run()
                 .expect("Failed to build telcoin-network binary"),
         )

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -105,8 +105,19 @@ cargo nextest run -p tn-reth --features adiri,test-utils --no-fail-fast
 # Prebuild the node binary once into the shared target tree and hand it to the e2e tests via
 # TN_BIN_PATH (mirroring `make test-e2e`), so the ignored suite reuses it instead of cold-building
 # the binary inside the first test, which nextest capture would otherwise hide as a multi-minute hang.
-cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir "$(pwd)/target"
-TN_BIN_PATH="$(pwd)/target/e2e/telcoin-network" \
+# Target root for the e2e node-binary build and its consumer, honoring CARGO_TARGET_DIR: its
+# value when set, cargo's default $(pwd)/target otherwise. A relative value is anchored here
+# (the workspace root) so TN_BIN_PATH stays absolute; nextest runs each test from the package
+# directory. The root is passed to the build as an explicit --target-dir and reused for
+# TN_BIN_PATH, so the producing and the consuming path come from one expression and cannot
+# diverge through any other target-dir channel.
+E2E_TARGET_ROOT="${CARGO_TARGET_DIR:-$(pwd)/target}"
+case "$E2E_TARGET_ROOT" in
+    /*) ;;
+    *) E2E_TARGET_ROOT="$(pwd)/$E2E_TARGET_ROOT" ;;
+esac
+cargo build --profile e2e --bin telcoin-network --features tn-storage/test-utils --target-dir "$E2E_TARGET_ROOT"
+TN_BIN_PATH="$E2E_TARGET_ROOT/e2e/telcoin-network" \
     cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features
 
 echo "all checks passed - submitting attestation on-chain..."


### PR DESCRIPTION
Closes #1123.

## Problem

Three sites force the e2e node-binary build into `<checkout>/target` with a hardcoded `--target-dir`:  the attest script (`etc/test-and-attest.sh`), the `build-e2e-bin` Makefile target, and the escargot fallback in `crates/e2e-tests/src/lib.rs`.  A CLI `--target-dir` outranks the `CARGO_TARGET_DIR` environment variable.  When a developer points `CARGO_TARGET_DIR` at a shared or custom location, the workspace test pass populates that tree, but the e2e build escapes it and cold-builds its full dependency closure into a second `<checkout>/target` tree.  Measured with `cargo --unit-graph` on the issue, that closure is 870 packages / 1043 compile units, all 870 already present in the workspace test pass that runs immediately before it.  The `e2e` profile inherits `release` (opt-level 2), so this is the most expensive closure in the pipeline, rebuilt once per checkout instead of once per machine.

This is a build-hygiene fix, not a CI change.  It is a strict no-op when `CARGO_TARGET_DIR` is unset, and CI never executes these lines (`pr.yaml`, `cache-deps.yaml`, and `maintainer-verify.yaml` reference neither the `e2e` profile nor `test-and-attest.sh` nor `--target-dir`).

## Fix

Keep the explicit `--target-dir`, but derive its value instead of hardcoding it:  `CARGO_TARGET_DIR` when set, the pre-change `<checkout>/target` otherwise.  The same derived root is then reused for the consumed binary path (`TN_BIN_PATH` / `E2E_BIN`), so the producing and the consuming path come from one expression and cannot diverge.  Keeping the flag (rather than dropping it) means every other target-dir channel (`CARGO_BUILD_TARGET_DIR`, a `config.toml` `build.target-dir`) keeps byte-identical pre-change behavior, overridden by the flag exactly as before;  this closes a silent-stale hazard where dropping the flag would let the build land in a config-selected root while the suite reads, and green-lights, a stale binary at the old path.

- [x] `etc/test-and-attest.sh`:  computes `E2E_TARGET_ROOT` (`CARGO_TARGET_DIR` when set, `$(pwd)/target` otherwise;  a relative value anchored at the workspace root so the path stays absolute), passes it to the build as `--target-dir`, and reuses it for `TN_BIN_PATH`.
- [x] `Makefile`:  same construction as `E2E_TARGET_ROOT := $(if ...)`, consumed by both the `build-e2e-bin` recipe and `E2E_BIN`, which covers `test-restarts`, `test-e2e`, and `public-tests`.  The absolute test is `$(filter /%,...)` with plain concatenation, not `$(abspath)`, because make functions split on whitespace and `$(abspath)` corrupts a path containing spaces.  All five `TN_BIN_PATH=$(E2E_BIN)` consume sites are now quoted so a spaced path survives the recipe shell.
- [x] `crates/e2e-tests/src/lib.rs`:  escargot's `.target_dir()` emits the `--target-dir` CLI flag, so the fallback derives the same way:  `CARGO_TARGET_DIR` when set (an empty value counts as unset, mirroring the shell `:-` fallback;  a relative value is anchored at the workspace root via `Path::join`, matching the root-invoked builds even though nextest sets the test cwd to the package directory), `<workspace root>/target` otherwise.
- [x] Docs:  the README example carries the derived `--target-dir` on its build line, keeps `TN_BIN_PATH` absolute via `$(cd ... >/dev/null && pwd)` (the redirect guards against a `CDPATH` echo corrupting the substitution), and states that the block runs from the workspace root, since with the variable unset `$(pwd)/target` follows the working directory;  the `eprintln!` hint in `lib.rs` now points at `make test-e2e` and the README instead of inlining an expression.

Correctness of the swap:  the produced binary is identical.  The feature set (`tn-storage/test-utils`) and every `[profile.e2e]` field are untouched;  only the cache location follows the developer's configuration.  Cargo's fingerprint covers the feature set and the profile, so a mismatched artifact can never be silently reused.  In the unset case each site passes the same `--target-dir` value it passed before the change.  The `e2e` profile still resolves from the repo's `.cargo/config.toml` through the working directory, which is unchanged at all three call sites.

Scope note (adversarially reviewed, accepted):  pointing several concurrent checkouts at one `CARGO_TARGET_DIR` means they share one `e2e/telcoin-network` path.  Cargo serializes the builds, not the test runs, so a `build-e2e-bin` from a sibling checkout can replace the binary while another checkout's suite is mid-run.  That is inherent to sharing one target tree and is the developer's tradeoff to make;  the per-checkout default keeps the old isolation.

## Testing

- Differential expansion check over five polarities (unset, absolute, relative, empty, spaces in the path), asserting the producing build line and the consuming path together in the make lane (`make -n build-e2e-bin` / `make -n test-e2e`), the attest-script expression, and the README expression, each with a negative control (the sentinel root never leaks into the unset case).  Unset and empty:  `--target-dir "<checkout>/target"` (the pre-change value) and the matching `TN_BIN_PATH`.  Absolute:  both follow the sentinel.  Relative:  both come out absolute, anchored at the checkout root.  Spaces:  both lines survive quoted and unsplit.
- `bash -n etc/test-and-attest.sh` passes.
- `cargo +nightly-2026-03-20 fmt -- --check` clean (the attest fmt gate).
- `cargo +1.94 check -p e2e-tests --all-targets --all-features` green in an isolated target dir with `-j 2`, so every test target compiles on the pinned toolchain.
- `cargo +nightly-2026-03-20 clippy -p e2e-tests --all-features -- -D warnings` (the clippy shape `make attest` runs) green on the same tree.  Adding `--all-targets` surfaces 25 pre-existing lints in `tests/it/*.rs`;  those files are byte-identical to `origin/main` and stay untouched here.
