### PR TITLE
fix(network): gate kad provider capacity check on new keys only

### DIFF
--- a/crates/network-libp2p/src/kad.rs
+++ b/crates/network-libp2p/src/kad.rs
@@ -510,15 +510,6 @@ impl<DB: Database> RecordStore for KadStore<DB> {
     }
 
     fn add_provider(&mut self, record: ProviderRecord) -> libp2p::kad::store::Result<()> {
-        if self.num_providers >= self.config.max_provided_keys {
-            // Try to free a slot by evicting fully-expired provider key groups.
-            self.evict_expired_providers();
-        }
-        // Re-check after the eviction attempt; still full is a hard error.
-        (self.num_providers < self.config.max_provided_keys)
-            .then_some(())
-            .ok_or(Error::MaxProvidedKeys)?;
-
         let key = self.key_to_hash(&record.key);
         let kr: KadProviderRecord = record.into();
         let stored = match self.kad_type {
@@ -533,6 +524,23 @@ impl<DB: Database> RecordStore for KadStore<DB> {
         // genuinely new key it is already counted in `num_providers`, so only a missing
         // row bumps the gauge (issue #999).
         let row_exists = stored.is_some();
+
+        // The capacity check applies only to a brand-new key, mirroring `put`'s
+        // `new_record` gate: an overwrite of an existing, already-counted row cannot
+        // grow the table, so a refresh of a key this node already stores (including
+        // its own self-provide) must succeed even when byzantine peers have
+        // saturated the table with other keys (issue #1195).
+        if !row_exists {
+            if self.num_providers >= self.config.max_provided_keys {
+                // Try to free a slot by evicting fully-expired provider key groups.
+                self.evict_expired_providers();
+            }
+            // Re-check after the eviction attempt; still full is a hard error.
+            (self.num_providers < self.config.max_provided_keys)
+                .then_some(())
+                .ok_or(Error::MaxProvidedKeys)?;
+        }
+
         let merged = stored
             .as_deref()
             .and_then(|raw| decode_providers(&key, raw))
@@ -1084,6 +1092,81 @@ mod test {
         assert!(matches!(kad_store_worker.put(rec.clone()), Err(Error::MaxRecords)));
     }
 
+    // ---- issue #1195: the provider capacity check gates only brand-new keys ----
+
+    /// A refresh of an existing provider key is an overwrite, not a new row: it must
+    /// succeed at capacity and leave the count unchanged, while a brand-new key is
+    /// still rejected. Mirrors `test_kad_put_limit`, which locks the same gating for
+    /// `put`.
+    #[test]
+    fn test_kad_add_provider_refresh_allowed_at_capacity() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+        let mut kad_store =
+            KadStore::new(db.clone(), PeerId::random(), &key_config, NetworkType::Primary);
+        let mut kad_store_worker =
+            KadStore::new(db, PeerId::random(), &key_config, NetworkType::Worker(0));
+        // A small cap keeps the test fast; the gating logic does not depend on the
+        // cap's value.
+        kad_store.config.max_provided_keys = 4;
+        kad_store_worker.config.max_provided_keys = 4;
+
+        // Fill both tables to capacity with distinct live keys, keeping one record
+        // to refresh later.
+        let refresh_rec = live_provider_under(&fresh_record_key());
+        kad_store.add_provider(refresh_rec.clone()).expect("add provider");
+        kad_store_worker.add_provider(refresh_rec.clone()).expect("add provider");
+        (1..4).for_each(|_| {
+            let rec = live_provider_under(&fresh_record_key());
+            kad_store.add_provider(rec.clone()).expect("add provider");
+            kad_store_worker.add_provider(rec).expect("add provider");
+        });
+        assert_eq!(kad_store.num_providers, 4);
+        assert_eq!(kad_store_worker.num_providers, 4);
+
+        // The refresh of an existing key must succeed at capacity (issue #1195: the
+        // node keeps its own provider records live this way).
+        (0..10).for_each(|_| {
+            kad_store.add_provider(refresh_rec.clone()).expect("refresh at capacity");
+            kad_store_worker.add_provider(refresh_rec.clone()).expect("refresh at capacity");
+        });
+        assert_eq!(kad_store.num_providers, 4, "refresh must not change the count");
+        assert_eq!(kad_store_worker.num_providers, 4, "refresh must not change the count");
+
+        // Positive control: a brand-new key is still rejected while full.
+        let new_rec = live_provider_under(&fresh_record_key());
+        assert!(matches!(kad_store.add_provider(new_rec.clone()), Err(Error::MaxProvidedKeys)));
+        assert!(matches!(kad_store_worker.add_provider(new_rec), Err(Error::MaxProvidedKeys)));
+    }
+
+    /// A brand-new key at capacity still triggers the expired-group eviction attempt
+    /// before the hard error: moving the capacity check behind the new-key gate
+    /// (issue #1195) must not lose the eviction. Mirrors
+    /// `test_kad_put_evicts_expired_when_full`.
+    #[test]
+    fn test_kad_add_provider_evicts_expired_when_full() {
+        let tmp_dir = TempDir::new().expect("temp dir");
+        let db = open_db(tmp_dir.path());
+        let key_config = test_key_config();
+        let mut kad_store = KadStore::new(db, PeerId::random(), &key_config, NetworkType::Primary);
+        kad_store.config.max_provided_keys = 4;
+
+        // Saturate the table with already-expired provider groups.
+        (0..4).for_each(|_| {
+            kad_store
+                .add_provider(expired_provider_under(&fresh_record_key()))
+                .expect("add expired provider");
+        });
+        assert_eq!(kad_store.num_providers, 4);
+
+        // A live record under a brand-new key must succeed: eviction makes room.
+        let fresh_key = fresh_record_key();
+        kad_store.add_provider(live_provider_under(&fresh_key)).expect("eviction must make room");
+        assert_eq!(kad_store.num_providers, 1, "only the fresh row should remain");
+        assert_eq!(kad_store.providers(&fresh_key).len(), 1, "fresh provider retained");
+    }
+
     /// Lock the per-role, chain-namespaced wire-protocol names. These strings are a
     /// peer-compatibility contract: a silent change would prevent peers from
     /// negotiating sessions, and the chain id keeps different chains from ever
@@ -1264,6 +1347,13 @@ mod test {
     fn live_provider_under(key: &RecordKey) -> ProviderRecord {
         let provider = PeerId::random();
         let expires = Instant::now().checked_add(Duration::from_secs(60 * 60 * 24));
+        ProviderRecord { key: key.clone(), provider, expires, addresses: vec![] }
+    }
+
+    /// A provider record under `key` whose expiry is already in the past.
+    fn expired_provider_under(key: &RecordKey) -> ProviderRecord {
+        let provider = PeerId::random();
+        let expires = Instant::now().checked_sub(Duration::from_secs(60));
         ProviderRecord { key: key.clone(), provider, expires, addresses: vec![] }
     }
 


### PR DESCRIPTION
Fixes #1195.

## Problem

`add_provider` runs the `max_provided_keys` capacity check before it determines whether the provider key already exists. The sibling `put` path gates its `max_records` check on `new_record` (an update of an existing key is allowed at capacity), but the ordering was not mirrored onto the provider path.

Byzantine peers that fill the provider table with distinct keys within the record TTL need no validator key. Once the table holds `max_provided_keys` entries (1024 by default), every later `add_provider` returns `Err(MaxProvidedKeys)`, including:

- A legitimate refresh of a key the node already provides. The refresh keeps the record live, so the node's own valid provider records can expire.
- The node's own startup self-provide, which has no retry. The node then does not announce itself as a provider for its intended keys.

This is availability griefing of an honest node's own provider records, not a chain halt.

## Root cause

The capacity-check ordering was corrected for `put` and not mirrored onto `add_provider`. The provider path checks capacity before it knows whether the key is new, so it cannot tell a new insertion from a refresh of an existing key.

## Fix

- [x] `crates/network-libp2p/src/kad.rs`: `add_provider` computes the key lookup (`row_exists`) first, then applies the expired-group eviction attempt and the capacity check only when the key is new, inside `if !row_exists { ... }`. This mirrors `put`'s `if new_record { ... }` gate exactly.

The cap itself is unchanged and still binds: an overwrite of an existing, already-counted row cannot grow the table, and a brand-new key at capacity is still rejected after the eviction attempt. The check now gates the same event on both store paths (`put` for records, `add_provider` for provider keys), so the two capacity bounds behave symmetrically.

## Testing

- [x] `test_kad_add_provider_refresh_allowed_at_capacity`: fills the primary and worker tables to a small cap, refreshes an existing key 10 times at capacity (must succeed, count unchanged), then confirms a brand-new key is still rejected with `MaxProvidedKeys` (positive control).
- [x] `test_kad_add_provider_evicts_expired_when_full`: saturates the table with expired provider groups and confirms a brand-new live key still succeeds through the eviction attempt, mirroring `test_kad_put_evicts_expired_when_full`.

Commands run under the pinned toolchain (`cargo +1.94 test -p tn-network-libp2p -- test_kad`, shared target, `-j 2`): 15 passed, 0 failed, including the 13 pre-existing kad store tests.

Each new test was confirmed by mutation against the staged fix:

- Gate reverted to unconditional (`if !row_exists` replaced by `if true`, the pre-fix ordering): `test_kad_add_provider_refresh_allowed_at_capacity` fails (2 passed, 1 failed).
- Capacity check deleted (`if false`): both new tests fail, the refresh test at its new-key rejection control (1 passed, 2 failed).
- Eviction call deleted: `test_kad_add_provider_evicts_expired_when_full` fails (2 passed, 1 failed).

The source was byte-restored after each mutant (verified identical to the staged copy) and the full kad filter re-ran green (15 passed, 0 failed).

Static ladder also green: nightly `fmt --check` clean; in-crate `clippy --no-deps --all-features --all-targets` clean; ctxcat-review over the staged diff returned no findings; an independent logic review confirmed the counter invariant on every provider path and verified against the lockfile-pinned `libp2p-kad 0.48.0` that upstream `MemoryStore::add_provider` applies `max_provided_keys` only to a vacant key, so this change restores parity with the upstream store contract as well as with `put`.
