### PR TITLE
fix(tn-reth): seed reth's process-global RPC defaults and disable IPC for temp chains

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 use telcoin_network_cli::{genesis::GenesisArgs, keytool::KeyArgs, node::NodeCommand, NoArgs};
 use tn_config::{Config, ConfigFmt, ConfigTrait, KeyConfig, Parameters};
 use tn_node::launch_node;
-use tn_reth::init_txpool_defaults;
+use tn_reth::init_reth_defaults;
 use tn_types::{test_utils::CommandParser, Address, Genesis, GenesisAccount};
 use tracing::{error, info};
 // unused deps warnings
@@ -319,8 +319,9 @@ pub fn spawn_local_testnet(
             ipc_path: ipc_path_str.clone(),
         });
 
-        // seed reth's pool defaults before the parse resolves `--txpool.max-account-slots`
-        init_txpool_defaults();
+        // seed reth's process-global defaults before the parse resolves
+        // `--txpool.max-account-slots`
+        init_reth_defaults();
         let command = NodeCommand::parse_from([
             "tn",
             "--http",

--- a/crates/telcoin-network-cli/src/cli.rs
+++ b/crates/telcoin-network-cli/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Parser, Subcommand};
 use std::{ffi::OsString, fmt, path::PathBuf, str::FromStr};
 use tn_config::KeyConfig;
 use tn_node::engine::TnBuilder;
-use tn_reth::{dirs::DEFAULT_ROOT_DIR, init_txpool_defaults, LogArgs};
+use tn_reth::{dirs::DEFAULT_ROOT_DIR, init_reth_defaults, LogArgs};
 use tokio::{runtime::Builder, task::JoinHandle};
 use tracing::info_span;
 
@@ -75,24 +75,24 @@ pub struct Cli<Ext: clap::Args + fmt::Debug = NoArgs> {
 impl<Ext: clap::Args + fmt::Debug> Cli<Ext> {
     /// Parsers only the default CLI arguments
     ///
-    /// Seeds reth's transaction pool defaults first: the clap default for
+    /// Seeds reth's process-global defaults first: the clap default for
     /// `--txpool.max-account-slots` is resolved while the command is built, so seeding after the
     /// parse would be too late. Prefer this over [`clap::Parser::parse`] for that reason, and note
     /// that it is generic over `Ext` so an extended binary gets the same defaults as `tn` itself.
     pub fn parse_args() -> Self {
-        init_txpool_defaults();
+        init_reth_defaults();
         Self::parse()
     }
 
     /// Parsers only the default CLI arguments from the given iterator
     ///
-    /// Seeds reth's transaction pool defaults first, for the same reason as [`Self::parse_args`].
+    /// Seeds reth's process-global defaults first, for the same reason as [`Self::parse_args`].
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        init_txpool_defaults();
+        init_reth_defaults();
         Self::try_parse_from(itr)
     }
 

--- a/crates/test-utils/src/execution.rs
+++ b/crates/test-utils/src/execution.rs
@@ -6,7 +6,7 @@ use std::{path::Path, str::FromStr, sync::Arc};
 use telcoin_network_cli::{node::NodeCommand, NoArgs};
 use tn_config::Config;
 use tn_node::engine::{ExecutionNode, TnBuilder};
-use tn_reth::{init_txpool_defaults, RethChainSpec, RethCommand, RethConfig, RethEnv};
+use tn_reth::{init_reth_defaults, RethChainSpec, RethCommand, RethConfig, RethEnv};
 use tn_types::{
     gas_accumulator::GasAccumulator, Address, TaskManager, TimestampSec, Withdrawals, B256,
 };
@@ -64,9 +64,9 @@ fn execution_builder<CliExt: clap::Args + fmt::Debug>(
         default_args.to_vec()
     };
 
-    // use same approach as telcoin-network binary, including seeding reth's pool defaults before
-    // the parse resolves `--txpool.max-account-slots`
-    init_txpool_defaults();
+    // use same approach as telcoin-network binary, including seeding reth's process-global defaults
+    // before the parse resolves `--txpool.max-account-slots`
+    init_reth_defaults();
     let command = NodeCommand::<CliExt>::try_parse_from(cli_args)?;
 
     let NodeCommand { instance, ext, reth, healthcheck, .. } = command;

--- a/crates/tn-reth/src/cli.rs
+++ b/crates/tn-reth/src/cli.rs
@@ -18,10 +18,11 @@
 //!   against fully indexed history. [`RethConfig::ensure_archive_mode`] enforces this at startup
 //!   rather than leaving it to the defaults above, and `etc/archive-mode-guard.sh` fails the build
 //!   if a pruner entry point is introduced.
-//! - The per-sender transaction-pool slot default is raised to
-//!   [`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`] (256, vs reth's 16) by seeding reth's global pool
-//!   defaults via [`init_txpool_defaults`], which must run before any [`TxPoolArgs`] is parsed or
-//!   default-constructed.
+//! - Reth's process-global defaults are seeded with TN's values via [`init_reth_defaults`], which
+//!   must run before any [`TxPoolArgs`] or reth `RpcServerArgs` is parsed or default-constructed:
+//!   the per-sender transaction-pool slot default is raised to
+//!   [`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`] (256, vs reth's 16), and the default IPC endpoint
+//!   becomes TN's [`DEFAULT_IPC_ENDPOINT`] (`tn.ipc`) rather than reth's `reth.ipc`.
 
 use std::{
     collections::HashSet,
@@ -34,9 +35,9 @@ use std::{
 use clap::Parser;
 use reth::{
     args::{
-        DatabaseArgs, DebugArgs, DefaultTxPoolValues, DevArgs, DiscoveryArgs, EngineArgs, EraArgs,
-        EraSourceArgs, MetricArgs, NetworkArgs, PayloadBuilderArgs, PruningArgs, StaticFilesArgs,
-        StorageArgs, TxPoolArgs,
+        DatabaseArgs, DebugArgs, DefaultRpcServerArgs, DefaultTxPoolValues, DevArgs, DiscoveryArgs,
+        EngineArgs, EraArgs, EraSourceArgs, MetricArgs, NetworkArgs, PayloadBuilderArgs,
+        PruningArgs, StaticFilesArgs, StorageArgs, TxPoolArgs,
     },
     network::transactions::{
         config::TransactionPropagationKind, TransactionIngressPolicy, TransactionPropagationMode,
@@ -54,7 +55,10 @@ use reth_node_core::node_config::DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB;
 use tn_types::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use tracing::warn;
 
-use crate::{dirs::path_to_datadir, rpc_server_args::RpcServerArgs};
+use crate::{
+    dirs::path_to_datadir,
+    rpc_server_args::{RpcServerArgs, DEFAULT_IPC_ENDPOINT},
+};
 
 /// A wrapper abstraction around a Reth node config.
 #[derive(Clone, Debug)]
@@ -100,21 +104,30 @@ const ALL_MODULES: [RethRpcModule; 6] = [
 /// including back down to reth's 16.
 pub const TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER: usize = 256;
 
-/// Seed reth's global transaction pool defaults with [`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`].
+/// Seed reth's process-global defaults with TN's values.
 ///
-/// Must run before any [`TxPoolArgs`] is parsed or default-constructed. Reth resolves the
-/// `--txpool.max-account-slots` clap default out of a process-wide `OnceLock`, and the first
-/// read of that lock fixes it for the life of the process, so a late call cannot take effect.
-/// Both the clap default and `TxPoolArgs::default()` read it.
+/// Must run before any [`TxPoolArgs`] or reth `RpcServerArgs` is parsed or default-constructed.
+/// Reth resolves those defaults out of process-wide `OnceLock`s, and the first read of each lock
+/// fixes it for the life of the process, so a late call cannot take effect. The clap defaults and
+/// the `Default` impls both read the locks.
 ///
-/// Seeding is what makes an explicit `--txpool.max-account-slots 16` reachable: the value clap
-/// injects when the flag is absent becomes 256, so an operator-supplied 16 is no longer
-/// indistinguishable from an unset flag and needs no sentinel to detect.
+/// Transaction pool: the per-sender slot default becomes
+/// [`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`] (256, vs reth's 16). Seeding is what makes an
+/// explicit `--txpool.max-account-slots 16` reachable: the value clap injects when the flag is
+/// absent becomes 256, so an operator-supplied 16 is no longer indistinguishable from an unset
+/// flag and needs no sentinel to detect.
 ///
-/// Idempotent, and safe to call from more than one entry point. A call that loses the race, or
-/// that arrives after some other code has already read the lock, warns only when the effective
+/// RPC server: the default `ipcpath` becomes TN's [`DEFAULT_IPC_ENDPOINT`] (`tn.ipc`, vs reth's
+/// `reth.ipc`). TN's own [`RpcServerArgs`] already carries that default through CLI parsing; the
+/// seed covers the construction paths that never parse. Without it, `NodeConfig::default()` fills
+/// a temp chain's config with reth's `ipcpath`, and every test env binds a socket at the fixed
+/// global path `/tmp/reth.ipc` (issue #1165). TN's `From` impl also fills reth-side fields with
+/// `..Default::default()`, which reads the same lock.
+///
+/// Idempotent, and safe to call from more than one entry point. A call that loses a race, or
+/// that arrives after some other code has already read a lock, warns only when an effective
 /// default actually differs from TN's, so repeat calls are silent.
-pub fn init_txpool_defaults() {
+pub fn init_reth_defaults() {
     if DefaultTxPoolValues::default()
         .with_max_account_slots(TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER)
         .try_init()
@@ -128,6 +141,22 @@ pub fn init_txpool_defaults() {
                 effective,
                 expected = TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
                 "reth transaction pool defaults already initialized; TN per-sender slot default not applied"
+            );
+        }
+    }
+    if DefaultRpcServerArgs::default()
+        .with_ipcpath(DEFAULT_IPC_ENDPOINT.to_string())
+        .try_init()
+        .is_err()
+    {
+        // The lock is already taken, so reading it back cannot change the outcome.
+        let effective = reth::args::RpcServerArgs::default().ipcpath;
+        if effective != DEFAULT_IPC_ENDPOINT {
+            warn!(
+                target: "tn::reth",
+                effective = %effective,
+                expected = DEFAULT_IPC_ENDPOINT,
+                "reth RPC server defaults already initialized; TN IPC endpoint default not applied"
             );
         }
     }
@@ -172,7 +201,7 @@ impl RethConfig {
         // create a reth DatadirArgs from tn datadir
         let datadir = path_to_datadir(datadir.as_ref());
         // TN's per-sender slot default is seeded into reth's global pool defaults by
-        // `init_txpool_defaults` before parsing, so `txpool` already carries either that default
+        // `init_reth_defaults` before parsing, so `txpool` already carries either that default
         // or the operator's explicit value. Nothing to override here.
         let RethCommand { mut rpc, txpool, db } = reth_config;
 
@@ -469,7 +498,7 @@ mod tests {
     /// [`RethConfig::new`] used to raise reth's default to TN's by sentinel equality against
     /// reth's constant, so an explicit `--txpool.max-account-slots 16` was indistinguishable from
     /// an absent flag and was silently rewritten to 256. The default now arrives through
-    /// [`init_txpool_defaults`], leaving nothing for this function to override. Restoring that
+    /// [`init_reth_defaults`], leaving nothing for this function to override. Restoring that
     /// guard fails this test.
     ///
     /// Only the explicit case is asserted here. What an *absent* flag resolves to depends on
@@ -499,7 +528,7 @@ mod tests {
     /// `NodeConfig::default` locks reth's process-wide per-sender slot default, and these tests
     /// should not be the thing that pins it at reth's 16 for the rest of the binary.
     fn config_with_pruning(enable: impl FnOnce(&mut PruningArgs)) -> RethConfig {
-        init_txpool_defaults();
+        init_reth_defaults();
         let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
         let mut config = RethConfig(NodeConfig { chain, ..NodeConfig::default() });
         enable(&mut config.0.pruning);

--- a/crates/tn-reth/src/env/genesis.rs
+++ b/crates/tn-reth/src/env/genesis.rs
@@ -50,7 +50,7 @@ use std::{path::Path, sync::Arc};
 use alloy::{hex, sol_types::SolConstructor as _};
 use eyre::OptionExt as _;
 use reth::{
-    args::{DatabaseArgs, DatadirArgs},
+    args::{DatabaseArgs, DatadirArgs, RpcServerArgs},
     dirs::MaybePlatformPath,
 };
 use reth_chainspec::ChainSpec as RethChainSpec;
@@ -75,7 +75,7 @@ use tn_types::{
 use tracing::debug;
 
 use crate::{
-    init_txpool_defaults,
+    init_reth_defaults,
     system_calls::{
         ConsensusRegistry, WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS, PRECOMPILE_GENESIS_BYTECODE,
     },
@@ -100,11 +100,12 @@ impl RethEnv {
         /// (reth pairs its 8 TB default with a 4 GiB step; mirror reth's `test()` 4 MiB step).
         const TEMP_CHAIN_DB_GROWTH_STEP: usize = 4 * 1024 * 1024; // 4 MiB
 
-        // `NodeConfig::default` reads reth's process-wide pool defaults through
-        // `TxPoolArgs::default`, which locks them. Seed first so a temp chain built before any
-        // command is parsed does not fix the per-sender slot default at reth's 16 for the rest of
-        // the process, which would then also apply to every node parsed later.
-        init_txpool_defaults();
+        // `NodeConfig::default` reads reth's process-wide pool and RPC-server defaults through
+        // the args types' `Default` impls, which lock them. Seed first so a temp chain built
+        // before any command is parsed does not fix reth's own values (per-sender slots 16,
+        // ipcpath `reth.ipc`) for the rest of the process, which would then also apply to every
+        // node parsed later.
+        init_reth_defaults();
 
         let node_config = NodeConfig {
             datadir: DatadirArgs {
@@ -121,6 +122,13 @@ impl RethEnv {
                 growth_step: Some(TEMP_CHAIN_DB_GROWTH_STEP),
                 ..Default::default()
             },
+            // A temp chain parses no CLI, so its IPC path can only be a process-global
+            // default: a fixed path shared by every process on the host. Concurrent test runs
+            // would race to bind it and leave the socket file behind (issue #1165: every test
+            // env bound reth's `/tmp/reth.ipc`). Nothing connects to a temp chain over IPC
+            // (tests that exercise IPC spawn nodes through the CLI with a per-tempdir
+            // `--ipcpath`), so disable the IPC server outright.
+            rpc: RpcServerArgs { ipcdisable: true, ..Default::default() },
             ..NodeConfig::default()
         };
         let reth_config = RethConfig(node_config);
@@ -487,7 +495,7 @@ mod tests {
     /// predicate itself is covered by the `ensure_archive_mode` tests in `cli.rs`).
     #[tokio::test]
     async fn test_reth_env_new_rejects_pruned_config() -> eyre::Result<()> {
-        init_txpool_defaults();
+        init_reth_defaults();
         let chain: Arc<RethChainSpec> = Arc::new(tn_types::test_genesis().into());
         let tmp_dir = TempDir::new()?;
         let task_manager = TaskManager::new("Archive Mode Test Task Manager");
@@ -510,6 +518,23 @@ mod tests {
         let err = RethEnv::new(&config, &task_manager, database, None, GasAccumulator::default())
             .expect_err("RethEnv::new must refuse a pruned config");
         assert!(err.to_string().contains("archive mode"), "unexpected error: {err}");
+        Ok(())
+    }
+
+    /// A temp chain must not open an IPC socket. Its config never passes CLI parsing, so its
+    /// `ipcpath` can only be a process-global default: a fixed path every process on the host
+    /// shares, which concurrent test runs would race for (issue #1165: every test env bound
+    /// reth's `/tmp/reth.ipc`). `ipcdisable` is asserted rather than the path because which path
+    /// the global holds depends on which test in this binary read reth's RPC defaults first; the
+    /// seeded path itself is pinned in the `reth_defaults` integration test that owns its
+    /// process.
+    #[tokio::test]
+    async fn test_temp_chain_disables_ipc() -> eyre::Result<()> {
+        let chain: Arc<RethChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("Temp Chain IPC Test Task Manager");
+        let reth_env = RethEnv::new_for_temp_chain(chain, tmp_dir.path(), &task_manager, None)?;
+        assert!(reth_env.node_config().rpc.ipcdisable, "temp chain must disable the IPC server");
         Ok(())
     }
 }

--- a/crates/tn-reth/src/lib.rs
+++ b/crates/tn-reth/src/lib.rs
@@ -135,7 +135,7 @@ pub mod system_calls;
 mod types;
 pub mod worker;
 pub use cli::{
-    init_txpool_defaults, RethCommand, RethConfig, TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+    init_reth_defaults, RethCommand, RethConfig, TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
 };
 pub use env::*;
 #[cfg(feature = "faucet")]

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -16,7 +16,7 @@
 //!   distribution happens via the worker batch protocol, and observer nodes forward RPC submissions
 //!   to committee validators over JSON-RPC (see `forward.rs`) — never via devp2p gossip.
 //! - The per-sender slot default is 256 (`TN_TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER` in `src/cli.rs`,
-//!   seeded process-wide by `init_txpool_defaults`) instead of reth's 16.
+//!   seeded process-wide by `init_reth_defaults`) instead of reth's 16.
 //! - Blob (EIP-4844) transactions are unsupported in batches: the batch builder strips them via
 //!   [`TxPool::remove_eip4844_txs`] (removes descendants and deletes sidecars from the blob store),
 //!   and every canonical pool update — `process_canon_state_update` here and the batch builder's

--- a/crates/tn-reth/tests/reth_defaults.rs
+++ b/crates/tn-reth/tests/reth_defaults.rs
@@ -1,0 +1,37 @@
+//! Pins what reth's process-global RPC server defaults resolve to after seeding.
+//!
+//! Reth reads `RpcServerArgs::default()` out of a process-wide `OnceLock` whose first read fixes
+//! it for the life of the process, so this assertion only means something in a process where the
+//! seeding call runs before anything reads the lock. That is why it lives in its own integration
+//! test binary, mirroring `telcoin-network-cli/tests/txpool_defaults.rs`: every test here seeds
+//! before it reads, so any interleaving of these tests yields the same lock contents.
+
+// An integration test binary links every dependency of its crate but uses only a few.
+#![allow(unused_crate_dependencies)]
+
+use tn_reth::{init_reth_defaults, rpc_server_args::DEFAULT_IPC_ENDPOINT};
+
+/// Reth's own IPC default, spelled out rather than imported.
+///
+/// Hard-coding it keeps the divergence assertion below honest if TN's default is ever changed to
+/// coincide with reth's, which is the condition that made temp chains bind reth's socket in the
+/// first place.
+#[cfg(windows)]
+const RETH_IPC_ENDPOINT: &str = r"\\.\pipe\reth.ipc";
+
+/// Reth's own IPC default, spelled out rather than imported (non-Windows spelling).
+#[cfg(not(windows))]
+const RETH_IPC_ENDPOINT: &str = "/tmp/reth.ipc";
+
+/// After seeding, a reth-side `RpcServerArgs::default()` carries TN's IPC endpoint, so every
+/// construction path that fills from reth's defaults (`NodeConfig::default()` for temp chains,
+/// the `..Default::default()` fill in TN's `From` impl) stops resurrecting reth's `reth.ipc`
+/// (issue #1165). The seed leaves the IPC server enabled: only temp chains disable it.
+#[test]
+fn seeded_reth_rpc_default_carries_tn_ipcpath() {
+    init_reth_defaults();
+    let args = reth::args::RpcServerArgs::default();
+    assert_eq!(args.ipcpath, DEFAULT_IPC_ENDPOINT);
+    assert_ne!(args.ipcpath, RETH_IPC_ENDPOINT);
+    assert!(!args.ipcdisable, "seeding must not disable IPC for parsed nodes");
+}


### PR DESCRIPTION
Closes #1165.

## Problem

`RethEnv::new_for_temp_chain` fills its config from `NodeConfig::default()`, and reth's `RpcServerArgs::default()` clones a process-global `DefaultRpcServerArgs` that the workspace never seeded. The global therefore kept reth's own values (`ipcdisable: false`, `ipcpath: "/tmp/reth.ipc"`), and the worker RPC server starts unconditionally during component init. Every test env built through `new_for_temp_chain` (for example `default_test_execution_node`) bound a unix domain socket at that fixed global path: outside the test's `TempDir`, left behind after the run, raced by any concurrent test run on the same host, and colliding with a locally running reth node. No attacker required. #1164 (the #1155 remediation) fixed TN's own `RpcServerArgs::default()`, but the temp-chain construction path never goes through TN's struct.

## Fix

- [x] `crates/tn-reth/src/cli.rs`: rename `init_txpool_defaults` to `init_reth_defaults` and seed reth's `DefaultRpcServerArgs` (ipcpath = TN's `DEFAULT_IPC_ENDPOINT`) next to the existing txpool seeding, in the spirit of that precedent. The ordering contract is the same one the pool comment documents: the global is get-or-init and any reth-side `RpcServerArgs::default()` locks it, so the seed must run first. Renaming the one choke point means every existing call site (both CLI parse entry points, e2e, test-utils, temp chains) now seeds both globals with no new call to forget.
- [x] `crates/tn-reth/src/env/genesis.rs`: `new_for_temp_chain` additionally sets `rpc: RpcServerArgs { ipcdisable: true, ..Default::default() }` explicitly. Seeding alone would only move the collision from `/tmp/reth.ipc` to `/tmp/tn.ipc` (and make the test suite race a production TN node instead of a reth one). A throwaway chain parses no CLI and nothing in the workspace connects to one over IPC (the tests that exercise IPC spawn nodes through the CLI with a per-tempdir `--ipcpath`), so it must not bind any fixed global path at all.
- [x] Call-site comments, module docs, and the `lib.rs` re-export updated for the rename across `telcoin-network-cli`, `e2e-tests`, `test-utils`, and `tn-reth`.

## Testing

- [x] New regression test `test_temp_chain_disables_ipc` (tn-reth `env/genesis.rs` tests): a temp-chain env's node config has `ipcdisable` set. It pins the order-independent half of the invariant; the doc comment explains why the path itself is not asserted there (which path the global holds depends on which test in the binary reads reth's RPC defaults first). Confirmed by mutation: reverting the `rpc:` field fails it.
- [x] New integration test binary `crates/tn-reth/tests/reth_defaults.rs`, owning its process for the same reason `telcoin-network-cli/tests/txpool_defaults.rs` does: after seeding, a reth-side `RpcServerArgs::default()` carries TN's `DEFAULT_IPC_ENDPOINT`, differs from reth's hard-coded `/tmp/reth.ipc`, and keeps the IPC server enabled for parsed nodes (only temp chains disable it). Confirmed by mutation: dropping the `with_ipcpath` seed fails it.
- [x] `cargo +1.94 test -p tn-reth --lib` (146 passed), `cargo +1.94 test -p tn-reth --test reth_defaults`, and `cargo +1.94 test -p telcoin-network-cli --test txpool_defaults` green on the pinned toolchain.
- [x] `cargo +nightly fmt -- --check` and `cargo +1.94 clippy --all-targets` green in an isolated target dir; `make attest` run before push.
