### PR TITLE
fix(tn-reth): reject blob and set-code txns at pool admission (#1159)

### DIFF
--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -19,7 +19,7 @@ use tn_test_utils::wait_until;
 use tn_types::{
     gas_accumulator::GasAccumulator, test_genesis, Address, Batch, BatchValidation, Bytes,
     Certificate, CertifiedBatch, CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database,
-    Encodable2718, NoopTxnForwarder, ReputationScores, SealedBatch, TaskManager,
+    Encodable2718, GenesisAccount, NoopTxnForwarder, ReputationScores, SealedBatch, TaskManager,
     MIN_PROTOCOL_BASE_FEE, U160, U256,
 };
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
@@ -201,11 +201,11 @@ async fn test_make_batch_el_to_cl() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Create 4 valid EIP-1559 transactions.
+/// Create 4 valid EIP-1559 transactions and 1 valid EIP-4844 (blob) transaction.
 ///
-/// No blob transaction is involved: the pool now rejects EIP-4844 transactions at admission,
-/// so none can reach the batch builder. First 3 transactions mined in the first batch.
-/// Before a canonical state change, mine the 4th transaction in the next batch.
+/// The pool rejects the blob transaction at admission (issue #1159), so it never reaches the
+/// batch builder. First 3 transactions mined in the first batch. Before a canonical state
+/// change, mine the 4th transaction in the next batch.
 #[tokio::test]
 async fn test_batch_builder_produces_valid_batches() {
     //
@@ -213,6 +213,14 @@ async fn test_batch_builder_produces_valid_batches() {
     //
     // adiri genesis with TxFactory funded
     let genesis = test_genesis();
+
+    // fund a second random factory for the eip-4844 transaction, so its rejection below can
+    // only come from the pool's type gate, never from insufficient balance
+    let mut blob_tx_factory = TransactionFactory::new_random();
+    let genesis = genesis.extend_accounts([(
+        blob_tx_factory.address(),
+        GenesisAccount::default().with_balance(U256::MAX),
+    )]);
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
     let address = Address::from(U160::from(333));
     let tmp_dir = TempDir::new().unwrap();
@@ -278,10 +286,14 @@ async fn test_batch_builder_produces_valid_batches() {
     let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
     assert_matches!(added_result, hash if &hash == transaction3.hash());
 
-    // txpool size
+    // submit a valid eip-4844 blob transaction: the pool must reject it at admission (#1159)
+    let blob_pooled = blob_tx_factory.create_eip4844_pooled(chain.clone(), None, gas_price);
+    let blob_result = txpool.add_transaction_local(blob_pooled).await;
+    assert!(blob_result.is_err());
+
+    // txpool size: the rejected blob left nothing behind
     let pool_size = txpool.pool_size();
     assert_eq!(pool_size.pending, 3);
-    // blobs are rejected at pool admission, so none can be present
     assert_eq!(pool_size.blob, 0);
 
     // spawn batch_builder once worker is ready

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -19,7 +19,7 @@ use tn_test_utils::wait_until;
 use tn_types::{
     gas_accumulator::GasAccumulator, test_genesis, Address, Batch, BatchValidation, Bytes,
     Certificate, CertifiedBatch, CommittedSubDag, ConsensusHeaderDigest, ConsensusOutput, Database,
-    Encodable2718, GenesisAccount, NoopTxnForwarder, ReputationScores, SealedBatch, TaskManager,
+    Encodable2718, NoopTxnForwarder, ReputationScores, SealedBatch, TaskManager,
     MIN_PROTOCOL_BASE_FEE, U160, U256,
 };
 use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
@@ -201,12 +201,11 @@ async fn test_make_batch_el_to_cl() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Create 5 transactions.
+/// Create 4 valid EIP-1559 transactions.
 ///
-/// First 4 mined in first batch.
-/// One of the transactions is EIP-4844 blob which is discarded.
-/// (only 3 valid txs in first batch)
-/// Before a canonical state change, mine the 5th transaction in the next batch.
+/// No blob transaction is involved: the pool now rejects EIP-4844 transactions at admission,
+/// so none can reach the batch builder. First 3 transactions mined in the first batch.
+/// Before a canonical state change, mine the 4th transaction in the next batch.
 #[tokio::test]
 async fn test_batch_builder_produces_valid_batches() {
     //
@@ -214,15 +213,6 @@ async fn test_batch_builder_produces_valid_batches() {
     //
     // adiri genesis with TxFactory funded
     let genesis = test_genesis();
-
-    // create random tx factory for eip-4844 transaction reth does not allow
-    // different tx types in pool at same time from same address
-    // see Err: ExistingConflictingTransactionType
-    let mut blob_tx_factory = TransactionFactory::new_random();
-    let genesis = genesis.extend_accounts([(
-        blob_tx_factory.address(),
-        GenesisAccount::default().with_balance(U256::MAX),
-    )]);
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
     let address = Address::from(U160::from(333));
     let tmp_dir = TempDir::new().unwrap();
@@ -288,15 +278,10 @@ async fn test_batch_builder_produces_valid_batches() {
     let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
     assert_matches!(added_result, hash if &hash == transaction3.hash());
 
-    // submit eip-4844 blob transaction
-    let _ = blob_tx_factory
-        .create_and_submit_eip4844(chain.clone(), None, gas_price, txpool.clone())
-        .await;
-
     // txpool size
     let pool_size = txpool.pool_size();
-    assert_eq!(pool_size.pending, 4);
-    // ensure blob is not under valued
+    assert_eq!(pool_size.pending, 3);
+    // blobs are rejected at pool admission, so none can be present
     assert_eq!(pool_size.blob, 0);
 
     // spawn batch_builder once worker is ready
@@ -326,7 +311,8 @@ async fn test_batch_builder_produces_valid_batches() {
         )
         .await;
 
-    // assert 4 txs in pending pool - blob should be removed while creating first batch
+    // assert 4 txs in pending pool - the 3 original txs are not mined until the ack,
+    // plus the 1 new tx submitted above
     let pool_size = txpool.pool_size();
     assert_eq!(pool_size.pending, 4);
     assert_eq!(pool_size.blob, 0);
@@ -351,7 +337,7 @@ async fn test_batch_builder_produces_valid_batches() {
         received_at: None,
         ..*first_batch.batch()
     };
-    // assert only 3 transactions in batch - blob should be discarded
+    // assert only the first 3 transactions in batch
     let batch_txs = first_batch.batch().transactions();
     assert_eq!(batch_txs, expected_batch.transactions());
 

--- a/crates/tn-reth/src/test_utils.rs
+++ b/crates/tn-reth/src/test_utils.rs
@@ -503,14 +503,16 @@ impl TransactionFactory {
         TransactionSigned::new_unhashed(tx.into(), signature)
     }
 
-    /// Create and sign an EIP4844 transaction.
-    pub async fn create_and_submit_eip4844(
+    /// Create and sign a valid EIP-4844 (blob) transaction, wrapped as a pooled transaction with
+    /// its sidecar and ready to submit. Uses the "zero blob" whose KZG commitment and proof are the
+    /// known point at infinity, so the envelope passes KZG validation and the only reason a pool
+    /// can reject it is a type-level policy such as `no_eip4844`.
+    pub fn create_eip4844_pooled(
         &mut self,
         chain: Arc<RethChainSpec>,
         gas_limit: Option<u64>,
         gas_price: u128,
-        pool: WorkerTxPool,
-    ) -> TxHash {
+    ) -> EthPooledTransaction {
         // Use the "zero blob" - a blob filled with zeros
         // This has known valid KZG commitments and proofs
         let blob_data = [0u8; 131072]; // 128KB of zeros
@@ -541,15 +543,13 @@ impl TransactionFactory {
         let sidecar: BlobTransactionSidecarVariant =
             BlobTransactionSidecarVariant::Eip4844(sidecar);
 
-        // construct transaction, sign, and submit to pool
+        // construct transaction and sign
         let blob_versioned_hashes = vec![versioned_hash.into()]; // use computed hash
         let signed_tx =
             self.create_eip4844(chain.chain_id(), gas_limit, gas_price, blob_versioned_hashes);
         let recovered = signed_tx.try_into_recovered().expect("recovered tx");
-        let pooled_tx = EthPooledTransaction::try_from_eip4844(recovered, sidecar)
-            .expect("recovered into eth pooled tx");
-        let hash = pool.add_transaction_local(pooled_tx).await.expect("recovered tx added to pool");
-        hash.hash
+        EthPooledTransaction::try_from_eip4844(recovered, sidecar)
+            .expect("recovered into eth pooled tx")
     }
 
     /// Create and sign an EIP1559 transaction with all possible parameters passed.

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -114,6 +114,19 @@ impl WorkerTxPool {
             blockchain_provider.clone(),
             evm_config.clone(),
         )
+        // Reject EIP-4844 (blob) and EIP-7702 (set-code) transactions at admission. TN never
+        // mines either type: the batch builder strips them and the batch validator rejects any
+        // batch that carries one, so an admitted transaction of either type can never be executed.
+        // For blobs this is also a denial-of-service fix. On a successful add reth writes the blob
+        // sidecar to the on-disk DiskFileBlobStore, but that store uses deferred deletion whose
+        // only unlink runs in reth's maintain_transaction_pool loop. TN drives pool
+        // maintenance itself and never runs that loop, so nothing removes the sidecars at
+        // runtime and a remote unprivileged sender could grow a validator's disk without
+        // bound. Rejecting both unsupported types here, before insertion, closes that
+        // vector and mirrors reth's own node builder for a chain that supports neither
+        // type. See issue #1159.
+        .no_eip4844()
+        .no_eip7702()
         .kzg_settings(EnvKzgSettings::Default)
         .with_local_transactions_config(pool_config.local_transactions_config.clone())
         .with_additional_tasks(node_config.txpool.additional_validation_tasks)
@@ -432,9 +445,30 @@ mod tests {
     use super::*;
     use crate::{test_utils::TransactionFactory, RethChainSpec, RethEnv};
     use rand::{rngs::StdRng, SeedableRng as _};
+    use reth_chainspec::EthChainSpec as _;
     use std::sync::Arc;
     use tempfile::TempDir;
-    use tn_types::{test_genesis, Address, Bytes, Encodable2718 as _, TaskManager, U256};
+    use tn_types::{
+        test_genesis, Address, Bytes, Encodable2718 as _, GenesisAccount, TaskManager, U256,
+    };
+
+    /// Build a pool over a chain whose genesis funds the factory's sender, so a rejected
+    /// transaction can only be refused by a validator policy, never by insufficient balance.
+    fn funded_pool_for_test(
+        tx_factory: &TransactionFactory,
+        tmp_dir: &TempDir,
+        task_manager: &TaskManager,
+    ) -> (Arc<RethChainSpec>, RethEnv, WorkerTxPool) {
+        let genesis = test_genesis().extend_accounts([(
+            tx_factory.address(),
+            GenesisAccount::default().with_balance(U256::MAX),
+        )]);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), task_manager, None).unwrap();
+        let pool = reth_env.init_txn_pool().unwrap();
+        (chain, reth_env, pool)
+    }
 
     #[test]
     fn test_recover_raw_transaction_preserves_signer() {
@@ -488,6 +522,54 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(pool.pool_size().pending, 1);
         assert!(pool.get(&hash).is_some());
+    }
+
+    /// The DoS fix for issue #1159: the pool refuses EIP-4844 (blob) transactions at
+    /// admission. The sender is funded at genesis and the blob's KZG proof is valid, so the
+    /// only remaining reason for rejection is the `.no_eip4844()` type gate in
+    /// [`WorkerTxPool::new`].
+    #[tokio::test]
+    async fn test_pool_rejects_blob_transaction() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let mut tx_factory = TransactionFactory::new_random();
+        let (chain, reth_env, pool) = funded_pool_for_test(&tx_factory, &tmp_dir, &task_manager);
+
+        let gas_price = reth_env.get_gas_price().unwrap();
+        let pooled = tx_factory.create_eip4844_pooled(chain.clone(), None, gas_price);
+        let result = pool.add_transaction_local(pooled).await;
+        assert!(result.is_err());
+
+        // The pool admitted nothing. Reth writes the blob sidecar to the blob store only on
+        // successful insertion, so an empty pool proves no sidecar reached disk.
+        let s = pool.pool_size();
+        assert_eq!(s.pending, 0);
+        assert_eq!(s.blob, 0);
+        assert_eq!(s.queued, 0);
+    }
+
+    /// The pool refuses EIP-7702 (set-code) transactions at admission. Prague is active at
+    /// genesis so the transaction is fork-valid, and the sender is funded, so rejection is due
+    /// to the `.no_eip7702()` type gate in [`WorkerTxPool::new`], consistent with TN's existing
+    /// policy of treating EIP-7702 as an unsupported transaction type.
+    #[tokio::test]
+    async fn test_pool_rejects_eip7702_transaction() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let mut tx_factory = TransactionFactory::new_random();
+        let (chain, reth_env, pool) = funded_pool_for_test(&tx_factory, &tmp_dir, &task_manager);
+
+        let gas_price = reth_env.get_gas_price().unwrap();
+        let signed = tx_factory.create_eip7702(chain.chain_id(), None, gas_price);
+        // 7702 carries no sidecar, so the production external ingress accepts the raw tx.
+        let result = pool.add_raw_transaction_external(signed).await;
+        assert!(result.is_err());
+
+        // The pool admitted nothing.
+        let s = pool.pool_size();
+        assert_eq!(s.pending, 0);
+        assert_eq!(s.blob, 0);
+        assert_eq!(s.queued, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Reject EIP-4844 (blob) and EIP-7702 (set-code) transactions at transaction-pool admission by
adding `.no_eip4844()` and `.no_eip7702()` to the validator builder in `WorkerTxPool::new`. This
closes the unbounded on-disk blob-sidecar denial-of-service described in #1159 and brings pool
admission in line with the batch builder and batch validator, which already refuse both types.

Closes #1159. (Cantina #1)

## Problem

TN admits blob transactions and writes each sidecar to the on-disk `DiskFileBlobStore`, but nothing
removes those files at runtime, so a remote unprivileged sender can exhaust a validator's disk and
crash the node.

The decisive chain, verified at `origin/main` (1c73e8a3) against the pinned reth `v1.11.3`:

- The validator is built with a real `DiskFileBlobStore` and does not disable type 3
  (`crates/tn-reth/src/txn_pool.rs`). Blob validation has no fee floor, so a fresh unfunded key with
  all-zero fees is admitted (`cost <= balance` with `cost = 0`), and because the transaction is
  never mined the sender is never charged.
- On any successful add, reth writes the sidecar unconditionally, for every subpool
  (`on_added_transaction` -> `insert_blob` -> `blob_store.insert`).
- The reth blob store uses deferred deletion: `delete` / `delete_all` only mark hashes in an
  in-memory set; the sole `fs::remove_file` lives in `cleanup()`, which is reachable only through
  `Pool::cleanup_blobs`, whose only production caller is reth's `maintain_transaction_pool` loop.
- TN does not run that loop. It drives the pool itself via `process_canon_state_update` ->
  `on_canonical_state_change`, which only marks discarded blobs, never calls `cleanup()`. A tree-wide
  search finds no call to `maintain_transaction_pool`, `cleanup_blobs`, or `BlobStoreCanonTracker`.
- Blob transactions are never mined (the batch builder strips them, the batch validator rejects any
  batch that carries one), so the mined-removal path never fires either.
- The startup wipe in `DiskFileBlobStore::open` (`remove_dir_all`) only runs at process start, so a
  restart recovers the disk but the attacker resumes immediately.

Each type-3 transaction carries up to ~128 KB per blob (up to 6 blobs), and distinct keys mint
distinct hashes, so disk fills quickly at near-zero cost.

Finding surfaced by Haxatron in the collaborative review. This PR records the verified reth wiring
and closes the vector.

## Fix

Add `.no_eip4844()` and `.no_eip7702()` on the `EthTransactionValidatorBuilder` in
`WorkerTxPool::new`. In reth `v1.11.3` this flips `EthTransactionValidatorBuilder::eip4844` /
`eip7702` (default `true`) to `false`, so `validate_one` rejects the type before any subpool or
blob-store side effect: the `EIP4844_TX_TYPE_ID` arm returns
`InvalidTransactionError::Eip4844Disabled` and the `EIP7702_TX_TYPE_ID` arm returns
`Eip7702Disabled`. That check runs ahead of origin branching, so it rejects local, external, and
gossipped submissions alike. With no blob transaction ever inserted, no sidecar is ever written, and
the DoS surface is gone.

EIP-7702 is included because TN already treats it as an unsupported type (the batch builder strips it
and the batch validator maps it to `UnsupportedTxType`); rejecting it at the pool is the same policy
applied one layer earlier, not a new design decision.

The change is intentionally minimal. The existing batch-builder sweep and batch-validator rejection
are kept as defense in depth. The `DiskFileBlobStore` and `kzg_settings` are left in place: with
blobs rejected before insertion the store is never written, and removing it would change the pool's
public type parameters for no security benefit.

## Threat model

- Attacker: any party that can reach a validator's transaction ingress (its own RPC, or the
  gossip/forwarding path). No funds, no privilege, no prior state.
- Before: a stream of valid zero-fee blob transactions writes sidecars that are never reclaimed at
  runtime, growing the validator's disk without bound until the node crashes; the attacker resumes
  after any restart. Single-node availability / liveness impact (Medium; escalates if several
  validators are targeted toward a liveness-threatening fault fraction).
- After: every blob and set-code transaction is rejected at `validate_one`, before it can be
  inserted or write a sidecar, on every ingress path.

## Testing

Built against an isolated target with the pinned toolchain (`cargo +1.94`, sccache, `-j 2`).

New unit tests in `crates/tn-reth/src/txn_pool.rs`:

- `test_pool_rejects_blob_transaction`: funds the sender at genesis and builds a valid-KZG blob
  transaction, so the only remaining ground for rejection is the `.no_eip4844()` type gate.
  `add_transaction_local` returns an error and the pool stays empty (`pending`, `blob`, and `queued`
  all `0`). An empty pool proves no sidecar reached the on-disk blob store, which is the exact DoS
  surface #1159 describes.
- `test_pool_rejects_eip7702_transaction`: funds the sender, submits a fork-valid EIP-7702 set-code
  transaction through the external raw-ingress path (`add_raw_transaction_external`), and asserts the
  same error-and-empty-pool result via the `.no_eip7702()` gate.

Suites:

- `cargo +1.94 test -p tn-reth --lib`: `141 passed; 0 failed`, including both new tests.
- `cargo +1.94 test -p tn-batch-builder --test it test_batch_builder_produces_valid_batches`:
  `1 passed; 0 failed`. This existing test previously submitted a blob and expected the batch builder
  to discard it. With blobs rejected at admission the blob setup is removed and the assertions now
  track the observed pool state: the initial pending count drops from 4 to 3 (no blob in the pool),
  the mid-run pending count stays 4 (the three funded EIP-1559 transactions remain pending and a
  fourth is submitted before the canonical-state ack), and the first batch carries the three original
  transactions.

Formatting: `cargo +nightly-2026-03-20 fmt --check` clean on both crates.
Lint: `cargo +nightly-2026-03-20 clippy -p tn-reth -p tn-batch-builder --all-features` clean (exit 0, no warnings).

## References

- reth `v1.11.3`: `crates/transaction-pool/src/validate/eth.rs` (`no_eip4844` / `no_eip7702`
  builder methods; the `EIP4844_TX_TYPE_ID` / `EIP7702_TX_TYPE_ID` reject arms in `validate_one`);
  `crates/transaction-pool/src/blobstore/disk.rs` (deferred deletion, `cleanup`);
  `crates/transaction-pool/src/maintain.rs` (`maintain_transaction_pool`).
- TN: `crates/tn-reth/src/txn_pool.rs` (pool build and `process_canon_state_update`);
  `crates/batch-builder/src/batch.rs`, `crates/batch-validator/src/validator.rs` (blob/7702 never
  mined).
- Precedent: PR #1104, issue #1067 (batch-validator tx-type allowlist).
