### PR TITLE
fix(tn-reth): refuse pinned reads below the restored-state floor (#1105)

### DIFF
--- a/crates/telcoin-network-cli/src/db.rs
+++ b/crates/telcoin-network-cli/src/db.rs
@@ -316,10 +316,15 @@ fn chain_data_dirs(datadir: &Path) -> [PathBuf; 3] {
     [datadir.join("db"), datadir.join("static_files"), datadir.join("consensus-db")]
 }
 
-/// Best-effort removal of the chain-data dirs a failed import created — every [`chain_data_dirs`]
-/// entry not already present in `preexisting`. Skipping pre-existing dirs is a safety guard: even
-/// if `db load-state` were pointed at a populated datadir, this never deletes data the import did
-/// not create. Removal errors are logged, not fatal (the import is already failing).
+/// Best-effort removal of the chain data a failed import created — every [`chain_data_dirs`]
+/// entry not already present in `preexisting`, then the restored-state floor marker
+/// (`import_chain_scaffold` writes it before any chain data commits, so a failed import can
+/// leave it orphaned; a stale floor would poison a later normal sync of this datadir by
+/// refusing pinned reads it can actually serve). The marker goes last: removing it before the
+/// dirs could leave restored chain data without its floor if this cleanup itself dies midway.
+/// Skipping pre-existing dirs is a safety guard: even if `db load-state` were pointed at a
+/// populated datadir, this never deletes data the import did not create. Removal errors are
+/// logged, not fatal (the import is already failing).
 fn clean_created_chain_data(datadir: &Path, preexisting: &HashSet<PathBuf>) {
     for dir in chain_data_dirs(datadir) {
         if preexisting.contains(&dir) {
@@ -333,6 +338,12 @@ fn clean_created_chain_data(datadir: &Path, preexisting: &HashSet<PathBuf>) {
             }
         }
     }
+    let marker = tn_reth::RethEnv::restored_state_floor_marker(datadir);
+    fs::remove_file(&marker)
+        .or_else(|e| (e.kind() == std::io::ErrorKind::NotFound).then_some(()).ok_or(e))
+        .unwrap_or_else(|e| {
+            eprintln!("warning: could not remove {} during import cleanup: {e}", marker.display())
+        });
 }
 
 /// Reject an export bundle that cannot produce a resumable node, returning `Err` before any datadir

--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -760,10 +760,33 @@ impl RethEnv {
     /// `HistoryInfo::MaybeInPlainState`, silently falling back to TIP state for this "pinned"
     /// read — exactly the nondeterminism pinning exists to prevent. Revisit every pinned read
     /// before enabling pruning.
+    ///
+    /// RESTORED-DATADIR FLOOR: a datadir bootstrapped from a snapshot holds state ONLY at the
+    /// snapshot's final block `B` — window headers below `B` carry real, resolvable hashes but
+    /// no state and no history, and blocks below the window are zero-hash placeholders (see
+    /// `SnapshotRestorer::import_chain_scaffold` in `snapshot.rs`). reth's checkpoint-less
+    /// history walk answers reads anywhere below `B` with `Ok(None)` per account ("never
+    /// written") — no error, no log — so pins below the persisted floor (= `B`) are refused
+    /// HERE, before any state is built, as [`StateReadError::Provider`]: the gap is this node's
+    /// datadir, not the chain, and a peer with full history answers the same read correctly.
     fn pinned_state_and_env(
         &self,
         header: &SealedHeader,
     ) -> StateReadResult<(State<StateProviderDatabase<StateProviderBox>>, EvmEnv)> {
+        // refuse pins below the restored-state floor before touching the provider: below it the
+        // datadir holds headers but no state, and the read would resolve silently to "never
+        // written" values instead of failing
+        self.inner.restored_state_floor.filter(|floor| header.number < *floor).map_or(
+            Ok(()),
+            |floor| {
+                Err(StateReadError::Provider(format!(
+                    "pinned read at block {} is below this datadir's restored-state floor \
+                     (block {floor}, the snapshot's final block): the snapshot shipped no state \
+                     below it",
+                    header.number
+                )))
+            },
+        )?;
         let db = self.read_only_state_db(header.hash()).map_err(|e| {
             StateReadError::Provider(format!("state provider at {}: {e}", header.hash()))
         })?;

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -14,8 +14,14 @@
 //!   the LOCAL chain spec in the supplied config — genesis is never fetched from the network.
 //! - [`RethEnv::new`] has two process-global side effects (base-fee address pinning and metrics
 //!   registration) — see its docs.
+//! - Opening an env loads the datadir's restored-state floor marker when one exists (a datadir
+//!   bootstrapped from a snapshot); pinned state reads below the floor are refused — see
+//!   `pinned_state_and_env` in `env/epoch.rs`.
 
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use reth_chainspec::ChainSpec as RethChainSpec;
 use reth_db::{init_db, DatabaseEnv};
@@ -69,6 +75,16 @@ struct RethEnvInner {
     evm_config: TnEvmConfig,
     /// The type to spawn tasks.
     task_spawner: TaskSpawner,
+    /// The snapshot's final block `B` — the first block whose state this datadir holds — when it
+    /// was bootstrapped from a snapshot; `None` on a normally-synced node.
+    ///
+    /// Loaded once from the [`RESTORED_STATE_FLOOR_FILE`] marker at construction. The restore
+    /// imports state ONLY at `B`: window headers below `B` carry real, resolvable hashes but no
+    /// state and no history, and blocks below the window are zero-hash placeholders. So
+    /// `pinned_state_and_env` (`env/epoch.rs`) refuses every pin below the floor: reth's
+    /// checkpoint-less history walk would otherwise answer such reads `Ok(None)` per account,
+    /// silently reading every account as "never written".
+    restored_state_floor: Option<u64>,
     /// TEST-ONLY: number of pending injected pre-commit persist faults.
     ///
     /// While non-zero, each call to `RethEnv::persist_executed_output` consumes one count
@@ -109,6 +125,15 @@ fn set_basefee_address(address: Option<Address>) {
     let _ = BASEFEE_ADDRESS.set(address.unwrap_or(GOVERNANCE_SAFE_ADDRESS));
 }
 
+/// File name, relative to the datadir root, of the restored-state floor marker.
+///
+/// `SnapshotRestorer::import_chain_scaffold` (`snapshot.rs`) writes it — before any chain data
+/// commits — with the snapshot's final block number (the first block whose state the datadir
+/// holds), and [`RethEnv::new`] reads it on
+/// every construction over the datadir. The file is absent on a normally-synced node. It sits at
+/// the datadir root (beside `db` and `static_files`) so any whole-datadir copy carries it.
+const RESTORED_STATE_FLOOR_FILE: &str = "restored-state-floor";
+
 impl RethEnv {
     /// Produce a new wrapped Reth environment from a config, DB path and task manager.
     ///
@@ -140,6 +165,7 @@ impl RethEnv {
         let provider_factory = Self::init_provider_factory(&node_config, database)?;
         let blockchain_provider = BlockchainProvider::new(provider_factory)?;
         let task_spawner = task_manager.get_spawner();
+        let restored_state_floor = Self::read_restored_state_floor(&node_config)?;
         set_basefee_address(basefee_address);
         // baseline the block-building counters at zero now, while the recorder is known to be
         // installed, so a node that never drops a transaction still exports both series
@@ -151,6 +177,7 @@ impl RethEnv {
                 blockchain_provider,
                 evm_config,
                 task_spawner,
+                restored_state_floor,
                 #[cfg(any(feature = "test-utils", test))]
                 persist_fault_injections: std::sync::atomic::AtomicU32::new(0),
                 #[cfg(any(feature = "test-utils", test))]
@@ -173,6 +200,86 @@ impl RethEnv {
         // with_metrics: record per-operation db latency metrics (noop unless the global
         // metrics recorder is installed, i.e. the node runs with `--metrics`)
         Ok(Arc::new(init_db(db_path, reth_config.0.db.database_args())?.with_metrics()))
+    }
+
+    /// Absolute path of the restored-state floor marker inside `node_config`'s datadir root.
+    pub(crate) fn restored_state_floor_path(node_config: &NodeConfig<RethChainSpec>) -> PathBuf {
+        Self::restored_state_floor_marker(node_config.datadir().data_dir())
+    }
+
+    /// Absolute path of the restored-state floor marker under a TN datadir root, for callers
+    /// outside this crate that hold only the datadir path: the CLI's failed-import cleanup
+    /// removes the marker through this, so an aborted restore cannot leave a stale floor that
+    /// poisons a later normal sync of the same datadir.
+    pub fn restored_state_floor_marker(datadir: impl AsRef<Path>) -> PathBuf {
+        datadir.as_ref().join(RESTORED_STATE_FLOOR_FILE)
+    }
+
+    /// Read the datadir's restored-state floor marker, if one exists.
+    ///
+    /// A missing file is the normal case (`Ok(None)`): the node was not bootstrapped from a
+    /// snapshot. An unreadable or unparseable file is a hard error rather than `None` — treating
+    /// a corrupt marker as "no floor" would silently re-admit the below-floor pinned reads the
+    /// marker exists to refuse.
+    fn read_restored_state_floor(
+        node_config: &NodeConfig<RethChainSpec>,
+    ) -> eyre::Result<Option<u64>> {
+        let path = Self::restored_state_floor_path(node_config);
+        std::fs::read_to_string(&path)
+            .map(Some)
+            .or_else(|e| (e.kind() == std::io::ErrorKind::NotFound).then_some(None).ok_or(e))
+            .map_err(|e| {
+                eyre::eyre!("failed to read restored-state floor marker {}: {e}", path.display())
+            })?
+            .map(|contents| {
+                contents.trim().parse::<u64>().map_err(|e| {
+                    eyre::eyre!(
+                        "restored-state floor marker {} does not hold a block number: {e}; \
+                         delete the file ONLY if this datadir was never bootstrapped from a \
+                         snapshot — a restored datadir without its floor silently serves empty \
+                         state for pre-snapshot reads",
+                        path.display()
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    /// Persist the datadir's restored-state floor marker: the snapshot's final block `B`, the
+    /// only block whose state the restore imports — nothing below it is readable.
+    ///
+    /// Called by `SnapshotRestorer::import_chain_scaffold` (`snapshot.rs`) BEFORE any chain data
+    /// commits, so no restored datadir can exist without its floor. That ordering only survives
+    /// a crash if the marker is durable first: the scaffold's mdbx and static-file commits
+    /// fsync, while a bare `std::fs::write` can sit in the page cache indefinitely. So this
+    /// stages a temp file, fsyncs it, renames it over the final path (a torn marker can never be
+    /// observed), and fsyncs the parent directory. The marker is read back by [`RethEnv::new`]
+    /// on every later construction over this datadir — never by the env that wrote it:
+    /// `SnapshotRestorer`'s own env was built over the pre-scaffold empty datadir and keeps
+    /// `None`, and the restore's only pinned read targets the snapshot's final block, which the
+    /// floor admits.
+    pub(crate) fn write_restored_state_floor(&self, floor: u64) -> eyre::Result<()> {
+        let path = Self::restored_state_floor_path(self.node_config());
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, format!("{floor}\n")).map_err(|e| {
+            eyre::eyre!("failed to stage restored-state floor marker {}: {e}", tmp.display())
+        })?;
+        std::fs::File::open(&tmp).and_then(|f| f.sync_all()).map_err(|e| {
+            eyre::eyre!("failed to fsync restored-state floor marker {}: {e}", tmp.display())
+        })?;
+        std::fs::rename(&tmp, &path).map_err(|e| {
+            eyre::eyre!("failed to publish restored-state floor marker {}: {e}", path.display())
+        })?;
+        path.parent()
+            .map(|dir| std::fs::File::open(dir).and_then(|d| d.sync_all()))
+            .transpose()
+            .map(|_| ())
+            .map_err(|e| {
+                eyre::eyre!(
+                    "failed to fsync the datadir holding restored-state floor marker {}: {e}",
+                    path.display()
+                )
+            })
     }
 
     /// Initialize the provider factory and related components

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -446,7 +446,8 @@ impl RethEnv {
 /// 2. [`import_chain_scaffold`](Self::import_chain_scaffold) clears the genesis alloc from the
 ///    state tables and writes a header-only chain up to `B` (real hashes in the window, zero-hash
 ///    dummies below it), so the state import has a real `header(B)` to check its recomputed root
-///    against.
+///    against. It first records the restored-state floor marker (the window's first block), so
+///    every later env over this datadir refuses pinned state reads below the shipped window.
 /// 3. [`import_state`](Self::import_state) streams the pack's accounts into reth's state tables one
 ///    account header and one bounded storage chunk at a time, recomputes the state root from
 ///    scratch, and hard-fails on any mismatch with `header(B).state_root`.
@@ -520,6 +521,9 @@ impl SnapshotRestorer {
     ///   consistent.
     /// - Writes `HeaderNumbers` (hash → number) for every window header so `BLOCKHASH` resolves by
     ///   hash, and sets every stage checkpoint to `B`.
+    /// - Writes the datadir's restored-state floor marker (= `window[0].number`) BEFORE any of the
+    ///   above commits, so pinned state reads below the shipped window are refused for the life of
+    ///   this datadir (`pinned_state_and_env` in `env/epoch.rs`).
     ///
     /// Static files are committed BEFORE the database provider: the refuse-non-empty check in
     /// [`open`](Self::open) keys on the Headers static-file height, so committing static files
@@ -580,6 +584,14 @@ impl SnapshotRestorer {
                 )
             })
         })?;
+
+        // persist the restored-state floor (= block B, the ONLY block whose state the restore
+        // imports) BEFORE any chain data commits: a crash cannot produce a restored datadir
+        // without its floor. The floor is B and not the window's first block because window
+        // headers below B resolve by hash (their HeaderNumbers rows are written below) yet carry
+        // no state — a pin there would silently read every account as "never written" — while
+        // blocks below the window already fail loudly on an unresolvable hash
+        self.reth_env.write_restored_state_floor(b)?;
 
         info!(
             target: "tn::reth",
@@ -2374,7 +2386,7 @@ mod tests {
         let dst_dir = TempDir::new()?;
         let dst_tm = TaskManager::new("Entry Readiness Accept Dest");
         let restorer = restore_through_import(
-            chain,
+            chain.clone(),
             dst_dir.path(),
             &dst_tm,
             std::slice::from_ref(&closing),
@@ -2383,6 +2395,110 @@ mod tests {
         )?;
         restorer.entry_readiness_precondition(final_state)?;
         restorer.finish(final_state)?;
+
+        // a fresh env over the restored datadir loads the floor the scaffold persisted (= the
+        // snapshot's final block `B`; this single-header window IS `B`)
+        use crate::error::StateReadError;
+        let (dst_config, dst_db) = temp_config_and_db(chain.clone(), dst_dir.path())?;
+        let marker = std::fs::read_to_string(RethEnv::restored_state_floor_path(&dst_config.0))?;
+        assert_eq!(
+            marker.trim(),
+            closing.number.to_string(),
+            "the floor marker must hold the snapshot's final block"
+        );
+        let restored = RethEnv::new(&dst_config, &dst_tm, dst_db, None, GasAccumulator::default())?;
+
+        // below the floor: genesis still resolves in this datadir (its header was kept), but its
+        // state was cleared by the scaffold — the floor refuses the pin before any state is read,
+        // classified node-local so callers retry or halt rather than fail open
+        let err = restored
+            .get_current_epoch_info_at_header(&chain.sealed_genesis_header())
+            .expect_err("a pinned read below the restored window must be refused");
+        assert!(
+            matches!(&err, StateReadError::Provider(_)),
+            "the floor refusal must be node-local: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("below this datadir's restored-state floor"),
+            "the refusal must name the restored floor, got: {err}"
+        );
+
+        // positive control: the SAME reader at the snapshot's final block still answers — the
+        // floor admits `B` and the imported state seeds the entered epoch
+        let (epoch, _info) = restored.get_current_epoch_info_at_header(&closing)?;
+        assert_eq!(epoch, 1, "the closing block must still read as the entered epoch");
+
+        Ok(())
+    }
+
+    /// The scaffold persists the restored-state floor marker as the snapshot's FINAL block `B` —
+    /// not the window's first block, because window headers below `B` resolve by hash yet carry
+    /// no state — before any chain data commits, and a fresh env over the datadir refuses pinned
+    /// reads below `B` BEFORE attempting to resolve the pinned hash.
+    #[tokio::test]
+    async fn scaffold_persists_restored_state_floor_and_env_refuses_below_it() -> eyre::Result<()> {
+        use crate::error::StateReadError;
+
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let dst_dir = TempDir::new()?;
+        let tm = TaskManager::new("Restored Floor Scaffold");
+        let (reth_config, db) = temp_config_and_db(chain.clone(), dst_dir.path())?;
+        let restorer = SnapshotRestorer::open(&reth_config, db, &tm)?;
+
+        // a window that starts ABOVE block 1: blocks 3..=5. the first header's parent lies
+        // outside the window (linkage is only checked between window members), mirroring a real
+        // bounded window, so blocks 1..=2 become zero-hash placeholders
+        let h3 = synthetic_header(3, B256::from([0x33; 32]), B256::ZERO);
+        let h4 = synthetic_header(4, h3.hash(), B256::ZERO);
+        let h5 = synthetic_header(5, h4.hash(), B256::ZERO);
+        let window = vec![h3.clone(), h4, h5.clone()];
+        restorer.import_chain_scaffold(&window, BlockNumHash::new(5, h5.hash()))?;
+        drop(restorer);
+
+        // the marker holds the final block (5), not the window start (3)
+        let marker = std::fs::read_to_string(RethEnv::restored_state_floor_path(&reth_config.0))?;
+        assert_eq!(marker.trim(), "5", "the floor marker must hold the snapshot's final block");
+
+        let (reth_config, db) = temp_config_and_db(chain, dst_dir.path())?;
+        let env = RethEnv::new(&reth_config, &tm, db, None, GasAccumulator::default())?;
+
+        // below the floor: refused up front, before the (unresolvable) pin hash matters
+        let phantom =
+            SealedHeader::new(ExecHeader { number: 2, ..Default::default() }, B256::random());
+        let err = env
+            .get_current_epoch_info_at_header(&phantom)
+            .expect_err("a pinned read below the floor must be refused");
+        assert!(
+            matches!(&err, StateReadError::Provider(_)),
+            "the floor refusal must be node-local: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("below this datadir's restored-state floor"),
+            "the refusal must name the restored floor, got: {err}"
+        );
+
+        // window interior, REAL hash: blocks in [window start, B) resolve by hash (their
+        // HeaderNumbers rows are written by the scaffold) but carry no state — the silent
+        // empty-read class from #1105 — so the floor must refuse them too
+        let err = env
+            .get_current_epoch_info_at_header(&h3)
+            .expect_err("a pinned read inside the window but below B must be refused");
+        assert!(
+            err.to_string().contains("below this datadir's restored-state floor"),
+            "the window-interior refusal must come from the floor, got: {err}"
+        );
+
+        // boundary control: AT the floor (= B) the guard admits the pin — this read then fails
+        // on the unresolvable random hash instead, with reth's provider message, not the floor's
+        let at_floor =
+            SealedHeader::new(ExecHeader { number: 5, ..Default::default() }, B256::random());
+        let err = env
+            .get_current_epoch_info_at_header(&at_floor)
+            .expect_err("a random pin hash must not resolve");
+        assert!(
+            !err.to_string().contains("below this datadir's restored-state floor"),
+            "the floor must not refuse a pin at the floor itself, got: {err}"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Closes #1105.

## Problem

A snapshot-restored node silently answers pinned consensus-registry reads that fall below the
restored-state floor.  The restore scaffold imports state only at the snapshot's final block
`B`: window headers below `B` carry real, resolvable hashes but no state and no history, and
blocks below the window are zero-hash placeholders.  The restorer writes no `PruneCheckpoint`,
so reth's availability watermark (`is_account_history_available . . . unwrap_or(true)`) reports
the history as available.  The per-account history walk then resolves
`HistoryInfo::NotYetWritten` and the read returns `Ok(None)`: every account reads as never
written.  No error, no log, no metric.

Every pinned read routes through `pinned_state_and_env` (`crates/tn-reth/src/env/epoch.rs`), so
committee construction, epoch entry, epoch records, and worker fee configs are all exposed.  The
failure needs no attacker: an idle-worker epoch walk-back (#1106) or an RPC-driven historical
registry read is enough to pin a block below the floor.

## Fix

A TN-owned floor, as proposed in #1105, with two corrections:

1. The floor is the snapshot's final block `B`, not the window's first block.  The issue
   proposed `window_start`, but a pin strictly inside the window (`window_start <= n < B`)
   carries a real header hash, resolves normally, and then reads the same silent empty state:
   the datadir holds no state below `B` anywhere.  `B` is the first block whose state the
   datadir holds, so `B` is the floor.
2. `SnapshotRestorer::import_chain_scaffold` persists `B` into a `restored-state-floor` marker
   file at the datadir root, durably (write a temp file, fsync it, rename into place, fsync the
   datadir), BEFORE any chain data commits.  The mdbx and static-file commits that follow are
   fsynced, so ordering the bare-file marker first (and making its write atomic) means a crash
   at any point cannot surface committed restored data that is missing its floor, and a torn
   write cannot surface a half-written marker.

`RethEnv::new` loads the marker once into the env (`None` on a normally-synced node;  a corrupt
marker is a hard startup error with a remedy message, never `None`).  `pinned_state_and_env`
refuses `header.number < floor` with `StateReadError::Provider` before any state provider is
built.  `clean_created_chain_data` (the failed-import cleanup in `telcoin-network-cli`) removes
the marker LAST, after the chain-data dirs, so an aborted import cannot leave an orphan floor
that poisons a later normal sync of the same datadir, and a mid-cleanup crash never leaves
restored data floorless.

The classification is deliberate: the gap is this node's datadir, not the chain.  A peer with
full history answers the same read correctly, so the failure is not committee-deterministic and
callers must not fail open on it.  The existing call-site policy spread already handles this
class (`close_epoch.rs` halts on both error classes;  `run_epoch.rs` retries `Provider` and
fails open for `ChainGlobal` only), so no new error variant and no new call-site policy is
needed.  Cost on the hot path is one integer comparison per pinned read.

## Why not a reth `PruneCheckpoint`

Writing the missing checkpoint row at restore time looks like the reth-native fix (it would also
cover arbitrary historical RPC reads), but it is unsound here.  reth v1.11.3's
`HistoryInfo::from_lookup` returns `InChangeset(C)` instead of `NotYetWritten` whenever a prune
checkpoint EXISTS, without comparing the target block against the watermark
(`crates/storage/provider/src/providers/state/historical.rs`).  A checkpoint row would therefore
push in-window reads below `B` into change-set lookups, and the import deliberately writes no
change sets for `B` (see the "Why the block-`B` change sets are skipped" section on
`import_state`, whose soundness argument depends on the ABSENT prune boundary).  The TN-owned
floor stays outside reth's history resolution entirely.

## Changes

- [x] `crates/tn-reth/src/env/mod.rs`: `RESTORED_STATE_FLOOR_FILE` marker constant,
      `restored_state_floor` field on `RethEnvInner`, marker load in `RethEnv::new`
      (missing file is `Ok(None)`;  unreadable or unparseable is a hard startup error with a
      remedy message), the public `restored_state_floor_marker` path helper, and the durable
      `write_restored_state_floor` (temp file, fsync, rename, fsync the parent).  Module docs
      extended with the new construction invariant.
- [x] `crates/tn-reth/src/env/epoch.rs`: the floor guard in `pinned_state_and_env`, refusing
      below-floor pins as `StateReadError::Provider` with a message that names the floor, plus
      the RESTORED-DATADIR FLOOR doc section beside the existing ARCHIVE-MODE assumption.
- [x] `crates/tn-reth/src/snapshot.rs`: the scaffold writes the `B` marker before any chain
      data commits;  restore-flow and scaffold doc comments record the new step.
- [x] `crates/telcoin-network-cli/src/db.rs`: `clean_created_chain_data` removes the marker
      after the chain-data dirs it already removes.
- [x] Tests (see below).

## Scope notes

- `read_contract_inner` (`crates/tn-reth/src/helpers.rs`) builds its state provider directly
  via `read_only_state_db`, bypassing `pinned_state_and_env`, so ExEx and `eth_call`-style
  historical reads are not covered by the floor.  The consensus-critical pinned reads all route
  through the guarded path;  extending the floor to the direct path is a follow-up.
- Datadirs restored by binaries that predate this change carry no marker and keep the old
  behavior;  nothing on disk records their window, so there is no back-fill.  Re-running
  `db load-state` on a fresh datadir writes the marker.
- Whether a below-floor pin should hard-halt the node instead of surfacing through the existing
  per-caller `Provider` policy remains the #1105 open question (supported validator
  configuration);  this change keeps the documented policy spread untouched.

## Testing

- `scaffold_persists_restored_state_floor_and_env_refuses_below_it` (new, `snapshot.rs`): a
  window of blocks 3..=5 persists marker `5` (the snapshot's final block, NOT the window
  start);  a fresh env over the datadir refuses a pinned read at block 2 (below the window) as
  `Provider` with the floor message, before the pin hash is resolved;  a pinned read at block 3
  (INSIDE the window, real resolvable hash) is refused with the same message, which is exactly
  the case a `window_start` floor would miss;  at the floor itself the guard admits the pin
  (boundary control: a random hash at block 5 then fails with reth's unresolvable-hash message,
  not the floor's).
- `entry_readiness_accepts_epoch_boundary_snapshot` (extended, `snapshot.rs`): after a real
  export/restore/finish round trip, a fresh env loads the floor, refuses a genesis pin (genesis
  resolves in the datadir but its state was cleared by the scaffold) with the floor message, and
  still answers the same reader at `B` (positive control: the entered epoch reads back).
- Regression guards run unchanged: `restore_roundtrips_state_from_export`,
  `entry_readiness_rejects_non_boundary_final_block`,
  `test_state_read_classifies_provider_vs_chain_global`, and
  `epoch_state_at_epoch_start_epoch_zero_pins_genesis` (a normal node has no floor and genesis
  pins keep working).
- Commands: `cargo +nightly-2026-03-20 fmt -p tn-reth -p telcoin-network-cli`, `cargo +1.94
  check -p tn-reth -p telcoin-network-cli --all-targets`, `cargo +nightly-2026-03-20 clippy -p
  tn-reth -p telcoin-network-cli --all-targets --all-features`, `cargo +1.94 test -p tn-reth`
  (named tests), `cargo +1.94 test --no-run --workspace -j 2` in an isolated target dir, all on
  the repo-pinned toolchains.  All gates pass: fmt and clippy are clean, the six named tests
  pass 6/6, and the workspace test build compiles.
- The new tests were confirmed by mutation, three mutants, each restore byte-compared against
  the pre-mutation sources and the restored tree re-run green:
  - Guard removed (`epoch.rs`): both floor tests fail on the refusal-message assertion;  the
    error that surfaces without the guard is an incidental provider fault, which is the issue's
    premise.
  - Marker write deleted (`snapshot.rs`): both floor tests fail at the marker read because the
    file does not exist.
  - Floor written as `window_start` instead of `B` (`snapshot.rs`): the scaffold test fails at
    the marker-content assertion (the marker reads `3`, the window start, instead of `5`),
    upstream of the window-interior probe that the same floor would also fail by admitting the
    pin at block 3.
