### PR TITLE
fix(tn-reth): enforce the restored-state floor in read_only_state_db

### DIFF
--- a/crates/tn-reth/src/env/epoch.rs
+++ b/crates/tn-reth/src/env/epoch.rs
@@ -766,28 +766,17 @@ impl RethEnv {
     /// no state and no history, and blocks below the window are zero-hash placeholders (see
     /// `SnapshotRestorer::import_chain_scaffold` in `snapshot.rs`). reth's checkpoint-less
     /// history walk answers reads anywhere below `B` with `Ok(None)` per account ("never
-    /// written") — no error, no log — so pins below the persisted floor (= `B`) are refused
-    /// HERE, before any state is built, as [`StateReadError::Provider`]: the gap is this node's
-    /// datadir, not the chain, and a peer with full history answers the same read correctly.
+    /// written"), with no error and no log, so pins below the persisted floor (= `B`) are
+    /// refused in `read_only_state_db` (`env/mod.rs`), the shared state constructor this helper
+    /// builds on, before any state is built. The refusal surfaces here as
+    /// [`StateReadError::Provider`]:
+    /// the gap is this node's datadir, not the chain, and a peer with full history answers the
+    /// same read correctly.
     fn pinned_state_and_env(
         &self,
         header: &SealedHeader,
     ) -> StateReadResult<(State<StateProviderDatabase<StateProviderBox>>, EvmEnv)> {
-        // refuse pins below the restored-state floor before touching the provider: below it the
-        // datadir holds headers but no state, and the read would resolve silently to "never
-        // written" values instead of failing
-        self.inner.restored_state_floor.filter(|floor| header.number < *floor).map_or(
-            Ok(()),
-            |floor| {
-                Err(StateReadError::Provider(format!(
-                    "pinned read at block {} is below this datadir's restored-state floor \
-                     (block {floor}, the snapshot's final block): the snapshot shipped no state \
-                     below it",
-                    header.number
-                )))
-            },
-        )?;
-        let db = self.read_only_state_db(header.hash()).map_err(|e| {
+        let db = self.read_only_state_db(header).map_err(|e| {
             StateReadError::Provider(format!("state provider at {}: {e}", header.hash()))
         })?;
         let evm_env = self.inner.evm_config.evm_env(header).map_err(|e| {

--- a/crates/tn-reth/src/env/helpers.rs
+++ b/crates/tn-reth/src/env/helpers.rs
@@ -317,7 +317,9 @@ impl RethEnv {
     /// # Errors
     ///
     /// Same split as [`Self::read_contract`]; additionally, `block_hash` failing to resolve to
-    /// a known sealed header is an [`EvmReadError::Internal`].
+    /// a known sealed header is an [`EvmReadError::Internal`], and so is a pin below a restored
+    /// datadir's state floor, refused by `read_only_state_db` (`env/mod.rs`) before any state
+    /// is read instead of silently answering from the missing pre-snapshot history (#1136).
     pub fn read_contract_at_block(
         &self,
         block_hash: B256,
@@ -350,9 +352,8 @@ impl RethEnv {
         contract: Address,
         calldata: Bytes,
     ) -> EvmReadResult<Bytes> {
-        let mut db = self
-            .read_only_state_db(header.hash())
-            .map_err(|e| EvmReadError::Internal(e.to_string()))?;
+        let mut db =
+            self.read_only_state_db(header).map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let evm_env =
             self.evm_config().evm_env(header).map_err(|e| EvmReadError::Internal(e.to_string()))?;
         let mut tn_evm = self.evm_config().evm_factory().create_evm(&mut db, evm_env);

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -16,7 +16,7 @@
 //!   registration) — see its docs.
 //! - Opening an env loads the datadir's restored-state floor marker when one exists (a datadir
 //!   bootstrapped from a snapshot); pinned state reads below the floor are refused — see
-//!   `pinned_state_and_env` in `env/epoch.rs`.
+//!   `RethEnv::read_only_state_db` in this module.
 
 use std::{
     path::{Path, PathBuf},
@@ -29,15 +29,16 @@ use reth_db_common::init::init_genesis;
 use reth_node_builder::NodeConfig;
 use reth_provider::{
     providers::{BlockchainProvider, StaticFileProvider},
-    ProviderFactory, ProviderResult, StateProviderBox, StateProviderFactory as _,
+    ProviderError, ProviderFactory, ProviderResult, StateProviderBox, StateProviderFactory as _,
 };
 use reth_revm::{database::StateProviderDatabase, State};
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
-use tn_types::{gas_accumulator::GasAccumulator, Address, TaskManager, TaskSpawner, B256};
+use tn_types::{gas_accumulator::GasAccumulator, Address, SealedHeader, TaskManager, TaskSpawner};
 use tracing::{debug, info};
 
 use crate::{
-    evm::TnEvmConfig, traits::TelcoinNode, RethConfig, RethDb, WorkerTxPool, BASEFEE_ADDRESS,
+    error::RestoredStateFloorError, evm::TnEvmConfig, traits::TelcoinNode, RethConfig, RethDb,
+    WorkerTxPool, BASEFEE_ADDRESS,
 };
 
 mod epoch;
@@ -81,9 +82,10 @@ struct RethEnvInner {
     /// Loaded once from the [`RESTORED_STATE_FLOOR_FILE`] marker at construction. The restore
     /// imports state ONLY at `B`: window headers below `B` carry real, resolvable hashes but no
     /// state and no history, and blocks below the window are zero-hash placeholders. So
-    /// `pinned_state_and_env` (`env/epoch.rs`) refuses every pin below the floor: reth's
-    /// checkpoint-less history walk would otherwise answer such reads `Ok(None)` per account,
-    /// silently reading every account as "never written".
+    /// `read_only_state_db` (the shared state constructor every pinned read goes through)
+    /// refuses every pin below the floor: reth's checkpoint-less history walk would otherwise
+    /// answer such reads `Ok(None)` per account, silently reading every account as "never
+    /// written".
     restored_state_floor: Option<u64>,
     /// TEST-ONLY: number of pending injected pre-commit persist faults.
     ///
@@ -349,18 +351,44 @@ impl RethEnv {
         &self.inner.evm_config
     }
 
-    /// Build the read-only database stack over the state at `block_hash`: state provider →
+    /// Build the read-only database stack over the state at `header`: state provider →
     /// [`StateProviderDatabase`] → [`State`] with bundle updates enabled.
     ///
-    /// This is the shared construction for every pinned, non-committing contract read. Callers
-    /// create their own EVM over the returned stack and keep their site-specific mapping of the
-    /// [`ProviderResult`] error (node-local provider faults classify differently per caller).
-    /// Block-building paths use a different, cached DB stack and must not switch to this one.
+    /// This is the shared construction for every pinned, non-committing contract read, and the
+    /// ONE enforcement point for the restored-state floor: a pin below the floor is refused
+    /// here, before any provider state is touched, as a [`RestoredStateFloorError`] carried in
+    /// [`ProviderError::Other`], so every consumer inherits the refusal instead of silently
+    /// reading every account as "never written" (the gap `read_contract_at_block` had, #1136).
+    /// Taking the full [`SealedHeader`] rather than a bare hash removes the number/hash
+    /// ambiguity of the hash-only signature: every production caller resolves the header from
+    /// the provider, so the compared number and the resolved hash come from one record. A
+    /// hand-built `SealedHeader` can still pair a number with a foreign hash (tests do), so the
+    /// floor guards against API misuse, not against forged headers.
+    ///
+    /// ARCHIVE-MODE ASSUMPTION: the `state_by_block_hash` call below stays deterministic only
+    /// because this node never constructs a pruner; with pruning enabled, reth's historical
+    /// provider can silently fall back to TIP state for a pinned read. Revisit every consumer
+    /// of this constructor before enabling pruning (the full note lives on
+    /// `pinned_state_and_env` in `env/epoch.rs`).
+    ///
+    /// Callers create their own EVM over the returned stack and keep their site-specific mapping
+    /// of the [`ProviderResult`] error (node-local provider faults classify differently per
+    /// caller). Block-building paths use a different, cached DB stack and must not switch to
+    /// this one.
     pub(crate) fn read_only_state_db(
         &self,
-        block_hash: B256,
+        header: &SealedHeader,
     ) -> ProviderResult<State<StateProviderDatabase<StateProviderBox>>> {
-        let state_provider = self.inner.blockchain_provider.state_by_block_hash(block_hash)?;
+        // refuse pins below the restored-state floor before touching the provider: below it the
+        // datadir holds headers but no state, and the read would resolve silently to "never
+        // written" values instead of failing
+        self.inner
+            .restored_state_floor
+            .filter(|floor| header.number < *floor)
+            .map_or(Ok(()), |floor| {
+                Err(ProviderError::other(RestoredStateFloorError::new(header.number, floor)))
+            })?;
+        let state_provider = self.inner.blockchain_provider.state_by_block_hash(header.hash())?;
         let state = StateProviderDatabase::new(state_provider);
         Ok(State::builder().with_database(state).with_bundle_update().build())
     }

--- a/crates/tn-reth/src/error.rs
+++ b/crates/tn-reth/src/error.rs
@@ -151,3 +151,31 @@ pub enum StateReadError {
 
 /// Result of a committee-determinism-classified state read (see [`StateReadError`]).
 pub type StateReadResult<T> = Result<T, StateReadError>;
+
+/// Refusal of a pinned state read below a restored datadir's state floor.
+///
+/// Raised by `RethEnv::read_only_state_db` (the shared state constructor for every pinned,
+/// non-committing read) when the pinned block number is below the restored-state floor (the
+/// snapshot's final block `B`, the only block whose state the restore imports). Below `B` the
+/// datadir holds headers but no state, and reth's checkpoint-less history walk would answer the
+/// read with every account "never written" instead of an error. Carried through
+/// [`reth_errors::ProviderError::other`], so every caller observes it as a node-local provider
+/// fault.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "pinned read at block {pinned} is below this datadir's restored-state floor (block {floor}, \
+     the snapshot's final block): the snapshot shipped no state below it"
+)]
+pub struct RestoredStateFloorError {
+    /// The refused pin's block number.
+    pinned: u64,
+    /// The datadir's restored-state floor: the snapshot's final block `B`.
+    floor: u64,
+}
+
+impl RestoredStateFloorError {
+    /// Bundle the refused pin's block number with the floor it fell below.
+    pub(crate) fn new(pinned: u64, floor: u64) -> Self {
+        Self { pinned, floor }
+    }
+}

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -446,8 +446,9 @@ impl RethEnv {
 /// 2. [`import_chain_scaffold`](Self::import_chain_scaffold) clears the genesis alloc from the
 ///    state tables and writes a header-only chain up to `B` (real hashes in the window, zero-hash
 ///    dummies below it), so the state import has a real `header(B)` to check its recomputed root
-///    against. It first records the restored-state floor marker (the window's first block), so
-///    every later env over this datadir refuses pinned state reads below the shipped window.
+///    against. It first records the restored-state floor marker (= `B`, the window's final block,
+///    the only block whose state the restore imports), so every later env over this datadir refuses
+///    pinned state reads below `B`.
 /// 3. [`import_state`](Self::import_state) streams the pack's accounts into reth's state tables one
 ///    account header and one bounded storage chunk at a time, recomputes the state root from
 ///    scratch, and hard-fails on any mismatch with `header(B).state_root`.
@@ -521,9 +522,9 @@ impl SnapshotRestorer {
     ///   consistent.
     /// - Writes `HeaderNumbers` (hash → number) for every window header so `BLOCKHASH` resolves by
     ///   hash, and sets every stage checkpoint to `B`.
-    /// - Writes the datadir's restored-state floor marker (= `window[0].number`) BEFORE any of the
-    ///   above commits, so pinned state reads below the shipped window are refused for the life of
-    ///   this datadir (`pinned_state_and_env` in `env/epoch.rs`).
+    /// - Writes the datadir's restored-state floor marker (= `B`, the window's final block) BEFORE
+    ///   any of the above commits, so pinned state reads below `B` are refused for the life of this
+    ///   datadir (`read_only_state_db` in `env/mod.rs`).
     ///
     /// Static files are committed BEFORE the database provider: the refuse-non-empty check in
     /// [`open`](Self::open) keys on the Headers static-file height, so committing static files
@@ -2430,6 +2431,38 @@ mod tests {
         let (epoch, _info) = restored.get_current_epoch_info_at_header(&closing)?;
         assert_eq!(epoch, 1, "the closing block must still read as the entered epoch");
 
+        // #1136: `read_contract_at_block` builds its state through `read_only_state_db` without
+        // passing `pinned_state_and_env`: the floor must refuse it all the same. Genesis
+        // resolves in this datadir, so before the chokepoint check this read returned Ok with
+        // every account "never written" instead of an error
+        use crate::error::EvmReadError;
+        let err = restored
+            .read_contract_at_block(
+                chain.sealed_genesis_header().hash(),
+                Address::from_slice(&[0xdd; 20]),
+                Bytes::default(),
+            )
+            .expect_err("a contract read pinned below the floor must be refused");
+        assert!(
+            matches!(&err, EvmReadError::Internal(_)),
+            "the floor refusal must be an internal node fault, not a revert: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("below this datadir's restored-state floor"),
+            "the contract-read refusal must name the restored floor, got: {err}"
+        );
+
+        // positive control for the same path: pinned AT the floor the read is admitted and
+        // reaches the EVM (a codeless address answers with empty output, not a refusal)
+        let output = restored
+            .read_contract_at_block(
+                closing.hash(),
+                Address::from_slice(&[0xdd; 20]),
+                Bytes::default(),
+            )
+            .expect("a contract read pinned at the floor must be admitted");
+        assert!(output.is_empty(), "a codeless address must return empty output");
+
         Ok(())
     }
 
@@ -2488,6 +2521,36 @@ mod tests {
         assert!(
             err.to_string().contains("below this datadir's restored-state floor"),
             "the window-interior refusal must come from the floor, got: {err}"
+        );
+
+        // #1136: the same window-interior pin through `read_contract_at_block`, which does not
+        // pass `pinned_state_and_env`: the chokepoint in `read_only_state_db` must refuse it too
+        use crate::error::EvmReadError;
+        let err = env
+            .read_contract_at_block(h3.hash(), Address::from_slice(&[0xdd; 20]), Bytes::default())
+            .expect_err("a contract read pinned inside the window but below B must be refused");
+        assert!(
+            matches!(&err, EvmReadError::Internal(_)),
+            "the floor refusal must be an internal node fault, not a revert: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("below this datadir's restored-state floor"),
+            "the contract-read refusal must come from the floor, got: {err}"
+        );
+
+        // admit-side control for the same path: a contract read pinned AT the floor (real hash
+        // `h5`) must not be the floor's refusal, whatever else this scaffold-only datadir does
+        // with the read
+        let at_floor_read = env.read_contract_at_block(
+            h5.hash(),
+            Address::from_slice(&[0xdd; 20]),
+            Bytes::default(),
+        );
+        assert!(
+            at_floor_read.as_ref().err().is_none_or(|e| !e
+                .to_string()
+                .contains("below this datadir's restored-state floor")),
+            "the floor must not refuse a contract read at the floor itself, got: {at_floor_read:?}"
         );
 
         // boundary control: AT the floor (= B) the guard admits the pin — this read then fails

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -110,8 +110,8 @@ impl RethEnv {
 
     /// Create an EVM-environment from state provider.
     pub fn tn_evm(&self, hash: BlockHash) -> eyre::Result<TNEvmTestType> {
-        let header = self.header(hash)?.expect("provided hash in header table");
-        let db = self.read_only_state_db(hash)?;
+        let header = self.sealed_header_by_hash(hash)?.expect("provided hash in header table");
+        let db = self.read_only_state_db(&header)?;
         Ok(self.evm_config().evm_factory().create_evm(db, self.evm_config().evm_env(&header)?))
     }
 


### PR DESCRIPTION
Closes #1136.

## Problem

`RethEnv::read_contract_at_block` is a pinned read that does not route through
`pinned_state_and_env`: it builds its state from `read_only_state_db` directly, via
`read_contract_inner`. The restored-state floor added in #1131 was enforced only in
`pinned_state_and_env`, so this path never consulted it. On a snapshot-restored datadir, a call
pinned below the floor resolves through reth's checkpoint-less history walk and reads every
account and slot as "never written". No error, no log. That is exactly the silent outcome the
floor exists to refuse (#1105).

No production caller hits this today (the only call sites are test utilities), but the method is
public on `RethEnv`, the exex docs recommend it as the pinned alternative to tip reads, and
`evm/mod.rs` documents its gas ceiling . . . the next consumer inherits the gap silently.

## Root cause

The floor comparison lived one layer too high. `pinned_state_and_env` checked it, but the shared
state constructor beneath it (`read_only_state_db`) did not, so a second entry point into that
constructor bypassed the guard.

## Fix

Move the floor refusal into `read_only_state_db` itself (option 1 from the issue), so every
consumer of a pinned state provider inherits it by construction:

- `read_only_state_db` now takes the full `&SealedHeader` instead of a bare hash. The header ties
  the pinned number to the pinned hash, so the floor comparison cannot be handed a mismatched
  pair. Pins below the floor are refused before any provider state is touched, as a new
  `RestoredStateFloorError` carried through `ProviderError::other`.
- The refusal stays classified node-local (a `Provider` fault): the gap is this node's datadir,
  not the chain, and a peer with full history answers the same read correctly. No attacker is
  required for the failure this guards against; the operator's own pinned read is the victim, and
  the floor turns silent empty state into a loud error.
- `pinned_state_and_env` drops its now-duplicate check and inherits the refusal through the
  shared constructor. Its `StateReadError::Provider` classification and message substring are
  unchanged (existing floor tests pass unmodified).
- Surveyed every `read_only_state_db` caller for a legitimate below-floor read (the issue's open
  question on option 1): `pinned_state_and_env`, `read_contract_inner`, and the test-only
  `tn_evm`. None reads below the floor legitimately. The tip-read path (`read_contract`) now also
  flows through the check; a restored datadir's canonical tip starts at the floor `B`, so tip
  reads are always admitted.

## Changes

- [x] `crates/tn-reth/src/env/mod.rs`: floor check moved into `read_only_state_db`; signature
  takes `&SealedHeader`; docs name it the ONE enforcement point
- [x] `crates/tn-reth/src/error.rs`: new `RestoredStateFloorError`, carried via
  `ProviderError::other`
- [x] `crates/tn-reth/src/env/epoch.rs`: duplicate check removed from `pinned_state_and_env`;
  floor docs redirected to the chokepoint
- [x] `crates/tn-reth/src/env/helpers.rs`: `read_contract_inner` passes the header through;
  `read_contract_at_block` documents the refusal
- [x] `crates/tn-reth/src/test_utils.rs`: `tn_evm` resolves a `SealedHeader` and passes it through
- [x] `crates/tn-reth/src/snapshot.rs`: doc nit from the issue (the floor marker is `B`, the
  window's final block, not `window[0].number`) plus the regression tests below

## Testing

- New regression coverage in the two existing floor tests (`snapshot.rs`):
  `read_contract_at_block` pinned below the floor is refused on a real restored datadir (genesis
  pin) and on a scaffold-only datadir (window-interior pin at a real, resolvable hash), with the
  refusal naming the floor; pinned AT the floor the same path is admitted (a codeless address
  answers empty output, the positive control).
- Both new assertions were confirmed by mutation: with the floor check removed from
  `read_only_state_db`, both tests fail at exactly the new `expect_err` lines; restored, all 127
  `tn-reth` lib tests pass.
- `cargo +1.94 check --all-targets` over buildplan's full reverse-dependency closure (21
  crates): green.
- `cargo +1.94 test -p tn-reth --lib`: 127 passed, 0 failed.
- `cargo +nightly-2026-03-20 fmt -- --check`: clean.
- `cargo +nightly-2026-03-20 clippy --workspace` (default and `--all-features`, `-D warnings`)
  and the attest-exact `cargo +1.94 test --no-run --workspace -j 2` in an isolated target dir:
  PENDING (update before push once gates.log shows ALL-GATES-PASS).
