### PR TITLE
Don't verify the parent hash for consensus block 1- no need and its subject to change.

### DIFF
--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -951,8 +951,9 @@ impl Inner {
         .map_err(OpenError::IndexFileOpen)?;
         let mut parent_digest_expectation = if epoch == 0 {
             // Don't worry about consensus block 1 in epoch 0, if it is invalid other verifications
-            // will fail. This can be set but doing so leaves potential footguns around
-            // and this check is not really useful in this case.
+            // will fail (for instance epoch 0 final state will not verify). This can be set but
+            // doing so forces fork aware code here and verification will fail with an invalid value
+            // either way.
             HeaderExpectation::None
         } else {
             HeaderExpectation::Parent(previous_epoch.final_consensus.hash)

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -949,10 +949,13 @@ impl Inner {
             false,
         )
         .map_err(OpenError::IndexFileOpen)?;
-        let mut parent_digest = if epoch == 0 {
-            ConsensusHeader::default().digest()
+        let mut parent_digest_expectation = if epoch == 0 {
+            // Don't worry about consensus block 1 in epoch 0, if it is invalid other verifications
+            // will fail. This can be set but doing so leaves potential footguns around
+            // and this check is not really useful in this case.
+            HeaderExpectation::None
         } else {
-            previous_epoch.final_consensus.hash
+            HeaderExpectation::Parent(previous_epoch.final_consensus.hash)
         };
         let mut pack =
             Self { data, consensus_pos_idx, consensus_digests, batch_digests, epoch_meta };
@@ -966,7 +969,7 @@ impl Inner {
                     &mut stream_iter,
                     timeout,
                     &pack.epoch_meta.committee,
-                    HeaderExpectation::Parent(parent_digest),
+                    parent_digest_expectation,
                 )
                 .await
                 {
@@ -979,7 +982,7 @@ impl Inner {
                     &mut stream_iter,
                     timeout,
                     &pack.epoch_meta.committee,
-                    HeaderExpectation::Parent(parent_digest),
+                    parent_digest_expectation,
                 )
                 .await
                 {
@@ -995,7 +998,7 @@ impl Inner {
                     final_consensus_number,
                 ));
             }
-            parent_digest = output.digest();
+            parent_digest_expectation = HeaderExpectation::Parent(output.digest());
             pack.save_consensus_output(&output)?;
         }
         Ok(pack)

--- a/crates/storage/src/pack_validate.rs
+++ b/crates/storage/src/pack_validate.rs
@@ -180,6 +180,8 @@ impl PackValidationReport {
 /// [`verify_epoch_meta`] linkage checks run and the first header's `parent_hash` is anchored to the
 /// previous epoch's final consensus header. With no previous record those linkage checks and the
 /// first-header parent check are skipped (everything else still runs).
+/// Note the previous link is NOT checked on block 1 (epoch 0- first block after genesis).
+/// If this value is incorrect then all future linkage checks will fail (chain will be corrupted).
 pub fn validate_pack_file(
     path: &Path,
     epoch: Epoch,
@@ -225,9 +227,10 @@ pub fn validate_pack_file(
     // Expected `parent_hash` of the *next* consensus header. `None` = "no anchor, skip the check":
     // a bare file with no previous record cannot verify its first header's parent.
     let expected_parent: Option<ConsensusHeaderDigest> = if epoch == 0 {
-        // Don't worry about consensus block 1 in epoch 0, if it is invalid other verifications will
-        // fail. This can be set but doing so leaves potential footguns around and this
-        // check is not really useful in this case.
+        // Don't worry about consensus block 1 in epoch 0, if it is invalid other verifications
+        // will fail (for instance epoch 0 final state will not verify). This can be set but
+        // doing so forces fork aware code here and verification will fail with an invalid value
+        // either way.
         None
     } else {
         previous.map(|p| p.final_consensus.hash)

--- a/crates/storage/src/pack_validate.rs
+++ b/crates/storage/src/pack_validate.rs
@@ -225,7 +225,10 @@ pub fn validate_pack_file(
     // Expected `parent_hash` of the *next* consensus header. `None` = "no anchor, skip the check":
     // a bare file with no previous record cannot verify its first header's parent.
     let expected_parent: Option<ConsensusHeaderDigest> = if epoch == 0 {
-        Some(ConsensusHeader::default().digest())
+        // Don't worry about consensus block 1 in epoch 0, if it is invalid other verifications will
+        // fail. This can be set but doing so leaves potential footguns around and this
+        // check is not really useful in this case.
+        None
     } else {
         previous.map(|p| p.final_consensus.hash)
     };


### PR DESCRIPTION
Specifically keeping this check will require a bunch of fork code.  It does not matter since an invalid hash here will cause overall verification to fail so we can safely skip it to keep the verify code simpler in this on tiny edge case.