### PR TITLE
fix(storage): sync the write-behind remove in test_remove before the read-back

### DIFF
--- a/crates/storage/src/layered_db.rs
+++ b/crates/storage/src/layered_db.rs
@@ -481,6 +481,14 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
         Ok(())
     }
 
+    /// Remove the value for `key`.
+    ///
+    /// The mem-layer delete is visible at once, but the persistent delete runs on the
+    /// background thread and there is no tombstone. Until the queued remove is applied,
+    /// a `get` for the same key can fall through to the persistent layer and still see
+    /// the old value. Callers that remove and then read must call
+    /// [`Database::sync_persist`] (or await [`Database::persist`]) first, as
+    /// [`LayeredDbTxMut::commit`] documents for iteration.
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
         self.mem_db.remove::<T>(key)?;
         let rm = Box::new(KeyRemove::<T> { key: key.clone() });

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -417,6 +417,7 @@ mod test {
         assert!(db.get::<TestTable>(&123456789).expect("Failed to get").is_some());
 
         db.remove::<TestTable>(&123456789).expect("Failed to remove");
+        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
         assert!(db.get::<TestTable>(&123456789).expect("Failed to get").is_none());
     }
 


### PR DESCRIPTION
Closes #1189.

## Problem

`tn-storage layered_db::test::test_layereddb_remove` fails intermittently. Example from a full workspace `nextest` run on `main` (648b6f81):

```
FAIL [   0.104s] tn-storage layered_db::test::test_layereddb_remove
Summary [  37.953s] 1437 tests run: 1436 passed, 1 failed, 26 skipped
```

## Root cause

Three properties of `LayeredDatabase` combine (details and a deterministic reproduction in #1189):

- A bare `Insert` is applied by the background thread and, in cache mode, the value is then evicted from the mem layer.
- A bare `Remove` is a separate queued message. The mem-layer delete is immediate; the persistent delete lags. There is no tombstone.
- `get` falls through to the persistent layer on a mem miss, in every mode.

The shared `test_remove` helper reads back immediately after the remove. When the background thread has already persisted and evicted the insert but has not yet applied the remove, the read falls through and sees the not-yet-deleted key, and the final `is_none` assert fails. The window exists in all four variants (redb/mdbx, `full_memory` true/false). No attacker or load is required; a scheduling coincidence is enough.

## Fix

- [x] `crates/storage/src/lib.rs`: add `db.sync_persist();` between the remove and the final read in `test_remove`, matching the existing pattern in `test_iter` / `test_iter_reverse` ("Either a no-op or a chance for write ops to catch up"). For backends without a background writer the call is a no-op, so the helper stays valid for every `Database` impl it serves.
- [x] `crates/storage/src/layered_db.rs`: document the remove visibility gap on `LayeredDatabase::remove`, pointing callers that remove and then read at `sync_persist` / `persist`, as the `commit` doc already does for iteration.

No production behavior changes; the diff is one test line plus doc comments.

## Testing

- Fail side, before the fix, on `main` (648b6f81): a primed variant of the sequence (`sync_persist` between the insert and the remove, then an immediate read) showed 30/30 removed keys still visible through `get`. A control with a second `sync_persist` after the remove showed 0/30. This pins the mechanism described in #1189.
- With the fix: `cargo nextest run -p tn-storage -E 'test(remove)'` under the pinned 1.94 toolchain, 20 consecutive iterations, 11 tests per iteration (the layered, composite, mem, mdbx, and redb remove variants), 0 failures.
- `cargo +nightly fmt -- --check`: clean.
- `cargo +nightly clippy --locked -p tn-storage --no-deps -- -D warnings` (the CI lane shape, scoped): clean.
- The full workspace lanes (nightly clippy `--all --all-features`, workspace nextest, the adiri feature lane) run in CI on push.
