### PR TITLE
fix(tn-reth): enforce payability in the TEL precompile dispatcher

### DIFF
--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -221,6 +221,21 @@ impl TestEnv {
         calldata: Vec<u8>,
         gas_limit: u64,
     ) -> TestResult {
+        self.exec_value_to(caller, target, calldata, gas_limit, U256::ZERO)
+    }
+
+    /// Execute a transaction targeting `target` with the given gas limit and attached call value.
+    ///
+    /// Automatically increments the caller's nonce. Nonzero `value` exercises the precompile
+    /// dispatcher's payability gate.
+    pub fn exec_value_to(
+        &mut self,
+        caller: Address,
+        target: Address,
+        calldata: Vec<u8>,
+        gas_limit: u64,
+        value: U256,
+    ) -> TestResult {
         let nonce = self.nonces.entry(caller).or_insert(0);
         self.evm.ctx.set_tx(
             TxEnv::builder()
@@ -229,6 +244,7 @@ impl TestEnv {
                 .data(calldata.into())
                 .gas_limit(gas_limit)
                 .nonce(*nonce)
+                .value(value)
                 .build()
                 .unwrap(),
         );
@@ -236,6 +252,19 @@ impl TestEnv {
         // use mainnet handler with default gas to 0 for simpler test logic
         // pipeline tests use TN tools and account for gas usage
         MainnetHandler::default().run(&mut self.evm)
+    }
+
+    /// Execute a precompile call with the given gas limit and attached call value.
+    ///
+    /// [`exec`](Self::exec) with `value` wei attached; targets [`TELCOIN_PRECOMPILE_ADDRESS`].
+    pub fn exec_with_value(
+        &mut self,
+        caller: Address,
+        calldata: Vec<u8>,
+        gas_limit: u64,
+        value: U256,
+    ) -> TestResult {
+        self.exec_value_to(caller, TELCOIN_PRECOMPILE_ADDRESS, calldata, gas_limit, value)
     }
 
     /// Execute a precompile call with the default gas limit (100,000).

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -11,7 +11,10 @@
 //! intercepted and routed to [`telcoin_precompile`] instead of executing bytecode. Bypassing
 //! bytecode execution also bypasses the interpreter's static-call write protection, so
 //! [`telcoin_precompile`] enforces that itself: inside a `STATICCALL` frame it serves the
-//! read-only selectors and refuses every state-mutating one.
+//! read-only selectors and refuses every state-mutating one. Payability follows the same
+//! reasoning: the compiled `CALLVALUE` guard a Solidity dispatcher would run never executes
+//! here, so [`telcoin_precompile`] rejects nonzero call value on every selector except the
+//! explicitly payable `burn(uint256)`.
 //!
 //! # Module structure
 //!
@@ -42,6 +45,10 @@
 //! - **Any account**: can call `totalSupply()` (read-only).
 //! - **Static frames**: regardless of caller, only the read-only selectors (`totalSupply()`, plus
 //!   `hasMintRole` with the faucet feature) are served inside a `STATICCALL`.
+//! - **Call value**: only `burn(uint256)` accepts nonzero value, and only when the precompile is
+//!   the actual transfer target (a plain `CALL`): the attached wei tops up the pool that `burn`
+//!   destroys from, and any excess stays in the pool for later burns. Every other value-bearing
+//!   call is rejected, so `burn` is the single value inlet at [`TELCOIN_PRECOMPILE_ADDRESS`].
 //!
 //! # Feature flags
 //!
@@ -122,6 +129,9 @@ pub fn add_telcoin_precompile(map: &mut PrecompilesMap) {
 /// Rejection emitted when a state-mutating selector is reached inside a `STATICCALL` frame.
 const STATIC_CALL_MUTATION: &str = "static call: state mutation not permitted";
 
+/// Rejection emitted when nonzero call value is attached to a selector not named payable.
+const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
+
 /// Top-level dispatcher for the Telcoin precompile.
 ///
 /// Extracts the 4-byte selector from calldata and routes to the matching handler.
@@ -143,6 +153,30 @@ const STATIC_CALL_MUTATION: &str = "static call: state mutation not permitted";
 /// direction is a refused read rather than an unguarded write. One consequence is that an
 /// unrecognised selector inside a static frame reports [`STATIC_CALL_MUTATION`] rather than
 /// `"Unknown function selector"`; both are [`PrecompileError::Other`] and both revert the frame.
+///
+/// # Payability
+///
+/// The EVM credits attached call value to [`TELCOIN_PRECOMPILE_ADDRESS`] before the precompile
+/// runs, commits the transfer when the call succeeds, and reverts it only when the call errors.
+/// The `CALLVALUE` guard a compiled Solidity dispatcher would run never executes for calls routed
+/// here, so payability, like static-call write protection, is the precompile's own
+/// responsibility. A selector that accepted value it does not account for would strand the wei:
+/// no selector pays balance back out of [`TELCOIN_PRECOMPILE_ADDRESS`], so stray value could only
+/// ever be destroyed by a future governance `burn`, never returned.
+///
+/// [`burnCall`] is the single payable selector. `burn` destroys from the precompile's own
+/// balance, a plain value send reverts on the calldata-length check above, and the genesis
+/// account starts with zero balance, so attaching value to `burn(amount)` is the sanctioned inlet
+/// for the pool it draws from: `msg.value == amount` funds and burns in one transaction, and any
+/// excess stays in the pool for later burns. The classification is a payable-list rather than a
+/// reject-list for the same fail-safe reason as the static gate: a selector added later rejects
+/// value unless it is explicitly named payable, and an unrecognised value-bearing selector
+/// reports [`NON_PAYABLE_CALL_VALUE`] rather than `"Unknown function selector"`. Inside a
+/// `DELEGATECALL` or `CALLCODE` frame [`PrecompileInput::value`] carries the calling frame's
+/// apparent `msg.value` and nothing is transferred to the precompile, so the payable exemption
+/// additionally requires [`PrecompileInput::target_address`] to be the precompile itself:
+/// apparent value never funded the pool, so it cannot authorize a draw from it, and such calls
+/// are rejected like every other value-bearing call.
 fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
     if input.data.len() < 4 {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
@@ -159,6 +193,15 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
     (read_only || !input.is_static)
         .then_some(())
         .ok_or_else(|| PrecompileError::Other(STATIC_CALL_MUTATION.into()))?;
+
+    // Selectors permitted to carry nonzero call value: `burn` alone, and only when the precompile
+    // is the transfer target, so the value has actually landed in the pool the handler draws
+    // from. See "Payability" in the doc comment above.
+    let payable = matches!(selector, burnable::burnCall::SELECTOR)
+        && input.target_address == TELCOIN_PRECOMPILE_ADDRESS;
+    (payable || input.value == U256::ZERO)
+        .then_some(())
+        .ok_or_else(|| PrecompileError::Other(NON_PAYABLE_CALL_VALUE.into()))?;
 
     match selector {
         // State-mutating functions
@@ -201,7 +244,9 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::evm::precompile_test_utils::*;
+    use alloy::sol_types::SolCall;
     use tn_config::GOVERNANCE_SAFE_ADDRESS;
 
     #[test]
@@ -218,5 +263,115 @@ mod tests {
         data.extend_from_slice(&[0u8; 32]);
         let result = env.exec_default(GOVERNANCE_SAFE_ADDRESS, data);
         assert_not_success(&result);
+    }
+
+    #[test]
+    fn test_read_only_selector_rejects_value() {
+        let mut env = TestEnv::new();
+        let pool_before = env.get_balance(TELCOIN_PRECOMPILE_ADDRESS);
+        let user_before = env.get_balance(USER);
+        let result =
+            env.exec_with_value(USER, totalSupplyCall {}.abi_encode(), 100_000, U256::from(1));
+        assert_not_success(&result);
+        // The journaled value transfer is reverted: neither balance moves.
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before);
+        assert_eq!(env.get_balance(USER), user_before);
+        // Positive control: the same call without value succeeds.
+        let result =
+            env.exec_with_value(USER, totalSupplyCall {}.abi_encode(), 100_000, U256::ZERO);
+        assert_success(&result);
+    }
+
+    #[test]
+    #[cfg(not(feature = "faucet"))]
+    fn test_mutating_selector_rejects_value() {
+        let mut env = TestEnv::new();
+        let pool_before = env.get_balance(TELCOIN_PRECOMPILE_ADDRESS);
+        let calldata = mintCall { amount: U256::from(500) }.abi_encode();
+        let result =
+            env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata.clone(), 100_000, U256::from(1));
+        assert_not_success(&result);
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before);
+        // Positive control: the same call without value succeeds.
+        let result = env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata, 100_000, U256::ZERO);
+        assert_success(&result);
+    }
+
+    #[test]
+    fn test_burn_value_funds_pool_and_burns() {
+        // The pool starts empty (mainnet genesis also allocates the account zero balance).
+        let one_tel = U256::from(10).pow(U256::from(18));
+        let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
+        let amount = U256::from(500);
+        let gov_before = env.get_balance(GOVERNANCE_SAFE_ADDRESS);
+        let supply_before = env.get_total_supply();
+        let calldata = burnCall { amount }.abi_encode();
+        // Negative control: with an empty pool and no value, the burn has nothing to destroy.
+        assert_not_success(&env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            calldata.clone(),
+            100_000,
+            U256::ZERO,
+        ));
+        // Attaching `amount` funds the pool and the handler destroys it in the same call.
+        let result = env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata, 100_000, amount);
+        assert_success(&result);
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), U256::ZERO);
+        assert_eq!(env.get_balance(GOVERNANCE_SAFE_ADDRESS), gov_before - amount);
+        assert_eq!(env.get_total_supply(), supply_before - amount);
+    }
+
+    #[test]
+    fn test_burn_excess_value_stays_in_pool() {
+        let one_tel = U256::from(10).pow(U256::from(18));
+        let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
+        let supply_before = env.get_total_supply();
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            burnCall { amount: U256::from(200) }.abi_encode(),
+            100_000,
+            U256::from(500),
+        );
+        assert_success(&result);
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), U256::from(300));
+        // The supply decreases by the burn amount, never by the attached value.
+        assert_eq!(env.get_total_supply(), supply_before - U256::from(200));
+    }
+
+    #[test]
+    fn test_delegatecall_apparent_value_rejects_burn() {
+        // DELEGATECALL relay that propagates failure: copies calldata, delegatecalls the
+        // precompile, and reverts when the inner frame reverts (unlike the flag-popping relay
+        // in the integration tests). The precompile sees the relay frame's apparent
+        // `msg.value`, while no wei moves to the precompile address.
+        const RELAY_CODE: &[u8] = &[
+            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATASIZE PUSH1 0 PUSH1 0 CALLDATACOPY
+            0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // PUSH1 0 PUSH1 0 CALLDATASIZE PUSH1 0
+            0x61, 0x07, 0xe1, 0x5a, 0xf4, // PUSH2 0x07e1 GAS DELEGATECALL
+            0x3d, 0x60, 0x00, 0x60, 0x00,
+            0x3e, // RETURNDATASIZE PUSH1 0 PUSH1 0 RETURNDATACOPY
+            0x15, 0x60, 0x20, 0x57, // ISZERO PUSH1 0x20 JUMPI
+            0x3d, 0x60, 0x00, 0xf3, // RETURNDATASIZE PUSH1 0 RETURN
+            0x5b, 0x3d, 0x60, 0x00, 0xfd, // JUMPDEST RETURNDATASIZE PUSH1 0 REVERT
+        ];
+        const RELAY: Address = address!("4444444000000000000000000000000000000004");
+        let mut env = TestEnv::new();
+        env.deploy_code(RELAY, RELAY_CODE.into());
+        let pool_before = env.get_balance(TELCOIN_PRECOMPILE_ADDRESS);
+        let gov_before = env.get_balance(GOVERNANCE_SAFE_ADDRESS);
+        let amount = U256::from(100);
+        let calldata = burnCall { amount }.abi_encode();
+        // Apparent value never funds the pool, so the payable exemption does not apply.
+        let result =
+            env.exec_value_to(GOVERNANCE_SAFE_ADDRESS, RELAY, calldata.clone(), 200_000, amount);
+        assert_not_success(&result);
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before);
+        assert_eq!(env.get_balance(GOVERNANCE_SAFE_ADDRESS), gov_before);
+        // Positive control: the zero-value delegatecall burn passes the gate and draws from
+        // the pre-funded pool.
+        let result =
+            env.exec_value_to(GOVERNANCE_SAFE_ADDRESS, RELAY, calldata, 200_000, U256::ZERO);
+        assert_success(&result);
+        assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before - amount);
     }
 }


### PR DESCRIPTION
Closes #1190.  (Cantina #21)

## Problem

The dispatcher (`telcoin_precompile`) enforces static-call write protection itself, because the precompile registration bypasses the interpreter's checks. The same reasoning applies to payability, and the dispatcher does not enforce it. No code in the module reads `PrecompileInput::value`. Every selector, including the view `totalSupply()`, accepts a nonzero call value.

The EVM credits the attached value to `0x7e1` before the precompile runs. `revm-handler` journals the caller-to-target transfer before it invokes the precompile, and it commits the transfer when the call succeeds. A successful `totalSupply()` call with attached value therefore both returns the supply and credits `0x7e1`. No selector moves native balance out of `0x7e1`, so the value is stranded. Only a future governance `burn` can destroy it, and no party can recover it. A Solidity contract with the same ABI would revert these calls through its compiled `CALLVALUE` guard.

There is no attacker profit: the sender loses the funds, and nobody can extract them. The harm is an integration footgun. A wallet, a contract, or the governance flow that attaches `msg.value` destroys those funds, where Solidity semantics promise a revert.

## Fix

- [x] `crates/tn-reth/src/evm/tel_precompile/mod.rs`: add a payability gate next to the static gate. The gate rejects nonzero `input.value` for every selector that is not named in a payable list. The rejection errors the frame, so the journal revert returns the value to the caller.
- [x] The payable list holds one selector: `burn(uint256)`. `handle_burn` destroys from the precompile's own balance. A plain value send reverts on the calldata-length check, and the genesis account starts with zero balance. Attached value on `burn(amount)` is therefore the sanctioned inlet for the burn pool: `msg.value == amount` funds and burns in one transaction, and excess value stays in the pool for later burns. The e2e governance forwarder (`pipeline_helpers.rs`) already anticipates this path.
- [x] The payable exemption also requires `input.target_address == TELCOIN_PRECOMPILE_ADDRESS`. Under `DELEGATECALL` or `CALLCODE` the `value` field carries the calling frame's apparent `msg.value` and nothing is transferred to the precompile. Apparent value never funds the pool, so it cannot authorize a draw from it, and such calls are rejected.
- [x] The classification is a payable list, not a reject list. This keeps the fail-safe direction the static gate established: a selector added later rejects value unless it is explicitly named payable, with no attacker required to hit the failure.
- [x] Doc comments: the module doc, the access-control list, and the dispatcher doc gain a payability section. The section records the journal mechanism and the `DELEGATECALL`/`CALLCODE` semantics.
- [x] `crates/tn-reth/src/evm/precompile_test_utils.rs`: add `exec_value_to` and `exec_with_value` to the shared harness. `exec_to` now delegates with `U256::ZERO`, which builds a byte-identical `TxEnv` (the builder default is already zero).

If governance prefers to keep every selector non-payable, the change is one line: replace the `matches!` arm with `false`. Then the only remaining inlet to `0x7e1` is a `SELFDESTRUCT` force-send.

Scope note: the gate is ungated by fork, the same way the static-call gate shipped. A value-bearing call to `0x7e1` that succeeded before this change now reverts. If sealed history on a live chain contains such a call, replay of that history diverges. No in-repo caller sends value to `0x7e1`, so the exposure is limited to third-party transactions already on chain; please confirm none exist or gate the check on a fork if they do.

## Testing

New regression tests in `tel_precompile/mod.rs`, all run with `cargo +1.94 test -p tn-reth --lib tel_precompile -j 2`:

- `test_read_only_selector_rejects_value`: `totalSupply()` with 1 wei attached reverts, and neither balance moves. The same call with zero value succeeds as the positive control.
- `test_mutating_selector_rejects_value`: `mint(uint256)` with 1 wei attached reverts. The same call with zero value succeeds.
- `test_burn_value_funds_pool_and_burns`: the pool starts empty, which mirrors the mainnet genesis alloc. `burn(500)` with zero value fails (negative control). `burn(500)` with 500 wei attached succeeds, the pool returns to zero, the caller pays exactly 500 wei, and `totalSupply` decreases by 500.
- `test_burn_excess_value_stays_in_pool`: `burn(200)` with 500 wei attached succeeds, leaves 300 wei in the pool for later burns, and decreases `totalSupply` by the burn amount (200), never by the attached value.
- `test_delegatecall_apparent_value_rejects_burn`: a failure-propagating `DELEGATECALL` relay forwards `burn(100)` while the transaction attaches 100 wei. The precompile sees apparent value with no transfer, the call reverts, and no balance moves. The zero-value delegatecall burn succeeds as the positive control.

Mutation confirmation, one in-diff mutant per guard clause: with the gate neutralized (`payable || true`) the two reject tests fail. With the payable list emptied (`let payable = false`) the two burn tests fail. With the `target_address` conjunct dropped, the delegatecall test fails. The restored file passes the full `tel_precompile` battery. Static ladder run locally (nightly `fmt --check`, scoped nightly `clippy -p tn-reth --all-features --all-targets --no-deps -D warnings`). CI and the pinned `+1.94` attest own the dynamic tier.
