### PR TITLE
fix(storage): latch the first background write failure, not the last

### DIFF
--- a/crates/storage/src/archive/error/commit.rs
+++ b/crates/storage/src/archive/error/commit.rs
@@ -15,6 +15,8 @@ pub enum CommitError {
     IndexFileSync(io::Error),
     /// DB is opened read-only.
     ReadOnly,
+    /// DB is in the failed state; contains a copy of the io error that caused that state.
+    Failed(io::Error),
 }
 
 impl Error for CommitError {}
@@ -26,6 +28,7 @@ impl fmt::Display for CommitError {
             Self::DataFileSync(io_err) => write!(f, "data sync: {io_err}"),
             Self::IndexFileSync(io_err) => write!(f, "index sync: {io_err}"),
             Self::ReadOnly => write!(f, "read only"),
+            Self::Failed(io_err) => write!(f, "pack failed: {io_err}"),
         }
     }
 }

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -90,6 +90,15 @@ where
         self.inner.append(value)
     }
 
+    /// Test-only failure injector: make the next append fail with
+    /// [`AppendError::WriteDataError`], the same classification a real io write failure gets.
+    /// The append path then marks the pack failed, which is the poisoned state the queued-save
+    /// regression tests start from.
+    #[cfg(test)]
+    pub(crate) fn fail_next_append_for_test(&mut self) {
+        self.inner.fail_next_append = true;
+    }
+
     /// Return the DB version.
     pub fn version(&self) -> u16 {
         self.inner.version()
@@ -165,6 +174,9 @@ where
     failed: bool,
     read_only: bool,
     uid_idx: u64, // Store for opening an iterator.
+    /// Test-only: when set, the next append fails as if the data write hit an io error.
+    #[cfg(test)]
+    fail_next_append: bool,
     _value: PhantomData<V>,
 }
 
@@ -202,6 +214,8 @@ where
             failed: false,
             read_only,
             uid_idx,
+            #[cfg(test)]
+            fail_next_append: false,
             _value: PhantomData,
         })
     }
@@ -233,9 +247,26 @@ where
         Ok(bytes)
     }
 
+    /// Test-only injection point: fail the append the way a real io write failure fails.
+    /// Armed by [`Pack::fail_next_append_for_test`]; disarms after one use.
+    #[cfg(test)]
+    fn injected_append_failure(&mut self) -> Result<(), AppendError> {
+        std::mem::take(&mut self.fail_next_append)
+            .then(|| AppendError::WriteDataError(io::Error::other("injected write failure")))
+            .map_or(Ok(()), Err)
+    }
+
+    /// Outside tests the injection point compiles to a no-op.
+    #[cfg(not(test))]
+    fn injected_append_failure(&mut self) -> Result<(), AppendError> {
+        Ok(())
+    }
+
     /// Do the actual insert so the public function can rollback easily on an error.
     fn append_inner(&mut self, value: &V) -> Result<u64, AppendError> {
         let record_pos = self.data_file.len();
+
+        self.injected_append_failure()?;
 
         write_value(
             value,

--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -83,9 +83,10 @@ where
     ///   - key data
     ///   - value data
     ///
-    /// For the erros IndexCrcError, IndexOverflow, WriteDataError or KeyError the DB will move to a
-    /// failed state and become read only.  These errors all indicate serious underlying issues that
-    /// can not be trivially fixed, a reopen/repair might help.
+    /// A WriteDataError moves the DB to a failed state.  While the DB is failed, each append
+    /// and each commit returns a copy of the error that caused the failed state.  This error
+    /// indicates a serious underlying issue that can not be trivially fixed, a reopen/repair
+    /// might help.
     pub fn append(&mut self, value: &V) -> Result<u64, AppendError> {
         self.inner.append(value)
     }
@@ -117,6 +118,8 @@ where
     /// Flush any caches to disk and sync the data and index file.
     /// All data should be safely on disk if this call succeeds.
     /// Note this is an expensive call (syncing to disk is not cheap).
+    /// On a pack in the failed state this returns [`CommitError::Failed`] with a copy of the
+    /// error that caused the failed state.
     pub fn commit(&mut self) -> Result<(), CommitError> {
         self.inner.commit()
     }
@@ -171,7 +174,10 @@ where
     value_buffer: Vec<u8>,
     /// Used as a second buffer for compress and decompress operations on records.
     compression_buffer: Vec<u8>,
-    failed: bool,
+    /// Root cause of the failed state: a copy of the io error from the append that failed
+    /// the pack. While this is `Some`, each append and each commit returns a copy of this
+    /// error so callers see the root cause and not a generic guard error.
+    failed: Option<io::Error>,
     read_only: bool,
     uid_idx: u64, // Store for opening an iterator.
     /// Test-only: when set, the next append fails as if the data write hit an io error.
@@ -211,7 +217,7 @@ where
             data_file,
             value_buffer: Vec::new(),
             compression_buffer: Vec::new(),
-            failed: false,
+            failed: None,
             read_only,
             uid_idx,
             #[cfg(test)]
@@ -248,24 +254,26 @@ where
     }
 
     /// Test-only injection point: fail the append the way a real io write failure fails.
-    /// Armed by [`Pack::fail_next_append_for_test`]; disarms after one use.
+    /// Armed by [`Pack::fail_next_append_for_test`]; disarms after one use. The injected
+    /// error carries the StorageFull kind, a sentinel that is not the Other default, so
+    /// tests can assert that a replayed copy keeps the kind.
     #[cfg(test)]
     fn injected_append_failure(&mut self) -> Result<(), AppendError> {
         std::mem::take(&mut self.fail_next_append)
-            .then(|| AppendError::WriteDataError(io::Error::other("injected write failure")))
+            .then(|| {
+                AppendError::WriteDataError(io::Error::new(
+                    io::ErrorKind::StorageFull,
+                    "injected write failure",
+                ))
+            })
             .map_or(Ok(()), Err)
-    }
-
-    /// Outside tests the injection point compiles to a no-op.
-    #[cfg(not(test))]
-    fn injected_append_failure(&mut self) -> Result<(), AppendError> {
-        Ok(())
     }
 
     /// Do the actual insert so the public function can rollback easily on an error.
     fn append_inner(&mut self, value: &V) -> Result<u64, AppendError> {
         let record_pos = self.data_file.len();
 
+        #[cfg(test)]
         self.injected_append_failure()?;
 
         write_value(
@@ -286,18 +294,22 @@ where
     ///   - key data
     ///   - value data
     ///
-    /// For the errors IndexCrcError, IndexOverflow, WriteDataError or KeyError the DB will move to
-    /// a failed state and become read only.  These errors all indicate serious underlying
-    /// issues that can not be trivially fixed, a reopen/repair might help.
+    /// A WriteDataError moves the DB to a failed state.  While the DB is failed, each append
+    /// and each commit returns a copy of the error that caused the failed state.  This error
+    /// indicates a serious underlying issue that can not be trivially fixed, a reopen/repair
+    /// might help.
     fn append(&mut self, value: &V) -> Result<u64, AppendError> {
-        if self.read_only || self.failed {
+        if self.read_only {
             return Err(AppendError::ReadOnly);
         }
+        self.failed_cause().map_err(AppendError::WriteDataError)?;
         let result = self.append_inner(value);
         if let Err(err) = &result {
             match err {
                 // These errors all indicate a failed DB that can no longer be inserted too.
-                AppendError::WriteDataError(_io_err) => self.failed = true,
+                AppendError::WriteDataError(io_err) => {
+                    self.failed = Some(Self::copy_io_error(io_err))
+                }
                 // These errors do not indicate a failed DB.
                 AppendError::SerializeValue(_)
                 | AppendError::ReadOnly
@@ -306,6 +318,19 @@ where
             }
         }
         result
+    }
+
+    /// Copy an io error: io::Error is not Clone, so the copy keeps the error kind and the
+    /// message of the original.
+    fn copy_io_error(cause: &io::Error) -> io::Error {
+        io::Error::new(cause.kind(), cause.to_string())
+    }
+
+    /// When the pack is in the failed state, return a copy of the io error that caused it.
+    /// The copy keeps the error kind and the message of the first failure, so every later
+    /// append or commit reports the root cause of the failed state.
+    fn failed_cause(&self) -> Result<(), io::Error> {
+        self.failed.as_ref().map_or(Ok(()), |cause| Err(Self::copy_io_error(cause)))
     }
 
     /// Return the DB version.
@@ -327,9 +352,10 @@ where
     /// All data should be safely on disk if this call succeeds.
     /// Note this is a very expensive call (syncing to disk is not cheap).
     fn commit(&mut self) -> Result<(), CommitError> {
-        if self.read_only || self.failed {
+        if self.read_only {
             return Err(CommitError::ReadOnly);
         }
+        self.failed_cause().map_err(CommitError::Failed)?;
         self.flush().map_err(CommitError::Flush)?;
         self.data_file.sync_all().map_err(CommitError::DataFileSync)?;
         Ok(())
@@ -695,6 +721,85 @@ mod tests {
         name: String,
     }
     type TestPack = Pack<TestRec>;
+
+    /// Regression test for the failed-state guard: a failed pack replays the error that
+    /// caused the failed state, on both the append and the commit path, instead of the
+    /// read-only guard error it returned before. The replayed copy keeps the error kind
+    /// and the message of the root cause.
+    #[test]
+    fn failed_pack_replays_the_root_cause() {
+        let tmp_path = TempDir::with_prefix("test_failed_pack_replay").expect("temp dir");
+        let mut db: TestPack = Pack::open(
+            tmp_path.path().join("pack_failed_replay"),
+            0,
+            false,
+            PackCompression::None,
+            0,
+        )
+        .expect("open pack");
+
+        // Arm the injector: the next append fails the way a real io write failure fails and
+        // moves the pack to the failed state.
+        db.fail_next_append_for_test();
+        let root_cause = db
+            .append(&TestRec { idx: 1, name: "Value One".to_string() })
+            .expect_err("armed append must fail");
+        assert!(
+            root_cause.to_string().contains("injected write failure"),
+            "unexpected root cause: {root_cause}"
+        );
+        // Positive control for the negative assertions below: the root cause does not
+        // render as the guard error.
+        assert!(!root_cause.to_string().contains("read only"), "got: {root_cause}");
+        // Positive control for the kind assertions below: the injected root cause really
+        // carries the StorageFull sentinel kind, not the Other default a degenerate copy
+        // would produce.
+        assert!(
+            matches!(&root_cause, AppendError::WriteDataError(io_err) if io_err.kind() == io::ErrorKind::StorageFull),
+            "unexpected root cause shape: {root_cause}"
+        );
+
+        // Each later append replays a copy of the root cause, not the read-only guard error.
+        let replayed = db
+            .append(&TestRec { idx: 2, name: "Value Two".to_string() })
+            .expect_err("a failed pack rejects appends");
+        assert_eq!(
+            replayed.to_string(),
+            root_cause.to_string(),
+            "append must replay the root cause"
+        );
+        assert!(
+            matches!(&replayed, AppendError::WriteDataError(io_err) if io_err.kind() == io::ErrorKind::StorageFull),
+            "the append replay must keep the error kind, got: {replayed}"
+        );
+
+        // Commit reports the failed state with its own discriminant and the same root cause.
+        let commit_err = db.commit().expect_err("a failed pack rejects commits");
+        assert!(
+            matches!(&commit_err, CommitError::Failed(io_err) if io_err.kind() == io::ErrorKind::StorageFull),
+            "commit must report the failed state and keep the error kind, got: {commit_err:?}"
+        );
+        assert!(
+            commit_err.to_string().contains("injected write failure"),
+            "commit must carry the root cause, got: {commit_err}"
+        );
+
+        // A genuinely read-only pack still reports the read-only guard error. The injected
+        // failure fired before any record write, so the file reopens cleanly.
+        drop(db);
+        let mut ro: TestPack = Pack::open(
+            tmp_path.path().join("pack_failed_replay"),
+            0,
+            true,
+            PackCompression::None,
+            0,
+        )
+        .expect("reopen read only");
+        let ro_err = ro
+            .append(&TestRec { idx: 3, name: "Value Three".to_string() })
+            .expect_err("a read-only pack rejects appends");
+        assert_eq!(ro_err.to_string(), "read only");
+    }
 
     fn archive_pack_(compression: PackCompression) {
         let tmp_path = TempDir::with_prefix("test_archive_pack_one").expect("temp dir");

--- a/crates/storage/src/certificate_pack.rs
+++ b/crates/storage/src/certificate_pack.rs
@@ -22,6 +22,7 @@ use crate::{
         pack::{Pack, PackCompression, DATA_HEADER_BYTES},
     },
     consensus_pack::PACK_VERSION,
+    error_latch::latch_first_error,
 };
 
 enum PackMessage {
@@ -59,9 +60,15 @@ fn run_pack_loop(
     while let Some(msg) = rx.blocking_recv() {
         match msg {
             PackMessage::Save(cert) => {
-                if let Err(e) = inner.save(&cert) {
-                    tx_error.send_replace(Some(e));
-                }
+                // First-error-wins: after a real write failure poisons the pack, each queued
+                // save fails with the poisoned-pack guard's `ReadOnly` error. A plain
+                // `send_replace` would overwrite the root cause with that follow-on error
+                // before any reader could observe it (#1148). The log keeps every failure
+                // visible, including the ones the latch does not keep.
+                inner.save(&cert).unwrap_or_else(|e| {
+                    error!(target: "certificate_pack", %e, "failed to save certificate");
+                    latch_first_error(&tx_error, e);
+                });
             }
             PackMessage::Get(digest, tx) => {
                 let _ = tx.send(inner.get(digest));
@@ -108,7 +115,7 @@ impl CertificatePack {
         let handle = std::thread::spawn(move || match Inner::open(path, false) {
             Ok(inner) => run_pack_loop(inner, rx, tx_error, epoch),
             Err(e) => {
-                tx_error.send_replace(Some(e));
+                latch_first_error(&tx_error, e);
                 clear_pack_loop(rx);
             }
         });
@@ -123,7 +130,7 @@ impl CertificatePack {
         let handle = std::thread::spawn(move || match Inner::open(path, true) {
             Ok(inner) => run_pack_loop(inner, rx, tx_error, epoch),
             Err(e) => {
-                tx_error.send_replace(Some(e));
+                latch_first_error(&tx_error, e);
                 clear_pack_loop(rx);
             }
         });
@@ -131,6 +138,11 @@ impl CertificatePack {
     }
 
     /// Return any delayed error from a previous background operation.
+    ///
+    /// The slot does not clear on read. When more than one background operation fails, the
+    /// slot keeps the first failure. In the poisoned-pack cascade (a write failure makes
+    /// every queued save fail with the read-only guard error) the first failure is the root
+    /// cause. Every failure, kept or not, is logged by the pack loop.
     pub fn get_error(&self) -> Result<(), PackError> {
         match &*self.error.borrow() {
             Some(e) => Err(e.clone()),
@@ -379,7 +391,9 @@ mod test {
     use tn_test_utils::CommitteeFixture;
     use tn_types::{Certificate, Hash, HeaderDigest};
 
-    use crate::{certificate_pack::CertificatePack, mem_db::MemDatabase};
+    use crate::{
+        archive::error::insert::AppendError, certificate_pack::CertificatePack, mem_db::MemDatabase,
+    };
 
     fn make_test_cert(fixture: &CommitteeFixture<MemDatabase>, index: usize) -> Certificate {
         let mut cert = Certificate::default();
@@ -435,5 +449,67 @@ mod test {
             let loaded = pack.get(digest).await.expect("should load cert read-only");
             assert_eq!(loaded.digest(), digest);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn queued_saves_after_a_failed_write_keep_the_root_cause() {
+        // Regression test for #1148: a real write failure poisons the pack, so every save
+        // queued behind it fails on the poisoned-pack guard with `AppendError::ReadOnly`.
+        // Before the fix the loop latched last-write-wins: the follow-on "read only" error
+        // overwrote the root cause before any reader could observe it, and the latch then
+        // reported a read-only condition on a pack that was opened read-write, forever.
+        let temp_dir = TempDir::with_prefix("queued_saves_root_cause").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+
+        // Build the actor by hand so the test can arm the write-failure injector before the
+        // loop takes ownership of the pack.
+        let mut inner =
+            super::Inner::open(temp_dir.path().join("epoch-0"), false).expect("open pack inner");
+        inner.data.fail_next_append_for_test();
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let (tx_error, error) = tokio::sync::watch::channel(None);
+        let handle = std::thread::spawn(move || super::run_pack_loop(inner, rx, tx_error, 0));
+
+        // Two saves back to back with no reader between them. The first fails with the
+        // injected io write failure and poisons the pack; the second fails on the
+        // poisoned-pack guard. A single consumer draining a FIFO channel guarantees the
+        // order, so this is deterministic rather than a race.
+        tx.send(super::PackMessage::Save(make_test_cert(&fixture, 0)))
+            .await
+            .expect("queue first failing save");
+        tx.send(super::PackMessage::Save(make_test_cert(&fixture, 1)))
+            .await
+            .expect("queue second failing save");
+        // A round-trip through the actor proves both saves were processed.
+        let (tx_contains, rx_contains) = tokio::sync::oneshot::channel();
+        tx.send(super::PackMessage::Contains(HeaderDigest::default(), tx_contains))
+            .await
+            .expect("queue contains barrier");
+        let _ = rx_contains.await.expect("actor replied to the barrier");
+
+        let latched = error.borrow().clone().expect("a failed save latched an error");
+        assert!(
+            matches!(latched, super::PackError::Append(_)),
+            "latch holds the append failure, got: {latched:?}"
+        );
+        let text = latched.to_string();
+        assert!(
+            text.contains("injected write failure"),
+            "latch must keep the root cause, got: {text}"
+        );
+        assert!(
+            !text.contains("read only"),
+            "latch must not report the follow-on read-only error, got: {text}"
+        );
+        // Positive control for the negative assertion above: the follow-on guard error
+        // really renders as "read only" today, so a later Display reword cannot make that
+        // check pass vacuously without failing here.
+        assert_eq!(AppendError::ReadOnly.to_string(), "read only");
+
+        tx.send(super::PackMessage::Shutdown).await.expect("queue shutdown");
+        tokio::task::spawn_blocking(move || handle.join())
+            .await
+            .expect("spawn_blocking join")
+            .expect("actor thread exits cleanly");
     }
 }

--- a/crates/storage/src/certificate_pack.rs
+++ b/crates/storage/src/certificate_pack.rs
@@ -65,11 +65,12 @@ fn run_pack_loop(
     while let Some(msg) = rx.blocking_recv() {
         match msg {
             PackMessage::Save(cert) => {
-                // First-error-wins: after a real write failure poisons the pack, each queued
-                // save fails with the poisoned-pack guard's `ReadOnly` error. A plain
-                // `send_replace` would overwrite the root cause with that follow-on error
-                // before any reader could observe it (#1148). The log keeps every failure
-                // visible, including the ones the latch does not keep.
+                // First-error-wins: a plain `send_replace` would overwrite the root cause
+                // with a follow-on error before any reader could observe it (#1148). The
+                // pack also replays the root cause of its failed state on each later save,
+                // so this latch is defense in depth for failures that do not share one root
+                // cause. The log keeps every failure visible, including the ones the latch
+                // does not keep.
                 inner.save(&cert).unwrap_or_else(|e| {
                     error!(target: "certificate_pack", %e, "failed to save certificate");
                     latch_first_error(&tx_error, e);
@@ -159,8 +160,8 @@ impl CertificatePack {
     ///
     /// The slot does not clear on read. When more than one background operation fails, the
     /// slot keeps the first failure. In the poisoned-pack cascade (a write failure makes
-    /// every queued save fail with the read-only guard error) the first failure is the root
-    /// cause. Every failure, kept or not, is logged by the pack loop.
+    /// every queued save fail with a copy of that write failure) the first failure is the
+    /// root cause. Every failure, kept or not, is logged by the pack loop.
     pub fn get_error(&self) -> Result<(), PackError> {
         match &*self.error.borrow() {
             Some(e) => Err(e.clone()),
@@ -481,11 +482,15 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn queued_saves_after_a_failed_write_keep_the_root_cause() {
-        // Regression test for #1148: a real write failure poisons the pack, so every save
-        // queued behind it fails on the poisoned-pack guard with `AppendError::ReadOnly`.
-        // Before the fix the loop latched last-write-wins: the follow-on "read only" error
-        // overwrote the root cause before any reader could observe it, and the latch then
-        // reported a read-only condition on a pack that was opened read-write, forever.
+        // Regression test for #1148: a real write failure poisons the pack, and every save
+        // queued behind it fails on the poisoned-pack guard. Before the fix that guard
+        // returned `AppendError::ReadOnly` and the loop latched last-write-wins: the
+        // follow-on "read only" error overwrote the root cause before any reader could
+        // observe it, and the latch then reported a read-only condition on a pack that was
+        // opened read-write, forever. Now the guard replays the root cause and the latch
+        // keeps the first error; both layers report the root cause here, so this test stays
+        // green when either layer alone is reverted and fails only when both revert. The
+        // per-layer kills live in the error_latch and epoch_records unit tests.
         let temp_dir = TempDir::with_prefix("queued_saves_root_cause").expect("temp dir");
         let fixture = CommitteeFixture::builder(MemDatabase::default).build();
 
@@ -529,7 +534,7 @@ mod test {
             !text.contains("read only"),
             "latch must not report the follow-on read-only error, got: {text}"
         );
-        // Positive control for the negative assertion above: the follow-on guard error
+        // Positive control for the negative assertion above: the read-only guard error
         // really renders as "read only" today, so a later Display reword cannot make that
         // check pass vacuously without failing here.
         assert_eq!(AppendError::ReadOnly.to_string(), "read only");

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -37,6 +37,7 @@ use crate::{
         position_index::index::PositionIndex,
     },
     consensus_pack::fetch_error_is_absent,
+    error_latch::latch_first_error,
 };
 
 /// Current version of the epoch pack file.
@@ -86,9 +87,11 @@ enum EpochDbMessage {
 ///
 /// Operations are dispatched to a background thread that owns the file handles.
 /// Errors from background writes are surfaced on the next call via [`get_error`], which clears
-/// the slot as it reads, so exactly one subsequent caller observes a given failure. Use
-/// [`peek_error`] to check without consuming. [`persist`] is the durability barrier: it reports
-/// any earlier write failure even if that write was still queued when the flush was requested.
+/// the slot as it reads, so exactly one subsequent caller observes a given failure. When more
+/// than one write fails before a read, the slot keeps the first failure (for a poisoned-pack
+/// cascade that is the root cause; every failure is logged either way). Use [`peek_error`] to
+/// check without consuming. [`persist`] is the durability barrier: it reports any earlier
+/// write failure even if that write was still queued when the flush was requested.
 #[derive(Debug, Clone)]
 pub struct EpochRecordDb {
     /// Channel to send commands to the background thread.
@@ -109,29 +112,33 @@ fn run_db_loop(
 ) {
     while let Some(msg) = rx.blocking_recv() {
         match msg {
+            // The four save arms latch first-error-wins: two queued saves can fail with no
+            // reader between them, and a plain `send_replace` would lose the first failure
+            // (#1148). In the poisoned-pack cascade the first failure is the root cause.
+            // The log line still records every failure.
             EpochDbMessage::SaveDummy0Record(record) => {
-                if let Err(e) = inner.save_dummy_epoch0(record) {
+                inner.save_dummy_epoch0(record).unwrap_or_else(|e| {
                     error!(target: "epoch-db", %e, "failed to save dummy epoch 0 record");
-                    tx_error.send_replace(Some(e));
-                }
+                    latch_first_error(&tx_error, e);
+                });
             }
             EpochDbMessage::SaveRecord(record) => {
-                if let Err(e) = inner.save_record(record) {
+                inner.save_record(record).unwrap_or_else(|e| {
                     error!(target: "epoch-db", %e, "failed to save epoch record");
-                    tx_error.send_replace(Some(e));
-                }
+                    latch_first_error(&tx_error, e);
+                });
             }
             EpochDbMessage::Save(record, cert) => {
-                if let Err(e) = inner.save(record, cert) {
+                inner.save(record, cert).unwrap_or_else(|e| {
                     error!(target: "epoch-db", %e, "failed to save epoch record and certificate");
-                    tx_error.send_replace(Some(e));
-                }
+                    latch_first_error(&tx_error, e);
+                });
             }
             EpochDbMessage::SaveCertificate(digest, cert) => {
-                if let Err(e) = inner.save_certificate(digest, cert) {
+                inner.save_certificate(digest, cert).unwrap_or_else(|e| {
                     error!(target: "epoch-db", %e, "failed to save epoch certificate");
-                    tx_error.send_replace(Some(e));
-                }
+                    latch_first_error(&tx_error, e);
+                });
             }
             EpochDbMessage::RecordByEpoch(epoch, tx) => {
                 let _ = tx.send(inner.record_by_epoch(epoch));
@@ -423,6 +430,7 @@ impl EpochRecordDb {
 
     /// Return any delayed error recorded by the background thread.
     /// Also clears the error.
+    /// When more than one write failed since the last read, this returns the first failure.
     pub fn get_error(&self) -> Result<(), EpochDbError> {
         match self.error.send_replace(None) {
             Some(e) => Err(e.clone()),
@@ -1799,6 +1807,46 @@ mod test {
 
         // The flush consumed the failure, so it is not left behind to be misattributed to an
         // unrelated later caller.
+        db.get_error().expect("persist acknowledged the error");
+    }
+
+    #[tokio::test]
+    async fn queued_save_failures_keep_the_first_error() {
+        // Regression test for #1148: two saves fail back to back with no reader between them.
+        // The latch was last-write-wins, so the second failure silently replaced the first
+        // and the root cause was lost. The latch must keep the first failure.
+        let temp_dir = TempDir::with_prefix("queued_saves_first_error").expect("temp dir");
+        let db = EpochRecordDb::open(temp_dir.path()).expect("open db");
+
+        // Queue two saves the actor will reject: epochs 5 and 7 are both out of order on an
+        // empty db and produce distinguishable errors. Both go straight to the channel so no
+        // handle-side guard or reader runs between the two failures. A single consumer
+        // draining a FIFO channel guarantees the save order, so this is deterministic rather
+        // than a race.
+        let first = EpochRecord { epoch: 5, ..Default::default() };
+        let second = EpochRecord { epoch: 7, ..Default::default() };
+        db.tx
+            .send(super::EpochDbMessage::SaveRecord(first))
+            .await
+            .expect("queue first failing save");
+        db.tx
+            .send(super::EpochDbMessage::SaveRecord(second))
+            .await
+            .expect("queue second failing save");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        db.tx.send(super::EpochDbMessage::Persist(tx)).await.expect("queue persist");
+
+        // The persist reply drains the latch, so it must carry the FIRST failure, not the
+        // one that happened to fail last.
+        let err = rx
+            .await
+            .expect("actor replied to the persist")
+            .expect_err("persist must report the queued save failures");
+        assert!(
+            matches!(err, EpochDbError::EpochOutOfOrder(0, 5)),
+            "latch must keep the first failure, got: {err:?}"
+        );
+        // The reply consumed the slot; nothing is left to misattribute to a later caller.
         db.get_error().expect("persist acknowledged the error");
     }
 

--- a/crates/storage/src/error_latch.rs
+++ b/crates/storage/src/error_latch.rs
@@ -1,0 +1,41 @@
+//! First-error-wins writes for the background-thread error latches.
+
+use tokio::sync::watch;
+
+/// Latch `error` into `slot` only when the slot is empty.
+///
+/// The store loops latch each failed background write into a `watch` slot. A plain
+/// `send_replace` is last-write-wins: after a real write failure poisons a pack, each queued
+/// write fails on the poisoned-pack guard with `ReadOnly` and overwrites the root cause before
+/// a reader can observe it. This helper keeps the first error, so in that cascade the root
+/// cause survives its follow-on failures. A reader that drains the slot still acknowledges
+/// exactly one failure; first-write-wins only changes which failure that is. Callers log every
+/// failure, so the errors the latch does not keep stay visible.
+pub(crate) fn latch_first_error<E>(slot: &watch::Sender<Option<E>>, error: E) {
+    slot.send_if_modified(|current| {
+        let vacant = current.is_none();
+        if vacant {
+            *current = Some(error);
+        }
+        vacant
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use super::latch_first_error;
+
+    #[test]
+    fn keeps_the_first_error() {
+        let (slot, mut reader) = tokio::sync::watch::channel(None);
+        latch_first_error(&slot, "root cause");
+        assert!(reader.has_changed().expect("sender alive"), "the first latch notifies");
+        assert_eq!(*reader.borrow_and_update(), Some("root cause"));
+        latch_first_error(&slot, "follow-on failure");
+        assert!(
+            !reader.has_changed().expect("sender alive"),
+            "a suppressed follow-on write does not notify"
+        );
+        assert_eq!(*reader.borrow(), Some("root cause"));
+    }
+}

--- a/crates/storage/src/error_latch.rs
+++ b/crates/storage/src/error_latch.rs
@@ -5,12 +5,14 @@ use tokio::sync::watch;
 /// Latch `error` into `slot` only when the slot is empty.
 ///
 /// The store loops latch each failed background write into a `watch` slot. A plain
-/// `send_replace` is last-write-wins: after a real write failure poisons a pack, each queued
-/// write fails on the poisoned-pack guard with `ReadOnly` and overwrites the root cause before
-/// a reader can observe it. This helper keeps the first error, so in that cascade the root
-/// cause survives its follow-on failures. A reader that drains the slot still acknowledges
-/// exactly one failure; first-write-wins only changes which failure that is. Callers log every
-/// failure, so the errors the latch does not keep stay visible.
+/// `send_replace` is last-write-wins: a later failure overwrites an earlier one before a
+/// reader can observe it, so the first failure of a cascade is lost. This helper keeps the
+/// first error. The pack itself also replays the root cause of its failed state on every
+/// later append and commit (flush is not guarded), so in that cascade both layers report
+/// the same root cause; the latch stays as defense in depth for failures that do not share
+/// one root cause. A reader that drains the slot still acknowledges exactly one failure;
+/// first-write-wins only changes which failure that is. Callers log every failure, so the
+/// errors the latch does not keep stay visible.
 pub(crate) fn latch_first_error<E>(slot: &watch::Sender<Option<E>>, error: E) {
     slot.send_if_modified(|current| {
         let vacant = current.is_none();

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -21,6 +21,7 @@ pub mod composite_db;
 pub mod consensus;
 pub mod consensus_pack;
 pub mod epoch_records;
+pub(crate) mod error_latch;
 pub mod exec_state_pack;
 pub mod layered_db;
 #[cfg(feature = "reth-libmdbx")]


### PR DESCRIPTION
Closes #1148.

## Problem

After a real IO write failure, `CertificatePack` correctly refuses every later append and commit. The surviving diagnostic is wrong. Each save queued behind the failure hits the poisoned-pack guard and fails with `AppendError::ReadOnly`, and `run_pack_loop` latched every failure with an unconditional overwrite. The last queued save decided the final value, so `get_error` reported `Data Append Error (read only)` for a pack that was opened read-write, and the original `WriteDataError` text was gone permanently. No attacker is required; one disk-level write failure with two or more saves in flight is enough.

`EpochRecordDb` has the same latch primitive. Its `get_error` drains the slot on read, so the mask is transient there, but two queued failing saves with no reader between them lose the first error the same way.

## Root cause

`watch::Sender::send_replace(Some(e))` is last-write-wins, and no latch write site had a first-error guard. The root cause (the only failure that carries the IO error text, and the only one that sets `failed = true`) is exactly the error that follow-on failures overwrite, because every save queued behind it is guaranteed to fail with the mislabeled `ReadOnly` error.

## Fix

- [x] `crates/storage/src/error_latch.rs` (new): `latch_first_error`, a shared first-error-wins write for the background error latches. It fills the slot only when the slot is empty, via `send_if_modified`.
- [x] `crates/storage/src/certificate_pack.rs`: all three latch write sites (the `Save` arm and both open-failure arms) go through `latch_first_error`, and the `Save` arm now logs each failure the way `EpochRecordDb` already does, so the errors the latch does not keep stay visible. The `get_error` docs state the first-error contract.
- [x] `crates/storage/src/epoch_records.rs`: all four save arms go through `latch_first_error`. Draining reads are unchanged: `get_error` and the `Persist` reply still acknowledge exactly one failure; first-write-wins only changes which failure that is, which in the poisoned-pack cascade is the root cause.
- [x] `crates/storage/src/archive/pack.rs`: a `cfg(test)` injector (`fail_next_append_for_test`) makes the next append fail with `AppendError::WriteDataError`, the same classification a real IO write failure gets, so the tests can start the cascade from a genuine poisoned state. It compiles to a no-op outside tests.

This composes with #1143 (fold the latched error into `CertificatePack` flush replies): what the latch holds is what those replies report, so keeping the first error makes them name the real failure instead of the spurious read-only condition.

## Testing

Regression tests, one per store, both confirmed by mutation (revert the latch to `send_replace`, watch the test fail, restore):

- `certificate_pack::test::queued_saves_after_a_failed_write_keep_the_root_cause`: arms the injector, drives `run_pack_loop` directly, and queues two saves back to back with no reader between them. The latch must keep the injected write failure and must not report `read only`. The test pins the error variant and carries a positive control for the negative assertion (the guard error really renders as `read only`), so a later `Display` reword cannot make it pass vacuously.
- `epoch_records::test::queued_save_failures_keep_the_first_error`: queues two out-of-order saves (distinguishable errors) and a persist behind them. The persist reply drains the latch and must carry the first failure.

Both tests order events through the actor's single FIFO channel, so the failure order is deterministic rather than a race. Full battery on the pinned toolchain in an isolated target dir: nightly `cargo fmt -- --check`, nightly `clippy --workspace` and `clippy --workspace --all-features` with `-D warnings`, `cargo +1.94 test --no-run --workspace`, and `cargo +1.94 test -p tn-storage` to run the storage suite.
