### PR TITLE
fix(worker): keep observer txs pooled when a batch forward is refused

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -514,6 +514,142 @@ mod tests {
         assert_eq!(pending_pool_len, 3);
     }
 
+    /// An observer worker (no quorum waiter) whose forwarder admits nothing must keep its
+    /// transactions pending: every seal attempt returns `NotValidator`, the pool is not
+    /// drained, and the builder task stays alive to retry on a later build.
+    ///
+    /// The worker's batch channel is interposed so each seal attempt is observable: the
+    /// test receives each sealed batch, runs the real observer `seal` (which runs
+    /// `disburse_txns`), and forwards the result on the ack channel. Two full cycles prove
+    /// the builder processed the first refusal as non-fatal and kept looping.
+    #[tokio::test]
+    async fn test_observer_refused_forward_keeps_txs_in_pool() {
+        let tmp_dir = TempDir::new().unwrap();
+        let TestTools { mut tx_factory, execution_components, task_manager } =
+            get_test_tools(tmp_dir.path());
+        let TestExecutionComponents { reth_env, txpool, chain, .. } = execution_components;
+        let address = Address::from(U160::from(33));
+        let client = LocalNetwork::new_with_empty_id();
+        let worker_to_primary = Arc::new(MockWorkerToPrimaryHang {});
+        client.set_worker_to_primary_local_handler(worker_to_primary);
+        let temp_dir = TempDir::new().unwrap();
+        let store = open_db(temp_dir.path());
+        let seal_timeout = Duration::from_secs(5);
+        let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
+
+        // The real observer worker: no quorum waiter, a forwarder that admits nothing, and
+        // a test network handle that discovers no validator RPC endpoints.
+        let block_provider = Worker::new(
+            0,
+            None::<TestMakeBlockQuorumWaiter>,
+            client,
+            store,
+            seal_timeout,
+            WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+            Arc::new(NoopTxnForwarder),
+            Vec::new(),
+        );
+
+        // build execution block proposer with the interposed channel and a short delay so
+        // the retry after a refused seal arrives quickly
+        let batch_builder = BatchBuilder::new(
+            &reth_env,
+            txpool.clone(),
+            to_worker,
+            address,
+            Duration::from_millis(100),
+            task_manager.get_spawner(),
+            0,
+            MIN_PROTOCOL_BASE_FEE,
+            0,
+        )
+        .expect("batch builder");
+
+        let gas_price = reth_env.get_gas_price().unwrap();
+        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
+
+        // create 3 transactions
+        let transaction1 = tx_factory.create_eip1559(
+            chain.clone(),
+            None,
+            gas_price,
+            Some(Address::ZERO),
+            value, // 1 TEL
+            Bytes::new(),
+        );
+
+        let transaction2 = tx_factory.create_eip1559(
+            chain.clone(),
+            None,
+            gas_price,
+            Some(Address::ZERO),
+            value, // 1 TEL
+            Bytes::new(),
+        );
+
+        let transaction3 = tx_factory.create_eip1559(
+            chain.clone(),
+            None,
+            gas_price,
+            Some(Address::ZERO),
+            value, // 1 TEL
+            Bytes::new(),
+        );
+
+        let added_result = tx_factory.submit_tx_to_pool(transaction1.clone(), txpool.clone()).await;
+        assert_matches!(added_result, hash if &hash == transaction1.hash());
+
+        let added_result = tx_factory.submit_tx_to_pool(transaction2.clone(), txpool.clone()).await;
+        assert_matches!(added_result, hash if &hash == transaction2.hash());
+
+        let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
+        assert_matches!(added_result, hash if &hash == transaction3.hash());
+
+        // txpool size
+        let pending_pool_len = txpool.pool_size().pending;
+        assert_eq!(pending_pool_len, 3);
+
+        // spawn batch_builder once worker is ready
+        let batch_builder_task = tokio::spawn(batch_builder.run());
+
+        // plenty of time for each build attempt
+        let duration = std::time::Duration::from_secs(5);
+
+        // First attempt: the builder proposes all 3 transactions and the real observer seal
+        // refuses the batch because it was not admitted to a forward task.
+        let (sealed_batch, ack) = timeout(duration, from_batch_builder.recv())
+            .await
+            .expect("first batch built in time")
+            .expect("batch builder sender open");
+        assert_eq!(sealed_batch.batch().transactions().len(), 3);
+        let res = block_provider.seal(sealed_batch).await;
+        assert!(matches!(res, Err(BlockSealError::NotValidator)));
+        let _ = ack.send(res);
+
+        // Second attempt: another proposal proves the builder processed the first refusal
+        // as non-fatal and kept looping. The same 3 transactions are proposed again.
+        let (sealed_batch, ack) = timeout(duration, from_batch_builder.recv())
+            .await
+            .expect("second batch built in time")
+            .expect("batch builder sender open");
+        assert_eq!(sealed_batch.batch().transactions().len(), 3);
+        let res = block_provider.seal(sealed_batch).await;
+        assert!(matches!(res, Err(BlockSealError::NotValidator)));
+        let _ = ack.send(res);
+
+        // yield to try and give pool a chance to update
+        tokio::task::yield_now().await;
+
+        // The refused attempts must not evict anything from the pool.
+        let pending_pool_len = txpool.pool_size().pending;
+        assert_eq!(pending_pool_len, 3);
+
+        // `NotValidator` is non-fatal, so the builder task must still be running.
+        assert!(!batch_builder_task.is_finished());
+
+        batch_builder_task.abort();
+    }
+
     /// Convenience struct for creating test assets.
     struct TestTools {
         /// Factory for creating and signing valid transactions.

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -239,41 +239,50 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
     ///
     /// Replaces the previous gossip broadcast (issue #804): each transaction is forwarded to the
     /// JSON-RPC endpoint the owning validator advertised on its worker record, discovered over
-    /// kademlia. Forwarding is best-effort and runs on a background task so batch production is
-    /// never stalled by a slow or unreachable validator.
+    /// kademlia. Admission is decided here, synchronously, because the `Ok` this method returns
+    /// is what lets the batch builder evict these transactions from its pool as mined: a batch
+    /// that was never handed to a forward task must report [`BlockSealError::NotValidator`] so
+    /// the builder keeps its transactions pending and retries on a later build. Delivery stays
+    /// best-effort on a background task, so batch production is never stalled by a slow or
+    /// unreachable validator; discovery is a snapshot of already-fetched kademlia records, not
+    /// a blocking network round-trip.
     pub async fn disburse_txns(&self, sealed_batch: SealedBatch) -> Result<(), BlockSealError> {
         let transactions = sealed_batch.batch.transactions;
         if transactions.is_empty() {
             return Ok(());
         }
 
-        let network_handle = self.network_handle.clone();
-        let forwarder = self.forwarder.clone();
-        let committee_slots = self.committee_slots.clone();
-        self.network_handle.get_task_spawner().spawn_task("disburse-txns", async move {
-            match network_handle.get_all_validator_rpcs().await {
-                Ok(validator_rpcs) if !validator_rpcs.is_empty() => {
-                    forwarder.forward_txns(transactions, committee_slots, validator_rpcs);
-                }
-                Ok(_) => {
+        let validator_rpcs = self
+            .network_handle
+            .get_all_validator_rpcs()
+            .await
+            .inspect_err(|err| {
+                warn!(
+                    target: "worker::batch_provider",
+                    ?err,
+                    "failed to discover validator JSON-RPC endpoints for transaction forwarding"
+                );
+            })
+            .inspect(|rpcs| {
+                // Only the discovery-succeeded-but-empty case earns this message; a
+                // discovery failure already warned above with the actual error.
+                if rpcs.is_empty() {
                     warn!(
                         target: "worker::batch_provider",
                         "no committee validator has advertised a JSON-RPC endpoint; \
                          cannot forward accepted transactions"
                     );
                 }
-                Err(err) => {
-                    warn!(
-                        target: "worker::batch_provider",
-                        ?err,
-                        "failed to discover validator JSON-RPC endpoints for transaction forwarding"
-                    );
-                }
-            }
-            Ok(())
-        });
+            })
+            .unwrap_or_default();
 
-        Ok(())
+        let admitted = !validator_rpcs.is_empty()
+            && self.forwarder.forward_txns(
+                transactions,
+                self.committee_slots.clone(),
+                validator_rpcs,
+            );
+        admitted.then_some(()).ok_or(BlockSealError::NotValidator)
     }
 
     /// Seal and broadcast the current batch.

--- a/crates/consensus/worker/tests/it/batch_provider_tests.rs
+++ b/crates/consensus/worker/tests/it/batch_provider_tests.rs
@@ -4,7 +4,9 @@ use tempfile::TempDir;
 use tn_network_types::{local::LocalNetwork, MockWorkerToPrimary};
 use tn_reth::test_utils::transaction;
 use tn_storage::{open_db, tables::NodeBatchesCache};
-use tn_types::{test_chain_spec_arc, Batch, Database, NoopTxnForwarder, TaskManager};
+use tn_types::{
+    error::BlockSealError, test_chain_spec_arc, Batch, Database, NoopTxnForwarder, TaskManager,
+};
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
 
 #[tokio::test]
@@ -55,4 +57,50 @@ async fn make_batch() {
 
     // Ensure the batch is stored
     assert!(store.get::<NodeBatchesCache>(&expected_batch.digest()).unwrap().is_some());
+}
+
+/// An observer worker (no quorum waiter) must refuse a non-empty seal when the batch is not
+/// admitted to a forward task. The test network handle discovers no validator RPC endpoints
+/// and `NoopTxnForwarder` admits nothing, so `seal` returns `NotValidator` and never writes
+/// the batch cache. An empty batch stays a success because there is nothing to forward.
+#[tokio::test]
+async fn observer_seal_without_admission_returns_not_validator() {
+    let client = LocalNetwork::new_with_empty_id();
+    let temp_dir = TempDir::new().unwrap();
+    let store = open_db(temp_dir.path());
+
+    // Mock the primary client to always succeed.
+    let mock_server = MockWorkerToPrimary();
+    client.set_worker_to_primary_local_handler(Arc::new(mock_server));
+
+    // A `BatchProvider` instance without a quorum waiter: the observer path.
+    let id = 0;
+    let timeout = Duration::from_secs(5);
+    let task_manager = TaskManager::default();
+    let batch_provider = Worker::new(
+        id,
+        None::<TestMakeBlockQuorumWaiter>,
+        client,
+        store.clone(),
+        timeout,
+        WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
+        Arc::new(NoopTxnForwarder),
+        Vec::new(),
+    );
+
+    // Seal a batch with transactions.
+    let chain = test_chain_spec_arc();
+    let tx = transaction(chain);
+    let new_batch = Batch { transactions: vec![tx.clone(), tx], ..Default::default() };
+    let digest = new_batch.digest();
+
+    let res = batch_provider.seal(new_batch.seal_slow()).await;
+    assert!(matches!(res, Err(BlockSealError::NotValidator)));
+
+    // The observer path refuses before the batch cache write.
+    assert!(store.get::<NodeBatchesCache>(&digest).unwrap().is_none());
+
+    // An empty batch is still a success.
+    let empty_batch = Batch { transactions: vec![], ..Default::default() };
+    assert!(batch_provider.seal(empty_batch.seal_slow()).await.is_ok());
 }

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -462,7 +462,9 @@ pub(crate) fn start_validator_with_args(
 ///
 /// The genesis ceremony leaves `p2p_info.worker.rpc` unset, and a non-committee node
 /// forwards accepted transactions to whatever endpoints committee validators advertise
-/// (issue #804); with none advertised, observer-submitted transactions are dropped.
+/// (issue #804); with none advertised, each seal is refused with
+/// `BlockSealError::NotValidator` and the transactions stay pending in the node's own
+/// pool, retried roughly once per `max_batch_delay` until an endpoint is discoverable.
 /// Call this between the config ceremony and `start_validator`, passing the same
 /// `rpc_port` the validator will serve `--http` on; the node re-signs the record from
 /// its `node-info.yaml` at startup, so editing the file is sufficient.

--- a/crates/e2e-tests/tests/it/restarts.rs
+++ b/crates/e2e-tests/tests/it/restarts.rs
@@ -541,7 +541,8 @@ fn test_restarts_observer() -> eyre::Result<()> {
             .expect("Failed to get an ephemeral rpc port for child!");
         client_urls[i].push_str(&format!(":{rpc_port}"));
         // The observer forwards accepted txns to the committee's advertised RPC
-        // endpoints; without this the forward has no targets and txns are dropped.
+        // endpoints; without this each seal is refused with NotValidator and the txns
+        // stay pending in the observer's pool until an endpoint is discoverable.
         advertise_worker_rpc(&temp_path, i, rpc_port)?;
         guard.push(start_validator(i, &bin, &temp_path, rpc_port, "observer", 0));
     }

--- a/crates/e2e-tests/tests/it/sync.rs
+++ b/crates/e2e-tests/tests/it/sync.rs
@@ -68,7 +68,8 @@ async fn test_observer_pack_imports_after_epoch_close_inner() -> eyre::Result<()
             .expect("Failed to get an ephemeral rpc port for child!");
         client_urls[i].push_str(&format!(":{rpc_port}"));
         // The late-joining observer forwards accepted txns to the committee's advertised
-        // RPC endpoints; without this the forward has no targets and txns are dropped.
+        // RPC endpoints; without this each seal is refused with NotValidator and the
+        // txns stay pending in the observer's pool until an endpoint is discoverable.
         advertise_worker_rpc(&temp_path, i, rpc_port)?;
         guard.push(start_validator(i, &bin, &temp_path, rpc_port, "observer_pack_import", 0));
     }

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -596,20 +596,21 @@ impl TxnForwarder for WorkerRpcForwarder {
         transactions: Vec<Vec<u8>>,
         committee_slots: Vec<BlsPublicKey>,
         validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
-    ) {
+    ) -> bool {
         let committee_size = committee_slots.len() as u64;
         let queued = transactions.len();
         // Nothing to forward, or nowhere to forward it to: neither is a fault, so neither warns.
         let discovered = (queued > 0 && committee_size > 0 && !validator_rpcs.is_empty())
             .then(|| self.cached_providers(&validator_rpcs));
         // Endpoints were advertised but none of them resolved to a usable provider. That is a
-        // fault, and the batch is dropped for it.
+        // fault, and the batch is refused for it so the caller keeps its transactions.
         let admissible = discovered.filter(|providers| {
             let usable = !providers.is_empty();
             if !usable {
                 warn!(
                     target: "worker::forward",
-                    "no usable validator RPC endpoints; dropping forwarded transactions"
+                    "no usable validator RPC endpoints; refusing the batch so the caller keeps \
+                     its transactions"
                 );
             }
             usable
@@ -618,20 +619,21 @@ impl TxnForwarder for WorkerRpcForwarder {
         // Admission control. Reached after the cache refresh above, so eviction of
         // no-longer-advertised endpoints keeps happening while batches are being shed, and
         // before any spawn here, so a batch this node has no capacity to forward never becomes
-        // a forward task holding its bytes. (The upstream `disburse-txns` spawn that delivers
-        // the batch to this call is pre-existing and tracked by issue #1132.) Try-acquire, not
-        // acquire: see [`MAX_CONCURRENT_FORWARDS`] for why a batch that finds no permit is
-        // dropped rather than queued behind one.
-        if let Some(providers) = admissible {
+        // a forward task holding its bytes. (`disburse_txns` calls this synchronously and keeps
+        // the batch pooled on refusal: issue #1132.) Try-acquire, not acquire: see
+        // [`MAX_CONCURRENT_FORWARDS`] for why a batch that finds no permit is refused rather
+        // than queued behind one.
+        admissible.is_some_and(|providers| {
             Arc::clone(&self.forwards_in_flight).try_acquire_owned().map_or_else(
                 |_| {
                     warn!(
                         target: "worker::forward",
                         transactions = queued,
                         capacity = MAX_CONCURRENT_FORWARDS,
-                        "forward capacity exhausted; dropping a sealed batch rather than queueing it"
+                        "forward capacity exhausted; refusing a sealed batch rather than queueing it"
                     );
                     ForwarderMetrics::record_batch_shed();
+                    false
                 },
                 move |permit| {
                     self.spawn_forward(
@@ -640,10 +642,11 @@ impl TxnForwarder for WorkerRpcForwarder {
                         committee_slots,
                         committee_size,
                         providers,
-                    )
+                    );
+                    true
                 },
             )
-        }
+        })
     }
 }
 
@@ -1142,6 +1145,37 @@ mod tests {
             classify_server_error(-32000, "nonce too low: next nonce 42, tx nonce 41".to_string()),
             Disposition::Rejected(_)
         ));
+        Ok(())
+    }
+
+    /// With no advertised endpoint, or with only endpoints the policy refuses, the batch is
+    /// not admitted: `forward_txns` returns `false` so the caller keeps its transactions.
+    #[test]
+    fn forward_txns_refuses_when_no_endpoint_is_usable() -> eyre::Result<()> {
+        let forwarder = test_forwarder();
+
+        // No committee validator has advertised an endpoint.
+        assert!(!forwarder.forward_txns(vec![vec![0u8; 8]], vec![test_key(1)], vec![]));
+
+        // The only advertised endpoint is private, so the `PublicOnly` policy refuses it and
+        // no provider resolves.
+        let refused = vec![(test_key(1), test_rpc("http://10.0.0.1:8545")?)];
+        assert!(!forwarder.forward_txns(vec![vec![0u8; 8]], vec![test_key(1)], refused));
+        Ok(())
+    }
+
+    /// One public advertised endpoint resolves a provider, so the batch is admitted to a
+    /// forward task and `forward_txns` returns `true`. Admission is not delivery: the
+    /// background task is free to fail and is not awaited here.
+    #[tokio::test]
+    async fn forward_txns_admits_when_a_provider_resolves() -> eyre::Result<()> {
+        // Keep the task manager alive so the spawned forward task is tracked normally.
+        let task_manager = TaskManager::default();
+        let forwarder =
+            WorkerRpcForwarder::new(task_manager.get_spawner(), ForwardTargetPolicy::PublicOnly);
+        let rpcs = vec![(test_key(1), test_rpc("http://validator.example.com:8545")?)];
+
+        assert!(forwarder.forward_txns(vec![vec![0u8; 8]], vec![test_key(1)], rpcs));
         Ok(())
     }
 }

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -237,18 +237,25 @@ pub trait TxnForwarder: Send + Sync + Debug {
     /// single validator and nonce ordering is preserved. `validator_rpcs` is the set of
     /// currently-known advertised endpoints; a validator that has not advertised an endpoint is
     /// skipped in favor of one that has.
+    ///
+    /// Returns `true` if the batch was admitted to a forward task. `false` means it was dropped
+    /// at the door and the caller still owns these transactions: they must stay in the caller's
+    /// pool for a future batch. Admission is not delivery — delivery stays best-effort on the
+    /// background task.
     fn forward_txns(
         &self,
         transactions: Vec<Vec<u8>>,
         committee_slots: Vec<BlsPublicKey>,
         validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
-    );
+    ) -> bool;
 }
 
-/// A [`TxnForwarder`] that drops every transaction.
+/// A [`TxnForwarder`] that admits nothing.
 ///
 /// Committee voting validators never forward (they include transactions directly), so they can
 /// be constructed with this; it is also convenient in tests that do not exercise forwarding.
+/// Refusing admission keeps the honest contract: a caller that relies on forwarding sees the
+/// batch refused and keeps its transactions, instead of believing they were handed off.
 #[derive(Clone, Debug, Default)]
 pub struct NoopTxnForwarder;
 
@@ -258,7 +265,8 @@ impl TxnForwarder for NoopTxnForwarder {
         _transactions: Vec<Vec<u8>>,
         _committee_slots: Vec<BlsPublicKey>,
         _validator_rpcs: Vec<(BlsPublicKey, RpcInfo)>,
-    ) {
+    ) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
Closes #1132.

## Problem

An observer worker does not wait for its transaction forward to start.  `disburse_txns` spawned a background task and returned `Ok(())` at once (`crates/consensus/worker/src/worker.rs`).  `seal` returned that `Ok(())` when `quorum_waiter` is `None`.  The batch builder then treated every observer batch as sealed:  it incremented `batches_sealed_total` and reported every hash in the batch as mined.  The pool update pruned those hashes from the observer's own pool (`crates/batch-builder/src/lib.rs`, `crates/tn-reth/src/txn_pool.rs`).

When the forward is dropped for any reason, the transactions are lost.  No recovery path exists for observers:  the `OurNodeBatchesCache` write sits after the observer's early return, so `orphan_batches` has nothing to re-inject.  The default configuration hits this.  `worker.rpc` is `#[serde(default)]` and the genesis ceremony leaves it unset, so no endpoint is advertised and every observer forward is dropped.  A second effect follows:  `changed_accounts` advances the sender's tracked nonce, so the sender's next transaction parks as nonce-gapped and is never batched either.

## Root cause

The intended contract exists but was unreachable.  `BlockSealError::NotValidator` is defined, the batch builder handles it as a keep-the-transactions outcome, and it has a metrics label.  No code constructed it.  Admission was decided inside a spawned task, after `seal` had already reported success, so the success report and the forward outcome were fully decoupled.

## Fix

Make admission synchronous and construct `NotValidator` on refusal.  Delivery stays best-effort on a background task, so batch production is never stalled by a slow or unreachable validator.

- [x] `crates/types/src/worker/sealed_batch.rs`: `TxnForwarder::forward_txns` now returns `bool`.  `true` means the batch was admitted to a forward task.  `false` means it was dropped at the door and the caller still owns the transactions.  Admission is not delivery.  `NoopTxnForwarder` returns `false`.
- [x] `crates/consensus/worker/src/worker.rs`: `disburse_txns` awaits endpoint discovery inline.  The discovery call returns a snapshot of already-fetched kademlia records, so it is not a blocking network round-trip.  When discovery fails, when no endpoint is advertised, or when the forwarder refuses the batch, `disburse_txns` returns `Err(BlockSealError::NotValidator)`.
- [x] `crates/tn-reth/src/forward.rs`: `WorkerRpcForwarder::forward_txns` returns `false` on every refuse path (nothing to route, no usable provider after the target policy runs, or no free forward permit) and `true` once the forward task is spawned.

The batch builder already maps `NotValidator` to an empty mined set, which skips `update_canonical_state`.  The transactions stay pending and the next build retries them.

Threat model notes.  The failure needs no attacker:  the default genesis configuration alone drops every observer forward today.  The retry is bounded by the builder's own backoff (`max_batch_delay`, default 1s), so a refused observer re-mines about once per second and does not spin.  Re-forwarding a transaction that did reach a validator is safe:  the forwarder classifies an `already known` response as delivered.  Committee rotation windows self-correct:  seals return `NotValidator` while discovery converges, and the transactions wait in the pool instead of vanishing.  The validator seal path is untouched:  with a quorum waiter present, `seal` never reaches `disburse_txns`.

This branch sits on the forward hardening that landed on main (per-batch budget, a node-wide cap on live forward tasks, forwarder metrics).  The two admission gates compose:  a batch that finds every forward permit taken is refused with `NotValidator` instead of being dropped, so capacity shedding becomes lossless backpressure and the transactions stay pooled for the next build.

Residuals kept out of scope on purpose (tracked in a follow-up issue):  admission checks that a usable endpoint is advertised, not that it answers, so an advertised but dead endpoint still admits (and can still lose) a batch;  the epoch-close orphan-batch path (`close_epoch.rs`) discards the new refusal signal, a pre-existing loss path this PR makes observable but does not close;  and a permanently refused observer re-mines at ~1 Hz with an error log and a seal-failure metric increment per tick, so the follow-up proposes a refusal-specific backoff.

## Testing

- [x] New regression tests, each confirmed by mutation (fix arm reverted, test seen to FAIL, fix restored, test green):
  - `crates/consensus/worker/tests/it/batch_provider_tests.rs`:  an observer seal (`quorum_waiter: None`) with no admitted forward returns `Err(BlockSealError::NotValidator)`;  an empty batch still returns `Ok(())`;  no `NodeBatchesCache` entry is written.  Fails when the admission gate in `disburse_txns` is neutralized.
  - `crates/batch-builder/src/lib.rs`:  an observer builder whose every seal is refused keeps all pending transactions in the pool and keeps running (`NotValidator` is non-fatal).  Fails under the same gate mutation.
  - `crates/tn-reth/src/forward.rs`:  `forward_txns` returns `false` when no endpoint is usable and `true` when a provider resolves.  The refusal test fails when the no-provider branch is flipped to `true`.
- [x] `cargo +nightly fmt -- --check`
- [x] `cargo +1.94 check` and `cargo +1.94 clippy --all-targets -- -D warnings` over the touched crates
- [x] `cargo +1.94 test -p tn-types -p tn-reth -p tn-worker -p tn-batch-builder` (one crate at a time;  all green)
- [x] Attest proxy:  `cargo +1.94 test --no-run --workspace -j 2` in an isolated target dir
- [x] `cargo +nightly clippy --workspace --all-features -- -D warnings`
