### PR TITLE
fix(network-libp2p): cap per-entry multiaddrs on discovery ingest

### DIFF
--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -79,8 +79,8 @@ const MAX_PUBLISHED_TO_PEERS: NonZeroUsize = NonZeroUsize::new(10_000).expect("1
 /// the per-peer set cap `MAX_MULTIADDRS_PER_PEER`, so validation and storage agree on how many
 /// addresses one peer may present: a single validated record contributes at most as many addresses
 /// as the store keeps for a peer, and the set cap is what bounds accumulation across repeated
-/// records. Folding a record into an entry that already holds connection forms can still evict
-/// older forms; that only trims the peer-exchange payload built from the entry.
+/// records. Folding a record into an entry that already holds a connection form replaces that
+/// form; that only trims the peer-exchange payload built from the entry.
 const MAX_ADVERTISED_MULTIADDRS: usize = peers::MAX_MULTIADDRS_PER_PEER;
 
 /// Maximum number of concurrent established connections a single peer may hold, across both

--- a/crates/network-libp2p/src/consensus.rs
+++ b/crates/network-libp2p/src/consensus.rs
@@ -73,12 +73,15 @@ const MAX_PUBLISHED_TO_PEERS: NonZeroUsize = NonZeroUsize::new(10_000).expect("1
 
 /// Maximum number of multiaddrs a single signed `NodeRecord` may advertise.
 ///
-/// A legitimate node advertises exactly one address per record (see `get_peer_record`), so this is
-/// generous headroom. A record exceeding it is rejected at validation, bounding the attacker-chosen
-/// address data admitted per record before it can accumulate on the peer entry
-/// (GHSA-29v6-gvv5-45gx). This is defence in depth for the per-peer set cap
-/// `MAX_MULTIADDRS_PER_PEER`; that set cap is what bounds accumulation across repeated records.
-const MAX_ADVERTISED_MULTIADDRS: usize = 16;
+/// A legitimate node advertises exactly one address per record (see `get_peer_record`). A record
+/// exceeding the cap is rejected at validation, bounding the attacker-chosen address data admitted
+/// per record before it can accumulate on the peer entry (GHSA-29v6-gvv5-45gx). The cap is tied to
+/// the per-peer set cap `MAX_MULTIADDRS_PER_PEER`, so validation and storage agree on how many
+/// addresses one peer may present: a single validated record contributes at most as many addresses
+/// as the store keeps for a peer, and the set cap is what bounds accumulation across repeated
+/// records. Folding a record into an entry that already holds connection forms can still evict
+/// older forms; that only trims the peer-exchange payload built from the entry.
+const MAX_ADVERTISED_MULTIADDRS: usize = peers::MAX_MULTIADDRS_PER_PEER;
 
 /// Maximum number of concurrent established connections a single peer may hold, across both
 /// directions (inbound and outbound).

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -1095,13 +1095,16 @@ impl PeerManager {
         // via kad closest-peers or peer exchange) would otherwise be selected for
         // a self-dial during the heartbeat.
         !self.is_local_peer(&info.peer_id)
-            // reject entries with more addresses than an honest peer can share. The peer
-            // store bounds each peer's address set at MAX_MULTIADDRS_PER_PEER, so an honest
-            // exchange entry never exceeds it (kad records are bounded tighter at
-            // MAX_ADVERTISED_MULTIADDRS). Every stored address is dialed by the discovery
-            // heartbeat, so an uncapped list lets one PeerExchange message turn this node
-            // into a dial-amplification proxy against attacker-chosen targets (issue #1183).
-            // The heartbeat re-checks eligibility, so an oversized entry is also purged.
+            // reject entries with more addresses than an honest peer can share. An honest
+            // exchange entry is a copy of a sender's stored set for that peer, and the forms
+            // one honest address takes fit within MAX_MULTIADDRS_PER_PEER (see its doc)
+            // whatever cap the sender runs, so no honest entry is rejected. A kad
+            // closest-peers entry carries whatever the remote responder's routing table
+            // holds for that peer, which nothing upstream caps, so this is the first bound
+            // on that path too. Every stored address is dialed by the discovery heartbeat,
+            // so an uncapped list lets one PeerExchange message turn this node into a
+            // dial-amplification proxy against attacker-chosen targets (issue #1183). The
+            // heartbeat re-checks eligibility, so an oversized entry is also purged.
             && info.addrs.len() <= MAX_MULTIADDRS_PER_PEER
             && self.has_valid_unbanned_ips(&info.addrs)
             && self.peers.can_dial(&info.peer_id)

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -3,6 +3,7 @@
 use super::{
     all_peers::AllPeers,
     cache::BannedPeerCache,
+    peer::MAX_MULTIADDRS_PER_PEER,
     score::init_peer_score_config,
     status::NewConnectionStatus,
     types::{ConnectionDirection, ConnectionType, DialRequest, PeerAction},
@@ -1085,6 +1086,7 @@ impl PeerManager {
     ///
     /// A peer is eligible if:
     /// - it is not this node's own identity
+    /// - its address list is within [`MAX_MULTIADDRS_PER_PEER`]
     /// - it has at least one valid ip address (ipv4/ipv6)
     /// - none of its ip addresses are banned
     /// - it can be dialed (not connected/dialing/banned)
@@ -1093,6 +1095,14 @@ impl PeerManager {
         // via kad closest-peers or peer exchange) would otherwise be selected for
         // a self-dial during the heartbeat.
         !self.is_local_peer(&info.peer_id)
+            // reject entries with more addresses than an honest peer can share. The peer
+            // store bounds each peer's address set at MAX_MULTIADDRS_PER_PEER, so an honest
+            // exchange entry never exceeds it (kad records are bounded tighter at
+            // MAX_ADVERTISED_MULTIADDRS). Every stored address is dialed by the discovery
+            // heartbeat, so an uncapped list lets one PeerExchange message turn this node
+            // into a dial-amplification proxy against attacker-chosen targets (issue #1183).
+            // The heartbeat re-checks eligibility, so an oversized entry is also purged.
+            && info.addrs.len() <= MAX_MULTIADDRS_PER_PEER
             && self.has_valid_unbanned_ips(&info.addrs)
             && self.peers.can_dial(&info.peer_id)
     }

--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -1096,15 +1096,14 @@ impl PeerManager {
         // a self-dial during the heartbeat.
         !self.is_local_peer(&info.peer_id)
             // reject entries with more addresses than an honest peer can share. An honest
-            // exchange entry is a copy of a sender's stored set for that peer, and the forms
-            // one honest address takes fit within MAX_MULTIADDRS_PER_PEER (see its doc)
-            // whatever cap the sender runs, so no honest entry is rejected. A kad
-            // closest-peers entry carries whatever the remote responder's routing table
-            // holds for that peer, which nothing upstream caps, so this is the first bound
-            // on that path too. Every stored address is dialed by the discovery heartbeat,
-            // so an uncapped list lets one PeerExchange message turn this node into a
-            // dial-amplification proxy against attacker-chosen targets (issue #1183). The
-            // heartbeat re-checks eligibility, so an oversized entry is also purged.
+            // exchange entry is a copy of a sender's stored set for that peer, which holds the
+            // one address the peer most recently presented (MAX_MULTIADDRS_PER_PEER, see its
+            // doc). A kad closest-peers entry carries whatever the remote responder's routing
+            // table holds for that peer, which nothing upstream caps, so this is the first
+            // bound on that path too. Every stored address is dialed by the discovery
+            // heartbeat, so an uncapped list lets one PeerExchange message turn this node
+            // into a dial-amplification proxy against attacker-chosen targets (issue #1183).
+            // The heartbeat re-checks eligibility, so an oversized entry is also purged.
             && info.addrs.len() <= MAX_MULTIADDRS_PER_PEER
             && self.has_valid_unbanned_ips(&info.addrs)
             && self.peers.can_dial(&info.peer_id)

--- a/crates/network-libp2p/src/peers/mod.rs
+++ b/crates/network-libp2p/src/peers/mod.rs
@@ -12,9 +12,9 @@ mod types;
 pub(crate) use manager::PeerManager;
 pub(crate) use types::PeerEvent;
 pub use types::{PeerExchangeMap, Penalty};
+// the per-peer address cap also bounds the addresses a signed record may advertise
+pub(crate) use peer::MAX_MULTIADDRS_PER_PEER;
 
 // visibility for tests
-#[cfg(test)]
-pub(crate) use peer::MAX_MULTIADDRS_PER_PEER;
 #[cfg(test)]
 pub(crate) use score::GLOBAL_SCORE_CONFIG;

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -24,6 +24,10 @@ use tracing::{error, warn};
 /// over it (`known_ip_addresses`) bounded (GHSA-29v6-gvv5-45gx). A legitimate node advertises a
 /// single address, so the cap is never reached in normal operation, and address refresh and key
 /// rotation stay well within it.
+///
+/// The discovery path reuses this value as the per-entry ceiling in `eligible_for_discovery`:
+/// a PeerExchange entry with more addresses than this set can hold cannot come from an honest
+/// peer's store, so it is rejected before it reaches `discovery_peers` (issue #1183).
 pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 32;
 
 /// Information about a given connected peer.

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -20,15 +20,33 @@ use tracing::{error, warn};
 /// `register_outgoing`) and by the peer's own self-advertised kad `NodeRecord`s (`update_net`).
 /// A non-committee observer can republish its own signed record without bound (a record with a
 /// fresher timestamp is always accepted), so the advertised path is attacker-sustained. Capping
-/// the set keeps a single peer entry bounded in memory and keeps the reputation and ban scans
-/// over it (`known_ip_addresses`) bounded (GHSA-29v6-gvv5-45gx). A legitimate node advertises a
-/// single address, so the cap is never reached in normal operation, and address refresh and key
-/// rotation stay well within it.
+/// the set keeps a single peer entry bounded in memory and keeps the peer-exchange payload built
+/// from it (`exchange_info`) bounded (GHSA-29v6-gvv5-45gx).
+///
+/// The value is derived from the forms one honest address takes in this set. The protocol
+/// advertises exactly one address per node (`NodeRecord::build`, the committee `network_address`),
+/// but the set is keyed on exact `Multiaddr` equality and one endpoint appears in up to two
+/// syntactic forms, with and without the `/p2p/<peer_id>` suffix: the advertised form is whatever
+/// the operator configured (`keytool` writes it with `/p2p`, test fixtures without), the dialed
+/// form always carries `/p2p` (libp2p-swarm appends it to every dial and `register_outgoing`
+/// stores the address the connection was established on), and the inbound observed form
+/// (`send_back_addr`) never does. libp2p-quic dials from the listening socket, so for a peer
+/// whose observed source endpoint matches its advertised one (no NAT rewrite) the inbound form is
+/// its own listen address and adds no third endpoint. Two forms for the current address plus two
+/// for the previous one while an in-process address change is in flight gives 4. Such a peer stays
+/// within it, so nothing is evicted in normal operation. If a peer ever exceeds it (a NAT-rewritten
+/// endpoint adds a third form), eviction only trims the peer-exchange payload (`exchange_info`):
+/// dialing reads `known_peers`, kad and `discovery_peers`, and banning reads
+/// `observed_ip_addresses`, never this set. A tight value also bounds the dial fan-out one
+/// discovery entry can cause.
 ///
 /// The discovery path reuses this value as the per-entry ceiling in `eligible_for_discovery`:
 /// a PeerExchange entry with more addresses than this set can hold cannot come from an honest
-/// peer's store, so it is rejected before it reaches `discovery_peers` (issue #1183).
-pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 32;
+/// peer's store, so it is rejected before it reaches `discovery_peers` (issue #1183). The record
+/// validation cap `MAX_ADVERTISED_MULTIADDRS` is tied to this value, so validation and storage
+/// agree on how many addresses one peer may present: a record can never carry more addresses than
+/// the store keeps for a peer.
+pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 4;
 
 /// Information about a given connected peer.
 /// Note that bls_public_key and network_key are Optional.
@@ -156,12 +174,14 @@ impl Peer {
     ///
     /// A newly seen address is always admitted, so the most recent address a peer presents (a
     /// connection witnessed via `register_incoming` / `register_outgoing`, or the address it
-    /// advertises on a rotated network key via `update_net`) is always recorded for the ban path,
-    /// which reads [`Self::known_ip_addresses`]. If admitting it pushes the set over the cap, an
-    /// older address is evicted to restore the bound. Re-recording an address already present is a
-    /// no-op. A self-advertised republish flood therefore churns the set within the cap instead of
-    /// growing it without bound (GHSA-29v6-gvv5-45gx); a legitimate peer never approaches the cap,
-    /// so nothing is ever evicted.
+    /// advertises on a rotated network key via `update_net`) is always part of the peer-exchange
+    /// payload built by [`Self::exchange_info`]. If admitting it pushes the set over the cap, one
+    /// of the other addresses is evicted to restore the bound. Re-recording an address already
+    /// present is a no-op. A self-advertised republish flood therefore churns the set within the
+    /// cap instead of growing it without bound (GHSA-29v6-gvv5-45gx). The forms an honest peer's
+    /// address takes fit within the cap (see [`MAX_MULTIADDRS_PER_PEER`]), so nothing is evicted
+    /// in normal operation, and an eviction can only ever trim that payload: the ban path reads
+    /// [`Self::observed_ip_addresses`], not this set.
     fn note_multiaddr(&mut self, multiaddr: Multiaddr) {
         if self.multiaddrs.insert(multiaddr.clone())
             && self.multiaddrs.len() > MAX_MULTIADDRS_PER_PEER
@@ -488,6 +508,56 @@ mod tests {
             "the most recent address must be recorded even at the cap boundary"
         );
         assert!(peer.multiaddrs.len() <= MAX_MULTIADDRS_PER_PEER);
+    }
+
+    /// The cap is derived from the forms one honest address takes in the set (see
+    /// [`MAX_MULTIADDRS_PER_PEER`]): one endpoint with and without the `/p2p/<peer_id>` suffix,
+    /// for the current address and for the previous one while an in-process address change is in
+    /// flight. All four forms must be retained, so an honest peer never has an address evicted.
+    #[test]
+    fn honest_address_forms_fit_within_the_cap() {
+        // constructing a `Peer` builds its `Score`, which reads the global score config
+        super::super::score::init_peer_score_config(ScoreConfig::default());
+        let mut peer = Peer::default_for_test();
+        // the suffix a dial carries is this peer's own id (libp2p-swarm appends it to every dial)
+        let peer_id = peer.peer_id();
+        let with_p2p = |bare: &Multiaddr| {
+            peer_id.iter().fold(bare.clone(), |addr, id| addr.with(Protocol::P2p(*id)))
+        };
+        // a QUIC listen endpoint (TEST-NET-3), the shape this node advertises and dials
+        let endpoint = |host: u8| {
+            Multiaddr::empty()
+                .with(Protocol::Ip4([203, 0, 113, host].into()))
+                .with(Protocol::Udp(49_584))
+                .with(Protocol::QuicV1)
+        };
+        assert!(peer_id.is_some(), "the test peer carries a network key, so it has a peer id");
+
+        // the previous address: advertised bare (a record or committee entry), then dialed (the
+        // dial always carries `/p2p`), then seen on an inbound connection, which presents the
+        // bare listen address again because libp2p-quic dials from the listening socket.
+        let previous = endpoint(10);
+        peer.note_multiaddr(previous.clone());
+        peer.register_outgoing(with_p2p(&previous));
+        peer.register_incoming(previous.clone());
+        assert_eq!(peer.multiaddrs.len(), 2, "one honest address is at most two forms");
+
+        // an in-process address change: the new address arrives on a fresher record and is dialed
+        // while the previous pair is still stored
+        let current = endpoint(11);
+        peer.note_multiaddr(current.clone());
+        peer.register_outgoing(with_p2p(&current));
+
+        assert_eq!(
+            peer.multiaddrs.len(),
+            MAX_MULTIADDRS_PER_PEER,
+            "the honest forms of the current and previous address fill the cap exactly"
+        );
+        [previous.clone(), with_p2p(&previous), current.clone(), with_p2p(&current)]
+            .iter()
+            .for_each(|form| {
+                assert!(peer.multiaddrs.contains(form), "honest form {form} must not be evicted")
+            });
     }
 
     /// Regression (issue #1010, informational): the per-connection counters are `u8` and were

--- a/crates/network-libp2p/src/peers/peer.rs
+++ b/crates/network-libp2p/src/peers/peer.rs
@@ -23,22 +23,17 @@ use tracing::{error, warn};
 /// the set keeps a single peer entry bounded in memory and keeps the peer-exchange payload built
 /// from it (`exchange_info`) bounded (GHSA-29v6-gvv5-45gx).
 ///
-/// The value is derived from the forms one honest address takes in this set. The protocol
-/// advertises exactly one address per node (`NodeRecord::build`, the committee `network_address`),
-/// but the set is keyed on exact `Multiaddr` equality and one endpoint appears in up to two
-/// syntactic forms, with and without the `/p2p/<peer_id>` suffix: the advertised form is whatever
-/// the operator configured (`keytool` writes it with `/p2p`, test fixtures without), the dialed
-/// form always carries `/p2p` (libp2p-swarm appends it to every dial and `register_outgoing`
-/// stores the address the connection was established on), and the inbound observed form
-/// (`send_back_addr`) never does. libp2p-quic dials from the listening socket, so for a peer
-/// whose observed source endpoint matches its advertised one (no NAT rewrite) the inbound form is
-/// its own listen address and adds no third endpoint. Two forms for the current address plus two
-/// for the previous one while an in-process address change is in flight gives 4. Such a peer stays
-/// within it, so nothing is evicted in normal operation. If a peer ever exceeds it (a NAT-rewritten
-/// endpoint adds a third form), eviction only trims the peer-exchange payload (`exchange_info`):
-/// dialing reads `known_peers`, kad and `discovery_peers`, and banning reads
-/// `observed_ip_addresses`, never this set. A tight value also bounds the dial fan-out one
-/// discovery entry can cause.
+/// The protocol assumes exactly one address per peer: a `NodeRecord` advertises one address
+/// (`NodeRecord::build`), a committee entry carries one (`network_address`), and every consumer
+/// acts on a single address for a peer. The set therefore holds only the address the peer most
+/// recently presented. The set is keyed on exact `Multiaddr` equality and one endpoint appears
+/// in two syntactic forms, with and without the `/p2p/<peer_id>` suffix (the advertised form is
+/// whatever the operator configured, the dialed form always carries `/p2p` because libp2p-swarm
+/// appends it to every dial, the inbound observed form never does); under this cap those forms
+/// replace each other instead of accumulating, and either form dials the same endpoint. An
+/// eviction only trims the peer-exchange payload (`exchange_info`): dialing reads `known_peers`,
+/// kad and `discovery_peers`, and banning reads `observed_ip_addresses`, never this set. A cap of
+/// one also bounds the dial fan-out one discovery entry can cause to a single address.
 ///
 /// The discovery path reuses this value as the per-entry ceiling in `eligible_for_discovery`:
 /// a PeerExchange entry with more addresses than this set can hold cannot come from an honest
@@ -46,7 +41,7 @@ use tracing::{error, warn};
 /// validation cap `MAX_ADVERTISED_MULTIADDRS` is tied to this value, so validation and storage
 /// agree on how many addresses one peer may present: a record can never carry more addresses than
 /// the store keeps for a peer.
-pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 4;
+pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 1;
 
 /// Information about a given connected peer.
 /// Note that bls_public_key and network_key are Optional.
@@ -178,10 +173,11 @@ impl Peer {
     /// payload built by [`Self::exchange_info`]. If admitting it pushes the set over the cap, one
     /// of the other addresses is evicted to restore the bound. Re-recording an address already
     /// present is a no-op. A self-advertised republish flood therefore churns the set within the
-    /// cap instead of growing it without bound (GHSA-29v6-gvv5-45gx). The forms an honest peer's
-    /// address takes fit within the cap (see [`MAX_MULTIADDRS_PER_PEER`]), so nothing is evicted
-    /// in normal operation, and an eviction can only ever trim that payload: the ban path reads
-    /// [`Self::observed_ip_addresses`], not this set.
+    /// cap instead of growing it without bound (GHSA-29v6-gvv5-45gx). With the cap at one (see
+    /// [`MAX_MULTIADDRS_PER_PEER`]) the set is the address the peer most recently presented, and
+    /// the bare and `/p2p`-suffixed forms of one honest endpoint replace each other. An eviction
+    /// can only ever trim that payload: the ban path reads [`Self::observed_ip_addresses`], not
+    /// this set.
     fn note_multiaddr(&mut self, multiaddr: Multiaddr) {
         if self.multiaddrs.insert(multiaddr.clone())
             && self.multiaddrs.len() > MAX_MULTIADDRS_PER_PEER
@@ -510,12 +506,14 @@ mod tests {
         assert!(peer.multiaddrs.len() <= MAX_MULTIADDRS_PER_PEER);
     }
 
-    /// The cap is derived from the forms one honest address takes in the set (see
-    /// [`MAX_MULTIADDRS_PER_PEER`]): one endpoint with and without the `/p2p/<peer_id>` suffix,
-    /// for the current address and for the previous one while an in-process address change is in
-    /// flight. All four forms must be retained, so an honest peer never has an address evicted.
+    /// The cap holds the address a peer most recently presented (see
+    /// [`MAX_MULTIADDRS_PER_PEER`]). One honest endpoint reaches the set in two syntactic forms,
+    /// with and without the `/p2p/<peer_id>` suffix (advertised bare, dialed with `/p2p`, seen bare
+    /// again on an inbound connection). Each form replaces the previous one instead of
+    /// accumulating, so the set never grows past one and always holds a form that dials the
+    /// endpoint. The cap is exact: two forms of one endpoint would fill a cap of two.
     #[test]
-    fn honest_address_forms_fit_within_the_cap() {
+    fn honest_address_forms_replace_each_other_within_the_cap() {
         // constructing a `Peer` builds its `Score`, which reads the global score config
         super::super::score::init_peer_score_config(ScoreConfig::default());
         let mut peer = Peer::default_for_test();
@@ -525,39 +523,27 @@ mod tests {
             peer_id.iter().fold(bare.clone(), |addr, id| addr.with(Protocol::P2p(*id)))
         };
         // a QUIC listen endpoint (TEST-NET-3), the shape this node advertises and dials
-        let endpoint = |host: u8| {
-            Multiaddr::empty()
-                .with(Protocol::Ip4([203, 0, 113, host].into()))
-                .with(Protocol::Udp(49_584))
-                .with(Protocol::QuicV1)
-        };
+        let endpoint = Multiaddr::empty()
+            .with(Protocol::Ip4([203, 0, 113, 10].into()))
+            .with(Protocol::Udp(49_584))
+            .with(Protocol::QuicV1);
         assert!(peer_id.is_some(), "the test peer carries a network key, so it has a peer id");
 
-        // the previous address: advertised bare (a record or committee entry), then dialed (the
-        // dial always carries `/p2p`), then seen on an inbound connection, which presents the
-        // bare listen address again because libp2p-quic dials from the listening socket.
-        let previous = endpoint(10);
-        peer.note_multiaddr(previous.clone());
-        peer.register_outgoing(with_p2p(&previous));
-        peer.register_incoming(previous.clone());
-        assert_eq!(peer.multiaddrs.len(), 2, "one honest address is at most two forms");
+        // advertised bare (a record or committee entry)
+        peer.note_multiaddr(endpoint.clone());
+        assert_eq!(peer.multiaddrs.len(), MAX_MULTIADDRS_PER_PEER);
+        assert!(peer.multiaddrs.contains(&endpoint), "the advertised form is stored");
 
-        // an in-process address change: the new address arrives on a fresher record and is dialed
-        // while the previous pair is still stored
-        let current = endpoint(11);
-        peer.note_multiaddr(current.clone());
-        peer.register_outgoing(with_p2p(&current));
+        // then dialed: the dial always carries `/p2p`, and that form replaces the bare one
+        peer.register_outgoing(with_p2p(&endpoint));
+        assert_eq!(peer.multiaddrs.len(), 1, "one honest endpoint, one entry");
+        assert!(peer.multiaddrs.contains(&with_p2p(&endpoint)), "the dialed form is stored");
 
-        assert_eq!(
-            peer.multiaddrs.len(),
-            MAX_MULTIADDRS_PER_PEER,
-            "the honest forms of the current and previous address fill the cap exactly"
-        );
-        [previous.clone(), with_p2p(&previous), current.clone(), with_p2p(&current)]
-            .iter()
-            .for_each(|form| {
-                assert!(peer.multiaddrs.contains(form), "honest form {form} must not be evicted")
-            });
+        // then seen on an inbound connection, which presents the bare listen address again
+        // because libp2p-quic dials from the listening socket; it replaces the dialed form
+        peer.register_incoming(endpoint.clone());
+        assert_eq!(peer.multiaddrs.len(), 1, "one honest endpoint, one entry");
+        assert!(peer.multiaddrs.contains(&endpoint), "the most recently presented form is stored");
     }
 
     /// Regression (issue #1010, informational): the per-connection counters are `u8` and were

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -2543,6 +2543,50 @@ async fn test_node_record_validation() {
     assert!(network.peer_record_valid(&peer_record).is_none());
 }
 
+/// A signed record may advertise at most `MAX_MULTIADDRS_PER_PEER` addresses (the record cap is
+/// tied to the per-peer set cap): a record exactly at the cap is accepted, one address more is
+/// rejected (GHSA-29v6-gvv5-45gx). The boundary is exact.
+#[tokio::test]
+async fn test_node_record_validation_rejects_oversized_multiaddr_list() {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let network = peer1.network;
+    let key_config = peer1.config.key_config();
+    let cap = crate::peers::MAX_MULTIADDRS_PER_PEER;
+
+    // a correctly signed and published record carrying `count` distinct addresses
+    let record_with = |count: usize| {
+        let multiaddrs: Vec<Multiaddr> = (0..count)
+            .filter_map(|i| {
+                format!("/ip4/198.51.100.{}/udp/{}/quic-v1", i + 1, 49_000 + i).parse().ok()
+            })
+            .collect();
+        assert_eq!(multiaddrs.len(), count, "every fixture address must parse");
+        let info = NetworkInfo {
+            pubkey: key_config.primary_network_public_key(),
+            multiaddrs,
+            timestamp: now(),
+            rpc: None,
+        };
+        let signature = key_config.request_signature_direct(&encode(&info));
+        let mut record = network.get_peer_record();
+        record.value = encode(&NodeRecord { info, signature });
+        record
+    };
+
+    // exactly at the cap: accepted with every address intact
+    let at_cap = network.peer_record_valid(&record_with(cap));
+    assert!(
+        matches!(&at_cap, Some((_, node_record)) if node_record.info.multiaddrs.len() == cap),
+        "a record advertising exactly MAX_MULTIADDRS_PER_PEER addresses must be accepted"
+    );
+
+    // one address over the cap: rejected
+    assert!(
+        network.peer_record_valid(&record_with(cap + 1)).is_none(),
+        "a record advertising more than MAX_MULTIADDRS_PER_PEER addresses must be rejected"
+    );
+}
+
 /// Repeated `MissingAuthorities` reports for one key must not stack duplicate
 /// in-flight kad queries (issue #1135).
 ///

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -543,6 +543,76 @@ async fn test_process_peer_exchange() {
     assert!(peer_manager.next_dial_request().is_none());
 }
 
+/// Helper to build a distinct, deterministic multiaddr per index.
+///
+/// All addresses target the same IP with different ports, the shape of a dial-amplification
+/// payload aimed at one victim host (issue #1183).
+fn multiaddr_for_index(i: usize) -> Multiaddr {
+    Multiaddr::empty()
+        .with(Ipv4Addr::new(203, 0, 113, 1).into())
+        .with(Protocol::Tcp(8000 + u16::try_from(i).expect("index fits u16")))
+}
+
+#[tokio::test]
+async fn test_process_peer_exchange_rejects_oversized_multiaddr_list() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    let mut rng = StdRng::from_seed([0; 32]);
+    let bls_oversized = *BlsKeypair::generate(&mut rng).public();
+    let bls_at_cap = *BlsKeypair::generate(&mut rng).public();
+    let net_oversized: NetworkPublicKey =
+        NetworkKeypair::generate_ed25519().public().clone().into();
+    let net_at_cap: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().clone().into();
+    let peer_id_oversized: PeerId = net_oversized.clone().into();
+    let peer_id_at_cap: PeerId = net_at_cap.clone().into();
+
+    // one entry with one address more than an honest peer's store can hold
+    let oversized: HashSet<_> =
+        (0..crate::peers::MAX_MULTIADDRS_PER_PEER + 1).map(multiaddr_for_index).collect();
+    assert_eq!(oversized.len(), crate::peers::MAX_MULTIADDRS_PER_PEER + 1);
+
+    // one entry exactly at the cap
+    let at_cap: HashSet<_> =
+        (0..crate::peers::MAX_MULTIADDRS_PER_PEER).map(multiaddr_for_index).collect();
+    assert_eq!(at_cap.len(), crate::peers::MAX_MULTIADDRS_PER_PEER);
+
+    let mut exchange_map = HashMap::new();
+    exchange_map.insert(bls_oversized, (net_oversized, oversized));
+    exchange_map.insert(bls_at_cap, (net_at_cap, at_cap));
+
+    peer_manager.process_peer_exchange(PeerExchangeMap::from(exchange_map));
+
+    // the oversized entry is rejected; the at-cap entry is stored
+    assert!(
+        !peer_manager.discovery_peers.contains_key(&peer_id_oversized),
+        "entry over MAX_MULTIADDRS_PER_PEER must not enter discovery"
+    );
+    assert!(
+        peer_manager.discovery_peers.contains_key(&peer_id_at_cap),
+        "entry at MAX_MULTIADDRS_PER_PEER must enter discovery"
+    );
+}
+
+#[tokio::test]
+async fn test_discovery_heartbeat_purges_oversized_multiaddr_entry() {
+    let mut peer_manager = create_test_peer_manager(None);
+
+    // an oversized entry stored before the cap existed (or through any future ingest gap)
+    let peer_id = PeerId::random();
+    let addrs: Vec<_> =
+        (0..crate::peers::MAX_MULTIADDRS_PER_PEER + 1).map(multiaddr_for_index).collect();
+    peer_manager.discovery_peers.insert(peer_id, addrs);
+
+    peer_manager.discovery_heartbeat();
+
+    // the heartbeat re-checks eligibility: the entry is purged, never dialed
+    assert!(
+        !peer_manager.discovery_peers.contains_key(&peer_id),
+        "oversized entry must be purged by the heartbeat"
+    );
+    assert!(peer_manager.next_dial_request().is_none(), "oversized entry must not be dialed");
+}
+
 #[tokio::test]
 async fn test_prune_connected_peers() {
     let mut peer_manager = create_test_peer_manager(None);


### PR DESCRIPTION
Closes #1183.

## Problem

`process_peer_exchange` stores a peer's advertised multiaddr list with no cap on the number of
addresses per entry. The kad `NodeRecord` path caps its list at `MAX_ADVERTISED_MULTIADDRS`
inside `peer_record_valid`, but the PeerExchange path caps only the number of peer entries, not the
addresses inside each entry.

One unauthenticated, non-committee peer can send a single PeerExchange response that maps a fake
`peer_id` to an address list bounded only by the message-size limit. The victim stores the list in
`discovery_peers`, and the discovery heartbeat later dials the full list. The attacker chooses the
addresses, so the victim opens connection attempts against third-party IP:port targets the attacker
selects. A fake entry never completes a handshake, so it stays in `discovery_peers` and is dialed
again on later heartbeats. This turns an honest node into a sustained dial-amplification and
involuntary port-scan proxy. No validator key is required.

## Root cause

A resource cap was applied to one ingest path and was not mirrored onto its sibling.
`eligible_for_discovery` checks identity, IP validity, and ban status, but never the address count.

## Fix

- [x] `crates/network-libp2p/src/peers/manager.rs`: `eligible_for_discovery` now rejects any entry
  whose address list exceeds `MAX_MULTIADDRS_PER_PEER`.
- [x] `crates/network-libp2p/src/peers/peer.rs`: `MAX_MULTIADDRS_PER_PEER` lowered from 32 to 1
  (review follow-up, see below); doc note on its second role as the discovery per-entry ceiling.
- [x] `crates/network-libp2p/src/consensus.rs`: `MAX_ADVERTISED_MULTIADDRS` (was 16) is now tied
  to `MAX_MULTIADDRS_PER_PEER`, so validation and storage agree on how many addresses one peer may
  present.
- [x] `crates/network-libp2p/src/peers/mod.rs`: the cap is re-exported crate-wide (it was
  test-only) so the record validation can reference it.

The value follows the protocol assumption, agreed in review and at stand-up: there is exactly one
address per peer. A `NodeRecord` advertises one address (`NodeRecord::build`), a committee entry
carries one (`network_address`), and every consumer acts on a single address for a peer. So the
stored set holds only the address the peer most recently presented. The set is keyed on exact
`Multiaddr` equality and one endpoint reaches it in two syntactic forms, with and without the
`/p2p/<peer_id>` suffix (advertised as the operator configured it, dialed always with `/p2p` because
libp2p-swarm appends it to every dial, seen bare again on an inbound connection because libp2p-quic
dials from the listening socket); under a cap of 1 those forms replace each other instead of
accumulating, and either form dials the same endpoint. An eviction only trims the peer-exchange
payload (`exchange_info`): dialing reads `known_peers` / kad / `discovery_peers` and banning reads
`observed_ip_addresses`, never this set. The cap also bounds the dial fan-out of one discovery
entry to a single address.

Mixed-version note: a sender still on the pre-#1194 cap (32) may hold both forms of one honest
endpoint for a peer it dialed, so its exchange entry for that peer carries 2 addresses and a node on
this branch rejects it as ineligible for discovery. That only removes a discovery candidate during
the rollout window (kad closest-peers and committee dialing are unaffected); once senders run this
branch every honest entry carries exactly one address.

A legitimate exchange entry is a copy of the sender's stored set for that peer, so an honest sender
cannot exceed the cap. The check is a cheap length compare, runs before any dial resources are
spent, and is attacker-independent.

Enforcing the cap in `eligible_for_discovery` covers all three call sites with one guard:

- `process_peer_exchange`, the uncapped ingest this issue reports,
- `process_peers_for_discovery`, the kad closest-peers ingest. Those entries carry whatever the
  remote responder's routing table holds for a peer (`KadPeer.multiaddrs` in FIND_NODE replies),
  which nothing upstream caps and which never passes through `peer_record_valid`, so this guard is
  the first bound on that path too. Honest entries there hold one `/p2p` form per address, so no
  honest entry is affected.
- the `discovery_heartbeat` retain, which re-checks eligibility, so an oversized entry that reached
  `discovery_peers` through any other path is purged before it is dialed.

Rejection (not truncation) mirrors the kad `peer_record_valid` semantics and does not let the
attacker choose which addresses survive. The cap is also symmetric across producer and reader: the
producing path (`peer_exchange` / `exchange_info`) and the ingesting path bound the per-peer
address list with the same shared constant, and so does record validation.

## Testing

- `test_process_peer_exchange_rejects_oversized_multiaddr_list`: an exchange entry with
  `MAX_MULTIADDRS_PER_PEER + 1` addresses never enters `discovery_peers`; an entry with exactly
  `MAX_MULTIADDRS_PER_PEER` addresses does (the boundary is exact).
- `test_discovery_heartbeat_purges_oversized_multiaddr_entry`: an oversized entry already present
  in `discovery_peers` is purged by the heartbeat and produces no dial request.
- `honest_address_forms_replace_each_other_within_the_cap` (peer.rs): one endpoint advertised
  bare, then dialed with `/p2p`, then seen bare on an inbound connection: the set never grows past
  one entry and always holds the form most recently presented. Confirmed by mutation: cap 1 -> 2
  fails it, restored passes.
- `test_node_record_validation_rejects_oversized_multiaddr_list`: a signed record advertising
  exactly `MAX_MULTIADDRS_PER_PEER` addresses is accepted with every address intact; one address
  more is rejected.
- All four tests are deterministic (fixed TEST-NET-3 addresses, no sleeps, no timing assumptions).
  The two ingest tests were confirmed by mutation (cap guard neutralized: 0 passed, 2 failed;
  restored: 2 passed). The two new tests were confirmed by mutation as well (see the follow-up
  commit for the exact mutants).
- The existing cap tests reference the constant symbolically, so they run unchanged at the new
  value.
- The `tn-network-libp2p` test suite is green: 255 passed, 0 failed (`tn_network_libp2p` lib test binary).
- Nightly `cargo fmt -- --check` green. Scoped nightly
  `clippy -p tn-network-libp2p --no-deps --all-targets --all-features -- -D warnings` reports no
  lints in the changed files (it does surface a pre-existing `collapsible_match` in
  `tests/network_tests.rs`, untouched by this PR, under a nightly newer than CI's).
