### PR TITLE
fix(node): deliver epoch votes across the epoch-open certificate wait

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -18,8 +18,8 @@ use tn_network_libp2p::{
     error::NetworkError,
     read_frame,
     types::{
-        IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle, NetworkResponseMessage,
-        NetworkResult,
+        GossipPayload, IntoResponse as _, NetworkCommand, NetworkEvent, NetworkHandle,
+        NetworkResponseMessage, NetworkResult,
     },
     write_frame, DenyReason, GossipMessage, Penalty, PrimarySyncRequest, ResponseChannel, Stream,
     StreamError, SyncFrame, SyncFrameError,
@@ -31,12 +31,12 @@ use tn_storage::{
     PayloadStore,
 };
 use tn_types::{
-    encode, BlsPublicKey, BlsSignature, Certificate, ConsensusHeaderDigest, ConsensusOutput,
-    ConsensusResult, Database, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote,
-    Header, HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote,
+    encode, try_decode, BlsPublicKey, BlsSignature, Certificate, ConsensusHeaderDigest,
+    ConsensusOutput, ConsensusResult, Database, Epoch, EpochCertificate, EpochDigest, EpochRecord,
+    EpochVote, Header, HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 pub mod handler;
 mod message;
 mod sync_codec;
@@ -1611,4 +1611,171 @@ pub enum RequestVoteResult {
     /// If the peer was unable to verify parents for a proposed header, they respond requesting
     /// the missing certificate by digest.
     MissingParents(Vec<HeaderDigest>),
+}
+
+/// Buffered non-vote network events an [`EpochVotePump`] preserves for the next subscriber.
+type BufferedPrimaryEvents = Vec<NetworkEvent<Req, Res>>;
+
+/// Scoped forwarder that keeps epoch-vote gossip flowing while the per-epoch network task is
+/// down.
+///
+/// The only production path that moves a peer's [`EpochVote`] gossip from the node-lifetime
+/// `primary_network_events` channel into the vote collector is the per-epoch
+/// [`PrimaryNetwork`] event task, which spawns only after the epoch is open. The epoch open
+/// itself can block waiting for the prior epoch's certificate, and that certificate can only
+/// be aggregated from the very votes sitting undelivered on the channel, so a fleet-wide
+/// restart at an epoch boundary deadlocks: every node waits for a certificate no node can
+/// assemble (#1187). The pump closes that window. It holds the channel subscription for the
+/// duration of a bounded wait, forwards each decoded, signature-checked epoch vote into
+/// `new_epoch_votes` (the same send the gossip handler performs at the end of its epoch-vote
+/// arm), buffers every other event, and on [`Self::stop_and_replay`] releases the
+/// subscription and re-queues the buffered events for the real consumer.
+///
+/// # Certification safety
+///
+/// The pump skips the handler's topic, committee-membership, and duplicate checks, but keeps
+/// the per-vote signature check ([`EpochVote::check_signature`]) that the vote collector's
+/// aggregation loop documents as its precondition. Even without the skipped checks a
+/// forwarded vote cannot mint a bad certificate: the collector only aggregates votes whose
+/// `epoch_hash` matches its record and whose signer is in that record's committee, it dedups
+/// per authority, and it verifies the assembled certificate against a super quorum
+/// ([`EpochRecord::verify_with_cert`]) before anything is stored.
+///
+/// # Subscription contract
+///
+/// `primary_network_events` allows exactly one live receiver: the per-epoch consumer takes it
+/// when the primary network spawns, and a second live subscribe panics. Callers must
+/// therefore await [`Self::stop_and_replay`] (which joins the pump task strictly after its
+/// receiver has dropped and returned the subscription slot) before the per-epoch network is
+/// spawned, on every exit path.
+pub struct EpochVotePump {
+    /// Signals the pump task to stop draining and yield its buffer.
+    stop: oneshot::Sender<()>,
+    /// Resolves with the buffered non-vote events after the pump task has released the
+    /// `primary_network_events` subscription.
+    task: tokio::task::JoinHandle<BufferedPrimaryEvents>,
+    /// Bus used to re-queue the buffered events once the subscription is released.
+    consensus_bus: ConsensusBusApp,
+}
+
+impl std::fmt::Debug for EpochVotePump {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EpochVotePump").field("finished", &self.task.is_finished()).finish()
+    }
+}
+
+impl EpochVotePump {
+    /// Take the `primary_network_events` subscription and spawn the pump task.
+    ///
+    /// The subscription is taken synchronously, before the task spawns, per the `QueChannel`
+    /// contract. This is a raw `tokio::spawn` because the pump must hand its buffer back
+    /// through a join handle and [`TaskSpawner`] returns none; the task is bounded by the
+    /// stop signal (or the channel closing), so nothing outlives
+    /// [`Self::stop_and_replay`].
+    pub fn spawn(consensus_bus: &ConsensusBusApp) -> Self {
+        let events = consensus_bus.subscribe_primary_network_events();
+        let (stop, stop_rx) = oneshot::channel();
+        let bus = consensus_bus.clone();
+        let task = tokio::spawn(async move {
+            let event_stream = futures::stream::unfold(events, |mut receiver| async move {
+                receiver.recv().await.map(|event| (event, receiver))
+            });
+            let (_, buffered) = event_stream
+                .take_until(stop_rx)
+                .fold((bus, Vec::new()), |(bus, mut buffered), event| async move {
+                    Self::pump_event(&bus, event, &mut buffered).await;
+                    (bus, buffered)
+                })
+                .await;
+            // The fold above consumed the stream, so the receiver (and with it the
+            // subscription slot) is released before this task yields its buffer - the
+            // ordering `stop_and_replay`'s join relies on.
+            buffered
+        });
+        Self { stop, task, consensus_bus: consensus_bus.clone() }
+    }
+
+    /// Route one drained network event: forward a signature-checked epoch vote to the vote
+    /// collector, buffer everything else for replay.
+    async fn pump_event(
+        bus: &ConsensusBusApp,
+        event: NetworkEvent<Req, Res>,
+        buffered: &mut BufferedPrimaryEvents,
+    ) {
+        match event {
+            NetworkEvent::Gossip(payload) => {
+                let vote = Self::verified_epoch_vote(&payload);
+                if let Some(vote) = vote {
+                    // Fire-and-forget, mirroring the handler's forward; the send is only
+                    // dropped when no collector is subscribed.
+                    let _ = bus.new_epoch_votes().send(vote).await;
+                } else {
+                    // Non-vote gossip, and any payload the pump must not consume, is
+                    // preserved for the real consumer, which also owns penalty
+                    // attribution for malformed payloads.
+                    buffered.push(NetworkEvent::Gossip(payload));
+                }
+            }
+            event @ (NetworkEvent::Request { .. }
+            | NetworkEvent::Error(..)
+            | NetworkEvent::InboundStream { .. }) => buffered.push(event),
+        }
+    }
+
+    /// Decode an epoch vote from a gossip payload and verify its signature.
+    ///
+    /// Returns `None` for every payload the pump must not consume: non-vote gossip, bytes
+    /// that fail to decode, and votes whose signature does not verify (replaying the raw
+    /// event lets the real handler attribute the penalty instead).
+    fn verified_epoch_vote(payload: &GossipPayload) -> Option<EpochVote> {
+        try_decode::<PrimaryGossip>(&payload.message.data)
+            .ok()
+            .and_then(|gossip| match gossip {
+                PrimaryGossip::EpochVote(vote) => Some(*vote),
+                PrimaryGossip::Certificate(_) | PrimaryGossip::Consensus(_) => None,
+            })
+            .filter(EpochVote::check_signature)
+    }
+
+    /// Stop the pump, wait for it to release the `primary_network_events` subscription, and
+    /// re-queue the buffered non-vote events for the next subscriber.
+    ///
+    /// The join happens on the caller's critical path: it is what guarantees the
+    /// subscription slot is free before the per-epoch network subscribes. The replay
+    /// itself is detached onto its own task and NOT awaited, because the channel is
+    /// bounded and continuously fed by the node-lifetime swarm task while the only future
+    /// drainer (the per-epoch network task) cannot spawn until this method's caller
+    /// returns; awaiting a backpressuring send here could therefore suspend forever, a
+    /// self-inflicted deadlock. The detached sends always complete instead: the next
+    /// consumer drains the channel independently, and if the process exits first the task
+    /// dies with it, losing only events a dead process could not have handled anyway.
+    /// Replayed events may interleave with newer traffic that arrives after the slot is
+    /// released - a reordering the network layer tolerates (gossip is unordered and
+    /// requests carry their own deadlines).
+    pub async fn stop_and_replay(self) {
+        let Self { stop, task, consensus_bus } = self;
+        // An Err here only means the pump already stopped on its own (channel closed); the
+        // join below is the actual synchronization point either way.
+        let _ = stop.send(());
+        let buffered = task.await.unwrap_or_else(|e| {
+            error!(
+                target: "primary::network",
+                ?e,
+                "epoch vote pump task failed; its buffered events are lost"
+            );
+            Vec::new()
+        });
+        if !buffered.is_empty() {
+            // Detached on purpose; see the doc comment for why awaiting this here could
+            // deadlock against the bounded channel.
+            tokio::spawn(async move {
+                let bus = &consensus_bus;
+                futures::stream::iter(buffered)
+                    .for_each(|event| async move {
+                        let _ = bus.primary_network_events().send(event).await;
+                    })
+                    .await;
+            });
+        }
+    }
 }

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     error::PrimaryNetworkError,
     network::{
         message::{PrimaryGossip, PrimaryResponse},
-        try_admit_epoch_record, MissingCertificatesRequest, RequestHandler,
+        try_admit_epoch_record, EpochVotePump, MissingCertificatesRequest, RequestHandler,
         MAX_CONCURRENT_EPOCH_RECORD_REQUESTS, MAX_CONSENSUS_CERTS, MAX_PENDING_REQUESTS_PER_PEER,
         MAX_TALLIES_PER_SIGNER_PER_NUMBER,
     },
@@ -23,7 +23,10 @@ use std::{
 };
 use tempfile::TempDir;
 use tn_config::{ConsensusConfig, KeyConfig, Parameters};
-use tn_network_libp2p::{GossipMessage, TopicHash};
+use tn_network_libp2p::{
+    types::{GossipPayload, NetworkEvent},
+    GossipMessage, TopicHash,
+};
 use tn_storage::{
     consensus::{ConsensusChain, ConsensusChainError},
     consensus_pack::PackError,
@@ -37,8 +40,8 @@ use tn_types::{
     BlockHeader, BlockNumHash, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner as _, Certificate,
     CommittedSubDag, ConsensusHeaderDigest, ConsensusNumHash, ConsensusResult, Database, Epoch,
     EpochDigest, EpochRecord, EpochSeedMessage, EpochVote, ExecHeader, Hash as _, HeaderDigest,
-    ReputationScores, Round, SealedHeader, TaskManager, TnReceiver as _, VoteDigest, VoteInfo,
-    B256,
+    ReputationScores, Round, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, VoteDigest,
+    VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -2302,4 +2305,89 @@ async fn test_consensus_certs_large_committee_flood_survives() -> eyre::Result<(
     assert_eq!(handler.consensus_certs_len(), 0, "map must be cleared after a publish");
 
     Ok(())
+}
+
+/// The epoch-vote pump forwards a signature-checked vote to `new_epoch_votes`, buffers events
+/// it must not consume (undecodable gossip, a decodable vote with a bad signature), and on
+/// `stop_and_replay` releases the `primary_network_events` subscription and re-queues the
+/// buffered events in order for the next subscriber.
+#[tokio::test]
+async fn test_epoch_vote_pump_forwards_votes_and_replays_the_rest() {
+    let mut rng = StdRng::from_os_rng();
+    let key_config = KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut rng));
+    let epoch_rec = EpochRecord {
+        epoch: 1,
+        committee: vec![key_config.primary_public_key()],
+        next_committee: vec![key_config.primary_public_key()],
+        ..Default::default()
+    };
+    let vote = epoch_rec.sign_vote(&key_config);
+    assert!(vote.check_signature(), "fixture vote must verify");
+    // Decodes as an epoch vote but fails the signature check: the pump must not consume it.
+    let bad_vote = EpochVote { epoch_hash: EpochDigest::default(), ..vote };
+    assert!(!bad_vote.check_signature(), "fixture bad vote must not verify");
+
+    let topic = TopicHash::from_raw("test-epoch-vote-pump");
+    let gossip_event = |data: Vec<u8>| {
+        NetworkEvent::Gossip(Box::new(GossipPayload {
+            message: GossipMessage {
+                source: None,
+                data,
+                sequence_number: None,
+                topic: topic.clone(),
+            },
+            relayer: None,
+            author: None,
+        }))
+    };
+    let garbage_data = vec![0xde, 0xad, 0xbe, 0xef];
+    let vote_data = encode(&PrimaryGossip::EpochVote(Box::new(vote)));
+    let bad_vote_data = encode(&PrimaryGossip::EpochVote(Box::new(bad_vote)));
+
+    let consensus_bus = ConsensusBus::new();
+    let app = consensus_bus.app();
+    let mut votes_rx = app.subscribe_new_epoch_votes();
+
+    // Queue events before the pump starts; the channel queues without a subscriber.
+    app.primary_network_events().send(gossip_event(garbage_data.clone())).await.unwrap();
+    app.primary_network_events().send(gossip_event(vote_data)).await.unwrap();
+    app.primary_network_events().send(gossip_event(bad_vote_data.clone())).await.unwrap();
+
+    let pump = EpochVotePump::spawn(app);
+
+    // The valid vote reaches the collector channel while the pump holds the subscription.
+    let forwarded = tokio::time::timeout(Duration::from_secs(5), votes_rx.recv())
+        .await
+        .expect("pump must forward the vote before the timeout")
+        .expect("vote channel open");
+    assert_eq!(forwarded, vote);
+
+    // Give the pump time to route the trailing bad-signature event into its buffer.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    pump.stop_and_replay().await;
+
+    // The subscription slot is free again (this subscribe would panic otherwise). The
+    // replay itself is detached, so await the two replayed non-vote events instead of
+    // polling; they arrive in buffer order, and the consumed vote never does.
+    let mut events_rx = app.subscribe_primary_network_events();
+    let replayed_first = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+        .await
+        .expect("garbage event must be replayed before the timeout")
+        .expect("events channel open");
+    assert!(
+        matches!(&replayed_first, NetworkEvent::Gossip(payload) if payload.message.data == garbage_data),
+        "first replayed event must be the undecodable gossip"
+    );
+    let replayed_second = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+        .await
+        .expect("bad-signature event must be replayed before the timeout")
+        .expect("events channel open");
+    assert!(
+        matches!(&replayed_second, NetworkEvent::Gossip(payload) if payload.message.data == bad_vote_data),
+        "second replayed event must be the bad-signature vote"
+    );
+    // Give any straggling (incorrect) replay of the consumed vote time to land, then
+    // confirm the channel is empty.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(events_rx.try_recv().is_err(), "the consumed vote must not be replayed");
 }

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use tn_config::KeyConfig;
+use tn_config::{KeyConfig, LibP2pConfig};
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, epoch_records::EpochRecordDb};
 use tn_types::{
@@ -13,7 +13,7 @@ use tn_types::{
     EpochRecord, EpochVote, Noticer, TaskSpawner, TnReceiver as _,
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 type VoteQueue = VecDeque<(Epoch, Sender<EpochVote>, Option<Receiver<EpochVote>>)>;
 
@@ -385,6 +385,98 @@ pub(crate) fn spawn_epoch_vote_collector(
             }
         }
     });
+}
+
+/// Resume the epoch-close vote protocol for a persisted-but-uncertified latest epoch record.
+///
+/// A node that crashes (or is restarted) between persisting the epoch record at close -
+/// `write_epoch_record` flushes it durably before publishing - and storing its certificate
+/// comes back up with the record on disk but no certificate, and nothing on the restart path
+/// re-publishes the node's vote or re-fires `epoch_record_watch`. The vote collector then
+/// never aggregates, and the next epoch open blocks in `certified_prior_epoch_anchor` waiting
+/// for a certificate no restarted node is helping to form (#1187). Re-firing the watch with
+/// the persisted record replays the exact close-path handoff at the end of
+/// `write_epoch_record`: the node-lifetime collector spawned by
+/// [`spawn_epoch_vote_collector`] observes it, re-signs the same persisted bytes (the vote is
+/// a pure function of the record and the loaded key), publishes the vote, and drives the
+/// usual aggregation, certificate write, and peer-recovery machinery.
+///
+/// The persisted record is used verbatim and never rebuilt: `build_epoch_record` takes a live
+/// watch value as its `final_state` input, so a restarted process is not guaranteed to
+/// reproduce the digest, and a silently divergent digest would never aggregate with peer
+/// votes.
+///
+/// Gated on `record.epoch < current_epoch` (the epoch read from the canonical tip) so a
+/// record for an epoch still in progress is never voted on. In particular the epoch-0 dummy
+/// record - persisted uncertified at genesis while epoch 0 runs - must not reach the
+/// collector: certifying the dummy would permanently block the real epoch-0 record behind the
+/// certificate short-circuit in `write_epoch_record` and break sync.
+///
+/// # Gossip subscription
+///
+/// On a fresh restart the epoch-vote topic is not subscribed: the only per-epoch subscribe
+/// runs in `spawn_primary_network_for_epoch`, which a deadlocked epoch open never reaches.
+/// That is fatal on both legs - gossipsub fans a publish out only to peers that announced
+/// the subscription, and `verify_gossip` rejects inbound messages on a topic with no
+/// `authorized_publishers` entry. So before firing the watch this subscribes the topic
+/// itself, deriving the publisher window from the persisted record: `committee` (the
+/// outgoing voters) plus `next_committee`, the previous/current half of the wider
+/// previous/current/next window `boundary_publishers` uses at epoch start (the entering
+/// epoch's own next committee is not derivable from this record and is not needed to accept
+/// the resumed epoch's votes). The later per-epoch subscribe is safe to run on top: the
+/// swarm's `Subscribe` handler replaces the topic's publisher set outright, and a repeated
+/// gossipsub subscribe is an idempotent no-op.
+pub(crate) async fn resume_epoch_certification(
+    consensus_chain: &ConsensusChain,
+    consensus_bus: &ConsensusBusApp,
+    primary_network: &PrimaryNetworkHandle,
+    chain_id: u64,
+    current_epoch: Epoch,
+) {
+    let pending_epoch = consensus_chain
+        .epochs()
+        .latest_record()
+        .await
+        .filter(|record| record.epoch < current_epoch)
+        .map(|record| record.epoch);
+    if let Some(epoch) = pending_epoch {
+        if let Some((record, cert)) = consensus_chain.epochs().get_epoch_by_number(epoch).await {
+            if cert.is_some() {
+                debug!(
+                    target: "epoch-manager",
+                    epoch,
+                    "latest persisted epoch record is already certified; nothing to resume"
+                );
+            } else {
+                // Subscribe the epoch-vote topic before the collector starts publishing;
+                // see the doc section "Gossip subscription". A failure is logged rather
+                // than fatal: the collector's peer-recovery path can still fetch the
+                // certificate, and the next restart retries the subscribe.
+                let publishers: HashSet<BlsPublicKey> =
+                    record.committee.iter().chain(record.next_committee.iter()).copied().collect();
+                if let Err(e) = primary_network
+                    .inner_handle()
+                    .subscribe_with_publishers(LibP2pConfig::epoch_vote_topic(chain_id), publishers)
+                    .await
+                {
+                    warn!(
+                        target: "epoch-manager",
+                        ?e,
+                        epoch,
+                        "failed to subscribe the epoch vote topic for recovery; resuming anyway"
+                    );
+                }
+                let epoch_hash = record.digest();
+                info!(
+                    target: "epoch-manager",
+                    epoch,
+                    %epoch_hash,
+                    "resuming epoch-close vote protocol for persisted uncertified epoch record"
+                );
+                consensus_bus.epoch_record_watch().send_replace(Some(record));
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -884,5 +976,195 @@ mod epoch_vote_collector_tests {
 
         // Shutdown
         node_shutdown.notify();
+    }
+
+    /// Build a consensus chain holding a saved epoch-0 record plus a saved-but-uncertified
+    /// epoch-1 record (the crash-window shape: record persisted, certificate absent),
+    /// returning the chain, the epoch-1 record, and the key configs behind its committee.
+    /// The `TempDir` is returned so it outlives the chain.
+    async fn uncertified_epoch1_fixture(
+        prefix: &str,
+    ) -> (ConsensusChain, EpochRecord, Vec<KeyConfig>, TempDir) {
+        let mut rng = StdRng::from_os_rng();
+        let key_configs: Vec<KeyConfig> = (0..4)
+            .map(|_| KeyConfig::new_with_testing_key(BlsKeypair::generate(&mut rng)))
+            .collect();
+        let committee_keys: Vec<BlsPublicKey> =
+            key_configs.iter().map(|kc| kc.primary_public_key()).collect();
+
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let temp_dir = TempDir::with_prefix(prefix).unwrap();
+        let consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee).await.unwrap();
+
+        // `save_record` enforces in-order epochs, so store epoch 0 first and chain the
+        // epoch-1 record off its digest.
+        let epoch0_rec = EpochRecord {
+            epoch: 0,
+            committee: committee_keys.clone(),
+            next_committee: committee_keys.clone(),
+            ..Default::default()
+        };
+        consensus_chain.epochs().save_record(epoch0_rec.clone()).await.unwrap();
+        let epoch_rec = EpochRecord {
+            epoch: 1,
+            committee: committee_keys.clone(),
+            next_committee: committee_keys,
+            parent_hash: epoch0_rec.digest(),
+            ..Default::default()
+        };
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+
+        (consensus_chain, epoch_rec, key_configs, temp_dir)
+    }
+
+    /// Mock network handle whose command drain replies Ok to a single Subscribe command, so
+    /// a resume that subscribes (correctly or not) never hangs a test.
+    fn subscribe_replying_network() -> PrimaryNetworkHandle {
+        let (net_tx, mut net_rx) =
+            tokio::sync::mpsc::channel::<NetworkCommand<PrimaryRequest, PrimaryResponse>>(100);
+        tokio::spawn(async move {
+            if let Some(NetworkCommand::Subscribe { reply, .. }) = net_rx.recv().await {
+                let _ = reply.send(Ok(true));
+            }
+        });
+        PrimaryNetworkHandle::new_for_test(net_tx)
+    }
+
+    /// Restart with the latest record persisted but uncertified (the #1187 crash window):
+    /// the resume must subscribe the epoch-vote topic with the record-derived publisher
+    /// window, then re-fire `epoch_record_watch` with the persisted record so the
+    /// node-lifetime collector re-enters the vote protocol.
+    #[tokio::test]
+    async fn test_resume_fires_watch_for_uncertified_latest_record() {
+        let (consensus_chain, epoch_rec, _key_configs, _temp_dir) =
+            uncertified_epoch1_fixture("test_resume_fires_watch").await;
+        let consensus_bus = ConsensusBus::new();
+
+        // Capture the Subscribe command the resume must issue before the watch fires.
+        let (net_tx, mut net_rx) =
+            tokio::sync::mpsc::channel::<NetworkCommand<PrimaryRequest, PrimaryResponse>>(100);
+        let primary_network = PrimaryNetworkHandle::new_for_test(net_tx);
+        let (seen_tx, seen_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            if let Some(NetworkCommand::Subscribe { topic, publishers, reply }) =
+                net_rx.recv().await
+            {
+                let _ = reply.send(Ok(true));
+                let _ = seen_tx.send((topic, publishers));
+            }
+        });
+
+        resume_epoch_certification(&consensus_chain, consensus_bus.app(), &primary_network, 0, 2)
+            .await;
+
+        let resumed = consensus_bus.app().epoch_record_watch().borrow().clone();
+        assert_eq!(
+            resumed,
+            Some(epoch_rec),
+            "resume must publish the persisted record on the watch"
+        );
+        let (topic, publishers) = tokio::time::timeout(Duration::from_secs(5), seen_rx)
+            .await
+            .expect("resume must subscribe before the timeout")
+            .expect("subscribe command captured");
+        assert_eq!(topic, LibP2pConfig::epoch_vote_topic(0));
+        assert_eq!(
+            publishers.map(|p| p.len()),
+            Some(4),
+            "publisher window must be the record's committee plus next_committee"
+        );
+    }
+
+    /// Restart with the latest record already certified: the resume must do nothing, so the
+    /// collector never re-runs a finished vote protocol.
+    #[tokio::test]
+    async fn test_resume_skips_certified_latest_record() {
+        let (consensus_chain, epoch_rec, key_configs, _temp_dir) =
+            uncertified_epoch1_fixture("test_resume_skips_certified").await;
+        let epoch_hash = epoch_rec.digest();
+
+        // Store a genuine 3-of-4 certificate for the record.
+        let sigs: Vec<BlsSignature> =
+            key_configs.iter().take(3).map(|kc| epoch_rec.sign_vote(kc).signature).collect();
+        let aggregate = BlsAggregateSignature::aggregate(&sigs[..], true).unwrap();
+        let signed_authorities: roaring::RoaringBitmap = (0u32..3).collect();
+        let cert = EpochCertificate {
+            epoch_hash,
+            signature: aggregate.to_signature(),
+            signed_authorities,
+        };
+        assert!(epoch_rec.verify_with_cert(&cert), "fixture cert must verify");
+        consensus_chain.epochs().save_certificate(epoch_hash, cert).await.unwrap();
+
+        let consensus_bus = ConsensusBus::new();
+        let primary_network = subscribe_replying_network();
+        resume_epoch_certification(&consensus_chain, consensus_bus.app(), &primary_network, 0, 2)
+            .await;
+
+        assert!(
+            consensus_bus.app().epoch_record_watch().borrow().is_none(),
+            "a certified record must not re-enter the vote protocol"
+        );
+    }
+
+    /// A latest record from an epoch at or past the current one must never resume: the gate
+    /// is strictly `record.epoch < current_epoch`, not merely inequality.
+    #[tokio::test]
+    async fn test_resume_skips_record_from_a_future_epoch() {
+        let (consensus_chain, _epoch_rec, _key_configs, _temp_dir) =
+            uncertified_epoch1_fixture("test_resume_skips_future_epoch").await;
+        let consensus_bus = ConsensusBus::new();
+        let primary_network = subscribe_replying_network();
+
+        // Latest stored record is epoch 1; the node believes it is still in epoch 0.
+        resume_epoch_certification(&consensus_chain, consensus_bus.app(), &primary_network, 0, 0)
+            .await;
+
+        assert!(
+            consensus_bus.app().epoch_record_watch().borrow().is_none(),
+            "a record from an epoch past the current one must not resume"
+        );
+    }
+
+    /// Fresh genesis: with no stored record the resume is a no-op, and once the in-memory
+    /// epoch-0 dummy is registered (mirroring `open_epoch_pack`) the resume must still skip
+    /// it - certifying the dummy would permanently block the real epoch-0 record behind
+    /// `write_epoch_record`'s certificate short-circuit.
+    #[tokio::test]
+    async fn test_resume_skips_in_progress_epoch_dummy() {
+        let mut rng = StdRng::from_os_rng();
+        let keypair = BlsKeypair::generate(&mut rng);
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let temp_dir = TempDir::with_prefix("test_resume_skips_dummy").unwrap();
+        let consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), committee).await.unwrap();
+        let consensus_bus = ConsensusBus::new();
+        let primary_network = subscribe_replying_network();
+
+        // Empty store: nothing to resume.
+        resume_epoch_certification(&consensus_chain, consensus_bus.app(), &primary_network, 0, 1)
+            .await;
+        assert!(
+            consensus_bus.app().epoch_record_watch().borrow().is_none(),
+            "an empty record store must not fire the watch"
+        );
+
+        // The epoch-0 dummy (epoch still in progress) must never be voted on.
+        let dummy = EpochRecord {
+            epoch: 0,
+            committee: vec![*keypair.public()],
+            next_committee: vec![*keypair.public()],
+            ..Default::default()
+        };
+        consensus_chain.epochs().save_dummy_epoch0(dummy).await.unwrap();
+        resume_epoch_certification(&consensus_chain, consensus_bus.app(), &primary_network, 0, 0)
+            .await;
+        assert!(
+            consensus_bus.app().epoch_record_watch().borrow().is_none(),
+            "the in-progress epoch's dummy record must never be voted on"
+        );
     }
 }

--- a/crates/node/src/manager/mod.rs
+++ b/crates/node/src/manager/mod.rs
@@ -6,4 +6,4 @@ mod node;
 pub use export_exec::{ExecStateExporter, ExportOutcome};
 pub use node::*;
 
-pub(crate) use epoch_votes::spawn_epoch_vote_collector;
+pub(crate) use epoch_votes::{resume_epoch_certification, spawn_epoch_vote_collector};

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -15,7 +15,7 @@ use crate::{
     health::HealthcheckServer,
     manager::{
         exex::{run_critical_exex_future, run_isolated_exex_future},
-        spawn_epoch_vote_collector, ExecStateExporter,
+        resume_epoch_certification, spawn_epoch_vote_collector, ExecStateExporter,
     },
     metrics::EpochMetrics,
 };
@@ -751,6 +751,24 @@ where
             node_task_manager.get_spawner(),
             self.node_shutdown.subscribe(),
         );
+
+        // Resume the epoch-close vote protocol if the latest persisted epoch record has no
+        // certificate. A crash between the durable record write at epoch close and
+        // certification otherwise strands the record: nothing on the restart path
+        // re-publishes this node's vote or re-fires `epoch_record_watch`, and the next
+        // epoch open then blocks waiting for a certificate no restarted node is helping to
+        // form (#1187). The collector spawned above is already subscribed to the watch, so
+        // re-firing it replays the normal close-path handoff. The resume also subscribes
+        // the epoch-vote gossip topic first: the per-epoch subscribe only runs after the
+        // epoch open this recovery is unblocking.
+        resume_epoch_certification(
+            &self.consensus_chain,
+            &self.consensus_bus,
+            &primary_network_handle,
+            self.builder.tn_config.genesis().config.chain_id,
+            epoch,
+        )
+        .await;
 
         // spawn task to update the latest execution results for consensus
         self.spawn_engine_update_task(engine_update_rx, &node_task_manager);

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -35,7 +35,7 @@ use std::{
 };
 use tn_config::{NetworkConfig, TelcoinDirs};
 use tn_executor::subscriber::spawn_subscriber;
-use tn_primary::ConsensusBus;
+use tn_primary::{network::EpochVotePump, ConsensusBus};
 use tn_reth::{error::StateReadError, RethEnv};
 use tn_storage::{certificate_pack::CertificatePack, tables::OurNodeBatchesCache};
 use tn_types::{
@@ -746,6 +746,18 @@ where
     /// certificate that fails verification, is a hard error — never a silent fallback to the
     /// uncertified digest.
     ///
+    /// # Vote delivery during the wait
+    ///
+    /// The certificate is aggregated from epoch-vote gossip, but the per-epoch network task
+    /// that forwards that gossip to the vote collector only spawns after this wait returns
+    /// (`create_consensus`). An [`EpochVotePump`] therefore forwards epoch votes off
+    /// `primary_network_events` for the duration of the wait and buffers everything else.
+    /// Without it the wait can only be satisfied by a peer that already holds the
+    /// certificate; on a fleet-wide restart at the boundary no such peer exists, votes sit
+    /// undelivered, and every node blocks here forever (#1187). The pump is stopped - and
+    /// its subscription released for the real consumer - on both the success and the error
+    /// path before this function returns.
+    ///
     /// Returns the certified [`EpochRecord`] itself rather than just its digest, because the
     /// caller seeds the chain from it too. An earlier revision returned the digest and the
     /// caller cross-checked it against the record it had already resolved; that check aborted
@@ -774,10 +786,18 @@ where
                 current_epoch,
                 "previous epoch record not yet certified, waiting for its certificate"
             );
-            self.consensus_chain
+            // Deliver epoch-vote gossip while the wait blocks (see the doc section
+            // "Vote delivery during the wait"). `stop_and_replay` must run on both the
+            // Ok and the Err path so the `primary_network_events` subscription is
+            // released before `create_consensus` spawns the real consumer.
+            let vote_pump = EpochVotePump::spawn(&self.consensus_bus);
+            let waited = self
+                .consensus_chain
                 .epochs()
                 .certified_record_by_epoch_with_timeout(previous_epoch, CERTIFIED_ANCHOR_WAIT)
-                .await
+                .await;
+            vote_pump.stop_and_replay().await;
+            waited
         } else {
             fast
         }


### PR DESCRIPTION
## Problem

All five adiri validators crash-loop at the epoch 383 -> 384 boundary.  Each node closed epoch 383, durably persisted the epoch record, published it, and then blocked in `certified_prior_epoch_anchor` waiting for the epoch-383 certificate.  The certificate never forms, and restarts do not help.

## Root cause

The certificate is aggregated from `EpochVote` gossip.  The only production path that moves that gossip into the vote collector is the per-epoch primary network task, which `create_consensus` spawns after `open_epoch_pack` returns.  The epoch open itself blocks inside `open_epoch_pack` waiting for the certificate.  Votes therefore queue on `primary_network_events` with no consumer, on every node at once.  Restarting makes it worse: nothing on the restart path re-publishes a node's own vote, re-fires `epoch_record_watch`, or re-subscribes the epoch-vote gossip topic, so the collector never starts aggregating for epoch 383 at all.

## Fix

Two pieces, both reusing the existing vote machinery.

**1. A scoped epoch-vote pump around the certificate wait (`EpochVotePump`).**  Before awaiting the certificate, `certified_prior_epoch_anchor` takes the `primary_network_events` subscription and spawns a pump task.  The pump decodes each gossip event.  A signature-checked `EpochVote` goes into `new_epoch_votes` (the same send the gossip handler performs), and every other event is buffered.  When the wait returns, on both the success and the error path, the pump stops and releases the subscription; the buffered events are then re-queued from a detached task (see the threat model for why the re-queue must not run on the caller's critical path).  This closes the delivery gap at every future epoch boundary, not just for this outage.

**2. Resume the epoch-close vote protocol on startup.**  Right after the node-lifetime vote collector spawns, `EpochManager::run` reads the latest persisted epoch record.  If it exists, belongs to an already-closed epoch (`record.epoch < current_epoch`), and has no certificate, the node first subscribes the epoch-vote gossip topic itself, then re-fires `epoch_record_watch` with the persisted record.  The subscription is load-bearing: the only per-epoch subscribe runs in `spawn_primary_network_for_epoch`, after the epoch open this recovery unblocks, and until it runs gossipsub neither fans our publishes out nor accepts peer votes (`verify_gossip` rejects messages on a topic with no `authorized_publishers` entry).  The publisher window is derived from the persisted record: `committee` (the outgoing voters) plus `next_committee`, the previous/current half of the previous/current/next window the epoch-start path builds as `boundary_publishers`.  The later per-epoch subscribe replaces that publisher set outright (the swarm's `Subscribe` handler is a map insert) and a repeated gossipsub subscribe is idempotent, so the recovery-time subscription cannot pollute normal operation.  Firing the watch replays the exact close-path handoff: the collector re-signs the same persisted bytes (the vote is a pure function of the record and the loaded key), publishes the vote, re-publishes it on every 2.5s recv-timeout tick, and drives the normal aggregation, certificate write, and peer-recovery machinery.  An INFO line marks the resume with the epoch and digest, and a DEBUG line marks the certified-record skip.

Deployed to the five validators, each restarted node re-publishes its epoch-383 vote (piece 2) and delivers its peers' votes while blocked at the epoch-384 open (piece 1).  Any 4-of-5 quorum then certifies the record, the anchor wait polls the certificate out of storage, and state-sync serves it to any node still behind.

### Threat model

- **Forwarding unverified gossip cannot mint a bad certificate.**  The pump skips the handler's topic, committee, and dedup gates, but keeps the per-vote `check_signature` the collector's aggregation loop documents as its precondition.  Aggregation itself only counts votes whose `epoch_hash` matches the collector's record and whose signer is in that record's committee, dedups per authority (`committee_keys.remove` plus the `signed_authorities.insert` guard), and verifies the assembled certificate against a 2/3+1 super quorum (`EpochRecord::verify_with_cert`) before anything is stored.
- **The receiver take/drop ordering is sound.**  `primary_network_events` allows one live subscription, and a second live subscribe panics.  `QueChanReceiver::drop` returns the inner receiver to the channel's slot.  The pump task's stream owns the receiver and drops it before the task yields its buffer, and `stop_and_replay` joins the task before returning, on both exit paths of the wait.  The real consumer takes the subscription only later, in `spawn_primary_network_for_epoch`.
- **The replay is detached, deliberately.**  The channel is bounded and continuously fed by the node-lifetime swarm task, while the only future drainer (the per-epoch network task) cannot spawn until `certified_prior_epoch_anchor` returns.  Awaiting a backpressuring re-queue send on that critical path could therefore suspend forever.  The detached task's sends always complete because the next consumer drains the channel independently; if the process exits first the task dies with it, losing only events a dead process could not have handled.  Replayed events may interleave with newer traffic, a reordering the network layer tolerates (gossip is unordered and requests carry their own deadlines).  Undecodable or bad-signature gossip is replayed rather than consumed, so penalty attribution stays with the real handler.
- **The resume cannot certify an in-progress epoch.**  The `record.epoch < current_epoch` gate keeps the epoch-0 dummy record, and any record for the epoch still running, away from the collector.  Certifying the dummy would permanently block the real epoch-0 record behind `write_epoch_record`'s certificate short-circuit.  The persisted record is used verbatim, never rebuilt, so the re-signed vote digest matches the one peers voted on.

## Changes

- [x] `crates/consensus/primary/src/network/mod.rs`: add `EpochVotePump` (scoped subscribe, signature-checked vote forwarding, buffering, stop-then-detached-replay).
- [x] `crates/node/src/manager/node/run_epoch.rs`: run the pump around the `certified_record_by_epoch_with_timeout` wait in `certified_prior_epoch_anchor`, stopping it on both the Ok and the Err path.
- [x] `crates/node/src/manager/epoch_votes.rs`: add `resume_epoch_certification` (latest-record read, certificate gate, recovery-time `subscribe_with_publishers` on the epoch-vote topic with the record-derived publisher window, watch re-fire, INFO/DEBUG ops logging).
- [x] `crates/node/src/manager/node.rs`: invoke the resume in `EpochManager::run`, right after `spawn_epoch_vote_collector`.
- [x] `crates/node/src/manager/mod.rs`: re-export the resume helper.
- [x] Tests: pump forward/buffer/detached-replay plus subscription release (`network_tests.rs`), and the resume trigger matrix in `epoch_votes.rs` (uncertified record fires the watch and subscribes with the right topic and publisher window, certified record skips, empty store skips, epoch-0 dummy skips, future-epoch record skips).

## Deployment note

Restart at least 4 of the 5 validators within about a minute of each other.  A restarted node re-publishes its epoch-383 vote every 2.5 seconds, but only for roughly 65 seconds (the collector's 24-plus-2 recv-timeout windows) before it falls back to certificate peer recovery, and a publish that finds no subscribed peer yet fails silently until the next tick.  A round that misses the window is safely retried by restarting the fleet together again;  the resume re-fires on every restart for as long as the record remains uncertified.

## Testing

- `cargo +nightly fmt --all --check` (the toolchain CI's fmt lane uses): clean, workspace-wide.
- `cargo +1.94 clippy --no-deps` for the two touched crates: DEFERRED to CI.  The build machine was below the local disk floor (11 GiB free), so no local build, clippy, or test run was attempted.  CI and the second machine own the dynamic tier for this change.
- New unit tests, to run in CI: `test_epoch_vote_pump_forwards_votes_and_replays_the_rest`, `test_resume_fires_watch_for_uncertified_latest_record`, `test_resume_skips_certified_latest_record`, `test_resume_skips_in_progress_epoch_dummy`, `test_resume_skips_record_from_a_future_epoch`.
- The resume-to-certificate composition is covered by the existing collector tests, which drive `manage_epoch_votes` through the same `epoch_record_watch` fire the resume performs.

Closes #1187
