### PR TITLE
test: pin the zero-word entry fee of the adiri pre-fork epoch close

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,6 +111,41 @@ jobs:
       - name: Run tests
         run: cargo nextest run --locked --workspace --exclude tn-faucet --no-fail-fast --profile ci
 
+  # Adiri feature lane: the adiri-gated suites (the legacy header wire-format pins in
+  # tn-types, the consensus-registry fork tests in tn-reth, and the pre-fork entry-fee pin
+  # in tn-node) only compile under the adiri features, so the default-feature test job
+  # above never builds or runs them. tn-storage is excluded: two of its consensus_pack
+  # tests (dup_batch_across_certs, v0_shared_batch_served_as_v1_bytes) fail under the
+  # adiri features today, independent of this lane.
+  adiri-test:
+    needs: skip-maintainers
+    if: >-
+      needs.skip-maintainers.outputs.is_maintainer == 'false' &&
+      github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+        with:
+          shared-key: adiri-test-cache
+          cache-on-failure: "true"
+
+      - name: Run adiri-gated tests
+        run: cargo nextest run --locked -p tn-types -p tn-reth -p tn-node --features tn-types/adiri,tn-reth/adiri,tn-reth/test-utils,tn-node/adiri --no-fail-fast --profile ci
+
   # Guard: rocksdb (librocksdb-sys, the entire RocksDB C++ engine and the single largest
   # native compile in the tree) must stay out of the default feature graph. It is gated
   # behind the off-by-default `rocksdb` feature; this catches a future reth bump whose
@@ -152,13 +187,14 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, clippy, test, rocksdb-gate]
+    needs: [fmt, clippy, test, adiri-test, rocksdb-gate]
     steps:
       - name: Check all jobs passed
         run: |
           if [[ "${{ needs.fmt.result }}" == "failure" || \
                 "${{ needs.clippy.result }}" == "failure" || \
                 "${{ needs.test.result }}" == "failure" || \
+                "${{ needs.adiri-test.result }}" == "failure" || \
                 "${{ needs.rocksdb-gate.result }}" == "failure" ]]; then
             echo "One or more checks failed"
             exit 1

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -43,7 +43,8 @@ serde_json = { workspace = true }
 
 [features]
 # Propagate the adiri-testnet feature to every downstream crate that has adiri-gated fork logic, so
-# a `--features adiri` node build actually compiles it in. tn-node has no adiri code of its own.
+# a `--features adiri` node build actually compiles it in. tn-node's own adiri code is test-only:
+# the pre-fork entry-fee pin in `manager::node::run_epoch::tests`.
 adiri = [
     "tn-engine/adiri",
     "tn-executor/adiri",

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -2114,6 +2114,73 @@ mod tests {
         Ok(())
     }
 
+    /// On the live adiri testnet EVERY epoch close takes the legacy pre-fork path: the deployed
+    /// registry still carries the pre-fork code, so `apply_closing_epoch_contract_call` routes to
+    /// the two-call legacy sequence, which has no fourth system call and never writes the
+    /// per-worker `WorkerConfigs.data` word. The production entry read every node runs at the
+    /// next epoch ([`read_base_fees_for_entered_epoch`]) therefore sees a zero word and floors it
+    /// to `MIN_PROTOCOL_BASE_FEE` through `entry_fee_for_worker`, whose doc names that floor an
+    /// empirical fact about adiri (no governance write has moved a worker's fee off the protocol
+    /// minimum), NOT a structural identity.
+    ///
+    /// Threat: a change to the legacy close that starts recording a fee word, or a governance
+    /// write to `WorkerConfigs` landing before the fork, changes every adiri node's entry fee
+    /// with no failing test. The `data.is_zero()` assert below is the positive control for the
+    /// first half: it fails the moment the legacy close writes the word. The MIN pin is the
+    /// decision from issues #1106/#1122: a zero word maps to the protocol minimum on entry, and
+    /// this test is the one place the LIVE pre-fork path is held to it.
+    ///
+    /// Drives ONE legacy close directly off the committed adiri genesis (`tn_types::test_genesis`
+    /// embeds `chain-configs/testnet/genesis.yaml`: pre-fork registry plus a `WorkerConfigs`
+    /// deployment with exactly one worker, `Eip1559 { target_gas: u64::MAX }`, data word zero)
+    /// and pins the entry read to the closing header: the pre-fork `concludeEpoch` bumps
+    /// `currentEpoch` 0 -> 1 and stamps `blockHeight = closing.number + 1`, so the pin guard in
+    /// [`read_base_fees_for_entered_epoch`] accepts the header and the read must return exactly
+    /// `[MIN_PROTOCOL_BASE_FEE]`.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn prefork_legacy_close_enters_the_next_epoch_at_the_min_fee() -> eyre::Result<()> {
+        // the committed adiri genesis: pre-fork registry code + pre-fork WorkerConfigs state
+        let chain: Arc<RethChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let tmp_dir = TempDir::with_prefix("prefork_min_entry_fee")?;
+        let task_manager = TaskManager::new("prefork min entry fee");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        // ONE legacy epoch close directly off genesis; the registry's pre-fork code hash routes
+        // the boundary through apply_closing_epoch_contract_call_legacy
+        let output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &output);
+        let block = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![])?;
+        let h = block.recovered_block.clone_sealed_header();
+
+        // positive controls at the closing block: one worker, still EIP-1559, and the data word
+        // UNWRITTEN. The zero-assert is the control that fails if the legacy close ever starts
+        // writing the fee word.
+        let (num_workers, entries) = read_worker_config_entries_at(&reth_env, h.hash())?;
+        assert_eq!(num_workers, 1, "the committed adiri genesis deploys a single worker");
+        assert_eq!(
+            entries[0].config,
+            WorkerFeeConfig::Eip1559 { target_gas: u64::MAX },
+            "the committed adiri genesis configures worker 0 as EIP-1559"
+        );
+        assert!(
+            entries[0].data.is_zero(),
+            "the legacy close must leave the worker data word unwritten"
+        );
+
+        // the LIVE entry read, pinned to the closing header: epoch 1 begins at h.number + 1
+        let read = read_base_fees_for_entered_epoch(&reth_env, 1, &h).await?;
+        assert_eq!(read.num_workers, 1, "entry read must see the single worker");
+        assert_eq!(
+            read.fees,
+            vec![MIN_PROTOCOL_BASE_FEE],
+            "a zero word maps to the protocol minimum on entry (#1106/#1122)"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_check_output_continuity() {
         // stale: anything at or below the last forwarded number

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -1164,7 +1164,9 @@ mod tests {
         ExecStateAccount, ExecStatePackReader, ExecStatePackWriter, STORAGE_CHUNK_SLOTS,
     };
     use tn_types::{
-        gas_accumulator::{next_base_fee_for_config, GasAccumulator, WorkerFeeConfig},
+        gas_accumulator::{
+            entry_fee_for_worker, next_base_fee_for_config, GasAccumulator, WorkerFeeConfig,
+        },
         keccak256, test_genesis, Address, BlockNumHash, Bytes, ExecHeader, GenesisAccount,
         SealedHeader, SolCall as _, TaskManager, B256, EMPTY_WITHDRAWALS, MIN_PROTOCOL_BASE_FEE,
         U256,
@@ -2513,6 +2515,108 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("worker 0"), "error must name the worker: {msg}");
         assert!(msg.contains("exceeds u64::MAX"), "error must name the oversized word: {msg}");
+
+        Ok(())
+    }
+
+    /// An EIP-1559 row whose `data` word is ZERO passes the restore, and the production
+    /// interpretation seam prices the entered epoch at exactly `MIN_PROTOCOL_BASE_FEE`: the
+    /// default-feature pin of the zero-word -> MIN mapping (`entry_fee_for_worker`) that the
+    /// adiri pre-fork close relies on for every live epoch entry (#1122).
+    ///
+    /// A genuine close always rewrites every EIP-1559 row's word LAST (the boundary system calls
+    /// run in `finish`, after user transactions), and it records at least the protocol floor, so
+    /// a zero can only reach a boundary read through the same ordering exploit the poison test
+    /// uses: block 1 genuinely closes epoch 0 (recording a nonzero word, the fixture sentinel
+    /// that keeps the zero-assert below from passing vacuously), block 2 carries the governance
+    /// owner's `setWorkerConfig` write landing the zero, and the snapshot ships under a
+    /// forged-but-self-consistent boundary header: number 1, keeping the registry's
+    /// `blockHeight == B + 1` boundary claim intact, over block 2's real state root. Header
+    /// provenance is outside restore's trust boundary (see the module docs), so readiness must
+    /// judge the WORD, and a zero word is acceptable by decision: it reads as the protocol
+    /// minimum, never as an error.
+    #[tokio::test]
+    async fn entry_readiness_accepts_a_zero_word_eip1559_row_at_the_min_fee() -> eyre::Result<()> {
+        const TARGET_GAS: u64 = 1_000_000;
+
+        let genesis = test_genesis_with_consensus_registry_and_workers(1, vec![(0u8, TARGET_GAS)]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let src_dir = TempDir::new()?;
+        let src_tm = TaskManager::new("Entry Readiness Zero Word Source");
+        let source = RethEnv::new_for_temp_chain(chain.clone(), src_dir.path(), &src_tm, None)?;
+
+        // block 1 closes epoch 0: a real close over the fresh registry
+        let consensus_output = consensus_output_for_tests(2, 0, 1, true);
+        let payload = TNPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+        let block1 = execute_payload_and_update_canonical_chain(&source, payload, vec![])?;
+        let closing = block1.recovered_block.clone_sealed_header();
+
+        // fixture sentinel: the close always records at least the protocol floor, never zero,
+        // so the zero asserted below can only come from the governance write
+        let (_, entries) = read_worker_config_entries_at(&source, closing.hash())?;
+        assert!(
+            !entries[0].data.is_zero(),
+            "fixture: the close must record a nonzero word, or the zero-word assert is vacuous"
+        );
+
+        // block 2 (mid-epoch-1): the owner rewrites worker 0's row with a ZERO data word; no
+        // close runs here, so nothing rewrites it back
+        let mut governance = governance_owner_factory();
+        let zero_tx = governance.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            Some(WORKER_CONFIGS_ADDRESS),
+            U256::ZERO,
+            WorkerConfigs::setWorkerConfigCall {
+                workerId: 0,
+                strategy: 0,
+                value: TARGET_GAS,
+                data: U184::ZERO,
+            }
+            .abi_encode()
+            .into(),
+        );
+        let consensus_output = consensus_output_for_tests(2, 1, 2, false);
+        let payload = TNPayload::new_for_test(closing.clone(), &consensus_output);
+        let block2 = execute_payload_and_update_canonical_chain(&source, payload, vec![zero_tx])?;
+        let zeroed = block2.recovered_block.clone_sealed_header();
+
+        // positive controls: the zero word stuck on an EIP-1559 row, and the production seam
+        // floors it to the protocol minimum (the default-feature fee pin)
+        let (num_workers, entries) = read_worker_config_entries_at(&source, zeroed.hash())?;
+        assert_eq!(num_workers, 1);
+        assert_eq!(
+            entries[0].config,
+            WorkerFeeConfig::Eip1559 { target_gas: TARGET_GAS },
+            "the zeroed row must still decode as EIP-1559"
+        );
+        assert_eq!(entries[0].data, U184::ZERO, "the owner tx must land the zero word");
+        assert_eq!(
+            entry_fee_for_worker(0, &entries[0]),
+            Ok(MIN_PROTOCOL_BASE_FEE),
+            "a zero word must price the entered epoch at the protocol minimum"
+        );
+
+        // forge a self-consistent boundary header over the zero-word state: number 1 (so the
+        // registry's blockHeight 2 still reads as B + 1) with block 2's real state root
+        let forged = synthetic_header(1, chain.sealed_genesis_header().hash(), zeroed.state_root);
+        let final_state = BlockNumHash::new(forged.number, forged.hash());
+        let pack_dir = TempDir::new()?;
+        export_pack(&source, zeroed.state_root, &[forged.header().clone()], pack_dir.path());
+
+        let dst_dir = TempDir::new()?;
+        let dst_tm = TaskManager::new("Entry Readiness Zero Word Dest");
+        let restorer = restore_through_import(
+            chain,
+            dst_dir.path(),
+            &dst_tm,
+            &[forged],
+            final_state,
+            pack_dir.path(),
+        )?;
+        restorer.entry_readiness_precondition(final_state)?;
+        restorer.finish(final_state)?;
 
         Ok(())
     }

--- a/etc/test-and-attest.sh
+++ b/etc/test-and-attest.sh
@@ -98,9 +98,13 @@ echo "clippy for workspace: default and all features passed"
 #
 # default features
 cargo nextest run --workspace --no-fail-fast
-# adiri-gated suite: the consensus-registry fork tests and their determinism oracles only
-# compile under these features, so no default-feature run above ever builds or runs them
-cargo nextest run -p tn-reth --features adiri,test-utils --no-fail-fast
+# adiri-gated suites: the legacy header wire-format pins in tn-types, the consensus-registry
+# fork tests and their determinism oracles in tn-reth, and the pre-fork entry-fee pin in
+# tn-node. These tests only compile under the adiri features. No default-feature run above
+# builds or runs them. With multiple -p flags, cargo requires package-qualified feature
+# names. tn-storage is excluded: two of its consensus_pack tests fail under the adiri
+# features today, independent of this lane.
+cargo nextest run -p tn-types -p tn-reth -p tn-node --features tn-types/adiri,tn-reth/adiri,tn-reth/test-utils,tn-node/adiri --no-fail-fast
 # run the e2e restart and epoch tests, they are seperate to avoid any port/node confusion.
 # Prebuild the node binary once into the shared target tree and hand it to the e2e tests via
 # TN_BIN_PATH (mirroring `make test-e2e`), so the ignored suite reuses it instead of cold-building


### PR DESCRIPTION
Closes #1122.

## Summary

Every epoch close on the live adiri testnet takes the legacy pre-fork path in `apply_closing_epoch_contract_call_legacy`.  The legacy close never writes the per-worker fee word, so the next epoch always enters with a zero word.  The only guard that keeps the entry fee at the protocol minimum is the `MIN_PROTOCOL_BASE_FEE` floor in `entry_fee_for_worker`.  Before this change, no test pinned either half of that invariant, and no CI job compiled or ran any adiri-gated test in any crate.  A refactor could remove the floor, or make the legacy close start writing the word, and no gate would fail.  No attacker is required for this failure mode: the zero word rides every pre-fork close on the live network.

## Changes

- [x] `crates/node/src/manager/node/run_epoch.rs`: add `prefork_legacy_close_enters_the_next_epoch_at_the_min_fee` (adiri-gated).  It closes epoch 0 from the committed pre-fork genesis, asserts the close routes through the legacy registry (the fee word stays zero), and pins `read_base_fees_for_entered_epoch` at `MIN_PROTOCOL_BASE_FEE`.
- [x] `crates/tn-reth/src/snapshot.rs`: add `entry_readiness_accepts_a_zero_word_eip1559_row_at_the_min_fee` (default features).  A real close first records a nonzero word (the positive control), then a governance transaction zeroes it in a follow-up block.  `check_entry_readiness` accepts the row and prices it at the minimum.
- [x] `.github/workflows/pr.yaml`: add the `adiri-test` job and gate `ci-success` on it.  It runs `cargo nextest run --locked -p tn-types -p tn-reth -p tn-node --features tn-types/adiri,tn-reth/adiri,tn-reth/test-utils,tn-node/adiri --no-fail-fast --profile ci`: the legacy header wire-format pins in tn-types, the consensus-registry fork tests in tn-reth, and the new pre-fork entry-fee pin in tn-node.  tn-storage is excluded: two of its consensus_pack tests fail under the adiri features today, on code this PR does not touch (see Verification).
- [x] `etc/test-and-attest.sh`: extend the adiri lane to the same three crates with package-qualified features.
- [x] `crates/node/Cargo.toml`: correct the `adiri` feature comment.  The crate now has test-only adiri code of its own, so "tn-node has no adiri code" is no longer true.

## Acceptance criteria

- [x] An `adiri`-gated test drives `apply_closing_epoch_contract_call_legacy` through to `read_base_fees_for_entered_epoch`, asserts the fee word is zero, and pins the entry fee at `MIN_PROTOCOL_BASE_FEE`.
- [x] CI executes that test with the `adiri` features.
- [x] A default-features test makes `check_entry_readiness` accept a zero-word `Eip1559` row and pins the same fee.
- [x] The first test fails if the legacy close starts writing the fee word.  Both fee pins fail if `entry_fee_for_worker` stops flooring at the minimum.

## Verification

Commands run on the pinned 1.94 toolchain in an isolated target dir with the `-j 2` cap:

- `cargo +1.94 nextest run --locked -p tn-reth -E 'test(entry_readiness_accepts_a_zero_word_eip1559_row_at_the_min_fee)'`: PASS (0.43s).
- `cargo +1.94 nextest run --locked -p tn-node --features adiri -E 'test(prefork_legacy_close_enters_the_next_epoch_at_the_min_fee)'`: PASS (0.21s).
- `cargo +1.94 clippy -p tn-node --features adiri --tests -- -D warnings` and `cargo +1.94 clippy -p tn-reth --tests -- -D warnings`: clean.
- `cargo +nightly fmt -p tn-reth -p tn-node -- --check`: clean.
- A four-crate adiri lane (the three above plus tn-storage): 585 tests, 583 passed.  The two failures are pre-existing: `tn-storage consensus_pack::test::test_consensus_pack_dup_batch_across_certs` and `test_v0_shared_batch_served_as_v1_bytes` both panic at `consensus_pack.rs:2248` ("Batch lengths within the certified batch are not the same", left 1, right 2) under the adiri features, in code this PR does not touch.  The CI lane therefore selects the three green crates;  the tn-storage failures deserve their own issue.
- The exact three-crate adiri lane that CI runs (same crates, features, and `--no-fail-fast` as the workflow): PASS, 389 tests run, 389 passed (62.1s).

Mutation confirmation (each mutant reverted after the run):

- Remove `.max(MIN_PROTOCOL_BASE_FEE)` from `entry_fee_for_worker`: the snapshot test fails with `left: Ok(0), right: Ok(7)` ("a zero word must price the entered epoch at the protocol minimum") and the run_epoch test fails with `left: [0], right: [7]` ("a zero word maps to the protocol minimum on entry").
- Append `self.record_next_epoch_base_fees()?;` to the legacy close: the adiri test fails.  The injected write reverts against the pre-fork genesis, so the close aborts.  A write that landed would instead trip the zero-word positive control.  Both mutant behaviors fail the test.
