### PR TITLE
fix(consensus): fork-gate strictly increasing commit timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,19 +144,29 @@ E2E_BIN := $(E2E_TARGET_ROOT)/e2e/telcoin-network
 # seed_signature_override_is_inert_when_unset requires a process WITHOUT the variable.
 TN_SEED_SIGNATURE_FORK_EPOCH ?= 4294967295
 
+# Strict-commit-timestamp fork epoch for the e2e lanes (#1191), same shape as the
+# seed-signature pin above: u32::MAX = fork DORMANT. The e2e harness itself defaults the
+# spawned nodes to dormant (TestBinary::command), because sub-second e2e header delays make
+# the strict floor advance chain time faster than wall clock; this variable exists so a
+# fork-active lane can override that default. Only test-utils builds consult it
+# (tn_types::forks::strict_commit_timestamp_fork_epoch_override). Same caveat as above:
+# never set it on a bare --workspace run (strict_commit_timestamp_override_is_inert_when_unset
+# requires a process WITHOUT the variable).
+TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH ?= 4294967295
+
 # run restart integration tests
 test-restarts: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH=$(TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # run epoch integration tests (same filter as the public-tests epoch line). The scheduled
 # Durable e2e lane (#1149) runs this and test-restarts with TN_TEST_MDBX_SYNC=durable
 # exported so every spawned node opens MDBX in Durable.
 test-epochs: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH=$(TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
 
 # run e2e tests
 test-e2e: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH=$(TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
 
 # run tests with coverage (using llvm-cov + nextest)
 coverage:
@@ -232,8 +242,8 @@ revert-submodule:
 # workspace tests that don't require faucet credentials
 public-tests: build-e2e-bin
 	TN_BIN_PATH="$(E2E_BIN)" cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH=$(TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH=$(TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # local checks to ensure PR is ready
 pr:

--- a/crates/consensus/primary/tests/it/output_tests.rs
+++ b/crates/consensus/primary/tests/it/output_tests.rs
@@ -94,9 +94,16 @@ fn test_monotonically_incremented_commit_timestamps() {
         tn_types::EpochSeedChainValue::genesis_placeholder(),
     );
 
-    // THEN the latest sub dag should have the highest committed timestamp - basically the
-    // same as the previous commit round
-    assert_eq!(sub_dag_round_4.commit_timestamp(), sub_dag_round_2.commit_timestamp());
+    // THEN the commit timestamp never decreases. While the strict fork is dormant (adiri
+    // builds pre-fork) the value clamps to the previous commit's timestamp. Once the fork is
+    // active (non-adiri builds are active from genesis) the floor is `previous + 1`, so every
+    // commit in an epoch records a unique timestamp (#1191).
+    let expected = if tn_types::forks::strict_commit_timestamp_active(0) {
+        sub_dag_round_2.commit_timestamp() + 1
+    } else {
+        sub_dag_round_2.commit_timestamp()
+    };
+    assert_eq!(sub_dag_round_4.commit_timestamp(), expected);
 }
 
 #[test]

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -36,14 +36,18 @@ pub enum TestBinary {
 impl TestBinary {
     /// Build a [`std::process::Command`] that runs this binary.
     ///
-    /// Pins `TN_SEED_SIGNATURE_FORK_EPOCH` on the child so every spawned node runs the fork
-    /// point the harness states rather than the build default (non-adiri builds are otherwise
-    /// active from genesis). With nothing in the harness environment the pin is `u32::MAX`:
-    /// fork dormant, wire-identical to pre-fork mainnet. A harness-level value is forwarded
-    /// verbatim so a fork-active lane can export `TN_SEED_SIGNATURE_FORK_EPOCH=0`, and a
-    /// single test can still override the pin with its own later `env()` call. Only binaries
-    /// built with `tn-types/test-utils` (pulled in via `tn-storage/test-utils`, see
-    /// `make build-e2e-bin`) consult the variable; production binaries ignore it.
+    /// Pins `TN_SEED_SIGNATURE_FORK_EPOCH` and `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` on the
+    /// child so every spawned node runs the fork points the harness states rather than the
+    /// build default (non-adiri builds are otherwise active from genesis). With nothing in the
+    /// harness environment each pin is `u32::MAX`: fork dormant, wire-identical to pre-fork
+    /// mainnet. The strict-commit-timestamp pin matters here because e2e networks run
+    /// sub-second header delays, where the strict `previous + 1` floor advances chain time
+    /// faster than wall clock and breaks the harness's host-clock-vs-block-timestamp phase
+    /// math (`wait_for_mid_epoch`). A harness-level value is forwarded verbatim so a
+    /// fork-active lane can export either variable as `0`, and a single test can still
+    /// override a pin with its own later `env()` call. Only binaries built with
+    /// `tn-types/test-utils` (pulled in via `tn-storage/test-utils`, see `make build-e2e-bin`)
+    /// consult the variables; production binaries ignore them.
     pub fn command(&self) -> std::process::Command {
         let mut command = match self {
             TestBinary::Prebuilt(path) => std::process::Command::new(path),
@@ -52,6 +56,9 @@ impl TestBinary {
         let fork_epoch =
             std::env::var("TN_SEED_SIGNATURE_FORK_EPOCH").unwrap_or_else(|_| u32::MAX.to_string());
         command.env("TN_SEED_SIGNATURE_FORK_EPOCH", fork_epoch);
+        let strict_fork_epoch = std::env::var("TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH")
+            .unwrap_or_else(|_| u32::MAX.to_string());
+        command.env("TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH", strict_fork_epoch);
         command
     }
 }

--- a/crates/engine/tests/it/main.rs
+++ b/crates/engine/tests/it/main.rs
@@ -3531,3 +3531,186 @@ async fn test_uneven_batches_and_digests_tolerated_on_early_adiri_epoch() -> eyr
 
     Ok(())
 }
+
+/// Two consecutive outputs whose leaders share one wall-clock second keep BOTH
+/// `ConsensusHeader` digests retrievable from the repurposed EIP-4788 beacon-roots ring
+/// buffer (#1191).
+///
+/// Both leaders carry the same `created_at`, so before the strict-commit-timestamp fork the
+/// two outputs recorded identical `commit_timestamp`s and the second output's pre-block
+/// system call silently overwrote the first output's digest (both writes keyed
+/// `timestamp % 8191`). Under the strict arm - active from genesis in this default-feature
+/// build - the second output commits at `previous + 1` and the pair keys two distinct slots.
+///
+/// The per-block `assert_eip4788` checks in the other tests read each block's OWN historical
+/// state, where the overwritten digest was still visible, so they could never catch the
+/// collision. This test asserts from the FINAL canonical state instead, which is where the
+/// overwrite used to land.
+///
+/// Adiri builds keep the legacy tie while `STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` is dormant,
+/// so the non-collision property this test pins simply does not hold there yet.
+#[cfg(not(feature = "adiri"))]
+#[tokio::test]
+async fn test_same_second_outputs_keep_both_beacon_roots_digests() -> eyre::Result<()> {
+    let _guard = IT_TEST_GUARD.lock();
+    let tmp_dir = TempDir::new().expect("temp dir");
+    // create batches for consensus output
+    let chain = test_chain_spec_arc();
+    let mut batches_1 = tn_reth::test_utils::batches(chain.clone(), 1);
+    let mut batches_2 = tn_reth::test_utils::batches(chain, 1);
+
+    // seed genesis with the batch signers
+    let genesis = test_genesis_with_consensus_registry(4);
+    let all_batches = [batches_1.clone(), batches_2.clone()].concat();
+    let (genesis, _txs_by_block, _signers_by_block) =
+        seeded_genesis_from_random_batches(genesis, all_batches.iter());
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // execution node components
+    let gas_accumulator = GasAccumulator::new(1); // 1 worker
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        tmp_dir.path(),
+        Some(gas_accumulator.clone()),
+    )?;
+    let committee =
+        create_committee_from_state(execution_node.epoch_state_from_canonical_tip().await?).await?;
+    let authority_1 = committee.authorities().first().expect("first in committee").id();
+    let authority_2 = committee.authorities().last().expect("last in committee").id();
+    let batch_producer =
+        committee.authorities().get(2).expect("third in committee").execution_address();
+    gas_accumulator.rewards_counter().set_committee(committee);
+
+    // execute batches so headers carry valid data
+    batches_1.iter_mut().chain(batches_2.iter_mut()).for_each(|batch| {
+        batch.beneficiary = batch_producer;
+        batch.base_fee_per_gas = MIN_PROTOCOL_BASE_FEE;
+        execute_test_batch(batch);
+    });
+
+    //=== Consensus: two chained outputs whose leaders tie on one second
+    //
+    // A fixed, deterministic second keeps the ring-buffer slots non-trivial: slot values must
+    // differ from the empty-storage default, and TIED_SECOND % 8191 (= 7096) does not wrap,
+    // so the pair's slots are adjacent.
+    const TIED_SECOND: u64 = 1_700_000_000;
+    let mut leader_1 = Certificate::default();
+    leader_1.update_header_author_for_test(authority_1);
+    leader_1.update_header_round_for_test(1);
+    leader_1.update_header_created_at_for_test(TIED_SECOND);
+    let batch_digests_1: VecDeque<BlockHash> = batches_1.iter().map(|b| b.digest()).collect();
+    let subdag_1 = CommittedSubDag::new(
+        vec![leader_1.clone()],
+        leader_1,
+        1,
+        ReputationScores::default(),
+        None,
+        tn_types::EpochSeedChainValue::genesis_placeholder(),
+    );
+    let consensus_output_1 = ConsensusOutput::new(
+        subdag_1.clone(),
+        ConsensusHeaderDigest::default(),
+        0,
+        false,
+        batch_digests_1,
+        vec![CertifiedBatch { address: batch_producer, batches: batches_1 }],
+    );
+
+    let mut leader_2 = Certificate::default();
+    leader_2.update_header_author_for_test(authority_2);
+    leader_2.update_header_round_for_test(2);
+    leader_2.update_header_created_at_for_test(TIED_SECOND);
+    let batch_digests_2: VecDeque<BlockHash> = batches_2.iter().map(|b| b.digest()).collect();
+    let subdag_2 = CommittedSubDag::new(
+        vec![leader_2.clone()],
+        leader_2,
+        2,
+        ReputationScores::default(),
+        Some(subdag_1.clone()),
+        tn_types::EpochSeedChainValue::genesis_placeholder(),
+    );
+    let ts_1 = subdag_1.commit_timestamp();
+    let ts_2 = subdag_2.commit_timestamp();
+    assert_eq!(ts_1, TIED_SECOND, "first commit records the leader second as-is");
+    assert_eq!(ts_2, ts_1 + 1, "tied leaders must commit at distinct consecutive seconds");
+    let consensus_output_2 = ConsensusOutput::new(
+        subdag_2,
+        consensus_output_1.consensus_header_hash(),
+        1,
+        false,
+        batch_digests_2,
+        vec![CertifiedBatch { address: batch_producer, batches: batches_2 }],
+    );
+    let digest_1: B256 = consensus_output_1.consensus_header_hash().into();
+    let digest_2: B256 = consensus_output_2.consensus_header_hash().into();
+
+    //=== Execution
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
+    let parent = chain.sealed_genesis_header();
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let reth_env = execution_node.get_reth_env().await;
+    let (engine_update_tx, _engine_update_rx) = tokio::sync::mpsc::channel(64);
+    let mut engine = ExecutorEngine::new(
+        reth_env.clone(),
+        None, // max_round
+        from_consensus,
+        parent,
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        gas_accumulator.clone(),
+        engine_update_tx,
+    );
+
+    // queue the first output, send the second, then close the channel so the engine
+    // executes both and shuts down
+    engine.push_back_queued_for_test(consensus_output_1.clone());
+    let broadcast_result = to_engine.send(consensus_output_2.clone()).await;
+    assert!(broadcast_result.is_ok());
+    drop(to_engine);
+
+    let (tx, rx) = oneshot::channel();
+    task_manager.spawn_task("test task eng", async move {
+        let res = engine.run().await;
+        let _ = tx.send(res);
+        Ok(())
+    });
+    let engine_task = timeout(Duration::from_secs(15), rx).await??;
+    assert_matches!(engine_task, Err(TnEngineError::ConsensusOutputStreamClosed));
+
+    // both single-batch outputs executed
+    assert_eq!(reth_env.last_block_number()?, 2, "one block per output");
+    let last_output = execution_node.last_executed_output().await?;
+    assert_eq!(last_output, consensus_output_2.consensus_header_hash());
+
+    // the collision surface: read BOTH outputs' ring-buffer slots from the FINAL state
+    let state_provider = reth_env.state_by_block_hash(reth_env.canonical_tip().hash())?;
+    let ts_slot_1 = U256::from(ts_1 % HISTORY_BUFFER_LENGTH);
+    let root_slot_1 = ts_slot_1 + U256::from(HISTORY_BUFFER_LENGTH);
+    let ts_slot_2 = U256::from(ts_2 % HISTORY_BUFFER_LENGTH);
+    let root_slot_2 = ts_slot_2 + U256::from(HISTORY_BUFFER_LENGTH);
+    assert_eq!(
+        state_provider.storage(BEACON_ROOTS_ADDRESS, ts_slot_1.into())?.unwrap_or_default(),
+        U256::from(ts_1),
+        "first output's timestamp slot must survive the second output"
+    );
+    assert_eq!(
+        state_provider.storage(BEACON_ROOTS_ADDRESS, root_slot_1.into())?.unwrap_or_default(),
+        U256::from_be_bytes(digest_1.0),
+        "first output's consensus digest must survive the second output (pre-#1191 this \
+         slot held the second output's digest)"
+    );
+    assert_eq!(
+        state_provider.storage(BEACON_ROOTS_ADDRESS, ts_slot_2.into())?.unwrap_or_default(),
+        U256::from(ts_2),
+        "second output's timestamp slot must be written"
+    );
+    assert_eq!(
+        state_provider.storage(BEACON_ROOTS_ADDRESS, root_slot_2.into())?.unwrap_or_default(),
+        U256::from_be_bytes(digest_2.0),
+        "second output's consensus digest must be written"
+    );
+
+    Ok(())
+}

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -234,6 +234,56 @@ pub fn seed_signature_fork_epoch_override() -> Option<Epoch> {
     })
 }
 
+#[cfg(feature = "adiri")]
+/// First epoch whose commits derive a strictly increasing `commit_timestamp` (#1191).
+///
+/// Pre-fork epochs keep the legacy clamp `max(previous, leader.created_at())`, which lets two
+/// consecutive commits of an epoch share one wall-clock second. Tied commits collide in the
+/// repurposed EIP-4788 beacon-roots ring buffer: the pre-block system call keys the buffer by
+/// `timestamp % 8191`, so the second commit of a tied pair silently overwrites the first
+/// commit's `ConsensusHeader` digest and the standard in-EVM proof path (`get(T)`) loses that
+/// digest permanently. From this epoch onward the floor moves to `previous + 1`
+/// ([`crate::CommittedSubDag::new`]), so every commit of an epoch records a unique timestamp
+/// and keeps a retrievable buffer slot. The guarantee is intra-epoch: the first commit of an
+/// epoch has no previous sub-dag (the per-epoch pack starts empty), so a tie with the prior
+/// epoch's closing commit stays possible across the boundary (#1191 residual).
+///
+/// The formula is consensus-critical: `commit_timestamp` is hashed into the sub-dag digest
+/// (`CommittedSubDag::digest`), so a mixed fleet would fork on the first tied pair. `u32::MAX`
+/// keeps the gate dormant. The rollout is the standard two-phase sequence documented on
+/// [`SEED_SIGNATURE_FORK_EPOCH`]: deploy this build fleet-wide first (safe indefinitely while
+/// dormant), then land a follow-up PR that sets the concrete epoch, re-verified against the
+/// live chain at merge time.
+///
+/// Non-adiri builds (mainnet) have no dormant period: the strict formula is active from
+/// genesis and this constant does not exist there.
+pub const STRICT_COMMIT_TIMESTAMP_FORK_EPOCH: Epoch = u32::MAX;
+
+/// Whether commits of `epoch` derive the strictly increasing `commit_timestamp` (#1191).
+///
+/// Callers MUST pass the epoch of the leader whose commit is being derived
+/// (`leader.epoch()`), never `Committee::epoch()` or other node-local state, for the same
+/// reason documented on [`seed_signature_active`]: the formula feeds the consensus digest, so
+/// it must follow the value being derived, not the node deriving it.
+///
+/// Adiri builds activate at [`STRICT_COMMIT_TIMESTAMP_FORK_EPOCH`]; all other builds are
+/// active from genesis. This gate deliberately has no `TN_*` environment override: exactly
+/// one production site consumes it (`CommittedSubDag::new`), and the formula behind it is a
+/// pure function with direct unit tests on both arms, so tests pin behavior without
+/// process-global state.
+#[inline]
+pub fn strict_commit_timestamp_active(epoch: Epoch) -> bool {
+    #[cfg(feature = "adiri")]
+    {
+        epoch >= STRICT_COMMIT_TIMESTAMP_FORK_EPOCH
+    }
+    #[cfg(not(feature = "adiri"))]
+    {
+        let _ = epoch;
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,6 +375,36 @@ mod tests {
                 "an unset override must not shift the gate at epoch {epoch}",
             );
         });
+    }
+
+    /// Pin the strict-commit-timestamp gate to the rollout contract this build implements
+    /// (#1191): dormant on adiri at every real epoch until a follow-up PR sets the concrete
+    /// fork epoch, active from genesis on every other build (which is the build that produces
+    /// both the shipped node binary and the e2e binary).
+    #[test]
+    fn strict_commit_timestamp_gate_matches_this_builds_rollout_contract() {
+        #[cfg(not(feature = "adiri"))]
+        [0, 1, 2, u32::MAX].into_iter().for_each(|epoch| {
+            assert!(
+                strict_commit_timestamp_active(epoch),
+                "non-adiri builds run the strict formula from genesis; epoch {epoch} must be \
+                 active",
+            );
+        });
+        #[cfg(feature = "adiri")]
+        {
+            [0, 1, 2, STRICT_COMMIT_TIMESTAMP_FORK_EPOCH - 1].into_iter().for_each(|epoch| {
+                assert!(
+                    !strict_commit_timestamp_active(epoch),
+                    "adiri stays dormant before STRICT_COMMIT_TIMESTAMP_FORK_EPOCH; epoch \
+                     {epoch} must be pre-fork",
+                );
+            });
+            assert!(
+                strict_commit_timestamp_active(STRICT_COMMIT_TIMESTAMP_FORK_EPOCH),
+                "the gate must fire from the fork epoch onward (`>=`, not `>`)",
+            );
+        }
     }
 
     /// Pin [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`] to the worker-configs code committed in

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -274,6 +274,12 @@ pub const STRICT_COMMIT_TIMESTAMP_FORK_EPOCH: Epoch = u32::MAX;
 #[inline]
 pub fn strict_commit_timestamp_active(epoch: Epoch) -> bool {
     #[cfg(feature = "adiri")]
+    #[expect(
+        clippy::absurd_extreme_comparisons,
+        reason = "STRICT_COMMIT_TIMESTAMP_FORK_EPOCH is a `u32::MAX` placeholder; `>=` (not \
+                  `==`) is the gate the future epoch-setting PR relies on, and this expectation \
+                  flags itself for removal once that PR lowers the constant"
+    )]
     {
         epoch >= STRICT_COMMIT_TIMESTAMP_FORK_EPOCH
     }

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -267,12 +267,31 @@ pub const STRICT_COMMIT_TIMESTAMP_FORK_EPOCH: Epoch = u32::MAX;
 /// it must follow the value being derived, not the node deriving it.
 ///
 /// Adiri builds activate at [`STRICT_COMMIT_TIMESTAMP_FORK_EPOCH`]; all other builds are
-/// active from genesis. This gate deliberately has no `TN_*` environment override: exactly
-/// one production site consumes it (`CommittedSubDag::new`), and the formula behind it is a
-/// pure function with direct unit tests on both arms, so tests pin behavior without
-/// process-global state.
+/// active from genesis. Under `test-utils`, an explicit
+/// `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` override takes precedence over both (see
+/// [`strict_commit_timestamp_fork_epoch_override`]), so a test states the fork point it
+/// means rather than inheriting whichever one its feature set happens to select.
 #[inline]
 pub fn strict_commit_timestamp_active(epoch: Epoch) -> bool {
+    #[cfg(feature = "test-utils")]
+    {
+        strict_commit_timestamp_fork_epoch_override()
+            .map_or_else(|| build_strict_commit_timestamp_active(epoch), |fork| epoch >= fork)
+    }
+    #[cfg(not(feature = "test-utils"))]
+    {
+        build_strict_commit_timestamp_active(epoch)
+    }
+}
+
+/// This build's compile-time strict-commit-timestamp fork point, with no test override
+/// applied.
+///
+/// Unchanged from [`STRICT_COMMIT_TIMESTAMP_FORK_EPOCH`]'s documented contract: adiri
+/// (testnet, which carries pre-fork history) is dormant before the fork epoch and active
+/// from it, and every other build (mainnet) is active from genesis.
+#[inline]
+const fn build_strict_commit_timestamp_active(epoch: Epoch) -> bool {
     #[cfg(feature = "adiri")]
     #[expect(
         clippy::absurd_extreme_comparisons,
@@ -288,6 +307,33 @@ pub fn strict_commit_timestamp_active(epoch: Epoch) -> bool {
         let _ = epoch;
         true
     }
+}
+
+/// Test-only override of the effective strict-commit-timestamp fork epoch, read once from
+/// `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` (`4294967295` for "never fires", `0` for "active
+/// from genesis").
+///
+/// An environment variable for the same process-boundary reason as
+/// [`seed_signature_fork_epoch_override`]: e2e tests drive real node processes spawned via
+/// `TN_BIN_PATH`, which share no memory with the harness. The e2e harness pins this fork
+/// dormant on every spawned node: its networks run sub-second header delays (250-500 ms), so
+/// commits arrive faster than one per wall-clock second, the second-granularity `created_at`
+/// ties on nearly every commit, and the strict `previous + 1` floor would advance chain time
+/// roughly twice as fast as wall time, breaking every harness comparison of host clock
+/// against block timestamps. Production cadences (a 1 s minimum header delay and one leader
+/// per two rounds) do not produce that regime.
+///
+/// Compiled out entirely without `test-utils`, so a production binary keeps the compile-time
+/// behavior and cannot be repointed at runtime by its environment. An unparseable value is
+/// ignored rather than defaulted, leaving the build's own fork point in force.
+#[cfg(feature = "test-utils")]
+pub fn strict_commit_timestamp_fork_epoch_override() -> Option<Epoch> {
+    static OVERRIDE: std::sync::OnceLock<Option<Epoch>> = std::sync::OnceLock::new();
+    *OVERRIDE.get_or_init(|| {
+        std::env::var("TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH")
+            .ok()
+            .and_then(|raw| raw.trim().parse().ok())
+    })
 }
 
 #[cfg(test)]
@@ -387,12 +433,15 @@ mod tests {
     /// (#1191): dormant on adiri at every real epoch until a follow-up PR sets the concrete
     /// fork epoch, active from genesis on every other build (which is the build that produces
     /// both the shipped node binary and the e2e binary).
+    ///
+    /// Asserts against [`build_strict_commit_timestamp_active`], the override-free decision,
+    /// so the result does not depend on whether `test-utils` was unified into this build.
     #[test]
     fn strict_commit_timestamp_gate_matches_this_builds_rollout_contract() {
         #[cfg(not(feature = "adiri"))]
         [0, 1, 2, u32::MAX].into_iter().for_each(|epoch| {
             assert!(
-                strict_commit_timestamp_active(epoch),
+                build_strict_commit_timestamp_active(epoch),
                 "non-adiri builds run the strict formula from genesis; epoch {epoch} must be \
                  active",
             );
@@ -401,16 +450,38 @@ mod tests {
         {
             [0, 1, 2, STRICT_COMMIT_TIMESTAMP_FORK_EPOCH - 1].into_iter().for_each(|epoch| {
                 assert!(
-                    !strict_commit_timestamp_active(epoch),
+                    !build_strict_commit_timestamp_active(epoch),
                     "adiri stays dormant before STRICT_COMMIT_TIMESTAMP_FORK_EPOCH; epoch \
                      {epoch} must be pre-fork",
                 );
             });
             assert!(
-                strict_commit_timestamp_active(STRICT_COMMIT_TIMESTAMP_FORK_EPOCH),
+                build_strict_commit_timestamp_active(STRICT_COMMIT_TIMESTAMP_FORK_EPOCH),
                 "the gate must fire from the fork epoch onward (`>=`, not `>`)",
             );
         }
+    }
+
+    /// With no `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` in the environment, the test override
+    /// must be completely inert: the gate answers exactly as the compile-time contract does.
+    #[cfg(feature = "test-utils")]
+    #[test]
+    fn strict_commit_timestamp_override_is_inert_when_unset() {
+        // The override latches in a process-wide `OnceLock`, so a harness launched WITH the
+        // variable set cannot observe the unset behaviour. Fail loudly rather than assert a
+        // property this process cannot hold; a silent skip here would read as a pass.
+        assert!(
+            strict_commit_timestamp_fork_epoch_override().is_none(),
+            "this test requires a process without TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH set; \
+             the override is OnceLock-latched, so run the unset case in its own process",
+        );
+        [0, 1, 2, u32::MAX].into_iter().for_each(|epoch| {
+            assert_eq!(
+                strict_commit_timestamp_active(epoch),
+                build_strict_commit_timestamp_active(epoch),
+                "an unset override must not shift the gate at epoch {epoch}",
+            );
+        });
     }
 
     /// Pin [`WORKER_CONFIGS_PRE_FORK_CODE_HASH`] to the worker-configs code committed in

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::mpsc;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 /// A global sequence number assigned to every CommittedSubDag.
 pub type SequenceNumber = u64;
@@ -375,6 +375,45 @@ impl Default for CommittedSubDag {
     }
 }
 
+/// Resolve the `commit_timestamp` a new [`CommittedSubDag`] records.
+///
+/// Pre-fork (`strict` false) this is the legacy clamp `max(previous, leader_created_at)`,
+/// byte-identical to the historical chain: two consecutive commits may share one wall-clock
+/// second, and a tied pair collides in the repurposed EIP-4788 beacon-roots ring buffer
+/// (#1191). Post-fork (`strict` true, see [`crate::forks::strict_commit_timestamp_active`])
+/// the floor moves to `previous + 1`: consecutive commits never tie, so every commit of an
+/// epoch keys a unique buffer slot. The recorded time may then run ahead of wall clock while
+/// commits arrive faster than one per second; the drift is bounded by the longest
+/// faster-than-one-per-second commit run and shrinks again whenever a real second passes with
+/// no commit, every downstream consumer reads this same chain (block timestamps,
+/// epoch-boundary checks), and no consumer re-validates it against local wall clock, so the
+/// drift is self-consistent.
+///
+/// A commit with no previous sub-dag has no floor in either arm and records the leader
+/// timestamp as-is. That makes the strict guarantee intra-epoch only: the first commit of an
+/// epoch starts from an empty per-epoch pack (`previous` is `None`), so it can still tie the
+/// prior epoch's closing commit — a documented residual of #1191, not covered by this fork.
+/// The `+ 1` saturates at `u64::MAX`, where strictness degrades to the legacy tie rather than
+/// wrapping; that ceiling is unreachable for wall-clock seconds.
+///
+/// `previous` is the previous sub-dag's raw stored `commit_timestamp`, not the
+/// [`CommittedSubDag::commit_timestamp`] accessor: the pre-fork arm must reproduce the
+/// historical clamp byte-for-byte, and the accessor's zero-means-uninitialized fallback
+/// cannot apply in the strict arm, because the previous sub-dag always belongs to the same
+/// (post-fork) epoch and every sub-dag derived under this code records a nonzero timestamp.
+fn resolved_commit_timestamp(
+    strict: bool,
+    previous: Option<TimestampSec>,
+    leader_created_at: TimestampSec,
+) -> TimestampSec {
+    let floor = if strict {
+        previous.map(|ts| ts.saturating_add(1)).unwrap_or_default()
+    } else {
+        previous.unwrap_or_default()
+    };
+    floor.max(leader_created_at)
+}
+
 impl CommittedSubDag {
     /// Create a new CommittedSubDag.
     /// Note that leader MUST be the first element or certificates or this will panic.
@@ -394,13 +433,22 @@ impl CommittedSubDag {
     ) -> Self {
         // Narwhal enforces some invariants on the header.created_at, so we can use it as a
         // timestamp.
-        let previous_sub_dag_ts =
-            previous_sub_dag.map(|s| s.inner.commit_timestamp).unwrap_or_default();
-        let commit_timestamp = previous_sub_dag_ts.max(*leader.header().created_at());
+        let previous_sub_dag_ts = previous_sub_dag.map(|s| s.inner.commit_timestamp);
+        let commit_timestamp = resolved_commit_timestamp(
+            crate::forks::strict_commit_timestamp_active(leader.epoch()),
+            previous_sub_dag_ts,
+            *leader.header().created_at(),
+        );
 
-        if previous_sub_dag_ts > *leader.header().created_at() {
-            warn!(sub_dag_index = ?sub_dag_index, "Leader timestamp {} is older than previously committed sub dag timestamp {}. Auto-correcting to max {}.",
-                leader.header().created_at(), previous_sub_dag_ts, commit_timestamp);
+        if previous_sub_dag_ts.unwrap_or_default() > *leader.header().created_at() {
+            warn!(sub_dag_index = ?sub_dag_index, "Leader timestamp {} is older than previously committed sub dag timestamp {}. Auto-correcting to {}.",
+                leader.header().created_at(), previous_sub_dag_ts.unwrap_or_default(), commit_timestamp);
+        } else if commit_timestamp != *leader.header().created_at() {
+            // Only the strict arm reaches this branch: a tie with the previous commit was
+            // bumped one second past the leader-reported time (#1191). Ties are routine while
+            // commits arrive faster than one per second, so this is debug, not warn.
+            debug!(sub_dag_index = ?sub_dag_index, "Tied leader timestamp {} bumped to {} to keep commit timestamps strictly increasing.",
+                leader.header().created_at(), commit_timestamp);
         }
         // Make sure the leader is the LAST certificate.
         //
@@ -577,3 +625,90 @@ crate::crypto::digest_newtype! {
 }
 
 // See test_utils output_tests.rs for this modules tests.
+//
+// The tests below are the deliberate exception: `resolved_commit_timestamp` is private, so its
+// arms are only reachable from inside the crate, and the fork-arm split must run under BOTH CI
+// lanes (default features and `adiri`), which build tn-types but not the integration-test
+// crates.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The legacy arm is byte-identical to the historical clamp `max(previous, created_at)`:
+    /// ties and decreases both collapse onto the previous timestamp, which is the pre-fork
+    /// wire behavior every already-committed sub-dag digest depends on.
+    #[test]
+    fn legacy_commit_timestamp_matches_history() {
+        // No previous sub-dag: the leader timestamp is recorded as-is, including zero.
+        assert_eq!(resolved_commit_timestamp(false, None, 0), 0);
+        assert_eq!(resolved_commit_timestamp(false, None, 7), 7);
+        // Advancing leader wins.
+        assert_eq!(resolved_commit_timestamp(false, Some(10), 11), 11);
+        // Tie collapses onto the shared second (the #1191 collision case).
+        assert_eq!(resolved_commit_timestamp(false, Some(10), 10), 10);
+        // Decrease clamps to the previous timestamp, again a tie.
+        assert_eq!(resolved_commit_timestamp(false, Some(10), 9), 10);
+    }
+
+    /// The strict arm floors at `previous + 1`: no chained pair of commits can share a
+    /// timestamp, so no two commits of an epoch key the same EIP-4788 ring-buffer slot
+    /// (#1191).
+    #[test]
+    fn strict_commit_timestamp_never_ties_previous() {
+        // No previous sub-dag: unchanged from the legacy arm, including zero.
+        assert_eq!(resolved_commit_timestamp(true, None, 0), 0);
+        assert_eq!(resolved_commit_timestamp(true, None, 7), 7);
+        // Advancing leader wins exactly as before.
+        assert_eq!(resolved_commit_timestamp(true, Some(10), 11), 11);
+        // Tie bumps past the shared second instead of colliding.
+        assert_eq!(resolved_commit_timestamp(true, Some(10), 10), 11);
+        // Decrease also lands strictly past the previous commit.
+        assert_eq!(resolved_commit_timestamp(true, Some(10), 9), 11);
+        // The floor saturates at the ceiling instead of wrapping.
+        assert_eq!(resolved_commit_timestamp(true, Some(u64::MAX), 0), u64::MAX);
+    }
+
+    /// `CommittedSubDag::new` wires the gate for this build: default-feature builds are
+    /// strict from genesis, adiri builds stay on the legacy clamp while
+    /// [`crate::forks::STRICT_COMMIT_TIMESTAMP_FORK_EPOCH`] is dormant. Both leaders carry
+    /// epoch 0 and one shared NONZERO `created_at`, so the chained pair is a genuine tie and
+    /// the first commit's recorded value is observable (a zero would also satisfy the
+    /// accessor's uninitialized fallback, making the assertion vacuous).
+    #[test]
+    fn new_applies_this_builds_fork_arm_to_tied_leaders() {
+        const TIED_SECOND: TimestampSec = 7;
+        let mut leader = Certificate::default();
+        leader.update_header_created_at_for_test(TIED_SECOND);
+        let first = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader.clone(),
+            0,
+            ReputationScores::default(),
+            None,
+            EpochSeedChainValue::genesis_placeholder(),
+        );
+        let second = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader,
+            1,
+            ReputationScores::default(),
+            Some(first.clone()),
+            EpochSeedChainValue::genesis_placeholder(),
+        );
+        assert_eq!(
+            first.inner.commit_timestamp, TIED_SECOND,
+            "the first commit must record the leader second as-is",
+        );
+        #[cfg(not(feature = "adiri"))]
+        assert_eq!(
+            second.inner.commit_timestamp,
+            TIED_SECOND + 1,
+            "default-feature builds must bump a tied pair past the shared second",
+        );
+        #[cfg(feature = "adiri")]
+        assert_eq!(
+            second.inner.commit_timestamp, TIED_SECOND,
+            "adiri must keep the legacy tie while the fork is dormant",
+        );
+    }
+}

--- a/crates/types/src/primary/output.rs
+++ b/crates/types/src/primary/output.rs
@@ -383,11 +383,16 @@ impl Default for CommittedSubDag {
 /// (#1191). Post-fork (`strict` true, see [`crate::forks::strict_commit_timestamp_active`])
 /// the floor moves to `previous + 1`: consecutive commits never tie, so every commit of an
 /// epoch keys a unique buffer slot. The recorded time may then run ahead of wall clock while
-/// commits arrive faster than one per second; the drift is bounded by the longest
-/// faster-than-one-per-second commit run and shrinks again whenever a real second passes with
-/// no commit, every downstream consumer reads this same chain (block timestamps,
-/// epoch-boundary checks), and no consumer re-validates it against local wall clock, so the
-/// drift is self-consistent.
+/// commits arrive faster than one per second; the drift shrinks only when a real second
+/// passes with no commit, so a sustained sub-second commit cadence (where second-granularity
+/// `created_at` values tie on nearly every commit) advances chain time faster than wall time
+/// for as long as it lasts. Production cadences hold a 1 s minimum header delay with one
+/// leader per two rounds and do not sustain that regime; the e2e harness, which does
+/// (250-500 ms header delays), pins the fork dormant via
+/// `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` (see
+/// [`crate::forks::strict_commit_timestamp_active`]). Every downstream consumer reads this
+/// same chain (block timestamps, epoch-boundary checks), and no consumer re-validates it
+/// against local wall clock, so the drift is self-consistent.
 ///
 /// A commit with no previous sub-dag has no floor in either arm and records the leader
 /// timestamp as-is. That makes the strict guarantee intra-epoch only: the first commit of an


### PR DESCRIPTION
Closes #1191. (Cantina #7)

## Problem

Two consecutive `ConsensusOutput`s routinely commit in the same wall-clock second: `commit_timestamp` is only monotonic non-decreasing (`previous_sub_dag_ts.max(leader.created_at())`), consensus header validation deliberately accepts `>=` timestamps, and the default header delays are 1000/2500 ms against second-granularity stamps. The repurposed EIP-4788 pre-block system call writes each output's `ConsensusHeader` digest into the canonical beacon-roots contract, which keys its ring buffer purely by `timestamp % 8191`. When outputs O1 and O2 share second T, both writes target the same two storage slots and O2 silently replaces O1's digest. From any later state, `get(T)` returns only O2; O1's digest is permanently unretrievable through the standard in-EVM proof path that the repurposing is meant to provide. No attacker is required . . . honest operation alone produces the tie (a Byzantine leader can also force it, but the fix does not depend on who created it).

## Root cause

Ethereum never hits this because L1 header validity requires `timestamp > parent.timestamp`, so a same-key different-root overwrite is impossible. Telcoin bypasses reth's header-chain validation (blocks are BFT-final) and accepts equal consecutive timestamps by design, but kept the L1 contract's timestamp-keyed buffer unchanged. The uniqueness assumption the contract encodes was never re-established at the consensus layer.

## Fix

- [x] `crates/types/src/forks.rs`: new epoch fork gate `strict_commit_timestamp_active(epoch)` with `STRICT_COMMIT_TIMESTAMP_FORK_EPOCH = u32::MAX` on adiri (dormant; standard two-phase rollout, a follow-up PR sets the concrete epoch exactly as the seed-signature fork did in #1086). Non-adiri builds are active from genesis and carry no legacy period.
- [x] `crates/types/src/primary/output.rs`: the commit-timestamp derivation moves into a pure helper `resolved_commit_timestamp`. Post-fork the floor is `previous + 1` (saturating), so no two chained commits of an epoch share a second; pre-fork stays byte-identical to the historical clamp, so already-committed sub-dag digests are reproduced exactly.
- [x] The gate keys on `leader.epoch()` (the epoch inside the value being derived), never node-local committee state, for the same reason documented on `seed_signature_active`: the timestamp feeds the sub-dag digest, so a mixed fleet would fork on the first tied pair without an epoch-boundary cutover. `CommittedSubDag::new` is the single production derivation point (`bullshark.rs`); replay and pack verification consume the stored value and never re-derive it.
- [x] Observability: a tie-bump now emits a `debug!` line (the existing `warn!` only covers the decrease case, so the exact scenario this fork corrects would otherwise never log). Debug rather than warn because ties are routine during faster-than-one-per-second bursts.
- [x] Test-only fork override, mirroring the seed-signature fork: `TN_STRICT_COMMIT_TIMESTAMP_FORK_EPOCH` (`crates/types/src/forks.rs`, compiled only under `test-utils`; production binaries cannot be repointed). The e2e harness pins the fork dormant on every spawned node (`TestBinary::command`, next to the existing seed-signature pin) and the Makefile forwards the variable on the e2e lanes, defaulting to dormant.

The recorded time can run ahead of wall clock while commits arrive faster than one per second, and the drift shrinks only when a real second passes with no commit. Production cadences (a 1 s minimum header delay, one leader per two rounds) do not sustain faster-than-one-per-second commits, so the floor is inert there in practice. The e2e networks do sustain it (250-500 ms header delays), which made chain time run about twice as fast as wall time and broke the harness's host-clock-vs-block-timestamp phase math (`wait_for_mid_epoch` computes `now.saturating_sub(block_timestamp)`, which pins at 0 once chain time passes the host clock); that is why the e2e lane runs the fork dormant via the override. Every downstream consumer (block timestamps, epoch-boundary checks) reads this same chain; no consumer re-validates it against a local clock.

## Out of scope (documented residuals)

- Cross-epoch ties: the first commit of an epoch has no previous sub-dag (the per-epoch consensus pack starts empty), so it can still tie the prior epoch's closing commit. Documented in the fork const and the helper docs; closing it needs the epoch manager to thread the prior epoch's closing timestamp into consensus startup, which deserves its own PR.
- The buffer still covers at most 8,191 seconds (about 2 h 16 min) of history; that window is a property of the deployed contract, not of this formula.
- The EIP-2935 blockhashes path (keyed by unique block number) is untouched and remains the indirect proof route for pre-fork history.
- While chain time is ahead of wall clock (sustained sub-second commit cadences only), guards built on `TimestampSec::elapsed()` saturate to zero and pass vacuously (for example the CVV rejoin staleness check in `subscriber.rs`). Production cadences do not sustain that regime and the e2e harness pins the fork dormant, so this stays a documented property rather than a change in observed behavior; tightening those guards for future-dated timestamps deserves its own issue.

## Testing

- `crates/types/src/primary/output.rs` unit tests pin both formula arms case by case (tie, decrease, advance, no-previous, `u64::MAX` saturation) and drive `CommittedSubDag::new` end to end with a tied chained pair, split per build: default-feature builds must bump, adiri builds must keep the legacy tie while dormant. `crates/types/src/forks.rs` pins the gate's rollout contract per build. These run in both CI lanes (default workspace nextest and the adiri feature lane, which builds `tn-types`).
- New engine e2e test `test_same_second_outputs_keep_both_beacon_roots_digests`: executes two chained single-batch outputs whose leaders share one fixed second and asserts BOTH outputs' timestamp and digest slots from the FINAL canonical state. The existing per-block `assert_eip4788` checks read each block's own historical state, where the overwritten digest was still visible, so they could never catch the collision; the final-state read is where it used to land. Deterministic fixed second (no wall clock).
- Gate rollout-contract tests assert against the override-free build decision, and a new `test-utils` test pins the override inert when the variable is unset (both mirroring the seed-signature fork's tests). The `tn-types` suite also runs under `--features test-utils` locally to compile the override arm.
- Updated the pre-existing `tn-primary::it` test `test_monotonically_incremented_commit_timestamps`: it pinned the legacy clamp (a round-4 leader with an older `created_at` commits with a timestamp equal to the previous commit's), which the strict formula deliberately changes to `previous + 1`. The test now derives its expected value from `forks::strict_commit_timestamp_active`, so it pins the correct arm under both CI lanes.
- Mutation-confirmed: reverting the strict arm to the legacy clamp fails the tn-types tests and the engine e2e test; forcing the non-adiri gate dormant fails the gate-contract and end-to-end tests. Sources restored byte-exact afterwards.
- Local static ladder: nightly `fmt --all -- --check`, scoped clippy (`-p tn-types --no-deps --all-features --all-targets`, `-p tn-engine --no-deps` at attest scope, plus nightly passes on `tn-types` default and `--features adiri`), `nextest -p tn-types` (default and `--features adiri`), `nextest -p tn-primary --test it`, the engine test above, plus a multi-lens diff review. The dynamic tier (workspace nextest, nightly workspace clippy, the pinned `+1.94` attest) runs on CI and the second machine per the 2026-08-13 policy.
