### PR TITLE
test(storage): add TN_TEST_MDBX_SYNC runtime override and scheduled Durable e2e lane

### DIFF
--- a/.github/workflows/durable-e2e.yaml
+++ b/.github/workflows/durable-e2e.yaml
@@ -31,6 +31,11 @@ on:
           - safe-no-sync
         default: durable
 
+# The job only reads the repository (checkout + build + test); the token gets no
+# write scopes (least privilege, CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings -D unused_extern_crates"

--- a/.github/workflows/durable-e2e.yaml
+++ b/.github/workflows/durable-e2e.yaml
@@ -1,0 +1,92 @@
+# Scheduled Durable-mode e2e lane (#1149, follow-up to #982 / #917).
+#
+# PR CI runs the e2e suites with the test-build MDBX default (`SafeNoSync`, no hot-path
+# fsync; see crates/storage/src/mdbx/database.rs). That removed the Durable timing regime
+# -- where the externalization barriers (`persist().await` before a certificate, header,
+# or vote goes on the wire) wait on a real per-commit flush that races the proposer
+# timers -- from every test run. This lane restores that regime on a schedule by
+# exporting TN_TEST_MDBX_SYNC=durable, which every spawned node process inherits, at
+# zero wall-clock cost to PR CI. An invalid value fails MdbxDatabase::open outright, so
+# a typo here cannot green-run the wrong sync regime.
+#
+# The timings of the two suite steps, compared against a `safe-no-sync` dispatch run on
+# the same runner class, give the #917 acceptance measurement (Durable-vs-SafeNoSync
+# wall clock on a CI disk): post the first numbers on #1149. The untimed build step ahead
+# of them absorbs every compile (node binary and all test binaries) plus the cache state,
+# so the timed steps measure test execution only and the A/B pair stays comparable even
+# when one side runs cold.
+name: Durable e2e
+
+on:
+  schedule:
+    # Nightly at 08:17 UTC, off the top of the hour to dodge the scheduled-load spike.
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+    inputs:
+      sync_mode:
+        description: "TN_TEST_MDBX_SYNC value for the spawned nodes"
+        type: choice
+        options:
+          - durable
+          - safe-no-sync
+        default: durable
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-D warnings -D unused_extern_crates"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+
+jobs:
+  durable-e2e:
+    runs-on: ubuntu-latest
+    # Covers a cold cache: full workspace test-binary build plus both e2e suites run
+    # serialized (nextest pins the e2e group to max-threads 1) in the slower Durable regime.
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+        with:
+          shared-key: durable-e2e-cache
+          cache-on-failure: "true"
+
+      # Untimed: absorbs the node-binary build and every workspace test-binary compile, and
+      # validates the committed lockfile (`fetch --locked` fails on drift, matching the
+      # `--locked` discipline of pr.yaml), so the timed suite steps below are compile-free.
+      # TN_TEST_MDBX_SYNC is scoped to the suite steps, not exported job-wide: a build needs
+      # no override, and a future "variable must be unset" test (the
+      # TN_SEED_SIGNATURE_FORK_EPOCH pattern in the Makefile) must not inherit it.
+      - name: Build node binary and test binaries (untimed)
+        run: |
+          cargo fetch --locked
+          make build-e2e-bin
+          cargo nextest run --no-run --locked --workspace
+
+      - name: Run restart e2e tests
+        env:
+          # Scheduled runs get `durable`; a manual dispatch may select either side of the A/B.
+          TN_TEST_MDBX_SYNC: ${{ inputs.sync_mode || 'durable' }}
+        run: make test-restarts
+
+      - name: Run epoch e2e tests
+        env:
+          TN_TEST_MDBX_SYNC: ${{ inputs.sync_mode || 'durable' }}
+        run: make test-epochs
+
+      - name: Assert lockfile unchanged
+        run: git diff --exit-code -- Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,12 @@ TN_SEED_SIGNATURE_FORK_EPOCH ?= 4294967295
 test-restarts: build-e2e-bin
 	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
+# run epoch integration tests (same filter as the public-tests epoch line). The scheduled
+# Durable e2e lane (#1149) runs this and test-restarts with TN_TEST_MDBX_SYNC=durable
+# exported so every spawned node opens MDBX in Durable.
+test-epochs: build-e2e-bin
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+
 # run e2e tests
 test-e2e: build-e2e-bin
 	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;

--- a/crates/storage/src/mdbx/database.rs
+++ b/crates/storage/src/mdbx/database.rs
@@ -116,10 +116,41 @@ fn default_page_size() -> usize {
 /// The MDBX sync mode compiled into `test` and `test-utils` builds. `SafeNoSync` removes the
 /// hot-path `fsync` while still surviving a process kill+restart (see [`MdbxDatabase::open`]);
 /// it must never be `UtterlyNoSync`, which risks whole-DB corruption on an OS/power crash. This
-/// is the single source of truth `open` applies, so a test can pin it exactly. Production builds
-/// enable neither cfg and this const does not exist for them (the env stays `Durable`).
+/// is the default `open` applies when [`TN_TEST_MDBX_SYNC_ENV`] is unset, so a test can pin it
+/// exactly. Production builds enable neither cfg and this const does not exist for them (the
+/// env stays `Durable`).
 #[cfg(any(test, feature = "test-utils"))]
 const BUILD_SYNC_MODE: reth_libmdbx::SyncMode = reth_libmdbx::SyncMode::SafeNoSync;
+
+/// The environment variable a `test`/`test-utils` build reads at `open` to override
+/// [`BUILD_SYNC_MODE`] with no rebuild (#1149). `durable` restores the production per-commit
+/// fsync regime; `safe-no-sync` selects the compiled default explicitly. Any other value is a
+/// hard error from [`MdbxDatabase::open`]: a silent fallback could green-run a "Durable" e2e
+/// lane that never ran `Durable`. Production builds compile the read out with the rest of the
+/// cfg block.
+#[cfg(any(test, feature = "test-utils"))]
+const TN_TEST_MDBX_SYNC_ENV: &str = "TN_TEST_MDBX_SYNC";
+
+/// Resolves the sync mode a `test`/`test-utils` build opens the environment with: the parsed
+/// [`TN_TEST_MDBX_SYNC_ENV`] value when the variable is set, otherwise [`BUILD_SYNC_MODE`]. A
+/// set-but-invalid value (not UTF-8, or a spelling `SyncMode::from_str` rejects) is an error,
+/// never a fallback. Every spelling the parser accepts maps to `Durable` or `SafeNoSync`, so
+/// no environment value can reach `UtterlyNoSync`.
+#[cfg(any(test, feature = "test-utils"))]
+fn resolve_sync_mode(raw: Option<std::ffi::OsString>) -> eyre::Result<reth_libmdbx::SyncMode> {
+    raw.map(|value| {
+        value
+            .into_string()
+            .map_err(|value| eyre::eyre!("{TN_TEST_MDBX_SYNC_ENV} is not valid UTF-8: {value:?}"))
+            .and_then(|value| {
+                value
+                    .parse::<reth_libmdbx::SyncMode>()
+                    .map_err(|err| eyre::eyre!("invalid {TN_TEST_MDBX_SYNC_ENV} value: {err}"))
+            })
+    })
+    .transpose()
+    .map(|parsed| parsed.unwrap_or(BUILD_SYNC_MODE))
+}
 
 impl MdbxDatabase {
     /// Creates a new database at the specified path if it doesn't exist. Does NOT create tables.
@@ -165,11 +196,19 @@ impl MdbxDatabase {
         // separate processes built with `--features tn-storage/test-utils`, where `cfg(test)`
         // is not live, so no CLI plumbing is required to select the mode. Production builds
         // enable neither cfg, so this block is compiled out and the default `Durable` stands.
+        //
+        // #1149: `TN_TEST_MDBX_SYNC` overrides the compiled default at `open`. `durable`
+        // restores the production per-commit fsync regime for the scheduled Durable e2e lane
+        // (and for A/B timing runs like #1142's) with no rebuild; an invalid value fails
+        // `open` outright. The e2e nodes inherit the variable through `std::process::Command`
+        // (the harness never clears the child env), so a CI-level export reaches every
+        // spawned node.
         #[cfg(any(test, feature = "test-utils"))]
         {
             use reth_libmdbx::{EnvironmentFlags, Mode};
+            let sync_mode = resolve_sync_mode(std::env::var_os(TN_TEST_MDBX_SYNC_ENV))?;
             builder.set_flags(EnvironmentFlags {
-                mode: Mode::ReadWrite { sync_mode: BUILD_SYNC_MODE },
+                mode: Mode::ReadWrite { sync_mode },
                 ..Default::default()
             });
         }
@@ -469,27 +508,55 @@ mod test {
         db_simp_bench(db, "MDBX");
     }
 
-    /// #917: under the `test`/`test-utils` cfg the env must open in `SafeNoSync` (no hot-path
-    /// `fsync`) -- specifically not `Durable` (would keep the fsync) and, critically, not
-    /// `UtterlyNoSync` (risks whole-DB corruption on an OS/power crash). The e2e restart suite
-    /// cannot tell the two no-sync modes apart, so this const-assert is the real guard.
+    /// The harness-visible name of a test in this module: the module path minus the leading
+    /// crate-name segment, as libtest prints (and `--exact` matches) it.
+    fn child_test_name(fn_name: &str) -> String {
+        module_path!()
+            .split_once("::")
+            .map_or_else(|| fn_name.to_string(), |(_, module)| format!("{module}::{fn_name}"))
+    }
+
+    /// Runs one `#[ignore]` child test of THIS binary in a fresh process, with
+    /// `TN_TEST_MDBX_SYNC` set to `value` or explicitly removed (`None`). Env mutation in a
+    /// child process cannot race sibling tests in this one. The child's harness output must
+    /// report exactly one passed test: a drifted name would match nothing and still exit 0,
+    /// so exit status alone would be a vacuous pass.
+    fn run_child_test(fn_name: &str, value: Option<&str>) {
+        let exe = std::env::current_exe().expect("test binary path");
+        let name = child_test_name(fn_name);
+        let mut command = std::process::Command::new(exe);
+        command.args(["--exact", name.as_str(), "--ignored"]);
+        // The variable is never inherited: it is removed outright, then set only when this
+        // regime supplies a value, so ambient state cannot leak into any child.
+        command.env_remove(super::TN_TEST_MDBX_SYNC_ENV);
+        value.into_iter().for_each(|value| {
+            command.env(super::TN_TEST_MDBX_SYNC_ENV, value);
+        });
+        let output = command.output().expect("spawn child test");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success() && stdout.contains("1 passed"),
+            "child test {name} did not pass exactly once; status {:?}, stdout:\n{stdout}",
+            output.status
+        );
+    }
+
+    /// Child of [`test_open_uses_safe_no_sync_under_test_cfg`], spawned with
+    /// `TN_TEST_MDBX_SYNC` removed from its env: the compiled default must reach MDBX, so the
+    /// opened env reports a non-`Durable` mode (no hot-path fsync). NOTE: MDBX defines
+    /// `MDBX_UTTERLY_NOSYNC = MDBX_SAFE_NOSYNC | <extra bit>`, and reth-libmdbx's `mode()`
+    /// tests the UtterlyNoSync mask before the SafeNoSync one, so it reports `UtterlyNoSync`
+    /// for a genuine `SafeNoSync` env. We therefore assert only "not Durable / not read-only"
+    /// from the readback; the exact-mode guarantee is pinned by the parent's const assert. Do
+    /// not "fix" this into `assert_eq!(mode, ..SafeNoSync)` -- it cannot pass by construction.
     #[test]
-    fn test_open_uses_safe_no_sync_under_test_cfg() {
-        use super::BUILD_SYNC_MODE;
+    #[ignore = "spawned by test_open_uses_safe_no_sync_under_test_cfg with a controlled env"]
+    fn child_open_default_safe_no_sync() {
         use reth_libmdbx::{Mode, SyncMode};
-
-        // Pin the exact compiled mode. `SyncMode` is `PartialEq`, so this catches a drift to
-        // `Durable` (fsync back on) or to `UtterlyNoSync` (recovery broken) -- the latter is the
-        // one the readback below cannot see, so this assert is what guards the hard constraint.
-        assert_eq!(BUILD_SYNC_MODE, SyncMode::SafeNoSync);
-
-        // And prove the flag actually reached MDBX: the opened env reports a non-`Durable` mode,
-        // so the hot-path fsync is genuinely gone. NOTE: MDBX defines
-        // `MDBX_UTTERLY_NOSYNC = MDBX_SAFE_NOSYNC | <extra bit>`, and reth-libmdbx's `mode()`
-        // tests the UtterlyNoSync mask before the SafeNoSync one, so it reports `UtterlyNoSync`
-        // for a genuine `SafeNoSync` env. We therefore assert only "not Durable / not read-only"
-        // from the readback; the exact-mode guarantee is pinned by the const assert above. Do not
-        // "fix" this into `assert_eq!(mode, ..SafeNoSync)` -- it cannot pass by construction.
+        assert!(
+            std::env::var_os(super::TN_TEST_MDBX_SYNC_ENV).is_none(),
+            "this child expects TN_TEST_MDBX_SYNC absent from its env"
+        );
         let temp_dir = tempdir().expect("failed to create temp dir");
         let db = open_db(temp_dir.path());
         let mode = db.inner.info().expect("read env info").mode();
@@ -497,5 +564,103 @@ mod test {
             matches!(mode, Mode::ReadWrite { sync_mode } if sync_mode != SyncMode::Durable),
             "test-build MDBX env must not be Durable (hot-path fsync must be off), got {mode:?}"
         );
+    }
+
+    /// Child of [`test_open_uses_safe_no_sync_under_test_cfg`], spawned with
+    /// `TN_TEST_MDBX_SYNC=durable`: the override must force `Durable` at `open`. `Durable`
+    /// sets no no-sync bits, so the mask caveat on the default child does not apply and the
+    /// read-back is exact.
+    #[test]
+    #[ignore = "spawned by test_open_uses_safe_no_sync_under_test_cfg with a controlled env"]
+    fn child_open_durable_override() {
+        use reth_libmdbx::{Mode, SyncMode};
+        assert_eq!(
+            std::env::var_os(super::TN_TEST_MDBX_SYNC_ENV).as_deref(),
+            Some(std::ffi::OsStr::new("durable")),
+            "this child expects TN_TEST_MDBX_SYNC=durable in its env"
+        );
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let db = open_db(temp_dir.path());
+        let mode = db.inner.info().expect("read env info").mode();
+        assert!(
+            matches!(mode, Mode::ReadWrite { sync_mode: SyncMode::Durable }),
+            "TN_TEST_MDBX_SYNC=durable must open the env Durable, got {mode:?}"
+        );
+    }
+
+    /// Child of [`test_open_uses_safe_no_sync_under_test_cfg`], spawned with an invalid
+    /// `TN_TEST_MDBX_SYNC`: `open` must fail outright, and the error must name the variable
+    /// so the failure is attributable to the resolver rather than the environment setup. A
+    /// silent fallback here could green-run a "Durable" e2e lane that never ran Durable.
+    #[test]
+    #[ignore = "spawned by test_open_uses_safe_no_sync_under_test_cfg with a controlled env"]
+    fn child_open_invalid_value_errors() {
+        assert!(
+            std::env::var_os(super::TN_TEST_MDBX_SYNC_ENV).is_some(),
+            "this child expects an invalid TN_TEST_MDBX_SYNC in its env"
+        );
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let result = MdbxDatabase::open(temp_dir.path(), 4, 16 * MEGABYTE, 8 * MEGABYTE);
+        let error = result.err().map(|error| error.to_string()).unwrap_or_default();
+        assert!(
+            error.contains(super::TN_TEST_MDBX_SYNC_ENV),
+            "an invalid TN_TEST_MDBX_SYNC must be a hard error naming the variable, got: \
+             {error:?}"
+        );
+    }
+
+    /// #917/#1149: under the `test`/`test-utils` cfg the env must open in `SafeNoSync` (no
+    /// hot-path `fsync`) -- specifically not `Durable` (would keep the fsync) and, critically,
+    /// not `UtterlyNoSync` (risks whole-DB corruption on an OS/power crash) -- unless
+    /// `TN_TEST_MDBX_SYNC` overrides the mode at runtime: `durable` restores the production
+    /// fsync regime with no rebuild, and an invalid value is a hard error from `open`, never a
+    /// fallback. The e2e restart suite cannot tell the two no-sync modes apart, so the
+    /// const-assert is the real guard for the compiled default.
+    ///
+    /// Each live read-back runs in a CHILD process of this binary (`--exact` plus a controlled
+    /// child env), so no phase ever mutates this process's environment: sibling tests opening
+    /// databases on other threads (plain `cargo test`) can never observe a half-set variable,
+    /// a panicking phase cannot leak a poisoned value (it dies with its child process), and
+    /// the spawn path exercises the same env inheritance the Durable e2e lane relies on.
+    #[test]
+    fn test_open_uses_safe_no_sync_under_test_cfg() {
+        use super::{resolve_sync_mode, BUILD_SYNC_MODE, TN_TEST_MDBX_SYNC_ENV};
+        use reth_libmdbx::SyncMode;
+
+        // Pin the exact compiled mode. `SyncMode` is `PartialEq`, so this catches a drift to
+        // `Durable` (fsync back on) or to `UtterlyNoSync` (recovery broken) -- the latter is the
+        // one the readback below cannot see, so this assert is what guards the hard constraint.
+        assert_eq!(BUILD_SYNC_MODE, SyncMode::SafeNoSync);
+
+        // Pin the documented variable NAME too: the CI lane and the docs reference the
+        // literal, so a drift of the const away from it must fail here.
+        assert_eq!(TN_TEST_MDBX_SYNC_ENV, "TN_TEST_MDBX_SYNC");
+
+        // The resolver, exercised pure (no process-env mutation): unset keeps the compiled
+        // default; `durable` and `safe-no-sync` parse to their modes; garbage, the empty
+        // string, and a non-UTF-8 value are hard errors. `UtterlyNoSync` has no accepted
+        // spelling at all, so no environment value can reach it.
+        assert_eq!(resolve_sync_mode(None).expect("unset env resolves"), BUILD_SYNC_MODE);
+        assert_eq!(
+            resolve_sync_mode(Some("durable".into())).expect("durable resolves"),
+            SyncMode::Durable
+        );
+        assert_eq!(
+            resolve_sync_mode(Some("safe-no-sync".into())).expect("safe-no-sync resolves"),
+            SyncMode::SafeNoSync
+        );
+        assert!(resolve_sync_mode(Some("utterly-no-sync".into())).is_err());
+        assert!(resolve_sync_mode(Some("".into())).is_err());
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            let non_utf8 = std::ffi::OsString::from_vec(vec![0xff, 0xfe]);
+            assert!(resolve_sync_mode(Some(non_utf8)).is_err());
+        }
+
+        // Live read-backs against a real opened environment, one child process per regime.
+        run_child_test("child_open_default_safe_no_sync", None);
+        run_child_test("child_open_durable_override", Some("durable"));
+        run_child_test("child_open_invalid_value_errors", Some("utterly-no-sync"));
     }
 }


### PR DESCRIPTION
Closes #1149.

## Summary

PR #982 switched test-build MDBX environments to `SafeNoSync` at compile time.  That removed the Durable timing regime from every e2e run: under `Durable`, the externalization barriers (`persist().await` before a certificate, header, or vote goes on the wire) wait on a real per-commit flush that races the proposer timers (1000/2500 ms).  The #982 review thread asked for a runtime override plus a scheduled Durable lane;  this PR adds both.  `TN_TEST_MDBX_SYNC` now overrides the compiled default at `MdbxDatabase::open` in test builds, and a nightly workflow runs the restart and epoch e2e suites with `TN_TEST_MDBX_SYNC=durable`.  The lane's step timings give the #917 acceptance measurement (Durable vs SafeNoSync wall clock on a CI disk), and the override replaces the source edit #1142 needed for its A/B comparison.

## Changes

- [x] `crates/storage/src/mdbx/database.rs`: `resolve_sync_mode` reads `TN_TEST_MDBX_SYNC` inside the existing `#[cfg(any(test, feature = "test-utils"))]` block.  `durable` forces `Durable` at `open()`;  `safe-no-sync` selects the compiled default explicitly;  an unset variable keeps `BUILD_SYNC_MODE` (`SafeNoSync`).  A set-but-invalid value (a spelling `SyncMode::from_str` rejects, or a non-UTF-8 value) is a hard error from `open`, never a fallback: a silent fallback could green-run a "Durable" lane that never ran Durable.  Every spelling the parser accepts maps to `Durable` or `SafeNoSync`, so no environment value can reach `UtterlyNoSync`, and the `BUILD_SYNC_MODE` const assert still pins the compiled default.  Production builds compile the whole block out, variable read included.
- [x] `crates/storage/src/mdbx/database.rs`: the #982 guard test now covers the default, the override, and the invalid value, each against a live `open` (the invalid case proves `open` fails;  the other two read the opened environment back).  Every live read-back runs in a child process of the test binary (`--exact` plus a controlled child env), so the parent never mutates process env: sibling tests opening databases on other threads (plain `cargo test`) cannot observe a half-set variable, a panicking phase cannot leak a poisoned value, and the spawn path exercises the same env inheritance the Durable lane relies on.  Each child run asserts "1 passed" from the harness output, so a drifted test name cannot pass vacuously.  The override read-back is exact (`Durable` sets no no-sync bits, so the UtterlyNoSync mask caveat does not apply), and the test pins the literal variable name against const drift.
- [x] `Makefile`: new `test-epochs` target, the epoch twin of `test-restarts` (same filter as the `public-tests` epoch line).
- [x] `.github/workflows/durable-e2e.yaml`: nightly scheduled lane (08:17 UTC) running `make test-restarts` and `make test-epochs` with `TN_TEST_MDBX_SYNC=durable` set on the two suite steps (step-scoped, not job-wide, so a future "variable must be unset" test never inherits it).  An untimed build step ahead of them absorbs the node-binary build and every workspace test-binary compile and validates the committed lockfile (`cargo fetch --locked`, plus a final `git diff --exit-code -- Cargo.lock` assertion, matching pr.yaml's `--locked` discipline), so the timed steps measure test execution only and the A/B pair stays comparable even when one side runs cold.  Every spawned node inherits the variable through `std::process::Command` (the e2e harness never clears the child env), so no plumbing is needed.  `workflow_dispatch` takes a `sync_mode` choice (`durable` / `safe-no-sync`) so the same lane produces both sides of the A/B measurement on the same runner class.  The lane is scheduled and non-blocking;  PR CI cost is zero.

## Acceptance criteria (from #1149)

- [x] `TN_TEST_MDBX_SYNC=durable` forces `Durable` at `open()` in test builds;  unset keeps `SafeNoSync`;  invalid is a hard error, not a fallback.
- [x] The guard test covers the default mode and the override, with a live read-back of the opened environment.
- [x] Production builds do not read the variable (the read sits inside the cfg gate and release builds compile it out).
- [x] A scheduled CI lane runs the restart and epoch e2e tests with the override set.
- [ ] The measured wall-clock delta is posted on #1149 (first scheduled runs after merge;  compare a `durable` dispatch against a `safe-no-sync` dispatch).

## Verification

- `cargo +nightly fmt -- --check` clean;  `cargo +nightly clippy -p tn-storage -p telcoin-network --features tn-storage/test-utils -- -D warnings` clean (the diff only touches `tn-storage`, and the cfg-gated block enters its lib target under `test-utils`, so this lints every changed line;  selecting `telcoin-network` alongside reproduces the `build-e2e-bin` feature resolution).
- `cargo +1.94 nextest run -p tn-storage` green, including the extended guard test and its three child processes.
- Mutation-confirmed, three mutants, each seen to fail then pass after byte-exact restore: (1) a resolver that ignores the parsed override, (2) a drifted variable-name const, (3) an `open` that ignores the resolver (killed only by the live child read-backs, proving the override genuinely reaches the opened environment).
- Attest proxy: `cargo +1.94 test --no-run --workspace -j 2` green in an isolated target dir.
