### PR TITLE
fix(metrics): count transaction forwarding drops by reason

### DIFF
--- a/crates/consensus/worker/src/metrics.rs
+++ b/crates/consensus/worker/src/metrics.rs
@@ -8,6 +8,30 @@ use reth_metrics::{
 use std::time::Duration;
 use tn_types::WorkerId;
 
+/// Why the worker dropped a sealed batch's transactions instead of handing them to the
+/// transaction forwarder.
+///
+/// Both variants are whole-batch losses on the observer path (`disburse_txns`): the
+/// transactions were accepted by this node's RPC and never reached the forwarder, so the
+/// forwarder-side series (`tn_reth.forwarded_txns_*`) cannot see them (issue #1133).
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ForwardDropReason {
+    /// No committee validator advertised a JSON-RPC endpoint to forward to.
+    NoEndpointAdvertised,
+    /// Discovering the committee's advertised endpoints failed outright.
+    DiscoveryFailed,
+}
+
+impl ForwardDropReason {
+    /// The `reason` label value this variant records under.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::NoEndpointAdvertised => "no_endpoint_advertised",
+            Self::DiscoveryFailed => "discovery_failed",
+        }
+    }
+}
+
 /// Derive-backed metric handles for the worker, labeled per `worker`.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tn_worker")]
@@ -107,6 +131,24 @@ impl WorkerMetrics {
     pub(crate) fn record_batch_fetch_duration(&self, elapsed: Duration) {
         self.handles.batch_fetch_duration_seconds.record(elapsed);
     }
+
+    /// Record transactions dropped by the worker before they reached the transaction
+    /// forwarder, labeled by [`ForwardDropReason`].
+    ///
+    /// Modeled on [`Self::record_batches_fetched`]: a zero count records nothing, so a path
+    /// that never dropped creates no series. Every call site pairs with a `warn!` line; the
+    /// counter is what makes the loss visible on a dashboard, where an observer that drops
+    /// every transaction it accepts otherwise looks healthy (issue #1133).
+    pub(crate) fn record_forward_dropped(&self, reason: ForwardDropReason, count: usize) {
+        if count > 0 {
+            metrics::counter!(
+                "tn_worker.forwarded_txns_dropped_total",
+                "worker" => self.worker_id.to_string(),
+                "reason" => reason.label(),
+            )
+            .increment(u64::try_from(count).unwrap_or(u64::MAX));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -129,6 +171,8 @@ mod tests {
             metrics.record_batches_fetched("local", 3);
             metrics.record_batches_fetched("remote", 0); // no-op, no series
             metrics.record_batch_fetch_duration(Duration::from_millis(80));
+            metrics.record_forward_dropped(ForwardDropReason::NoEndpointAdvertised, 4);
+            metrics.record_forward_dropped(ForwardDropReason::DiscoveryFailed, 0); // no-op, no series
         });
 
         let snapshot = snapshotter.snapshot().into_vec();
@@ -158,11 +202,28 @@ mod tests {
         find("tn_worker.batch_validation_failures_total");
         find("tn_worker.batch_fetch_duration_seconds");
 
+        let (key, _, _, value) = find("tn_worker.forwarded_txns_dropped_total");
+        assert!(matches!(value, DebugValue::Counter(4)));
+        assert!(key
+            .key()
+            .labels()
+            .any(|l| l.key() == "reason" && l.value() == "no_endpoint_advertised"));
+        assert!(key.key().labels().any(|l| l.key() == "worker" && l.value() == "0"));
+
         // the zero-count fetch must not create a series
         assert!(
             !snapshot.iter().any(|(key, ..)| key.key().name() == "tn_worker.batches_fetched_total"
                 && key.key().labels().any(|l| l.value() == "remote")),
             "zero-count fetch should not register a remote series"
+        );
+
+        // neither must the zero-count forward drop
+        assert!(
+            !snapshot.iter().any(|(key, ..)| {
+                key.key().name() == "tn_worker.forwarded_txns_dropped_total"
+                    && key.key().labels().any(|l| l.value() == "discovery_failed")
+            }),
+            "zero-count forward drop should not register a series"
         );
     }
 }

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     batch_fetcher::BatchFetcher,
-    metrics::WorkerMetrics,
+    metrics::{ForwardDropReason, WorkerMetrics},
     network::primary::PrimaryReceiverHandler,
     quorum_waiter::{QuorumWaiter, QuorumWaiterTrait},
     WorkerNetworkHandle,
@@ -247,6 +247,10 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             return Ok(());
         }
 
+        // Captured before the vec moves into the spawned task: both drop arms below lose the
+        // whole batch, and by then the length is no longer reachable (issue #1133).
+        let num_txns = transactions.len();
+        let metrics = self.metrics.clone();
         let network_handle = self.network_handle.clone();
         let forwarder = self.forwarder.clone();
         let committee_slots = self.committee_slots.clone();
@@ -261,6 +265,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
                         "no committee validator has advertised a JSON-RPC endpoint; \
                          cannot forward accepted transactions"
                     );
+                    metrics
+                        .record_forward_dropped(ForwardDropReason::NoEndpointAdvertised, num_txns);
                 }
                 Err(err) => {
                     warn!(
@@ -268,6 +274,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
                         ?err,
                         "failed to discover validator JSON-RPC endpoints for transaction forwarding"
                     );
+                    metrics.record_forward_dropped(ForwardDropReason::DiscoveryFailed, num_txns);
                 }
             }
             Ok(())

--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -30,7 +30,10 @@
 //!
 //! [`submit_txn_if_mine`]: tn_types::BatchValidation::submit_txn_if_mine
 
-use crate::{metrics::ForwarderMetrics, recover_raw_transaction};
+use crate::{
+    metrics::{ForwardDropReason, ForwarderMetrics},
+    recover_raw_transaction,
+};
 use alloy::{
     providers::{Provider as _, RootProvider},
     transports::{RpcError, TransportErrorKind},
@@ -564,6 +567,24 @@ impl WorkerRpcForwarder {
                 }
             }
 
+            // The per-transaction losses, counted per batch rather than per event. A rejection
+            // is a considered verdict a validator saw; an unreached transaction exhausted its
+            // whole fallback chain. Both are transactions this node accepted and never
+            // delivered, so both subtract from the queued denominator - see
+            // [`ForwardDropReason`] for which of the two is alertable.
+            if rejected > 0 {
+                ForwarderMetrics::record_txns_dropped(
+                    ForwardDropReason::Rejected,
+                    u64::try_from(rejected).unwrap_or(u64::MAX),
+                );
+            }
+            if unreached > 0 {
+                ForwarderMetrics::record_txns_dropped(
+                    ForwardDropReason::Unreached,
+                    u64::try_from(unreached).unwrap_or(u64::MAX),
+                );
+            }
+
             // Everything the batch deadline cut off: whatever `map_while` stopped short of,
             // plus any transaction whose deadline-clamped budget expired mid-chain. Derived
             // from the individual outcome tallies rather than from a count of loop iterations
@@ -599,9 +620,21 @@ impl TxnForwarder for WorkerRpcForwarder {
     ) {
         let committee_size = committee_slots.len() as u64;
         let queued = transactions.len();
-        // Nothing to forward, or nowhere to forward it to: neither is a fault, so neither warns.
-        let discovered = (queued > 0 && committee_size > 0 && !validator_rpcs.is_empty())
-            .then(|| self.cached_providers(&validator_rpcs));
+        let queued_total = u64::try_from(queued).unwrap_or(u64::MAX);
+        if queued > 0 {
+            // The base series the drop and abandon counters read against: every transaction
+            // handed to the forwarder, counted before any admission decision.
+            ForwarderMetrics::record_txns_queued(queued_total);
+        }
+        // Nothing to forward, or nowhere to forward it to: neither is a fault, so neither
+        // warns - the worker warns and counts its own guard on the production path. But a
+        // batch with nowhere to go is still dropped, so it is counted (issue #1133).
+        let targets_known = committee_size > 0 && !validator_rpcs.is_empty();
+        if queued > 0 && !targets_known {
+            ForwarderMetrics::record_txns_dropped(ForwardDropReason::EmptyCommittee, queued_total);
+        }
+        let discovered =
+            (queued > 0 && targets_known).then(|| self.cached_providers(&validator_rpcs));
         // Endpoints were advertised but none of them resolved to a usable provider. That is a
         // fault, and the batch is dropped for it.
         let admissible = discovered.filter(|providers| {
@@ -610,6 +643,10 @@ impl TxnForwarder for WorkerRpcForwarder {
                 warn!(
                     target: "worker::forward",
                     "no usable validator RPC endpoints; dropping forwarded transactions"
+                );
+                ForwarderMetrics::record_txns_dropped(
+                    ForwardDropReason::NoUsableEndpoint,
+                    queued_total,
                 );
             }
             usable
@@ -632,6 +669,9 @@ impl TxnForwarder for WorkerRpcForwarder {
                         "forward capacity exhausted; dropping a sealed batch rather than queueing it"
                     );
                     ForwarderMetrics::record_batch_shed();
+                    // The transaction-level count beside the batch-level one, so shed batches
+                    // subtract from the queued denominator like every other drop.
+                    ForwarderMetrics::record_txns_dropped(ForwardDropReason::BatchShed, queued_total);
                 },
                 move |permit| {
                     self.spawn_forward(
@@ -761,11 +801,38 @@ mod tests {
         Ok(format!("http://{addr}"))
     }
 
+    /// One recorder capture. [`metrics_util::debugging::Snapshotter::snapshot`] drains the
+    /// accumulated values with it, so each test takes exactly one snapshot after its recorded
+    /// scope ends and every lookup below reads that capture; a second snapshot would read
+    /// zeros.
+    type Snapshot = Vec<(
+        metrics_util::CompositeKey,
+        Option<metrics::Unit>,
+        Option<metrics::SharedString>,
+        DebugValue,
+    )>;
+
     /// Read one counter out of a recorder snapshot, `None` if the series is not registered.
-    fn counter(snapshotter: &metrics_util::debugging::Snapshotter, name: &str) -> Option<u64> {
-        snapshotter.snapshot().into_vec().into_iter().find_map(|(key, _, _, value)| {
+    fn counter(snapshot: &Snapshot, name: &str) -> Option<u64> {
+        snapshot.iter().find_map(|(key, _, _, value)| {
             (key.key().name() == name).then_some(value).and_then(|value| match value {
-                DebugValue::Counter(count) => Some(count),
+                DebugValue::Counter(count) => Some(*count),
+                DebugValue::Gauge(_) | DebugValue::Histogram(_) => None,
+            })
+        })
+    }
+
+    /// The dropped-transactions counter for one `reason`, `None` if that series is absent.
+    ///
+    /// [`counter`] cannot serve here: every reason shares the metric name, so a name-only
+    /// lookup returns whichever series the snapshot happens to list first.
+    fn dropped_counter(snapshot: &Snapshot, reason: &str) -> Option<u64> {
+        snapshot.iter().find_map(|(key, _, _, value)| {
+            (key.key().name() == "tn_reth.forwarded_txns_dropped_total"
+                && key.key().labels().any(|l| l.key() == "reason" && l.value() == reason))
+            .then_some(value)
+            .and_then(|value| match value {
+                DebugValue::Counter(count) => Some(*count),
                 DebugValue::Gauge(_) | DebugValue::Histogram(_) => None,
             })
         })
@@ -878,11 +945,84 @@ mod tests {
         metrics::with_local_recorder(&recorder, || {
             forwarder.forward_txns(vec![vec![0_u8; 32]], vec![test_key(1)], rpcs);
         });
+        let snapshot = snapshotter.snapshot().into_vec();
 
         // No permit was free, so none was taken, and the shed is visible as a counter rather
-        // than only as a log line.
+        // than only as a log line - at batch grain and, since #1133, at transaction grain
+        // against the queued denominator.
         assert_eq!(forwarder.forwards_in_flight.available_permits(), 0);
-        assert_eq!(counter(&snapshotter, "tn_reth.forwarded_batches_shed_total"), Some(1));
+        assert_eq!(counter(&snapshot, "tn_reth.forwarded_batches_shed_total"), Some(1));
+        assert_eq!(counter(&snapshot, "tn_reth.forwarded_txns_queued_total"), Some(1));
+        assert_eq!(dropped_counter(&snapshot, "batch_shed"), Some(1));
+        Ok(())
+    }
+
+    /// A batch that reaches the forwarder with an empty committee is dropped without a warn by
+    /// design; the reason-labeled counter is what keeps the loss visible (issue #1133).
+    #[test]
+    fn forward_txns_counts_a_batch_with_no_committee_as_dropped() -> eyre::Result<()> {
+        let rpcs = vec![(test_key(1), test_rpc("http://validator-one.example.com:8545")?)];
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        // Built inside the recorder scope so `ForwarderMetrics::init` registers every series
+        // with this recorder; the zero assertions below read those registrations.
+        let forwarder = metrics::with_local_recorder(&recorder, || {
+            let forwarder = test_forwarder();
+            forwarder.forward_txns(vec![vec![0_u8; 32], vec![1_u8; 32]], vec![], rpcs);
+            forwarder
+        });
+        let snapshot = snapshotter.snapshot().into_vec();
+
+        assert_eq!(counter(&snapshot, "tn_reth.forwarded_txns_queued_total"), Some(2));
+        assert_eq!(dropped_counter(&snapshot, "empty_committee"), Some(2));
+        assert_eq!(dropped_counter(&snapshot, "no_usable_endpoint"), Some(0));
+        // Dropped at the routing check: no forward task was ever spawned.
+        assert_eq!(forwarder.forwards_in_flight.available_permits(), MAX_CONCURRENT_FORWARDS);
+        Ok(())
+    }
+
+    /// A committee is present but nobody advertised an endpoint: the same routing dead end
+    /// as an empty committee, counted under the same reason.
+    #[test]
+    fn forward_txns_counts_a_batch_with_no_advertised_endpoint_as_dropped() -> eyre::Result<()> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let forwarder = metrics::with_local_recorder(&recorder, || {
+            let forwarder = test_forwarder();
+            forwarder.forward_txns(vec![vec![0_u8; 32]], vec![test_key(1)], vec![]);
+            forwarder
+        });
+        let snapshot = snapshotter.snapshot().into_vec();
+
+        assert_eq!(counter(&snapshot, "tn_reth.forwarded_txns_queued_total"), Some(1));
+        assert_eq!(dropped_counter(&snapshot, "empty_committee"), Some(1));
+        assert_eq!(dropped_counter(&snapshot, "no_usable_endpoint"), Some(0));
+        assert_eq!(forwarder.forwards_in_flight.available_permits(), MAX_CONCURRENT_FORWARDS);
+        Ok(())
+    }
+
+    /// Endpoints were advertised but the policy refused every one: the batch is dropped and
+    /// the drop is counted under its own reason, apart from the empty-committee no-op.
+    #[test]
+    fn forward_txns_counts_a_batch_with_no_usable_endpoint_as_dropped() -> eyre::Result<()> {
+        // The shipped default policy refuses the loopback advertisement, so the committee is
+        // present but no endpoint resolves to a provider.
+        let rpcs = vec![(test_key(1), test_rpc("http://127.0.0.1:8545")?)];
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let forwarder = metrics::with_local_recorder(&recorder, || {
+            let forwarder = test_forwarder();
+            forwarder.forward_txns(vec![vec![0_u8; 32]], vec![test_key(1)], rpcs);
+            forwarder
+        });
+        let snapshot = snapshotter.snapshot().into_vec();
+
+        assert_eq!(counter(&snapshot, "tn_reth.forwarded_txns_queued_total"), Some(1));
+        assert_eq!(dropped_counter(&snapshot, "no_usable_endpoint"), Some(1));
+        assert_eq!(dropped_counter(&snapshot, "empty_committee"), Some(0));
+        assert_eq!(forwarder.forwards_in_flight.available_permits(), MAX_CONCURRENT_FORWARDS);
         Ok(())
     }
 

--- a/crates/tn-reth/src/metrics.rs
+++ b/crates/tn-reth/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Prometheus metrics for the reth execution environment.
 //!
-//! Four counter series are exported under the `tn_reth` scope, in two unrelated groups.
+//! The counter series are exported under the `tn_reth` scope, in two unrelated groups.
 //!
 //! Block building. Two series count transactions that `build_block_from_batch_payload`
 //! declines to include in a block: `tn_reth.unrecoverable_txs_dropped_total` (alertable - a
@@ -8,8 +8,11 @@
 //! `tn_reth.invalid_txs_skipped_total` (expected - duplicates/invalid transactions across
 //! independently-batching workers). See [`RethEnvMetrics`] for per-series semantics.
 //!
-//! Observer transaction forwarding. Two series count work the forwarder
-//! ([`crate::WorkerRpcForwarder`]) sheds to stay within its own bounds:
+//! Observer transaction forwarding. A base series counts every transaction handed to the
+//! forwarder ([`crate::WorkerRpcForwarder`]): `tn_reth.forwarded_txns_queued_total`. Read
+//! against it, `tn_reth.forwarded_txns_dropped_total` (labeled by `reason`, see
+//! [`ForwardDropReason`]) counts the transactions the pipeline gave up on, and two series count
+//! work the forwarder sheds to stay within its own bounds:
 //! `tn_reth.forwarded_batches_shed_total` and `tn_reth.forwarded_txns_abandoned_total`. See
 //! [`ForwarderMetrics`] for per-series semantics.
 //!
@@ -109,14 +112,76 @@ pub(crate) struct RethEnvMetrics {
 /// registration in [`ForwarderMetrics::init`] and the increments below cannot drift apart.
 const FORWARDED_BATCHES_SHED: &str = "tn_reth.forwarded_batches_shed_total";
 const FORWARDED_TXNS_ABANDONED: &str = "tn_reth.forwarded_txns_abandoned_total";
+const FORWARDED_TXNS_QUEUED: &str = "tn_reth.forwarded_txns_queued_total";
+const FORWARDED_TXNS_DROPPED: &str = "tn_reth.forwarded_txns_dropped_total";
+
+/// Why the forwarding pipeline gave up on transactions it had accepted.
+///
+/// The variants label `tn_reth.forwarded_txns_dropped_total`, one series per reason, all
+/// registered at zero by [`ForwarderMetrics::init`]. Together with
+/// `tn_reth.forwarded_txns_abandoned_total` they account for every queued transaction that was
+/// not delivered, so `queued - dropped - abandoned` is the number a dashboard can trust as
+/// delivered (issue #1133).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ForwardDropReason {
+    /// The batch reached the forwarder with an empty committee or no advertised endpoint, so
+    /// there was nowhere to route to. A silent no-op before it was counted; on the production
+    /// path the worker guards this case first and counts it under its own scope
+    /// (`tn_worker.forwarded_txns_dropped_total`).
+    EmptyCommittee,
+    /// Endpoints were advertised but none resolved to a usable provider - every one was
+    /// refused by the [`crate::ForwardTargetPolicy`] or failed to parse. Alertable: the node
+    /// is accepting transactions it can never hand on.
+    NoUsableEndpoint,
+    /// The whole batch was shed at admission because every forward permit was in flight. The
+    /// transaction-level twin of `tn_reth.forwarded_batches_shed_total`, so shed batches also
+    /// subtract from the queued denominator.
+    BatchShed,
+    /// A validator's RPC returned a considered rejection (bad nonce, underpriced, invalid).
+    /// Not alertable on its own: the rejection would repeat at every validator, the same way
+    /// `tn_reth.invalid_txs_skipped_total` is expected traffic at execution.
+    Rejected,
+    /// The whole fallback chain was tried inside the transaction's budget and no validator
+    /// accepted the connection or answered in time. Alertable on a sustained rate: the
+    /// committee is unreachable from this node while it keeps accepting transactions.
+    Unreached,
+}
+
+impl ForwardDropReason {
+    /// Every variant, for zero-registration in [`ForwarderMetrics::init`].
+    ///
+    /// Hand-maintained: the exhaustive match in [`Self::label`] is the compile-time tripwire
+    /// a new variant hits, and this list must be extended in the same edit - a variant
+    /// missing here skips zero-registration silently, and the register-at-zero test cannot
+    /// notice because it iterates this same list.
+    const ALL: [Self; 5] = [
+        Self::EmptyCommittee,
+        Self::NoUsableEndpoint,
+        Self::BatchShed,
+        Self::Rejected,
+        Self::Unreached,
+    ];
+
+    /// The `reason` label value this variant records under.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::EmptyCommittee => "empty_committee",
+            Self::NoUsableEndpoint => "no_usable_endpoint",
+            Self::BatchShed => "batch_shed",
+            Self::Rejected => "rejected",
+            Self::Unreached => "unreached",
+        }
+    }
+}
 
 /// Metrics for the observer transaction forwarder ([`crate::WorkerRpcForwarder`]).
 ///
-/// Both series count forwarding work the node deliberately gives up on to keep its own
-/// resource use bounded. Forwarding is best-effort, so shedding is a correct outcome rather
+/// The shed, abandoned, and dropped series count forwarding work the node deliberately gives
+/// up on to keep its own resource use bounded; the queued series is the intake denominator
+/// they read against. Forwarding is best-effort, so shedding is a correct outcome rather
 /// than an error - but it is an *absorbed* failure, invisible until it is not, which is
 /// exactly the category that needs to show up somewhere other than a `warn!` line. Transactions
-/// counted here were accepted by this node's RPC and never handed to a validator.
+/// counted as lost here were accepted by this node's RPC and never handed to a validator.
 ///
 /// Associated functions rather than instance handles, matching the epoch manager's
 /// `record_provider_fault_retry`: the emission sites are inside a spawned task that holds no
@@ -125,7 +190,8 @@ const FORWARDED_TXNS_ABANDONED: &str = "tn_reth.forwarded_txns_abandoned_total";
 pub(crate) struct ForwarderMetrics;
 
 impl ForwarderMetrics {
-    /// Register both forwarder counters with the current recorder without recording an event.
+    /// Register every forwarder series (shed, abandoned, queued, and one dropped series per
+    /// [`ForwardDropReason`]) with the current recorder without recording an event.
     ///
     /// Called from `WorkerRpcForwarder::new`, which runs at epoch start, long after the CLI
     /// installs the global recorder. The reason to register eagerly is the same one [`init`]
@@ -136,6 +202,10 @@ impl ForwarderMetrics {
     pub(crate) fn init() {
         metrics::counter!(FORWARDED_BATCHES_SHED).increment(0);
         metrics::counter!(FORWARDED_TXNS_ABANDONED).increment(0);
+        metrics::counter!(FORWARDED_TXNS_QUEUED).increment(0);
+        ForwardDropReason::ALL.iter().for_each(|reason| {
+            metrics::counter!(FORWARDED_TXNS_DROPPED, "reason" => reason.label()).increment(0);
+        });
     }
 
     /// Count one sealed batch dropped without being forwarded because every forward permit was
@@ -155,6 +225,23 @@ impl ForwarderMetrics {
     /// could not be walked inside its budget.
     pub(crate) fn record_txns_abandoned(count: u64) {
         metrics::counter!(FORWARDED_TXNS_ABANDONED).increment(count);
+    }
+
+    /// Count transactions handed to the forwarder, before any admission decision.
+    ///
+    /// The denominator the drop and abandon counters read against: without it a dashboard can
+    /// see what was lost but not what fraction of the intake that loss is.
+    pub(crate) fn record_txns_queued(count: u64) {
+        metrics::counter!(FORWARDED_TXNS_QUEUED).increment(count);
+    }
+
+    /// Count transactions the forwarding pipeline gave up on, labeled by [`ForwardDropReason`].
+    ///
+    /// Every call site pairs with a `warn!` (or a documented silent no-op), so the counter is
+    /// the dashboard-visible half of a loss the logs already describe: transactions counted
+    /// here were accepted by this node's RPC and never delivered to a validator.
+    pub(crate) fn record_txns_dropped(reason: ForwardDropReason, count: u64) {
+        metrics::counter!(FORWARDED_TXNS_DROPPED, "reason" => reason.label()).increment(count);
     }
 }
 
@@ -408,6 +495,52 @@ mod tests {
         assert!(matches!(series(&snapshot, FORWARDED_TXNS_ABANDONED), DebugValue::Counter(7)));
     }
 
+    /// [`ForwarderMetrics::init`] must register the queued base series and one dropped series
+    /// per [`ForwardDropReason`] at zero, and a recorded drop must move only its own reason's
+    /// series.
+    ///
+    /// The per-reason zero registrations carry the same weight as the unlabeled ones: a reason
+    /// that only appears once it fires cannot be told apart from a mistyped label value, and
+    /// its first `rate()` step is lost.
+    #[test]
+    fn test_forward_drop_reasons_register_at_zero_and_count_separately() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            ForwarderMetrics::init();
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert!(matches!(series(&snapshot, FORWARDED_TXNS_QUEUED), DebugValue::Counter(0)));
+        ForwardDropReason::ALL.into_iter().for_each(|reason| {
+            assert!(
+                matches!(reason_series(&snapshot, reason.label()), DebugValue::Counter(0)),
+                "reason {} must be registered at zero by init",
+                reason.label()
+            );
+        });
+
+        metrics::with_local_recorder(&recorder, || {
+            ForwarderMetrics::record_txns_queued(9);
+            ForwarderMetrics::record_txns_dropped(ForwardDropReason::BatchShed, 3);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        assert!(matches!(series(&snapshot, FORWARDED_TXNS_QUEUED), DebugValue::Counter(9)));
+        assert!(matches!(reason_series(&snapshot, "batch_shed"), DebugValue::Counter(3)));
+        ForwardDropReason::ALL
+            .into_iter()
+            .filter(|reason| *reason != ForwardDropReason::BatchShed)
+            .for_each(|reason| {
+                assert!(
+                    matches!(reason_series(&snapshot, reason.label()), DebugValue::Counter(0)),
+                    "a batch_shed drop must not move the {} series",
+                    reason.label()
+                );
+            });
+    }
+
     /// One series of a [`DebuggingRecorder`] snapshot, looked up by metric name.
     ///
     /// A free function rather than the closures the two tests above use, because this one is
@@ -428,6 +561,29 @@ mod tests {
             .find(|(key, ..)| key.key().name() == name)
             .map(|(.., value)| value)
             .unwrap_or_else(|| panic!("metric {name} not registered without an event"))
+    }
+
+    /// The dropped-transactions series for one `reason` label value.
+    ///
+    /// [`series`] cannot serve here: all reasons share the metric name, so a name-only lookup
+    /// returns whichever series the snapshot happens to list first.
+    fn reason_series<'a>(
+        snapshot: &'a [(
+            metrics_util::CompositeKey,
+            Option<metrics::Unit>,
+            Option<metrics::SharedString>,
+            DebugValue,
+        )],
+        reason: &str,
+    ) -> &'a DebugValue {
+        snapshot
+            .iter()
+            .find(|(key, ..)| {
+                key.key().name() == FORWARDED_TXNS_DROPPED
+                    && key.key().labels().any(|l| l.key() == "reason" && l.value() == reason)
+            })
+            .map(|(.., value)| value)
+            .unwrap_or_else(|| panic!("dropped series for reason {reason} not registered"))
     }
 
     /// Read one gauge out of a snapshot, selecting by `call` label when one is given.


### PR DESCRIPTION
Closes #1133.

## Summary

The forwarding pipeline counted drops on two paths (the admission-time batch shed and the batch-budget abandon) and only warned on every other one.  There is no tracing-to-metrics bridge in the codebase, so those warns reach no dashboard:  an observer that is dropping every transaction it accepts looks healthy on metrics.  This PR gives the pipeline one reason-labeled drop counter per scope, plus the queued-side base series the issue asked for, so the losses have both a signal and a denominator.

## Changes

- [x] `crates/tn-reth/src/metrics.rs`:  a `ForwardDropReason` sum type labeling `tn_reth.forwarded_txns_dropped_total{reason}` with `empty_committee`, `no_usable_endpoint`, `batch_shed`, `rejected`, and `unreached`, each documented with its alertability;  a queued-side base series `tn_reth.forwarded_txns_queued_total`;  both registered at zero in `ForwarderMetrics::init` for the reason the existing counters register eagerly (an absent series is indistinguishable from a broken exporter, and a `rate()` whose first sample is nonzero renders no step).
- [x] `crates/tn-reth/src/forward.rs`:  `forward_txns` counts the queued intake before any admission decision, counts the previously silent empty-committee no-op, counts the advertised-but-unusable endpoint drop beside its existing warn, and counts the shed batch at transaction grain beside the existing batch-grain counter;  `spawn_forward` tallies `rejected` and `unreached` outcomes into the same labeled counter at batch end.  `queued - dropped - abandoned` is now the number a dashboard can trust as delivered.
- [x] `crates/consensus/worker/src/metrics.rs`:  `WorkerMetrics::record_forward_dropped(reason, count)` modeled on the existing labeled recorders `record_quorum_failure` and `record_batches_fetched` (a zero count records nothing, so a path that never dropped creates no series), labeling `tn_worker.forwarded_txns_dropped_total{worker,reason}` with a worker-side `ForwardDropReason` sum type.
- [x] `crates/consensus/worker/src/worker.rs`:  the two discovery drop arms in `disburse_txns` (`no_endpoint_advertised`, `discovery_failed`) record the whole-batch loss;  the transaction count is captured before the vec moves into the spawned task, and the metrics handle moves in beside it.

Cardinality is bounded by construction:  every `reason` value comes from a closed sum type, so the series set is a compile-time constant and no attacker-influenced string (endpoint URL, error text) ever becomes a label value.

## Testing

Run under the pinned toolchain with the OOM cap:

- `cargo +1.94 test -j 2 -p tn-reth --lib -- metrics forward`:  new coverage for the drop reasons registering at zero and moving independently (`test_forward_drop_reasons_register_at_zero_and_count_separately`), both previously silent routing dead ends (`forward_txns_counts_a_batch_with_no_committee_as_dropped` and `forward_txns_counts_a_batch_with_no_advertised_endpoint_as_dropped`), the unusable-endpoint drop (`forward_txns_counts_a_batch_with_no_usable_endpoint_as_dropped`), and the shed path extended to assert the transaction-grain counter and the queued denominator.
- `cargo +1.94 test -j 2 -p tn-worker --lib -- metrics`:  `record_forward_dropped` asserted per `worker` and `reason` labels, with the zero-count negative half asserted the same way the fetch recorder's is (a zero count must not register a series).
- `cargo +nightly fmt` and `cargo +1.94 check -j 2 --all-targets -p tn-reth -p tn-worker`.

The `rejected` and `unreached` sites record from inside the spawned forward task, where a test-local recorder cannot be observed (the existing budget-abandon test asserts timing for the same reason);  their recorder helper is covered by the unit test above.

## Notes

- Based on current `main`, which now carries the admission-control forwarder (GHSA-7v6m) this instruments.  The companion fix for #1132 will reshape the worker-side sites into counted refusals that keep their transactions;  the reasons here are labeled per site, so that change moves the worker-side counter's semantics (from lost to refused) without invalidating the forwarder-side set.
- `ForwarderMetrics` stays `pub(crate)`, as the issue suggested.
- The existing `tn_reth.forwarded_batches_shed_total` and `tn_reth.forwarded_txns_abandoned_total` series are unchanged;  the abandon counter stays separate from the drop counter so the two subtract from the queued denominator without double counting.
