### PR TITLE
fix(tn-reth): use saturating_sub for unused_gas in calculate_gas_penalty

### DIFF
--- a/crates/tn-reth/src/evm/utils.rs
+++ b/crates/tn-reth/src/evm/utils.rs
@@ -70,7 +70,9 @@ pub fn calculate_gas_penalty(gas_limit: u64, gas_used: u64) -> u64 {
     }
 
     // calculate inefficiency (how far below 10% we are)
-    let unused_gas = gas_limit_u128 - gas_used_u128;
+    // saturating_sub: the threshold guard above guarantees gas_used < gas_limit here, but this
+    // consensus path must not depend on that non-local invariant to avoid underflow
+    let unused_gas = gas_limit_u128.saturating_sub(gas_used_u128);
     let inefficiency_scaled = THRESHOLD - usage_ratio_scaled;
     // square values then calculate penalty
     let inefficiency_squared = inefficiency_scaled.pow(2);
@@ -198,5 +200,30 @@ mod tests {
         // test with gas limit just above threshold
         let penalty = calculate_gas_penalty(210_001, 10_000);
         assert_eq!(penalty, 54_876, "Should have penalty above minimum threshold");
+    }
+
+    /// Pin the usage-ratio guard for overspent inputs.
+    ///
+    /// Any `gas_used >= gas_limit` puts the usage ratio at or above the 10% threshold, so the
+    /// guard returns zero before the subtraction at the top of the penalty math. This test
+    /// holds that door shut: a change that weakens the guard turns an overspent input into an
+    /// underflow at `inefficiency_scaled` in a consensus path.
+    #[test]
+    fn test_gas_used_above_limit_no_penalty() {
+        // gas used just above the limit
+        assert_eq!(calculate_gas_penalty(300_000, 300_001), 0, "overspent by one unit");
+
+        // gas used at exactly the limit (100% usage)
+        assert_eq!(calculate_gas_penalty(300_000, 300_000), 0, "full usage");
+
+        // gas used at double the limit
+        assert_eq!(calculate_gas_penalty(1_000_000, 2_000_000), 0, "overspent 2x");
+
+        // extreme overspend does not underflow or wrap
+        assert_eq!(
+            calculate_gas_penalty(MIN_GAS_LIMIT_THRESHOLD + 1, u64::MAX),
+            0,
+            "extreme overspend"
+        );
     }
 }


### PR DESCRIPTION
Closes #1179.

## Problem

`calculate_gas_penalty` computes `unused_gas` with a plain `u128` subtraction:

```rust
// crates/tn-reth/src/evm/utils.rs
let unused_gas = gas_limit_u128 - gas_used_u128;
```

The line cannot underflow on current code. Two guards foreclose it. The usage-ratio guard returns zero for any usage at or above 10%, and reaching the subtraction with `usage_ratio_scaled < THRESHOLD` implies `gas_used < gas_limit`. The single caller, `TNEvmHandler::reimburse_caller`, passes `gas_spent`, and revm reconstructs `Gas` on every exit path, so `gas.spent() <= tx.gas_limit()` always holds.

The concern is robustness in a consensus path. This is the only subtraction in the function whose safety rests on a non-local invariant. A change that weakens either guard turns the line into a debug-build panic, or a release-build wrap to a value near `u128::MAX` that feeds a consensus-critical account balance change. No attacker is required for the panic case; one overspent transaction after such a refactor is enough.

## Fix

- [x] `crates/tn-reth/src/evm/utils.rs`: compute `unused_gas` with `saturating_sub`, with a comment stating the invariant the guard provides. This matches the deterministic integer style the module already uses. No behavior change on any reachable input.
- [x] New regression test `test_gas_used_above_limit_no_penalty` pins the usage-ratio guard for overspent inputs (`gas_used >= gas_limit`, up to `u64::MAX`). The guard is what forecloses the subtraction, so the test holds that door shut.

## Testing

- `cargo +1.94 test -p tn-reth --lib evm::utils`: all module tests pass, existing penalty values unchanged.
- The saturating change itself is not observable through the public API on current code. The two guards close the whole input space, which is the point of the issue. The guard analysis above is the proof of equivalence.
- Mutation check on the new test: with the usage-ratio guard removed, the test fails (debug underflow panic in the penalty math for overspent inputs); with the guard restored, it passes. The test was seen to fail, so it is not vacuous.
- `cargo +nightly-2026-03-20 fmt -- --check` clean; `make attest` toolchain gates run on the pinned 1.94 workspace build.
