### PR TITLE
fix(network-libp2p): issue at most one in-flight kad query per missing authority

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -1724,10 +1724,24 @@ where
                 self.swarm.behaviour_mut().gossipsub.remove_blacklisted_peer(&peer_id);
             }
             PeerEvent::MissingAuthorities(missing) => {
+                // Polling callers such as `current_committee_rpcs` report a member as
+                // missing on every call until its record lands in `known_peers`, so the
+                // same key arrives here repeatedly while its lookup is still in flight.
+                // Issue at most one live `get_record` per key: skip keys already tracked
+                // in `kad_record_queries` (issue #1135). The map is safe as the dedupe
+                // source because every terminal query path removes its entry (see
+                // `close_kad_query`), so a skipped key becomes queryable again as soon
+                // as its current query ends. The removal there runs before any result
+                // filtering, so even a query whose record is dropped as stale or
+                // non-committee re-arms the key.
                 for bls_key in missing {
-                    let key = kad::RecordKey::new(&bls_key);
-                    let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
-                    self.kad_record_queries.insert(query_id, bls_key.into());
+                    if self.kad_record_queries.values().all(|q| q.request != bls_key) {
+                        let key = kad::RecordKey::new(&bls_key);
+                        let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
+                        self.kad_record_queries.insert(query_id, bls_key.into());
+                    } else {
+                        trace!(target: "network-kad", ?bls_key, "kad record query already in flight");
+                    }
                 }
             }
             PeerEvent::Discovery => {

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2543,6 +2543,70 @@ async fn test_node_record_validation() {
     assert!(network.peer_record_valid(&peer_record).is_none());
 }
 
+/// Repeated `MissingAuthorities` reports for one key must not stack duplicate
+/// in-flight kad queries (issue #1135).
+///
+/// `trigger_missing_authorities` filters on completed outcomes (`known_peers`)
+/// only, so a caller that polls `current_committee_rpcs` re-reports an
+/// unresolved member on every call. Before the fix, each report issued a fresh
+/// `get_record` and inserted a new `kad_record_queries` entry. The swarm is
+/// never polled in this test, so no query can terminate mid-test: every entry
+/// observed below is in flight by construction.
+#[tokio::test]
+async fn test_missing_authorities_dedupes_inflight_kad_queries() -> eyre::Result<()> {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+    let unknown_a = *BlsKeypair::generate(&mut StdRng::from_seed([11; 32])).public();
+    let unknown_b = *BlsKeypair::generate(&mut StdRng::from_seed([13; 32])).public();
+
+    // positive control: a first-time key must issue exactly one query
+    network.process_peer_manager_event(PeerEvent::MissingAuthorities(vec![unknown_a]))?;
+    assert_eq!(network.kad_record_queries.len(), 1, "first report must issue one query");
+
+    // a polling re-report of the same key alongside a new key: only the new
+    // key may issue a query
+    network
+        .process_peer_manager_event(PeerEvent::MissingAuthorities(vec![unknown_a, unknown_b]))?;
+    assert_eq!(network.kad_record_queries.len(), 2, "re-reported key must not issue a duplicate");
+    assert_eq!(
+        network.kad_record_queries.values().filter(|q| q.request == unknown_a).count(),
+        1,
+        "one in-flight query for the re-reported key"
+    );
+    assert_eq!(
+        network.kad_record_queries.values().filter(|q| q.request == unknown_b).count(),
+        1,
+        "one in-flight query for the new key"
+    );
+
+    // steady-state polling: nothing accumulates
+    network
+        .process_peer_manager_event(PeerEvent::MissingAuthorities(vec![unknown_a, unknown_b]))?;
+    assert_eq!(network.kad_record_queries.len(), 2, "steady-state polling must not accumulate");
+
+    // re-arm: every terminal query path runs `close_kad_query`, so once the
+    // in-flight query for a key ends, the next report must issue a fresh query
+    let old_id = network
+        .kad_record_queries
+        .iter()
+        .find(|(_, query)| query.request == unknown_a)
+        .map(|(id, _)| *id)
+        .ok_or_else(|| eyre!("in-flight query for unknown_a is tracked"))?;
+    network.close_kad_query(&old_id);
+    assert_eq!(network.kad_record_queries.len(), 1, "closed query must leave the map");
+    network.process_peer_manager_event(PeerEvent::MissingAuthorities(vec![unknown_a]))?;
+    assert_eq!(network.kad_record_queries.len(), 2, "closed key must re-arm on the next report");
+    let new_id = network
+        .kad_record_queries
+        .iter()
+        .find(|(_, query)| query.request == unknown_a)
+        .map(|(id, _)| *id)
+        .ok_or_else(|| eyre!("re-armed query for unknown_a is tracked"))?;
+    assert_ne!(old_id, new_id, "re-armed query must be a fresh kad query");
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_local_record_has_no_expiry() {
     let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();


### PR DESCRIPTION
Closes #1135.

## Problem

`current_committee_rpcs` triggers discovery for unknown committee members on every call.  The filter inside `trigger_missing_authorities` checks `known_peers`, which records completed outcomes rather than queries in flight, so a member whose record has not arrived yet is re-reported missing on every call.

Each `MissingAuthorities` event issued a fresh `get_record` and inserted a new entry into `kad_record_queries`, keyed by query id.  Entries are removed only when their own query completes.  A caller polling at N calls per second with M unknown members therefore accumulated on the order of N x M duplicate in-flight queries on the swarm loop, all resolving the same records.

No attacker is required.  The worst window is right after a committee rotation: `prune_known_peers` has just evicted rotated-out members, so M peaks exactly when callers start polling for the new committee's endpoints.

## Fix

- [x] `crates/network-libp2p/src/consensus.rs`: the `PeerEvent::MissingAuthorities` arm skips any key that already has a query tracked in `kad_record_queries`, so each missing member has at most one live `get_record`.

The dedupe source is the query map itself, not an auxiliary set (the alternative raised in the issue).  The map is authoritative for in-flight state: every terminal query path (record found, invalid record, no record, query error) removes its entry via `close_kad_query`, so a skipped key becomes queryable again as soon as its current query ends.  The removal there runs before any result filtering, so even a query whose record is dropped as stale or non-committee re-arms the key.  There is no second collection to keep in sync across the manager/network boundary, and no starvation window longer than one query lifetime (bounded by the kad query timeout).  In-flight `get_record` queries are now bounded by the number of distinct unresolved keys (at most the tracked committees), independent of caller polling rate.

One deliberate behavior change: while a query is in flight, the per-key retry cadence becomes once per completed query (typically the kad peer timeout, with the query timeout as the ceiling) instead of once per caller poll.  This is the point of the fix, and the suppressed branch logs at `trace` level so the state is observable.  Members we actually connect to still push their records directly on first connect, so the slower re-sample cadence only affects members never connected to.

## Testing

- [x] New regression test `test_missing_authorities_dedupes_inflight_kad_queries` drives `process_peer_manager_event` directly on an un-spawned `ConsensusNetwork`.  The swarm is never polled, so no query can terminate mid-test and every observed entry is in flight by construction (deterministic, no timing assumptions).  It asserts: a first-time key issues exactly one query (positive control), a polling re-report issues none, a new key alongside a re-report still issues its own, steady-state polling does not accumulate entries, and (re-arm) once `close_kad_query` ends a key's query, the next report issues a fresh query with a new query id.
- [x] Test confirmed by mutation: reverting the guard makes it fail;  restoring makes it pass.
- [x] `cargo +nightly fmt -- --check`, `cargo +1.94 clippy --all-targets`, and `cargo +1.94 test --no-run --workspace -j 2` (isolated target dir) green on the pinned toolchain.
- [x] `cargo +1.94 test -p tn-network-libp2p` green.
