### PR TITLE
fix(tn-reth): refuse DELEGATECALL/CALLCODE frames in the TEL precompile dispatcher

### DIFF
--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -2,7 +2,7 @@
 
 This directory implements a **native token-issuance precompile** for the Telcoin (TEL) token. The precompile owns the on-chain mint/claim/burn lifecycle and exposes a single read-only view (`totalSupply`). It does **not** expose an ERC-20 transfer/approve/permit surface — those flows live in user-space contracts and rely on native value transfers, which are equivalent to ERC-20 transfers because TEL balances are native account balances.
 
-The precompile is registered as a `DynPrecompile` inside reth's `PrecompilesMap` at address `0x00000000000000000000000000000000000007e1`. Any `CALL` or `STATICCALL` targeting this address is intercepted by the dispatcher in `mod.rs`, which routes on the 4-byte function selector. Routing is not unconditional for a `STATICCALL`: only the read-only selectors are served in a static frame — `totalSupply`, plus `hasMintRole` under the `faucet` feature — and every state-mutating selector is refused before dispatch. See "`STATICCALL` write protection" under Security considerations.
+The precompile is registered as a `DynPrecompile` inside reth's `PrecompilesMap` at address `0x00000000000000000000000000000000000007e1`. Every call frame whose code address is `0x7e1` is intercepted by the dispatcher in `mod.rs`. revm keys that lookup on the frame's `bytecode_address` alone, so `DELEGATECALL` and `CALLCODE` frames arrive there too; the dispatcher refuses those before doing anything else and serves only a direct `CALL` or `STATICCALL`, on which it routes on the 4-byte function selector (see "Direct-call guard" under Security considerations). Routing is not unconditional for a `STATICCALL`: only the read-only selectors are served in a static frame — `totalSupply`, plus `hasMintRole` under the `faucet` feature — and every state-mutating selector is refused before dispatch. See "`STATICCALL` write protection" under Security considerations.
 
 ## Module map
 
@@ -70,6 +70,7 @@ No pending state, no timelock. Mint roles can be granted/revoked by governance.
 | `grantMintRole` / `revokeMintRole` | Governance only (faucet feature)                   |
 | `hasMintRole` / `totalSupply`      | Any account (read-only)                            |
 | Any selector inside a `STATICCALL` | Read-only only — `totalSupply` (plus `hasMintRole` under `faucet`); mutating selectors refused regardless of caller |
+| Any selector via `DELEGATECALL` / `CALLCODE` | Refused before dispatch, regardless of caller and selector; only a direct `CALL`/`STATICCALL` to `0x7e1` reaches a handler |
 
 Governance is identified by `GOVERNANCE_SAFE_ADDRESS` from `tn-config`.
 
@@ -87,9 +88,18 @@ The rationale is that none of those selectors needed to live at the protocol lev
 
 Shrinking the surface to issuance-only is the actual reason for the deletion; the resulting protocol is simpler and exposes less authority than a full ERC-20 implementation would.
 
-### `DELEGATECALL` semantics under revm
+### Direct-call guard (`DELEGATECALL` / `CALLCODE`)
 
-For completeness: a contract that `DELEGATECALL`s into `0x7e1` runs the precompile's logic, but every `SSTORE` the precompile performs targets the literal address argument it passes — `TELCOIN_PRECOMPILE_ADDRESS` — not the calling contract's storage. The precompile dispatcher routes through `EvmInternals::sstore(TELCOIN_PRECOMPILE_ADDRESS, …)`, and revm's journaled state writes to the address argument verbatim with no `DELEGATECALL`-aware rewrite. A regression test in `crates/tn-reth/tests/it/tel_precompile_props.rs` (`test_delegatecall_writes_target_precompile_storage`) pins this behaviour against future revm upgrades.
+revm dispatches a precompile by the frame's `bytecode_address` alone (`PrecompilesMap::get(&inputs.bytecode_address)`), with no check on the call scheme, so a contract that `DELEGATECALL`s or `CALLCODE`s into `0x7e1` runs the dispatcher just as a `CALL` does. Two things make that frame shape unsafe to serve:
+
+- **The `caller` is not the contract in front of the precompile.** `DELEGATECALL` preserves the parent frame's `msg.sender`, so a contract `A` that governance chose to `CALL` presents `caller == GOVERNANCE_SAFE_ADDRESS` when it delegates into `0x7e1`, and every governance gate passes. (`CALLCODE` presents `A` itself as the caller, so it spoofs nothing on its own, but it is the same indirect frame shape and is refused for the same reason.)
+- **The storage does not follow `DELEGATECALL` semantics.** Every handler passes the literal `TELCOIN_PRECOMPILE_ADDRESS` to `EvmInternals::sstore` / `sload` and the balance helpers, and revm's journaled state writes to that address verbatim with no `DELEGATECALL`-aware rewrite. An indirect frame therefore acts on the **canonical** `0x7e1` ledger, not on the delegating contract's storage as it would against ordinary bytecode.
+
+On mainnet the combination is latent rather than live: `mint` hardcodes governance as the recipient and `claim` reverts on an empty pending slot, so a spoofed governance caller cannot direct funds to itself, and presenting a governance `caller` at all requires governance to execute the transaction (at which point a direct call to `0x7e1` is equally available to it). Under the `faucet` feature it is live: `mint(address, uint256)` credits a calldata-chosen recipient, so any contract a mint-role holder chose to `CALL` could mint to an address of its choosing. Either way the authorization gates were trusting a spoofable identity.
+
+The dispatcher therefore refuses every frame that is not a direct call, as its first check and ahead of selector dispatch: `PrecompileInput::is_direct_call()` (`target_address == bytecode_address`) holds for a direct `CALL`/`STATICCALL`, which set both to `0x7e1`, and fails for `DELEGATECALL`/`CALLCODE`, which keep the calling contract's own address as `target_address`. Read-only selectors are refused too; an indirect frame has no legitimate use of this precompile.
+
+Regression tests reach the precompile through the `DELEGATECALL` and `CALLCODE` relays in `crates/tn-reth/tests/it/precompile_relays.rs`: `test_delegatecall_cannot_reach_precompile`, `test_delegatecall_refuses_read_only_selectors_too` and `test_callcode_cannot_reach_precompile` (mainnet, in `tel_precompile_props.rs`), and `test_delegatecall_cannot_mint_faucet` and `test_callcode_cannot_mint_faucet` (`faucet`, in `tel_precompile_faucet_props.rs`). The `CALL` and `STATICCALL` positive controls in the static-call tests below prove the guard leaves direct calls untouched.
 
 ### `STATICCALL` write protection
 

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -7,11 +7,15 @@
 //! precompile.
 //!
 //! The precompile is registered as a [`DynPrecompile`] inside a [`PrecompilesMap`] at
-//! [`TELCOIN_PRECOMPILE_ADDRESS`] (`0x7e1`). Any `CALL`/`STATICCALL` targeting that address is
-//! intercepted and routed to [`telcoin_precompile`] instead of executing bytecode. Bypassing
-//! bytecode execution also bypasses the interpreter's static-call write protection, so
-//! [`telcoin_precompile`] enforces that itself: inside a `STATICCALL` frame it serves the
-//! read-only selectors and refuses every state-mutating one.
+//! [`TELCOIN_PRECOMPILE_ADDRESS`] (`0x7e1`). Every call frame whose code address is `0x7e1` is
+//! intercepted and routed to [`telcoin_precompile`] instead of executing bytecode. revm keys that
+//! lookup on the frame's `bytecode_address` alone, so `DELEGATECALL` and `CALLCODE` frames reach
+//! the dispatcher as well as `CALL`/`STATICCALL`. Bypassing bytecode execution leaves two frame
+//! properties for [`telcoin_precompile`] to enforce itself. It refuses any frame that did not
+//! reach `0x7e1` by a direct call: under `DELEGATECALL` the `caller` it would authorize is
+//! inherited from the parent frame, while every handler still writes the canonical `0x7e1`
+//! ledger. And inside a `STATICCALL` frame it serves the read-only selectors and refuses every
+//! state-mutating one.
 //!
 //! # Module structure
 //!
@@ -42,6 +46,8 @@
 //! - **Any account**: can call `totalSupply()` (read-only).
 //! - **Static frames**: regardless of caller, only the read-only selectors (`totalSupply()`, plus
 //!   `hasMintRole` with the faucet feature) are served inside a `STATICCALL`.
+//! - **Indirect frames**: regardless of caller and selector, a `DELEGATECALL` or `CALLCODE` into
+//!   `0x7e1` is refused before dispatch. Only a direct `CALL`/`STATICCALL` reaches a handler.
 //!
 //! # Feature flags
 //!
@@ -122,9 +128,29 @@ pub fn add_telcoin_precompile(map: &mut PrecompilesMap) {
 /// Rejection emitted when a state-mutating selector is reached inside a `STATICCALL` frame.
 const STATIC_CALL_MUTATION: &str = "static call: state mutation not permitted";
 
+/// Rejection emitted when the precompile is entered through `DELEGATECALL` or `CALLCODE` rather
+/// than by a direct call to its own address.
+const INDIRECT_ENTRY: &str = "telcoin precompile: only a direct call to 0x7e1 is permitted";
+
 /// Top-level dispatcher for the Telcoin precompile.
 ///
 /// Extracts the 4-byte selector from calldata and routes to the matching handler.
+///
+/// # Direct-call guard
+///
+/// revm looks a precompile up by the frame's `bytecode_address` alone, so a `DELEGATECALL` or
+/// `CALLCODE` whose code address is `0x7e1` lands here exactly like a plain `CALL`. Under
+/// `DELEGATECALL` the frame's `caller` is inherited from the parent frame: a contract that
+/// governance chose to `CALL`, delegating into `0x7e1`, presents `caller ==
+/// GOVERNANCE_SAFE_ADDRESS`. Every handler below reads and writes the canonical `0x7e1` ledger,
+/// never the delegating contract's storage, so the authorization gates would be trusting a
+/// spoofable identity. The first check therefore refuses any frame that is not a direct call,
+/// through [`PrecompileInput::is_direct_call`] (`target_address == bytecode_address`): a direct
+/// `CALL`/`STATICCALL` sets both to `0x7e1`, whereas `DELEGATECALL`/`CALLCODE` keep the calling
+/// contract's own address as `target_address`. It runs ahead of the calldata length check and of
+/// selector dispatch, so it covers the read-only selectors too: an indirect frame has no legitimate
+/// use of this precompile, and refusing it whole is cheaper to reason about than a per-selector
+/// exemption.
 ///
 /// # Static-call write protection
 ///
@@ -144,6 +170,12 @@ const STATIC_CALL_MUTATION: &str = "static call: state mutation not permitted";
 /// unrecognised selector inside a static frame reports [`STATIC_CALL_MUTATION`] rather than
 /// `"Unknown function selector"`; both are [`PrecompileError::Other`] and both revert the frame.
 fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
+    // Refuse DELEGATECALL/CALLCODE before anything else. See "Direct-call guard" above.
+    input
+        .is_direct_call()
+        .then_some(())
+        .ok_or_else(|| PrecompileError::Other(INDIRECT_ENTRY.into()))?;
+
     if input.data.len() < 4 {
         return Err(PrecompileError::Other("Invalid input: too short".into()));
     }

--- a/crates/tn-reth/tests/it/precompile_relays.rs
+++ b/crates/tn-reth/tests/it/precompile_relays.rs
@@ -1,16 +1,20 @@
 //! Hand-assembled relay contracts for reaching the TEL precompile from a nested call frame.
 //!
-//! A top-level transaction frame is never static and `TxEnv` carries no `is_static` to set, so a
-//! `STATICCALL` into `0x7e1` can only be expressed by routing through deployed bytecode. These
+//! A top-level transaction frame is always a plain call: `TxEnv` carries no `is_static` to set and
+//! no way to make `target_address` differ from the code address, so a `STATICCALL`, `DELEGATECALL`
+//! or `CALLCODE` into `0x7e1` can only be expressed by routing through deployed bytecode. These
 //! relays are shared by the mainnet and `faucet` precompile test modules so the two builds exercise
 //! byte-identical call paths.
 //!
-//! Both relays end by storing the inner call's success flag at memory word 0 and returning it, so a
-//! test can tell "the precompile accepted this" from "the precompile refused it". The
-//! `DELEGATECALL` relay in `tel_precompile_props.rs` instead `POP`s that flag and forwards the
-//! precompile's returndata, which cannot express this distinction: an accepted mutation and a
+//! Every relay ends by storing the inner call's success flag at memory word 0 and returning it, so
+//! a test can tell "the precompile accepted this" from "the precompile refused it". Forwarding the
+//! precompile's returndata instead cannot express that distinction: an accepted mutation and a
 //! refused one both return empty bytes, and the outer transaction succeeds either way because the
 //! relay always `RETURN`s.
+//!
+//! The four relays differ only in the call opcode (and in the `value` operand that `CALL` and
+//! `CALLCODE` take and `STATICCALL` and `DELEGATECALL` do not), so a difference in outcome between
+//! two of them is attributable to the call scheme alone.
 //!
 //! # Hosting address
 //!
@@ -19,6 +23,12 @@
 //! static guard exists, which would make a write-protection test pass vacuously. Deploy these at an
 //! address the precompile already trusts and drive the outer transaction from a different sender,
 //! since revm rejects a transaction whose sender has code (EIP-3607).
+//!
+//! `DELEGATECALL` is the opposite case: it preserves the parent frame's `msg.sender`, so the
+//! `DELEGATECALL` relay is hosted at a fresh address and driven from the trusted sender directly.
+//! That is what puts a genuine governance `caller` in front of the precompile together with a
+//! `target_address` that is not `0x7e1`. `CALLCODE` behaves like `STATICCALL` here (the relay
+//! itself is the `caller`), so its relay is hosted at the trusted address.
 
 /// Runtime bytecode forwarding calldata to `0x7e1` with `CALL`, returning the inner success flag.
 ///
@@ -60,6 +70,53 @@ pub(crate) const STATICCALL_RELAY_BYTECODE: &[u8] = &[
     0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
     0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // retSize, retOffset, argsSize, argsOffset
     0x61, 0x07, 0xe1, 0x5a, 0xfa, // PUSH2 0x07e1; GAS; STATICCALL
+    0x60, 0x00, 0x52, // MSTORE(0, success)
+    0x60, 0x20, 0x60, 0x00, 0xf3, // RETURN(0, 32)
+];
+
+/// Runtime bytecode forwarding calldata to `0x7e1` with `DELEGATECALL`, returning the success flag.
+///
+/// Identical to [`STATICCALL_RELAY_BYTECODE`] but for `0xf4` in place of `0xfa`: `DELEGATECALL`
+/// takes the same six operands. The inner frame keeps this relay's own address as `target_address`
+/// and inherits the relay's caller as `caller`, which is exactly the frame shape the dispatcher's
+/// direct-call guard must refuse.
+///
+/// Disassembly:
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize, argsOffset
+///   PUSH2 0x07e1; GAS; DELEGATECALL                // address, gas
+///   PUSH1 0; MSTORE                                // mem[0..32] = success flag
+///   PUSH1 32; PUSH1 0; RETURN                      // return that word
+/// ```
+pub(crate) const DELEGATECALL_RELAY_BYTECODE: &[u8] = &[
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // retSize, retOffset, argsSize, argsOffset
+    0x61, 0x07, 0xe1, 0x5a, 0xf4, // PUSH2 0x07e1; GAS; DELEGATECALL
+    0x60, 0x00, 0x52, // MSTORE(0, success)
+    0x60, 0x20, 0x60, 0x00, 0xf3, // RETURN(0, 32)
+];
+
+/// Runtime bytecode forwarding calldata to `0x7e1` with `CALLCODE`, returning the success flag.
+///
+/// Identical to [`CALL_RELAY_BYTECODE`] but for `0xf2` in place of `0xf1`: `CALLCODE` takes the
+/// same seven operands, `value` included. The inner frame keeps this relay's own address as
+/// `target_address` (with the relay itself as `caller`), the other indirect frame shape the
+/// direct-call guard must refuse.
+///
+/// Disassembly:
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize, argsOffset
+///   PUSH1 0; PUSH2 0x07e1; GAS; CALLCODE           // value, address, gas
+///   PUSH1 0; MSTORE                                // mem[0..32] = success flag
+///   PUSH1 32; PUSH1 0; RETURN                      // return that word
+/// ```
+pub(crate) const CALLCODE_RELAY_BYTECODE: &[u8] = &[
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, // retSize, retOffset, argsSize, argsOffset
+    0x60, 0x00, // value = 0
+    0x61, 0x07, 0xe1, 0x5a, 0xf2, // PUSH2 0x07e1; GAS; CALLCODE
     0x60, 0x00, 0x52, // MSTORE(0, success)
     0x60, 0x20, 0x60, 0x00, 0xf3, // RETURN(0, 32)
 ];

--- a/crates/tn-reth/tests/it/tel_precompile_faucet_props.rs
+++ b/crates/tn-reth/tests/it/tel_precompile_faucet_props.rs
@@ -5,7 +5,10 @@
 //! - Mint role grant/revoke semantics
 //! - Supply accounting with faucet mints
 
-use crate::precompile_relays::{CALL_RELAY_BYTECODE, STATICCALL_RELAY_BYTECODE};
+use crate::precompile_relays::{
+    CALLCODE_RELAY_BYTECODE, CALL_RELAY_BYTECODE, DELEGATECALL_RELAY_BYTECODE,
+    STATICCALL_RELAY_BYTECODE,
+};
 use alloy::sol_types::SolCall;
 use proptest::prelude::*;
 use reth_revm::primitives::{address, Address};
@@ -21,6 +24,13 @@ use tn_reth::{
 use tn_types::{Bytes, U256};
 
 const FAUCET: Address = address!("0000000000000000000000000000000000000F00");
+
+/// Address hosting the `DELEGATECALL` relay in [`test_delegatecall_cannot_mint_faucet`].
+///
+/// A fresh address, unlike the `STATICCALL` relays: `DELEGATECALL` preserves the parent frame's
+/// `msg.sender`, so driving this relay from [`GOVERNANCE`] is what presents `caller == GOVERNANCE`
+/// to the precompile together with `target_address == RELAY`.
+const RELAY: Address = address!("dddd0000000000000000000000000000000000d1");
 
 fn new_faucet_env() -> TestEnv {
     let mut env = TestEnv::new();
@@ -248,4 +258,61 @@ fn test_staticcall_still_serves_has_mint_role() {
         env.exec_to(USER, GOVERNANCE, hasMintRoleCall { addr: FAUCET }.abi_encode(), 200_000);
     assert_success(&result);
     assert!(decode_bool(&result), "hasMintRole must remain callable under STATICCALL");
+}
+
+/// A `DELEGATECALL` into `0x7e1` is refused before dispatch, and mints nothing.
+///
+/// This is the build where the direct-call guard closes a live path rather than a latent one. The
+/// faucet `mint(address, uint256)` credits a calldata-chosen recipient, so without the guard any
+/// contract that a mint-role holder chose to `CALL` could `DELEGATECALL` into `0x7e1` with the
+/// role holder's identity inherited as `caller` and mint to an address of its own choosing. The
+/// mainnet counterparts of this test live in `tel_precompile_props.rs`, which `main.rs` compiles
+/// only under `#[cfg(not(feature = "faucet"))]`.
+///
+/// The relay is hosted at [`RELAY`] and driven by [`GOVERNANCE`], which always holds the mint
+/// role. The positive control (a `CALL` relay frame with a governance caller is accepted) is the
+/// first half of [`test_staticcall_cannot_grant_mint_role`].
+#[test]
+fn test_delegatecall_cannot_mint_faucet() {
+    let mut env = new_faucet_env();
+    let recipient_before = env.get_balance(RECIPIENT);
+    let supply_before = env.get_total_supply();
+    env.deploy_code(RELAY, Bytes::from_static(DELEGATECALL_RELAY_BYTECODE));
+
+    let result = env.exec_to(
+        GOVERNANCE,
+        RELAY,
+        mintCall { recipient: RECIPIENT, amount: U256::from(1234) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&result);
+    assert!(!decode_bool(&result), "DELEGATECALL into the faucet mint must be refused");
+    assert_eq!(env.get_balance(RECIPIENT), recipient_before, "recipient must not be credited");
+    assert_eq!(env.get_total_supply(), supply_before, "totalSupply must be unchanged");
+}
+
+/// A `CALLCODE` into `0x7e1` is refused before dispatch, and mints nothing.
+///
+/// `CALLCODE` presents the calling contract itself as `caller`, so the relay is hosted **at**
+/// [`GOVERNANCE`] (as the `STATICCALL` relays are) and driven by [`USER`]: the inner frame then has
+/// a genuine governance `caller` and `target_address == GOVERNANCE`, and is refused all the same.
+/// The `CALL` relay at the same address is accepted in [`test_staticcall_cannot_grant_mint_role`],
+/// so the opcode is the only variable.
+#[test]
+fn test_callcode_cannot_mint_faucet() {
+    let mut env = new_faucet_env();
+    let recipient_before = env.get_balance(RECIPIENT);
+    let supply_before = env.get_total_supply();
+    env.deploy_code(GOVERNANCE, Bytes::from_static(CALLCODE_RELAY_BYTECODE));
+
+    let result = env.exec_to(
+        USER,
+        GOVERNANCE,
+        mintCall { recipient: RECIPIENT, amount: U256::from(1234) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&result);
+    assert!(!decode_bool(&result), "CALLCODE into the faucet mint must be refused");
+    assert_eq!(env.get_balance(RECIPIENT), recipient_before, "recipient must not be credited");
+    assert_eq!(env.get_total_supply(), supply_before, "totalSupply must be unchanged");
 }

--- a/crates/tn-reth/tests/it/tel_precompile_props.rs
+++ b/crates/tn-reth/tests/it/tel_precompile_props.rs
@@ -341,84 +341,13 @@ fn test_removed_selectors_are_rejected() {
 }
 
 // ==============================
-// `DELEGATECALL` storage-target regression
-// ==============================
-
-/// Address used to host the `DELEGATECALL` relay contract in
-/// [`test_delegatecall_writes_target_precompile_storage`].
-const RELAY_ADDR: Address = address!("dddd0000000000000000000000000000000000d1");
-
-/// Hand-assembled minimal runtime bytecode for a `DELEGATECALL` relay.
-///
-/// Forwards calldata to `0x7e1` via `DELEGATECALL` and returns whatever the
-/// precompile returned. Used to verify revm's storage-target semantics.
-///
-/// Disassembly:
-/// ```text
-///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY     // mem[0..csize] = calldata
-///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;          // retSize, retOffset, argsSize, argsOffset
-///   PUSH2 0x07e1; GAS; DELEGATECALL; POP              // delegatecall to TEL precompile
-///   RETURNDATASIZE; PUSH1 0; PUSH1 0; RETURNDATACOPY  // mem[0..rsize] = returndata
-///   RETURNDATASIZE; PUSH1 0; RETURN                   // return mem[0..rsize]
-/// ```
-const RELAY_BYTECODE: &[u8] = &[
-    0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
-    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x61, 0x07, 0xe1, 0x5a, 0xf4,
-    0x50, // DELEGATECALL
-    0x3d, 0x60, 0x00, 0x60, 0x00, 0x3e, // RETURNDATACOPY(0, 0, RETURNDATASIZE)
-    0x3d, 0x60, 0x00, 0xf3, // RETURN(0, RETURNDATASIZE)
-];
-
-/// Lock in revm's `DELEGATECALL`-into-precompile semantics: every `SSTORE` the
-/// precompile performs targets the literal `TELCOIN_PRECOMPILE_ADDRESS` it passes
-/// to `EvmInternals::sstore`, **not** the calling contract's storage.
-///
-/// A future revm upgrade that quietly changed this would silently invalidate the
-/// security rationale documented in `README.md`. This test fails in CI if that
-/// happens.
-///
-/// Test plan (mainnet feature only — exercises `mint` which writes the pending
-/// amount slot under `keccak256(governance, 0)`):
-/// 1. Deploy a relay contract that `DELEGATECALL`s `0x7e1` with the inbound calldata.
-/// 2. Send `mint(1234)` from `GOVERNANCE_SAFE_ADDRESS` to the relay. Because `msg.sender` is
-///    preserved across `DELEGATECALL`, the precompile's governance check passes inside the relay
-///    frame.
-/// 3. Assert the pending-mint slot under `TELCOIN_PRECOMPILE_ADDRESS` holds `1234`.
-/// 4. Assert the same slot under `RELAY_ADDR` is **untouched** (zero) — the `SSTORE` did not bleed
-///    into the caller's storage.
-#[test]
-#[cfg(not(feature = "faucet"))]
-fn test_delegatecall_writes_target_precompile_storage() {
-    let mut env = TestEnv::new();
-    env.deploy_code(RELAY_ADDR, Bytes::from_static(RELAY_BYTECODE));
-
-    let amount = U256::from(1234);
-    let calldata = mintCall { amount }.abi_encode();
-    let result = env.exec_to(GOVERNANCE_SAFE_ADDRESS, RELAY_ADDR, calldata, 200_000);
-    assert_success(&result);
-
-    // Pending-mint amount slot for governance: keccak256(abi.encode(GOVERNANCE_SAFE_ADDRESS, 0)).
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(GOVERNANCE_SAFE_ADDRESS.as_slice());
-    let pending_slot = U256::from_be_bytes(keccak256(buf).0);
-
-    assert_eq!(
-        env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, pending_slot),
-        amount,
-        "SSTORE under DELEGATECALL must land in the precompile's storage"
-    );
-    assert_eq!(
-        env.get_storage(RELAY_ADDR, pending_slot),
-        U256::ZERO,
-        "caller's storage must NOT be written by precompile under DELEGATECALL"
-    );
-}
-
-// ==============================
 // `STATICCALL` write protection
 // ==============================
 
-use crate::precompile_relays::{CALL_RELAY_BYTECODE, STATICCALL_RELAY_BYTECODE};
+use crate::precompile_relays::{
+    CALLCODE_RELAY_BYTECODE, CALL_RELAY_BYTECODE, DELEGATECALL_RELAY_BYTECODE,
+    STATICCALL_RELAY_BYTECODE,
+};
 
 /// Pending-mint amount slot for governance: `keccak256(abi.encode(GOVERNANCE_SAFE_ADDRESS, 0))`.
 fn governance_pending_slot() -> U256 {
@@ -511,4 +440,120 @@ fn test_staticcall_still_serves_read_only_selectors() {
         env.exec_to(USER, GOVERNANCE_SAFE_ADDRESS, totalSupplyCall {}.abi_encode(), 200_000);
     assert_success(&result);
     assert!(decode_bool(&result), "totalSupply() must remain callable under STATICCALL");
+}
+
+// ==============================
+// Direct-call guard: `DELEGATECALL` / `CALLCODE` refusal
+// ==============================
+
+/// Address hosting the `DELEGATECALL` relay in the direct-call guard tests.
+///
+/// The relay must live at an address other than [`GOVERNANCE_SAFE_ADDRESS`]: `DELEGATECALL`
+/// preserves the parent frame's `msg.sender`, so hosting it here and driving it from governance is
+/// what puts `caller == GOVERNANCE_SAFE_ADDRESS` in front of the precompile together with
+/// `target_address == RELAY_ADDR`.
+const RELAY_ADDR: Address = address!("dddd0000000000000000000000000000000000d1");
+
+/// A `DELEGATECALL` into `0x7e1` is refused before dispatch, and writes nothing.
+///
+/// revm dispatches a precompile by the frame's `bytecode_address` alone, so a `DELEGATECALL` whose
+/// code address is `0x7e1` reaches the dispatcher with `caller` inherited from the parent frame:
+/// here `GOVERNANCE_SAFE_ADDRESS`, because governance is the one calling the relay. Before the
+/// direct-call guard existed this frame passed the governance check and wrote the pending-mint
+/// slot under the canonical `0x7e1` (the handlers hardcode that address for every `SSTORE`, so
+/// nothing landed in the relay's own storage). This test pins the refusal: a contract that
+/// governance chooses to `CALL` must not be able to act as governance towards the precompile.
+///
+/// Test plan:
+/// 1. Host a `DELEGATECALL` relay at [`RELAY_ADDR`] and `mint(1234)` through it from
+///    [`GOVERNANCE_SAFE_ADDRESS`]. The inner frame has `caller == GOVERNANCE_SAFE_ADDRESS` and
+///    `target_address == RELAY_ADDR`, which is not `0x7e1`.
+/// 2. Assert the inner call reported failure.
+/// 3. Assert the pending-mint slot is untouched under both `0x7e1` and [`RELAY_ADDR`].
+///
+/// The positive control (the same governance authorization succeeds through a direct `CALL`
+/// relay frame) is the first half of [`test_staticcall_cannot_mutate_precompile_state`].
+#[test]
+#[cfg(not(feature = "faucet"))]
+fn test_delegatecall_cannot_reach_precompile() {
+    let pending_slot = governance_pending_slot();
+    let mut env = TestEnv::new();
+    env.deploy_code(RELAY_ADDR, Bytes::from_static(DELEGATECALL_RELAY_BYTECODE));
+
+    let result = env.exec_to(
+        GOVERNANCE_SAFE_ADDRESS,
+        RELAY_ADDR,
+        mintCall { amount: U256::from(1234) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&result);
+    assert!(
+        !decode_bool(&result),
+        "DELEGATECALL into the precompile must be refused even with a governance caller"
+    );
+    assert_eq!(
+        env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, pending_slot),
+        U256::ZERO,
+        "DELEGATECALL must not write the canonical pending-mint slot"
+    );
+    assert_eq!(
+        env.get_storage(RELAY_ADDR, pending_slot),
+        U256::ZERO,
+        "DELEGATECALL must not write the relay's storage either"
+    );
+}
+
+/// The direct-call guard is keyed on the call scheme, not the selector: `totalSupply()` is served
+/// to a `STATICCALL` but refused to a `DELEGATECALL`.
+///
+/// Pins the guard's placement ahead of the read-only classification, so an indirect frame is
+/// refused whatever it asks for. The same relay is refused a `mint` in
+/// [`test_delegatecall_cannot_reach_precompile`], and the same selector is served through the
+/// `STATICCALL` relay in [`test_staticcall_still_serves_read_only_selectors`], so the call scheme
+/// is the only variable.
+#[test]
+fn test_delegatecall_refuses_read_only_selectors_too() {
+    let mut env = TestEnv::new();
+    env.deploy_code(RELAY_ADDR, Bytes::from_static(DELEGATECALL_RELAY_BYTECODE));
+
+    let result = env.exec_to(USER, RELAY_ADDR, totalSupplyCall {}.abi_encode(), 200_000);
+    assert_success(&result);
+    assert!(!decode_bool(&result), "totalSupply() must be refused under DELEGATECALL");
+}
+
+/// A `CALLCODE` into `0x7e1` is refused before dispatch, and writes nothing.
+///
+/// `CALLCODE` sets the inner frame's `caller` to the calling contract itself (not the preserved
+/// grandparent that `DELEGATECALL` presents), so to put a governance caller in front of the
+/// precompile the relay is hosted **at** [`GOVERNANCE_SAFE_ADDRESS`], as the `STATICCALL` tests
+/// do, and driven by [`USER`] (EIP-3607 rejects a transaction whose sender has code). That is the
+/// strongest case: even a frame whose `caller` genuinely is governance is refused when it did not
+/// reach `0x7e1` by a direct call, because `target_address` is the relay's own address. The `CALL`
+/// relay at the same address is accepted in [`test_staticcall_cannot_mutate_precompile_state`], so
+/// the opcode is the only variable.
+#[test]
+#[cfg(not(feature = "faucet"))]
+fn test_callcode_cannot_reach_precompile() {
+    let pending_slot = governance_pending_slot();
+    let mut env = TestEnv::new();
+    env.deploy_code(GOVERNANCE_SAFE_ADDRESS, Bytes::from_static(CALLCODE_RELAY_BYTECODE));
+
+    let result = env.exec_to(
+        USER,
+        GOVERNANCE_SAFE_ADDRESS,
+        mintCall { amount: U256::from(1234) }.abi_encode(),
+        200_000,
+    );
+    assert_success(&result);
+    assert!(!decode_bool(&result), "CALLCODE into the precompile must be refused");
+    assert_eq!(
+        env.get_storage(TELCOIN_PRECOMPILE_ADDRESS, pending_slot),
+        U256::ZERO,
+        "CALLCODE must not write the canonical pending-mint slot"
+    );
+    assert_eq!(
+        env.get_storage(GOVERNANCE_SAFE_ADDRESS, pending_slot),
+        U256::ZERO,
+        "CALLCODE must not write the relay's storage either"
+    );
 }


### PR DESCRIPTION
Closes #1210.  (Cantina #6)

## Problem

`telcoin_precompile` authorizes every state-mutating selector on `input.caller` (through `has_governance_role` / `has_mint_role`) but never checks how the frame reached it. revm looks a precompile up by the frame's `bytecode_address` alone (`PrecompilesMap::get(&inputs.bytecode_address)`, alloy-evm 0.27.3), so `DELEGATECALL` and `CALLCODE` frames whose code address is `0x7e1` run the dispatcher exactly like a `CALL`. Two properties of that frame shape make it unsafe to serve:

- **The caller is spoofable.** `DELEGATECALL` preserves the parent frame's `msg.sender`. A contract `A` that governance chose to `CALL` presents `caller == GOVERNANCE_SAFE_ADDRESS` when it delegates into `0x7e1`, and every governance gate passes.
- **The storage does not follow `DELEGATECALL` semantics.** Every handler passes the literal `TELCOIN_PRECOMPILE_ADDRESS` to `sstore` / `sload` and the balance helpers, so the indirect frame acts on the canonical `0x7e1` ledger, not on `A`'s storage as it would against ordinary bytecode. `test_delegatecall_writes_target_precompile_storage` pinned exactly this: governance -> relay -> `DELEGATECALL 0x7e1` -> `mint(1234)` landed in the canonical pending-mint slot.

The module doc and README both state that "`CALL`/`STATICCALL` targeting that address" is what the dispatcher serves; the code enforced no such restriction.

Threat model. On mainnet this is latent, not live: `mint` hardcodes governance as the recipient, `claim` reverts on an empty pending slot, `burn` has no beneficiary, and presenting a governance `caller` at all needs governance to execute the transaction (at which point a direct call to `0x7e1` is equally available), so there is no attacker-profit path today (the issue records that verification). Under the `faucet` feature it is live: `mint(address, uint256)` credits a calldata-chosen recipient, so any contract a mint-role holder chose to `CALL` could mint to an address of its choosing. Either way the authorization gates were trusting a spoofable identity, and any later handler change that credits a calldata-chosen recipient on mainnet would have turned the latent path live without a compile-time signal. `CALLCODE` presents the calling contract itself as `caller`, so it spoofs nothing on its own, but it is the same indirect frame shape and is refused for the same reason. EIP-7702 is not a vector here (dispatch keys on the EOA's own address, and #1169 rejects set-code transactions at admission).

## Fix

The first statement of `telcoin_precompile`, ahead of the calldata length check and of selector dispatch, refuses any frame that is not a direct call, through the upstream predicate `PrecompileInput::is_direct_call()` (`target_address == bytecode_address`). A direct `CALL`/`STATICCALL` sets both to `0x7e1`; `DELEGATECALL`/`CALLCODE` keep the calling contract's own address as `target_address`. The rejection is `PrecompileError::Other("telcoin precompile: only a direct call to 0x7e1 is permitted")`, which reverts the inner frame like the existing static-call rejection does. Read-only selectors are refused too: an indirect frame has no legitimate use of this precompile, and refusing it whole is cheaper to reason about than a per-selector exemption. The guard is attacker-independent and costs one address comparison per call; it composes with the existing static-call guard rather than replacing it.

## Changes

- [x] `crates/tn-reth/src/evm/tel_precompile/mod.rs`: `INDIRECT_ENTRY` rejection constant; direct-call guard as the first statement of `telcoin_precompile`; module docs (interception paragraph, access-control list) and a `# Direct-call guard` section on the dispatcher doc.
- [x] `crates/tn-reth/tests/it/precompile_relays.rs`: `DELEGATECALL_RELAY_BYTECODE` (`0xf4`, six operands) and `CALLCODE_RELAY_BYTECODE` (`0xf2`, seven operands), byte-identical to the existing `STATICCALL` / `CALL` relays but for the opcode, both returning the inner success flag; module docs extended for the two new frame shapes and their hosting addresses.
- [x] `crates/tn-reth/tests/it/tel_precompile_props.rs`: `test_delegatecall_writes_target_precompile_storage` (which pinned the pre-fix behaviour) replaced by `test_delegatecall_cannot_reach_precompile` (governance -> relay at a fresh address -> `DELEGATECALL` `mint`; inner flag false, pending slot untouched under both `0x7e1` and the relay), `test_delegatecall_refuses_read_only_selectors_too` (`totalSupply()` refused under `DELEGATECALL`, served under `STATICCALL`; scheme is the only variable), and `test_callcode_cannot_reach_precompile` (relay hosted at governance so `caller` genuinely is governance; still refused). The forwarding `RELAY_BYTECODE` that could not distinguish accept from refuse is gone.
- [x] `crates/tn-reth/tests/it/tel_precompile_faucet_props.rs`: `test_delegatecall_cannot_mint_faucet` (governance -> relay -> `DELEGATECALL` `mint(RECIPIENT, 1234)`; refused, recipient balance and `totalSupply` unchanged) and `test_callcode_cannot_mint_faucet` (relay hosted at governance, driven by `USER`; refused), so the faucet build carries the live-path coverage the mainnet-only module cannot, and every relay is exercised under both feature sets.
- [x] `crates/tn-reth/src/evm/tel_precompile/README.md`: interception paragraph, access-control row for `DELEGATECALL` / `CALLCODE`, and the "`DELEGATECALL` semantics under revm" section rewritten as "Direct-call guard (`DELEGATECALL` / `CALLCODE`)" with the mechanic, the mainnet-latent / faucet-live framing, the guard, and the regression tests.

No selector, gas, ABI, or storage-layout change. Direct `CALL`/`STATICCALL` paths are untouched: the existing `CALL` relay positive controls (`test_staticcall_cannot_mutate_precompile_state`, `test_staticcall_cannot_grant_mint_role`), the `STATICCALL` read-only tests, and every top-level unit test in `burnable.rs` / `faucet.rs` still pass.

## Testing

Under the pinned toolchain from `rust-toolchain.toml`:

- `cargo +nightly fmt --all -- --check`: clean.
- `cargo +1.94 test -p tn-reth --lib evm::tel_precompile`: all direct-call unit tests pass (guard leaves top-level calls untouched).
- `cargo +1.94 test -p tn-reth --test it -- delegatecall callcode staticcall`: the three new mainnet relay tests plus the two `STATICCALL` tests (whose `CALL` relay halves are the positive controls) pass.
- `cargo +1.94 test -p tn-reth --test it --features faucet -- delegatecall callcode staticcall`: the two new faucet relay tests plus the two faucet `STATICCALL` tests pass.
- `cargo +nightly clippy -p tn-reth --all-features --all-targets --no-deps -- -D warnings`: clean.
- Mutation confirmation: with the guard removed (the four-line `is_direct_call` statement deleted, nothing else touched), all five new tests fail (`DELEGATECALL`/`CALLCODE` mint accepted, pending slot written or recipient credited; `totalSupply()` served under `DELEGATECALL`); restored, all pass. Each new test has been seen to fail against unfixed code.

CI (nightly fmt / clippy `--all --all-features`, `nextest --workspace`, adiri lane) fires on push; the pinned `cargo +1.94 test --no-run --workspace` attest runs on the second machine.
