### PR TITLE
fix(tn-reth): try the next validator on node-local -32000 refusals

### DIFF
--- a/crates/tn-reth/src/forward.rs
+++ b/crates/tn-reth/src/forward.rs
@@ -92,15 +92,44 @@ const FORWARD_BATCH_BUDGET: Duration = Duration::from_secs(120);
 /// and a tighter cap would shed batches an unstressed node could have delivered.
 const MAX_CONCURRENT_FORWARDS: usize = 64;
 
-/// JSON-RPC error codes reth returns for a validator-local, transient condition (a full pool,
-/// `-32003`, or an internal/IO error, `-32603`) rather than a verdict on the transaction itself.
-/// The forward falls through to the next advertised validator on these, since another validator
-/// may still accept the transaction.
+/// JSON-RPC error codes reth reserves for conditions that are validator-local or indeterminate,
+/// never cleanly a verdict on the transaction: `-32003` is a full pool (`TxPoolOverflow`) plus
+/// reth's catch-all for invalid-transaction variants with no explicit code of their own (for
+/// example insufficient funds), and `-32603` is an internal/IO error. The forward falls through
+/// to the next advertised validator on these: retrying a deterministic verdict caught in the
+/// `-32003` mix costs at most one bounded pass over the committee, while stopping on a full pool
+/// would drop a transaction another validator may still accept.
 const TRANSIENT_RPC_CODES: [i64; 2] = [-32003, -32603];
 
 /// Substring of reth's `eth_sendRawTransaction` error message when the transaction is already in a
 /// validator's pool (`code -32000`). Treated as a successful delivery, not a failure to retry.
 const ALREADY_KNOWN_MESSAGE: &str = "already known";
+
+/// The JSON-RPC code reth answers with for both chain-wide verdicts and the node-local refusals
+/// in [`NODE_LOCAL_MESSAGES`] (`EthRpcErrorCode::InvalidInput`). The message carve-out is scoped
+/// to this code so a matching substring under any other code keeps its terminal meaning.
+const INVALID_INPUT_RPC_CODE: i64 = -32000;
+
+/// Substrings of reth `eth_sendRawTransaction` error messages (code `-32000`) that describe one
+/// validator's pool contents or one operator's admission config rather than a verdict on the
+/// transaction itself. Reth maps almost every pool refusal to `-32000`, the same code it uses
+/// for chain-wide verdicts, so the code axis cannot make this split; the message can. The
+/// forward tries the next advertised validator on these, since a validator with different pool
+/// contents or config may accept the same bytes.
+const NODE_LOCAL_MESSAGES: [&str; 4] = [
+    // `RpcPoolError::Underpriced`: priced below that operator's `--txpool.minimal-protocol-fee`.
+    "transaction underpriced",
+    // `RpcPoolError::ReplaceUnderpriced`: a same-nonce transaction already sits in that
+    // validator's pool and the fee bump is below its `--txpool.pricebump`. Subsumed by the
+    // entry above under `contains`, pinned separately so a reth rewording of one message
+    // cannot silently drop coverage of the other.
+    "replacement transaction underpriced",
+    // `RpcPoolError::ExceedsFeeCap`: the fee is above that node's `--rpc.txfeecap`.
+    "exceeds the configured cap",
+    // `RpcPoolError::AddressAlreadyReserved`: blob-vs-regular sender exclusivity against that
+    // validator's current pool contents.
+    "address already reserved",
+];
 
 /// Whether the forwarder may dial an advertised endpoint whose host is not a public internet
 /// address.
@@ -511,8 +540,9 @@ impl WorkerRpcForwarder {
                                 result = ForwardOutcome::Rejected(reason);
                                 break;
                             }
-                            // Endpoint-local problem (timeout, transport error, full pool): the
-                            // transaction's fate is unknown here, so try the next validator.
+                            // Endpoint-local problem (timeout, transport error, full pool, or a
+                            // node-local refusal): the transaction's fate is unknown here, so
+                            // try the next validator.
                             Disposition::TryNext(reason) => {
                                 debug!(
                                     target: "worker::forward",
@@ -683,10 +713,11 @@ enum Disposition {
     /// The validator accepted the transaction, or it was already in a validator's pool.
     Delivered,
     /// The validator returned a considered rejection of the transaction itself (bad nonce,
-    /// underpriced, invalid, wrong fork). No other validator will accept it either.
+    /// invalid, wrong fork). No other validator will accept it either.
     Rejected(String),
-    /// This endpoint gave no verdict (timeout, transport error, or a transient full pool); the
-    /// transaction may still be accepted by another validator.
+    /// This endpoint gave no verdict (timeout, transport error, a transient full pool, or a
+    /// refusal tied to this validator's own pool contents or admission config); the transaction
+    /// may still be accepted by another validator.
     TryNext(String),
 }
 
@@ -712,15 +743,22 @@ fn classify_error(err: RpcError<TransportErrorKind>) -> Disposition {
 
 /// Classify a server-side JSON-RPC rejection of a forwarded transaction.
 fn classify_server_error(code: i64, message: String) -> Disposition {
-    if TRANSIENT_RPC_CODES.contains(&code) {
+    let lowered = message.to_ascii_lowercase();
+    match () {
         // A full pool or an internal error is validator-local; another validator may accept it.
-        Disposition::TryNext(message)
-    } else if message.to_ascii_lowercase().contains(ALREADY_KNOWN_MESSAGE) {
+        () if TRANSIENT_RPC_CODES.contains(&code) => Disposition::TryNext(message),
         // Already in a validator's pool: the transaction is delivered.
-        Disposition::Delivered
-    } else {
+        () if lowered.contains(ALREADY_KNOWN_MESSAGE) => Disposition::Delivered,
+        // A refusal tied to this validator's own pool contents or admission config, not a
+        // verdict: the next validator may accept the same bytes. Scoped to `-32000` so the
+        // substrings cannot hijack a verdict that arrives under any other code.
+        () if code == INVALID_INPUT_RPC_CODE
+            && NODE_LOCAL_MESSAGES.iter().any(|needle| lowered.contains(needle)) =>
+        {
+            Disposition::TryNext(message)
+        }
         // Every validator shares consensus state, so a considered rejection repeats everywhere.
-        Disposition::Rejected(format!("code {code}: {message}"))
+        () => Disposition::Rejected(format!("code {code}: {message}")),
     }
 }
 
@@ -1148,6 +1186,40 @@ mod tests {
             Disposition::Rejected(_)
         ));
         Ok(())
+    }
+
+    /// Reth answers `-32000` for refusals that depend on one validator's pool contents or one
+    /// operator's admission config. These are not verdicts on the transaction: the forward tries
+    /// the next advertised validator instead of dropping the transaction as rejected.
+    #[test]
+    fn classify_server_error_tries_next_on_node_local_refusals() {
+        [
+            "transaction underpriced",
+            "replacement transaction underpriced",
+            "tx fee (2000000000000000000 wei) exceeds the configured cap (1000000000000000000 wei)",
+            "address already reserved",
+            // The scan is case-insensitive, matching the `already known` handling.
+            "Transaction Underpriced",
+        ]
+        .into_iter()
+        .for_each(|message| {
+            assert_eq!(
+                classify_server_error(-32000, message.to_string()),
+                Disposition::TryNext(message.to_string())
+            )
+        });
+        // An adjacent chain-wide verdict stays terminal: sharing words with a carve-out entry
+        // is not a match.
+        assert!(matches!(
+            classify_server_error(-32000, "gas required exceeds allowance (21000)".to_string()),
+            Disposition::Rejected(_)
+        ));
+        // The carve-out is scoped to code -32000: the same substring under another code (for
+        // example a revert reason echoed under reth's code 3) stays terminal.
+        assert!(matches!(
+            classify_server_error(3, "execution reverted: transaction underpriced".to_string()),
+            Disposition::Rejected(_)
+        ));
     }
 
     /// With no advertised endpoint, or with only endpoints the policy refuses, the batch is


### PR DESCRIPTION
Closes #1168. (Cantina #19)

## Problem

`classify_server_error` in `crates/tn-reth/src/forward.rs` splits a server answer into a verdict on the transaction (`Rejected`, stop the fallback chain) or a validator-local condition (`TryNext`, try the next validator). The split uses the JSON-RPC error code alone. The pinned reth (`v1.11.3`) does not give node-local refusals their own code. Reth maps `Underpriced`, `ReplaceUnderpriced`, `ExceedsFeeCap`, and `AddressAlreadyReserved` to `-32000` (`crates/rpc/rpc-eth-types/src/error/mod.rs`, `From<RpcPoolError> for ErrorObject`). The same code carries chain-wide verdicts such as `nonce too low`.

A node-local refusal that arrives as `-32000` becomes `Disposition::Rejected`. The forward stops the fallback chain and drops the transaction. The next advertised validator would accept the same bytes. The submitting client already holds a success response from the observer RPC, so the loss is silent apart from one `warn!` line.

## Root cause

The code axis cannot express the node-local versus chain-wide split for `-32000`. Only `TxPoolOverflow` maps to `-32003`, and only `RpcPoolError::Other` maps to `-32603`. `TRANSIENT_RPC_CODES: [-32003, -32603]` therefore covers one node-local pool refusal and misses the other four.

## Fix

Classify the known node-local `-32000` refusals by message substring, with the same mechanism the function already uses for `already known`. A new `NODE_LOCAL_MESSAGES` table holds the four reth messages:

- `transaction underpriced` (`RpcPoolError::Underpriced`: below that operator's `--txpool.minimal-protocol-fee`)
- `replacement transaction underpriced` (`RpcPoolError::ReplaceUnderpriced`: below that validator's `--txpool.pricebump` against its current pool)
- `exceeds the configured cap` (`RpcPoolError::ExceedsFeeCap`: above that node's `--rpc.txfeecap`)
- `address already reserved` (`RpcPoolError::AddressAlreadyReserved`: blob-versus-regular sender exclusivity against that pool)

A match returns `Disposition::TryNext`, so the forward tries the next advertised validator. The carve-out is scoped to code `-32000` (`INVALID_INPUT_RPC_CODE`), so the same substring under any other code keeps its terminal meaning. An unrecognized `-32000` message keeps the terminal `Rejected` classification: chain-wide verdicts (bad nonce, wrong chain, malformed) dominate that code, and every validator repeats them.

The threat model does not change. Each attempt stays bounded by `FORWARD_SEND_TIMEOUT`, and the whole chain stays bounded by `FORWARD_TX_BUDGET`. A reclassified refusal costs at most one bounded pass over the committee. The failure this fixes needs no attacker: two honest validators with different pool contents (a same-nonce replacement) or different admission config (`--rpc.txfeecap`, `--txpool.pricebump`, `--txpool.minimal-protocol-fee`) are sufficient.

Out of scope: the `-32003` arm still returns `TryNext` for the deterministic verdicts reth folds into its catch-all (for example insufficient funds). That retry pass is bounded, and the corrected `TRANSIENT_RPC_CODES` doc comment now states the mix.

## Changes

- [x] `crates/tn-reth/src/forward.rs`: add `NODE_LOCAL_MESSAGES` and a `TryNext` arm for the four node-local `-32000` refusal messages in `classify_server_error`, scoped to `INVALID_INPUT_RPC_CODE` (`-32000`).
- [x] `crates/tn-reth/src/forward.rs`: correct the `TRANSIENT_RPC_CODES` doc comment. `-32003` is `TxPoolOverflow` plus reth's catch-all for invalid-transaction variants with no explicit code, not only a full pool.
- [x] `crates/tn-reth/src/forward.rs`: align the `Disposition` variant docs and the forward-loop comment with the new split.
- [x] `crates/tn-reth/src/forward.rs`: add `classify_server_error_tries_next_on_node_local_refusals` with a case-insensitivity row and two negative controls: an adjacent chain-wide verdict (`gas required exceeds allowance`) and a carve-out substring under a different code (code 3).

## Testing

- `cargo +1.94 test -p tn-reth --lib -- forward::tests::classify_server_error` runs both classifier tests in an isolated target dir.
- Mutation checks, each seen to fail: the `NODE_LOCAL_MESSAGES` arm disabled fails the new test; the lowercase fold removed fails the case-insensitivity row; the scoping constant skewed to `-32001` fails the positive rows. Restored, all pass.
- Attest proxy on the pinned toolchains in `.tn-1168-iso`: `cargo +nightly-2026-03-20 fmt`, `cargo +nightly-2026-03-20 clippy --workspace` and `--workspace --all-features`, `cargo +1.94 test --no-run --workspace -j 2`.

The four message strings match the pinned reth `v1.11.3` source verbatim (`crates/rpc/rpc-eth-types/src/error/mod.rs`, checkout `d6324d63e`).
