### PR TITLE
fix(batch-builder): carry real sender balance in optimistic pool update

### DIFF
--- a/crates/batch-builder/README.md
+++ b/crates/batch-builder/README.md
@@ -59,21 +59,24 @@ This allows the batch builder to immediately loop and build the next batch from 
 
 The pool receives updates from **two independent sources**:
 
-1. **Batch builder** (`lib.rs` → `update_canonical_state()`): Called immediately after quorum. Provides an early, optimistic update with mined transaction hashes and nonce advances. Uses `U256::MAX` for balances (see below).
+1. **Batch builder** (`lib.rs` → `update_canonical_state()`): Called immediately after quorum. Provides an early, optimistic update with mined transaction hashes and nonce advances. Carries each sender's real canonical balance (see below).
 
 2. **Canonical pool task** (`txn_pool.rs` → `process_canon_state_update()`): A separate background task subscribed to the engine's canonical state stream. Called after the engine executes the committed batches and produces a new canonical block. Provides authoritative nonce, balance, and mined transaction data derived from actual EVM execution.
 
 Both call `on_canonical_state_change()` on the underlying Reth pool. The engine's update overwrites the batch builder's optimistic state with the real post-execution values.
 
-### Why `U256::MAX` for Balance
+### Which Balance the Optimistic Update Carries
 
 The batch builder does not execute transactions and cannot know the post-execution balance.
-The balance field in `ChangedAccount` is set to `U256::MAX` for the following reasons:
+The balance field in `ChangedAccount` is set to the sender's **real canonical balance minus the cost of the transactions just mined for that sender** (balance read via `TxPool::get_account_balance`), not `U256::MAX`.
 
-- **Pre-execution balance is equally wrong.** After mining 8 transactions that each transfer value, the sender's real balance is lower than the pre-execution balance. Neither `U256::MAX` nor the pre-execution balance reflects reality — only the post-execution balance does, which requires EVM execution.
-- **No spam vector.** New transactions entering the pool are validated against the real on-chain balance by Reth's `TransactionValidationTaskExecutor`. The `changed_accounts` balance only affects whether the pool *demotes existing* transactions after mining — it does not bypass entry validation.
-- **Short persistence window.** The `U256::MAX` balance only persists until the engine's canonical update arrives (same consensus round), which overwrites it with the real post-execution balance.
-- **Prevents unnecessary demotion.** Using a lower balance could cause the pool to evict transactions that are actually valid, degrading throughput for legitimate senders.
+- **`U256::MAX` is an amplification vector.** The optimistic balance decides whether the pool *promotes existing* parked transactions after mining. With `U256::MAX`, a sender's queued insufficient-funds transactions all look affordable, so the pool promotes them and the batch builder packs them into the next batch built inside the optimistic window — before the engine's canonical update corrects the balance. Peer batch validation is purely structural, so that follow-up batch reaches quorum, is gossiped and stored, and is then skipped for free at execution. A funded attacker pays for roughly one transaction per sender but forces the network to certify and store up to `TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER - 1` extra invalid transactions per sender.
+- **Debiting the just-mined cost stops the burst.** Because the mined transactions' cost is subtracted from the reported balance, a sender that cannot actually fund its remaining transactions keeps them parked. The immediate amplification the issue's PoC relies on — queue many transactions, mine one, watch the rest promote into the very next batch — no longer occurs.
+- **Residual (known limitation).** The balance is re-derived from the last committed canonical balance on every in-window rebuild and does not accumulate debits across successive rebuilds before the engine's canonical update lands. A drip-fed sender can therefore still have on the order of one transaction promoted per rebuild until the canonical update corrects the balance. Fully closing this requires tracking cumulative optimistic spend across rebuilds, or a state-aware check on the follow-up batch path (directions 3 and 4 in issue #1158); both are larger design choices deferred to the maintainers.
+- **Entry validation is unaffected.** New transactions entering the pool are still validated against the real on-chain balance by Reth's `TransactionValidationTaskExecutor`. The `changed_accounts` balance only affects promotion/demotion of transactions already in the pool.
+- **Short persistence window.** The optimistic balance only persists until the engine's canonical update arrives (same consensus round), which overwrites it with the real post-execution balance.
+- **No unnecessary demotion for legitimate senders.** A sender whose remaining transactions are affordable at their real balance keeps them in `pending`; only genuinely underfunded transactions stay parked, which is correct.
+- **Conservative on read failure.** A missing account or a state-read error yields `U256::ZERO`, which can only keep transactions parked (never promote an unfunded one); the engine's authoritative update corrects it the same round.
 
 ## Security Considerations
 

--- a/crates/batch-builder/src/batch.rs
+++ b/crates/batch-builder/src/batch.rs
@@ -23,10 +23,13 @@ pub struct BatchBuilderOutput {
     pub(crate) batch: Batch,
     /// The transaction hashes mined in this worker's batch.
     pub(crate) mined_transactions: Vec<TxHash>,
-    /// Per-sender nonce updates for the pool after mining.
+    /// Per-sender pool updates applied after mining.
     ///
-    /// Keeps remaining transactions from the same sender in the pending sub-pool
-    /// rather than being demoted to queued due to a perceived nonce gap.
+    /// Each entry advances the sender's nonce past the mined transactions so remaining
+    /// transactions from the same sender stay in the pending sub-pool rather than being demoted
+    /// to queued over a perceived nonce gap. The balance is the sender's real canonical balance
+    /// minus the just-mined cost, so parked insufficient-funds transactions are not spuriously
+    /// promoted (see `build_batch`).
     pub(crate) changed_accounts: Vec<ChangedAccount>,
 }
 
@@ -66,6 +69,7 @@ pub fn build_batch<P: TxPool>(
     let mut blob_transactions = Vec::new();
     let mut unsupported_transactions = Vec::new();
     let mut sender_nonces: HashMap<Address, u64> = HashMap::new();
+    let mut sender_costs: HashMap<Address, U256> = HashMap::new();
 
     // begin loop through sorted "best" transactions in pending pool
     // and execute them to build the block
@@ -125,6 +129,14 @@ pub fn build_batch<P: TxPool>(
         let sender = pool_tx.sender();
         let nonce = pool_tx.nonce();
         sender_nonces.entry(sender).and_modify(|max| *max = (*max).max(nonce)).or_insert(nonce);
+
+        // accumulate the cost of the transactions mined for this sender so the optimistic balance
+        // update below can debit them (see the changed_accounts construction)
+        let cost = *pool_tx.cost();
+        sender_costs
+            .entry(sender)
+            .and_modify(|total| *total = total.saturating_add(cost))
+            .or_insert(cost);
     }
 
     // batch
@@ -137,19 +149,98 @@ pub fn build_batch<P: TxPool>(
     // remove any non-allowlisted transaction types that were submitted
     pool.remove_unsupported_txs(unsupported_transactions);
 
-    // construct changed_accounts for pool nonce updates
+    // construct changed_accounts for the optimistic pool update
     //
-    // NOTE: new transactions entering the pool are sanitized using account balance checks
-    // `balance: U256::MAX` only affects whether the pool demotes accounts after mining the batch
+    // The nonce is advanced past the mined transactions so remaining transactions from the same
+    // sender stay in `pending` rather than being demoted over a perceived nonce gap.
+    //
+    // The balance is the sender's real canonical balance minus the cost of the transactions just
+    // mined for that sender, NOT `U256::MAX`. `U256::MAX` made the pool treat a sender's parked
+    // (insufficient-funds) transactions as affordable and promote them into the next batch built
+    // inside this optimistic window; those transactions are then quorum-certified and gossiped
+    // only to be skipped for free at execution, a griefing/amplification vector (issue #1158).
+    // Debiting the just-mined cost keeps a sender's parked transactions parked when the sender
+    // cannot actually fund them, so the amplification the issue's PoC relies on (queue many
+    // transactions, mine one, watch the rest promote) no longer occurs.
+    //
+    // Residual: the balance is re-derived from the last committed canonical balance on every
+    // in-window rebuild and does not accumulate debits across successive rebuilds before the
+    // engine's canonical update lands, so a drip-fed sender can still have on the order of one
+    // transaction promoted per rebuild. Fully closing that requires tracking cumulative optimistic
+    // spend across rebuilds (or a state-aware check on the follow-up batch path); both are larger
+    // design choices left to the maintainers. See the crate README.
     let changed_accounts: Vec<ChangedAccount> = sender_nonces
         .into_iter()
         .map(|(address, max_nonce)| ChangedAccount {
             address,
             nonce: max_nonce + 1, // next expected nonce
-            balance: U256::MAX,   // corrected by engine's canonical update
+            balance: pool
+                .get_account_balance(address)
+                .saturating_sub(sender_costs.get(&address).copied().unwrap_or(U256::ZERO)),
         })
         .collect();
 
     // return output
     BatchBuilderOutput { batch, mined_transactions, changed_accounts }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestPool;
+    use std::sync::Arc;
+    use tn_reth::{test_utils::TransactionFactory, RethChainSpec};
+    use tn_types::{test_genesis, BatchBuilderArgs, Bytes, MIN_PROTOCOL_BASE_FEE, U256};
+
+    /// The optimistic `changed_accounts` update must carry the sender's real balance, not an
+    /// inflated `U256::MAX`. An inflated balance lets the pool promote a sender's parked
+    /// insufficient-funds transactions into the next batch, which is a griefing/amplification
+    /// vector (see the module docs and `crates/batch-builder/README.md`). The nonce must still be
+    /// advanced past the mined transactions so legitimate sequential senders keep flowing.
+    #[test]
+    fn changed_accounts_carry_real_balance_and_advance_nonce() {
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let mut tx_factory = TransactionFactory::new();
+        let sender = tx_factory.address();
+
+        // two sequential transactions (nonces 0 and 1) from the same sender
+        let tx0 = tx_factory.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            None,
+            U256::from(1),
+            Bytes::new(),
+        );
+        let tx1 = tx_factory.create_eip1559_encoded(
+            chain.clone(),
+            None,
+            100,
+            None,
+            U256::from(1),
+            Bytes::new(),
+        );
+
+        // the pool reports a large, finite balance for the sender
+        let real_balance = U256::from(1_000_000_000_000_000_000u128);
+        let pool = TestPool::new(&[tx0, tx1]).with_balance(sender, real_balance);
+        // both transactions are mined, so their cost is debited from the optimistic balance
+        let mined_cost = pool.total_cost();
+        assert!(mined_cost > U256::ZERO, "mined transactions must have non-zero cost");
+
+        let args = BatchBuilderArgs { pool, beneficiary: Address::ZERO, epoch: 0 };
+        let BatchBuilderOutput { changed_accounts, .. } =
+            build_batch(args, 0, MIN_PROTOCOL_BASE_FEE);
+
+        let changed = changed_accounts
+            .iter()
+            .find(|account| account.address == sender)
+            .expect("sender must have a changed_accounts entry after mining");
+
+        // the optimistic balance is the real balance minus the just-mined cost, never U256::MAX
+        assert_eq!(changed.balance, real_balance - mined_cost);
+        assert_ne!(changed.balance, U256::MAX);
+        // the nonce is still advanced past the highest mined nonce (throughput fix preserved)
+        assert_eq!(changed.nonce, 2);
+    }
 }

--- a/crates/batch-builder/src/test_utils.rs
+++ b/crates/batch-builder/src/test_utils.rs
@@ -10,7 +10,8 @@ use tn_reth::{
     SenderIdentifiers, TxPool,
 };
 use tn_types::{
-    Batch, BatchBuilderArgs, Recovered, TransactionTrait as _, TxHash, MIN_PROTOCOL_BASE_FEE,
+    Address, Batch, BatchBuilderArgs, Recovered, TransactionTrait as _, TxHash,
+    MIN_PROTOCOL_BASE_FEE, U256,
 };
 
 /// Attempt to update batch with accurate header information.
@@ -29,9 +30,12 @@ pub fn execute_test_batch(test_batch: &mut Batch) {
 
 /// A test pool that ensures every transaction is in the pending pool
 #[derive(Default, Clone, Debug)]
-struct TestPool {
+pub(crate) struct TestPool {
     transactions: Vec<Arc<PoolTxn>>,
     by_id: BTreeMap<PoolTxnId, Arc<PoolTxn>>,
+    /// Per-sender balances returned by [`TxPool::get_account_balance`]. A sender that is absent
+    /// here reports [`U256::MAX`], preserving the behavior of tests that do not exercise balance.
+    balances: BTreeMap<Address, U256>,
 }
 
 impl TxPool for TestPool {
@@ -51,11 +55,28 @@ impl TxPool for TestPool {
         self.transactions.retain(|tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
         self.by_id.retain(|_, tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
     }
+    fn get_account_balance(&self, address: Address) -> U256 {
+        self.balances.get(&address).copied().unwrap_or(U256::MAX)
+    }
 }
 
 impl TestPool {
+    /// Override the balance [`TxPool::get_account_balance`] reports for `address`.
+    #[cfg(test)]
+    pub(crate) fn with_balance(mut self, address: Address, balance: U256) -> Self {
+        self.balances.insert(address, balance);
+        self
+    }
+
+    /// Sum of the pool transactions' costs, used by tests to compute the expected optimistic
+    /// balance debit.
+    #[cfg(test)]
+    pub(crate) fn total_cost(&self) -> U256 {
+        self.transactions.iter().fold(U256::ZERO, |acc, tx| acc.saturating_add(*tx.cost()))
+    }
+
     /// Create a new instance of Self.
-    fn new(txs: &[Vec<u8>]) -> Self {
+    pub(crate) fn new(txs: &[Vec<u8>]) -> Self {
         let mut sender_ids = SenderIdentifiers::default();
         let mut by_id = Vec::with_capacity(txs.len());
         let transactions = txs
@@ -78,7 +99,7 @@ impl TestPool {
                 valid_tx
             })
             .collect();
-        Self { transactions, by_id: by_id.into_iter().collect() }
+        Self { transactions, by_id: by_id.into_iter().collect(), balances: BTreeMap::new() }
     }
 
     fn best_transactions_int(&self) -> Box<dyn BestTransactions<Item = Arc<PoolTxn>>> {

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -32,8 +32,8 @@ use reth_chainspec::ChainSpec;
 use reth_node_builder::{NodeConfig, RethTransactionPoolConfig};
 use reth_primitives_traits::SignerRecoverable;
 use reth_provider::{
-    providers::BlockchainProvider, CanonStateNotification, CanonStateSubscriptions as _, Chain,
-    ChangedAccount,
+    providers::BlockchainProvider, AccountReader as _, CanonStateNotification,
+    CanonStateSubscriptions as _, Chain, ChangedAccount,
 };
 use reth_rpc_eth_types::utils::recover_raw_transaction as reth_recover_raw_transaction;
 use reth_transaction_pool::{
@@ -48,7 +48,7 @@ use reth_transaction_pool::{
 use std::{sync::Arc, time::Instant};
 use tn_types::{
     Address, EnvKzgSettings, Recovered, SealedBlock, TaskError, TaskSpawner, TransactionSigned,
-    TxHash, MIN_PROTOCOL_BASE_FEE,
+    TxHash, MIN_PROTOCOL_BASE_FEE, U256,
 };
 use tracing::{debug, info, trace, warn};
 
@@ -83,12 +83,24 @@ pub trait TxPool {
     /// Remove transactions whose EIP-2718 type is outside the executable allowlist from the
     /// pool, along with their descendants.
     fn remove_unsupported_txs(&mut self, txs: Vec<TxHash>);
+    /// Return the canonical balance of `address` as of the latest committed block.
+    ///
+    /// Used to build the optimistic per-sender balance in a post-mining pool update. A missing
+    /// account (or a read error) yields [`U256::ZERO`], which is the conservative choice: it can
+    /// only keep a sender's remaining transactions parked, never promote an unfunded one, and the
+    /// engine's authoritative canonical update corrects it within the same consensus round.
+    fn get_account_balance(&self, address: Address) -> U256;
 }
 
 /// A telcoin network transaction pool.
+///
+/// The second field is a handle to the blockchain provider, retained so the pool can read a
+/// sender's canonical balance when constructing optimistic pool updates after mining a batch
+/// (see [`TxPool::get_account_balance`]).
 #[derive(Clone, Debug)]
 pub struct WorkerTxPool(
     EthTransactionPool<BlockchainProvider<TelcoinNode>, DiskFileBlobStore, TnEvmConfig>,
+    BlockchainProvider<TelcoinNode>,
 );
 
 impl From<WorkerTxPool>
@@ -147,7 +159,7 @@ impl WorkerTxPool {
         */
 
         let mut state_stream = blockchain_provider.canonical_state_stream();
-        let this = Self(transaction_pool);
+        let this = Self(transaction_pool, blockchain_provider.clone());
         let txn_pool_clone = this.clone();
         // Update the txn pool as the canonical tip changes.
         task_spawner.spawn_critical_task("canonical txn pool", async move {
@@ -338,6 +350,15 @@ impl TxPool for WorkerTxPool {
 
     fn remove_unsupported_txs(&mut self, txs: Vec<TxHash>) {
         self.0.remove_transactions_and_descendants(txs);
+    }
+
+    fn get_account_balance(&self, address: Address) -> U256 {
+        self.1
+            .basic_account(&address)
+            .ok()
+            .flatten()
+            .map(|account| account.balance)
+            .unwrap_or(U256::ZERO)
     }
 }
 


### PR DESCRIPTION
## Summary

The batch builder's optimistic post-mining pool update reported `balance: U256::MAX` for every sender that had a transaction mined in a batch. That inflated balance let Reth's transaction pool promote a sender's parked, insufficient-funds transactions into the very next batch, which the batch builder builds immediately inside the optimistic window before the engine's canonical update corrects the balance. Because peer batch validation is purely structural, the follow-up batch reaches quorum, is gossiped and stored, and is then skipped for free at execution.

This PR sets the optimistic balance to the sender's **real canonical balance minus the cost of the transactions just mined for that sender** instead of `U256::MAX`, so a sender that cannot fund its remaining transactions keeps them parked. The nonce advance that keeps legitimate sequential senders flowing is unchanged.

Fixes the Cantina finding reported by **Haxatron** and tracked in #1158.

## Problem

After a batch reaches quorum, `build_batch()` emits one `ChangedAccount` per sender that had a transaction in the batch, and `lib.rs` feeds those into `pool.update_canonical_state(...)` → Reth's `on_canonical_state_change`. When a sender's reported balance jumps to `U256::MAX`, Reth reclassifies that sender's queued (insufficient-funds) transactions into `pending`. The run loop then continues **without** waiting for the engine's authoritative canonical stream (this is deliberate, to avoid stalling legitimate sequential senders), so the next batch is built from transactions that only *look* affordable.

`validate_batch()` checks the digest, worker id, epoch, byte size, decoding, blob exclusion, gas limit, and base fee — but no balance or nonce against execution state — so the follow-up batch of underfunded transactions still receives quorum certification. At execution the sender's real balance is already spent, so those transactions fail stateful validation and are skipped with no fee and no state change.

Net effect: a funded attacker pays for roughly one successful transaction per sender but forces the network to gossip, decode, recover signatures for, quorum-certify, store, and execution-validate up to `TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER - 1` (255 at the current cap) extra invalid transactions per sender, at no cost. The documented "No spam vector" defense in the README covers a *different* claim — new transactions entering the pool are validated against real balance at entry — but the optimistic `changed_accounts` balance governs promotion/demotion of transactions **already** in the pool, which is exactly what the attack exploits.

## Fix

- **`TxPool::get_account_balance(address) -> U256`** (`crates/tn-reth/src/txn_pool.rs`): new trait method returning a sender's canonical balance as of the latest committed block. `WorkerTxPool` now retains a `BlockchainProvider` handle and answers via `basic_account`. A missing account or a state-read error yields `U256::ZERO`, the conservative choice: it can only keep a sender's remaining transactions parked, never promote an unfunded one, and the engine's authoritative update corrects it the same round.
- **`build_batch`** (`crates/batch-builder/src/batch.rs`): while packing, it accumulates each sender's mined-transaction cost, and the optimistic `ChangedAccount.balance` is now `pool.get_account_balance(address).saturating_sub(mined_cost)` instead of `U256::MAX`. The nonce advance (`max_nonce + 1`) is unchanged.
- **README** (`crates/batch-builder/README.md`): the balance-rationale section is rewritten to explain the real-balance-minus-mined-cost update, why `U256::MAX` was an amplification vector, and the known residual below.

### Why this is safe and preserves throughput

- **The burst is closed.** Debiting the just-mined cost means a sender whose real balance cannot cover its remaining transactions keeps them parked. The immediate amplification in the issue's PoC — queue up to 255 transactions, mine one, watch the rest promote into the very next batch — no longer occurs.
- **Legitimate senders unaffected.** A sender who actually funded its transactions keeps them in `pending` (real balance minus the mined spend still covers the rest); only genuinely underfunded transactions are parked, which is correct. The debit uses each transaction's max cost, so it errs toward parking rather than over-promoting, and the engine's canonical update restores the true balance within the same consensus round.
- **Entry validation unchanged.** New transactions are still validated against the real on-chain balance by Reth's `TransactionValidationTaskExecutor`.

### Known residual (deliberately not fixed here)

The optimistic balance is re-derived from the last committed canonical balance on every in-window rebuild and does **not** accumulate debits across successive rebuilds before the engine's canonical update lands. A carefully drip-fed sender can therefore still have on the order of one transaction promoted per rebuild (rather than the full parked set at once) until the canonical update corrects the balance. Fully closing this requires tracking cumulative optimistic spend across rebuilds, or a state-aware check on the follow-up batch path (directions 3 and 4 in the issue). Both are larger design choices with throughput trade-offs that the maintainers are best placed to make; this PR is the minimal, local change that removes the immediate burst without touching the consensus or execution paths. It implements directions 1 and 2 and strictly improves on the current behavior in the meantime.

## Testing

- New unit test `crates/batch-builder/src/batch.rs::tests::changed_accounts_carry_real_balance_and_advance_nonce`: builds two sequential transactions from one sender, has the pool report a large finite balance, calls `build_batch`, and asserts the produced `changed_accounts` entry carries `real_balance - mined_cost` (not `U256::MAX`) while still advancing the nonce past the highest mined nonce.
- `cargo +1.94 test -p tn-batch-builder --features test-utils --lib`
- `cargo +1.94 fmt --check`, nightly `clippy --workspace --all-features`, and `make attest` on the pinned toolchain.

## Notes

- All code references are on current `main`; the issue's line numbers are at its reference commit `7891daa5`.
- Related but out of scope: the per-sender slot cap of 256 (`crates/tn-reth/src/cli.rs`, up from Reth's default 16) sets the amplification factor and is left unchanged here.
