### PR TITLE
Added some comparative benchmarks for cache DB backends.

### DIFF
--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -2081,7 +2081,9 @@ pub(crate) mod test {
     /// Build a [`ConsensusOutput`] whose single leader header references `num_batches` unique
     /// batches, standing in for a deep sub-DAG that exceeds the old fixed reconstruction cap
     /// but stays within the committee-derived bound.
-    fn make_wide_test_output(
+    ///
+    /// Reused by `pack_bench` as the single output-width knob for the observation benchmark.
+    pub(crate) fn make_wide_test_output(
         committee: &Committee,
         chain: Arc<RethChainSpec>,
         number: u64,

--- a/crates/storage/src/db_bench.rs
+++ b/crates/storage/src/db_bench.rs
@@ -1,0 +1,456 @@
+//! Comparative benchmark harness for the consensus [`Database`] backends.
+//!
+//! [`crate::test::db_simp_bench`] times a single backend on one big 50k insert/commit. That hides
+//! what dominates real node DB cost: **many small, frequently-committed, durable transactions** on
+//! the consensus hot path (per-certificate ~3 inserts, externalized under a durability barrier),
+//! plus large epoch-boundary `clear_table`s. This module runs a *list* of backends through a
+//! battery of **basic** and **representative-of-real-usage** benchmarks and prints one easy-to-read
+//! side-by-side comparison, so the current DB implementation's performance can be examined.
+//!
+//! Run it on demand (it is `#[ignore]`d out of the default suite):
+//!
+//! ```text
+//! cargo test -p tn-storage db_backend_comparison -- --ignored --nocapture --test-threads 1
+//! ```
+//!
+//! ## What it models
+//!
+//! Values are sized `Vec<u8>` **proxies** for the real serialized records — the KV backends measure
+//! bytes, so a 1.5 KB blob stresses them exactly like a 1.5 KB `Certificate` without the heavy
+//! committee/BLS construction. Sizes: ~48 B index rows, ~1.5 KB certificates, ~256 KB batch bodies.
+//! Two tables exercise both `CompositeDatabase` routes: [`BenchEpoch`] (`Epoch` hint — the durable
+//! hot path) and [`BenchCache`] (`Cache` hint — the batch cache).
+//!
+//! ## Caveats (printed with the results too)
+//!
+//! - `LayeredDatabase`/`CompositeDatabase` `commit()` is **async** — it queues the disk write and
+//!   returns. The real per-commit durability cost shows up under `durable_commits`, which awaits
+//!   the production async `persist()` barrier after each commit (the same barrier the proposer /
+//!   vote / certifier `await` before externalizing); `small_commits` is the same workload without
+//!   it, so the delta is the durability cost. (The test-only `sync_persist` — which polls with a
+//!   100 ms sleep — is deliberately NOT used here; it would measure the poll, not the barrier.)
+//! - Under `#[cfg(test)]` the MDBX env opens `SafeNoSync` (no per-commit `fsync`, see
+//!   `mdbx/database.rs`), so these numbers reflect the **test** durability mode, not production
+//!   fsync.
+
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use tn_types::{Database, DbTx as _, DbTxMut as _, Table, TableHint};
+
+use tokio::runtime::Runtime;
+
+/// Durable hot-path table (certificates / indexes / votes live on the `Epoch` route).
+#[derive(Debug)]
+struct BenchEpoch;
+impl Table for BenchEpoch {
+    type Key = u64;
+    type Value = Vec<u8>;
+    const NAME: &'static str = "BenchEpoch";
+    const HINT: TableHint = TableHint::Epoch;
+}
+
+/// Batch-cache table (worker batches live on the non-durable `Cache` route).
+#[derive(Debug)]
+struct BenchCache;
+impl Table for BenchCache {
+    type Key = u64;
+    type Value = Vec<u8>;
+    const NAME: &'static str = "BenchCache";
+    const HINT: TableHint = TableHint::Cache;
+}
+
+// ---- workload sizing (heavier than db_simp_bench; this is an on-demand perf test) ----
+
+const BASIC_N: u64 = 50_000; // baseline bulk workload, matches db_simp_bench
+const SMALL_VAL: usize = 48; // index-row sized
+const CERT_VAL: usize = 1_536; // ~1.5 KB, certificate sized
+const BATCH_VAL: usize = 256 * 1024; // 256 KB, batch-body sized
+
+// The commit counts are kept modest because they dominate wall time on the disk backends (raw ReDB
+// is ~5 ms per durable commit — each is a full transaction). The relative signal is identical at
+// larger N — scale these up for more samples / heavier load.
+const SMALL_COMMITS: u64 = 500; // transactions, 3 small inserts each
+const DURABLE_COMMITS: u64 = 500; // same as SMALL_COMMITS, but + a `persist()` barrier per commit
+const CERT_ROWS: u64 = 5_000;
+const CERT_PER_TXN: u64 = 100; // ~per-round batch of certificate writes
+const BATCH_ROWS: u64 = 200;
+const BATCH_PER_TXN: u64 = 10;
+const CLEAR_ROWS: u64 = 20_000; // epoch-teardown population
+const MIXED_N: u64 = 1_000;
+
+/// A deterministic, non-trivial value of `size` bytes (so we aren't measuring an all-zero fast
+/// path).
+fn make_value(size: usize, seed: u64) -> Vec<u8> {
+    let s = seed.to_le_bytes();
+    (0..size).map(|i| s[i % 8].wrapping_add(i as u8)).collect()
+}
+
+/// Drive the production async `persist::<T>()` durability barrier to completion. Raw backends'
+/// default `persist` is a ready-`Ok` no-op (they are synchronously durable), so this is ~instant
+/// for them; the layered/composite backends await a real disk-commit ack. Driven on `rt` so the
+/// sync harness can use the async production barrier — not the test-only `sync_persist`, which
+/// merely polls with a sleep.
+fn barrier<T: Table, DB: Database>(rt: &Runtime, db: &DB) {
+    rt.block_on(db.persist::<T>()).expect("persist barrier");
+}
+
+/// Empty a table and durably settle it, so the next benchmark starts from a clean state. Untimed.
+fn reset<T: Table, DB: Database>(rt: &Runtime, db: &DB) {
+    db.clear_table::<T>().expect("clear_table");
+    barrier::<T, _>(rt, db);
+}
+
+// ---- the battery: each returns the timed duration for its measured region ----
+
+/// Bulk-load `BenchEpoch` with `BASIC_N` small rows in one transaction (insert + commit timed).
+fn bench_bulk_insert<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let start = Instant::now();
+    let mut txn = db.write_txn().expect("write_txn");
+    for i in 0..BASIC_N {
+        txn.insert::<BenchEpoch>(&i, &make_value(SMALL_VAL, i)).expect("insert");
+    }
+    txn.commit().expect("commit");
+    let elapsed = start.elapsed();
+    barrier::<BenchEpoch, _>(rt, db); // settle before the read benchmarks (untimed)
+    assert!(db.get::<BenchEpoch>(&0).expect("get").is_some(), "bulk insert must be visible");
+    elapsed
+}
+
+/// Full forward iteration over the `BASIC_N` rows left by [`bench_bulk_insert`].
+fn bench_iter_forward<DB: Database>(db: &DB) -> Duration {
+    let start = Instant::now();
+    let count = db.iter::<BenchEpoch>().count();
+    let elapsed = start.elapsed();
+    assert_eq!(count as u64, BASIC_N, "forward iter must see every row");
+    elapsed
+}
+
+/// Full reverse iteration over the same rows.
+fn bench_iter_reverse<DB: Database>(db: &DB) -> Duration {
+    let start = Instant::now();
+    let count = db.reverse_iter::<BenchEpoch>().count();
+    let elapsed = start.elapsed();
+    assert_eq!(count as u64, BASIC_N, "reverse iter must see every row");
+    elapsed
+}
+
+/// Point-get every key inside a single read transaction.
+fn bench_point_get_txn<DB: Database>(db: &DB) -> Duration {
+    let start = Instant::now();
+    let txn = db.read_txn().expect("read_txn");
+    let mut found = 0u64;
+    for i in 0..BASIC_N {
+        if txn.get::<BenchEpoch>(&i).expect("get").is_some() {
+            found += 1;
+        }
+    }
+    drop(txn);
+    let elapsed = start.elapsed();
+    assert_eq!(found, BASIC_N, "every key must be found");
+    elapsed
+}
+
+/// Clear the populated `BenchEpoch` table in one transaction.
+fn bench_clear_table<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    let start = Instant::now();
+    let mut txn = db.write_txn().expect("write_txn");
+    txn.clear_table::<BenchEpoch>().expect("clear_table");
+    txn.commit().expect("commit");
+    let elapsed = start.elapsed();
+    barrier::<BenchEpoch, _>(rt, db);
+    elapsed
+}
+
+/// `SMALL_COMMITS` tiny transactions, each 3 inserts + commit — isolates per-commit overhead (the
+/// per-round certificate write pattern). Commit is async on the layered backends.
+fn bench_small_commits<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let val = make_value(SMALL_VAL, 7);
+    let start = Instant::now();
+    for r in 0..SMALL_COMMITS {
+        let mut txn = db.write_txn().expect("write_txn");
+        let base = r * 3;
+        txn.insert::<BenchEpoch>(&base, &val).expect("insert cert");
+        txn.insert::<BenchEpoch>(&(base + 1), &val).expect("insert idx1");
+        txn.insert::<BenchEpoch>(&(base + 2), &val).expect("insert idx2");
+        txn.commit().expect("commit");
+    }
+    start.elapsed()
+}
+
+/// Like [`bench_small_commits`] but `sync_persist`s after each commit — the durable externalization
+/// pattern (proposer header / vote / proposed-cert), where losing a record across a crash would let
+/// an honest node equivocate. This is the row where async-layered and raw-durable diverge most.
+fn bench_durable_commits<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let val = make_value(SMALL_VAL, 9);
+    let start = Instant::now();
+    for r in 0..DURABLE_COMMITS {
+        let mut txn = db.write_txn().expect("write_txn");
+        let base = r * 3;
+        txn.insert::<BenchEpoch>(&base, &val).expect("insert cert");
+        txn.insert::<BenchEpoch>(&(base + 1), &val).expect("insert idx1");
+        txn.insert::<BenchEpoch>(&(base + 2), &val).expect("insert idx2");
+        txn.commit().expect("commit");
+        barrier::<BenchEpoch, _>(rt, db); // production async `persist()` durability barrier
+    }
+    start.elapsed()
+}
+
+/// `CERT_ROWS` certificate-sized (~1.5 KB) rows written in `CERT_PER_TXN`-sized batches (a round's
+/// worth of certificates per commit).
+fn bench_cert_writes<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let val = make_value(CERT_VAL, 11);
+    let start = Instant::now();
+    let mut key = 0u64;
+    while key < CERT_ROWS {
+        let mut txn = db.write_txn().expect("write_txn");
+        for _ in 0..CERT_PER_TXN {
+            if key >= CERT_ROWS {
+                break;
+            }
+            txn.insert::<BenchEpoch>(&key, &val).expect("insert cert");
+            key += 1;
+        }
+        txn.commit().expect("commit");
+    }
+    start.elapsed()
+}
+
+/// `BATCH_ROWS` batch-sized (256 KB) values into the `Cache`-routed table.
+fn bench_batch_writes<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchCache, _>(rt, db);
+    let val = make_value(BATCH_VAL, 13);
+    let start = Instant::now();
+    let mut key = 0u64;
+    while key < BATCH_ROWS {
+        let mut txn = db.write_txn().expect("write_txn");
+        for _ in 0..BATCH_PER_TXN {
+            if key >= BATCH_ROWS {
+                break;
+            }
+            txn.insert::<BenchCache>(&key, &val).expect("insert batch");
+            key += 1;
+        }
+        txn.commit().expect("commit");
+    }
+    let elapsed = start.elapsed();
+    barrier::<BenchCache, _>(rt, db);
+    elapsed
+}
+
+/// Populate `CLEAR_ROWS` durable rows (untimed) then clear them all in one transaction — the
+/// epoch-teardown pattern (`close_epoch.rs` clears the epoch tables in a single txn).
+fn bench_epoch_clear<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let val = make_value(SMALL_VAL, 15);
+    let mut txn = db.write_txn().expect("write_txn");
+    for i in 0..CLEAR_ROWS {
+        txn.insert::<BenchEpoch>(&i, &val).expect("insert");
+    }
+    txn.commit().expect("commit");
+    barrier::<BenchEpoch, _>(rt, db);
+
+    let start = Instant::now();
+    let mut txn = db.write_txn().expect("write_txn");
+    txn.clear_table::<BenchEpoch>().expect("clear_table");
+    txn.commit().expect("commit");
+    let elapsed = start.elapsed();
+    barrier::<BenchEpoch, _>(rt, db);
+    elapsed
+}
+
+/// Interleave a committed insert with a read of a previously-written key (read-your-writes during
+/// consensus).
+fn bench_mixed_rw<DB: Database>(rt: &Runtime, db: &DB) -> Duration {
+    reset::<BenchEpoch, _>(rt, db);
+    let val = make_value(SMALL_VAL, 17);
+    let start = Instant::now();
+    for i in 0..MIXED_N {
+        db.insert::<BenchEpoch>(&i, &val).expect("insert");
+        if i > 0 {
+            let _ = db.get::<BenchEpoch>(&(i - 1)).expect("get");
+        }
+    }
+    start.elapsed()
+}
+
+/// The ordered battery. Keep names short and stable — they are the report's row labels.
+fn run_battery<DB: Database>(rt: &Runtime, db: &DB) -> Vec<(&'static str, Duration)> {
+    // Basic ops share `BenchEpoch` state in sequence, like `db_simp_bench`.
+    vec![
+        ("bulk_insert 50k", bench_bulk_insert(rt, db)),
+        ("iter_forward 50k", bench_iter_forward(db)),
+        ("iter_reverse 50k", bench_iter_reverse(db)),
+        ("point_get_txn 50k", bench_point_get_txn(db)),
+        ("clear_table 50k", bench_clear_table(rt, db)),
+        // Representative node-usage patterns (each resets its own table first).
+        ("small_commits 500 x3", bench_small_commits(rt, db)),
+        ("durable_commits 50 x3", bench_durable_commits(rt, db)),
+        ("cert_writes 5k x1.5KB", bench_cert_writes(rt, db)),
+        ("batch_writes 200 x256KB", bench_batch_writes(rt, db)),
+        ("epoch_clear 20k", bench_epoch_clear(rt, db)),
+        ("mixed_rw 1k", bench_mixed_rw(rt, db)),
+    ]
+}
+
+/// Collects one results column per backend and prints an aligned comparison table.
+struct BenchSuite {
+    /// Benchmark row labels, captured from the first backend and reused for alignment.
+    order: Vec<&'static str>,
+    /// `(backend name, per-benchmark durations aligned to `order`)`.
+    columns: Vec<(String, Vec<Duration>)>,
+}
+
+impl BenchSuite {
+    fn new() -> Self {
+        Self { order: Vec::new(), columns: Vec::new() }
+    }
+
+    /// Run the whole battery on `db`, appending a comparison column. Generic per backend because
+    /// `Database: Clone` is not object-safe (so no `Vec<Box<dyn Database>>`).
+    fn run<DB: Database>(&mut self, rt: &Runtime, db: DB, name: &str) {
+        println!("  running battery for {name} ...");
+        let results = run_battery(rt, &db);
+        if self.order.is_empty() {
+            self.order = results.iter().map(|(n, _)| *n).collect();
+        }
+        self.columns.push((name.to_string(), results.into_iter().map(|(_, d)| d).collect()));
+        // Drop the backend (and its temp files / background writer) before the next one.
+        drop(db);
+    }
+
+    /// Print the side-by-side comparison (milliseconds; lower is better).
+    fn report(&self) {
+        let label_w = self.order.iter().map(|s| s.len()).max().unwrap_or(0).max("benchmark".len());
+        let cell_w = 12usize;
+
+        println!("\n=== DB backend comparison (ms; lower is better) ===");
+        println!("legend: layered/composite commit() is async (see durable_commits); test-cfg MDBX is SafeNoSync (no fsync).");
+
+        // header
+        print!("{:<label_w$}", "benchmark", label_w = label_w);
+        for (name, _) in &self.columns {
+            print!(" {:>cell_w$}", name, cell_w = cell_w);
+        }
+        println!();
+
+        // rows
+        for (row, label) in self.order.iter().enumerate() {
+            print!("{:<label_w$}", label, label_w = label_w);
+            for (_, times) in &self.columns {
+                let ms = times[row].as_secs_f64() * 1000.0;
+                print!(" {:>cell_w$}", format!("{ms:.2}"), cell_w = cell_w);
+            }
+            println!();
+        }
+        println!();
+    }
+}
+
+// ---- backend construction (mirrors the module-local `open_*` helpers) ----
+
+use crate::{
+    composite_db::CompositeDatabase, layered_db::LayeredDatabase, mem_db::MemDatabase, ReDB,
+};
+
+/// Open both bench tables on `db`; `open_table` propagates through the layered/composite wrappers.
+fn open_bench_tables<DB: Database>(db: &DB) {
+    db.open_table::<BenchEpoch>().expect("open BenchEpoch");
+    db.open_table::<BenchCache>().expect("open BenchCache");
+}
+
+fn build_mem() -> MemDatabase {
+    let db = MemDatabase::new();
+    open_bench_tables(&db);
+    db
+}
+
+fn build_redb(path: &Path) -> ReDB {
+    let db = ReDB::open(path).expect("open redb");
+    open_bench_tables(&db);
+    db
+}
+
+fn build_layered_redb(path: &Path) -> LayeredDatabase<ReDB> {
+    let db = LayeredDatabase::open(ReDB::open(path).expect("open redb"), true);
+    open_bench_tables(&db);
+    db
+}
+
+fn build_composite_redb(base: &Path) -> CompositeDatabase<ReDB> {
+    std::fs::create_dir_all(base).expect("create composite dir");
+    let epoch = ReDB::open(base.join("epoch")).expect("open redb epoch");
+    let kad = ReDB::open(base.join("kad")).expect("open redb kad");
+    let cache = ReDB::open(base.join("cache")).expect("open redb cache");
+    let db = CompositeDatabase::open(epoch, kad, cache);
+    open_bench_tables(&db);
+    db
+}
+
+#[cfg(feature = "reth-libmdbx")]
+use crate::mdbx::database::{MdbxDatabase, MEGABYTE};
+
+/// Generous single-env size — the bench holds ~50 MB of batch bodies plus the small/cert tables.
+#[cfg(feature = "reth-libmdbx")]
+const MDBX_SIZE: usize = 512 * 1024 * 1024;
+#[cfg(feature = "reth-libmdbx")]
+fn build_mdbx(path: &Path) -> MdbxDatabase {
+    let db = MdbxDatabase::open(path, 8, MDBX_SIZE, 8 * MEGABYTE).expect("open mdbx");
+    open_bench_tables(&db);
+    db
+}
+
+#[cfg(feature = "reth-libmdbx")]
+fn build_layered_mdbx(path: &Path) -> LayeredDatabase<MdbxDatabase> {
+    let inner = MdbxDatabase::open(path, 8, MDBX_SIZE, 8 * MEGABYTE).expect("open mdbx");
+    let db = LayeredDatabase::open(inner, true);
+    open_bench_tables(&db);
+    db
+}
+
+#[cfg(feature = "reth-libmdbx")]
+fn build_composite_mdbx(base: &Path) -> CompositeDatabase<MdbxDatabase> {
+    std::fs::create_dir_all(base).expect("create composite dir");
+    let epoch =
+        MdbxDatabase::open(base.join("epoch"), 8, MDBX_SIZE, 8 * MEGABYTE).expect("mdbx epoch");
+    let kad = MdbxDatabase::open(base.join("kad"), 8, MDBX_SIZE, 8 * MEGABYTE).expect("mdbx kad");
+    let cache =
+        MdbxDatabase::open(base.join("cache"), 8, MDBX_SIZE, 8 * MEGABYTE).expect("mdbx cache");
+    let db = CompositeDatabase::open(epoch, kad, cache);
+    open_bench_tables(&db);
+    db
+}
+
+/// Compare every available consensus `Database` backend through the benchmark battery.
+///
+/// On-demand perf test (kept out of the default suite). Run with:
+/// `cargo test -p tn-storage db_backend_comparison -- --ignored --nocapture --test-threads 1`.
+#[test]
+#[ignore = "on-demand DB performance comparison; run with --ignored --nocapture --test-threads 1"]
+fn db_backend_comparison() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let base = tmp.path();
+    let mut suite = BenchSuite::new();
+    let runtime = tokio::runtime::Runtime::new().expect("create tokio runtime");
+
+    suite.run(&runtime, build_mem(), "MemDb");
+    suite.run(&runtime, build_redb(&base.join("redb")), "ReDB");
+    suite.run(&runtime, build_layered_redb(&base.join("redb_layered")), "Layered<ReDB>");
+    suite.run(&runtime, build_composite_redb(&base.join("redb_composite")), "Composite<ReDB>");
+
+    #[cfg(feature = "reth-libmdbx")]
+    {
+        suite.run(&runtime, build_mdbx(&base.join("mdbx")), "MDBX");
+        suite.run(&runtime, build_layered_mdbx(&base.join("mdbx_layered")), "Layered<MDBX>");
+        // The production default: CompositeDatabase<MdbxDatabase>.
+        suite.run(&runtime, build_composite_mdbx(&base.join("mdbx_composite")), "Composite<MDBX>");
+    }
+
+    suite.report();
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -20,6 +20,9 @@ pub mod certificate_pack;
 pub mod composite_db;
 pub mod consensus;
 pub mod consensus_pack;
+/// On-demand comparative benchmark harness across the `Database` backends (see `db_bench.rs`).
+#[cfg(test)]
+mod db_bench;
 pub mod epoch_records;
 pub mod exec_state_pack;
 pub mod layered_db;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -29,6 +29,9 @@ pub mod layered_db;
 #[cfg(feature = "reth-libmdbx")]
 pub mod mdbx;
 pub mod mem_db;
+/// On-demand observation benchmark for consensus pack files (see `pack_bench.rs`).
+#[cfg(test)]
+mod pack_bench;
 pub mod pack_validate;
 pub mod redb;
 

--- a/crates/storage/src/pack_bench.rs
+++ b/crates/storage/src/pack_bench.rs
@@ -1,0 +1,438 @@
+//! On-demand **observation** benchmark for consensus pack files ([`ConsensusPack`]).
+//!
+//! The sibling [`crate::db_bench`] compares the KV [`Database`](tn_types::Database) backends
+//! against each other. Pack files are a different storage path with a *single* implementation —
+//! append-only archive files (BCS + per-record ZStd) with position/digest indexes, driven by one
+//! background thread per pack — so there is nothing to compare *against*. This harness instead
+//! **observes** that one implementation across the read/write/stream patterns production actually
+//! uses, and prints one side-by-side table.
+//!
+//! Run it on demand (it is `#[ignore]`d out of the default suite):
+//!
+//! ```text
+//! cargo test -p tn-storage pack_file_bench -- --ignored --nocapture --test-threads 1
+//! ```
+//!
+//! ## What it models (columns = consensus-output width)
+//!
+//! The one knob that drives pack cost in production is how many batches each consensus output
+//! carries — a shallow leader vs a deep sub-DAG. So the report's **columns are output widths**
+//! (`narrow`/`typical`/`wide` = batches per output); every row is the same production pattern run
+//! at each width, so you can read off how each pattern scales with output size. Each column writes
+//! [`NUM_OUTPUTS`] chained outputs built with [`make_wide_test_output`], whose batches are
+//! genuinely distinct across outputs (random transactions), matching production where each output
+//! commits its own batches.
+//!
+//! The rows, grouped, capture the real call sites traced through `consensus_pack.rs` /
+//! `consensus.rs` / `state-sync/src/lib.rs`:
+//!
+//! - **writes** — `save_seq` is the executor hot path (append-only, no barrier); `save_durable`
+//!   adds the async `persist()` barrier after every output (the state-sync `save_consensus` +
+//!   persist pattern). Their delta is the per-output durability cost.
+//! - **persist** — one bulk `persist()` flushing many un-persisted saves (the periodic-flush cost).
+//! - **reads** — random access by number (`header_by_number`), full decode (`full_output`), the raw
+//!   serve-to-peer bytes (`output_bytes`), digest-keyed header and batch lookups
+//!   (`header_by_digest` / `batch_by_digest`, the `HdxIndex` path), and the reverse-scan metadata
+//!   reads (`read_last_committed` / `latest_header`).
+//! - **streams** — the partial catch-up prefix (`prefix_stream` = `consensus_output_end` + read
+//!   `[0, end)`), the full state-sync serve (`full_stream` = sequential read to EOF), and the
+//!   receive side (`stream_import` = replay a whole epoch into a fresh pack).
+//! - **lifecycle** — `reopen_static` opens the finished pack cold (the pack-cache-miss + index-load
+//!   cost).
+//!
+//! ## Caveats (printed with the results too)
+//!
+//! - Test batches carry **one transaction each** — this is the "representative & scalable" sizing:
+//!   width (batches/output), not batch body size, is the lever here. Production batches can be far
+//!   larger; scale [`NUM_OUTPUTS`] / [`WIDTHS`] up for heavier runs.
+//! - `save`/`persist` timings include the background thread's disk IO (the async API awaits its
+//!   ack), on a `tempfile` dir — so they reflect that filesystem, not a specific production disk.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use tempfile::TempDir;
+use tn_reth::RethChainSpec;
+use tn_test_utils::CommitteeFixture;
+use tn_types::{
+    test_genesis, BlockHash, Committee, ConsensusHeader, ConsensusHeaderDigest, ConsensusOutput,
+    Epoch, EpochRecord,
+};
+use tokio::io::AsyncReadExt as _;
+
+use crate::{
+    consensus_pack::{test::make_wide_test_output, ConsensusPack, DATA_NAME},
+    mem_db::MemDatabase,
+};
+
+// ---- workload sizing (representative & scalable; this is an on-demand perf test) ----
+
+/// Consensus outputs written per column. A few hundred keeps the on-demand run quick while giving
+/// stable per-op signal; scale up for heavier samples.
+const NUM_OUTPUTS: u64 = 200;
+
+/// Output shapes: `(label, batches-per-output)`. These are the report columns — the single knob is
+/// how many batches each consensus output carries (shallow leader vs deep sub-DAG), which is what
+/// drives pack read/write/stream cost.
+const WIDTHS: &[(&str, usize)] = &[("narrow x4", 4), ("typical x16", 16), ("wide x64", 64)];
+
+/// Bounded sample for the digest-keyed batch lookups — there are `width * NUM_OUTPUTS` batches, so
+/// a fixed sample keeps `batch_by_digest` comparable to the `header_by_digest` row across widths.
+const BATCH_SAMPLE: usize = 512;
+
+/// Generous ceiling for the state-sync `stream_import` path.
+const IMPORT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cheap-to-clone fixtures shared across every column.
+struct Fixtures {
+    committee: Committee,
+    chain: Arc<RethChainSpec>,
+    previous_epoch: EpochRecord,
+}
+
+impl Fixtures {
+    fn new() -> Self {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        // Default epoch-0 record: keeps `start_consensus_number == 1`, so outputs number from 1.
+        let previous_epoch = EpochRecord {
+            epoch: 0,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            ..Default::default()
+        };
+        Self { committee, chain, previous_epoch }
+    }
+
+    /// On-disk data file for a pack opened at `path` for this epoch (`<path>/epoch-<e>/data`).
+    fn data_path(&self, path: &Path) -> PathBuf {
+        path.join(format!("epoch-{}", self.committee.epoch())).join(DATA_NAME)
+    }
+}
+
+/// Build `NUM_OUTPUTS` chained outputs of the given width (untimed setup). Numbering and parent
+/// chaining mirror `test_consensus_pack`; the batches are distinct per output (random txs).
+fn build_outputs(fx: &Fixtures, width: usize) -> Vec<ConsensusOutput> {
+    let mut outputs = Vec::with_capacity(NUM_OUTPUTS as usize);
+    let mut parent = ConsensusHeader::default().digest();
+    for number in 1..=NUM_OUTPUTS {
+        let output = make_wide_test_output(&fx.committee, fx.chain.clone(), number, parent, width);
+        parent = output.consensus_header_hash();
+        outputs.push(output);
+    }
+    outputs
+}
+
+/// Open a fresh append pack and save every output, un-persisted (setup for the read/stream
+/// battery).
+async fn populate(fx: &Fixtures, outputs: &[ConsensusOutput]) -> (ConsensusPack, TempDir) {
+    let dir = TempDir::with_prefix("pack_bench_read").expect("temp dir");
+    let pack =
+        ConsensusPack::open_append(dir.path(), fx.previous_epoch.clone(), fx.committee.clone())
+            .expect("open pack");
+    for output in outputs {
+        pack.save_consensus_output(output.clone()).await.expect("save");
+    }
+    (pack, dir)
+}
+
+// ---- the battery: each returns the timed duration for its measured region ----
+
+/// Save every output append-only, no durability barrier (the executor hot-path write).
+async fn bench_save_seq(fx: &Fixtures, outputs: &[ConsensusOutput]) -> Duration {
+    let dir = TempDir::with_prefix("pack_bench_save").expect("temp dir");
+    let pack =
+        ConsensusPack::open_append(dir.path(), fx.previous_epoch.clone(), fx.committee.clone())
+            .expect("open pack");
+    let start = Instant::now();
+    for output in outputs {
+        pack.save_consensus_output(output.clone()).await.expect("save");
+    }
+    let elapsed = start.elapsed();
+    pack.persist().await.expect("persist"); // settle before drop (untimed)
+    elapsed
+}
+
+/// Save every output, each followed by a `persist()` barrier (state-sync save + persist). The delta
+/// vs [`bench_save_seq`] is the per-output durability cost.
+async fn bench_save_durable(fx: &Fixtures, outputs: &[ConsensusOutput]) -> Duration {
+    let dir = TempDir::with_prefix("pack_bench_durable").expect("temp dir");
+    let pack =
+        ConsensusPack::open_append(dir.path(), fx.previous_epoch.clone(), fx.committee.clone())
+            .expect("open pack");
+    let start = Instant::now();
+    for output in outputs {
+        pack.save_consensus_output(output.clone()).await.expect("save");
+        pack.persist().await.expect("persist");
+    }
+    start.elapsed()
+}
+
+/// One bulk `persist()` flushing all the un-persisted saves left by [`populate`].
+async fn bench_persist(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    pack.persist().await.expect("persist");
+    start.elapsed()
+}
+
+/// Random-access read of every header by number (index lookup + fetch + decode).
+async fn bench_header_by_number(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    for number in 1..=NUM_OUTPUTS {
+        pack.consensus_header_by_number(number).await.expect("header by number");
+    }
+    start.elapsed()
+}
+
+/// Full decode of every output (range read + decode incl. all batches).
+async fn bench_full_output(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    for number in 1..=NUM_OUTPUTS {
+        pack.get_consensus_output(number).await.expect("full output");
+    }
+    start.elapsed()
+}
+
+/// Raw pack-file bytes for every output (the serve-to-peer path: range read, no decode).
+async fn bench_output_bytes(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    for number in 1..=NUM_OUTPUTS {
+        pack.get_consensus_output_bytes(number).await.expect("output bytes");
+    }
+    start.elapsed()
+}
+
+/// Digest-keyed header lookups over every header digest (the consensus `HdxIndex`).
+async fn bench_header_by_digest(
+    pack: &ConsensusPack,
+    digests: &[ConsensusHeaderDigest],
+) -> Duration {
+    let start = Instant::now();
+    for digest in digests {
+        pack.consensus_header_by_digest(*digest).await.expect("header by digest");
+    }
+    start.elapsed()
+}
+
+/// Digest-keyed batch lookups over a bounded sample (the batch `HdxIndex`).
+async fn bench_batch_by_digest(pack: &ConsensusPack, digests: &[BlockHash]) -> Duration {
+    let start = Instant::now();
+    for digest in digests {
+        pack.batch(*digest).await.expect("batch by digest");
+    }
+    start.elapsed()
+}
+
+/// The `rev_iter(50)` reverse-scan behind `read_last_committed`.
+async fn bench_read_last_committed(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    pack.read_last_committed().await.expect("read last committed");
+    start.elapsed()
+}
+
+/// Single index-tail read of the latest header.
+async fn bench_latest_header(pack: &ConsensusPack) -> Duration {
+    let start = Instant::now();
+    pack.latest_consensus_header().await.expect("latest header");
+    start.elapsed()
+}
+
+/// Partial catch-up serve: resolve the prefix byte offset for the mid output, then read `[0, end)`
+/// of the data file (mirrors `get_partial_epoch_stream`).
+async fn bench_prefix_stream(pack: &ConsensusPack, data_path: &Path) -> Duration {
+    let mid = NUM_OUTPUTS / 2;
+    let start = Instant::now();
+    let end = pack.consensus_output_end(mid).await.expect("output end");
+    let mut file = tokio::fs::File::open(data_path).await.expect("open data file");
+    let mut buf = vec![0u8; end as usize];
+    file.read_exact(&mut buf).await.expect("read prefix");
+    start.elapsed()
+}
+
+/// Full state-sync serve: sequential read of the whole data file to EOF.
+async fn bench_full_stream(data_path: &Path) -> Duration {
+    let start = Instant::now();
+    let mut file = tokio::fs::File::open(data_path).await.expect("open data file");
+    let mut sink = Vec::new();
+    file.read_to_end(&mut sink).await.expect("read all");
+    start.elapsed()
+}
+
+/// Receive side of state sync: replay a whole epoch's data file into a fresh pack.
+async fn bench_stream_import(fx: &Fixtures, data_path: &Path) -> Duration {
+    let dir = TempDir::with_prefix("pack_bench_import").expect("temp dir");
+    let stream = tokio::fs::File::open(data_path).await.expect("open data file");
+    let start = Instant::now();
+    let pack = ConsensusPack::stream_import(
+        dir.path(),
+        stream,
+        fx.committee.epoch(),
+        &fx.previous_epoch,
+        NUM_OUTPUTS,
+        IMPORT_TIMEOUT,
+    )
+    .await
+    .expect("stream import");
+    let elapsed = start.elapsed();
+    // stream_import drains the whole stream before returning, so the epoch is already present.
+    pack.get_consensus_output(NUM_OUTPUTS).await.expect("last output present after import");
+    elapsed
+}
+
+/// Cold-open the finished pack read-only, touching the index (the pack-cache-miss open cost).
+async fn bench_reopen_static(path: &Path, epoch: Epoch) -> Duration {
+    let start = Instant::now();
+    let pack = ConsensusPack::open_static(path, epoch).expect("open static");
+    pack.latest_consensus_header().await.expect("latest after reopen");
+    start.elapsed()
+}
+
+/// One report column: the ordered rows plus the on-disk size of the populated pack.
+struct Column {
+    rows: Vec<(&'static str, Duration)>,
+    data_len: u64,
+}
+
+/// Run the whole battery for one output width and collect its column.
+async fn run_battery(fx: &Fixtures, width: usize) -> Column {
+    let outputs = build_outputs(fx, width);
+    let header_digests: Vec<ConsensusHeaderDigest> =
+        outputs.iter().map(|o| o.consensus_header_hash()).collect();
+    let batch_digests: Vec<BlockHash> =
+        outputs.iter().flat_map(|o| o.batch_digests().iter().copied()).take(BATCH_SAMPLE).collect();
+
+    // Writes each build (and drop) their own pack.
+    let save_seq = bench_save_seq(fx, &outputs).await;
+    let save_durable = bench_save_durable(fx, &outputs).await;
+
+    // One populated pack shared by the read/stream battery.
+    let (pack, dir) = populate(fx, &outputs).await;
+    let data_path = fx.data_path(dir.path());
+
+    // Bulk-persist first so the un-persisted saves are flushed for the direct-file stream reads.
+    let persist = bench_persist(&pack).await;
+    let data_len = std::fs::metadata(&data_path).expect("data file metadata").len();
+
+    let header_by_number = bench_header_by_number(&pack).await;
+    let full_output = bench_full_output(&pack).await;
+    let output_bytes = bench_output_bytes(&pack).await;
+    let header_by_digest = bench_header_by_digest(&pack, &header_digests).await;
+    let batch_by_digest = bench_batch_by_digest(&pack, &batch_digests).await;
+    let read_last_committed = bench_read_last_committed(&pack).await;
+    let latest_header = bench_latest_header(&pack).await;
+    let prefix_stream = bench_prefix_stream(&pack, &data_path).await;
+    let full_stream = bench_full_stream(&data_path).await;
+    let stream_import = bench_stream_import(fx, &data_path).await;
+
+    // Reopen read-only after the writer is gone (index load / cache-miss open).
+    drop(pack);
+    let reopen_static = bench_reopen_static(dir.path(), fx.committee.epoch()).await;
+    drop(dir);
+
+    Column {
+        rows: vec![
+            ("save_seq", save_seq),
+            ("save_durable", save_durable),
+            ("persist bulk", persist),
+            ("header_by_number", header_by_number),
+            ("full_output", full_output),
+            ("output_bytes", output_bytes),
+            ("header_by_digest", header_by_digest),
+            ("batch_by_digest", batch_by_digest),
+            ("read_last_committed", read_last_committed),
+            ("latest_header", latest_header),
+            ("prefix_stream", prefix_stream),
+            ("full_stream", full_stream),
+            ("stream_import", stream_import),
+            ("reopen_static", reopen_static),
+        ],
+        data_len,
+    }
+}
+
+/// Collects one column per output width and prints an aligned table (ms; single implementation).
+struct Report {
+    /// Row labels, captured from the first column and reused for alignment.
+    order: Vec<&'static str>,
+    /// `(width label, column)`.
+    columns: Vec<(String, Column)>,
+}
+
+impl Report {
+    fn new() -> Self {
+        Self { order: Vec::new(), columns: Vec::new() }
+    }
+
+    fn push(&mut self, name: &str, col: Column) {
+        if self.order.is_empty() {
+            self.order = col.rows.iter().map(|(n, _)| *n).collect();
+        }
+        self.columns.push((name.to_string(), col));
+    }
+
+    fn print(&self) {
+        let label_w =
+            self.order.iter().map(|s| s.len()).max().unwrap_or(0).max("bytes/output".len());
+        let cell_w = 14usize;
+
+        println!(
+            "\n=== consensus pack-file benchmark (ms; single implementation, observation) ==="
+        );
+        println!("legend: columns are output widths (batches/output); save_durable adds a persist() barrier per output; test batches carry 1 tx each (representative, not production-sized).");
+
+        // header
+        print!("{:<label_w$}", "benchmark", label_w = label_w);
+        for (name, _) in &self.columns {
+            print!(" {:>cell_w$}", name, cell_w = cell_w);
+        }
+        println!();
+
+        // timed rows
+        for (row, label) in self.order.iter().enumerate() {
+            print!("{:<label_w$}", label, label_w = label_w);
+            for (_, col) in &self.columns {
+                let ms = col.rows[row].1.as_secs_f64() * 1000.0;
+                print!(" {:>cell_w$}", format!("{ms:.2}"), cell_w = cell_w);
+            }
+            println!();
+        }
+
+        // observational footer: pack size per column
+        print!("{:<label_w$}", "data MiB", label_w = label_w);
+        for (_, col) in &self.columns {
+            let mib = col.data_len as f64 / (1024.0 * 1024.0);
+            print!(" {:>cell_w$}", format!("{mib:.2}"), cell_w = cell_w);
+        }
+        println!();
+        print!("{:<label_w$}", "bytes/output", label_w = label_w);
+        for (_, col) in &self.columns {
+            print!(" {:>cell_w$}", col.data_len / NUM_OUTPUTS, cell_w = cell_w);
+        }
+        println!("\n({NUM_OUTPUTS} outputs per column)\n");
+    }
+}
+
+/// Observe the single consensus pack-file implementation across production usage patterns.
+///
+/// On-demand perf test (kept out of the default suite). Run with:
+/// `cargo test -p tn-storage pack_file_bench -- --ignored --nocapture --test-threads 1`.
+#[test]
+#[ignore = "on-demand pack-file observation benchmark; run with --ignored --nocapture --test-threads 1"]
+fn pack_file_bench() {
+    // Mirror `db_bench`: a plain test driving the async pack API on a tokio runtime.
+    let runtime = tokio::runtime::Runtime::new().expect("create tokio runtime");
+    runtime.block_on(async {
+        let fx = Fixtures::new();
+        let mut report = Report::new();
+        for &(label, width) in WIDTHS {
+            println!("  running battery for {label} ...");
+            let col = run_battery(&fx, width).await;
+            report.push(label, col);
+        }
+        report.print();
+    });
+}


### PR DESCRIPTION
Added some DB benches to compare backends.  Should run it with a release build.  Can run it with ```cargo test --release -p tn-storage db_backend_comparison -- --ignored --nocapture --test-threads 1```

@MavenRain Note that commenting out (since this is a test MDBX will have sync mode off) does not seem to effect the MDBX times:
        #[cfg(any(test, feature = "test-utils"))]
        {
            use reth_libmdbx::{EnvironmentFlags, Mode};
            builder.set_flags(EnvironmentFlags {
                mode: Mode::ReadWrite { sync_mode: BUILD_SYNC_MODE },
                ..Default::default()
            });
        }
We may not need to do this?  Also, not sure how this would not matter or even how MDBX seems to "persist" durably as fast it does...  Still some questions to answer here.

The layered DB does still seem to help for most benches and costs almost nothing in the few it does not.  So probably worth keeping for now.