### PR TITLE
fix(tn-reth): pin the blob gas price in evm_env to match block execution

### DIFF
--- a/crates/tn-reth/README.md
+++ b/crates/tn-reth/README.md
@@ -60,7 +60,11 @@ TN repurposes several Ethereum header fields for protocol data. Assembly happens
   (`set_genesis_defaults` in `tn-types` `genesis.rs`). The chain is post-merge from genesis.
   `TnEvmConfig` (`src/evm/config.rs`) resolves the revm spec from that schedule.
 - **EIP-4844 blob transactions are economically disabled, not fork-disabled.** The block
-  environment prices blob gas at `u128::MAX` (`next_evm_env`), the pool's canonical-state update
+  environment prices blob gas at `u128::MAX` on every path (`TN_BLOB_EXCESS_GAS_AND_PRICE` in
+  `src/evm/config.rs`, shared by `next_evm_env` for block building and execution and by `evm_env`
+  for every header-derived environment: `eth_call`, tracing and block re-execution, so
+  `BLOBBASEFEE` agrees between simulation, re-execution and execution), the pool's canonical-state
+  update
   passes `pending_block_blob_fee = Some(u128::MAX)` (`src/txn_pool.rs`), and the batch builder
   (`crates/batch-builder/src/batch.rs`) marks blob transactions invalid via
   `BestTxns::ignore_eip4844` and purges them and their descendants with

--- a/crates/tn-reth/src/evm/config.rs
+++ b/crates/tn-reth/src/evm/config.rs
@@ -34,6 +34,12 @@
 //! an epoch-closing block there would price every EIP-1559 worker from one empty slot (zero gas,
 //! `MIN_PROTOCOL_BASE_FEE`) and produce a divergent state root, not merely degraded reward
 //! accounting.
+//!
+//! Blob gas is not priced on TN. Both block-environment constructors (`evm_env` for every
+//! header-derived environment: `eth_call`, tracing, the replay-side registry queries and reth's
+//! block re-execution through `executor_for_block`; `next_evm_env` for block building and
+//! execution) pin [`TN_BLOB_EXCESS_GAS_AND_PRICE`] instead of deriving the price from the header,
+//! so `BLOBBASEFEE` reads the same value in simulation, in re-execution and on chain.
 
 use super::{TNBlockAssembler, TNBlockExecutionCtx, TNBlockExecutorFactory, TNEvmFactory};
 use crate::{error::TnRethError, payload::TNPayload, TNPrimitives};
@@ -49,6 +55,20 @@ use std::sync::Arc;
 use tn_types::{
     gas_accumulator::GasAccumulator, BlockHeader as _, SealedBlock, SealedHeader, B256, U256,
 };
+
+/// The blob gas values every TN block environment carries: no excess blob gas and a blob gas
+/// price of `u128::MAX`.
+///
+/// EIP-4844 transactions never reach a TN block (the batch builder skips them, the batch validator
+/// rejects any batch that carries one, and the pool prices them out of the pending set with
+/// `pending_block_blob_fee = Some(u128::MAX)`), so blob gas has no market and the price is pinned
+/// rather than derived from the header. `evm_env` and `next_evm_env` both use this one value:
+/// deriving it in only one place made `BLOBBASEFEE` return `1` in every `evm_env` environment
+/// (`eth_call` / `eth_estimateGas` / tracing, and a block re-executed through
+/// `executor_for_block`) but `u128::MAX` in block building and execution (#1205). Every TN header
+/// carries `excess_blob_gas: Some(0)` (`TNBlockAssembler`), matching `excess_blob_gas` here.
+const TN_BLOB_EXCESS_GAS_AND_PRICE: BlobExcessGasAndPrice =
+    BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: u128::MAX };
 
 /// TN-related EVM configuration.
 #[derive(Debug, Clone)]
@@ -119,15 +139,13 @@ impl ConfigureEvm for TnEvmConfig {
             cfg_env.set_max_blobs_per_tx(blob_params.max_blob_count);
         }
 
-        // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
-        // blobparams
-        let blob_excess_gas_and_price = header
-            .excess_blob_gas
-            .zip(self.chain_spec().blob_params_at_timestamp(header.timestamp))
-            .map(|(excess_blob_gas, params)| {
-                let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
-                BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
-            });
+        // TN does not price blob gas: use the value block execution pins (see
+        // `TN_BLOB_EXCESS_GAS_AND_PRICE`) instead of `params.calc_blob_fee(excess_blob_gas)`,
+        // which is `1` for every TN header and made `BLOBBASEFEE` disagree between `eth_call` and
+        // execution. Keep upstream's `Option` shape: `None` only when the header carries no
+        // `excess_blob_gas` or the timestamp has no blob params (pre-Cancun, which TN never is).
+        let blob_excess_gas_and_price =
+            header.excess_blob_gas.zip(blob_params).map(|_| TN_BLOB_EXCESS_GAS_AND_PRICE);
 
         let block_env = BlockEnv {
             number: U256::from(header.number()),
@@ -175,10 +193,8 @@ impl ConfigureEvm for TnEvmConfig {
             prevrandao: Some(payload.prev_randao()),
             gas_limit: payload.gas_limit,
             basefee: payload.base_fee_per_gas,
-            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: 0,       // no excess gas for blobs
-                blob_gasprice: u128::MAX, // eip4844 transactions are ignored
-            }),
+            // eip4844 transactions are ignored: pinned, and shared with `evm_env`
+            blob_excess_gas_and_price: Some(TN_BLOB_EXCESS_GAS_AND_PRICE),
         };
 
         let evm_env = EvmEnv::new(cfg, block_env);
@@ -243,7 +259,99 @@ impl ConfigureEvm for TnEvmConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tn_types::{Block, Bytes, ExecHeader};
+    use reth_evm::{Evm as _, EvmFactory as _};
+    use reth_revm::{bytecode::Bytecode, context::TxEnv, db::InMemoryDB, state::AccountInfo};
+    use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv as _;
+    use tn_types::{Address, Block, Bytes, ExecHeader, TxKind};
+
+    /// Run `BLOBBASEFEE PUSH0 MSTORE PUSH1 32 PUSH0 RETURN` through the TN EVM under `env`, from
+    /// a funded caller sending a plain (non-blob) call, and decode the returned word.
+    fn blobbasefee_under(config: &TnEvmConfig, env: EvmEnv) -> U256 {
+        let caller = Address::ZERO;
+        let contract = Address::with_last_byte(0xaa);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo::from_balance(U256::from(10u64).pow(U256::from(18u64))),
+        );
+        db.insert_account_info(
+            contract,
+            AccountInfo::from_bytecode(Bytecode::new_raw(Bytes::from_static(&[
+                0x4a, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3,
+            ]))),
+        );
+        // pay exactly the block's base fee so validation passes without touching the env
+        let gas_price = u128::from(env.block_env.basefee);
+        let mut evm = config.evm_factory().create_evm(db, env);
+        let tx = TxEnv {
+            caller,
+            kind: TxKind::Call(contract),
+            gas_limit: 100_000,
+            gas_price,
+            chain_id: None,
+            ..Default::default()
+        };
+        let result = evm.transact(tx).expect("transact").result;
+        assert!(result.is_success(), "BLOBBASEFEE probe did not succeed: {result:?}");
+        U256::from_be_slice(&result.into_output().expect("returned word"))
+    }
+
+    /// The observable form of the invariant: `BLOBBASEFEE` (what a contract reads under
+    /// `eth_call` / `eth_estimateGas` / tracing, which run under `evm_env`) returns the same
+    /// pinned price the block executor's environment (`next_evm_env`) exposes on chain.
+    #[test]
+    fn test_blobbasefee_opcode_reads_pinned_price_under_both_envs() {
+        let chain: Arc<ChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let config = TnEvmConfig::new(chain.clone(), GasAccumulator::default());
+        let genesis = chain.sealed_genesis_header();
+        let read = config.evm_env(&genesis).expect("evm env");
+        let executed = config
+            .next_evm_env(&genesis, &TNPayload::build_pending_env(&genesis))
+            .expect("next evm env");
+        let pinned = U256::from(u128::MAX);
+        assert_eq!(blobbasefee_under(&config, read), pinned, "evm_env (RPC reads)");
+        assert_eq!(blobbasefee_under(&config, executed), pinned, "next_evm_env (execution)");
+    }
+
+    /// `evm_env` (RPC reads, tracing, replay-side registry queries) and `next_evm_env` (block
+    /// building and execution) must carry the same blob gas values, or `BLOBBASEFEE` returns one
+    /// answer in `eth_call` / `eth_estimateGas` and another on chain (#1205).
+    #[test]
+    fn test_evm_env_blob_gasprice_matches_next_evm_env() {
+        let chain: Arc<ChainSpec> = Arc::new(tn_types::test_genesis().into());
+        let config = TnEvmConfig::new(chain.clone(), GasAccumulator::default());
+        // every TN header carries `excess_blob_gas: Some(0)` (see `TNBlockAssembler`); the
+        // genesis header does too because Cancun is active at genesis
+        let genesis = chain.sealed_genesis_header();
+        assert_eq!(genesis.excess_blob_gas, Some(0));
+
+        let executed = config
+            .next_evm_env(&genesis, &TNPayload::build_pending_env(&genesis))
+            .expect("next evm env");
+        let read = config.evm_env(&genesis).expect("evm env");
+
+        assert_eq!(
+            read.block_env.blob_excess_gas_and_price,
+            executed.block_env.blob_excess_gas_and_price,
+        );
+        // the pinned execution value, not the header-derived `calc_blob_fee(0) = 1`
+        assert_eq!(
+            read.block_env.blob_excess_gas_and_price,
+            Some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: u128::MAX }),
+        );
+    }
+
+    /// `evm_env` keeps upstream's `Option` shape: a header without `excess_blob_gas` (the
+    /// pre-Cancun header shape, which TN never produces) still yields no blob gas values rather
+    /// than the pinned ones.
+    #[test]
+    fn test_evm_env_blob_gasprice_none_without_header_excess_blob_gas() {
+        let chain: ChainSpec = tn_types::test_genesis().into();
+        let config = TnEvmConfig::new(Arc::new(chain), GasAccumulator::default());
+        let header = ExecHeader { excess_blob_gas: None, ..Default::default() };
+        let env = config.evm_env(&header).expect("evm env");
+        assert!(env.block_env.blob_excess_gas_and_price.is_none());
+    }
 
     /// Replay-path `extra_data` decode: empty → no epoch close, 32 bytes → the closing-epoch
     /// digest, anything else → an error rather than a `B256::from_slice` panic.


### PR DESCRIPTION
Closes #1205.  (Cantina #8)

## Problem

`TnEvmConfig` builds the EVM block environment in two places, and they disagreed on the EIP-4844 blob gas price:

- `next_evm_env` (block building and execution, `eth_simulateV1`) pins `BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: u128::MAX }`.
- `evm_env(header)` (every header-derived environment: `eth_call`, `eth_estimateGas`, `eth_createAccessList`, `debug_trace*`, `trace_*` at `latest`, historical and `pending`; the replay-side read-only registry queries in `env/epoch.rs`; and reth's block re-execution through `executor_for_block`, e.g. `debug_executionWitness` and the test executor) derived the price from the header: `blob_params.calc_blob_fee(header.excess_blob_gas)`.

Every TN header carries `excess_blob_gas: Some(0)` and Cancun/Prague are active at timestamp 0, so the derived value is always `calc_blob_fee(0) = 1`. `BLOBBASEFEE` (`block.blobbasefee`) therefore returned `1` in simulation and re-execution but `u128::MAX` on chain. A contract that branches on it can pass `eth_call` / `eth_estimateGas` and behave differently in the block, a block that runs such a contract re-executes to a different state root than the one the builder produced, and a hand-built type-3 request passed the `BlobGasPriceGreaterThanMax` check in `eth_call` but failed it in execution and `eth_simulateV1`.

Not consensus-critical: every canonical execution, including replay and catch-up, goes through the payload builder and therefore `next_evm_env`; the `evm_env` re-execution path is ad hoc (`debug_executionWitness`, tests). None of the TN-owned contracts (`ConsensusRegistry`, `WorkerConfigs`) that the replay-side `evm_env` reads touch reads `block.blobbasefee`. No fund is at risk. Reported by Haxatron in the Cantina collaborative review.

## Root cause

Both constructors landed together in #889. `next_evm_env` carries the deliberate TN deviation (blob gas is not priced because blob transactions never reach a block), while `evm_env` kept upstream reth's header-derived computation. Two copies of one policy, only one of them updated.

## Fix

Keep the execution semantics (`u128::MAX`) and make `evm_env` agree, through one shared constant so the two cannot drift again:

- `TN_BLOB_EXCESS_GAS_AND_PRICE` (private `const` in `crates/tn-reth/src/evm/config.rs`, documented) holds `{ excess_blob_gas: 0, blob_gasprice: u128::MAX }`.
- `next_evm_env` uses `Some(TN_BLOB_EXCESS_GAS_AND_PRICE)` (same value as before, no behavior change on chain).
- `evm_env` uses `header.excess_blob_gas.zip(blob_params).map(|_| TN_BLOB_EXCESS_GAS_AND_PRICE)`: upstream's `Option` shape is preserved (`None` only for a header without `excess_blob_gas` or a timestamp without blob params, which TN never produces), only the value changes. `blob_params` is the value already computed for `max_blobs_per_tx`, so the fork lookup is not repeated.

The reverse (deriving the price from the header in `next_evm_env`) would change what `BLOBBASEFEE` returns on chain, i.e. an execution-semantics change, so it is not done.

Intended RPC behavior change: `BLOBBASEFEE` now reads `u128::MAX` in `eth_call` / `eth_estimateGas` / `eth_createAccessList` / `debug_trace*` / `trace_*`, matching execution and `eth_simulateV1`. A hand-built type-3 request to those endpoints now fails `BlobGasPriceGreaterThanMax` unless it sets `maxFeePerBlobGas` to `u128::MAX`, exactly as it already did in execution. Non-blob transactions (types 0, 1, 2, 4) are unaffected: revm reads `blob_gasprice` only for `BLOBBASEFEE` and for the EIP-4844 fee-cap check and blob-fee deduction, which are gated on the transaction type.

revm's only other reader of `blob_gasprice` for a non-blob transaction is `calculate_caller_fee`, whose blob term is gated on `TransactionType::Eip4844` and uses saturating / checked arithmetic, so `u128::MAX` cannot overflow or panic there. reth's default local pending-block builder does narrow the block env's `blob_gasprice` to `u64`, but TN configures `PendingBlockKind::None` and serves a real pending block (`env/rpc.rs`), so that path is not reached (and it was already fed `next_evm_env`'s `u128::MAX`).

Out of scope (separate, cosmetic decision): `eth_blobBaseFee` still returns `1` because reth computes it from the header, not from the EVM env. The pool's `pending_block_blob_fee = Some(u128::MAX)` (`txn_pool.rs`, batch builder) already agrees with the pinned value and is untouched. Pool admission itself is not gated on blob transactions until #1169 lands; today the pool prices them out of the pending set and the batch builder / validator keep them out of blocks, which is what the new constant's doc comment says.

## Changes

- [x] `crates/tn-reth/src/evm/config.rs`: new documented `TN_BLOB_EXCESS_GAS_AND_PRICE` constant; `evm_env` and `next_evm_env` both use it; module doc gains a "blob gas is not priced on TN" paragraph.
- [x] `crates/tn-reth/src/evm/config.rs` tests (3 new):
  - `test_evm_env_blob_gasprice_matches_next_evm_env` builds the execution env from the genesis header plus `TNPayload::build_pending_env` and asserts `evm_env(genesis)` carries the same `blob_excess_gas_and_price`, and that it is the pinned `{ 0, u128::MAX }` (fails on `main` with `blob_gasprice: 1`).
  - `test_blobbasefee_opcode_reads_pinned_price_under_both_envs` is the observable form: it runs `BLOBBASEFEE PUSH0 MSTORE PUSH1 32 PUSH0 RETURN` through the real TN EVM (`TNEvmFactory::create_evm` on an `InMemoryDB`, plain non-blob call) under the `evm_env` environment and under the `next_evm_env` environment and asserts both return `u128::MAX` (on `main` the `evm_env` run returns `1`).
  - `test_evm_env_blob_gasprice_none_without_header_excess_blob_gas` pins the preserved `Option` shape.
- [x] `crates/tn-reth/README.md`: the "Fork and EVM configuration" bullet names the shared constant and states that `BLOBBASEFEE` agrees between simulation, re-execution and execution.

## Testing

Local checks under the pinned toolchains:

- `cargo +nightly fmt --all -- --check`: clean.
- `cargo +nightly clippy -p tn-reth --all-features --all-targets --no-deps -j 2 -- -D warnings`: clean.
- `cargo +1.94 test -p tn-reth --lib evm::config::tests -j 2`: 4 passed (3 new + the existing `extra_data` test).
- Mutation confirmation of the new tests (mutate, run, byte-restore): restoring the header-derived price in `evm_env` fails the parity test and the opcode test; pricing the shared constant at `1` fails both as well; making `evm_env` unconditionally `Some` fails the `Option`-shape test.

Dynamic tier: GitHub CI (`nextest --workspace`, workspace clippy, adiri lane) runs on push; `make attest` (pinned 1.94, workspace test build) is run separately.
