### PR TITLE
fix(tn-reth): use TN's DEFAULT_IPC_ENDPOINT in RpcServerArgs::default()

### DIFF
--- a/crates/tn-reth/src/rpc_server_args.rs
+++ b/crates/tn-reth/src/rpc_server_args.rs
@@ -224,7 +224,7 @@ impl Default for RpcServerArgs {
             ws_allowed_origins: None,
             ws_api: None,
             ipcdisable: false,
-            ipcpath: constants::DEFAULT_IPC_ENDPOINT.to_string(),
+            ipcpath: DEFAULT_IPC_ENDPOINT.to_string(),
             rpc_jwtsecret: None,
             rpc_max_request_size: RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into(),
             rpc_max_response_size: RPC_DEFAULT_MAX_RESPONSE_SIZE_MB.into(),
@@ -309,5 +309,28 @@ impl TypedValueParser for RpcModuleSelectionValueParser {
     fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
         let values = RethRpcModule::all_variant_names().iter().map(PossibleValue::new);
         Some(Box::new(values))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::RethCommand;
+    use clap::Parser;
+
+    /// The manual `Default` impl and the clap CLI default must agree on TN's own
+    /// IPC endpoint, not reth's `/tmp/reth.ipc`.
+    #[test]
+    fn default_ipcpath_matches_cli_default() {
+        assert_eq!(RpcServerArgs::default().ipcpath, DEFAULT_IPC_ENDPOINT);
+    }
+
+    /// The mirror-image regression: a bare CLI parse must agree with the manual `Default`
+    /// impl on `ipcpath`, so the clap default cannot drift back to reth's constant either.
+    #[test]
+    fn cli_default_ipcpath_matches_default_impl() -> eyre::Result<()> {
+        let parsed = RethCommand::try_parse_from(["tn-reth"])?;
+        assert_eq!(parsed.rpc.ipcpath, RpcServerArgs::default().ipcpath);
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #1155.  (Cantina #13)

## Problem

`crates/tn-reth/src/rpc_server_args.rs` defines TN's own IPC endpoint (`/tmp/tn.ipc`, a `\\.\pipe\tn.ipc` named pipe on windows) and uses it for the clap default on `--ipcpath`.  The manual `Default` impl reaches into reth's constants module instead, so `RpcServerArgs::default()` returns `ipcpath = "/tmp/reth.ipc"`.  The two defaults disagree.

Impact today is low: every current construction path goes through clap (`NodeCommand::try_parse_from`, `RethCommand::parse_from`), so a running node gets `/tmp/tn.ipc`, and the workspace has no `RpcServerArgs::default()` call site.  But the impl is public API.  Any future programmatic caller (test utilities, downstream consumers of `tn-reth`) gets a socket at `/tmp/reth.ipc`: that path collides with a reth node on the same host and silently diverges from the documented CLI default.  On windows the divergence is worse, because the reth constant is a unix path, not a named pipe.

Found by Haxatron during the current Cantina collaborative review;  #1155 tracks the remediation.

## Fix

- [x] `crates/tn-reth/src/rpc_server_args.rs`: the `Default` impl now uses the local `DEFAULT_IPC_ENDPOINT`, the same constant the clap default on `--ipcpath` uses.  The `constants` import stays for the port / gas / proof defaults, which are genuinely reth's.
- [x] Regression tests pin the pair in both directions.  `default_ipcpath_matches_cli_default` pins `RpcServerArgs::default().ipcpath` to `DEFAULT_IPC_ENDPOINT` (the `cfg(windows)` constant variant means the same assertion pins the named pipe on windows).  `cli_default_ipcpath_matches_default_impl` parses `RethCommand` bare and asserts the clap default equals the `Default` impl, so the clap side cannot drift back to reth's constant either.

## Testing

- `cargo +nightly-2026-03-20 fmt -- --check` clean.
- `cargo +1.94 test -p tn-reth --lib` green in an isolated target dir, including both new tests.
- Mutation-confirmed in both directions: reverting the `Default` arm to `constants::DEFAULT_IPC_ENDPOINT` fails `default_ipcpath_matches_cli_default`;  flipping the clap default to reth's constant fails `cli_default_ipcpath_matches_default_impl` while the first test stays green;  byte-exact restores pass again both times.
- `cargo +nightly-2026-03-20 clippy --workspace -- -D warnings` and `cargo +nightly-2026-03-20 clippy --workspace --all-features -- -D warnings` clean.
- Attest proxy: `cargo +1.94 test --no-run --workspace -j 2` green in an isolated target dir.
