### PR TITLE
test(e2e): cut eject restart test runtime by about 36%

### DIFF
--- a/crates/e2e-tests/tests/it/eject.rs
+++ b/crates/e2e-tests/tests/it/eject.rs
@@ -60,15 +60,32 @@ use tracing::info;
 /// (genesis creation requires the extra node) but never starts it.
 const GENESIS_OBSERVER: &str = "genesis-observer";
 
-/// Per-test epoch duration (seconds) for the mid-epoch restart regression.
+/// Sequence-epoch duration (seconds) for the mid-epoch restart regression.
 ///
 /// [`test_committee_member_restarted_mid_epoch_after_ejection`] must fit its whole in-epoch
-/// sequence — fresh-boundary entry, one full leader rotation, the governance burn, the burn-block
-/// execution pin, kill, restart, and the mid-epoch consensus rejoin — inside ONE epoch. That
-/// sequence's worst case is ~29s, so the module-wide [`EPOCH_DURATION`] (10s) cannot host it;
-/// 40s banks comfortable margin without stretching the test into extra epochs. Every timeout in
-/// that test which scales with epoch length derives from this constant, not [`EPOCH_DURATION`].
+/// sequence (one full leader rotation, the governance burn, the burn-block execution pin, kill,
+/// restart, and the mid-epoch consensus rejoin) inside ONE epoch. That sequence's worst case is
+/// ~29s, so the module-wide [`EPOCH_DURATION`] (10s) cannot host it; 40s banks comfortable
+/// margin without stretching the sequence across extra epochs.
+///
+/// This constant is the anchor, not the genesis seed: genesis ships the short
+/// [`RESTART_WARMUP_EPOCH_DURATION`] and the test restores this duration on chain (via
+/// `upgradeStakeVersion`) for the epoch hosting the sequence, because only that epoch needs the
+/// 40s. Every timeout in the test which scales with epoch length keeps deriving from this
+/// constant, not [`EPOCH_DURATION`] and not the warmup seed.
 const RESTART_EPOCH_DURATION: u64 = 40;
+
+/// Genesis epoch duration (seconds) for the mid-epoch restart regression's warmup epochs.
+///
+/// The warmup epochs before the sequence epoch have one job: produce and certify epoch record 0,
+/// which the kill gate requires the kill target to serve. Genesis seeds ONE duration for every
+/// epoch, so without a second lever the warmup would pay the 40s that only the sequence epoch
+/// needs; instead genesis seeds this short duration and the test's startup `upgradeStakeVersion`
+/// restores [`RESTART_EPOCH_DURATION`] from the next epoch opening on. 8s sits above the
+/// documented 5s consensus minimum (`basefee.rs` / `epochs.rs` ship 5s, the sibling test 6s per
+/// [`EJECT_EPOCH_DURATION`]) with margin for the upgrade to confirm inside epoch 0 on the
+/// nominal path.
+const RESTART_WARMUP_EPOCH_DURATION: u64 = 8;
 
 /// Per-test epoch duration (seconds) for the mid-epoch current-committee ejection test.
 ///
@@ -118,6 +135,43 @@ async fn burn_with_retry<P: Provider>(
         Ok((_hash, block)) => Ok(block),
         Err(first_try) => {
             info!(target: "eject-test", %first_try, ?victim, "burn confirmation failed; retrying once");
+            governance_wallet.set_nonce(nonce);
+            wait_for_mid_epoch(provider, rpc_url).await?;
+            let (_hash, block) = send_owner_tx(rpc_url, governance_wallet, chain, calldata).await?;
+            Ok(block)
+        }
+    }
+}
+
+/// Submit the governance `upgradeStakeVersion` that restores [`RESTART_EPOCH_DURATION`], with
+/// owner nonce `nonce`, and wait for confirmation.
+///
+/// The new config copies the current `StakeConfig` verbatim except `epochDuration`, so stake and
+/// issuance stay byte-identical. A confirmation straddling an epoch boundary can get orphaned
+/// and lost; on failure the identical tx is retried once with the same nonce (idempotent: same
+/// payload, same hash) from the next measured mid-epoch window. Returns the block the upgrade's
+/// receipt landed in.
+async fn upgrade_duration_with_retry<P: Provider>(
+    provider: &P,
+    rpc_url: &str,
+    governance_wallet: &mut TransactionFactory,
+    chain: Arc<RethChainSpec>,
+    nonce: u64,
+) -> eyre::Result<u64> {
+    let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, provider);
+    let current = registry.getCurrentStakeConfig().call().await?;
+    let new_config = ConsensusRegistry::StakeConfig {
+        stakeAmount: current.stakeAmount,
+        minWithdrawAmount: current.minWithdrawAmount,
+        epochIssuance: current.epochIssuance,
+        epochDuration: u32::try_from(RESTART_EPOCH_DURATION)?,
+    };
+    let calldata: Bytes =
+        ConsensusRegistry::upgradeStakeVersionCall { newConfig: new_config }.abi_encode().into();
+    match send_owner_tx(rpc_url, governance_wallet, chain.clone(), calldata.clone()).await {
+        Ok((_hash, block)) => Ok(block),
+        Err(first_try) => {
+            info!(target: "eject-test", %first_try, "upgrade confirmation failed; retrying once");
             governance_wallet.set_nonce(nonce);
             wait_for_mid_epoch(provider, rpc_url).await?;
             let (_hash, block) = send_owner_tx(rpc_url, governance_wallet, chain, calldata).await?;
@@ -680,6 +734,11 @@ async fn test_validator_ejected_from_current_committee_mid_epoch() -> eyre::Resu
 ///   (the current epoch when its remaining budget clears the margin, otherwise a fresh flip into
 ///   the next epoch), and every wait re-checks that epoch E is still current, failing loudly as
 ///   "premise broken" if the sequence straddles a boundary.
+/// - TWO-DURATION SCHEDULE: genesis seeds the short [`RESTART_WARMUP_EPOCH_DURATION`] (warmup
+///   epochs exist only to get record 0 certified for the kill gate); a governance
+///   `upgradeStakeVersion` submitted at startup restores the 40s sequence duration, and the test
+///   enters the first epoch observed running it. Only the sequence epoch pays for the ~29s
+///   sequence. Bonus coverage: no other e2e test exercises `upgradeStakeVersion` end to end.
 ///
 /// The detectors, in order: (a) the restarted node's consensus height re-advances past
 /// everything it could have held at death — commits it can only acquire by verifying the
@@ -703,7 +762,8 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
     // the victim (burned mid-epoch, node stays up); the kill target is validator-2 = index 1
     let victim_addr = nodes[4].1;
 
-    // setup genesis with the longer per-test epoch (see RESTART_EPOCH_DURATION)
+    // setup genesis with the short warmup epoch; the sequence duration is restored on chain at
+    // startup (see RESTART_WARMUP_EPOCH_DURATION)
     let temp_dir = tempfile::TempDir::with_prefix("eject_restart")?;
     let temp_path = temp_dir.path();
 
@@ -714,7 +774,7 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
         (GENESIS_OBSERVER, observer_wallet.address()),
         governance_wallet.address(),
         &nodes,
-        RESTART_EPOCH_DURATION,
+        RESTART_WARMUP_EPOCH_DURATION,
     )?;
 
     // start all six nodes (committee + genesis observer)
@@ -730,30 +790,65 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
     wait_for_rpc(&provider).await?;
     let registry = ConsensusRegistry::new(CONSENSUS_REGISTRY_ADDRESS, &provider);
 
-    // ---- Phase 0: cross the 0 -> 1 boundary ----
-    wait_for_epoch_at_least(&provider, 1).await?;
-
+    // ---- Kill gate, spawned concurrently: certified record 0 on the kill target ----
     // Before killing validator-2, require ITS datadir to hold the certified epoch-0 record.
     // `save_dummy_epoch0` is in-memory only, so a node killed after executing the epoch-0
     // closing block but before persisting the real record 0 cannot restart (`run_epoch` exits:
     // "We have epoch 0 in our database if we are past epoch 0"). That crash window is a
     // pre-existing product issue orthogonal to the pinning fix under test; gating the kill on
-    // the kill target serving certified record 0 keeps this test deterministic.
-    fetch_verified_epoch_record(&endpoints[1].http_url, 0, RESTART_EPOCH_DURATION * 2).await?;
+    // the kill target serving certified record 0 keeps this test deterministic. Spawned here and
+    // awaited before the sequence epoch is entered, so certification overlaps the warmup work
+    // below and its latency can never land inside the measured sequence budget. The ceiling is
+    // 3x the sequence duration because its clock starts at process launch, so it must cover
+    // multi-process cold boot as well as warmup-epoch certification.
+    let record0_url = endpoints[1].http_url.clone();
+    let record0_gate = tokio::spawn(async move {
+        fetch_verified_epoch_record(&record0_url, 0, RESTART_EPOCH_DURATION * 3).await
+    });
 
-    // ---- Enter epoch E: reuse the epoch we are already in when it still has runway ----
-    // Phase 0 crossed into the current epoch within a poll cadence of the flip, so we are already
-    // fresh in it. The in-epoch sequence below (rotation, burn, pin, kill, restart, rejoin)
-    // worst-cases at ~29s; if the current epoch still holds that much runway plus margin, run the
-    // sequence here and save a whole ~40s warm-up epoch. Otherwise (for example a slow record-0
-    // certification above that burned into the budget) fall back to the next fresh boundary, which
-    // banks the full epoch duration. The fall-back branch is exactly the prior behavior, so this
-    // is a strict improvement; the budget guard is REQUIRED, not cosmetic: without it a
-    // degraded-network record-0 fetch could shove the ~29s sequence past the boundary and trip a
-    // spurious "premise broken" at one of the in-epoch guards below.
+    // ---- Restore the sequence duration on chain, concurrently with warmup ----
+    // Genesis seeded every epoch with the short warmup duration; store the 40s sequence config
+    // now. Each epoch opened after the receipt stamps the new duration, so the entry wait below
+    // keys on the OBSERVED duration rather than on "receipt epoch + 1": under CI load the
+    // receipt may land in epoch 1 instead of 0, and a receipt in an epoch's closing block can
+    // defer the stamp one more epoch; every such path must stay green and costs only extra
+    // short warmup epochs. Nonce 0: the upgrade is the governance wallet's first transaction.
+    let upgrade_block =
+        upgrade_duration_with_retry(&provider, &rpc_url, &mut governance_wallet, chain.clone(), 0)
+            .await?;
+    let upgrade_epoch = epoch_of_block(&provider, upgrade_block).await?;
+    info!(
+        target: "eject-test",
+        upgrade_block,
+        epoch = upgrade_epoch,
+        "sequence duration stored on chain"
+    );
+
+    // ---- Kill gate due: the record-0 fetch spawned above must deliver before the sequence ----
+    // Awaited here rather than at the kill site: any gate latency lands in the warmup phase
+    // (or eats runway the budget guard below still observes and falls back on), and a gate
+    // failure aborts the test before the irreversible governance burn.
+    record0_gate.await??;
+
+    // ---- Enter epoch E: the first epoch running the restored sequence duration ----
+    // The poll observes the boundary within its cadence, so entry is fresh; the budget guard
+    // below remains REQUIRED, not cosmetic: a stall between the flip and the guard (or a slow
+    // startup path) could still burn the runway, and without the guard that would shove the
+    // ~29s sequence past the boundary and trip a spurious "premise broken" at one of the
+    // in-epoch guards below. Its fall-back branch banks a full fresh epoch, exactly the prior
+    // behavior.
     //
     // ~29s worst-case sequence (see `RESTART_EPOCH_DURATION`) plus ~4s margin.
     const SEQUENCE_BUDGET_SECS: u64 = 33;
+    wait_until(
+        Duration::from_secs(RESTART_EPOCH_DURATION * 2),
+        &format!(
+            "sequence entry: waiting for the first {RESTART_EPOCH_DURATION}s epoch after the \
+             upgrade receipt (epoch {upgrade_epoch}) on node 0"
+        ),
+        || async { Ok(current_epoch(&provider).await?.epoch_duration == RESTART_EPOCH_DURATION) },
+    )
+    .await?;
     let entry = current_epoch(&provider).await?;
     let e = if epoch_seconds_remaining(&rpc_url, &entry)? >= SEQUENCE_BUDGET_SECS {
         info!(
@@ -816,8 +911,8 @@ async fn test_committee_member_restarted_mid_epoch_after_ejection() -> eyre::Res
 
     // ---- Governance burn of the victim, mid-epoch E — deliberately NO retry ----
     // A retry could slide the burn across the boundary and silently break the mid-epoch
-    // premise; the ensure below turns that into a loud failure instead. Nonce 0: the burn is
-    // this wallet's first transaction.
+    // premise; the ensure below turns that into a loud failure instead. The burn is this
+    // wallet's second transaction (nonce 1); the duration upgrade at startup was its first.
     let calldata: Bytes =
         ConsensusRegistry::burnCall { validatorAddress: victim_addr }.abi_encode().into();
     let (_burn_hash, burn_block) =

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -234,6 +234,14 @@ sol!(
         function getNextCommitteeSize() external view returns (uint16);
         /// Returns the current stake config version.
         function getCurrentStakeVersion() external view returns (uint8);
+        /// Returns the active stake config (`versions[stakeVersion]`); a config stored by
+        /// `upgradeStakeVersion` is visible here immediately, with no settlement delay.
+        function getCurrentStakeConfig() external view returns (StakeConfig memory);
+        /// Store `newConfig` as a new stake version and activate it immediately, returning the
+        /// new version. Owner-only; rejects a zero `epochDuration`. Every epoch opened after the
+        /// call stamps its `EpochInfo.epochDuration` from this config; epochs already opened
+        /// keep their stamped duration.
+        function upgradeStakeVersion(StakeConfig calldata newConfig) external override onlyOwner returns (uint8);
         /// Returns true if the BLS pubkey belongs to a known validator.
         ///
         /// NOTE (post-`CONSENSUS_REGISTRY_FORK_EPOCH`): the upgraded contract keys its internal


### PR DESCRIPTION
Closes #1147.

## Summary

`eject::test_committee_member_restarted_mid_epoch_after_ejection` ran about 84s. After #1009, #1117, and #1120 the profile is two full wall-clock epochs at `RESTART_EPOCH_DURATION = 40` plus about 4s of real work. Only the sequence epoch needs the 40 seconds. The warmup epoch exists only to produce and certify epoch record 0 for the kill gate. This PR gives the two epochs different durations with the governance path that already exists (`upgradeStakeVersion`). Test-only plus two additive bindings; no node changes.

## Changes

- [x] `crates/e2e-tests/tests/it/eject.rs`: new `RESTART_WARMUP_EPOCH_DURATION = 8` genesis seed. The `RESTART_EPOCH_DURATION = 40` doc contract now separates its two roles: it stays the anchor for every budget and ceiling, and is no longer the genesis seed. 8s sits above the documented 5s consensus minimum (`basefee.rs` / `epochs.rs` ship 5s, the sibling eject test 6s).
- [x] `crates/e2e-tests/tests/it/eject.rs`: new `upgrade_duration_with_retry` helper. At startup the governance wallet (nonce 0) sends `upgradeStakeVersion` with the current `StakeConfig` copied verbatim except `epochDuration = 40`. Same one-retry boundary-orphan pattern as `burn_with_retry`.
- [x] `crates/e2e-tests/tests/it/eject.rs`: the test enters the first epoch observed running the 40s duration, not "receipt epoch + 1". A receipt that lands in epoch 1, or in a closing block (the stamp then defers one epoch), only adds one more 8s warmup epoch and stays green. The `SEQUENCE_BUDGET_SECS = 33` runway guard and its fresh-boundary fallback are unchanged.
- [x] `crates/e2e-tests/tests/it/eject.rs`: the record-0 kill gate is spawned concurrently at startup and awaited before the sequence epoch is entered, so the short warmup does not squeeze record-0 certification, gate latency stays outside the measured 33s sequence budget, and a gate failure aborts before the irreversible governance burn. Its 120s ceiling starts at process launch, so it also covers multi-process cold boot.
- [x] `crates/tn-reth/src/system_calls.rs`: two additive `sol!` bindings, `upgradeStakeVersion(StakeConfig)` and `getCurrentStakeConfig()`, with doc comments. Verified against tn-contracts @ dc248c0d: `upgradeStakeVersion` is owner-only, bumps the version immediately, and `_updateEpochInfo` stamps `epochDuration` fresh from `getCurrentStakeConfig()` when it opens the next epoch (`futureEpochInfo` pre-pins committees, not config).

## Coverage is unchanged

- Certified epoch records embed no duration, and the test asserts no duration constancy. The regression assertions (mid-epoch rejoin, boundary close on all six nodes, record verification 0..=E with hash equality, liveness through the restarted node) run exactly as today, in a 40s epoch with the same 33s budget.
- Reward math reads the per-validator genesis stake version. Copying the three non-duration `StakeConfig` fields verbatim keeps stake and issuance byte-identical.
- The entry guard stays sound under mixed durations: `epoch_seconds_remaining` computes from the entered epoch's own on-chain duration snapshot, not a compile-time constant.
- An ineffective upgrade cannot pass silently: the duration-keyed entry wait times out at `RESTART_EPOCH_DURATION * 2` and fails the test loudly. Confirmed by mutation (see Verification).
- Bonus coverage: this is the only e2e exercise of `upgradeStakeVersion` end to end (config authored in epoch N activates at N+1).

## Verification

Measured on 80171ff9 (12 cores, prebuilt `TN_BIN_PATH`, nextest, solo):

| Variant | Runs |
| --- | --- |
| baseline | about 84s (issue #1147 wait audit; profile: two 40s epochs plus about 4s of work) |
| patched | 55.996s, 53.936s, 53.633s |

All three patched runs sit on the nominal schedule (8s warmup + 40s sequence + tail). The degraded path (upgrade receipt in epoch 1) would read about 60-62s and stays green by design.

- Mutation confirmation: with the upgrade made a no-op (it writes the warmup duration again), the duration-keyed entry wait timed out and the test failed loudly (rc=100). The file was then restored from the index and re-verified byte-identical.
- Gates, all green: nightly `fmt --check`, `+1.94 clippy --all-targets`, nightly `clippy --workspace --all-features`, and the attest proxy `+1.94 test --no-run --workspace -j 2` in an isolated target dir.
