### PR TITLE
fix(types): add one-shot ShutdownNotifier so a subscribe after notify resolves

### DIFF
--- a/bin/worker-gateway/src/app.rs
+++ b/bin/worker-gateway/src/app.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use reqwest::Client;
-use tn_types::{Notifier, TaskManager};
+use tn_types::{ShutdownNotifier, TaskManager};
 use tracing::info;
 
 use crate::{
@@ -81,7 +81,7 @@ pub(crate) async fn run(settings: Settings) -> eyre::Result<()> {
             .unwrap_or(u64::MAX),
     );
     let spawner = task_manager.get_spawner();
-    let shutdown = Notifier::new();
+    let shutdown = ShutdownNotifier::new();
 
     // Optional Prometheus scrape endpoint on its own listener. Reuses the node's
     // `tn-metrics` recorder + server so the gateway's `tn_worker_gateway_*` series

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -9,7 +9,7 @@ use std::{
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
     Authority, AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Epoch,
-    EpochDigest, Hash as _, HeaderDigest, Multiaddr, NetworkPublicKey, Notifier,
+    EpochDigest, Hash as _, HeaderDigest, Multiaddr, NetworkPublicKey, ShutdownNotifier,
 };
 use tracing::info;
 
@@ -43,7 +43,7 @@ struct ConsensusConfigInner<DB> {
 #[derive(Debug, Clone)]
 pub struct ConsensusConfig<DB> {
     inner: Arc<ConsensusConfigInner<DB>>,
-    shutdown: Notifier,
+    shutdown: ShutdownNotifier,
 }
 
 impl<DB> ConsensusConfig<DB>
@@ -194,7 +194,7 @@ where
         let primary_public_key = key_config.primary_public_key();
         let authority = committee.authority_by_key(&primary_public_key);
 
-        let shutdown = Notifier::new();
+        let shutdown = ShutdownNotifier::new();
         let genesis = Certificate::genesis(&committee)
             .into_iter()
             .map(|cert| (cert.digest(), cert))
@@ -221,7 +221,7 @@ where
     ///
     /// The shutdown notifier can be used to either subscribe to shutdown events
     /// or trigger shutdown across consensus components.
-    pub fn shutdown(&self) -> &Notifier {
+    pub fn shutdown(&self) -> &ShutdownNotifier {
         &self.shutdown
     }
 

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -21,7 +21,7 @@ use tn_network_libp2p::types::NetworkResult;
 use tn_storage::CertificateStore;
 use tn_types::{
     validate_fetched_certificate, AuthorityIdentifier, BlsPublicKey, Certificate, Committee,
-    Database, Header, Noticer, Notifier, Round, TaskManager, TaskSpawner, TnReceiver,
+    Database, Header, Noticer, Round, ShutdownNotifier, TaskManager, TaskSpawner, TnReceiver,
 };
 use tokio::{
     sync::oneshot,
@@ -460,7 +460,7 @@ async fn fetch_from_peers<F: MissingCertFetcher>(
     fallback_delay: Duration,
 ) -> CertManagerResult<Vec<Certificate>> {
     let (tx_results, mut rx_results) = tokio::sync::mpsc::unbounded_channel();
-    let cancel_signal = Arc::new(Notifier::new());
+    let cancel_signal = Arc::new(ShutdownNotifier::new());
 
     // track requests per peer
     let mut peer_index = 0;

--- a/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
+++ b/crates/consensus/primary/src/consensus/tests/bullshark_tests.rs
@@ -17,7 +17,7 @@ use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStor
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     AuthorityIdentifier, ConsensusHeaderDigest, ConsensusNumHash, EpochDigest, EpochRecord,
-    ExecHeader, Header, Notifier, SealedHeader, TaskManager, TnReceiver, TnSender, B256,
+    ExecHeader, Header, SealedHeader, ShutdownNotifier, TaskManager, TnReceiver, TnSender, B256,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tracing::info;
@@ -832,8 +832,8 @@ async fn committed_round_after_restart() {
         Certificate::genesis(&committee).iter().map(|x| x.digest()).collect::<BTreeSet<_>>();
     let (certificates, _) = make_certificates_with_epoch(&committee, 1..=11, epoch, &genesis, &ids);
 
-    let config = fixture.authorities().next().unwrap().consensus_config();
-    let store = config.node_storage().clone();
+    let fixture_config = fixture.authorities().next().unwrap().consensus_config();
+    let store = fixture_config.node_storage().clone();
     let temp_dir = TempDir::new().unwrap();
     let consensus_chain =
         ConsensusChain::new(temp_dir.path().to_owned(), committee.clone()).unwrap();
@@ -847,6 +847,17 @@ async fn committed_round_after_restart() {
 
     let mut consensus_number = 0u64;
     for input_round in (1..=11usize).step_by(2) {
+        // Build a fresh config for each restart so its one-shot shutdown cannot
+        // leak across iterations; node storage is shared so committed state
+        // survives the restart (same pattern as `restart_with_new_committee`).
+        let config = ConsensusConfig::new_with_committee_for_test(
+            fixture_config.config().clone(),
+            fixture_config.node_storage().clone(),
+            fixture_config.key_config().clone(),
+            committee.clone(),
+            NetworkConfig::default(),
+        )
+        .unwrap();
         let bullshark = Bullshark::new(
             committee.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
@@ -906,8 +917,8 @@ async fn committed_round_after_restart() {
         info!("Committed round adanced to {}", input_round.saturating_sub(1));
 
         // Shutdown consensus and wait for it to stop.
-        fixture.notify_shutdown();
-        let _ = task_manager.join(Notifier::default()).await;
+        config.shutdown().notify();
+        let _ = task_manager.join(ShutdownNotifier::default()).await;
     }
 }
 
@@ -1173,7 +1184,7 @@ async fn restart_with_new_committee() {
         config.shutdown().notify();
 
         // Ensure consensus stopped.
-        let _ = task_manager.join(Notifier::default()).await;
+        let _ = task_manager.join(ShutdownNotifier::default()).await;
     }
 }
 

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::consensus::LeaderSwapTable;
 use indexmap::IndexMap;
 use std::collections::BTreeSet;
+use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{error::HeaderError, now, HeaderBuilder, B256, MAX_HEADER_NUM_OF_BATCHES};
@@ -224,9 +225,22 @@ async fn test_equivocation_protection_after_restart() {
     let cb = ConsensusBus::new();
     let mut rx_headers = cb.subscribe_headers();
     let task_manager = TaskManager::default();
+    // Build a fresh config for the restart, as production does per epoch: the
+    // old config's one-shot shutdown is latched, so a proposer subscribing to
+    // it would exit immediately. Node storage is shared so the equivocation
+    // guard still sees the first proposal.
+    let config = primary.consensus_config();
+    let restarted_config = ConsensusConfig::new_with_committee_for_test(
+        config.config().clone(),
+        config.node_storage().clone(),
+        config.key_config().clone(),
+        committee.clone(),
+        NetworkConfig::default(),
+    )
+    .unwrap();
     let proposer = Proposer::new(
-        primary.consensus_config(),
-        primary.consensus_config().authority_id().expect("authority"),
+        restarted_config.clone(),
+        restarted_config.authority_id().expect("authority"),
         cb.clone(),
         LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
         task_manager.get_spawner(),

--- a/crates/node/src/manager/exex.rs
+++ b/crates/node/src/manager/exex.rs
@@ -84,7 +84,7 @@ mod exex_isolation_tests {
     //! load-bearing and a failing one instead shuts the node down.
     use super::{run_critical_exex_future, run_isolated_exex_future};
     use std::time::Duration;
-    use tn_types::{Notifier, TaskError, TaskJoinError, TaskManager};
+    use tn_types::{ShutdownNotifier, TaskError, TaskJoinError, TaskManager};
 
     #[tokio::test]
     async fn isolated_exex_future_contains_panic_error_and_completion() {
@@ -142,7 +142,7 @@ mod exex_isolation_tests {
         // panicking/finished ExExes had shut the node down, `join` would have
         // returned with one of THEIR names instead of "node-alive".
         stop_tx.send(()).expect("sentinel still running");
-        match task_manager.join(Notifier::default()).await {
+        match task_manager.join(ShutdownNotifier::default()).await {
             Err(TaskJoinError::CriticalExitError(name, _)) => {
                 assert_eq!(name, "node-alive", "shutdown must originate from the critical task");
             }
@@ -180,7 +180,7 @@ mod exex_isolation_tests {
             }),
         );
 
-        match task_manager.join(Notifier::default()).await {
+        match task_manager.join(ShutdownNotifier::default()).await {
             Err(TaskJoinError::CriticalExitError(name, _)) => {
                 assert_eq!(name, "exex-critical", "shutdown must originate from the critical exex");
             }

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -31,8 +31,9 @@ use tn_types::{
     deconstruct_nonce,
     gas_accumulator::{entry_fee_for_worker, GasAccumulator},
     BlsPublicKey, BootstrapServer, Committee, ConsensusHeader, ConsensusHeaderDigest,
-    ConsensusNumHash, ConsensusOutput, Database as TNDatabase, EngineUpdate, Epoch, Notifier,
-    SealedHeader, TaskError, TaskManager, TaskSpawner, TimestampSec, WorkerId, DEFAULT_WORKER_ID,
+    ConsensusNumHash, ConsensusOutput, Database as TNDatabase, EngineUpdate, Epoch, SealedHeader,
+    ShutdownNotifier, TaskError, TaskManager, TaskSpawner, TimestampSec, WorkerId,
+    DEFAULT_WORKER_ID,
 };
 // The canonical worker-attribution helper lives in `tn-types` (one implementation, no drift);
 // re-export so the crate-internal call sites and tests keep referring to it by bare name.
@@ -92,8 +93,8 @@ pub(crate) struct EpochManager<P, DB> {
     worker_network_handle: Option<WorkerNetworkHandle>,
     /// Key config - loaded once for application lifetime.
     key_config: KeyConfig,
-    /// The epoch manager's [Notifier] to shutdown all node processes.
-    node_shutdown: Notifier,
+    /// The epoch manager's [ShutdownNotifier] to shutdown all node processes.
+    node_shutdown: ShutdownNotifier,
     /// The timestamp to close the current epoch.
     ///
     /// The manager monitors leader timestamps for the epoch boundary.
@@ -577,7 +578,7 @@ where
         let _ = std::fs::create_dir_all(&epochs_db_path);
         let consensus_chain = ConsensusChain::new(epochs_db_path, committee_zero)?;
         // shutdown long-running node components
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         let reth_db = builder.reth_db.clone();
 

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -42,8 +42,8 @@ use tn_types::{
     forks::seed_signature_active,
     gas_accumulator::{next_base_fee_for_config, GasAccumulator},
     BlsPublicKey, Committee, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase, Epoch,
-    EpochDigest, EpochRecord, Notifier, SealedHeader, TaskJoinError, TaskManager, TaskSpawner,
-    TnReceiver,
+    EpochDigest, EpochRecord, SealedHeader, ShutdownNotifier, TaskJoinError, TaskManager,
+    TaskSpawner, TnReceiver,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
@@ -891,7 +891,7 @@ where
 
     /// Finalize an epoch once its boundary output has been identified.
     ///
-    /// Begins shutting consensus down (when a [`Notifier`] is supplied) so it winds down in
+    /// Begins shutting consensus down (when a [`ShutdownNotifier`] is supplied) so it winds down in
     /// parallel while the engine finishes executing up to `target_hash`, then blocks until that
     /// execution is confirmed. On the live boundary path it then recomputes each worker's
     /// next-epoch base fee ([`adjust_base_fees`]); the restart replay-and-close and leftover-drain
@@ -907,7 +907,7 @@ where
     /// [`GasAccumulator`] so the next epoch starts from zero.
     async fn close_epoch(
         &self,
-        shutdown_consensus: Option<Notifier>,
+        shutdown_consensus: Option<ShutdownNotifier>,
         reth_env: &RethEnv,
         gas_accumulator: &GasAccumulator,
         target_hash: ConsensusHeaderDigest,

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -9,7 +9,7 @@ use tn_primary::{
 };
 use tn_storage::{certificate_pack::CertificatePack, consensus::ConsensusChain};
 use tn_types::{
-    Committee, Database as ConsensusDatabase, Notifier, TaskManager,
+    Committee, Database as ConsensusDatabase, ShutdownNotifier, TaskManager,
     DEFAULT_BAD_NODES_STAKE_THRESHOLD,
 };
 use tokio::sync::RwLock;
@@ -152,8 +152,8 @@ impl<CDB: ConsensusDatabase> PrimaryNode<CDB> {
         self.internal.read().await.primary.state_sync()
     }
 
-    /// Return the [Noticer] shutdown for consensus.
-    pub async fn shutdown_signal(&self) -> Notifier {
+    /// Return the [ShutdownNotifier] shutdown for consensus.
+    pub async fn shutdown_signal(&self) -> ShutdownNotifier {
         self.internal.read().await.consensus_config.shutdown().clone()
     }
 

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -33,16 +33,16 @@ pub fn default_test_execution_node(
     )?;
 
     // create engine node
+    // Leak the manager: a dropped TaskManager latches its one-shot shutdown, which
+    // would cancel every task later spawned through the retained spawner.
+    let task_manager = Box::leak(Box::new(TaskManager::default()));
     let engine = if let Some(chain) = opt_chain {
         ExecutionNode::new(
             &builder,
-            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir, &TaskManager::default(), rewards)?,
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir, task_manager, rewards)?,
         )?
     } else {
-        ExecutionNode::new(
-            &builder,
-            RethEnv::new_for_test(tmp_dir, &TaskManager::default(), rewards)?,
-        )?
+        ExecutionNode::new(&builder, RethEnv::new_for_test(tmp_dir, task_manager, rewards)?)?
     };
 
     Ok(engine)

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -552,7 +552,9 @@ mod tests {
     }
 
     fn test_forwarder_with(policy: ForwardTargetPolicy) -> WorkerRpcForwarder {
-        WorkerRpcForwarder::new(TaskManager::default().get_spawner(), policy)
+        // Leak the manager: a dropped TaskManager latches its one-shot shutdown,
+        // which would cancel any task later spawned through the spawner.
+        WorkerRpcForwarder::new(Box::leak(Box::new(TaskManager::default())).get_spawner(), policy)
     }
 
     fn test_key(seed: u8) -> BlsPublicKey {

--- a/crates/types/src/notifier.rs
+++ b/crates/types/src/notifier.rs
@@ -65,6 +65,64 @@ impl Default for Notifier {
     }
 }
 
+/// One-shot variant of [`Notifier`] for signals that fire at most once, like shutdown or
+/// cancellation.
+///
+/// The notified state is sticky: once notify() is called, every later subscribe() returns a
+/// [`Noticer`] that resolves immediately. This closes the orphan path where a subscriber that
+/// arrives after the signal would wait forever. Use [`Notifier`] instead when the signal
+/// re-arms after each notify() (like the certifier's per-proposal cancel).
+#[derive(Clone, Debug)]
+pub struct ShutdownNotifier {
+    /// The sticky notified flag and the Noticers subscribed before notify().
+    inner: Arc<Mutex<(bool, Vec<Noticer>)>>,
+}
+
+impl ShutdownNotifier {
+    /// Create a new un-notified ShutdownNotifier.
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new((false, Vec::new()))) }
+    }
+
+    /// Get a Noticer that will resolve once this ShutdownNotifier is notified.
+    /// A subscribe() after notify() returns a Noticer that resolves immediately.
+    pub fn subscribe(&self) -> Noticer {
+        let mut inner = self.inner.lock();
+        let notified = inner.0;
+        let lock = Arc::new(Mutex::new((notified, None)));
+        let noticer = Noticer { lock: lock.clone() };
+        if !notified {
+            inner.1.push(Noticer { lock });
+        }
+        noticer
+    }
+
+    /// Resolve all the subscribed Noticers and latch the notified state so any later
+    /// subscribe() resolves immediately.
+    pub fn notify(&self) {
+        let mut inner = self.inner.lock();
+        inner.0 = true;
+        let wakers: Vec<Waker> = inner
+            .1
+            .drain(..)
+            .filter_map(|noticer| {
+                let mut guard = noticer.lock.lock();
+                guard.0 = true;
+                guard.1.take()
+            })
+            .collect();
+        drop(inner);
+        // Wake everyone up after all flags are set to true to avoid races in noticers.
+        wakers.into_iter().for_each(Waker::wake);
+    }
+}
+
+impl Default for ShutdownNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Noticer {
     /// Return true of this Noticer has been noticed.
     /// I.e. the future has or will resolve.
@@ -105,9 +163,52 @@ impl Future for &Noticer {
 
 #[cfg(test)]
 mod test {
-    use crate::Notifier;
+    use crate::{Notifier, ShutdownNotifier};
     use parking_lot::Mutex;
     use std::{sync::Arc, time::Duration};
+
+    #[tokio::test]
+    async fn test_shutdown_notifier_late_subscribe_resolves() {
+        let notifier = ShutdownNotifier::new();
+        let early = notifier.subscribe();
+        let (early_done_tx, early_done_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            early.await;
+            let _ = early_done_tx.send(());
+        });
+        // Let the spawned task park on the noticer so notify() must wake it
+        // (covers the waker path, not just the sticky flag).
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        notifier.notify();
+        tokio::time::timeout(Duration::from_secs(1), early_done_rx)
+            .await
+            .expect("notify wakes the parked noticer")
+            .expect("early subscriber task completes");
+        let late = notifier.subscribe();
+        assert!(late.noticed());
+        tokio::time::timeout(Duration::from_secs(1), late)
+            .await
+            .expect("noticer subscribed after notify resolves");
+    }
+
+    #[tokio::test]
+    async fn test_notifier_rearms_after_notify() {
+        // Pin the re-arm behavior the certifier depends on: a subscribe after a notify
+        // starts un-noticed and resolves on the next notify.
+        let notifier = Notifier::new();
+        let first = notifier.subscribe();
+        notifier.notify();
+        tokio::time::timeout(Duration::from_secs(1), first)
+            .await
+            .expect("first subscription resolves on first notify");
+        let second = notifier.subscribe();
+        assert!(!second.noticed());
+        notifier.notify();
+        tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("second subscription resolves on second notify");
+    }
 
     #[tokio::test]
     async fn test_notifier() {

--- a/crates/types/src/task_manager.rs
+++ b/crates/types/src/task_manager.rs
@@ -1,6 +1,6 @@
 //! Task manager interface to spawn tasks to the tokio runtime.
 
-use crate::Notifier;
+use crate::ShutdownNotifier;
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use std::{
     fmt::{Debug, Display},
@@ -135,7 +135,7 @@ pub struct TaskManager {
     new_task_tx: mpsc::Sender<TaskHandle>,
     /// This is used to notify any spawned tasks to exit when task manager is dropped.
     /// Otherwise we will end up with orphaned tasks when epochs change.
-    local_shutdown: Notifier,
+    local_shutdown: ShutdownNotifier,
     /// How long to wait for joins to complete.  This will be used twice (so double it).
     join_wait_millis: u64,
 }
@@ -154,7 +154,7 @@ impl Drop for TaskManager {
 pub struct TaskSpawner {
     /// The channel to forward task handles to the parent [TaskManager].
     new_task_tx: mpsc::Sender<TaskHandle>,
-    local_shutdown: Notifier,
+    local_shutdown: ShutdownNotifier,
 }
 
 impl TaskSpawner {
@@ -198,7 +198,7 @@ impl TaskSpawner {
         });
         if let Err(err) = self.new_task_tx.try_send(TaskHandle::new(name.clone(), handle, critical))
         {
-            tracing::error!(target: "tn::tasks", "Task error sending joiner for {name}: {err}");
+            tracing::error!(target: "tn::tasks", "Failed to track spawned task {name}: {err}. The task is already spawned but untracked: it can never be joined or aborted, and only its shutdown notice can end it.");
         }
     }
 
@@ -301,14 +301,13 @@ impl TaskManager {
             name: name.to_string(),
             new_task_rx,
             new_task_tx,
-            local_shutdown: Notifier::default(),
+            local_shutdown: ShutdownNotifier::default(),
             join_wait_millis: 2000,
         }
     }
 
-    /// Sets the amount of time this task manager will wait on tasks/submanagers to complete.
-    /// Will be used twice in join, once for tasks and once for subtasks so max wait will
-    /// 2x this value (min).
+    /// Sets the amount of time this task manager will wait for its tasks to complete
+    /// during shutdown (the timeout for [`Self::wait_for_task_shutdown`]).
     pub fn set_join_wait(&mut self, millis: u64) {
         self.join_wait_millis = millis;
     }
@@ -362,7 +361,7 @@ impl TaskManager {
     ///
     /// The manager tracks critical and non-critical tasks. Critical tasks
     /// that stop force the process to shutdown.
-    pub async fn join(&mut self, shutdown: Notifier) -> Result<(), TaskJoinError> {
+    pub async fn join(&mut self, shutdown: ShutdownNotifier) -> Result<(), TaskJoinError> {
         self.join_internal(shutdown, false).await
     }
 
@@ -371,7 +370,10 @@ impl TaskManager {
     /// Note the manager is based on the assumption that all tasks added via spawn_task
     /// are critical and and one stopping is problem.
     /// Also will end if the user hits ctrl-c or sends a SIGTERM to the app.
-    pub async fn join_until_exit(&mut self, shutdown: Notifier) -> Result<(), TaskJoinError> {
+    pub async fn join_until_exit(
+        &mut self,
+        shutdown: ShutdownNotifier,
+    ) -> Result<(), TaskJoinError> {
         self.join_internal(shutdown, true).await
     }
 
@@ -382,7 +384,7 @@ impl TaskManager {
     /// are critical and and one stopping is problem.
     /// Also will end if the user hits ctrl-c or sends a SIGTERM to the app.
     /// This will not join the tasks but resolves as soon as shutdown is indicated.
-    pub async fn until_exit(&mut self, shutdown: Notifier) -> Result<(), TaskJoinError> {
+    pub async fn until_exit(&mut self, shutdown: ShutdownNotifier) -> Result<(), TaskJoinError> {
         self.until_exit_internal(shutdown, true).await
     }
 
@@ -391,7 +393,10 @@ impl TaskManager {
     /// Note the manager is based on the assumption that all tasks added via spawn_task
     /// are critical and and one stopping is problem.
     /// This will not join the tasks but resolves as soon as shutdown is indicated.
-    pub async fn until_task_ends(&mut self, shutdown: Notifier) -> Result<(), TaskJoinError> {
+    pub async fn until_task_ends(
+        &mut self,
+        shutdown: ShutdownNotifier,
+    ) -> Result<(), TaskJoinError> {
         self.until_exit_internal(shutdown, false).await
     }
 
@@ -409,7 +414,7 @@ impl TaskManager {
         }
     }
 
-    /// Abort all tasks including submanagers.
+    /// Abort all of this manager's tasks.
     ///
     /// This is used to close epoch-related tasks.
     pub fn abort_all_tasks(&mut self) {
@@ -430,7 +435,7 @@ impl TaskManager {
     /// Resolves when the task manager should exit.
     async fn until_exit_internal(
         &mut self,
-        shutdown: Notifier,
+        shutdown: ShutdownNotifier,
         do_exit: bool,
     ) -> Result<(), TaskJoinError> {
         let rx_shutdown = shutdown.subscribe();
@@ -538,7 +543,7 @@ impl TaskManager {
     /// Implements the join logic for the manager.
     async fn join_internal(
         &mut self,
-        shutdown: Notifier,
+        shutdown: ShutdownNotifier,
         do_exit: bool,
     ) -> Result<(), TaskJoinError> {
         let result = self.until_exit_internal(shutdown, do_exit).await;
@@ -637,7 +642,7 @@ mod test {
 
     use tokio::sync::mpsc::{self, Receiver, Sender};
 
-    use crate::{Notifier, TaskError, TaskJoinError, TaskManager};
+    use crate::{ShutdownNotifier, TaskError, TaskJoinError, TaskManager};
 
     struct Ping {
         ping_rx: Receiver<u32>,
@@ -807,7 +812,7 @@ mod test {
     async fn test_task_manager_join() {
         let mut task_manager = TaskManager::default();
         task_manager.spawn_critical_task("Crit 1", async move { Ok(()) });
-        match task_manager.join(Notifier::default()).await {
+        match task_manager.join(ShutdownNotifier::default()).await {
             Ok(_) => {}
             Err(TaskJoinError::CriticalExitOk(name)) => assert!(name.eq("Crit 1")),
             Err(TaskJoinError::CriticalJoinError(_name, _err)) => panic!("wrong error"),
@@ -820,7 +825,7 @@ mod test {
         });
         task_manager
             .spawn_critical_task("Crit 2", async move { Err(TaskError::from_message("BOOM!")) });
-        match task_manager.join(Notifier::default()).await {
+        match task_manager.join(ShutdownNotifier::default()).await {
             Ok(_) => {}
             Err(TaskJoinError::CriticalExitOk(_name)) => panic!("should not be OK"),
             Err(TaskJoinError::CriticalJoinError(_name, _err)) => panic!("wrong error"),


### PR DESCRIPTION
Closes #1134.

## Problem

`Notifier` keeps its subscribers in a vec, and `notify` flags only the subscribers that exist at that moment. A `subscribe` that happens after `notify` starts unflagged, and nothing ever flags it, so the returned future is pending forever.

For shutdown this is a real orphan path. The only place `local_shutdown.notify` runs is `TaskManager::Drop`, and `create_task` subscribes at spawn time. A task spawned through a `TaskSpawner` whose manager has already dropped gets a shutdown future that never fires: the task runs untracked and cannot be cancelled. Stale spawners exist across epoch boundaries (the worker network handle's spawner is replaced only at the next epoch start; the RPC forwarder captures its spawner once at construction and never refreshes it), so no attacker is required . . . an ordinary epoch transition can leak such tasks.

## Fix

- [x] `crates/types/src/notifier.rs`: add `ShutdownNotifier`, a one-shot variant whose notified state is sticky. A `subscribe` after `notify` returns a `Noticer` that resolves immediately. `Notifier` keeps its re-arming semantics for the certifier's per-proposal cancel (`new_proposal`), which is re-subscribed on every proposal and must not auto-cancel after the first header.
- [x] Adopt `ShutdownNotifier` where the semantics are genuinely one-shot: `TaskManager::local_shutdown` (and its `TaskSpawner` clone), the consensus config's shutdown, the certificate fetcher's per-fetch cancel signal, the epoch manager's `node_shutdown`, and the worker gateway's shutdown. The `TaskManager` join family (`join`, `join_until_exit`, `until_exit`, `until_task_ends`) now takes `ShutdownNotifier`: `until_exit_internal` notifies the passed signal on exit, so every signal that flows through it is one-shot by contract. Per-epoch safety holds because each epoch constructs a fresh `ConsensusConfig` (and so a fresh notifier); stickiness cannot leak across epochs.
- [x] `crates/types/src/task_manager.rs`: the `try_send` failure log in `create_task` now states the real consequence (the task is already spawned but untracked: it can never be joined or aborted, and only its shutdown notice can end it). The two doc comments that referenced nonexistent submanagers (`set_join_wait`, `abort_all_tasks`) are corrected.
- [x] Test infrastructure adapted to the one-shot contract. `committed_round_after_restart` reused one fixture config across six restart iterations and re-armed it with `notify_shutdown`; it now builds a fresh per-iteration config over the shared store, the same pattern `restart_with_new_committee` already uses. `test_equivocation_protection_after_restart` restarted its proposer against the same latched config, which made the second proposer exit at startup and the test hang at the digest ack; its restart phase now builds a fresh config over the same store, so the equivocation guard still sees the first proposal. `test-utils` `default_test_execution_node` and the `tn-reth` forwarder test fixture passed a temporary `TaskManager` whose immediate drop now latches shutdown; both leak the manager instead so tasks spawned through the retained spawner still run.

## Testing

- New `test_shutdown_notifier_late_subscribe_resolves`: an early subscriber parks on its `Noticer` in a spawned task (covering the waker path), then a subscribe after `notify` resolves immediately. Confirmed by mutation twice: with the sticky-flag seed reverted the test fails on `late.noticed()`, and with the wake call deleted it fails on the parked subscriber timeout.
- New `test_notifier_rearms_after_notify`: pins the re-arm behavior the certifier depends on. Subscribe, notify, subscribe again, notify again; both subscriptions resolve, the second one only on the second notify.
- `cargo +1.94 check --all-targets` green over the full 25-crate reverse-dependency closure; `cargo +1.94 test -p tn-types` (notifier and task manager suites) and `cargo +1.94 test -p tn-primary` (full proposer suite plus `committed_round_after_restart`, `restart_with_new_committee`) green. The proposer restart hang was reproduced against the unadapted test and resolves with the fresh-config restart.
- `make attest` gates on the pinned toolchain: nightly fmt check, nightly `clippy --workspace` (default and `--all-features`), and `cargo +1.94 test --no-run --workspace` in an isolated target dir.
