### PR TITLE
fix(tn-reth): gate blsVerify on the O(1) gas floor before decoding calldata

### DIFF
--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -71,6 +71,10 @@ sol! {
 ///
 /// The length-dependent portion of hash-to-curve is charged separately by
 /// [`BLS_VERIFY_PER_WORD_GAS_COST`]; the total for a given message is [`bls_verify_gas_cost`].
+///
+/// The base is also the O(1) gas floor that [`handle_bls_verify`] checks before it decodes the
+/// calldata: no accepted call pays less than this, so a call that cannot fund it is refused before
+/// any of its `bytes` arguments are copied.
 const BLS_VERIFY_GAS_COST: u64 = 150_000;
 
 /// Per-32-byte-word surcharge over the hashed `message`.
@@ -140,13 +144,28 @@ fn dispatch(data: &[u8], gas: u64) -> PrecompileResult {
 
 /// `blsVerify(bytes,bytes,bytes) -> bool`.
 ///
-/// Decoding precedes the gas gate so the message length - which determines the charge - is known
-/// before pricing (the decode is cheap; the previous early gate was only a coarse floor). The
-/// message is capped at [`MAX_BLS_VERIFY_MESSAGE_LEN`] and then charged [`bls_verify_gas_cost`]
-/// (base plus a per-word surcharge), so a caller supplying a long message pays for the extra
-/// hash-to-curve work it induces instead of riding the flat base. An over-cap message is rejected
-/// as `Other`; an under-funded call is `OutOfGas`.
+/// Gas is gated twice, cheapest first.
+///
+/// 1. An O(1) floor of [`BLS_VERIFY_GAS_COST`] runs before the calldata is decoded. The base is the
+///    least any accepted call pays, so a call that cannot fund it is refused before its three
+///    `bytes` arguments are copied out of calldata. That copy is the only O(calldata) work in the
+///    precompile that no earlier charge covers: the precompile address is warm, and a `STATICCALL`
+///    can reach it with 0 forwarded gas, so without the floor a warm call's 100 gas base buys an
+///    arbitrarily large memcpy on every executing node (the `signature` and `pubkey` fields are
+///    unbounded `bytes`, so the message cap alone does not bound the copy).
+/// 2. The decode then yields the message length, which fixes the exact charge. The message is
+///    capped at [`MAX_BLS_VERIFY_MESSAGE_LEN`] and charged [`bls_verify_gas_cost`] (base plus a
+///    per-word surcharge), so a caller supplying a long message pays for the extra hash-to-curve
+///    work it induces instead of riding the flat base.
+///
+/// An over-cap message is rejected as `Other`; an under-funded call is `OutOfGas` at whichever
+/// gate it fails. Every accepted call clears both gates, so the floor changes neither the accepted
+/// set nor `gas_used`. The one observable difference is that an under-funded call whose calldata
+/// is malformed or carries an over-cap message is now `OutOfGas` instead of `Other`; the EVM treats
+/// both the same way (the caller frame gets `0` and its forwarded gas is consumed).
 fn handle_bls_verify(calldata: &[u8], gas_limit: u64) -> PrecompileResult {
+    (gas_limit >= BLS_VERIFY_GAS_COST).then_some(()).ok_or(PrecompileError::OutOfGas)?;
+
     let decoded = blsVerifyCall::abi_decode_raw(calldata)
         .map_err(|e| PrecompileError::Other(format!("blsVerify: {e}").into()))?;
 
@@ -367,13 +386,44 @@ mod tests {
         assert_eq!(out.gas_used, expected);
     }
 
-    /// Verification with less gas than the length-dependent cost is metered as out-of-gas.
+    /// Verification with less gas than the length-dependent cost is metered as out-of-gas. The
+    /// budget here (`cost - 1`) clears the O(1) floor and fails only the exact post-decode charge,
+    /// so this pins the second gate independently of the first.
     #[test]
     fn dispatch_verify_out_of_gas() {
         let v = vector(7, 0x42);
         let cost = bls_verify_gas_cost(v.message.len()).expect("cost fits u64");
+        assert!(cost > BLS_VERIFY_GAS_COST, "budget must clear the floor to reach the exact gate");
         let res = dispatch(&encode_verify(&v.sig, &v.pubkey, &v.message), cost - 1);
         assert!(matches!(res, Err(PrecompileError::OutOfGas)));
+    }
+
+    /// The O(1) gas floor is checked before the calldata is decoded. Under-funded calls are
+    /// `OutOfGas` even when the calldata would not decode or carries an over-cap message, and the
+    /// same bytes with the floor met reach the decoder and fail as `Other`. Restoring decode-first
+    /// flips the under-funded cases to `Other`, so this pins the ordering.
+    #[test]
+    fn dispatch_gas_floor_precedes_decode() {
+        // Three head words of 0xff: offsets far past the end of the data, so decoding fails.
+        let malformed = [blsVerifyCall::SELECTOR.as_slice(), [0xffu8; 96].as_slice()].concat();
+        assert!(matches!(dispatch(&malformed, 0), Err(PrecompileError::OutOfGas)));
+        assert!(matches!(
+            dispatch(&malformed, BLS_VERIFY_GAS_COST - 1),
+            Err(PrecompileError::OutOfGas)
+        ));
+        // Positive control: with the floor met, the decoder runs and rejects the bytes, so the
+        // `OutOfGas` above comes from the floor and not from a decoder that never saw the input.
+        assert!(matches!(
+            dispatch(&malformed, BLS_VERIFY_GAS_COST),
+            Err(PrecompileError::Other(_))
+        ));
+
+        // An over-cap 1 MiB message under the floor is refused by the floor, not by the cap that
+        // runs after the decode; with the floor met the same call reaches the cap.
+        let big_message = vec![0u8; 1 << 20];
+        let over = encode_verify(&[0u8; 48], &[0u8; 96], &big_message);
+        assert!(matches!(dispatch(&over, 0), Err(PrecompileError::OutOfGas)));
+        assert!(matches!(dispatch(&over, BLS_VERIFY_GAS_COST), Err(PrecompileError::Other(_))));
     }
 
     /// `bls_verify_gas_cost` is the flat base plus the per-word surcharge, rounding the message up


### PR DESCRIPTION
Closes #1211.

## Problem

`handle_bls_verify` (`crates/tn-reth/src/evm/bls_precompile/mod.rs`) called `blsVerifyCall::abi_decode_raw` before any gas check. The decode copies all three `bytes` arguments into owned `Bytes` (three allocations plus three memcpy). Every other cost in the precompile is charged before the work it covers. Nothing covered this copy:

- The precompile address is warm, so a `STATICCALL` costs the caller 100 gas, and the caller may forward 0 gas. Neither revm nor alloy-evm short-circuits a 0-gas precompile call, and alloy-evm hands the precompile a borrowed slice of shared memory (no copy on the way in).
- `signature` and `pubkey` are unbounded `bytes` in the ABI. Their 48 / 96 length gate is inside `bls_verify`, after the decode. So the 4096-byte `message` cap did not bound the copy: a multi-MB `signature` with a 119-byte message decodes in full and only then fails the exact gas gate.
- Memory expansion is charged once, and the decoder accepts overlapping offsets, so a loop can re-drive the same 2.27 MB region with all three fields aliased. Model from the gas constants: about 140 gas per iteration, about 142k iterations in a 30M-gas block, hundreds of GB of unmetered memcpy per block on every executing node. That is seconds of engine CPU per block for at most 30M gas at the base fee. The engine executes serially behind an 8-deep output queue, so sustained blocks of this shape backpressure into consensus delivery.

The work is transient and gas-bounded per block; there is no state corruption. This is a cost-asymmetry / liveness hardening item (Medium, borderline Low, in the issue). Batch validators do not execute transactions, so only executing nodes pay.

## Root cause

PR #1051 replaced the flat `if gas_limit < BLS_VERIFY_GAS_COST { OutOfGas }` gate with the per-word charge and moved the decode ahead of the gas check so the message length is known before pricing. The exact charge needs the decode; the O(1) floor does not. Dropping the floor left the decode as the one O(calldata) step ahead of any charge.

## Fix

Gate twice, cheapest first (the shape every pinned eth precompile uses: `identity`, `sha256`, `ripemd160` all check an O(1) cost before their O(len) work):

- [x] `handle_bls_verify`: `(gas_limit >= BLS_VERIFY_GAS_COST).then_some(()).ok_or(PrecompileError::OutOfGas)?;` is the first statement, ahead of `abi_decode_raw`. The base charge is the least any accepted call pays, so the floor is attacker-independent and derived from the existing constant, not a new number.
- [x] The exact post-decode charge (`MAX_BLS_VERIFY_MESSAGE_LEN` cap, then `bls_verify_gas_cost(len)`, then `gas_limit >= cost`) is unchanged.
- [x] Doc comments on `handle_bls_verify` and `BLS_VERIFY_GAS_COST` describe the two-gate ordering and why the floor exists.

Behavior: every accepted call already had `gas_limit >= cost >= BLS_VERIFY_GAS_COST`, so the Ok-set and `gas_used` are byte-identical. The only observable change is for calls with `gas_limit < 150_000` whose calldata is malformed or carries an over-cap message: they now fail as `OutOfGas` instead of `Other`. Both are the same error class to the EVM (`return_error!`: the caller frame gets `0`, and the forwarded gas is consumed), so state, gas, and stack are indistinguishable on chain. `ConsensusRegistry` (fixed 48 / 96 / 119 lengths, ample gas) is unaffected.

Not done, on purpose: no raw-calldata length ceiling before the decode. A total-length cap is not behavior-preserving (a canonical call with an oversized `pubkey` returns `Ok(false)` today, and the decoder ignores trailing bytes), and the floor alone brings the residual down to at most about 132 decodes per 30M block, the same class as `MCOPY`-metered work.

## Testing

- New `dispatch_gas_floor_precedes_decode` (unit, `evm::bls_precompile`): malformed calldata (head words of `0xff`) at gas `0` and at `BLS_VERIFY_GAS_COST - 1` is `OutOfGas`; the same bytes at exactly `BLS_VERIFY_GAS_COST` reach the decoder and fail as `Other` (positive control, which also pins the `>=` boundary); a 1 MiB over-cap message at gas `0` is `OutOfGas`, and at the floor it is the cap's `Other`.
- `dispatch_verify_out_of_gas` gained a guard that its `cost - 1` budget clears the floor, so it keeps pinning the exact post-decode gate on its own.
- Mutation-confirmed with both mutants taken from the diff: (A) floor removed (the origin/main ordering) and (B) `>=` flipped to `>`. Each fails exactly `dispatch_gas_floor_precedes_decode`; bytes restored, suite green again.
- Commands (pinned toolchain, `-j 2`): `cargo +1.94 test -p tn-reth --lib evm::bls_precompile` (15 passed, 0 failed) and `cargo +1.94 test -p tn-reth --test it -- bls_precompile` (11 passed, 0 failed; the EVM-level proptests and the `STATICCALL` relay path). `cargo +nightly fmt --all -- --check` and `cargo +nightly clippy -p tn-reth --all-features --all-targets -- -D warnings` are clean.
- Well-formed under-cap inputs are observationally identical under both orderings (only the work differs), so the discriminating inputs are exactly malformed calldata and over-cap messages under the floor. The bench numbers for the sig-heavy payload are in #1211.
