### PR TITLE
fix(tn-reth): apply node_config.rpc.eth_config() when building the EthApi

### DIFF
--- a/crates/tn-reth/src/env/rpc.rs
+++ b/crates/tn-reth/src/env/rpc.rs
@@ -2,8 +2,8 @@
 //!
 //! TN assembles reth's RPC builder stack over the worker's transaction pool and the
 //! [`WorkerNetwork`] shim; there is no engine namespace because consensus drives execution
-//! directly. Namespace exposure and transport limits come from the CLI allowlist
-//! (`crate::cli`) via `node_config().rpc`.
+//! directly. Namespace exposure, transport limits, and the `eth` API knobs (gas cap, proof
+//! window, cache sizes) come from the CLI allowlist (`crate::cli`) via `node_config().rpc`.
 //!
 //! Note: [`RethEnv::get_rpc_server`] swallows a failure to merge the TN-specific module at
 //! `error!` level — the server still starts and serves the standard namespaces with the TN
@@ -14,9 +14,11 @@ use std::sync::Arc;
 use jsonrpsee::Methods;
 use reth::rpc::{
     builder::{config::RethRpcServerConfig as _, RpcModuleBuilder, RpcServerHandle},
-    eth::EthApi,
+    eth::{EthApi, EthApiBuilder},
 };
 use reth_provider::providers::BlockchainProvider;
+use reth_rpc_eth_api::RpcNodeCore;
+use reth_rpc_eth_types::EthConfig;
 use reth_transaction_pool::{blobstore::DiskFileBlobStore, EthTransactionPool};
 
 use crate::{
@@ -26,6 +28,41 @@ use crate::{
     worker::WorkerNetwork,
     RethEnv, RpcServer, WorkerTxPool,
 };
+
+/// Apply the operator's [`EthConfig`] values to the `eth` API builder.
+///
+/// Mirrors `EthApiCtx::eth_api_builder` (reth v1.11.3, `crates/node/builder/src/rpc.rs`),
+/// which TN's launch path does not run. Without this, each `--rpc.*` eth flag parses and
+/// then silently keeps the reth default (#1156).
+///
+/// Three deltas against reth's reference:
+/// - cache: TN spawns no shared state cache up front, so the configured sizes go in as
+///   `eth_state_cache_config` for `build` to spawn from. Equivalent for TN, which has no other
+///   consumer of the cache.
+/// - `send_raw_transaction_sync_timeout`: applied here, absent from reth's reference. No CLI flag
+///   feeds it yet, so it re-applies the default (forward compatibility).
+/// - task spawner: reth injects its own; TN keeps the builder's default executor, the same behavior
+///   as before this fix.
+fn apply_eth_config<N: RpcNodeCore, Rpc, NextEnv>(
+    builder: EthApiBuilder<N, Rpc, NextEnv>,
+    config: EthConfig,
+) -> EthApiBuilder<N, Rpc, NextEnv> {
+    builder
+        .gas_cap(config.rpc_gas_cap.into())
+        .max_simulate_blocks(config.rpc_max_simulate_blocks)
+        .eth_proof_window(config.eth_proof_window)
+        .eth_state_cache_config(config.cache)
+        .fee_history_cache_config(config.fee_history_cache)
+        .proof_permits(config.proof_permits)
+        .gas_oracle_config(config.gas_oracle)
+        .max_batch_size(config.max_batch_size)
+        .max_blocking_io_requests(config.max_blocking_io_requests)
+        .pending_block_kind(config.pending_block_kind)
+        .raw_tx_forwarder(config.raw_tx_forwarder)
+        .send_raw_transaction_sync_timeout(config.send_raw_transaction_sync_timeout)
+        .evm_memory_limit(config.rpc_evm_memory_limit)
+        .force_blob_sidecar_upcasting(config.force_blob_sidecar_upcasting)
+}
 
 impl RethEnv {
     /// Build and return the RPC server for the instance.
@@ -51,11 +88,14 @@ impl RethEnv {
             .with_consensus(tn_execution.clone());
 
         let modules_config = self.node_config().rpc.transport_rpc_module_config();
-        let eth_api = EthApi::builder(
-            self.inner.blockchain_provider.clone(),
-            transaction_pool,
-            network,
-            self.inner.evm_config.clone(),
+        let eth_api = apply_eth_config(
+            EthApi::builder(
+                self.inner.blockchain_provider.clone(),
+                transaction_pool,
+                network,
+                self.inner.evm_config.clone(),
+            ),
+            self.node_config().rpc.eth_config(),
         )
         .build();
 
@@ -72,5 +112,107 @@ impl RethEnv {
     pub async fn start_rpc(&self, server: &RpcServer) -> TnRethResult<RpcServerHandle> {
         let server_config = self.node_config().rpc.rpc_server_config();
         Ok(server_config.start(server).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{rpc_server_args::RpcServerArgs as TnRpcServerArgs, RethChainSpec};
+    use reth::args::RpcStateCacheArgs;
+    use reth_network_api::noop::NoopNetwork;
+    use reth_rpc_eth_types::{
+        builder::config::PendingBlockKind, EthStateCacheConfig, FeeHistoryCacheConfig,
+        ForwardConfig, GasPriceOracleConfig,
+    };
+    use reth_transaction_pool::noop::NoopTransactionPool;
+    use tempfile::TempDir;
+    use tn_types::{test_genesis, TaskManager};
+    use url::Url;
+
+    /// Every applied [`EthConfig`] value reaches the [`EthApiBuilder`]: build a builder over
+    /// a temp env, apply a config whose asserted fields all differ from the defaults, and
+    /// read each value back through the builder's getters.
+    ///
+    /// Regression guard for #1156, where `get_rpc_server` built the `EthApi` with reth's
+    /// defaults. `max_blocking_io_requests`, `send_raw_transaction_sync_timeout`,
+    /// `evm_memory_limit`, and `force_blob_sidecar_upcasting` have no builder getter, so
+    /// only their setter calls in [`apply_eth_config`] cover them.
+    #[tokio::test]
+    async fn test_apply_eth_config_overrides_every_builder_default() -> eyre::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::default();
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let reth_env = RethEnv::new_for_temp_chain(chain, tmp_dir.path(), &task_manager, None)?;
+
+        let config = EthConfig {
+            fee_history_cache: FeeHistoryCacheConfig { max_blocks: 5, resolution: 9 },
+            raw_tx_forwarder: ForwardConfig {
+                tx_forwarder: Some(Url::parse("http://127.0.0.1:8555/")?),
+            },
+            ..EthConfig::default()
+                .rpc_gas_cap(12_345_678)
+                .rpc_max_simulate_blocks(42)
+                .eth_proof_window(99)
+                .proof_permits(7)
+                .max_batch_size(13)
+                .pending_block_kind(PendingBlockKind::None)
+                .state_cache(EthStateCacheConfig {
+                    max_blocks: 11,
+                    max_receipts: 12,
+                    max_headers: 13,
+                    max_concurrent_db_requests: 14,
+                    max_cached_tx_hashes: 15,
+                })
+                .gpo_config(GasPriceOracleConfig {
+                    blocks: 3,
+                    percentile: 77,
+                    ..Default::default()
+                })
+        };
+
+        let builder = apply_eth_config(
+            EthApiBuilder::new(
+                reth_env.blockchain_provider().clone(),
+                NoopTransactionPool::default(),
+                NoopNetwork::default(),
+                reth_env.evm_config().clone(),
+            ),
+            config.clone(),
+        );
+
+        assert_eq!(builder.get_gas_cap().0, config.rpc_gas_cap);
+        assert_eq!(builder.get_max_simulate_blocks(), config.rpc_max_simulate_blocks);
+        assert_eq!(builder.get_eth_proof_window(), config.eth_proof_window);
+        assert_eq!(*builder.get_eth_state_cache_config(), config.cache);
+        assert_eq!(*builder.get_fee_history_cache_config(), config.fee_history_cache);
+        assert_eq!(builder.get_proof_permits(), config.proof_permits);
+        assert_eq!(*builder.get_gas_oracle_config(), config.gas_oracle);
+        assert_eq!(builder.get_max_batch_size(), config.max_batch_size);
+        assert_eq!(builder.get_pending_block_kind(), config.pending_block_kind);
+        assert_eq!(*builder.get_raw_tx_forwarder(), config.raw_tx_forwarder);
+
+        Ok(())
+    }
+
+    /// The five TN CLI eth flags survive the TN-args-to-reth-args conversion and land in the
+    /// [`EthConfig`] that [`RethEnv::get_rpc_server`] hands to [`apply_eth_config`].
+    #[test]
+    fn test_tn_rpc_args_reach_eth_config() {
+        let args = TnRpcServerArgs {
+            rpc_gas_cap: 100_000_000,
+            rpc_max_simulate_blocks: 42,
+            rpc_eth_proof_window: 99,
+            rpc_proof_permits: 7,
+            rpc_state_cache: RpcStateCacheArgs { max_blocks: 11, ..Default::default() },
+            ..Default::default()
+        };
+        let config = reth::args::RpcServerArgs::from(args).eth_config();
+
+        assert_eq!(config.rpc_gas_cap, 100_000_000);
+        assert_eq!(config.rpc_max_simulate_blocks, 42);
+        assert_eq!(config.eth_proof_window, 99);
+        assert_eq!(config.proof_permits, 7);
+        assert_eq!(config.cache.max_blocks, 11);
     }
 }


### PR DESCRIPTION
Closes #1156.  (Cantina #14)

## Problem

`RethEnv::get_rpc_server` builds the `eth` API with `EthApi::builder(...).build()` and never applies `node_config.rpc.eth_config()`. The neighbor lines do consume `node_config.rpc` (module selection via `transport_rpc_module_config()`, server limits via `rpc_server_config()`), so only the eth-config values were dropped. The five eth-config flags TN exposes parse cleanly and then silently do nothing:

- `--rpc.gascap` . . . `eth_call` / `eth_estimateGas` stay capped at the default 50M
- `--rpc.max-simulate-blocks` . . . `eth_simulateV1` stays at the default 256
- `--rpc.eth-proof-window` . . . `eth_getProof` keeps the default window of 0
- `--rpc.proof-permits` . . . concurrent proof permits keep the default
- `--rpc.state-cache.*` . . . the eth state cache keeps the default sizes

These flags are resource bounds on the public RPC surface. No attacker is required: an operator who lowers a bound to harden a public endpoint (or raises one for an internal tool) gets the reth default instead, with no warning. The filter/pubsub half of the config was never affected, because `transport_rpc_module_config()` already embeds `RpcModuleConfig::new(self.eth_config())`; only the `EthApi` itself was unconfigured.

## Fix

- [x] `crates/tn-reth/src/env/rpc.rs`: add `apply_eth_config`, a mirror of reth's own `EthApiCtx::eth_api_builder` (reth v1.11.3, `crates/node/builder/src/rpc.rs:1180-1196`), and chain it into `get_rpc_server` between `EthApi::builder(...)` and `.build()`. The config source is `self.node_config().rpc.eth_config()`, the same call the module-selection line already uses, so the five supported flags flow through and every knob TN does not expose keeps its reth default (identical values to today).
- [x] The mirror applies the full `EthConfig`, not only the five exposed flags: `gas_cap`, `max_simulate_blocks`, `eth_proof_window`, `eth_state_cache_config`, `fee_history_cache_config`, `proof_permits`, `gas_oracle_config`, `max_batch_size`, `max_blocking_io_requests`, `pending_block_kind`, `raw_tx_forwarder`, `send_raw_transaction_sync_timeout`, `evm_memory_limit`, `force_blob_sidecar_upcasting`. Three deltas against reth's reference, called out in the doc comment: the state cache goes in as `eth_state_cache_config` (reth passes a pre-spawned shared cache; TN has no other cache consumer, so `build()` spawning one is equivalent), `send_raw_transaction_sync_timeout` is applied here though reth's reference skips it (no CLI flag feeds it yet, so it re-applies the default), and TN keeps the builder's default task executor where reth injects its own (same behavior as before this fix). The extras are no-ops today (the values equal the defaults) and keep this call site correct if TN exposes more flags later.

## Testing

- [x] `test_apply_eth_config_overrides_every_builder_default`: builds an `EthApiBuilder` over a temp `RethEnv`, applies an `EthConfig` whose asserted fields all differ from the defaults, and reads each value back through the builder's getters (gas cap, simulate blocks, proof window, state cache, fee history cache, proof permits, gas oracle, batch size, pending block kind, raw tx forwarder). `max_blocking_io_requests`, `send_raw_transaction_sync_timeout`, `evm_memory_limit`, and `force_blob_sidecar_upcasting` have no builder getter, so only the setter calls cover them.
- [x] `test_tn_rpc_args_reach_eth_config`: drives the five TN CLI flags through the TN-args-to-reth-args conversion into `eth_config()` and asserts each lands in the `EthConfig`.
- [x] Both tests confirmed by mutation: reverting a setter in `apply_eth_config` fails the first test; the second fails if a flag is dropped from the conversion.
- [x] `cargo +1.94 test -p tn-reth` green on the pinned toolchain.
- [x] attest proxy battery: `cargo +nightly fmt -- --check`, `cargo +1.94 clippy --all-targets`, and `cargo +1.94 test --no-run --workspace -j 2` in an isolated target dir, all green.
- [x] Default-equivalence audit: for every field `apply_eth_config` applies, `EthConfig::default()` equals the builder's own default (checked per field against the reth v1.11.3 source), so a node run without `--rpc.*` flags gets a byte-identical `EthApi` before and after this change.
- Known limit: the two tests cover the helper and the config chain; the single wiring expression in `get_rpc_server` is covered by review, not by test. A testable seam would need a custom `NodeConfig` through the test env constructors . . . happy to do that as a follow-up if wanted.

## Out of scope

- `--rpc.txfeecap` is the same bug class on the pool side (parses, then nothing applies it; reth wires it only in its `PoolBuilder` launch path, which TN does not run). Filed separately so this PR stays a mirror of the reth eth-API path.
- Injecting `RethEnv`'s task spawner into the `EthApi` builder (reth's reference does; TN today keeps the builder's default executor for the fee-history cache task). Behavior-neutral for this fix, worth its own decision.

## Credit

Reported by Haxatron during the collaborative review (#1156).
