### PR TITLE
feat(config,types): multi-worker configuration foundation (#554, PR 1)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,12 +111,13 @@ jobs:
       - name: Run tests
         run: cargo nextest run --locked --workspace --exclude tn-faucet --no-fail-fast --profile ci
 
-  # Adiri feature lane: the adiri-gated suites (the legacy header wire-format pins in
-  # tn-types, the consensus-registry fork tests in tn-reth, and the pre-fork entry-fee pin
-  # in tn-node) only compile under the adiri features, so the default-feature test job
-  # above never builds or runs them. tn-storage is excluded: two of its consensus_pack
-  # tests (dup_batch_across_certs, v0_shared_batch_served_as_v1_bytes) fail under the
-  # adiri features today, independent of this lane.
+  # Adiri feature lane: the adiri-gated suites only compile under the adiri features, so
+  # the default-feature test job above never builds or runs them - the legacy header
+  # wire-format pins and the frozen pre-fork committee vectors in tn-types, the
+  # consensus-registry fork tests in tn-reth, the pre-fork entry-fee pin in tn-node, the
+  # frozen pre-fork consensus-pack fixtures in tn-storage, and the pre-fork genesis
+  # rejection in tn-config. Every crate that forwards `adiri` and has adiri-gated tests
+  # belongs on this line: one left off silently stops testing its pre-fork lane.
   adiri-test:
     needs: skip-maintainers
     if: >-
@@ -144,7 +145,7 @@ jobs:
           cache-on-failure: "true"
 
       - name: Run adiri-gated tests
-        run: cargo nextest run --locked -p tn-types -p tn-reth -p tn-node --features tn-types/adiri,tn-reth/adiri,tn-reth/test-utils,tn-node/adiri --no-fail-fast --profile ci
+        run: cargo nextest run --locked -p tn-types -p tn-reth -p tn-node -p tn-storage -p tn-config --features tn-types/adiri,tn-reth/adiri,tn-reth/test-utils,tn-node/adiri,tn-storage/adiri,tn-config/adiri --no-fail-fast --profile ci
 
   # Guard: rocksdb (librocksdb-sys, the entire RocksDB C++ engine and the single largest
   # native compile in the tree) must stay out of the default feature graph. It is gated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
  "tn-config",
  "tn-node",
  "tn-reth",
+ "tn-storage",
  "tn-test-utils",
  "tn-types",
  "tokio",

--- a/Makefile
+++ b/Makefile
@@ -144,19 +144,29 @@ E2E_BIN := $(E2E_TARGET_ROOT)/e2e/telcoin-network
 # seed_signature_override_is_inert_when_unset requires a process WITHOUT the variable.
 TN_SEED_SIGNATURE_FORK_EPOCH ?= 4294967295
 
+# Multi-workers fork epoch for the e2e lanes (#554). Same shape as the seed-signature
+# variable above and armed independently of it: defaults to u32::MAX so the default lanes run
+# the fork DORMANT (legacy single-worker committee layout, what adiri carries on disk);
+# non-adiri builds are otherwise active from genesis. Override for a fork-active lane:
+#   TN_MULTI_WORKERS_FORK_EPOCH=1 make test-epochs
+# Only test-utils builds consult it (tn_types::forks::multi_workers_fork_epoch_override).
+# Set only on name-filtered nextest lines, never a bare --workspace run: tn-types'
+# multi_workers_override_is_inert_when_unset requires a process WITHOUT the variable.
+TN_MULTI_WORKERS_FORK_EPOCH ?= 4294967295
+
 # run restart integration tests
 test-restarts: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_MULTI_WORKERS_FORK_EPOCH=$(TN_MULTI_WORKERS_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # run epoch integration tests (same filter as the public-tests epoch line). The scheduled
 # Durable e2e lane (#1149) runs this and test-restarts with TN_TEST_MDBX_SYNC=durable
 # exported so every spawned node opens MDBX in Durable.
 test-epochs: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_MULTI_WORKERS_FORK_EPOCH=$(TN_MULTI_WORKERS_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
 
 # run e2e tests
 test-e2e: build-e2e-bin
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_MULTI_WORKERS_FORK_EPOCH=$(TN_MULTI_WORKERS_FORK_EPOCH) cargo nextest run -p e2e-tests --run-ignored ignored-only --all-features ;
 
 # run tests with coverage (using llvm-cov + nextest)
 coverage:
@@ -232,8 +242,8 @@ revert-submodule:
 # workspace tests that don't require faucet credentials
 public-tests: build-e2e-bin
 	TN_BIN_PATH="$(E2E_BIN)" cargo nextest run --workspace --exclude tn-faucet --no-fail-fast ;
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
-	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_MULTI_WORKERS_FORK_EPOCH=$(TN_MULTI_WORKERS_FORK_EPOCH) cargo nextest run -p e2e-tests --test it --run-ignored all test_epoch ;
+	TN_BIN_PATH="$(E2E_BIN)" TN_SEED_SIGNATURE_FORK_EPOCH=$(TN_SEED_SIGNATURE_FORK_EPOCH) TN_MULTI_WORKERS_FORK_EPOCH=$(TN_MULTI_WORKERS_FORK_EPOCH) cargo nextest run --run-ignored all test_restarts ;
 
 # local checks to ensure PR is ready
 pr:

--- a/chain-configs/mainnet/committee.yaml
+++ b/chain-configs/mainnet/committee.yaml
@@ -19,34 +19,34 @@ bootstrap_servers:
       network_address: /ip4/127.0.0.1/udp/53413/quic-v1/p2p/12D3KooWNAW3PfSJFaB7mfWgTycudE6tLW7vdjQgTHMxSifsz2nu
       network_key: 4XTTMDVBhEouNrwJmoKy6b1WjmpkYpB7Nkx1vBVmiUxHQwoa1
       rpc: ~
-    worker:
-      network_address: /ip4/127.0.0.1/udp/57353/quic-v1/p2p/12D3KooWQEkF5yLEYmmS12ZhGAMprbWFqiW9Ej12PYq7zuiY4U8s
-      network_key: 4XTTMFZRtw7oKA8u62h27PCFf1C9vKPVbMwcG7mEt39L52Euy
-      rpc: ~
+    workers:
+      - network_address: /ip4/127.0.0.1/udp/57353/quic-v1/p2p/12D3KooWQEkF5yLEYmmS12ZhGAMprbWFqiW9Ej12PYq7zuiY4U8s
+        network_key: 4XTTMFZRtw7oKA8u62h27PCFf1C9vKPVbMwcG7mEt39L52Euy
+        rpc: ~
   o7NWSzVPGRpGajDT7VNDnZ9VDa3uAVFBFVwCwkgGUxRo4BU5RtGuDJPwjfF4psedjWPDeyGJjiLki9raddCcLDmaHWaEbzs2yVhbRiwZoS8s4VNCg5w9rhTKQEMTy1ReiJU:
     primary:
       network_address: /ip4/127.0.0.1/udp/35850/quic-v1/p2p/12D3KooWSitWHV8En1R9xqFXuHkk1zNTPqfPBEvxQ6fMFYmUiHfn
       network_key: 4XTTMJ3aA8dbKPNYozVhx2KeaAb27sWeqJTYC8K57HnP1g4St
       rpc: ~
-    worker:
-      network_address: /ip4/127.0.0.1/udp/54111/quic-v1/p2p/12D3KooWJSfTszhEoRPgQ4ET5MirNQkBNeyeeHfb9Zj5Cm5mbMzo
-      network_key: 4XTTM9mM7j9AKQnXLRigsCPcgX1PqrKy6mWGpsn8qEzhJZ8mu
-      rpc: ~
+    workers:
+      - network_address: /ip4/127.0.0.1/udp/54111/quic-v1/p2p/12D3KooWJSfTszhEoRPgQ4ET5MirNQkBNeyeeHfb9Zj5Cm5mbMzo
+        network_key: 4XTTM9mM7j9AKQnXLRigsCPcgX1PqrKy6mWGpsn8qEzhJZ8mu
+        rpc: ~
   rQKFx4X14MUGMYhTp2wffazXkczDsMXjBLoPeVuV2RLaqCpmzBhksCTBKfGrfauNnxGRNKa2urGBVdHD6eYz9P9v5HgjoL9EUCQPiV99A4m8XK6T2EDZKitCG8qia3Xe8fx:
     primary:
       network_address: /ip4/127.0.0.1/udp/55477/quic-v1/p2p/12D3KooWL3LRyr1VGQS1zgaQyBMhQAkJxzWwnBQDAZJfmpDkiTF9
       network_key: 4XTTMBN25pzUZsmZg2M2q6DFXYmPySfWPuQ1StmiRp3qHgE2F
       rpc: ~
-    worker:
-      network_address: /ip4/127.0.0.1/udp/55927/quic-v1/p2p/12D3KooWHW91LtbwhnKztDQv8fjNnEKVzJZVugsic8YfqRdtAd6X
-      network_key: 4XTTM8ppfC352K9TeussLFhdCvpyATyYx2uUxLLxRsfFR8Psd
-      rpc: ~
+    workers:
+      - network_address: /ip4/127.0.0.1/udp/55927/quic-v1/p2p/12D3KooWHW91LtbwhnKztDQv8fjNnEKVzJZVugsic8YfqRdtAd6X
+        network_key: 4XTTM8ppfC352K9TeussLFhdCvpyATyYx2uUxLLxRsfFR8Psd
+        rpc: ~
   26x8EEpcsTJAnx1cBMws576SNSExvuCnwp2CfZYjxTEPCdMNaoWtQDyGYj1mEq98TrjXQud2tgbSMP62impV4JGu34iKifXLeDQVdcSnE8gwSMXfkNfaNqHVEBSi6D9YdqDM:
     primary:
       network_address: /ip4/127.0.0.1/udp/36537/quic-v1/p2p/12D3KooWAb8MpY1UW5w7J6xXUz23GrYVeAcoBjZt7hSJC1JEcuF7
       network_key: 4XTTM1up1fgUZ7T4mKmQwc1usRTCA7qcFJxB7qur4EEumag2D
       rpc: ~
-    worker:
-      network_address: /ip4/127.0.0.1/udp/32816/quic-v1/p2p/12D3KooWBAB1A5DySPEovSyHiZNWnLrevFpQztStLLEcXa1Qea5n
-      network_key: 4XTTM2Urf1Dh43kNTx7RhqbGLvwWKPvos87484YeNZocwcLrt
-      rpc: ~
+    workers:
+      - network_address: /ip4/127.0.0.1/udp/32816/quic-v1/p2p/12D3KooWBAB1A5DySPEovSyHiZNWnLrevFpQztStLLEcXa1Qea5n
+        network_key: 4XTTM2Urf1Dh43kNTx7RhqbGLvwWKPvos87484YeNZocwcLrt
+        rpc: ~

--- a/chain-configs/testnet/committee.yaml
+++ b/chain-configs/testnet/committee.yaml
@@ -21,34 +21,34 @@ bootstrap_servers:
     primary:
       network_address: /ip4/35.203.41.59/udp/49590/quic-v1/p2p/12D3KooWCnizjv4ctsBTwwYJxZP3duCuoebJfbk1fUQv6Vg1dVUh
       network_key: 4XTTM47Qeb4XhWEK7ybzj5bGsnVraHKaknpMFPgpg8jHYbGFo
-    worker:
-      network_address: /ip4/35.203.41.59/udp/49594/quic-v1/p2p/12D3KooWHGdbYerasxspuhZW4KqNMbbpqvLNCG6LGpS5yx6b8x2x
-      network_key: 4XTTM8bKFPoKfVL1UwN1vBMjCWCFVKbKpKUha12qr2Bi86ip4
+    workers:
+      - network_address: /ip4/35.203.41.59/udp/49594/quic-v1/p2p/12D3KooWHGdbYerasxspuhZW4KqNMbbpqvLNCG6LGpS5yx6b8x2x
+        network_key: 4XTTM8bKFPoKfVL1UwN1vBMjCWCFVKbKpKUha12qr2Bi86ip4
   rZdhyVGJAtz7kyFtFARWVVcw5DB3o9E4GvPN6zuKfUhUBGFRvEK2PgEV44CJt9wu9GMyssFQBFXRknrenuhJixo9KCADrZzHdtcvAwAYDmcLc7Ugh9epGc5LRZC5TK2hnYA:
     primary:
       network_address: /ip4/34.105.191.161/udp/49590/quic-v1/p2p/12D3KooWBRH7XpYhxCPTrw364UnmaSYDR4hCotoTHxTWTjKfrcUm
       network_key: 4XTTM2jxmNy1nZZX7tbVWBWgbj3Bstjgew7Qh2AsGVxwCpPFs
-    worker:
-      network_address: /ip4/34.105.191.161/udp/49594/quic-v1/p2p/12D3KooWFf6gRgYGnob7zhSZEnswRAHs4tSuh9UZXc5HzeKNut14
-      network_key: 4XTTM6ynLGq1MQAin2MtyMpmmZkwXYZSMpN5oFpV42svusenA
+    workers:
+      - network_address: /ip4/34.105.191.161/udp/49594/quic-v1/p2p/12D3KooWFf6gRgYGnob7zhSZEnswRAHs4tSuh9UZXc5HzeKNut14
+        network_key: 4XTTM6ynLGq1MQAin2MtyMpmmZkwXYZSMpN5oFpV42svusenA
   24JaKrebALhvhXxsAabjd5ZK22k1W4zKwGepKD5pcobQwBkZyiruYyhRM3hkLap8Ssc4qUdcRUJSrs2389hUoV7G83HKYrmkz2pTzCJiQURV5vtkrh8gFRKBQWKFTWLWah9s:
     primary:
       network_address: /ip4/34.102.122.126/udp/49590/quic-v1/p2p/12D3KooWSwK9yPLNtDr116cX74FS4Ehs2Nx2fWAUjpnsGrNkNGKd
       network_key: 4XTTMJFzopXoTVayf2m4wE69GCqMXW3wUnimiU3CdK5zHL36j
-    worker:
-      network_address: /ip4/34.102.122.126/udp/49594/quic-v1/p2p/12D3KooWESQQ5KghAFnUwWJq7niJuVjrLDooNzypjmRfwsySMXhC
-      network_key: 4XTTM5m63vU9mmcv8yAmFEpc946PWotoFWDb4TyqRz7ayKJUJ
+    workers:
+      - network_address: /ip4/34.102.122.126/udp/49594/quic-v1/p2p/12D3KooWESQQ5KghAFnUwWJq7niJuVjrLDooNzypjmRfwsySMXhC
+        network_key: 4XTTM5m63vU9mmcv8yAmFEpc946PWotoFWDb4TyqRz7ayKJUJ
   26L1XwWTr6bBNnxJmDJXJgTqMAyD4ExkqwPYYJqDD3gob3jzejypQoewqRmqb9D2Yudk7zjcPqaTzFcEtXhrYXUtNx2ZYeLKC8V77LL2J136Hvw8eCGXpadGAbymThMhWYAa:
     primary:
       network_address: /ip4/34.141.203.172/udp/49590/quic-v1/p2p/12D3KooWA2LvcWr3dvLx3CFnayoY4Q1mUX1qC2RuA2iAbUXjCpjM
       network_key: 4XTTM1M2aTfK8FHUc4riCi1hNCzfRxC1HKF38tF7vdi9GAbWT
-    worker:
-      network_address: /ip4/34.141.203.172/udp/49594/quic-v1/p2p/12D3KooWDWAL8TE8PikV2Jxt3WSEkXCKcDKipDdVsFJVJMMxEbGz
-      network_key: 4XTTM4pqyybhD15t93yRJAYL4u7qz5tKAwSEjbTiFLayVCN46
+    workers:
+      - network_address: /ip4/34.141.203.172/udp/49594/quic-v1/p2p/12D3KooWDWAL8TE8PikV2Jxt3WSEkXCKcDKipDdVsFJVJMMxEbGz
+        network_key: 4XTTM4pqyybhD15t93yRJAYL4u7qz5tKAwSEjbTiFLayVCN46
   26L3gmkBzxAxEwvVuDrxEmKf2XwYGnYj1EQSiZSX3PBAvRa6Z5tegfmDAGHTsBwdtjFuAd7ayQEemE1AUE5ajSSK8wn3uz1MY5vjbGdeh3RoUv1TKLfbNTTULq9qdtaSTHhL:
     primary:
       network_address: /ip4/34.40.242.29/udp/49590/quic-v1/p2p/12D3KooWMUuChs1v4umTNiHivmD9G764hbcTTooRrMUpLZ9Tgpn5
       network_key: 4XTTMCoarZ1UzgGu7QNk93o6yQhjjBGbub2QfaZtaNnkzebZB
-    worker:
-      network_address: /ip4/34.40.242.29/udp/49594/quic-v1/p2p/12D3KooWE8p62tGetgUeJbKKyctPB2ky1zpahA6wPVr18R7iBtLB
-      network_key: 4XTTM5TVjt2jjW3cJLFmk6enDKdQdVfp2pNiB7iFmAejF9f7H
+    workers:
+      - network_address: /ip4/34.40.242.29/udp/49594/quic-v1/p2p/12D3KooWE8p62tGetgUeJbKKyctPB2ky1zpahA6wPVr18R7iBtLB
+        network_key: 4XTTM5TVjt2jjW3cJLFmk6enDKdQdVfp2pNiB7iFmAejF9f7H

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -39,6 +39,9 @@ tempfile = { workspace = true }
 [features]
 default = []
 test-utils = []
+# Adiri testnet: tn-config has no adiri-gated code of its own, but its genesis validation consults
+# tn-types' fork schedule, so the forward lets those tests run against the testnet schedule.
+adiri = ["tn-types/adiri"]
 
 [lints]
 workspace = true

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -9,7 +9,7 @@ use std::{
 use tn_network_types::local::LocalNetwork;
 use tn_types::{
     Authority, AuthorityIdentifier, BlsPublicKey, Certificate, Committee, Database, Epoch,
-    EpochDigest, Hash as _, HeaderDigest, Multiaddr, NetworkPublicKey, ShutdownNotifier,
+    EpochDigest, Hash as _, HeaderDigest, Multiaddr, NetworkPublicKey, ShutdownNotifier, WorkerId,
 };
 use tracing::info;
 
@@ -341,9 +341,8 @@ where
         self.inner.committee.is_authority(id)
     }
 
-    /// Retrieve the worker's network address by id.
-    /// Note, will panic if id is not valid.
-    pub fn worker_address(&self) -> Multiaddr {
-        self.inner.config.node_info.p2p_info.worker.network_address.clone()
+    /// Retrieve the network address of worker `worker_id`, if this node runs that worker.
+    pub fn worker_address(&self, worker_id: WorkerId) -> Option<Multiaddr> {
+        self.inner.config.node_info.worker_network_address(worker_id).cloned()
     }
 }

--- a/crates/config/src/genesis.rs
+++ b/crates/config/src/genesis.rs
@@ -10,9 +10,9 @@ use std::{
     path::Path,
 };
 use tn_types::{
-    address, test_genesis, verify_proof_of_possession_bls, Address, BlsPublicKey, BlsSignature,
-    Committee, CommitteeBuilder, Genesis, GenesisAccount, Multiaddr, NetworkPublicKey, NodeP2pInfo,
-    P2pNode, WorkerId,
+    address, forks::multi_workers_fork_active, test_genesis, verify_proof_of_possession_bls,
+    Address, BlsPublicKey, BlsSignature, Committee, CommitteeBuilder, Genesis, GenesisAccount,
+    Multiaddr, NetworkPublicKey, NodeP2pInfo, P2pNode, WorkerId,
 };
 use tracing::{info, warn};
 
@@ -128,7 +128,8 @@ impl NetworkGenesis {
 
     /// Validate each validator:
     /// - verify proof of possession
-    /// - every validator runs the same, non-zero number of workers
+    /// - every validator runs the same, non-zero number of workers, and that count is one the
+    ///   epoch-0 [`Committee`] layout can hold
     pub fn validate(&self) -> eyre::Result<()> {
         for (pubkey, validator) in self.validators.iter() {
             info!(target: "genesis::validate", "verifying validator: {}", pubkey);
@@ -147,6 +148,13 @@ impl NetworkGenesis {
     ///
     /// The count is a protocol-level value, so genesis is rejected when validators disagree or
     /// when any validator advertises no worker. An empty validator set yields one worker.
+    ///
+    /// A count above one additionally requires [`multi_workers_fork_active`] at epoch 0, the epoch
+    /// of the committee this genesis produces. Below that fork the [`Committee`] bcs layout has no
+    /// field to carry a worker count, so the encoder refuses the value outright — a genesis that
+    /// slipped through here would not fail until the first consensus pack tried to write its
+    /// `EpochMeta`, i.e. a panic at epoch-0 startup rather than a config error while generating
+    /// genesis.
     fn agreed_num_workers(&self) -> eyre::Result<NonZeroUsize> {
         let counts = self
             .validators
@@ -158,12 +166,23 @@ impl NetworkGenesis {
             })
             .collect::<eyre::Result<Vec<_>>>()?;
         let first = counts.first().map_or(NonZeroUsize::MIN, |(_, count)| *count);
-        counts.iter().find(|(_, count)| *count != first).map_or(Ok(first), |(pubkey, count)| {
-            Err(eyre::eyre!(
+        // disagreement is checked before the fork gate so its message stays the same in every
+        // build: a mismatched set is malformed regardless of which counts the fork allows
+        if let Some((pubkey, count)) = counts.iter().find(|(_, count)| *count != first) {
+            eyre::bail!(
                 "validator {pubkey} advertises {count} workers but the first validator advertises \
                  {first}: all validators must run the same number of workers"
-            ))
-        })
+            );
+        }
+        // the committee built from this genesis is epoch 0, which is the epoch the gate reads
+        if first.get() != 1 && !multi_workers_fork_active(0) {
+            eyre::bail!(
+                "genesis validators agree on {first} workers but the multi-workers fork is not \
+                 active at epoch 0: the pre-fork committee layout cannot hold a worker count, so \
+                 this network must be generated with one worker per validator"
+            );
+        }
+        Ok(first)
     }
 
     /// Create a [Committee] from the validators in [NetworkGenesis].
@@ -408,8 +427,27 @@ mod tests {
         }
     }
 
+    /// Default builds have the multi-worker committee layout active from genesis, so an agreed
+    /// count above one is a valid genesis and reaches the committee unchanged; the adiri lane
+    /// covers the pre-fork rejection below.
+    ///
+    /// The `cfg` selects this test on this crate's feature set, but the gate it relies on lives in
+    /// tn-types — so the two can desync, and the runtime check below is what names it. A build
+    /// where tn-config compiles without `adiri` while tn-types compiles with it (feature
+    /// unification from elsewhere in the graph, or a missing `tn-config/adiri` forward) would
+    /// otherwise reach `validate` and fail with a fork-rejection message this lane never expects.
+    #[cfg(not(feature = "adiri"))]
     #[test]
     fn test_validate_genesis_agrees_on_worker_count() {
+        // spelled out through tn_types rather than the module's import, because which crate owns
+        // the gate is the whole point of the desync this catches
+        assert!(
+            tn_types::forks::multi_workers_fork_active(0),
+            "epoch 0 must be post-fork for this lane to mean anything: tn-config compiled without \
+             `adiri` yet the gate is dormant, so tn-types' `adiri` feature is desynced from this \
+             crate's; is TN_MULTI_WORKERS_FORK_EPOCH set in the environment?"
+        );
+
         let mut network_genesis = NetworkGenesis::new_for_test();
         (0..4).for_each(|v| network_genesis.add_validator(validator_with_workers(v, 2)));
         assert!(network_genesis.validate().is_ok());
@@ -419,6 +457,32 @@ mod tests {
         assert!(bootstrap.values().all(|server| server.num_workers() == 2));
     }
 
+    /// Pre-fork the committee layout has no field for a worker count, so an agreed count above one
+    /// is rejected while generating genesis instead of panicking the first time epoch 0's
+    /// `EpochMeta` is encoded. A single worker still validates.
+    ///
+    /// The adiri fork epoch is a `u32::MAX` placeholder and its arming constraint floors it at 407,
+    /// so epoch 0 is pre-fork in this lane however the constant moves.
+    /// `TN_MULTI_WORKERS_FORK_EPOCH` is deliberately not used to stage that: the override's
+    /// `OnceLock` is process-wide and the whole test binary shares one process.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn test_validate_genesis_rejects_multiple_workers_pre_fork() {
+        let mut network_genesis = NetworkGenesis::new_for_test();
+        (0..4).for_each(|v| network_genesis.add_validator(validator_with_workers(v, 2)));
+        let err = network_genesis.validate().expect_err("pre-fork multi-worker genesis must fail");
+        assert!(err.to_string().contains("multi-workers fork is not active"), "{err}");
+        assert!(network_genesis.create_committee().is_err());
+
+        let mut single_worker = NetworkGenesis::new_for_test();
+        (0..4).for_each(|v| single_worker.add_validator(validator_with_workers(v, 1)));
+        single_worker.validate().expect("single-worker genesis is valid pre-fork");
+        let committee = single_worker.create_committee().expect("committee");
+        assert_eq!(committee.number_of_workers(), 1);
+    }
+
+    /// Validators disagreeing is malformed in every build, so this assertion holds in both lanes:
+    /// the disagreement check runs before the fork gate.
     #[test]
     fn test_validate_genesis_rejects_mismatched_worker_count() {
         let mut network_genesis = NetworkGenesis::new_for_test();

--- a/crates/config/src/genesis.rs
+++ b/crates/config/src/genesis.rs
@@ -6,11 +6,13 @@ use std::{
     collections::{BTreeMap, HashMap},
     ffi::OsStr,
     fs,
+    num::NonZeroUsize,
     path::Path,
 };
 use tn_types::{
     address, test_genesis, verify_proof_of_possession_bls, Address, BlsPublicKey, BlsSignature,
     Committee, CommitteeBuilder, Genesis, GenesisAccount, Multiaddr, NetworkPublicKey, NodeP2pInfo,
+    P2pNode, WorkerId,
 };
 use tracing::{info, warn};
 
@@ -126,6 +128,7 @@ impl NetworkGenesis {
 
     /// Validate each validator:
     /// - verify proof of possession
+    /// - every validator runs the same, non-zero number of workers
     pub fn validate(&self) -> eyre::Result<()> {
         for (pubkey, validator) in self.validators.iter() {
             info!(target: "genesis::validate", "verifying validator: {}", pubkey);
@@ -135,13 +138,41 @@ impl NetworkGenesis {
                 &validator.execution_address,
             )?;
         }
+        self.agreed_num_workers()?;
         info!(target: "genesis::validate", "all validators valid for genesis");
         Ok(())
     }
 
+    /// Return the worker count shared by every validator.
+    ///
+    /// The count is a protocol-level value, so genesis is rejected when validators disagree or
+    /// when any validator advertises no worker. An empty validator set yields one worker.
+    fn agreed_num_workers(&self) -> eyre::Result<NonZeroUsize> {
+        let counts = self
+            .validators
+            .iter()
+            .map(|(pubkey, validator)| {
+                NonZeroUsize::new(validator.num_workers()).map(|count| (pubkey, count)).ok_or_else(
+                    || eyre::eyre!("validator {pubkey} advertises no workers in genesis"),
+                )
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+        let first = counts.first().map_or(NonZeroUsize::MIN, |(_, count)| *count);
+        counts.iter().find(|(_, count)| *count != first).map_or(Ok(first), |(pubkey, count)| {
+            Err(eyre::eyre!(
+                "validator {pubkey} advertises {count} workers but the first validator advertises \
+                 {first}: all validators must run the same number of workers"
+            ))
+        })
+    }
+
     /// Create a [Committee] from the validators in [NetworkGenesis].
+    ///
+    /// The committee's worker count is the count every validator agrees on (see
+    /// [Self::validate]); the bootstrap record for each validator carries all of its workers.
     pub fn create_committee(&self) -> eyre::Result<Committee> {
-        let mut committee_builder = CommitteeBuilder::new(0);
+        let num_workers = self.agreed_num_workers()?;
+        let mut committee_builder = CommitteeBuilder::new(0).with_num_workers(num_workers);
         for (pubkey, validator) in self.validators.iter() {
             committee_builder.add_authority_and_bootstrap(
                 *pubkey,
@@ -150,11 +181,7 @@ impl NetworkGenesis {
                     validator.primary_network_key().clone(),
                 )
                     .into(),
-                (
-                    validator.worker_network_address().clone(),
-                    validator.worker_network_key().clone(),
-                )
-                    .into(),
+                validator.worker_p2p_nodes().to_vec(),
                 validator.execution_address,
             );
         }
@@ -223,14 +250,24 @@ impl NodeInfo {
         &self.p2p_info.primary.network_address
     }
 
-    /// Return the primary's public network key.
-    pub fn worker_network_key(&self) -> &NetworkPublicKey {
-        &self.p2p_info.worker.network_key
+    /// Return the public network key of worker `worker_id`, if this node runs that worker.
+    pub fn worker_network_key(&self, worker_id: WorkerId) -> Option<&NetworkPublicKey> {
+        self.p2p_info.worker(worker_id).map(|worker| &worker.network_key)
     }
 
-    /// Return the primary's network address.
-    pub fn worker_network_address(&self) -> &Multiaddr {
-        &self.p2p_info.worker.network_address
+    /// Return the network address of worker `worker_id`, if this node runs that worker.
+    pub fn worker_network_address(&self, worker_id: WorkerId) -> Option<&Multiaddr> {
+        self.p2p_info.worker(worker_id).map(|worker| &worker.network_address)
+    }
+
+    /// Return the p2p info of every worker, indexed by [WorkerId].
+    pub fn worker_p2p_nodes(&self) -> &[P2pNode] {
+        &self.p2p_info.workers
+    }
+
+    /// Return the number of workers this node runs.
+    pub fn num_workers(&self) -> usize {
+        self.p2p_info.num_workers()
     }
 }
 
@@ -286,7 +323,9 @@ mod tests {
             let worker_network_address = Multiaddr::empty();
             let primary_info = NodeP2pInfo::new(
                 (network_keypair.public().clone().into(), primary_network_address).into(),
-                (worker_network_keypair.public().clone().into(), worker_network_address).into(),
+                vec![
+                    (worker_network_keypair.public().clone().into(), worker_network_address).into()
+                ],
             );
             let name = format!("validator-{v}");
             // create validator
@@ -323,7 +362,9 @@ mod tests {
             let worker_network_address = Multiaddr::empty();
             let primary_info = NodeP2pInfo::new(
                 (network_keypair.public().clone().into(), primary_network_address).into(),
-                (worker_network_keypair.public().clone().into(), worker_network_address).into(),
+                vec![
+                    (worker_network_keypair.public().clone().into(), worker_network_address).into()
+                ],
             );
             let name = format!("validator-{v}");
             // create validator
@@ -339,5 +380,52 @@ mod tests {
         }
         // validate should fail
         assert!(network_genesis.validate().is_err(), "proof of possession should fail")
+    }
+
+    /// Build a valid validator with `num_workers` workers.
+    fn validator_with_workers(index: usize, num_workers: usize) -> NodeInfo {
+        let seed = u8::try_from(index).expect("validator index fits a seed byte");
+        let bls_keypair = BlsKeypair::generate(&mut StdRng::from_seed([seed; 32]));
+        let network_keypair = NetworkKeypair::generate_ed25519();
+        let address = Address::from_raw_public_key(&[0; 64]);
+        let proof_of_possession =
+            generate_proof_of_possession_bls_for_test(&bls_keypair, &address).unwrap();
+        let workers = (0..num_workers)
+            .map(|_| {
+                (NetworkKeypair::generate_ed25519().public().clone().into(), Multiaddr::empty())
+                    .into()
+            })
+            .collect();
+        NodeInfo {
+            name: format!("validator-{index}"),
+            bls_public_key: *bls_keypair.public(),
+            p2p_info: NodeP2pInfo::new(
+                (network_keypair.public().clone().into(), Multiaddr::empty()).into(),
+                workers,
+            ),
+            execution_address: address,
+            proof_of_possession,
+        }
+    }
+
+    #[test]
+    fn test_validate_genesis_agrees_on_worker_count() {
+        let mut network_genesis = NetworkGenesis::new_for_test();
+        (0..4).for_each(|v| network_genesis.add_validator(validator_with_workers(v, 2)));
+        assert!(network_genesis.validate().is_ok());
+        let committee = network_genesis.create_committee().expect("committee");
+        assert_eq!(committee.number_of_workers(), 2);
+        let bootstrap = committee.bootstrap_servers();
+        assert!(bootstrap.values().all(|server| server.num_workers() == 2));
+    }
+
+    #[test]
+    fn test_validate_genesis_rejects_mismatched_worker_count() {
+        let mut network_genesis = NetworkGenesis::new_for_test();
+        (0..3).for_each(|v| network_genesis.add_validator(validator_with_workers(v, 2)));
+        network_genesis.add_validator(validator_with_workers(3, 1));
+        let err = network_genesis.validate().expect_err("mismatched worker counts must fail");
+        assert!(err.to_string().contains("same number of workers"), "{err}");
+        assert!(network_genesis.create_committee().is_err());
     }
 }

--- a/crates/config/src/network.rs
+++ b/crates/config/src/network.rs
@@ -4,7 +4,7 @@ use crate::{ConfigFmt, ConfigTrait, TelcoinDirs};
 use libp2p::kad::K_VALUE;
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, time::Duration};
-use tn_types::Round;
+use tn_types::{Round, WorkerId};
 
 impl ConfigTrait for NetworkConfig {}
 
@@ -181,9 +181,12 @@ impl LibP2pConfig {
         format!("tn-epoch-vote-{chain_id}")
     }
 
-    /// Return the worker-batch gossip topic for `chain_id`.
-    pub fn worker_batch_topic(chain_id: u64) -> String {
-        format!("tn-worker-{chain_id}")
+    /// Return the worker-batch gossip topic for worker `worker_id` on `chain_id`.
+    ///
+    /// Every worker has its own batch gossip mesh, so a batch gossiped by worker `k` of one
+    /// validator only reaches worker `k` of the others.
+    pub fn worker_batch_topic(chain_id: u64, worker_id: WorkerId) -> String {
+        format!("tn-worker-{chain_id}-{worker_id}")
     }
 }
 
@@ -668,7 +671,12 @@ hostname: "my-validator"
         assert_eq!(LibP2pConfig::primary_topic(2017), "tn-primary-2017");
         assert_eq!(LibP2pConfig::consensus_output_topic(2017), "tn-consensus-output-2017");
         assert_eq!(LibP2pConfig::epoch_vote_topic(2017), "tn-epoch-vote-2017");
-        assert_eq!(LibP2pConfig::worker_batch_topic(2017), "tn-worker-2017");
+        assert_eq!(LibP2pConfig::worker_batch_topic(2017, 0), "tn-worker-2017-0");
+        // each worker has its own batch mesh
+        assert_ne!(
+            LibP2pConfig::worker_batch_topic(2017, 0),
+            LibP2pConfig::worker_batch_topic(2017, 1)
+        );
         // a different chain id yields a different topic
         assert_ne!(LibP2pConfig::primary_topic(1), LibP2pConfig::primary_topic(2));
     }

--- a/crates/config/src/node.rs
+++ b/crates/config/src/node.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Write, time::Duration};
 use tn_types::{
     get_available_udp_port, test_genesis, Address, BlsPublicKey, BlsSignature, Genesis,
-    NetworkPublicKey, MAINNET_COMMITTEE, MAINNET_GENESIS, MAINNET_PARAMETERS, TESTNET_COMMITTEE,
-    TESTNET_GENESIS, TESTNET_PARAMETERS,
+    NetworkPublicKey, WorkerId, MAINNET_COMMITTEE, MAINNET_GENESIS, MAINNET_PARAMETERS,
+    TESTNET_COMMITTEE, TESTNET_GENESIS, TESTNET_PARAMETERS,
 };
 use tracing::info;
 
@@ -189,10 +189,19 @@ impl Config {
         Ok(())
     }
 
-    /// Update the worker network key.
-    pub fn update_worker_network_key(&mut self, value: NetworkPublicKey) -> eyre::Result<()> {
-        self.node_info.p2p_info.worker.network_key = value;
-        Ok(())
+    /// Update the network key of worker `worker_id`.
+    ///
+    /// Errors if this node runs no worker with that id.
+    pub fn update_worker_network_key(
+        &mut self,
+        worker_id: WorkerId,
+        value: NetworkPublicKey,
+    ) -> eyre::Result<()> {
+        self.node_info
+            .p2p_info
+            .worker_mut(worker_id)
+            .map(|worker| worker.network_key = value)
+            .ok_or_else(|| eyre::eyre!("no worker {worker_id} in node info"))
     }
 
     /// Update the authority execution address.

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -469,7 +469,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(10);
         let task_manager = TaskManager::default();
         let handle =
-            WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
+            WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0, 0);
 
         let connected_peers_calls = Arc::new(AtomicUsize::new(0));
         let calls = connected_peers_calls.clone();

--- a/crates/consensus/worker/src/network/handle.rs
+++ b/crates/consensus/worker/src/network/handle.rs
@@ -20,7 +20,7 @@ use tn_network_libp2p::{
 };
 use tn_types::{
     encode, max_batch_size, try_decode, Batch, BlockHash, BlsPublicKey, Epoch, RpcInfo,
-    SealedBatch, TaskSpawner,
+    SealedBatch, TaskSpawner, WorkerId,
 };
 use tracing::{debug, warn};
 
@@ -85,13 +85,16 @@ pub struct WorkerNetworkHandle {
     sync_capability: Arc<Mutex<HashMap<BlsPublicKey, bool>>>,
     /// The genesis chain id, used to namespace gossip topics this handle publishes.
     chain_id: u64,
+    /// The id of the worker this handle belongs to, used to select its gossip topics.
+    worker_id: WorkerId,
 }
 
 impl WorkerNetworkHandle {
-    /// Create a new instance of [Self].
+    /// Create a new instance of [Self] for worker `worker_id`.
     pub fn new(
         handle: NetworkHandle<Req, Res>,
         task_spawner: TaskSpawner,
+        worker_id: WorkerId,
         epoch: Epoch,
         chain_id: u64,
     ) -> Self {
@@ -100,8 +103,14 @@ impl WorkerNetworkHandle {
             task_spawner,
             epoch,
             chain_id,
+            worker_id,
             sync_capability: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Return the id of the worker this handle belongs to.
+    pub fn worker_id(&self) -> WorkerId {
+        self.worker_id
     }
 
     /// Return a reference to the task spawner.
@@ -118,7 +127,10 @@ impl WorkerNetworkHandle {
     pub(crate) async fn publish_batch(&self, batch_digest: BlockHash) -> NetworkResult<()> {
         let data = encode(&WorkerGossip::Batch(self.epoch, batch_digest));
         self.handle
-            .publish(tn_config::LibP2pConfig::worker_batch_topic(self.chain_id), data)
+            .publish(
+                tn_config::LibP2pConfig::worker_batch_topic(self.chain_id, self.worker_id),
+                data,
+            )
             .await?;
         Ok(())
     }
@@ -547,6 +559,7 @@ impl WorkerNetworkHandle {
             task_spawner,
             epoch: 0,
             chain_id: 0,
+            worker_id: tn_types::DEFAULT_WORKER_ID,
             sync_capability: Arc::new(Mutex::new(HashMap::new())),
         }
     }

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -153,7 +153,8 @@ where
             WorkerGossip::Batch(epoch, batch_hash) => {
                 ensure!(
                     topic.to_string().eq(&tn_config::LibP2pConfig::worker_batch_topic(
-                        self.consensus_config.chain_id()
+                        self.consensus_config.chain_id(),
+                        self.id,
                     )),
                     WorkerNetworkError::InvalidTopic
                 );

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -65,7 +65,7 @@ pub fn new_worker<DB: Database>(
     info!(target: "worker::worker",
         "Worker {} successfully booted on {}",
         id,
-        consensus_config.config().node_info.p2p_info.worker.network_address
+        consensus_config.worker_address(id).map_or_else(|| "<no address>".to_string(), |addr| addr.to_string())
     );
 
     batch_provider

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -53,8 +53,13 @@ fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
     let worker_id = 0;
     let batch_validator = Arc::new(NoopBatchValidator);
     let (tx, network_commands_rx) = mpsc::channel(10);
-    let network_handle =
-        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, chain_id);
+    let network_handle = WorkerNetworkHandle::new(
+        NetworkHandle::new(tx),
+        task_manager.get_spawner(),
+        0,
+        0,
+        chain_id,
+    );
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
 }
@@ -73,7 +78,7 @@ fn create_test_types_with_validator(
     let worker_id = 0;
     let (tx, network_commands_rx) = mpsc::channel(10);
     let network_handle =
-        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0, 0);
     let handler = RequestHandler::new(worker_id, validator, config, network_handle);
     (TestTypes { committee, handler, task_manager, network_commands_rx }, store)
 }
@@ -129,7 +134,7 @@ async fn test_batch_gossip_topics() {
     let batch_digest = B256::random();
     let gossip = WorkerGossip::Batch(0, batch_digest);
     let data = tn_types::encode(&gossip);
-    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0));
+    let topic = TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0, 0));
     let good_msg = GossipMessage { source: None, data: data.clone(), sequence_number: None, topic };
     assert!(handler.pub_process_gossip_for_test(&good_msg).await.is_ok());
 
@@ -154,7 +159,7 @@ async fn test_batch_gossip_topic_is_chain_namespaced() {
         source: None,
         data: data.clone(),
         sequence_number: None,
-        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(2017)),
+        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(2017, 0)),
     };
     assert!(handler.pub_process_gossip_for_test(&good).await.is_ok());
 
@@ -163,7 +168,7 @@ async fn test_batch_gossip_topic_is_chain_namespaced() {
         source: None,
         data,
         sequence_number: None,
-        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0)),
+        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0, 0)),
     };
     assert_matches!(
         handler.pub_process_gossip_for_test(&bad).await,
@@ -185,7 +190,7 @@ async fn test_batch_gossip_prefetch_deduplicates_in_flight_digest() {
         source: None,
         data: data.clone(),
         sequence_number: None,
-        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0)),
+        topic: TopicHash::from_raw(tn_config::LibP2pConfig::worker_batch_topic(0, 0)),
     };
 
     // Task A: the first prefetch. It reaches `request_batches` (emitting a network
@@ -293,7 +298,8 @@ async fn test_unknown_stream_request_error_type() {
 async fn test_request_batches_no_peers() {
     let (tx, mut rx) = mpsc::channel(10);
     let task_manager = TaskManager::default();
-    let handle = WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0);
+    let handle =
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0, 0);
 
     // reply with empty peer list
     tokio::spawn(async move {

--- a/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
+++ b/crates/consensus/worker/tests/it/quorum_waiter_tests.rs
@@ -23,7 +23,7 @@ async fn test_wait_for_quorum_happy_path() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -74,7 +74,7 @@ async fn test_batch_rejected_timeout() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -128,7 +128,7 @@ async fn test_batch_some_rejected_stake_still_passes() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -201,7 +201,7 @@ async fn test_batch_rejected_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -263,7 +263,7 @@ async fn test_batch_rejected_antiquorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -313,7 +313,7 @@ async fn test_batch_early_anti_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     // Spawn a `QuorumWaiter` instance.
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
@@ -393,7 +393,7 @@ async fn test_network_error_retry_then_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -449,7 +449,7 @@ async fn test_network_error_partial_retry_success() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -526,7 +526,7 @@ async fn test_network_error_all_retries_exhausted() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -578,7 +578,7 @@ async fn test_recoverable_error_retry_then_quorum() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),
@@ -638,7 +638,7 @@ async fn test_recoverable_error_exhausts_retries_as_network() {
     // setup network
     let (sender, mut network_rx) = mpsc::channel(100);
     let network =
-        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0);
+        WorkerNetworkHandle::new(NetworkHandle::new(sender), task_manager.get_spawner(), 0, 0, 0);
     let quorum_waiter = QuorumWaiter::new(
         my_primary.authority().clone(),
         committee.clone(),

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -33,6 +33,10 @@ alloy = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
+# `pack_validate` re-runs a node's own epoch pack integrity checks from the harness. `test-utils`
+# is `tn-types/test-utils`, which the fork-epoch overrides live behind: the harness decodes pack
+# bytes itself, so it has to honor the same fork pins it forwards to every spawned node.
+tn-storage = { workspace = true, features = ["test-utils"] }
 tn-test-utils = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -36,22 +36,27 @@ pub enum TestBinary {
 impl TestBinary {
     /// Build a [`std::process::Command`] that runs this binary.
     ///
-    /// Pins `TN_SEED_SIGNATURE_FORK_EPOCH` on the child so every spawned node runs the fork
-    /// point the harness states rather than the build default (non-adiri builds are otherwise
-    /// active from genesis). With nothing in the harness environment the pin is `u32::MAX`:
-    /// fork dormant, wire-identical to pre-fork mainnet. A harness-level value is forwarded
-    /// verbatim so a fork-active lane can export `TN_SEED_SIGNATURE_FORK_EPOCH=0`, and a
-    /// single test can still override the pin with its own later `env()` call. Only binaries
-    /// built with `tn-types/test-utils` (pulled in via `tn-storage/test-utils`, see
-    /// `make build-e2e-bin`) consult the variable; production binaries ignore it.
+    /// Pins every fork-epoch override on the child so spawned nodes run the fork points the
+    /// harness states rather than their build defaults (non-adiri builds are otherwise active
+    /// from genesis for both forks). With nothing in the harness environment each pin is
+    /// `u32::MAX`, holding that fork dormant: wire-identical to pre-fork mainnet for the seed
+    /// signature, the legacy single-worker layout for the committee worker list. A harness-level
+    /// value is forwarded verbatim so a fork-active lane can export
+    /// `TN_SEED_SIGNATURE_FORK_EPOCH=0` or `TN_MULTI_WORKERS_FORK_EPOCH=1`, and a single test
+    /// can still override a pin with its own later `env()` call. Only binaries built with
+    /// `tn-types/test-utils` (pulled in via `tn-storage/test-utils`, see `make build-e2e-bin`)
+    /// consult these variables; production binaries ignore them.
     pub fn command(&self) -> std::process::Command {
         let mut command = match self {
             TestBinary::Prebuilt(path) => std::process::Command::new(path),
             TestBinary::Cargo(run) => run.command(),
         };
-        let fork_epoch =
-            std::env::var("TN_SEED_SIGNATURE_FORK_EPOCH").unwrap_or_else(|_| u32::MAX.to_string());
-        command.env("TN_SEED_SIGNATURE_FORK_EPOCH", fork_epoch);
+        // one loop rather than a block per variable so the two forks cannot drift apart in
+        // mechanism; they arm independently, so each is read and forwarded on its own
+        for var in ["TN_SEED_SIGNATURE_FORK_EPOCH", "TN_MULTI_WORKERS_FORK_EPOCH"] {
+            let fork_epoch = std::env::var(var).unwrap_or_else(|_| u32::MAX.to_string());
+            command.env(var, fork_epoch);
+        }
         command
     }
 }

--- a/crates/e2e-tests/tests/it/common.rs
+++ b/crates/e2e-tests/tests/it/common.rs
@@ -43,7 +43,8 @@ use tn_test_utils::{wait_until, wait_until_blocking};
 use tn_types::{
     address, get_available_tcp_port, keccak256,
     test_utils::{init_test_tracing, CommandParser},
-    Address, EpochCertificate, EpochRecord, Genesis, GenesisAccount, NodeMode, RpcInfo, U256,
+    Address, EpochCertificate, EpochRecord, Genesis, GenesisAccount, NodeMode, RpcInfo,
+    DEFAULT_WORKER_ID, U256,
 };
 use tokio::{
     runtime::Builder,
@@ -460,7 +461,7 @@ pub(crate) fn start_validator_with_args(
 
 /// Advertise a validator's JSON-RPC endpoint on its worker record.
 ///
-/// The genesis ceremony leaves `p2p_info.worker.rpc` unset, and a non-committee node
+/// The genesis ceremony leaves `p2p_info.workers[0].rpc` unset, and a non-committee node
 /// forwards accepted transactions to whatever endpoints committee validators advertise
 /// (issue #804); with none advertised, each seal is refused with
 /// `BlockSealError::NotValidator` and the transactions stay pending in the node's own
@@ -475,8 +476,12 @@ pub(crate) fn advertise_worker_rpc(
 ) -> eyre::Result<()> {
     let path = base_dir.join(format!("validator-{}", instance + 1)).join("node-info.yaml");
     let mut node_info = Config::load_from_path::<NodeInfo>(&path, ConfigFmt::YAML)?;
-    node_info.p2p_info.worker.rpc =
-        Some(RpcInfo { http: format!("http://127.0.0.1:{rpc_port}").parse()?, ws: None });
+    let rpc = Some(RpcInfo { http: format!("http://127.0.0.1:{rpc_port}").parse()?, ws: None });
+    node_info
+        .p2p_info
+        .worker_mut(DEFAULT_WORKER_ID)
+        .map(|worker| worker.rpc = rpc)
+        .ok_or_else(|| eyre::eyre!("validator-{} node info has no worker 0", instance + 1))?;
     Config::write_to_path(&path, &node_info, ConfigFmt::YAML)?;
     Ok(())
 }

--- a/crates/e2e-tests/tests/it/epochs.rs
+++ b/crates/e2e-tests/tests/it/epochs.rs
@@ -9,16 +9,26 @@ use super::common::{
 use alloy::providers::{Provider, ProviderBuilder};
 use e2e_tests::NodeEndpoints;
 use rand::{rngs::StdRng, SeedableRng as _};
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use tn_reth::{
     system_calls::{ConsensusRegistry, CONSENSUS_REGISTRY_ADDRESS},
     test_utils::TransactionFactory,
     RethChainSpec,
 };
+use tn_storage::pack_validate::{validate_pack_file, Verdict};
 use tn_test_utils::wait_until;
-use tn_types::{Address, EpochCertificate, EpochRecord, Genesis};
+use tn_types::{
+    forks::{multi_workers_fork_active, seed_signature_active},
+    keccak256, Address, Epoch, EpochCertificate, EpochRecord, Genesis, B256,
+};
 use tokio::time::timeout;
-use tracing::debug;
+use tracing::{debug, info};
 
 const MIN_EPOCHS_TO_TEST: usize = 6;
 // Epoch init creates HDX index files per epoch (open_epoch_pack → new_epoch →
@@ -29,6 +39,23 @@ const MIN_EPOCHS_TO_TEST: usize = 6;
 // constant, because certificate production is a fixed async quorum-voting cost that does
 // not shrink with the epoch cadence.
 const EPOCH_DURATION: u64 = 5;
+
+/// Environment variable selecting the multi-workers fork epoch (#554) for this process and
+/// every node it spawns (`tn_types::forks::multi_workers_fork_epoch_override`).
+const MULTI_WORKERS_FORK_ENV: &str = "TN_MULTI_WORKERS_FORK_EPOCH";
+
+/// Environment variable selecting the seed-signature fork epoch (#1032) for this process and every
+/// node it spawns (`tn_types::forks::seed_signature_fork_epoch_override`).
+const SEED_SIGNATURE_FORK_ENV: &str = "TN_SEED_SIGNATURE_FORK_EPOCH";
+
+/// Multi-workers fork epoch for [`test_epoch_sync_across_multi_workers_fork`].
+///
+/// The kill in [`test_epoch_sync_inner`] happens after `loop_epochs` has watched three boundaries
+/// pass, so the epoch open at that point is at least 3 and the sealed set — which stops two below
+/// it, see [`sealed_epochs`] — always covers epochs 0 and 1. Pinning the fork at 1 therefore
+/// guarantees those sealed packs straddle it: epoch 0 in the legacy single-worker committee
+/// layout, epoch 1 onward in the multi-worker one.
+const CROSS_FORK_EPOCH: Epoch = 1;
 
 async fn test_epoch_boundary_inner(
     genesis: Genesis,
@@ -278,14 +305,23 @@ async fn assert_tn_registry_endpoints<P: Provider>(provider: &P) -> eyre::Result
     Ok(())
 }
 
+/// Kill one node, advance several epochs without it, restart it against its existing datadir, and
+/// assert it back-fills everything it missed.
+///
+/// Returns the epochs whose pack files were fingerprinted before the kill and revalidated after
+/// the restart (see [`sealed_epochs`]), so a caller can assert what those packs cover.
+///
+/// `test` names the log directory under `test_logs/` for the restarted node, matching the one the
+/// caller used for the initial spawn.
 async fn test_epoch_sync_inner(
     guard: &mut ProcessGuard,
     kill_idx: usize,
     nodes_to_start: &[(&str, Address)],
     committee: &[(&str, Address)],
     temp_path: &Path,
+    test: &str,
     endpoints: &mut Vec<NodeEndpoints>,
-) -> eyre::Result<()> {
+) -> eyre::Result<Range<Epoch>> {
     // create rpc client for node1 default rpc address
     let rpc_url = &endpoints[0].http_url;
     let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
@@ -305,7 +341,7 @@ async fn test_epoch_sync_inner(
 
     // No pre-pad sleep is needed here: loop_epochs polls until the epoch changes.
     // Go through at least 3 epochs.
-    loop_epochs(0, 3, &endpoints[0].http_url, EPOCH_DURATION).await?;
+    let epoch_at_kill = loop_epochs(0, 3, &endpoints[0].http_url, EPOCH_DURATION).await?;
     // Kill a node
     if let Some(mut taken) = guard.take(kill_idx) {
         super::common::kill_child(&mut taken);
@@ -316,10 +352,22 @@ async fn test_epoch_sync_inner(
     let killed_provider = ProviderBuilder::new().connect_http(killed_url.parse()?);
     assert!(killed_provider.get_chain_id().await.is_err(), "Node not down!");
 
+    // Fingerprint the killed node's sealed packs while its datadir is quiescent: the process is
+    // gone, so nothing is appending to them and nothing has re-imported them yet. Step 8 below
+    // compares against these bytes once the node is back and caught up.
+    let killed_datadir = temp_path.join(committee[kill_idx].0);
+    let sealed = sealed_epochs(epoch_at_kill);
+    let sealed_before = fingerprint_sealed_packs(&killed_datadir, sealed.clone())?;
+    info!(
+        target: "epoch-test",
+        epoch_at_kill,
+        ?sealed,
+        "fingerprinted sealed epoch packs of the killed node",
+    );
+
     loop_epochs(3, 3, &endpoints[0].http_url, EPOCH_DURATION).await?;
     // Restart the node
-    let (mut new_children, mut new_endpoints) =
-        start_nodes(temp_path, nodes_to_start, "epoch_sync", 2)?;
+    let (mut new_children, mut new_endpoints) = start_nodes(temp_path, nodes_to_start, test, 2)?;
     let new_child = new_children.pop().expect("child");
     guard.replace(kill_idx, new_child);
     // Update the endpoint for the restarted node (new dynamic ports)
@@ -332,15 +380,13 @@ async fn test_epoch_sync_inner(
     // after epoch boundaries via quorum voting.
     // TODO issue 375, should use tn_latestConsensusHeader RPC for this when fixed.
     let latest_epoch = current_epoch - 1;
+    // The killed node's certified records, kept so the pack revalidation below can anchor each
+    // sealed pack to its predecessor (see `assert_sealed_packs_unchanged`).
+    let mut killed_epoch_records = BTreeMap::new();
     for (i, ep) in endpoints.iter().enumerate() {
         for epoch in 0..=latest_epoch {
             let val_name = committee[i].0;
-            let file_test = temp_path
-                .join(val_name)
-                .join("consensus-db")
-                .join("epochs")
-                .join(format!("epoch-{epoch}"))
-                .join("data");
+            let file_test = epoch_pack_path(&temp_path.join(val_name), epoch);
             let pack_file_exists = std::fs::exists(file_test).unwrap_or_default();
             assert!(pack_file_exists, "Missing an epoch pack file for {val_name} on epoch {epoch}");
             // A node was killed and restarted earlier in this test, so it must back-fill the
@@ -361,10 +407,237 @@ async fn test_epoch_sync_inner(
                 "final block for {epoch} for {val_name} missing {}",
                 epoch_rec.final_state.number
             ));
+            if i == kill_idx {
+                killed_epoch_records.insert(epoch, epoch_rec);
+            }
         }
     }
 
+    // Existence and a served epoch record say nothing about the bytes on disk, so re-read them:
+    // the restart must not have rewritten history it already had.
+    assert_sealed_packs_unchanged(&killed_datadir, &sealed_before, &killed_epoch_records)?;
+
+    Ok(sealed)
+}
+
+/// The epochs whose pack files must survive a kill and restart byte-for-byte, given the epoch
+/// `loop_epochs` last observed before the node was killed.
+///
+/// Two epochs of margin below `epoch_at_kill`, not one:
+///
+/// - `epoch_at_kill` was open when the node died, so its pack is mid-append. A restarted node
+///   re-requests every epoch whose pack is incomplete (`state_sync::request_epochs`), so the
+///   restart is entitled to replace that one wholesale.
+/// - `epoch_at_kill - 1` is only known sealed on the node whose RPC `loop_epochs` polled. The node
+///   this test kills can still be a beat behind executing that epoch's closing block, and a pack is
+///   flushed when the NEXT epoch opens (`ConsensusChain::new_epoch` persists the outgoing pack).
+///   Killing it inside that window leaves a short pack that the restart legitimately re-imports.
+///
+/// Everything below that closed at least one full epoch before the kill, so it is quiescent on
+/// every node.
+fn sealed_epochs(epoch_at_kill: Epoch) -> Range<Epoch> {
+    0..epoch_at_kill.saturating_sub(1)
+}
+
+/// Path of the consensus pack `data` file for `epoch` inside a node's datadir.
+///
+/// This file alone is the byte stream a syncing peer receives and imports, which is why both the
+/// fingerprint and the offline validator below run against it: the `idx`/`hash` sidecars are
+/// needed to *use* a pack, not to judge it.
+fn epoch_pack_path(datadir: &Path, epoch: Epoch) -> PathBuf {
+    datadir.join("consensus-db").join("epochs").join(format!("epoch-{epoch}")).join("data")
+}
+
+/// Fingerprint the pack file of every epoch in `sealed` under `datadir`.
+fn fingerprint_sealed_packs(
+    datadir: &Path,
+    sealed: Range<Epoch>,
+) -> eyre::Result<BTreeMap<Epoch, B256>> {
+    sealed
+        .map(|epoch| {
+            let path = epoch_pack_path(datadir, epoch);
+            let bytes = std::fs::read(&path)
+                .map_err(|e| eyre::eyre!("reading sealed pack {}: {e}", path.display()))?;
+            Ok((epoch, keccak256(bytes)))
+        })
+        .collect()
+}
+
+/// Assert every pack sealed before the kill survived the restart untouched and still imports.
+///
+/// Two independent checks per epoch:
+///
+/// 1. `validate_pack_file` walks the whole `data` stream applying the integrity rules
+///    `ConsensusPack::stream_import` applies to a pack arriving from a peer, so a pack that passes
+///    here is one a syncing node would accept. `records` supplies the previous epoch's certified
+///    [`EpochRecord`], which additionally turns on the epoch-linkage checks (start consensus
+///    number, genesis exec state, the committee the previous record commits to) and anchors the
+///    first header's `parent_hash`.
+/// 2. Byte equality against the pre-restart fingerprint. This is the load-bearing half: a pack can
+///    be internally valid and still have been rewritten — re-imported from a peer, or healed —
+///    which would mask the regression this pins, that restarting into an existing datadir leaves
+///    closed epochs alone.
+///
+/// Decoding a pack reaches two epoch-gated layouts: the [`tn_types::Committee`] in its `EpochMeta`
+/// record, selected by the committee's own epoch against the multi-workers fork
+/// ([`multi_workers_fork_active`]), and every nested `ConsensusHeader`, selected against the
+/// seed-signature fork ([`seed_signature_active`]). This process therefore has to sit on the same
+/// fork epochs the nodes wrote under for BOTH, which is what [`pin_fork_epochs`] arranges.
+fn assert_sealed_packs_unchanged(
+    datadir: &Path,
+    fingerprints: &BTreeMap<Epoch, B256>,
+    records: &BTreeMap<Epoch, EpochRecord>,
+) -> eyre::Result<()> {
+    for (&epoch, before) in fingerprints {
+        let path = epoch_pack_path(datadir, epoch);
+        // epoch 0 has no predecessor; the validator anchors it on the default consensus header
+        let previous = epoch.checked_sub(1).and_then(|prev| records.get(&prev));
+        let report = validate_pack_file(&path, epoch, previous)
+            .map_err(|e| eyre::eyre!("sealed pack {} did not open: {e}", path.display()))?;
+        eyre::ensure!(
+            report.verdict == Verdict::Valid,
+            "sealed pack {} is invalid after the restart: {:?}",
+            path.display(),
+            report.issues,
+        );
+
+        let after = keccak256(
+            std::fs::read(&path)
+                .map_err(|e| eyre::eyre!("re-reading sealed pack {}: {e}", path.display()))?,
+        );
+        eyre::ensure!(
+            after == *before,
+            "sealed pack {} changed across the restart: {before} -> {after}",
+            path.display(),
+        );
+        info!(
+            target: "epoch-test",
+            epoch,
+            consensus_headers = report.consensus_count,
+            batches = report.batch_count,
+            "sealed epoch pack survived the restart unchanged",
+        );
+    }
     Ok(())
+}
+
+/// Pin every fork epoch this suite's decoding depends on — the multi-workers fork (#554) and
+/// the seed-signature fork (#1032) — for this process and every node it spawns.
+///
+/// Step 8 decodes sealed pack bytes in the harness, and that reaches both gates: the `EpochMeta`'s
+/// [`tn_types::Committee`] is laid out by [`multi_workers_fork_active`] and every nested
+/// `ConsensusHeader` by [`seed_signature_active`]. So the harness has to resolve both to the same
+/// fork points the nodes wrote under. Left alone the two sides disagree the same way for each
+/// fork: `TestBinary::command` forwards `u32::MAX` to a child when the variable is unset, while
+/// this (non-adiri) harness build is active from genesis without it. Writing the variables settles
+/// both sides at once — children inherit them verbatim at spawn, and the harness's own overrides
+/// latch them on first read.
+///
+/// Both forks are pinned, not just the one a given test is about. Pinning only one leaves the other
+/// asymmetric whenever the suite runs outside the Makefile wrapper that exports it, and the
+/// symptom is misleading: children write dormant-layout headers, the harness decodes them as
+/// genesis-active, and step 8 reports a corrupt pack rather than an environment mismatch.
+///
+/// `force_multi_workers` states the multi-workers fork epoch outright, for a test whose
+/// claim is about a specific boundary. `None` — and the seed-signature pin always — inherits
+/// whatever the lane exported, defaulting to the dormant `u32::MAX` that `TestBinary::command`
+/// would have forwarded anyway, so `TN_MULTI_WORKERS_FORK_EPOCH=1 make test-epochs` keeps
+/// meaning what it says.
+///
+/// Call once per test, before the first node spawn and before anything in the process reads either
+/// gate: the overrides are process-wide `OnceLock`s and the environment is process-wide too. That
+/// is sound because nextest runs each test in its own process (`.config/nextest.toml`); under
+/// plain `cargo test` two of these tests in one process would fight over it, and the assertions
+/// below are what turn that into a loud failure instead of a mis-decoded pack.
+fn pin_fork_epochs(force_multi_workers: Option<Epoch>) {
+    // what `TestBinary::command` would forward to a child: the value the lane exported, or the
+    // dormant `u32::MAX` when it exported nothing. an unparseable value normalizes to the same
+    // dormant default the gate would have fallen back to.
+    let lane = |var: &str| -> Epoch {
+        std::env::var(var).ok().and_then(|raw| raw.trim().parse().ok()).unwrap_or(u32::MAX)
+    };
+
+    // one shared helper rather than a block per fork, mirroring `TestBinary::command`, so the two
+    // cannot drift apart in mechanism; they arm independently, so each carries its own gate
+    pin_fork_epoch(
+        MULTI_WORKERS_FORK_ENV,
+        force_multi_workers.unwrap_or_else(|| lane(MULTI_WORKERS_FORK_ENV)),
+        multi_workers_fork_active,
+    );
+    pin_fork_epoch(SEED_SIGNATURE_FORK_ENV, lane(SEED_SIGNATURE_FORK_ENV), seed_signature_active);
+}
+
+/// Write `fork_epoch` to the `var` override and check `gate` reads the same fork point back.
+///
+/// Reading the gate here, rather than leaving it to whatever decodes a pack minutes later, is what
+/// turns an override that latched before this pin into a named failure instead of a corrupt-looking
+/// pack.
+fn pin_fork_epoch(var: &str, fork_epoch: Epoch, gate: impl Fn(Epoch) -> bool) {
+    std::env::set_var(var, fork_epoch.to_string());
+
+    // The gate is `>=`, so it fires at the fork epoch and nowhere below it; both assertions hold
+    // for the dormant pin too, since `u32::MAX >= u32::MAX`.
+    assert!(
+        gate(fork_epoch),
+        "harness gate must be active at the pinned fork epoch {fork_epoch}: {var} latched to \
+         another value before this test pinned it"
+    );
+    if let Some(below) = fork_epoch.checked_sub(1) {
+        assert!(
+            !gate(below),
+            "harness gate must be dormant below the pinned fork epoch {fork_epoch}: {var} latched \
+             to another value before this test pinned it"
+        );
+    }
+    info!(target: "epoch-test", var, fork_epoch, "pinned a fork epoch");
+}
+
+/// Spin up the epoch-sync network and run [`test_epoch_sync_inner`] against it.
+///
+/// `test` names both the temp-dir prefix and the `test_logs/` directory, so callers running the
+/// same scenario under different fork epochs keep separate node logs. Keep it short: every node's
+/// IPC socket path is built under the temp dir, and a unix socket path is capped at ~104 bytes.
+async fn run_epoch_sync_scenario(test: &str) -> eyre::Result<Range<Epoch>> {
+    // create validator and governance wallets for adding new validator later
+    let new_validator = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(6));
+    let mut committee = vec![
+        ("validator-1", Address::from_slice(&[0x11; 20])),
+        ("validator-2", Address::from_slice(&[0x22; 20])),
+        ("validator-3", Address::from_slice(&[0x33; 20])),
+        ("validator-4", Address::from_slice(&[0x44; 20])),
+        ("validator-5", Address::from_slice(&[0x55; 20])),
+    ];
+
+    // setup genesis
+    let temp_dir = tempfile::TempDir::with_prefix(test)?;
+    let temp_path = temp_dir.path();
+
+    let governance_wallet =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+    let _genesis = create_genesis_for_test(
+        temp_path,
+        (NEW_VALIDATOR, new_validator.address()),
+        governance_wallet.address(),
+        &committee,
+        EPOCH_DURATION,
+    )?;
+
+    // start nodes (committee + new validator)
+    committee.push((NEW_VALIDATOR, new_validator.address()));
+    let (procs, mut endpoints) = start_nodes(temp_path, &committee, test, 1)?;
+    // Guard ensures processes are killed on drop (normal return, error, or panic).
+    let mut guard = ProcessGuard::new(procs);
+
+    test_epoch_sync_inner(
+        &mut guard,
+        2,
+        &[("validator-3", Address::from_slice(&[0x33; 20]))],
+        &committee[..],
+        temp_path,
+        test,
+        &mut endpoints,
+    )
+    .await
 }
 
 #[ignore = "only run independently from all other it tests"]
@@ -411,43 +684,41 @@ async fn test_epoch_boundary() -> eyre::Result<()> {
 /// Test that sync works to fill in missing epochs.
 async fn test_epoch_sync() -> eyre::Result<()> {
     let _permit = super::common::acquire_test_permit();
-    // create validator and governance wallets for adding new validator later
-    let new_validator = TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(6));
-    let mut committee = vec![
-        ("validator-1", Address::from_slice(&[0x11; 20])),
-        ("validator-2", Address::from_slice(&[0x22; 20])),
-        ("validator-3", Address::from_slice(&[0x33; 20])),
-        ("validator-4", Address::from_slice(&[0x44; 20])),
-        ("validator-5", Address::from_slice(&[0x55; 20])),
-    ];
+    // whatever fork epochs the lane stated, dormant by default - this test is about sync, not about
+    // either fork, but the harness still decodes pack bytes and must agree with the nodes
+    pin_fork_epochs(None);
 
-    // setup genesis
-    let temp_dir = tempfile::TempDir::with_prefix("epoch_sync")?;
-    let temp_path = temp_dir.path();
+    run_epoch_sync_scenario("epoch_sync").await.map(|_sealed| ())
+}
 
-    let governance_wallet =
-        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
-    let _genesis = create_genesis_for_test(
-        temp_path,
-        (NEW_VALIDATOR, new_validator.address()),
-        governance_wallet.address(),
-        &committee,
-        EPOCH_DURATION,
-    )?;
+#[ignore = "only run independently from all other it tests"]
+#[tokio::test(flavor = "multi_thread")]
+/// Test that an epoch pack archive spanning the multi-workers fork boundary (#554) survives a
+/// restart.
+///
+/// The same kill/restart scenario as [`test_epoch_sync`], with the fork pinned at
+/// [`CROSS_FORK_EPOCH`] so one datadir holds both committee layouts: epoch 0 written in the legacy
+/// single-worker layout, every later epoch in the multi-worker one. The restarted node has to read
+/// its own history back across that boundary to decide which epochs it still needs, and step 8
+/// then decodes both layouts again from the harness.
+async fn test_epoch_sync_across_multi_workers_fork() -> eyre::Result<()> {
+    let _permit = super::common::acquire_test_permit();
+    // forced rather than inherited: this test's claim is a crossing at a known multi-workers
+    // epoch, so it states that fork point even when the lane exported a different one. the
+    // seed-signature pin still follows the lane - this test makes no claim about it.
+    pin_fork_epochs(Some(CROSS_FORK_EPOCH));
 
-    // start nodes (committee + new validator)
-    committee.push((NEW_VALIDATOR, new_validator.address()));
-    let (procs, mut endpoints) = start_nodes(temp_path, &committee, "epoch_sync", 1)?;
-    // Guard ensures processes are killed on drop (normal return, error, or panic).
-    let mut guard = ProcessGuard::new(procs);
+    let sealed = run_epoch_sync_scenario("epoch_sync_fork").await?;
 
-    test_epoch_sync_inner(
-        &mut guard,
-        2,
-        &[("validator-3", Address::from_slice(&[0x33; 20]))],
-        &committee[..],
-        temp_path,
-        &mut endpoints,
-    )
-    .await
+    // The revalidated packs span both layouts only if the fork epoch sits strictly inside them.
+    // Assert it rather than trusting the arithmetic in `CROSS_FORK_EPOCH`: a shorter run, or a
+    // wider safety margin in `sealed_epochs`, would otherwise quietly reduce this to the
+    // single-layout test above.
+    assert!(
+        sealed.start < CROSS_FORK_EPOCH && CROSS_FORK_EPOCH < sealed.end,
+        "sealed epochs {sealed:?} do not straddle the multi-workers fork at \
+         {CROSS_FORK_EPOCH}: the restart proved only one committee layout"
+    );
+
+    Ok(())
 }

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -13,7 +13,7 @@ use tn_config::{ConsensusConfig, NetworkConfig};
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::mem_db::MemDatabase;
 use tn_test_utils::{wait_until, CommitteeFixture};
-use tn_types::{BlsKeypair, Certificate, Header, TaskManager};
+use tn_types::{BlsKeypair, Certificate, Header, TaskManager, DEFAULT_WORKER_ID};
 use tokio::{sync::mpsc, time::timeout};
 
 /// Test topic for gossip.
@@ -724,7 +724,7 @@ async fn test_primary_worker_protocol_isolation() -> eyre::Result<()> {
         MemDatabase::default(),
         task_manager.get_spawner(),
         NetworkType::Worker(0),
-        config_2.worker_address(),
+        config_2.worker_address(DEFAULT_WORKER_ID).expect("worker 0 address"),
         None,
     )
     .expect("worker network created");
@@ -735,7 +735,9 @@ async fn test_primary_worker_protocol_isolation() -> eyre::Result<()> {
 
     // start listening
     primary.start_listening(config_1.primary_address()).await?;
-    worker.start_listening(config_2.worker_address()).await?;
+    worker
+        .start_listening(config_2.worker_address(DEFAULT_WORKER_ID).expect("worker 0 address"))
+        .await?;
     let worker_addr = worker.listeners().await?.first().expect("worker listen addr").clone();
     let primary_peer_id = primary.local_peer_id().await?;
 
@@ -852,7 +854,7 @@ async fn test_unsupported_protocol_does_not_penalize() -> eyre::Result<()> {
         MemDatabase::default(),
         task_manager.get_spawner(),
         NetworkType::Worker(0),
-        config_2.worker_address(),
+        config_2.worker_address(DEFAULT_WORKER_ID).expect("worker 0 address"),
         None,
     )
     .expect("worker network created");
@@ -862,7 +864,9 @@ async fn test_unsupported_protocol_does_not_penalize() -> eyre::Result<()> {
     });
 
     primary.start_listening(config_1.primary_address()).await?;
-    worker.start_listening(config_2.worker_address()).await?;
+    worker
+        .start_listening(config_2.worker_address(DEFAULT_WORKER_ID).expect("worker 0 address"))
+        .await?;
     let worker_addr = worker.listeners().await?.first().expect("worker listen addr").clone();
     let worker_peer_id = worker.local_peer_id().await?;
     let worker_bls = config_2.key_config().primary_public_key();

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = { workspace = true }
 # a `--features adiri` node build actually compiles it in. tn-node's own adiri code is test-only:
 # the pre-fork entry-fee pin in `manager::node::run_epoch::tests`.
 adiri = [
+    "tn-config/adiri",
     "tn-engine/adiri",
     "tn-executor/adiri",
     "tn-reth/adiri",

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -308,6 +308,39 @@ pub async fn sync_num_workers_from_chain(
     gas_accumulator: &GasAccumulator,
     epoch_first_block: u64,
 ) -> eyre::Result<()> {
+    let read_block = epoch_first_block.saturating_sub(1);
+    let num_workers = read_num_workers_at_epoch_entry(reth_env, epoch_first_block).await?;
+
+    let current = gas_accumulator.num_workers();
+    if current != num_workers {
+        info!(
+            target: "epoch-manager",
+            current,
+            on_chain = num_workers,
+            read_block,
+            "syncing GasAccumulator worker count to on-chain WorkerConfigs"
+        );
+    }
+    gas_accumulator.set_num_workers(num_workers);
+    Ok(())
+}
+
+/// Read the on-chain worker count for the epoch whose first block is `epoch_first_block`.
+///
+/// The count is the `WorkerConfigs` state at block `epoch_first_block - 1`, the previous epoch's
+/// closing block (`saturating_sub` makes epoch 0 read genesis state). This is the single read
+/// behind both consumers of the count: [`sync_num_workers_from_chain`] sizes the
+/// [`GasAccumulator`] with it, and the epoch manager stamps it onto the epoch's [`Committee`]
+/// (`Committee::number_of_workers`) so header validation and execution agree on the count.
+///
+/// READ-FAILURE POLICY: both failure classes halt (see [`sync_num_workers_from_chain`]); a
+/// [`Provider`](tn_reth::error::StateReadError::Provider) fault is retried briefly first.
+///
+/// [`Committee`]: tn_types::Committee
+pub(super) async fn read_num_workers_at_epoch_entry(
+    reth_env: &RethEnv,
+    epoch_first_block: u64,
+) -> eyre::Result<usize> {
     // `read_block` is derived from the caller's `epoch_first_block`, so the header resolved here is
     // the pin the retry below threads into every attempt.
     let read_block = epoch_first_block.saturating_sub(1);
@@ -324,19 +357,7 @@ pub async fn sync_num_workers_from_chain(
         .wrap_err_with(|| {
             format!("failed to read WorkerConfigs at block {read_block} while syncing worker count")
         })?;
-
-    let current = gas_accumulator.num_workers();
-    if current != num_workers {
-        info!(
-            target: "epoch-manager",
-            current,
-            on_chain = num_workers,
-            read_block,
-            "syncing GasAccumulator worker count to on-chain WorkerConfigs"
-        );
-    }
-    gas_accumulator.set_num_workers(num_workers);
-    Ok(())
+    Ok(num_workers)
 }
 
 /// Per-worker base fees for an entered epoch, read from the previous epoch's closing block by
@@ -1015,10 +1036,18 @@ where
         // validator's JSON-RPC endpoint via kademlia. validators that did not
         // configure RPC leave the descriptor `None`. fail fast on a misconfigured
         // endpoint rather than advertising something peers will reject.
-        let worker_rpc = self.builder.tn_config.node_info.p2p_info.worker.rpc.clone();
+        let worker_p2p = self
+            .builder
+            .tn_config
+            .node_info
+            .p2p_info
+            .worker(DEFAULT_WORKER_ID)
+            .ok_or_else(|| eyre!("no worker {DEFAULT_WORKER_ID} in node info"))?
+            .clone();
+        let worker_rpc = worker_p2p.rpc;
         if let Some(rpc) = &worker_rpc {
             rpc.validate()
-                .wrap_err("invalid `node_info.p2p_info.worker.rpc` endpoint in node config")?;
+                .wrap_err("invalid `node_info.p2p_info.workers[0].rpc` endpoint in node config")?;
         }
 
         // create long-running network task for worker
@@ -1029,7 +1058,7 @@ where
             self.key_config.clone(),
             self.consensus_db.clone(),
             node_task_spawner.clone(),
-            self.builder.tn_config.node_info.worker_network_address().clone(),
+            worker_p2p.network_address,
             worker_rpc,
         )?;
         let worker_network_handle = worker_network.network_handle();
@@ -1052,6 +1081,7 @@ where
         self.worker_network_handle = Some(WorkerNetworkHandle::new(
             worker_network_handle,
             node_task_spawner.clone(),
+            DEFAULT_WORKER_ID,
             epoch,
             network_config.chain_id(),
         ));

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -24,7 +24,7 @@
 //! yet executed is replayed to the engine, with a guard that refuses to cross an
 //! epoch boundary.
 
-use super::run_epoch::retry_provider_faults;
+use super::{read_num_workers_at_epoch_entry, run_epoch::retry_provider_faults};
 use crate::{
     engine::ExecutionNode, manager::EpochManager, primary::PrimaryNode, worker::WorkerNode,
     EngineToPrimaryRpc,
@@ -32,6 +32,7 @@ use crate::{
 use eyre::{eyre, OptionExt, WrapErr as _};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
@@ -174,8 +175,10 @@ where
             .collect::<Result<HashMap<_, _>, _>>()
             .map_err(|err| eyre!("failed to create bls key from on-chain bytes: {err:?}"))?;
 
+        let reth_env = engine.get_reth_env().await;
         Ok((
-            self.create_committee_from_state(epoch, validators).await?,
+            self.create_committee_from_state(&reth_env, epoch, epoch_info.blockHeight, validators)
+                .await?,
             epoch_info,
             epoch_start,
             epoch_start_header,
@@ -239,7 +242,8 @@ where
                 .builder
                 .tn_config
                 .node_info
-                .worker_network_address()
+                .worker_network_address(DEFAULT_WORKER_ID)
+                .ok_or_eyre("no worker network address in node info")?
                 .clone(),
             version: self.version_str,
         };
@@ -335,27 +339,53 @@ where
     /// Epoch 0 has no on-chain history, so the genesis committee is loaded from the
     /// committee file on disk. Every later epoch is built with a [`CommitteeBuilder`] from the
     /// statically configured bootstrap servers plus the on-chain validator set for that epoch.
+    ///
+    /// In both cases the committee's worker count comes from the on-chain `WorkerConfigs` state
+    /// at the previous epoch's closing block (`epoch_first_block - 1`; genesis state for epoch
+    /// 0), the same read that sizes the [`GasAccumulator`], so the count that validates header
+    /// payloads is the count execution runs with. A failed read halts epoch entry.
     async fn create_committee_from_state(
         &self,
+        reth_env: &tn_reth::RethEnv,
         epoch: Epoch,
+        epoch_first_block: u64,
         validators: HashMap<BlsPublicKey, &ConsensusRegistry::ValidatorInfo>,
     ) -> eyre::Result<Committee> {
         info!(target: "epoch-manager", "creating committee from state");
 
+        let num_workers = read_num_workers_at_epoch_entry(reth_env, epoch_first_block)
+            .await
+            .and_then(|count| {
+                NonZeroUsize::new(count)
+                    .ok_or_else(|| eyre!("on-chain WorkerConfigs reports zero workers"))
+            })
+            .wrap_err("failed to read the committee worker count from chain")?;
+        if num_workers.get() != 1 {
+            warn!(
+                target: "epoch-manager",
+                epoch,
+                num_workers,
+                spawned_worker = DEFAULT_WORKER_ID,
+                "committee runs multiple workers but this node version spawns only worker {DEFAULT_WORKER_ID}: \
+                 ids >= 1 are accepted by header validation but not produced locally"
+            );
+        }
+
         // the network must be live
         let committee = if epoch == 0 {
-            // read from fs for genesis
+            // read from fs for genesis, then stamp the on-chain count
             Config::load_from_path_or_default::<Committee>(
                 self.tn_datadir.committee_path(),
                 ConfigFmt::YAML,
             )?
+            .with_num_workers(num_workers)
         } else {
-            let mut committee_builder = CommitteeBuilder::new(epoch);
+            let mut committee_builder = CommitteeBuilder::new(epoch).with_num_workers(num_workers);
             for (key, bootstrap) in &self.bootstrap_servers {
                 committee_builder.add_bootstrap_server(
                     *key,
                     bootstrap.primary.clone(),
-                    bootstrap.worker.clone(),
+                    bootstrap.workers.clone(),
                 );
             }
 
@@ -771,7 +801,9 @@ where
             .committee()
             .bootstrap_servers()
             .iter()
-            .map(|(k, v)| (*k, v.worker.clone()))
+            // worker 0 always exists (the non-empty list invariant is enforced at deserialize), so
+            // this `filter_map` cannot drop a peer
+            .filter_map(|(k, v)| v.worker(DEFAULT_WORKER_ID).cloned().map(|worker| (*k, worker)))
             .collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
@@ -790,12 +822,14 @@ where
             let worker_address = Self::parse_listener_address_for_swarm(
                 "WORKER_LISTENER_MULTIADDR",
                 consensus_config.primary_networkkey(),
-                consensus_config.worker_address(),
+                consensus_config
+                    .worker_address(DEFAULT_WORKER_ID)
+                    .ok_or_eyre("no worker network address in node info")?,
             )?;
             network_handle.inner_handle().start_listening(worker_address).await?;
         }
 
-        let worker_address = consensus_config.worker_address();
+        let worker_address = consensus_config.worker_address(DEFAULT_WORKER_ID);
 
         // always attempt to dial peers for the new epoch
         // the network's peer manager will intercept dial attempts for peers that are already
@@ -824,7 +858,10 @@ where
         // later epoch unless the subscription is explicitly dropped. Skipping alone would also
         // skip the only refresh of this topic's authorized-publisher allowlist, freezing it on
         // the committee that was current when the node last subscribed.
-        let batch_topic = tn_config::LibP2pConfig::worker_batch_topic(consensus_config.chain_id());
+        let batch_topic = tn_config::LibP2pConfig::worker_batch_topic(
+            consensus_config.chain_id(),
+            DEFAULT_WORKER_ID,
+        );
         let mode = self.consensus_bus.current_node_mode();
         if should_subscribe_batch_topic(mode) {
             debug!(target: "epoch-manager", ?mode, "subscribing to worker batch topic");

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -51,10 +51,10 @@ use tn_reth::{
 };
 use tn_rpc::RpcNodeInfo;
 use tn_types::{
-    gas_accumulator::GasAccumulator, BatchValidation, BlsPublicKey, BlsSigner, Committee,
-    CommitteeBuilder, ConsensusHeaderDigest, ConsensusOutput, Database as TNDatabase, Epoch,
-    EpochDigest, Multiaddr, NetworkPublicKey, P2pNode, SealedHeader, TaskManager, TaskSpawner,
-    DEFAULT_WORKER_ID,
+    forks::multi_workers_fork_active, gas_accumulator::GasAccumulator, BatchValidation,
+    BlsPublicKey, BlsSigner, Committee, CommitteeBuilder, ConsensusHeaderDigest, ConsensusOutput,
+    Database as TNDatabase, Epoch, EpochDigest, Multiaddr, NetworkPublicKey, P2pNode, SealedHeader,
+    TaskManager, TaskSpawner, DEFAULT_WORKER_ID,
 };
 use tn_worker::{WorkerNetwork, WorkerNetworkHandle};
 use tokio::sync::mpsc;
@@ -343,7 +343,8 @@ where
     /// In both cases the committee's worker count comes from the on-chain `WorkerConfigs` state
     /// at the previous epoch's closing block (`epoch_first_block - 1`; genesis state for epoch
     /// 0), the same read that sizes the [`GasAccumulator`], so the count that validates header
-    /// payloads is the count execution runs with. A failed read halts epoch entry.
+    /// payloads is the count execution runs with. A failed read halts epoch entry, and so does a
+    /// count the epoch's committee layout cannot hold (see [`check_committee_worker_count`]).
     async fn create_committee_from_state(
         &self,
         reth_env: &tn_reth::RethEnv,
@@ -360,16 +361,7 @@ where
                     .ok_or_else(|| eyre!("on-chain WorkerConfigs reports zero workers"))
             })
             .wrap_err("failed to read the committee worker count from chain")?;
-        if num_workers.get() != 1 {
-            warn!(
-                target: "epoch-manager",
-                epoch,
-                num_workers,
-                spawned_worker = DEFAULT_WORKER_ID,
-                "committee runs multiple workers but this node version spawns only worker {DEFAULT_WORKER_ID}: \
-                 ids >= 1 are accepted by header validation but not produced locally"
-            );
-        }
+        check_committee_worker_count(epoch, num_workers)?;
 
         // the network must be live
         let committee = if epoch == 0 {
@@ -1072,9 +1064,48 @@ fn should_subscribe_batch_topic(mode: NodeMode) -> bool {
     }
 }
 
+/// Whether `epoch` may be entered with an on-chain worker count of `num_workers`.
+///
+/// A single worker is always fine. Above one, the answer depends on the multi-workers fork
+/// ([`multi_workers_fork_active`]), evaluated at the epoch being entered - the same epoch carried
+/// inside the [`Committee`] this count is about to be stamped onto, so the gate here and the gate
+/// the encoder consults cannot disagree:
+///
+/// - pre-fork the legacy committee layout has no field to carry a worker count, so the encoder
+///   refuses the value. Halting here turns that into a diagnosable epoch-entry failure instead of a
+///   panic from the first pack write, which is the only thing the node could do about it anyway:
+///   the count is chain state and cannot be talked down locally.
+/// - post-fork the count is representable and epoch entry proceeds. It still only warns, because
+///   this node version spawns worker [`DEFAULT_WORKER_ID`] alone: header payloads keyed to higher
+///   worker ids validate, but nothing local produces them.
+fn check_committee_worker_count(epoch: Epoch, num_workers: NonZeroUsize) -> eyre::Result<()> {
+    if num_workers.get() == 1 {
+        return Ok(());
+    }
+
+    if !multi_workers_fork_active(epoch) {
+        return Err(eyre!(
+            "on-chain WorkerConfigs reports {num_workers} workers but the multi-workers fork \
+             is not active at epoch {epoch}: the pre-fork committee layout cannot hold a worker \
+             count, so this epoch's committee cannot be encoded"
+        ));
+    }
+
+    warn!(
+        target: "epoch-manager",
+        epoch,
+        num_workers,
+        spawned_worker = DEFAULT_WORKER_ID,
+        "committee runs multiple workers but this node version spawns only worker {DEFAULT_WORKER_ID}: \
+         ids >= 1 are accepted by header validation but not produced locally"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{should_subscribe_batch_topic, NodeMode};
+    use super::{check_committee_worker_count, should_subscribe_batch_topic, NodeMode};
+    use std::num::NonZeroUsize;
 
     /// An active committee validator prefetches batches for the vote path.
     #[test]
@@ -1093,5 +1124,38 @@ mod tests {
     #[test]
     fn observer_does_not_subscribe_to_batch_topic() {
         assert!(!should_subscribe_batch_topic(NodeMode::Observer));
+    }
+
+    /// One worker is representable in both committee layouts, so entry never blocks on it.
+    #[test]
+    fn single_worker_epoch_entry_is_always_allowed() {
+        for epoch in [0, 1, 407, u32::MAX] {
+            check_committee_worker_count(epoch, NonZeroUsize::MIN)
+                .expect("one worker is representable at every epoch");
+        }
+    }
+
+    /// Pre-fork the legacy committee layout cannot carry a worker count, so entry halts rather than
+    /// deferring the failure to the first pack write.
+    ///
+    /// The adiri fork epoch is a `u32::MAX` placeholder and its arming constraint floors it at 407,
+    /// so epoch 0 is pre-fork in this lane however the constant moves.
+    /// `TN_MULTI_WORKERS_FORK_EPOCH` is deliberately not used to stage that: the override's
+    /// `OnceLock` is process-wide and the whole test binary shares one process.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn pre_fork_epoch_entry_rejects_multiple_workers() {
+        let err = check_committee_worker_count(0, NonZeroUsize::new(2).expect("2 is not 0"))
+            .expect_err("a pre-fork multi-worker committee cannot be encoded");
+        assert!(err.to_string().contains("multi-workers fork is not active"), "{err}");
+    }
+
+    /// Default builds have the multi-worker layout active from genesis, so a count above one is
+    /// representable and entry proceeds (with a warning that this node still spawns one worker).
+    #[cfg(not(feature = "adiri"))]
+    #[test]
+    fn post_fork_epoch_entry_allows_multiple_workers() {
+        check_committee_worker_count(0, NonZeroUsize::new(2).expect("2 is not 0"))
+            .expect("the post-fork layout holds a worker count");
     }
 }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -1385,6 +1385,20 @@ fn collect_batches(consensus: &ConsensusOutput) -> BTreeMap<BlockHash, Batch> {
 /// Extracted from [`Inner::stream_import`] as a free function (it is stateless) so the offline pack
 /// validator ([`crate::pack_validate`]) can reuse the exact same epoch-linkage checks without
 /// duplicating them.
+///
+/// Beyond the linkage this also pins the record's two internal identities to each other: the
+/// embedded [`Committee`]'s own epoch must equal the record's `epoch`. The committee's epoch is
+/// what SELECTED its bcs layout on the way in —
+/// [`multi_workers_fork_active`](tn_types::forks::multi_workers_fork_active) reads the epoch
+/// carried inside the value being decoded, not the record's — so a record whose committee claims a
+/// different epoch was parsed under a layout the record's own epoch does not select, and no later
+/// reader can tell. Both halves are then used as if they agreed: `epoch_meta.epoch` decides which
+/// outputs [`Inner::save_consensus_output`] accepts, while `epoch_meta.committee` is the validator
+/// set every output in the pack is decoded and verified against, and
+/// [`ConsensusPack::stream_import`] reports `epoch()` from the request while `committee()` comes
+/// from this record. A local write cannot break the equality — [`Inner::open_append`] derives the
+/// record's epoch FROM the committee — so a divergence only ever arrives over the wire (peer epoch
+/// sync) or from an imported bundle, which is precisely what this function screens.
 pub(crate) fn verify_epoch_meta(
     epoch: Epoch,
     previous_epoch: &EpochRecord,
@@ -1394,6 +1408,16 @@ pub(crate) fn verify_epoch_meta(
         return Err(PackError::InvalidEpoch(
             epoch,
             format!("meta data epoch is {}", epoch_meta.epoch),
+        ));
+    }
+    if epoch_meta.committee.epoch() != epoch_meta.epoch {
+        return Err(PackError::InvalidEpoch(
+            epoch,
+            format!(
+                "meta data epoch is {} but its committee is for epoch {}",
+                epoch_meta.epoch,
+                epoch_meta.committee.epoch()
+            ),
         ));
     }
     let start_consensus_number =
@@ -3323,6 +3347,133 @@ pub(crate) mod test {
         assert!(matches!(err, PackError::InvalidEpoch(2, _)), "got {err:?}");
     }
 
+    /// `verify_epoch_meta` pins the [`EpochMeta`]'s embedded committee to the record's own epoch.
+    ///
+    /// The committee's epoch is what selects its bcs layout, so a meta whose outer epoch and
+    /// committee epoch disagree carries a committee decoded under a layout that record does not
+    /// select — while `epoch_meta.epoch` and `epoch_meta.committee` are used downstream as if they
+    /// agreed. Every other check here is satisfied (identical key set, matching start number and
+    /// genesis links), so only the committee-epoch check can reject these metas, and the error text
+    /// is asserted to prove it is the arm that fired.
+    #[test]
+    fn test_verify_epoch_meta_rejects_committee_epoch_mismatch() {
+        use std::collections::BTreeMap;
+
+        use rand::{rngs::StdRng, SeedableRng as _};
+        use tn_types::{Address, Authority, BlsKeypair, BlsPublicKey};
+
+        use crate::consensus_pack::{verify_epoch_meta, EpochMeta, PackError};
+
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+        let keys: Vec<BlsPublicKey> =
+            (0..3).map(|_| *BlsKeypair::generate(&mut rng).public()).collect();
+        let authorities = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, Authority::new_for_test(*k, Address::repeat_byte(i as u8 + 1))))
+            .collect::<BTreeMap<_, _>>();
+        let committee = Committee::new_for_test(authorities, 1, BTreeMap::default());
+
+        let previous = EpochRecord {
+            epoch: 0,
+            committee: keys.clone(),
+            next_committee: keys.clone(),
+            final_consensus: ConsensusNumHash::new(77, ConsensusHeaderDigest::default()),
+            ..Default::default()
+        };
+        let meta_with = |committee: Committee| EpochMeta {
+            epoch: 1,
+            committee,
+            start_consensus_number: previous.final_consensus.number + 1,
+            genesis_exec_state: previous.final_state,
+            genesis_consensus: previous.final_consensus,
+        };
+
+        // A committee carrying the record's own epoch verifies.
+        verify_epoch_meta(1, &previous, &meta_with(committee.clone()))
+            .expect("a committee at the record's epoch must verify");
+
+        // A committee from either side of the record's epoch does not, even though its key set is
+        // the one the previous record hands off to.
+        for committee_epoch in [0, 2] {
+            let meta = meta_with(committee.advance_epoch_for_test(committee_epoch));
+            let Err(err) = verify_epoch_meta(1, &previous, &meta) else {
+                panic!("committee epoch {committee_epoch} must not verify in an epoch-1 record")
+            };
+            assert!(
+                matches!(err, PackError::InvalidEpoch(1, _)),
+                "committee epoch {committee_epoch}: got {err:?}"
+            );
+            assert!(
+                err.to_string().contains(&format!("committee is for epoch {committee_epoch}")),
+                "committee epoch {committee_epoch}: a different check rejected this meta: {err}"
+            );
+        }
+    }
+
+    /// PEER PATH: `stream_import` rejects a record stream whose [`EpochMeta`] carries a committee
+    /// for a different epoch, and rejects it before appending anything.
+    ///
+    /// This is the door the check exists for: a local write cannot produce such a meta, since
+    /// `Inner::open_append` derives the record's epoch from the committee it is handed. Only a
+    /// hostile or buggy peer (or an imported bundle) can, and the committee it ships is the
+    /// validator set every output in the pack would then be verified against.
+    #[tokio::test]
+    async fn test_stream_import_rejects_committee_epoch_mismatch() {
+        use crate::{
+            archive::pack::Pack,
+            consensus_pack::{EpochMeta, PackError, PackRecord},
+        };
+
+        let temp_dir = TempDir::with_prefix("test_cp_meta_committee_epoch").expect("temp dir");
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let committee = fixture.committee();
+        let previous_epoch = test_previous_epoch(&committee);
+
+        // The container and every linkage field are well formed for epoch 0; only the embedded
+        // committee claims epoch 1.
+        let source = temp_dir.path().join("peer_stream");
+        {
+            let mut pack: Pack<PackRecord> =
+                Pack::open(&source, 0, false, PackCompression::ZStd, PACK_VERSION)
+                    .expect("open peer stream");
+            pack.append(&PackRecord::EpochMeta(EpochMeta {
+                epoch: 0,
+                committee: committee.advance_epoch_for_test(1),
+                start_consensus_number: 1,
+                genesis_exec_state: previous_epoch.final_state,
+                genesis_consensus: previous_epoch.final_consensus,
+            }))
+            .expect("append hostile meta");
+            pack.commit().expect("commit peer stream");
+        }
+
+        let target = TempDir::with_prefix("test_cp_meta_committee_epoch_out").expect("temp dir");
+        let stream = tokio::fs::File::open(&source).await.expect("open peer stream");
+        let err = ConsensusPack::stream_import(
+            target.path(),
+            stream,
+            0,
+            &previous_epoch,
+            1,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("a meta whose committee is for another epoch must not import");
+        assert!(matches!(err, PackError::InvalidEpoch(0, _)), "got {err:?}");
+        assert!(
+            err.to_string().contains("committee is for epoch 1"),
+            "a different check rejected the import: {err}"
+        );
+
+        // Rejected before the append: the epoch has no readable meta record, so no reader can pick
+        // the hostile committee up.
+        assert!(
+            ConsensusPack::open_append_exists(target.path(), 0).is_err(),
+            "the rejected meta was appended anyway"
+        );
+    }
+
     /// Deterministic BLS seed signature for fork-active fixture headers: the keypair comes
     /// from a seeded rng and BLS signing is deterministic, so the fixture bytes are stable
     /// across runs.
@@ -3420,6 +3571,664 @@ pub(crate) mod test {
         assert_eq!(
             expected_gate, decoded_gate,
             "per-element gate visibility must survive the round trip"
+        );
+    }
+
+    /// Epoch of the frozen pre-fork pack: 406.
+    ///
+    /// One epoch below `CONSENSUS_REGISTRY_FORK_EPOCH` (407), the documented arming floor of the
+    /// multi-workers fork (#554), and the same epoch `tn_types`' `LEGACY_FIXTURE_EPOCH`
+    /// pins — so the frozen committee vector there and the frozen pack file here describe one wire
+    /// moment from opposite ends of the stack.
+    ///
+    /// One below the floor rather than the floor itself, because the fork may legally be armed AT
+    /// 407: the gate is `>=`, so 407 would become post-fork and the anti-vacuity assert in
+    /// `test_golden_legacy_pack_regenerates` would fail. 406 is structurally pre-fork under every
+    /// legal arming, so the embedded [`Committee`] encodes in the legacy single-worker layout
+    /// whichever epoch the arming PR picks. It is still at or above `SEED_SIGNATURE_FORK_EPOCH`
+    /// (383), so the nested headers carry `seed_signature`: exactly the shape of an epoch pack
+    /// sitting on an adiri node's disk today.
+    const LEGACY_PACK_EPOCH: Epoch = 406;
+
+    /// Final consensus number of the epoch before [`LEGACY_PACK_EPOCH`].
+    ///
+    /// Nonzero on purpose: it keeps the fixture on the `previous_epoch.final_consensus.number + 1`
+    /// branch of `Inner::open_append` rather than the epoch-0 special case, so the frozen
+    /// `start_consensus_number` is a value the linkage checks can actually disagree with.
+    const LEGACY_PACK_PREV_CONSENSUS: u64 = 9_100;
+
+    /// First consensus number in the frozen pack.
+    ///
+    /// Only the `adiri` lane ever reads it: on a post-fork build the frozen bytes never decode far
+    /// enough to have a consensus range at all.
+    #[cfg(feature = "adiri")]
+    const LEGACY_PACK_FIRST_CONSENSUS: u64 = LEGACY_PACK_PREV_CONSENSUS + 1;
+
+    /// Last consensus number in the frozen pack, which holds two outputs.
+    const LEGACY_PACK_LAST_CONSENSUS: u64 = LEGACY_PACK_PREV_CONSENSUS + 2;
+
+    /// FROZEN pre-fork epoch pack: the complete, sealed `epoch-406/data` file (978 bytes) a build
+    /// of this crate writes at [`LEGACY_PACK_EPOCH`] on the `adiri` lane — data header, then an
+    /// `EpochMeta` record whose [`Committee`] is in the legacy single-worker layout, then two
+    /// consensus outputs (header record followed by its batch record, the v1 ordering).
+    ///
+    /// This is the layout of every consensus pack already on adiri disk: `Committee` is embedded in
+    /// `EpochMeta`, the FIRST record of every pack, and bcs is not self-describing. Before the
+    /// epoch-gated encoder landed, every adiri node restarting against an existing consensus-db
+    /// failed to decode this record and exited 1, and epoch-pack peer sync broke across versions.
+    /// The tests below open these exact bytes through every read door in the crate.
+    ///
+    /// If a test here fails, work out WHICH pin moved before touching this constant:
+    ///
+    /// - [`LEGACY_PACK_EPOCH`] moving is the one legitimate reason to re-freeze these bytes: the
+    ///   epoch is a field of the `EpochMeta`, of every nested header and of every batch, so its
+    ///   bytes move with it. Regenerate from `test_golden_legacy_pack_regenerates`, never by hand.
+    /// - `tn_types`' `golden_legacy_committee_wire_bytes_pinned` also failing means the committee
+    ///   wire layout moved. That is a compatibility break to fix in the encoder, NOT a constant to
+    ///   refresh — refreshing it strands every pack already written.
+    /// - that pin still passing means the container moved, not the payload: the record framing, the
+    ///   crc, the zstd encoder, or the fixture. `test_golden_legacy_pack_regenerates` cross-checks
+    ///   the committee bytes inside the frozen container for exactly this reason, so a green
+    ///   committee assertion next to a red byte-identity assertion is the "container moved" signal.
+    ///
+    /// The fixture takes no rng, no clock and no OS-assigned port, so nothing else can move it.
+    const GOLDEN_LEGACY_PACK_HEX: &str = "74656c6e6574010091dcabc6ad9363a20100000001000000a9434593aa01000028b52ffd00580d0d0004170096010000026085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e8735140260ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b8444414010b047f00000191029c41cd032408011220b14a3296426492458270c2e577fdc549b6d67155e5800b0bf96c3f4106b4ae7100a029c602145e9a9f1672b151652377fa8c23fc78ded1add621fe177d33b8ebcd4214009c40e0fcb53429020d03e8f4e471ec73993f9329ad0d76e69cfdfcb08c94aa39fdab28055139b0f6daf33b3fdc294e2bfc1ad914de91f7d6e9f717b4509c047fbc6acc008d2300921000205e8c207a1100b88654650c7403e7886b049c00d2c0070e2df686f8d09a0f642c550918b62b0d7882a193613a78d24e27a71005806fcb4ec500000028b52ffd0058e50500740a02207a017b403bb2f1bcfe223c27bf0d350aa0dc2e7f02f257580d538ac8a36f21223d29010000009601000001000120c0a1c7fd531551d30b3db2802e873b75067059e1d41d433b8e086c0b79143b5e002000309455941aa83bcaa9f33fa21533d526c4b824ef51132c5629a21619f9975befc7fcf1097d590c01356c37ba346bfc2c42203cd4585ccad5b8f09b28c2444dfda62125ab6d4c235efc635ecc10ddf4f447048d2307000833c000bf60980d828607f61b184a03dc39a570361e00000028b52ffd0058ad000060010108019601000014000700031000044e2523027f4c188fe300000028b52ffd0058d50600640c0220e9ef2e767a88948d2c477c097f516a936acdc86a3ea64f290630d28c5030d6e3015237b9c5d795289c9a054ba2761ff631cd622c9d94df6ab749814cede8549d3f02000000960100000200012031a3a82b0b9828c83bafb69afd821c11801ec62cfb6a88b7fed03599e21b507c002000309455941aa83bcaa9f33fa21533d526c4b824ef51132c5629a21619f9975befc7fcf1097d590c01356c37ba346bfc2c42206f9ec6c464377d4f9f935156387873e428662cfe18ef258641136a71aa5cb7da8e2306000833c000bf60980d828607f637033003692185471e00000028b52ffd0058ad000060010108029601000014000700031000044e252302fb1782dc";
+
+    /// Decode [`GOLDEN_LEGACY_PACK_HEX`], failing loudly on a malformed constant.
+    fn golden_legacy_pack_bytes() -> Vec<u8> {
+        tn_types::hex::decode(GOLDEN_LEGACY_PACK_HEX).expect("frozen hex vector must be valid hex")
+    }
+
+    /// Lay the frozen bytes down as a bare `epoch-406/data` file with NO sidecar indexes, and
+    /// return its path.
+    ///
+    /// The strictest shape a read door can be handed: nothing but the pack stream, so whatever it
+    /// learns about the epoch it learns by decoding the `EpochMeta` record itself.
+    fn write_golden_legacy_data_file(dir: &std::path::Path) -> std::path::PathBuf {
+        let base = dir.join(format!("epoch-{LEGACY_PACK_EPOCH}"));
+        std::fs::create_dir_all(&base).expect("create pack dir");
+        let path = base.join(Inner::DATA_NAME);
+        std::fs::write(&path, golden_legacy_pack_bytes()).expect("write frozen data file");
+        path
+    }
+
+    /// Deterministic BLS keypair for fixture slot `slot`.
+    ///
+    /// A fixed scalar rather than a seeded rng, so the derived public key — and with it the
+    /// `authorities` map order and every frozen byte above — survives `rand` and `blst` bumps as
+    /// well as reruns. The leading bytes stay zero, which keeps the scalar nonzero and far below
+    /// the BLS12-381 group order, the only two values `blst` rejects.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_bls_keypair(slot: u8) -> tn_types::BlsKeypair {
+        let mut scalar = [0_u8; 32];
+        scalar[30] = slot;
+        scalar[31] = 0x2A;
+        tn_types::BlsKeypair::from_bytes(&scalar)
+            .expect("fixture bls scalar is a valid private key")
+    }
+
+    /// A fixture [`P2pNode`](tn_types::P2pNode) from a fixed ed25519 seed and port.
+    ///
+    /// ed25519 secret keys *are* 32-byte seeds, so a fixed seed yields a fixed public key with no
+    /// rng in the path, and the multiaddr comes from a literal rather than an OS-assigned port.
+    /// `rpc` stays `None`: the `Some` arm needs a `url::Url`, which this crate does not depend on,
+    /// and `tn_types`' frozen committee vectors already pin both arms.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_p2p_node(tag: u8, slot: u8, port: u16) -> tn_types::P2pNode {
+        let mut seed = [0_u8; 32];
+        seed[0] = tag;
+        seed[1] = slot;
+        tn_types::P2pNode {
+            network_address: format!("/ip4/127.0.0.1/udp/{port}/quic-v1")
+                .parse()
+                .expect("fixture multiaddr parses"),
+            network_key: tn_types::NetworkKeypair::ed25519_from_bytes(seed)
+                .expect("a 32-byte array is a valid ed25519 secret seed")
+                .public()
+                .clone()
+                .into(),
+            rpc: None,
+        }
+    }
+
+    /// The frozen pack's committee: two authorities, each with a single-worker bootstrap server.
+    ///
+    /// Two is the minimum — `CommitteeInner::load` asserts a committee larger than one — and the
+    /// point of the fixture is the wire layout, not the quorum math, so it stays at the minimum to
+    /// keep the frozen vector small. One worker per server is the only shape the legacy layout can
+    /// express at all.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_committee() -> Committee {
+        use std::collections::BTreeMap;
+
+        use tn_types::{Address, Authority, BootstrapServer};
+
+        let mut authorities = BTreeMap::new();
+        let mut bootstrap_servers = BTreeMap::new();
+        for slot in 0..2_u8 {
+            let key = *legacy_pack_bls_keypair(slot).public();
+            authorities.insert(key, Authority::new_for_test(key, Address::repeat_byte(slot + 1)));
+            bootstrap_servers.insert(
+                key,
+                BootstrapServer::new(
+                    legacy_pack_p2p_node(0xB0, slot, 40_000 + u16::from(slot)),
+                    vec![legacy_pack_p2p_node(0xC0, slot, 41_000 + u16::from(slot))],
+                ),
+            );
+        }
+        Committee::new_for_test(authorities, LEGACY_PACK_EPOCH, bootstrap_servers)
+    }
+
+    /// The previous epoch's record the frozen pack links to.
+    ///
+    /// Every field here is frozen INTO the pack: `open_append` copies `final_state` and
+    /// `final_consensus` into the `EpochMeta` and derives `start_consensus_number` from them, and
+    /// `verify_epoch_meta` re-checks all three plus the committee key set on every import and
+    /// validation. Feeding this record to those doors therefore pins the meta's fields, not just
+    /// its committee.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_previous_epoch(committee: &Committee) -> EpochRecord {
+        EpochRecord {
+            epoch: LEGACY_PACK_EPOCH - 1,
+            committee: committee.bls_keys().iter().copied().collect(),
+            next_committee: committee.bls_keys().iter().copied().collect(),
+            final_state: tn_types::BlockNumHash::new(4_242, tn_types::B256::repeat_byte(0x5E)),
+            final_consensus: ConsensusNumHash::new(
+                LEGACY_PACK_PREV_CONSENSUS,
+                ConsensusHeaderDigest::from([0x7A_u8; 32]),
+            ),
+            ..Default::default()
+        }
+    }
+
+    /// One fully deterministic output for the frozen pack: a single-certificate sub-DAG whose
+    /// leader header references exactly one batch.
+    ///
+    /// `tag` seeds every value that distinguishes one fixture output from another (round,
+    /// `created_at`, the batch's payload bytes, and which authority authors it), so the two outputs
+    /// differ in every hashed field while neither reaches for a clock or an rng. The seed signature
+    /// is a real BLS signature over a fixed message: BLS signing takes no nonce, so it is
+    /// reproducible, and it is on the wire at this epoch because the seed-signature fork is active
+    /// here.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_output(
+        committee: &Committee,
+        number: u64,
+        parent: ConsensusHeaderDigest,
+        tag: u8,
+    ) -> ConsensusOutput {
+        use tn_types::Signer as _;
+
+        let batch =
+            Batch::new_for_test(vec![vec![tag; 8]], ExecHeader::default(), 0, LEGACY_PACK_EPOCH);
+        let authorities = committee.authorities();
+        let authority = authorities
+            .get(usize::from(tag) % authorities.len())
+            .expect("modulo keeps the index in range");
+        let seed_signature = legacy_pack_bls_keypair(0xF0).sign(b"pack-fixture-seed");
+        let header = HeaderBuilder::default()
+            .author(authority.id())
+            .round(u32::from(tag))
+            .epoch(LEGACY_PACK_EPOCH)
+            .created_at(u64::from(tag))
+            .seed_signature(seed_signature)
+            .with_payload_batch(&batch, 0_u16)
+            .build();
+        let mut leader = Certificate::default();
+        leader.update_header_for_test(header);
+        let sub_dag = CommittedSubDag::new(
+            vec![leader.clone()],
+            leader,
+            u64::from(tag),
+            ReputationScores::default(),
+            None,
+            tn_types::EpochSeedChainValue::genesis_placeholder(),
+        );
+        let batch_digests: VecDeque<BlockHash> = [batch.digest()].into_iter().collect();
+        ConsensusOutput::new(
+            sub_dag,
+            parent,
+            number,
+            false,
+            batch_digests,
+            vec![CertifiedBatch { address: authority.execution_address(), batches: vec![batch] }],
+        )
+    }
+
+    /// The frozen pack's two outputs, chained: the first parents off the previous epoch's final
+    /// consensus header, the second off the first. Tags 1 and 2 land on different authorities, so
+    /// both committee members author one output and the decoder's author lookup is exercised for
+    /// each.
+    #[cfg(feature = "adiri")]
+    fn legacy_pack_outputs(committee: &Committee, previous: &EpochRecord) -> Vec<ConsensusOutput> {
+        let mut parent = previous.final_consensus.hash;
+        let mut number = previous.final_consensus.number + 1;
+        let mut outputs = Vec::new();
+        for tag in [1_u8, 2] {
+            let output = legacy_pack_output(committee, number, parent, tag);
+            parent = output.digest();
+            number += 1;
+            outputs.push(output);
+        }
+        outputs
+    }
+
+    /// Write the fixture pack through the normal write path (`open_append` +
+    /// `save_consensus_output`) into `dir` and return the resulting `data` file bytes.
+    ///
+    /// On the `adiri` lane at [`LEGACY_PACK_EPOCH`] the gated encoder emits the legacy committee
+    /// layout, which `tn_types`' differentials prove is byte-identical to the pre-#554 derive. A
+    /// pack this writes at that epoch therefore IS a pre-fork pack, byte for byte — which is what
+    /// makes freezing its output a fixture of history rather than of this build.
+    #[cfg(feature = "adiri")]
+    async fn write_legacy_pack(dir: &std::path::Path) -> Vec<u8> {
+        let committee = legacy_pack_committee();
+        let previous_epoch = legacy_pack_previous_epoch(&committee);
+        let pack = ConsensusPack::open_append(dir, previous_epoch.clone(), committee.clone())
+            .expect("open fixture pack for append");
+        for output in legacy_pack_outputs(&committee, &previous_epoch) {
+            pack.save_consensus_output(output).await.expect("save fixture output");
+        }
+        pack.persist().await.expect("persist fixture pack");
+        drop(pack);
+        std::fs::read(dir.join(format!("epoch-{LEGACY_PACK_EPOCH}")).join(Inner::DATA_NAME))
+            .expect("read fixture data file")
+    }
+
+    /// Materialize a complete pack directory (data file plus sidecar indexes) in `dir` FROM the
+    /// frozen bytes, by feeding them to `stream_import` the way a peer stream arrives.
+    ///
+    /// `stream_import` is the only path that builds a pack's indexes from a record stream, so it is
+    /// how the doors that need sidecars (`open_static`, and reading outputs back through
+    /// `open_append_exists` / `open_append`) get an on-disk pack whose `data` file is provably the
+    /// frozen constant — asserted here, so every caller inherits the guarantee.
+    #[cfg(feature = "adiri")]
+    async fn import_golden_legacy_pack(dir: &std::path::Path) {
+        let frozen = golden_legacy_pack_bytes();
+        let source = dir.join("peer_stream");
+        std::fs::write(&source, &frozen).expect("write peer stream");
+        let committee = legacy_pack_committee();
+        let previous_epoch = legacy_pack_previous_epoch(&committee);
+        let stream = tokio::fs::File::open(&source).await.expect("open peer stream");
+        let pack = ConsensusPack::stream_import(
+            dir,
+            stream,
+            LEGACY_PACK_EPOCH,
+            &previous_epoch,
+            LEGACY_PACK_LAST_CONSENSUS,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("stream import of the frozen pre-fork pack");
+        pack.persist().await.expect("persist imported pack");
+        drop(pack);
+        let on_disk =
+            std::fs::read(dir.join(format!("epoch-{LEGACY_PACK_EPOCH}")).join(Inner::DATA_NAME))
+                .expect("read imported data file");
+        assert_eq!(
+            tn_types::hex::encode(&on_disk),
+            GOLDEN_LEGACY_PACK_HEX,
+            "the materialized pack's data file is not the frozen pre-fork bytes"
+        );
+    }
+
+    /// Assert `pack`'s handle-level committee is the frozen pre-fork committee, in the legacy
+    /// single-worker shape.
+    ///
+    /// `Committee`'s `PartialEq` deliberately ignores bootstrap servers, so the map is compared
+    /// separately — without that a pack whose bootstrap hints decoded to something else entirely
+    /// would compare equal.
+    #[cfg(feature = "adiri")]
+    fn assert_legacy_pack_committee(pack: &ConsensusPack) {
+        let expected = legacy_pack_committee();
+        assert_eq!(pack.epoch(), LEGACY_PACK_EPOCH, "pack epoch moved");
+        assert_eq!(pack.committee().epoch(), LEGACY_PACK_EPOCH, "meta committee epoch moved");
+        assert_eq!(pack.committee().size(), 2, "meta committee authority count moved");
+        assert_eq!(
+            pack.committee().number_of_workers(),
+            1,
+            "the legacy layout carries no worker count, so it must decode as single-worker"
+        );
+        assert_eq!(pack.committee().bootstrap_servers().len(), 2, "bootstrap server count moved");
+        assert!(
+            pack.committee().bootstrap_servers().values().all(|server| server.num_workers() == 1),
+            "the legacy layout holds exactly one worker per bootstrap server"
+        );
+        assert_eq!(*pack.committee(), expected, "the meta holds a different committee");
+        assert_eq!(
+            pack.committee().bootstrap_servers(),
+            expected.bootstrap_servers(),
+            "the meta holds different bootstrap servers"
+        );
+    }
+
+    /// Read both frozen outputs back through `pack` and compare them to the fixture, and confirm
+    /// the frozen `start_consensus_number` by rejecting the number just below it.
+    #[cfg(feature = "adiri")]
+    async fn assert_legacy_pack_outputs(pack: &ConsensusPack) {
+        let committee = legacy_pack_committee();
+        let previous_epoch = legacy_pack_previous_epoch(&committee);
+        let expected = legacy_pack_outputs(&committee, &previous_epoch);
+        for output in &expected {
+            let read_back = pack.get_consensus_output(output.number()).await.unwrap_or_else(|e| {
+                panic!("read output {} from the frozen pack: {e}", output.number())
+            });
+            compare_outputs(&read_back, output);
+        }
+        assert!(
+            pack.get_consensus_output(LEGACY_PACK_PREV_CONSENSUS).await.is_err(),
+            "a number below the frozen start_consensus_number must be rejected"
+        );
+        assert!(
+            !pack
+                .contains_consensus_header_number(LEGACY_PACK_PREV_CONSENSUS)
+                .await
+                .expect("query the frozen pack"),
+            "the frozen pack must not claim the previous epoch's final consensus number"
+        );
+        assert!(
+            pack.contains_consensus_header_number(LEGACY_PACK_LAST_CONSENSUS)
+                .await
+                .expect("query the frozen pack"),
+            "the frozen pack must claim its own last consensus number"
+        );
+    }
+
+    /// ANCHOR (adiri): the frozen pre-fork pack is exactly what this build's normal write path
+    /// produces at [`LEGACY_PACK_EPOCH`], so the fixture cannot drift away from the encoder it is
+    /// meant to hold still.
+    ///
+    /// Also the anti-vacuity check for the whole group: it asserts the two gates that decide the
+    /// frozen layout, so a stray `TN_MULTI_WORKERS_FORK_EPOCH` in the environment (or the fork
+    /// being armed) fails here with a diagnosis instead of downstream as an unexplained byte diff.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_regenerates() {
+        use tn_types::{encode, forks};
+
+        assert!(
+            !forks::multi_workers_fork_active(LEGACY_PACK_EPOCH),
+            "epoch {LEGACY_PACK_EPOCH} must be PRE-fork for the frozen pack to be a legacy-layout \
+             pack; is TN_MULTI_WORKERS_FORK_EPOCH set in the environment, or has the fork been \
+             armed?"
+        );
+        assert!(
+            forks::seed_signature_active(LEGACY_PACK_EPOCH),
+            "epoch {LEGACY_PACK_EPOCH} must be seed-signature-active for the frozen headers to \
+             carry seed_signature; is TN_SEED_SIGNATURE_FORK_EPOCH set in the environment?"
+        );
+
+        let first = TempDir::with_prefix("golden_legacy_pack_a").expect("temp dir");
+        let bytes = write_legacy_pack(first.path()).await;
+        assert_eq!(
+            tn_types::hex::encode(&bytes),
+            GOLDEN_LEGACY_PACK_HEX,
+            "the pre-fork write path diverged from the frozen pack"
+        );
+
+        // a second, independent write of the same fixture must produce the same file: no rng,
+        // clock or OS-assigned port leaked into the fixture
+        let second = TempDir::with_prefix("golden_legacy_pack_b").expect("temp dir");
+        assert_eq!(
+            write_legacy_pack(second.path()).await,
+            bytes,
+            "the fixture pack is not reproducible"
+        );
+
+        // Cross-check the committee bytes INSIDE the frozen container. This separates the two ways
+        // the byte-identity assertion above can fail: if this still passes, the container moved
+        // (framing, crc, zstd) and not the committee wire layout.
+        let pack = ConsensusPack::open_append_exists(first.path(), LEGACY_PACK_EPOCH)
+            .expect("reopen the pack just written");
+        assert_eq!(
+            tn_types::hex::encode(encode(pack.committee())),
+            tn_types::hex::encode(encode(&legacy_pack_committee())),
+            "the committee stored in the frozen pack is not the legacy-layout fixture committee"
+        );
+        assert_legacy_pack_committee(&pack);
+    }
+
+    /// DOOR 1 (adiri): warm restart — `open_append_exists`, the door that exited 1 in production.
+    ///
+    /// Driven twice over the same frozen bytes: first as a bare `data` file with no sidecar
+    /// indexes, which is the strictest form (everything the door knows about the epoch it decodes
+    /// out of the `EpochMeta` record itself), then over a full pack directory, where the frozen
+    /// outputs must also read back. Opening for append must not rewrite the file either way.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_opens_append_exists() {
+        let bare = TempDir::with_prefix("golden_legacy_warm_bare").expect("temp dir");
+        let data_file = write_golden_legacy_data_file(bare.path());
+        {
+            let pack = ConsensusPack::open_append_exists(bare.path(), LEGACY_PACK_EPOCH)
+                .expect("warm restart against a bare frozen pre-fork data file");
+            assert_eq!(pack.version, PACK_VERSION, "frozen pack version moved");
+            assert!(!pack.is_static(), "a warm-restart handle is writable");
+            assert_legacy_pack_committee(&pack);
+            pack.persist().await.expect("persist");
+        }
+        assert_eq!(
+            tn_types::hex::encode(std::fs::read(&data_file).expect("reread data file")),
+            GOLDEN_LEGACY_PACK_HEX,
+            "opening a pre-fork pack for append rewrote or truncated it"
+        );
+
+        let full = TempDir::with_prefix("golden_legacy_warm_full").expect("temp dir");
+        import_golden_legacy_pack(full.path()).await;
+        let pack = ConsensusPack::open_append_exists(full.path(), LEGACY_PACK_EPOCH)
+            .expect("warm restart against a complete frozen pre-fork pack");
+        assert_legacy_pack_committee(&pack);
+        assert_legacy_pack_outputs(&pack).await;
+    }
+
+    /// DOOR 2 (adiri): historical reads — `open_static` over the frozen bytes.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_opens_static() {
+        let dir = TempDir::with_prefix("golden_legacy_static").expect("temp dir");
+        import_golden_legacy_pack(dir.path()).await;
+
+        let pack = ConsensusPack::open_static(dir.path(), LEGACY_PACK_EPOCH)
+            .expect("read-only open of the frozen pre-fork pack");
+        assert!(pack.is_static(), "open_static must yield a read-only handle");
+        assert_legacy_pack_committee(&pack);
+        assert_legacy_pack_outputs(&pack).await;
+    }
+
+    /// DOOR 3 (adiri): peer epoch sync — `stream_import` of the frozen bytes.
+    ///
+    /// The load-bearing assertion is byte identity: importing and then serving a pre-fork pack must
+    /// leave the meta record exactly as it arrived, because those same bytes are what this node
+    /// hands to a peer still running a pre-fork build. A rewritten meta would decode here and
+    /// nowhere else.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_stream_imports() {
+        let dir = TempDir::with_prefix("golden_legacy_import").expect("temp dir");
+        // asserts the imported data file is byte-identical to the frozen bytes
+        import_golden_legacy_pack(dir.path()).await;
+
+        let committee = legacy_pack_committee();
+        let previous_epoch = legacy_pack_previous_epoch(&committee);
+        let expected = legacy_pack_outputs(&committee, &previous_epoch);
+        let pack = ConsensusPack::open_append_exists(dir.path(), LEGACY_PACK_EPOCH)
+            .expect("reopen the imported pack");
+        assert_legacy_pack_committee(&pack);
+        assert_legacy_pack_outputs(&pack).await;
+
+        // serving: the bytes handed to a peer decode back to the same outputs under the pack's own
+        // (legacy-layout) committee
+        for output in &expected {
+            let served = pack
+                .get_consensus_output_bytes(output.number())
+                .await
+                .expect("serve a frozen output to a peer");
+            let decoded = pack.decode_output(served).await.expect("peer-side decode");
+            compare_outputs(&decoded, output);
+        }
+        pack.persist().await.expect("persist after serving");
+        drop(pack);
+
+        let on_disk = std::fs::read(
+            dir.path().join(format!("epoch-{LEGACY_PACK_EPOCH}")).join(Inner::DATA_NAME),
+        )
+        .expect("reread the imported data file");
+        assert_eq!(
+            tn_types::hex::encode(&on_disk),
+            GOLDEN_LEGACY_PACK_HEX,
+            "importing and serving a pre-fork pack rewrote its bytes, so peers on a pre-fork build \
+             would no longer be able to read it"
+        );
+    }
+
+    /// DOOR 4 (adiri): the meta-compare arm of `open_append`.
+    ///
+    /// Reopening a pre-fork pack with the same committee takes the compare branch — the meta this
+    /// build constructs must equal the one decoded off disk — so it must succeed WITHOUT appending
+    /// a second `EpochMeta` record. The file length and bytes are unchanged.
+    #[cfg(feature = "adiri")]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_reopens_append_without_duplicate_meta() {
+        let dir = TempDir::with_prefix("golden_legacy_reappend").expect("temp dir");
+        import_golden_legacy_pack(dir.path()).await;
+        let data_file =
+            dir.path().join(format!("epoch-{LEGACY_PACK_EPOCH}")).join(Inner::DATA_NAME);
+        let len_before = std::fs::metadata(&data_file).expect("stat data file").len();
+
+        let committee = legacy_pack_committee();
+        let previous_epoch = legacy_pack_previous_epoch(&committee);
+        {
+            let pack =
+                ConsensusPack::open_append(dir.path(), previous_epoch.clone(), committee.clone())
+                    .expect("reopen the frozen pre-fork pack for append with the same committee");
+            assert_legacy_pack_committee(&pack);
+            assert_legacy_pack_outputs(&pack).await;
+            pack.persist().await.expect("persist");
+        }
+
+        assert_eq!(
+            std::fs::metadata(&data_file).expect("stat data file").len(),
+            len_before,
+            "open_append grew a pre-fork pack, so it appended a duplicate EpochMeta"
+        );
+        assert_eq!(
+            tn_types::hex::encode(std::fs::read(&data_file).expect("reread data file")),
+            GOLDEN_LEGACY_PACK_HEX,
+            "open_append rewrote the frozen pre-fork bytes"
+        );
+
+        // A validation pass proves the file still holds exactly one EpochMeta: a second one is
+        // reported as an EpochMetaMismatch issue.
+        let report = crate::pack_validate::validate_pack_file(
+            &data_file,
+            LEGACY_PACK_EPOCH,
+            Some(&previous_epoch),
+        )
+        .expect("validate after reopen");
+        assert_eq!(
+            report.verdict,
+            crate::pack_validate::Verdict::Valid,
+            "reopened pre-fork pack no longer validates: {:?}",
+            report.issues
+        );
+    }
+
+    /// DOOR 5 (adiri): the offline validator — `validate_pack_file` over the bare frozen bytes.
+    ///
+    /// Run with the previous epoch's record so the full `verify_epoch_meta` linkage executes: this
+    /// is what pins the frozen meta's `start_consensus_number`, `genesis_exec_state`,
+    /// `genesis_consensus` and committee key set, not just its committee layout.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn test_golden_legacy_pack_validates() {
+        use crate::pack_validate::{validate_pack_file, Verdict};
+
+        let dir = TempDir::with_prefix("golden_legacy_validate").expect("temp dir");
+        let data_file = write_golden_legacy_data_file(dir.path());
+        let previous_epoch = legacy_pack_previous_epoch(&legacy_pack_committee());
+
+        let report = validate_pack_file(&data_file, LEGACY_PACK_EPOCH, Some(&previous_epoch))
+            .expect("validate the frozen pre-fork pack");
+        assert_eq!(
+            report.verdict,
+            Verdict::Valid,
+            "the frozen pre-fork pack must validate clean: {:?}",
+            report.issues
+        );
+        assert_eq!(report.epoch, LEGACY_PACK_EPOCH);
+        assert_eq!(
+            report.start_consensus_number, LEGACY_PACK_FIRST_CONSENSUS,
+            "frozen start_consensus_number moved"
+        );
+        assert_eq!(report.consensus_count, 2, "frozen consensus record count moved");
+        assert_eq!(report.batch_count, 2, "frozen batch record count moved");
+        assert_eq!(report.first_consensus_number, Some(LEGACY_PACK_FIRST_CONSENSUS));
+        assert_eq!(report.last_consensus_number, Some(LEGACY_PACK_LAST_CONSENSUS));
+    }
+
+    /// PIN (non-adiri): the frozen pre-fork bytes are indecodable in a build whose multi-workers
+    /// gate is active from genesis, and every read door says so loudly.
+    ///
+    /// This documents the build-gate contract at the storage layer rather than a gap: no non-adiri
+    /// network carries pre-fork packs, so mainnet's gate is active at every epoch and the legacy
+    /// layout is unreadable there BY DESIGN. What matters is that it fails with an error instead of
+    /// decoding into a plausible-looking committee — a silent misparse of the first record of every
+    /// pack is how a node ends up verifying consensus against the wrong validator set.
+    #[cfg(not(feature = "adiri"))]
+    #[tokio::test]
+    async fn test_golden_legacy_pack_rejected_without_adiri() {
+        assert!(
+            tn_types::forks::multi_workers_fork_active(LEGACY_PACK_EPOCH),
+            "a non-adiri build must be post-fork at every epoch, epoch {LEGACY_PACK_EPOCH} included"
+        );
+
+        let dir = TempDir::with_prefix("golden_legacy_non_adiri").expect("temp dir");
+        let data_file = write_golden_legacy_data_file(dir.path());
+
+        // the warm-restart door: the meta fails to decode, so the open fails
+        let warm = ConsensusPack::open_append_exists(dir.path(), LEGACY_PACK_EPOCH);
+        assert!(
+            matches!(warm, Err(super::PackError::EpochLoad(_))),
+            "expected the legacy-layout meta to fail decoding, got {:?}",
+            warm.map(|pack| pack.epoch())
+        );
+
+        // The offline validator reports the same failure rather than a clean pack. Anti-vacuity:
+        // the failure must NOT be an open error — the frozen container (data header, framing) is
+        // well formed on every lane, and only the legacy-layout record inside it is unreadable
+        // here. Without that the assertion would also pass on a garbage constant.
+        let validated =
+            crate::pack_validate::validate_pack_file(&data_file, LEGACY_PACK_EPOCH, None);
+        match validated {
+            Err(super::PackError::Open(e)) => {
+                panic!("the frozen pack container must open on any lane, got open error {e}")
+            }
+            Err(_) => {}
+            Ok(report) => panic!(
+                "the offline validator must reject legacy-layout bytes on a post-fork build, got \
+                 {:?}",
+                report.verdict
+            ),
+        }
+
+        // the peer-sync door: the first streamed record fails to decode
+        let source = dir.path().join("peer_stream");
+        std::fs::write(&source, golden_legacy_pack_bytes()).expect("write peer stream");
+        let stream = tokio::fs::File::open(&source).await.expect("open peer stream");
+        let imported = TempDir::with_prefix("golden_legacy_non_adiri_import").expect("temp dir");
+        let import = ConsensusPack::stream_import(
+            imported.path(),
+            stream,
+            LEGACY_PACK_EPOCH,
+            &EpochRecord::default(),
+            LEGACY_PACK_LAST_CONSENSUS,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(
+            import.is_err(),
+            "peer sync must reject legacy-layout bytes on a post-fork build, got {:?}",
+            import.map(|pack| pack.epoch())
         );
     }
 }

--- a/crates/telcoin-network-cli/src/keytool/generate.rs
+++ b/crates/telcoin-network-cli/src/keytool/generate.rs
@@ -6,7 +6,9 @@ use crate::{
 };
 use clap::{value_parser, Args, Subcommand};
 use tn_config::{Config, ConfigFmt, ConfigTrait as _, KeyConfig, NodeInfo, TelcoinDirs};
-use tn_types::{get_available_udp_port, Address, BlsPublicKey, Multiaddr, Protocol, RpcInfo};
+use tn_types::{
+    get_available_udp_port, Address, BlsPublicKey, Multiaddr, Protocol, RpcInfo, DEFAULT_WORKER_ID,
+};
 use tracing::info;
 use url::Url;
 
@@ -190,29 +192,32 @@ impl KeygenArgs {
 
         info!(target: "tn::generate_keys", primary=?node_info.p2p_info.primary.network_address, "updating primary external network address");
 
-        // network keypair for workers
+        // network keypair for workers (the key config holds worker 0's key)
         let network_publickey = key_config.worker_network_public_key();
-        node_info.p2p_info.worker.network_key = network_publickey.clone();
-        node_info.p2p_info.worker.network_address =
-            if let Some(worker_addrs) = &self.external_worker_addrs {
-                if let Some(worker_addr) = worker_addrs.first() {
-                    worker_addr.clone().with_p2p(network_publickey.into()).map_err(|_| {
-                        eyre::eyre!("worker address already contains a different P2P protocol")
-                    })?
-                } else {
-                    let worker_udp_port = get_available_udp_port("127.0.0.1").unwrap_or(49584);
-                    let addr: Multiaddr =
-                        format!("/ip4/127.0.0.1/udp/{worker_udp_port}/quic-v1").parse()?;
-                    addr.with(Protocol::P2p(network_publickey.into()))
-                }
+        let worker = node_info
+            .p2p_info
+            .worker_mut(DEFAULT_WORKER_ID)
+            .ok_or_else(|| eyre::eyre!("node info has no worker {DEFAULT_WORKER_ID}"))?;
+        worker.network_key = network_publickey.clone();
+        worker.network_address = if let Some(worker_addrs) = &self.external_worker_addrs {
+            if let Some(worker_addr) = worker_addrs.first() {
+                worker_addr.clone().with_p2p(network_publickey.into()).map_err(|_| {
+                    eyre::eyre!("worker address already contains a different P2P protocol")
+                })?
             } else {
                 let worker_udp_port = get_available_udp_port("127.0.0.1").unwrap_or(49584);
                 let addr: Multiaddr =
                     format!("/ip4/127.0.0.1/udp/{worker_udp_port}/quic-v1").parse()?;
                 addr.with(Protocol::P2p(network_publickey.into()))
-            };
+            }
+        } else {
+            let worker_udp_port = get_available_udp_port("127.0.0.1").unwrap_or(49584);
+            let addr: Multiaddr =
+                format!("/ip4/127.0.0.1/udp/{worker_udp_port}/quic-v1").parse()?;
+            addr.with(Protocol::P2p(network_publickey.into()))
+        };
 
-        info!(target: "tn::generate_keys", worker=?node_info.p2p_info.worker.network_address, "updating worker external network address");
+        info!(target: "tn::generate_keys", worker=?worker.network_address, "updating worker external network address");
 
         Ok(())
     }
@@ -246,8 +251,12 @@ impl KeygenArgs {
         self.update_keys(&mut node_info, key_config)?;
 
         // execution address is set inside `set_proof_of_possession` (called by `update_keys`);
-        // only `worker.rpc` is set here (update_keys owns the worker network key/address).
-        node_info.p2p_info.worker.rpc = worker_rpc;
+        // only worker 0's `rpc` is set here (update_keys owns the worker network key/address).
+        node_info
+            .p2p_info
+            .worker_mut(DEFAULT_WORKER_ID)
+            .map(|worker| worker.rpc = worker_rpc)
+            .ok_or_else(|| eyre::eyre!("node info has no worker {DEFAULT_WORKER_ID}"))?;
         Config::write_to_path(tn_datadir.node_info_path(), &node_info, ConfigFmt::YAML)?;
 
         Ok(())

--- a/crates/telcoin-network-cli/src/keytool/mod.rs
+++ b/crates/telcoin-network-cli/src/keytool/mod.rs
@@ -141,7 +141,9 @@ mod tests {
     use crate::{cli::Cli, NoArgs};
     use clap::Parser;
     use tn_config::{Config, ConfigFmt, ConfigTrait, NodeInfo};
-    use tn_types::{hex, verify_proof_of_possession_bls, Address, BlsPublicKey, RpcInfo};
+    use tn_types::{
+        hex, verify_proof_of_possession_bls, Address, BlsPublicKey, RpcInfo, DEFAULT_WORKER_ID,
+    };
     use url::Url;
 
     /// Test that generate keys command works.
@@ -472,7 +474,7 @@ mod tests {
 
         // worker rpc is exactly what we passed in.
         assert_eq!(
-            node_info.p2p_info.worker.rpc,
+            node_info.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc,
             Some(RpcInfo { http, ws: Some(ws) }),
             "worker rpc should match the provided endpoints"
         );
@@ -510,7 +512,7 @@ mod tests {
         )
         .expect("node info loaded");
         assert!(
-            node_info.p2p_info.worker.rpc.is_none(),
+            node_info.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc.is_none(),
             "worker rpc should stay unset without --rpc-http"
         );
     }
@@ -700,7 +702,10 @@ mod tests {
         let before = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
             .expect("node info loaded before set-rpc");
         // the worker starts with no advertised rpc.
-        assert!(before.p2p_info.worker.rpc.is_none(), "worker rpc should start unset");
+        assert!(
+            before.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc.is_none(),
+            "worker rpc should start unset"
+        );
 
         let http = Url::parse("https://validator.example.com:8545/").expect("http url");
         let ws = Url::parse("wss://validator.example.com:8546/").expect("ws url");
@@ -713,7 +718,7 @@ mod tests {
 
         // worker rpc is exactly what we passed in.
         assert_eq!(
-            after.p2p_info.worker.rpc,
+            after.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc,
             Some(RpcInfo { http, ws: Some(ws) }),
             "worker rpc should match the provided endpoints"
         );
@@ -743,14 +748,20 @@ mod tests {
             .expect("set-rpc sets worker rpc");
         let set = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
             .expect("node info loaded after set");
-        assert!(set.p2p_info.worker.rpc.is_some(), "worker rpc should be set before clearing");
+        assert!(
+            set.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc.is_some(),
+            "worker rpc should be set before clearing"
+        );
 
         SetRpcArgs { http: None, ws: None, clear: true }
             .execute(&datadir)
             .expect("set-rpc clears worker rpc");
         let cleared = Config::load_from_path::<NodeInfo>(&node_info_path, ConfigFmt::YAML)
             .expect("node info loaded after clear");
-        assert!(cleared.p2p_info.worker.rpc.is_none(), "worker rpc should be cleared");
+        assert!(
+            cleared.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc.is_none(),
+            "worker rpc should be cleared"
+        );
     }
 
     /// `set-rpc` errors with a "generate keys first" hint when `node-info.yaml`
@@ -795,7 +806,10 @@ mod tests {
             ConfigFmt::YAML,
         )
         .expect("node info still loads");
-        assert!(after.p2p_info.worker.rpc.is_none(), "rejected endpoint must not be persisted");
+        assert!(
+            after.p2p_info.worker(DEFAULT_WORKER_ID).expect("worker 0").rpc.is_none(),
+            "rejected endpoint must not be persisted"
+        );
     }
 
     /// The `set-rpc` clap relations: `--http` is required unless `--clear`, and

--- a/crates/telcoin-network-cli/src/keytool/set_rpc.rs
+++ b/crates/telcoin-network-cli/src/keytool/set_rpc.rs
@@ -3,7 +3,7 @@
 //!
 //! A node advertises an optional JSON-RPC endpoint to peers over kademlia so
 //! wallets/dapps can discover where to submit transactions. That endpoint lives
-//! in `node_info.p2p_info.worker.rpc` (type `Option<RpcInfo>`). The runtime
+//! in `node_info.p2p_info.workers[0].rpc` (type `Option<RpcInfo>`). The runtime
 //! reads it at node startup, validates it, and hands it to the worker network
 //! for advertisement - this command only populates the config field.
 //!
@@ -20,7 +20,7 @@ use crate::args::clap_url_parser;
 use clap::Args;
 use eyre::WrapErr as _;
 use tn_config::{Config, ConfigFmt, ConfigTrait as _, NodeInfo, TelcoinDirs};
-use tn_types::RpcInfo;
+use tn_types::{RpcInfo, DEFAULT_WORKER_ID};
 use tracing::{info, warn};
 use url::Url;
 
@@ -87,8 +87,12 @@ impl SetRpcArgs {
                 },
             )?;
 
+        // the RPC endpoint is advertised on worker 0's record
+        let worker = node_info.p2p_info.worker_mut(DEFAULT_WORKER_ID).ok_or_else(|| {
+            eyre::eyre!("node-info.yaml at {} has no worker 0", dir.node_info_path().display())
+        })?;
         if self.clear {
-            if node_info.p2p_info.worker.rpc.take().is_some() {
+            if worker.rpc.take().is_some() {
                 warn!(target: "tn::keytool", "cleared existing worker RPC endpoint");
             } else {
                 info!(target: "tn::keytool", "no worker RPC endpoint set; nothing to clear");
@@ -97,15 +101,16 @@ impl SetRpcArgs {
             // clap guarantees --http is present unless --clear.
             let rpc = build_worker_rpc(self.http.clone(), self.ws.clone())?
                 .ok_or_else(|| eyre::eyre!("clap requires --http unless --clear"))?;
-            if node_info.p2p_info.worker.rpc.is_some() {
+            if worker.rpc.is_some() {
                 warn!(target: "tn::keytool", "overwriting existing worker RPC endpoint");
             }
-            node_info.p2p_info.worker.rpc = Some(rpc);
+            worker.rpc = Some(rpc);
         }
+        let worker_rpc = worker.rpc.clone();
 
         Config::write_to_path(dir.node_info_path(), &node_info, ConfigFmt::YAML)?;
         println!("OK  node-info.yaml updated: {}", dir.node_info_path().display());
-        match &node_info.p2p_info.worker.rpc {
+        match &worker_rpc {
             Some(rpc) => {
                 println!("    worker rpc http: {}", rpc.http);
                 if let Some(ws) = &rpc.ws {

--- a/crates/telcoin-network-cli/src/node.rs
+++ b/crates/telcoin-network-cli/src/node.rs
@@ -118,16 +118,21 @@ impl<Ext: clap::Args + fmt::Debug> NodeCommand<Ext> {
 
         // Log the compiled fork schedule once per process start (#1086) so operators can diff it
         // across the fleet before a fork epoch arrives. Adiri builds carry epoch-gated forks;
-        // every other build has the seed-signature wire format (#1032) active from genesis.
+        // every other build has both the seed-signature (#1032) and multi-worker committee (#554)
+        // wire formats active from genesis.
         #[cfg(feature = "adiri")]
         info!(
             target: "cli",
             consensus_registry_fork_epoch = tn_types::forks::CONSENSUS_REGISTRY_FORK_EPOCH,
             seed_signature_fork_epoch = tn_types::forks::SEED_SIGNATURE_FORK_EPOCH,
+            multi_workers_fork_epoch = tn_types::forks::MULTI_WORKERS_FORK_EPOCH,
             "fork schedule (adiri)"
         );
         #[cfg(not(feature = "adiri"))]
-        info!(target: "cli", "fork schedule: seed_signature active from genesis");
+        info!(
+            target: "cli",
+            "fork schedule: seed_signature and multi_workers active from genesis"
+        );
 
         // Raise the fd limit of the process.
         // Does not do anything on windows.

--- a/crates/test-utils-committee/src/authority.rs
+++ b/crates/test-utils-committee/src/authority.rs
@@ -6,7 +6,7 @@ use tn_config::{Config, ConsensusConfig, KeyConfig, NetworkConfig, Parameters};
 use tn_types::{
     Address, Authority, AuthorityIdentifier, BlsKeypair, BlsPublicKey, BlsSignature, Certificate,
     Committee, Database, Epoch, EpochDigest, EpochSeedMessage, Genesis, Hash as _, Header,
-    HeaderBuilder, NetworkKeypair, NetworkPublicKey, Round, Vote,
+    HeaderBuilder, NetworkKeypair, NetworkPublicKey, P2pNode, Round, Vote, DEFAULT_WORKER_ID,
 };
 
 /// Fixture representing an validator node within the network.
@@ -142,18 +142,32 @@ impl<DB: Database> AuthorityFixture<DB> {
         // Make sure our keys are correct.
         assert_eq!(&key_config.primary_public_key(), authority.protocol_key());
         assert_eq!(primary_keypair.public(), &key_config.primary_public_key());
-        // Currently only support one worker per node.
-        // If/when this is relaxed then the key_config below will need to change.
-        assert_eq!(number_of_workers.get(), 1);
         let mut config = Config::default_for_test_with_genesis(genesis);
         // overwrite default parameters if provided
         if let Some(overwrite) = parameters {
             config.parameters = overwrite.clone();
         }
+        // The node info defaults to one worker; give the fixture `number_of_workers` entries so
+        // its p2p info matches the committee. Worker 0 keeps the key config's worker key (the
+        // key config holds a single worker key); workers 1.. are the SAME nodes the committee's
+        // bootstrap entry advertises for this authority, so committee and node info agree.
+        let advertised: Vec<P2pNode> = committee
+            .bootstrap_servers()
+            .get(authority.protocol_key())
+            .map(|server| server.workers.iter().skip(1).cloned().collect())
+            .unwrap_or_default();
+        assert_eq!(
+            advertised.len() + 1,
+            number_of_workers.get(),
+            "bootstrap entry must advertise number_of_workers workers"
+        );
+        config.node_info.p2p_info.workers =
+            config.node_info.p2p_info.workers.iter().take(1).cloned().chain(advertised).collect();
         // These key updates don't return errors...
         let _ = config.update_protocol_key(key_config.primary_public_key());
         let _ = config.update_primary_network_key(key_config.primary_network_public_key());
-        let _ = config.update_worker_network_key(key_config.worker_network_public_key());
+        let _ = config
+            .update_worker_network_key(DEFAULT_WORKER_ID, key_config.worker_network_public_key());
 
         let consensus_config = ConsensusConfig::new_with_committee_and_prior_epoch_record_for_test(
             config,

--- a/crates/test-utils-committee/src/builder.rs
+++ b/crates/test-utils-committee/src/builder.rs
@@ -8,8 +8,8 @@ use std::{collections::BTreeMap, marker::PhantomData, num::NonZeroUsize};
 use tn_config::{KeyConfig, NetworkConfig, Parameters};
 use tn_types::{
     get_available_udp_port, test_genesis, Address, Authority, AuthorityIdentifier, BlsKeypair,
-    BootstrapServer, Committee, Database, Epoch, EpochDigest, Multiaddr, TimestampSec,
-    DEFAULT_WORKER_PORT,
+    BootstrapServer, Committee, Database, Epoch, EpochDigest, Multiaddr, NetworkKeypair, P2pNode,
+    TimestampSec, DEFAULT_WORKER_PORT,
 };
 
 /// The committee builder for tests.
@@ -58,6 +58,15 @@ where
     DB: Database,
     F: Fn() -> DB,
 {
+    /// Set the number of workers every authority runs (defaults to one).
+    ///
+    /// Worker 0 uses the authority's [KeyConfig] worker network key; every further worker
+    /// gets a fresh network keypair, since [KeyConfig] holds a single worker key.
+    pub fn number_of_workers(mut self, number_of_workers: NonZeroUsize) -> Self {
+        self.number_of_workers = number_of_workers;
+        self
+    }
+
     pub fn committee_size(mut self, committee_size: NonZeroUsize) -> Self {
         self.committee_size = committee_size;
         self
@@ -145,13 +154,26 @@ where
             };
             let primary_network_address: Multiaddr =
                 format!("/ip4/{host}/udp/{port}/quic-v1").parse().unwrap();
-            let port = if self.randomize_ports {
-                get_available_udp_port(host).unwrap_or(DEFAULT_WORKER_PORT)
-            } else {
-                0
+            let randomize_ports = self.randomize_ports;
+            let worker_address = move || -> Multiaddr {
+                let port = if randomize_ports {
+                    get_available_udp_port(host).unwrap_or(DEFAULT_WORKER_PORT)
+                } else {
+                    0
+                };
+                format!("/ip4/{host}/udp/{port}/quic-v1").parse().unwrap()
             };
-            let worker_network_address: Multiaddr =
-                format!("/ip4/{host}/udp/{port}/quic-v1").parse().unwrap();
+            // worker 0 carries the key config's worker key; further workers get fresh keys
+            let worker_nodes: Vec<P2pNode> = (0..self.number_of_workers.get())
+                .map(|worker_id| {
+                    let key = if worker_id == 0 {
+                        key_config.worker_network_public_key()
+                    } else {
+                        NetworkKeypair::generate_ed25519().public().into()
+                    };
+                    (worker_address(), key).into()
+                })
+                .collect();
             let authority = Authority::new_for_test(
                 key_config.primary_public_key(),
                 Address::random_with(&mut rng),
@@ -160,7 +182,7 @@ where
                 *authority.protocol_key(),
                 BootstrapServer::new(
                     (primary_network_address, key_config.primary_network_public_key()).into(),
-                    (worker_network_address, key_config.worker_network_public_key()).into(),
+                    worker_nodes,
                 ),
             );
             authorities.insert(
@@ -185,7 +207,8 @@ where
             authorities.into_iter().map(|(k, (_, _, a))| (k, a)).collect(),
             self.epoch,
             bootstrap_servers,
-        );
+        )
+        .with_num_workers(self.number_of_workers);
         let genesis = test_genesis();
         // All the authorities use the same worker cache.
         let authorities: BTreeMap<AuthorityIdentifier, AuthorityFixture<DB>> = committee_info

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -110,38 +110,78 @@ impl From<(NetworkPublicKey, Multiaddr)> for P2pNode {
     }
 }
 
-/// On-disk representations of a primary plus its worker list.
+/// The current on-disk shape of a primary plus its worker list: `{ primary, workers }`.
 ///
-/// Shared by [BootstrapServer] and `NodeP2pInfo`, which both persist the same
-/// `{ primary, workers }` shape. `Current` is the shape written today. `Legacy` is the
-/// pre-multi-worker single `worker` map, still accepted on read so files written before the
-/// worker list existed load unchanged.
+/// Shared by [BootstrapServer] and `NodeP2pInfo`. This is the only shape written today and the
+/// only shape binary codecs (bcs: the consensus store and pack encoding) read.
+#[derive(Deserialize)]
+pub(crate) struct PrimaryWorkersCurrent {
+    /// The p2p info of the primary.
+    pub(crate) primary: P2pNode,
+    /// The p2p info for each worker, never empty.
+    #[serde(deserialize_with = "deserialize_non_empty_workers")]
+    pub(crate) workers: Vec<P2pNode>,
+}
+
+/// The legacy single-worker shape: `{ primary, worker }`.
+///
+/// Still accepted from human-readable files written before the worker list existed.
+#[derive(Deserialize)]
+pub(crate) struct PrimaryWorkersLegacy {
+    /// The p2p info of the primary.
+    pub(crate) primary: P2pNode,
+    /// The p2p info of the single worker.
+    pub(crate) worker: P2pNode,
+}
+
+/// Human-readable (YAML, JSON) representations of a primary plus its worker list.
+///
+/// Both variants are boxed so the enum stays small (clippy `large_enum_variant`; `P2pNode` is
+/// wide). Untagged: serde tries [PrimaryWorkersCurrent] first, then [PrimaryWorkersLegacy].
+/// Untagged enums buffer the input through `deserialize_any`, which non-self-describing codecs
+/// (bcs) do not support, so this enum is only used when the deserializer reports
+/// `is_human_readable()`; see [deserialize_primary_workers].
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub(crate) enum PrimaryWorkersRepr {
     /// The current shape: `workers: [..]`.
-    Current {
-        /// The p2p info of the primary.
-        primary: P2pNode,
-        /// The p2p info for each worker, never empty.
-        #[serde(deserialize_with = "deserialize_non_empty_workers")]
-        workers: Vec<P2pNode>,
-    },
+    Current(Box<PrimaryWorkersCurrent>),
     /// The legacy shape: `worker: {..}`.
-    Legacy {
-        /// The p2p info of the primary.
-        primary: P2pNode,
-        /// The p2p info of the single worker (boxed to keep the variants a similar size).
-        worker: Box<P2pNode>,
-    },
+    Legacy(Box<PrimaryWorkersLegacy>),
 }
 
 impl From<PrimaryWorkersRepr> for (P2pNode, Vec<P2pNode>) {
     fn from(value: PrimaryWorkersRepr) -> Self {
         match value {
-            PrimaryWorkersRepr::Current { primary, workers } => (primary, workers),
-            PrimaryWorkersRepr::Legacy { primary, worker } => (primary, vec![*worker]),
+            PrimaryWorkersRepr::Current(current) => {
+                let PrimaryWorkersCurrent { primary, workers } = *current;
+                (primary, workers)
+            }
+            PrimaryWorkersRepr::Legacy(legacy) => {
+                let PrimaryWorkersLegacy { primary, worker } = *legacy;
+                (primary, vec![worker])
+            }
         }
+    }
+}
+
+/// Deserialize the `(primary, workers)` pair shared by [BootstrapServer] and `NodeP2pInfo`.
+///
+/// Human-readable formats (the YAML and JSON config and committee files) accept both the
+/// current `workers: [..]` list and the legacy single `worker: {..}` map. Binary formats (bcs,
+/// used by the consensus store and the consensus pack) carry only the current shape and are read
+/// directly: the untagged legacy fallback needs `deserialize_any`, which bcs rejects.
+pub(crate) fn deserialize_primary_workers<'de, D>(
+    deserializer: D,
+) -> Result<(P2pNode, Vec<P2pNode>), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        PrimaryWorkersRepr::deserialize(deserializer).map(Into::into)
+    } else {
+        PrimaryWorkersCurrent::deserialize(deserializer)
+            .map(|PrimaryWorkersCurrent { primary, workers }| (primary, workers))
     }
 }
 
@@ -171,8 +211,7 @@ where
 /// Serialization: the current on-disk shape is `workers: [..]`. The legacy single-worker shape
 /// `worker: {..}` is still accepted on read so existing committee files load unchanged; it is
 /// written back in the new shape.
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
-#[serde(from = "PrimaryWorkersRepr")]
+#[derive(Clone, Serialize, Debug, Eq, PartialEq)]
 pub struct BootstrapServer {
     /// The p2p info the primary.
     pub primary: P2pNode,
@@ -180,10 +219,13 @@ pub struct BootstrapServer {
     pub workers: Vec<P2pNode>,
 }
 
-impl From<PrimaryWorkersRepr> for BootstrapServer {
-    fn from(value: PrimaryWorkersRepr) -> Self {
-        let (primary, workers) = value.into();
-        Self { primary, workers }
+impl<'de> Deserialize<'de> for BootstrapServer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserialize_primary_workers(deserializer)
+            .map(|(primary, workers)| Self { primary, workers })
     }
 }
 
@@ -964,6 +1006,44 @@ mod tests {
         let doc = format!("primary:\n{}\nworkers: []\n", indent(&primary_yaml));
         let result: Result<BootstrapServer, _> = serde_yaml::from_str(&doc);
         assert!(result.is_err(), "empty workers must be rejected");
+    }
+
+    #[test]
+    fn bootstrap_server_bcs_round_trips() {
+        // bcs is not self-describing: the legacy-tolerant untagged path cannot run there, so the
+        // binary codec must read the current shape directly.
+        let bootstrap = bootstrap_with_workers(2);
+        let bytes = crate::encode(&bootstrap);
+        let decoded: BootstrapServer = crate::try_decode(&bytes).expect("bcs deserialize");
+        assert_eq!(decoded, bootstrap);
+    }
+
+    #[test]
+    fn committee_bcs_round_trips_with_bootstrap_servers() {
+        // The consensus store and the consensus pack persist committees with bcs.
+        let mut rng = rng();
+        let authorities = (0..4u8)
+            .map(|i| {
+                let keypair = BlsKeypair::generate(&mut rng);
+                (*keypair.public(), Authority::new(*keypair.public(), Address::repeat_byte(i)))
+            })
+            .collect::<BTreeMap<BlsPublicKey, Authority>>();
+        let bootstrap_servers = authorities
+            .keys()
+            .map(|key| (*key, bootstrap_with_workers(2)))
+            .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
+        let committee = Committee::new(
+            authorities,
+            7,
+            bootstrap_servers,
+            std::num::NonZeroUsize::new(2).expect("2 is not 0"),
+        );
+        let bytes = crate::encode(&committee);
+        let decoded: Committee = crate::try_decode(&bytes).expect("bcs deserialize");
+        assert_eq!(decoded, committee);
+        assert_eq!(decoded.number_of_workers(), 2);
+        assert_eq!(decoded.bootstrap_servers().len(), 4);
+        assert!(decoded.bootstrap_servers().values().all(|server| server.num_workers() == 2));
     }
 
     #[test]

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     crypto::{BlsPublicKey, NetworkPublicKey},
-    Address, Multiaddr,
+    Address, Multiaddr, WorkerId,
 };
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter},
-    num::NonZeroU64,
+    num::{NonZeroU64, NonZeroUsize},
     str::FromStr,
     sync::Arc,
 };
@@ -110,19 +110,106 @@ impl From<(NetworkPublicKey, Multiaddr)> for P2pNode {
     }
 }
 
+/// On-disk representations of a primary plus its worker list.
+///
+/// Shared by [BootstrapServer] and `NodeP2pInfo`, which both persist the same
+/// `{ primary, workers }` shape. `Current` is the shape written today. `Legacy` is the
+/// pre-multi-worker single `worker` map, still accepted on read so files written before the
+/// worker list existed load unchanged.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(crate) enum PrimaryWorkersRepr {
+    /// The current shape: `workers: [..]`.
+    Current {
+        /// The p2p info of the primary.
+        primary: P2pNode,
+        /// The p2p info for each worker, never empty.
+        #[serde(deserialize_with = "deserialize_non_empty_workers")]
+        workers: Vec<P2pNode>,
+    },
+    /// The legacy shape: `worker: {..}`.
+    Legacy {
+        /// The p2p info of the primary.
+        primary: P2pNode,
+        /// The p2p info of the single worker (boxed to keep the variants a similar size).
+        worker: Box<P2pNode>,
+    },
+}
+
+impl From<PrimaryWorkersRepr> for (P2pNode, Vec<P2pNode>) {
+    fn from(value: PrimaryWorkersRepr) -> Self {
+        match value {
+            PrimaryWorkersRepr::Current { primary, workers } => (primary, workers),
+            PrimaryWorkersRepr::Legacy { primary, worker } => (primary, vec![*worker]),
+        }
+    }
+}
+
+/// Deserialize a worker list and reject an empty one.
+///
+/// A node must run at least one worker, so an empty list is a configuration error rather than a
+/// valid value.
+pub(crate) fn deserialize_non_empty_workers<'de, D>(
+    deserializer: D,
+) -> Result<Vec<P2pNode>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let workers = Vec::<P2pNode>::deserialize(deserializer)?;
+    (!workers.is_empty())
+        .then_some(workers)
+        .ok_or_else(|| serde::de::Error::custom("`workers` must contain at least one entry"))
+}
+
 /// Bootstrap p2p server info to join the network.
+///
+/// `workers` holds one [P2pNode] per worker, indexed by [WorkerId], and is never empty. It is a
+/// dial-hint list, not a validated invariant: a bootstrap entry may advertise fewer workers than
+/// [Committee::number_of_workers] (today every entry advertises exactly one). Per-worker
+/// bootstrap addresses arrive with the per-worker swarms.
+///
+/// Serialization: the current on-disk shape is `workers: [..]`. The legacy single-worker shape
+/// `worker: {..}` is still accepted on read so existing committee files load unchanged; it is
+/// written back in the new shape.
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(from = "PrimaryWorkersRepr")]
 pub struct BootstrapServer {
     /// The p2p info the primary.
     pub primary: P2pNode,
-    /// The p2p info the worker.
-    pub worker: P2pNode,
+    /// The p2p info for each worker, indexed by [WorkerId].
+    pub workers: Vec<P2pNode>,
+}
+
+impl From<PrimaryWorkersRepr> for BootstrapServer {
+    fn from(value: PrimaryWorkersRepr) -> Self {
+        let (primary, workers) = value.into();
+        Self { primary, workers }
+    }
 }
 
 impl BootstrapServer {
-    pub fn new(primary_node: P2pNode, worker_node: P2pNode) -> Self {
-        Self { primary: primary_node, worker: worker_node }
+    /// Create a new [BootstrapServer] with one [P2pNode] per worker.
+    pub fn new(primary_node: P2pNode, worker_nodes: Vec<P2pNode>) -> Self {
+        Self { primary: primary_node, workers: worker_nodes }
     }
+
+    /// Return the [P2pNode] for `worker_id`, or `None` if the server has no such worker.
+    pub fn worker(&self, worker_id: WorkerId) -> Option<&P2pNode> {
+        self.workers.get(usize::from(worker_id))
+    }
+
+    /// Return the number of workers this bootstrap server advertises.
+    pub fn num_workers(&self) -> usize {
+        self.workers.len()
+    }
+}
+
+/// The default worker count for a committee: one worker per validator.
+const ONE_WORKER: NonZeroUsize = NonZeroUsize::MIN;
+
+/// Serde default for [CommitteeInner::num_workers] so committee files without the field load.
+fn default_num_workers() -> NonZeroUsize {
+    ONE_WORKER
 }
 
 /// Immutable authority data.
@@ -197,7 +284,7 @@ impl<'de> Deserialize<'de> for Authority {
 }
 
 /// The committee lists all validators that participate in consensus.
-#[derive(Serialize, Deserialize, Debug, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Eq)]
 struct CommitteeInner {
     /// The authorities of epoch.
     authorities: BTreeMap<BlsPublicKey, Authority>,
@@ -216,6 +303,27 @@ struct CommitteeInner {
     /// The bootstrap servers to initially join a network (probably the initial committee).
     /// Note, not included in partial eq since they are not relevand to overall committee equality.
     bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapServer>,
+    /// The number of workers every validator in this committee runs.
+    ///
+    /// This is a protocol-level value: all nodes must agree on it. Its source of truth is the
+    /// on-chain `WorkerConfigs` contract, read at the previous epoch's closing block when the
+    /// committee for an epoch is created. Committee files without the field default to one.
+    #[serde(default = "default_num_workers")]
+    num_workers: NonZeroUsize,
+}
+
+impl Default for CommitteeInner {
+    fn default() -> Self {
+        Self {
+            authorities: BTreeMap::default(),
+            authorities_by_id: BTreeMap::default(),
+            epoch: Epoch::default(),
+            quorum_threshold: VotingPower::default(),
+            validity_threshold: VotingPower::default(),
+            bootstrap_servers: BTreeMap::default(),
+            num_workers: ONE_WORKER,
+        }
+    }
 }
 
 impl PartialEq for CommitteeInner {
@@ -223,6 +331,7 @@ impl PartialEq for CommitteeInner {
         self.epoch == other.epoch
             && self.quorum_threshold == other.quorum_threshold
             && self.validity_threshold == other.validity_threshold
+            && self.num_workers == other.num_workers
             && self.authorities.eq(&other.authorities)
     }
 }
@@ -419,6 +528,7 @@ impl Committee {
         authorities: BTreeMap<BlsPublicKey, Authority>,
         epoch: Epoch,
         bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapServer>,
+        num_workers: NonZeroUsize,
     ) -> Self {
         let mut committee = CommitteeInner {
             authorities,
@@ -427,6 +537,7 @@ impl Committee {
             validity_threshold: 0,
             quorum_threshold: 0,
             bootstrap_servers,
+            num_workers,
         };
         committee.load();
 
@@ -443,7 +554,7 @@ impl Committee {
     /// on new.
     ///
     /// Pass an optional epoch_boundary timestamp. Defaults to u64::MAX to disable epoch
-    /// transitions.
+    /// transitions. The committee has one worker; use [Committee::with_num_workers] to widen it.
     pub fn new_for_test(
         authorities: BTreeMap<BlsPublicKey, Authority>,
         epoch: Epoch,
@@ -456,6 +567,7 @@ impl Committee {
             validity_threshold: 0,
             quorum_threshold: 0,
             bootstrap_servers,
+            num_workers: ONE_WORKER,
         };
 
         committee.authorities_by_id = committee
@@ -599,11 +711,32 @@ impl Committee {
     }
 
     /// Return the number of workers that are in use for this committee.
+    ///
     /// This is a protocol level value, all nodes have to agree on this and be
-    /// running the required number of workers.
-    /// Currently 1 but may change with a future fork on an epoch boundary.
+    /// running the required number of workers. The source of truth is the on-chain
+    /// `WorkerConfigs` contract at the previous epoch's closing block, so a change takes
+    /// effect at an epoch boundary. Committees built without an explicit count have one worker.
     pub fn number_of_workers(&self) -> usize {
-        1
+        self.inner.num_workers.get()
+    }
+
+    /// Return a copy of this committee with the worker count set to `num_workers`.
+    ///
+    /// The epoch-0 committee is loaded from the committee file, whose count is a default; the
+    /// epoch manager uses this to stamp the on-chain count onto it. Every other field, including
+    /// the derived indexes and thresholds, is copied as-is: this does not re-run
+    /// `CommitteeInner::load`, so it is safe on a default (empty) committee as well.
+    pub fn with_num_workers(&self, num_workers: NonZeroUsize) -> Committee {
+        let inner = CommitteeInner {
+            authorities: self.inner.authorities.clone(),
+            authorities_by_id: self.inner.authorities_by_id.clone(),
+            epoch: self.inner.epoch,
+            quorum_threshold: self.inner.quorum_threshold,
+            validity_threshold: self.inner.validity_threshold,
+            bootstrap_servers: self.inner.bootstrap_servers.clone(),
+            num_workers,
+        };
+        Committee { inner: Arc::new(inner) }
     }
 }
 
@@ -637,12 +770,25 @@ pub struct CommitteeBuilder {
     authorities: BTreeMap<BlsPublicKey, Authority>,
     /// The map of [BlsPublicKey] for each [BootstrapServer].
     bootstrap_server: BTreeMap<BlsPublicKey, BootstrapServer>,
+    /// The number of workers every validator runs (defaults to one).
+    num_workers: NonZeroUsize,
 }
 
 impl CommitteeBuilder {
     /// Create a new instance of [CommitteeBuilder] for making a new [Committee].
     pub fn new(epoch: Epoch) -> Self {
-        Self { epoch, authorities: BTreeMap::default(), bootstrap_server: BTreeMap::default() }
+        Self {
+            epoch,
+            authorities: BTreeMap::default(),
+            bootstrap_server: BTreeMap::default(),
+            num_workers: ONE_WORKER,
+        }
+    }
+
+    /// Set the number of workers every validator in the committee runs.
+    pub fn with_num_workers(mut self, num_workers: NonZeroUsize) -> Self {
+        self.num_workers = num_workers;
+        self
     }
 
     /// Add an authority and bootstrap server to the committee builder.
@@ -650,12 +796,12 @@ impl CommitteeBuilder {
         &mut self,
         protocol_key: BlsPublicKey,
         primary_node: P2pNode,
-        worker_node: P2pNode,
+        worker_nodes: Vec<P2pNode>,
         execution_address: Address,
     ) {
         let authority = Authority::new(protocol_key, execution_address);
         self.authorities.insert(protocol_key, authority);
-        let bootstrap = BootstrapServer::new(primary_node, worker_node);
+        let bootstrap = BootstrapServer::new(primary_node, worker_nodes);
         self.bootstrap_server.insert(protocol_key, bootstrap);
     }
 
@@ -665,19 +811,20 @@ impl CommitteeBuilder {
         self.authorities.insert(protocol_key, authority);
     }
 
-    /// Add an authority to the committee builder.
+    /// Add a bootstrap server to the committee builder.
     pub fn add_bootstrap_server(
         &mut self,
         protocol_key: BlsPublicKey,
         primary_node: P2pNode,
-        worker_node: P2pNode,
+        worker_nodes: Vec<P2pNode>,
     ) {
-        let bootstrap = BootstrapServer::new(primary_node, worker_node);
+        let bootstrap = BootstrapServer::new(primary_node, worker_nodes);
         self.bootstrap_server.insert(protocol_key, bootstrap);
     }
 
+    /// Build the [Committee].
     pub fn build(self) -> Committee {
-        Committee::new(self.authorities, self.epoch, self.bootstrap_server)
+        Committee::new(self.authorities, self.epoch, self.bootstrap_server, self.num_workers)
     }
 }
 
@@ -723,7 +870,7 @@ mod tests {
 
                 let b = BootstrapServer::new(
                     (Multiaddr::empty(), primary_keypair.public().clone().into()).into(),
-                    (Multiaddr::empty(), worker_keypair.public().clone().into()).into(),
+                    vec![(Multiaddr::empty(), worker_keypair.public().clone().into()).into()],
                 );
 
                 (*key, b)
@@ -731,7 +878,7 @@ mod tests {
             .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
 
         // WHEN
-        let committee = Committee::new(authorities, 10, bootstrap_servers);
+        let committee = Committee::new(authorities, 10, bootstrap_servers, super::ONE_WORKER);
 
         // THEN
         assert_eq!(committee.inner.authorities_by_id.len() as u64, num_of_authorities);
@@ -760,6 +907,136 @@ mod tests {
         assert_eq!(total, num_of_authorities);
     }
 
+    /// A [BootstrapServer] with fresh keys and `num_workers` workers.
+    fn bootstrap_with_workers(num_workers: usize) -> BootstrapServer {
+        let primary_keypair = NetworkKeypair::generate_ed25519();
+        BootstrapServer::new(
+            (Multiaddr::empty(), primary_keypair.public().clone().into()).into(),
+            (0..num_workers)
+                .map(|_| {
+                    let keypair = NetworkKeypair::generate_ed25519();
+                    (Multiaddr::empty(), keypair.public().clone().into()).into()
+                })
+                .collect(),
+        )
+    }
+
+    /// Indent every line of a YAML fragment by two spaces so it nests under a key (the document
+    /// start marker is dropped).
+    fn indent(fragment: &str) -> String {
+        fragment
+            .lines()
+            .filter(|l| *l != "---")
+            .map(|l| format!("  {l}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn bootstrap_server_new_shape_round_trips() {
+        let bootstrap = bootstrap_with_workers(2);
+        let yaml = serde_yaml::to_string(&bootstrap).expect("serialize");
+        assert!(yaml.contains("workers:"), "new shape must serialize `workers`: {yaml}");
+        assert!(!yaml.contains("\nworker:"), "new shape must not serialize `worker`: {yaml}");
+        let decoded: BootstrapServer = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(decoded, bootstrap);
+        assert_eq!(decoded.num_workers(), 2);
+        assert_eq!(decoded.worker(1), bootstrap.workers.get(1));
+        assert!(decoded.worker(2).is_none());
+    }
+
+    #[test]
+    fn bootstrap_server_legacy_shape_decodes_as_one_worker() {
+        let expected = bootstrap_with_workers(1);
+        let worker = expected.worker(0).expect("one worker").clone();
+        let primary_yaml = serde_yaml::to_string(&expected.primary).expect("serialize primary");
+        let worker_yaml = serde_yaml::to_string(&worker).expect("serialize worker");
+        let legacy =
+            format!("primary:\n{}\nworker:\n{}\n", indent(&primary_yaml), indent(&worker_yaml));
+        let decoded: BootstrapServer = serde_yaml::from_str(&legacy).expect("legacy deserialize");
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn bootstrap_server_empty_workers_rejected() {
+        let bootstrap = bootstrap_with_workers(1);
+        let primary_yaml = serde_yaml::to_string(&bootstrap.primary).expect("serialize primary");
+        let doc = format!("primary:\n{}\nworkers: []\n", indent(&primary_yaml));
+        let result: Result<BootstrapServer, _> = serde_yaml::from_str(&doc);
+        assert!(result.is_err(), "empty workers must be rejected");
+    }
+
+    #[test]
+    fn committee_yaml_without_num_workers_defaults_to_one() {
+        let mut rng = rng();
+        let authorities = (0..4u8)
+            .map(|i| {
+                let keypair = BlsKeypair::generate(&mut rng);
+                (*keypair.public(), Authority::new(*keypair.public(), Address::repeat_byte(i)))
+            })
+            .collect::<BTreeMap<BlsPublicKey, Authority>>();
+        let bootstrap_servers = authorities
+            .keys()
+            .map(|key| (*key, bootstrap_with_workers(1)))
+            .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
+        let committee = Committee::new(
+            authorities,
+            3,
+            bootstrap_servers,
+            std::num::NonZeroUsize::new(2).expect("2 is not 0"),
+        );
+        assert_eq!(committee.number_of_workers(), 2);
+
+        // strip the field: an older committee file has no `num_workers`
+        let mut yaml_value = serde_yaml::to_value(&committee).expect("YAML serialization failed");
+        let map = yaml_value.as_mapping_mut().expect("committee should serialize to a mapping");
+        assert!(map.remove(&serde_yaml::Value::String("num_workers".to_string())).is_some());
+        let decoded: Committee = serde_yaml::from_value(yaml_value).expect("deserialize");
+        assert_eq!(decoded.number_of_workers(), 1);
+        assert_eq!(decoded.epoch(), 3);
+        // and the count round-trips when present
+        let yaml = serde_yaml::to_string(&committee).expect("serialize");
+        let decoded: Committee = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(decoded.number_of_workers(), 2);
+        assert_eq!(decoded.with_num_workers(std::num::NonZeroUsize::MIN).number_of_workers(), 1);
+    }
+
+    #[test]
+    fn with_num_workers_keeps_derived_fields_and_accepts_default_committee() {
+        // a default (empty) committee is what a missing committee file loads as: no panic
+        let widened = Committee::default()
+            .with_num_workers(std::num::NonZeroUsize::new(2).expect("2 is not 0"));
+        assert_eq!(widened.number_of_workers(), 2);
+        assert_eq!(widened.size(), 0);
+
+        // a real committee keeps its authorities, indexes and thresholds
+        let mut rng = rng();
+        let authorities = (0..4u8)
+            .map(|i| {
+                let keypair = BlsKeypair::generate(&mut rng);
+                (*keypair.public(), Authority::new(*keypair.public(), Address::repeat_byte(i)))
+            })
+            .collect::<BTreeMap<BlsPublicKey, Authority>>();
+        let bootstrap_servers = authorities
+            .keys()
+            .map(|key| (*key, bootstrap_with_workers(1)))
+            .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
+        let committee =
+            Committee::new(authorities, 5, bootstrap_servers, std::num::NonZeroUsize::MIN);
+        let widened =
+            committee.with_num_workers(std::num::NonZeroUsize::new(3).expect("3 is not 0"));
+        assert_eq!(widened.number_of_workers(), 3);
+        assert_eq!(widened.epoch(), 5);
+        assert_eq!(widened.size(), committee.size());
+        assert_eq!(widened.quorum_threshold(), committee.quorum_threshold());
+        assert_eq!(widened.validity_threshold(), committee.validity_threshold());
+        assert_eq!(widened.bootstrap_servers().len(), 4);
+        assert!(committee
+            .authorities()
+            .iter()
+            .all(|authority| widened.authority(&authority.id()).is_some()));
+    }
+
     #[test]
     fn committee_yaml_deserialize_with_legacy_authority_voting_power() {
         let mut rng = rng();
@@ -782,13 +1059,13 @@ mod tests {
                 let worker_keypair = NetworkKeypair::generate_ed25519();
                 let bootstrap = BootstrapServer::new(
                     (Multiaddr::empty(), primary_keypair.public().clone().into()).into(),
-                    (Multiaddr::empty(), worker_keypair.public().clone().into()).into(),
+                    vec![(Multiaddr::empty(), worker_keypair.public().clone().into()).into()],
                 );
                 (*key, bootstrap)
             })
             .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
 
-        let committee = Committee::new(authorities, 0, bootstrap_servers);
+        let committee = Committee::new(authorities, 0, bootstrap_servers, super::ONE_WORKER);
         let mut yaml_value = serde_yaml::to_value(&committee).expect("YAML serialization failed");
         let committee_map =
             yaml_value.as_mapping_mut().expect("committee should serialize to a mapping");

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -2,9 +2,10 @@
 
 use crate::{
     crypto::{BlsPublicKey, NetworkPublicKey},
+    forks::multi_workers_fork_active,
     Address, Multiaddr, WorkerId,
 };
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter},
@@ -229,6 +230,13 @@ impl<'de> Deserialize<'de> for BootstrapServer {
     }
 }
 
+impl From<PrimaryWorkersLegacy> for BootstrapServer {
+    fn from(value: PrimaryWorkersLegacy) -> Self {
+        let PrimaryWorkersLegacy { primary, worker } = value;
+        Self { primary, workers: vec![worker] }
+    }
+}
+
 impl BootstrapServer {
     /// Create a new [BootstrapServer] with one [P2pNode] per worker.
     pub fn new(primary_node: P2pNode, worker_nodes: Vec<P2pNode>) -> Self {
@@ -326,21 +334,25 @@ impl<'de> Deserialize<'de> for Authority {
 }
 
 /// The committee lists all validators that participate in consensus.
-#[derive(Serialize, Deserialize, Debug, Eq)]
+///
+/// Deliberately carries no serde derives: the binary wire layout is epoch-gated (#554, gated by
+/// [`crate::forks::multi_workers_fork_active`]), so every encode and decode path routes through the
+/// hand-written impls below. Human-readable formats keep the derive's exact behavior through
+/// [`CommitteeInnerHr`].
+#[derive(Debug, Eq)]
 struct CommitteeInner {
     /// The authorities of epoch.
     authorities: BTreeMap<BlsPublicKey, Authority>,
     /// Keeps and index of the Authorities by their respective identifier
     /// This is a helper struct, not included in serde or equality.
-    #[serde(skip)]
     authorities_by_id: BTreeMap<AuthorityIdentifier, Authority>,
     /// The epoch number of this committee
     epoch: Epoch,
     /// The quorum threshold (2f+1)
-    #[serde(skip)]
+    /// Derived from the authorities, never serialized.
     quorum_threshold: VotingPower,
     /// The validity threshold (f+1)
-    #[serde(skip)]
+    /// Derived from the authorities, never serialized.
     validity_threshold: VotingPower,
     /// The bootstrap servers to initially join a network (probably the initial committee).
     /// Note, not included in partial eq since they are not relevand to overall committee equality.
@@ -350,7 +362,6 @@ struct CommitteeInner {
     /// This is a protocol-level value: all nodes must agree on it. Its source of truth is the
     /// on-chain `WorkerConfigs` contract, read at the previous epoch's closing block when the
     /// committee for an epoch is created. Committee files without the field default to one.
-    #[serde(default = "default_num_workers")]
     num_workers: NonZeroUsize,
 }
 
@@ -379,6 +390,28 @@ impl PartialEq for CommitteeInner {
 }
 
 impl CommitteeInner {
+    /// Assemble the wire fields of a committee into a [CommitteeInner].
+    ///
+    /// The three derived indexes are left at their defaults: they are absent from every wire
+    /// layout in both directions, and [`Committee::deserialize`] rebuilds them by calling
+    /// [`CommitteeInner::load`].
+    fn from_wire_fields(
+        authorities: BTreeMap<BlsPublicKey, Authority>,
+        epoch: Epoch,
+        bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapServer>,
+        num_workers: NonZeroUsize,
+    ) -> Self {
+        Self {
+            authorities,
+            authorities_by_id: BTreeMap::default(),
+            epoch,
+            quorum_threshold: VotingPower::default(),
+            validity_threshold: VotingPower::default(),
+            bootstrap_servers,
+            num_workers,
+        }
+    }
+
     /// Updates the committee internal secondary indexes.
     fn load(&mut self) {
         self.authorities_by_id = self
@@ -411,6 +444,190 @@ impl CommitteeInner {
 
     fn total_voting_power(&self) -> VotingPower {
         self.authorities.len() as VotingPower
+    }
+}
+
+/// Number of `CommitteeInner` wire fields on the legacy (pre-multi-worker) layout.
+const COMMITTEE_FIELDS_LEGACY: usize = 3;
+/// Number of `CommitteeInner` wire fields once the multi-worker layout is active for the
+/// committee's epoch.
+const COMMITTEE_FIELDS_V1: usize = 4;
+/// Field names for [`serde::Deserializer::deserialize_struct`], superset (post-fork) layout.
+///
+/// Naming all four fields is load-bearing, not cosmetic: bcs sizes its field sequence from this
+/// list, so a three-entry list would make the post-fork read of the trailing `num_workers` return
+/// `None` instead of decoding it. The legacy arm simply stops after three fields, which bcs
+/// permits — it never checks that the sequence was drained.
+const COMMITTEE_FIELD_NAMES: [&str; COMMITTEE_FIELDS_V1] =
+    ["authorities", "epoch", "bootstrap_servers", "num_workers"];
+
+/// Human-readable (YAML, JSON) representation of [`CommitteeInner`], carrying the exact field set
+/// and attributes the removed derive had.
+///
+/// The epoch gate is binary-only. Human-readable formats name their fields, so a committee file
+/// written by any build loads on any other: `num_workers` defaults when absent (as in every
+/// `chain-configs/*/committee.yaml` today), and each [`BootstrapServer`] still accepts the legacy
+/// `worker:` key through its own deserializer. Both are covered by the tests below.
+#[derive(Deserialize)]
+#[serde(rename = "CommitteeInner")]
+struct CommitteeInnerHr {
+    /// The authorities of epoch.
+    authorities: BTreeMap<BlsPublicKey, Authority>,
+    /// The epoch number of this committee.
+    epoch: Epoch,
+    /// The bootstrap servers to initially join a network.
+    bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapServer>,
+    /// The number of workers every validator in this committee runs.
+    #[serde(default = "default_num_workers")]
+    num_workers: NonZeroUsize,
+}
+
+/// Borrowed serialization view writing a [`BootstrapServer`] in the legacy single-worker shape
+/// (`{ primary, worker }`), byte-identical to the pre-#554 derive.
+///
+/// Used only by the pre-fork arm of [`CommitteeInner`]'s binary serializer. The shape cannot
+/// represent more than one worker, so the view fails closed rather than silently dropping the
+/// rest: a committee that the legacy layout cannot express must be unrepresentable, not
+/// mis-encoded. Callers below the fork epoch are structurally single-worker (the pre-fork
+/// on-chain registry exposes no path that raises the count), so this error means a bug or a
+/// governance action taken too early, never routine operation.
+struct BootstrapServerLegacyRef<'a>(&'a BootstrapServer);
+
+impl Serialize for BootstrapServerLegacyRef<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let [worker] = self.0.workers.as_slice() else {
+            return Err(serde::ser::Error::custom(format!(
+                "the pre-fork layout holds exactly one worker per bootstrap server, got {}",
+                self.0.workers.len()
+            )));
+        };
+        // serialize_struct mirrors the pre-#554 derive exactly: bcs emits no framing for structs,
+        // so the wire bytes are the concatenated fields in declaration order.
+        let mut state = serializer.serialize_struct("BootstrapServer", 2)?;
+        state.serialize_field("primary", &self.0.primary)?;
+        state.serialize_field("worker", worker)?;
+        state.end()
+    }
+}
+
+/// Extracts the next element of the committee field sequence, converting an early end of input
+/// into a field-labeled error (bcs would otherwise surface only a distal `Eof`).
+fn next_committee_field<'de, A, T>(seq: &mut A, field: &'static str) -> Result<T, A::Error>
+where
+    A: serde::de::SeqAccess<'de>,
+    T: Deserialize<'de>,
+{
+    seq.next_element()?.ok_or_else(|| serde::de::Error::missing_field(field))
+}
+
+impl Serialize for CommitteeInner {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // human-readable formats name their fields, so the committee file is never gated: it
+        // carries the current shape at every epoch, exactly as the derive wrote it. for binary
+        // formats the gate reads the epoch inside this committee, never node-local state, so a
+        // historical committee keeps its historical layout at any nesting depth (pack records,
+        // epoch records, state-sync payloads).
+        if serializer.is_human_readable() || multi_workers_fork_active(self.epoch) {
+            let mut state = serializer.serialize_struct("CommitteeInner", COMMITTEE_FIELDS_V1)?;
+            state.serialize_field("authorities", &self.authorities)?;
+            state.serialize_field("epoch", &self.epoch)?;
+            state.serialize_field("bootstrap_servers", &self.bootstrap_servers)?;
+            state.serialize_field("num_workers", &self.num_workers)?;
+            return state.end();
+        }
+
+        // fail closed: the legacy layout has no field to carry a worker count, so encoding a
+        // multi-worker committee below the fork epoch would silently write a committee that
+        // decodes as single-worker on every node, including this one.
+        if self.num_workers != ONE_WORKER {
+            return Err(serde::ser::Error::custom(format!(
+                "committee for epoch {} runs {} workers, which the pre-fork layout cannot hold",
+                self.epoch, self.num_workers
+            )));
+        }
+        let legacy_servers: BTreeMap<&BlsPublicKey, BootstrapServerLegacyRef<'_>> = self
+            .bootstrap_servers
+            .iter()
+            .map(|(key, server)| (key, BootstrapServerLegacyRef(server)))
+            .collect();
+        let mut state = serializer.serialize_struct("CommitteeInner", COMMITTEE_FIELDS_LEGACY)?;
+        state.serialize_field("authorities", &self.authorities)?;
+        state.serialize_field("epoch", &self.epoch)?;
+        state.serialize_field("bootstrap_servers", &legacy_servers)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CommitteeInner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let CommitteeInnerHr { authorities, epoch, bootstrap_servers, num_workers } =
+                CommitteeInnerHr::deserialize(deserializer)?;
+            return Ok(Self::from_wire_fields(authorities, epoch, bootstrap_servers, num_workers));
+        }
+
+        /// Reads the two ungated fields, then branches on the just-decoded `epoch`: pre-fork
+        /// values carry one unprefixed `worker` per bootstrap server and no `num_workers`.
+        struct CommitteeInnerVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for CommitteeInnerVisitor {
+            type Value = CommitteeInner;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "a CommitteeInner: authorities and epoch, then bootstrap servers in the \
+                     layout that epoch selects, plus num_workers once the multi-workers fork \
+                     is active",
+                )
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let authorities = next_committee_field(&mut seq, "authorities")?;
+                let epoch: Epoch = next_committee_field(&mut seq, "epoch")?;
+                if multi_workers_fork_active(epoch) {
+                    let bootstrap_servers = next_committee_field(&mut seq, "bootstrap_servers")?;
+                    let num_workers = next_committee_field(&mut seq, "num_workers")?;
+                    return Ok(CommitteeInner::from_wire_fields(
+                        authorities,
+                        epoch,
+                        bootstrap_servers,
+                        num_workers,
+                    ));
+                }
+
+                // the legacy value type is the whole discriminator: the two shapes are not
+                // self-describing under bcs (`primary ++ worker` against `primary ++ ULEB128(n)
+                // ++ n worker`), so sniffing the bytes is unsound and only the epoch decides.
+                let legacy: BTreeMap<BlsPublicKey, PrimaryWorkersLegacy> =
+                    next_committee_field(&mut seq, "bootstrap_servers")?;
+                let bootstrap_servers =
+                    legacy.into_iter().map(|(key, server)| (key, server.into())).collect();
+                Ok(CommitteeInner::from_wire_fields(
+                    authorities,
+                    epoch,
+                    bootstrap_servers,
+                    ONE_WORKER,
+                ))
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "CommitteeInner",
+            &COMMITTEE_FIELD_NAMES,
+            CommitteeInnerVisitor,
+        )
     }
 }
 
@@ -879,12 +1096,13 @@ pub fn quorum_threshold(committee_members: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Address, Authority, AuthorityIdentifier, BlsKeypair, BlsPublicKey, BootstrapServer,
-        Committee, Multiaddr, NetworkKeypair, ParseAuthorityIdentifierError, ReputationScores,
-        EQUAL_VOTING_POWER,
+        encode, try_decode, Address, Authority, AuthorityIdentifier, BlsKeypair, BlsPublicKey,
+        BootstrapServer, Committee, Epoch, Multiaddr, NetworkKeypair, P2pNode,
+        ParseAuthorityIdentifierError, ReputationScores, RpcInfo, EQUAL_VOTING_POWER,
     };
     use rand::rng;
-    use std::collections::BTreeMap;
+    use serde::{Deserialize, Serialize};
+    use std::{collections::BTreeMap, num::NonZeroUsize};
 
     #[test]
     fn committee_load() {
@@ -1018,6 +1236,61 @@ mod tests {
         assert_eq!(decoded, bootstrap);
     }
 
+    /// A committee at `epoch` with four authorities whose bootstrap servers each advertise
+    /// `workers_per_server` workers, with the committee's worker count set to match.
+    #[cfg(feature = "adiri")]
+    fn committee_with_workers(epoch: crate::Epoch, workers_per_server: usize) -> Committee {
+        let mut rng = rng();
+        let authorities = (0..4u8)
+            .map(|i| {
+                let keypair = BlsKeypair::generate(&mut rng);
+                (*keypair.public(), Authority::new(*keypair.public(), Address::repeat_byte(i)))
+            })
+            .collect::<BTreeMap<BlsPublicKey, Authority>>();
+        let bootstrap_servers = authorities
+            .keys()
+            .map(|key| (*key, bootstrap_with_workers(workers_per_server)))
+            .collect::<BTreeMap<BlsPublicKey, BootstrapServer>>();
+        Committee::new(
+            authorities,
+            epoch,
+            bootstrap_servers,
+            std::num::NonZeroUsize::new(workers_per_server).expect("worker count is not 0"),
+        )
+    }
+
+    /// Below the fork epoch a committee is encoded in the legacy single-worker layout, which has
+    /// no field for a worker count: the encoder refuses a committee it cannot represent rather
+    /// than write one that decodes as single-worker on every node.
+    ///
+    /// The adiri fork epoch is a `u32::MAX` placeholder, so every epoch is pre-fork in this lane.
+    /// `TN_MULTI_WORKERS_FORK_EPOCH` is deliberately not used to stage that: the override's
+    /// `OnceLock` is process-wide and the whole test binary shares one process.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn committee_bcs_legacy_layout_refuses_multi_worker() {
+        // bcs directly rather than `crate::encode`, which panics on a serializer error
+        let multi_worker = committee_with_workers(7, 2);
+        assert!(
+            bcs::to_bytes(&multi_worker).is_err(),
+            "the pre-fork layout cannot represent a two-worker committee"
+        );
+
+        // a single-worker committee round-trips, and re-encoding the decoded value reproduces the
+        // exact bytes: a pre-fork pack survives the decode/re-append cycle unchanged
+        let committee = committee_with_workers(7, 1);
+        let bytes = bcs::to_bytes(&committee).expect("legacy encode");
+        let decoded: Committee = crate::try_decode(&bytes).expect("bcs deserialize");
+        assert_eq!(decoded, committee);
+        assert_eq!(decoded.number_of_workers(), 1);
+        assert_eq!(decoded.bootstrap_servers().len(), 4);
+        assert!(decoded.bootstrap_servers().values().all(|server| server.num_workers() == 1));
+        assert_eq!(bcs::to_bytes(&decoded).expect("legacy re-encode"), bytes);
+    }
+
+    /// Default builds have the multi-worker layout active from genesis, so this exercises the
+    /// post-fork arm; the adiri lane covers the legacy arm above.
+    #[cfg(not(feature = "adiri"))]
     #[test]
     fn committee_bcs_round_trips_with_bootstrap_servers() {
         // The consensus store and the consensus pack persist committees with bcs.
@@ -1044,6 +1317,638 @@ mod tests {
         assert_eq!(decoded.number_of_workers(), 2);
         assert_eq!(decoded.bootstrap_servers().len(), 4);
         assert!(decoded.bootstrap_servers().values().all(|server| server.num_workers() == 2));
+    }
+
+    /// Legacy (pre-#554) shadow of the [`BootstrapServer`] wire layout: a primary plus a single
+    /// unprefixed `worker`.
+    ///
+    /// Derived serde, so it is byte-identical to the `origin/main` `BootstrapServer` derive output
+    /// BY CONSTRUCTION — same field types, same order, same attributes. #554 left [`P2pNode`]
+    /// untouched, so the real type is reused here rather than shadowed: only the field that
+    /// changed shape gets a shadow.
+    #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct BootstrapReprLegacy {
+        /// The p2p info the primary.
+        primary: P2pNode,
+        /// The p2p info the worker.
+        worker: P2pNode,
+    }
+
+    impl From<BootstrapReprLegacy> for BootstrapServer {
+        fn from(value: BootstrapReprLegacy) -> Self {
+            let BootstrapReprLegacy { primary, worker } = value;
+            Self { primary, workers: vec![worker] }
+        }
+    }
+
+    /// Post-fork shadow of the [`BootstrapServer`] wire layout: a primary plus a length-prefixed
+    /// worker list.
+    ///
+    /// Derived serde, so it is byte-identical to a plain derive on [`BootstrapServer`] BY
+    /// CONSTRUCTION — and that derive is what the post-fork arm writes, since #554 hand-wrote only
+    /// the enclosing committee's serializer, not this one. Pairs with [`BootstrapReprLegacy`]: the
+    /// two shapes differ by exactly the ULEB128 worker-list prefix.
+    #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct BootstrapReprV1 {
+        /// The p2p info the primary.
+        primary: P2pNode,
+        /// The p2p info for each worker, indexed by [`crate::WorkerId`].
+        workers: Vec<P2pNode>,
+    }
+
+    /// Legacy (pre-#554) shadow of the [`CommitteeInner`] wire layout: its three serialized
+    /// fields, with derived serde, so it is byte-identical to the `origin/main` derive output BY
+    /// CONSTRUCTION.
+    ///
+    /// `origin/main` interleaved three `#[serde(skip)]` helper fields between these
+    /// (`authorities_by_id`, `quorum_threshold`, `validity_threshold`). Skipped fields never reach
+    /// the wire, so omitting them preserves both the field set and its order. Names are absent
+    /// too: bcs writes neither struct nor field names, so only the types and their order decide
+    /// the bytes and no `#[serde(rename)]` is load-bearing here.
+    #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct CommitteeReprLegacy {
+        /// The authorities of epoch.
+        authorities: BTreeMap<BlsPublicKey, Authority>,
+        /// The epoch number of this committee.
+        epoch: Epoch,
+        /// The bootstrap servers to initially join a network.
+        bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapReprLegacy>,
+    }
+
+    /// Post-fork shadow of the [`CommitteeInner`] wire layout: its four serialized fields with
+    /// derived serde, byte-identical to a plain derive on the current struct BY CONSTRUCTION.
+    ///
+    /// The same reasoning as [`CommitteeReprLegacy`] applies to the field set: the three helper
+    /// fields the real struct carries are absent from every wire layout, and bcs writes neither
+    /// struct nor field names, so only the types and their order decide the bytes. Anchors the
+    /// post-fork golden vector independently of the hand-written epoch gate.
+    #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+    struct CommitteeReprV1 {
+        /// The authorities of epoch.
+        authorities: BTreeMap<BlsPublicKey, Authority>,
+        /// The epoch number of this committee.
+        epoch: Epoch,
+        /// The bootstrap servers to initially join a network.
+        bootstrap_servers: BTreeMap<BlsPublicKey, BootstrapReprV1>,
+        /// The number of workers every validator in this committee runs.
+        num_workers: NonZeroUsize,
+    }
+
+    /// Build the real [`Committee`] a legacy shadow describes.
+    ///
+    /// The worker count is one: the legacy layout holds exactly one worker per bootstrap server
+    /// and carries no count field, so a single-worker committee is the only thing it can express.
+    fn committee_from_legacy_repr(repr: &CommitteeReprLegacy) -> Committee {
+        let bootstrap_servers = repr
+            .bootstrap_servers
+            .iter()
+            .map(|(key, server)| (*key, server.clone().into()))
+            .collect();
+        Committee::new(repr.authorities.clone(), repr.epoch, bootstrap_servers, super::ONE_WORKER)
+    }
+
+    /// Project a [`Committee`] onto its legacy shadow, so both sides of the differential can also
+    /// be derived from a single committee rather than only from a single fixture.
+    ///
+    /// # Panics
+    ///
+    /// If any bootstrap server advertises anything other than exactly one worker. The legacy
+    /// layout has no field to hold a second worker, so such a committee has no legacy shadow at
+    /// all — the same value the pre-fork encoder refuses to write rather than truncate.
+    fn legacy_repr_from_committee(committee: &Committee) -> CommitteeReprLegacy {
+        let bootstrap_servers = committee
+            .inner
+            .bootstrap_servers
+            .iter()
+            .map(|(key, server)| {
+                let [worker] = server.workers.as_slice() else {
+                    panic!(
+                        "the legacy layout holds exactly one worker per bootstrap server, got {}",
+                        server.workers.len()
+                    );
+                };
+                let repr =
+                    BootstrapReprLegacy { primary: server.primary.clone(), worker: worker.clone() };
+                (*key, repr)
+            })
+            .collect();
+        CommitteeReprLegacy {
+            authorities: committee.inner.authorities.clone(),
+            epoch: committee.inner.epoch,
+            bootstrap_servers,
+        }
+    }
+
+    /// Epoch of the legacy-layout fixtures: 406, one epoch below `CONSENSUS_REGISTRY_FORK_EPOCH`
+    /// (407), which is the documented arming floor of the multi-workers fork.
+    ///
+    /// One below the floor rather than the floor itself, because the fork may legally be armed AT
+    /// 407: the gate is `>=`, so 407 would become post-fork and every anti-vacuity assert below
+    /// would fail — with the frozen vectors then tempting exactly the re-freeze they forbid. 406
+    /// is structurally pre-fork under every legal arming, whichever epoch the arming PR picks, so
+    /// `adiri` encodes it in the legacy layout while staying adjacent to the floor: the pre-fork
+    /// region with the least margin for error.
+    ///
+    /// Moving this constant is the one legitimate reason to re-freeze the vectors below. The epoch
+    /// is a field of the encoded value, so its bytes move with it; any OTHER divergence is a
+    /// compatibility break to fix in the encoder.
+    const LEGACY_FIXTURE_EPOCH: Epoch = 406;
+
+    /// Epoch of the post-fork-layout fixtures: `u32::MAX`, the one epoch that carries the
+    /// multi-worker layout under every build, armed or not.
+    ///
+    /// Non-adiri is post-fork from genesis. Adiri gates on `epoch >= MULTI_WORKERS_FORK_EPOCH`
+    /// and that constant is the `u32::MAX` placeholder, so the top epoch is post-fork even while
+    /// the fork is dormant — and stays post-fork once the epoch-setting PR lowers the constant. One
+    /// frozen vector therefore pins the post-fork bytes on every lane, before and after arming.
+    const V1_FIXTURE_EPOCH: Epoch = u32::MAX;
+
+    /// Seed tag marking a fixture primary's network key, so no primary shares a key with a worker.
+    const PRIMARY_SEED_TAG: u8 = 0xB0;
+    /// Seed tag marking a fixture worker's network key.
+    const WORKER_SEED_TAG: u8 = 0xC0;
+
+    /// Deterministic BLS keypair for fixture authority slot `slot`.
+    ///
+    /// Built from a fixed scalar rather than a seeded rng, so the derived public key — and with it
+    /// the `authorities` map order and every encoded byte — is stable across `rand` version bumps
+    /// as well as across runs. The leading bytes stay zero, which keeps the scalar far below the
+    /// BLS12-381 group order and nonzero, the only two values `blst` rejects.
+    fn fixture_bls_keypair(slot: u8) -> BlsKeypair {
+        let mut scalar = [0_u8; 32];
+        scalar[30] = slot;
+        scalar[31] = 0x2A;
+        BlsKeypair::from_bytes(&scalar).expect("fixture bls scalar is a valid private key")
+    }
+
+    /// A fixed 32-byte ed25519 secret seed identifying one fixture node.
+    fn fixture_seed(tag: u8, authority: u8, worker: u8) -> [u8; 32] {
+        let mut seed = [0_u8; 32];
+        seed[0] = tag;
+        seed[1] = authority;
+        seed[2] = worker;
+        seed
+    }
+
+    /// A [`P2pNode`] from a fixed ed25519 seed and port.
+    ///
+    /// ed25519 secret keys *are* 32-byte seeds, so a fixed seed yields a fixed public key with no
+    /// rng in the path; the multiaddr comes from a literal rather than an OS-assigned port.
+    fn fixture_p2p_node(seed: [u8; 32], port: u16, rpc: Option<RpcInfo>) -> P2pNode {
+        P2pNode {
+            network_address: format!("/ip4/127.0.0.1/udp/{port}/quic-v1")
+                .parse()
+                .expect("fixture multiaddr parses"),
+            network_key: NetworkKeypair::ed25519_from_bytes(seed)
+                .expect("a 32-byte array is a valid ed25519 secret seed")
+                .public()
+                .clone()
+                .into(),
+            rpc,
+        }
+    }
+
+    /// The primary node of fixture authority `authority`. Primaries never advertise rpc.
+    fn fixture_primary_node(authority: u8) -> P2pNode {
+        fixture_p2p_node(
+            fixture_seed(PRIMARY_SEED_TAG, authority, 0),
+            40_000 + u16::from(authority),
+            None,
+        )
+    }
+
+    /// Worker `worker` of fixture authority `authority`.
+    ///
+    /// The first worker of the first authority advertises an rpc endpoint and no other worker
+    /// does, so both arms of [`P2pNode::rpc`]'s `Option` appear in the encoded fixture.
+    fn fixture_worker_node(authority: u8, worker: u8) -> P2pNode {
+        let rpc = (authority == 0 && worker == 0).then(|| RpcInfo {
+            http: "https://validator0.example.com:8545/".parse().expect("fixture http url"),
+            ws: Some("wss://validator0.example.com:8546/".parse().expect("fixture ws url")),
+        });
+        fixture_p2p_node(
+            fixture_seed(WORKER_SEED_TAG, authority, worker),
+            41_000 + u16::from(authority) * 8 + u16::from(worker),
+            rpc,
+        )
+    }
+
+    /// Shape of a deterministic committee fixture for wire-layout tests.
+    ///
+    /// Every value it produces — BLS keys, network keys, multiaddrs, execution addresses, rpc
+    /// endpoints — is derived from a constant plus a slot index, with no rng, no clock and no
+    /// OS-assigned port, so the encoded bytes are reproducible across runs, machines and
+    /// dependency bumps. Here that matters more than realism: these fixtures anchor the
+    /// differential assertions below and, later, frozen golden byte vectors.
+    #[derive(Clone, Copy, Debug)]
+    struct CommitteeWireFixture {
+        /// The committee's epoch, which is the only input the wire-layout gate reads.
+        epoch: Epoch,
+        /// Number of authorities. Must be at least two: `CommitteeInner::load` asserts a committee
+        /// larger than one.
+        authorities: u8,
+        /// Number of bootstrap servers, attached to authority slots `0..bootstrap_servers`.
+        ///
+        /// Tracked separately from [`Self::authorities`] because the two maps are independent on
+        /// the wire: a committee may carry fewer bootstrap hints than it has authorities. Letting
+        /// the two lengths differ gives the maps distinct ULEB128 length prefixes, so a layout
+        /// that read one where the other belongs would not line up.
+        bootstrap_servers: u8,
+        /// Workers each bootstrap server advertises, which is also the committee's worker count.
+        workers_per_server: u8,
+    }
+
+    impl CommitteeWireFixture {
+        /// A single-worker fixture: the only shape the legacy layout can express.
+        const fn single_worker(epoch: Epoch, authorities: u8, bootstrap_servers: u8) -> Self {
+            Self { epoch, authorities, bootstrap_servers, workers_per_server: 1 }
+        }
+
+        /// A fixture whose every bootstrap server advertises `workers_per_server` workers, which is
+        /// also the committee's worker count: a shape only the post-fork layout can express.
+        const fn multi_worker(
+            epoch: Epoch,
+            authorities: u8,
+            bootstrap_servers: u8,
+            workers_per_server: u8,
+        ) -> Self {
+            Self { epoch, authorities, bootstrap_servers, workers_per_server }
+        }
+
+        /// The committee-level worker count this fixture describes.
+        fn num_workers(self) -> NonZeroUsize {
+            NonZeroUsize::new(usize::from(self.workers_per_server))
+                .expect("a fixture runs at least one worker per server")
+        }
+
+        /// The fixture's authorities, keyed by BLS public key.
+        ///
+        /// Shared by both builders below: #554 left this field's layout untouched, and a byte
+        /// comparison is only meaningful when both sides hold the same values. Only the fields
+        /// whose shape changed are built twice.
+        fn authority_map(self) -> BTreeMap<BlsPublicKey, Authority> {
+            (0..self.authorities)
+                .map(|slot| {
+                    let key = *fixture_bls_keypair(slot).public();
+                    (key, Authority::new(key, Address::repeat_byte(slot)))
+                })
+                .collect()
+        }
+
+        /// The `(slot, bls key)` pairs that carry a bootstrap server.
+        ///
+        /// # Panics
+        ///
+        /// If the fixture has more bootstrap servers than authorities: servers attach to authority
+        /// slots, so a wider fixture would key them off nonexistent authorities.
+        fn bootstrap_slots(self) -> impl Iterator<Item = (u8, BlsPublicKey)> {
+            assert!(
+                self.bootstrap_servers <= self.authorities,
+                "fixture has {} bootstrap servers but only {} authorities to attach them to",
+                self.bootstrap_servers,
+                self.authorities
+            );
+            (0..self.bootstrap_servers).map(|slot| (slot, *fixture_bls_keypair(slot).public()))
+        }
+
+        /// Build the [`Committee`] this fixture describes.
+        fn committee(self) -> Committee {
+            let bootstrap_servers = self
+                .bootstrap_slots()
+                .map(|(slot, key)| {
+                    let workers = (0..self.workers_per_server)
+                        .map(|worker| fixture_worker_node(slot, worker))
+                        .collect();
+                    (key, BootstrapServer::new(fixture_primary_node(slot), workers))
+                })
+                .collect();
+            Committee::new(self.authority_map(), self.epoch, bootstrap_servers, self.num_workers())
+        }
+
+        /// Build the legacy shadow this fixture describes.
+        ///
+        /// Reaches the shadow reprs straight from the slot-derived keys and nodes, never through
+        /// [`Self::committee`], so a bug in the gated encoder cannot make the two sides of the
+        /// differential agree.
+        ///
+        /// # Panics
+        ///
+        /// If the fixture runs more than one worker per server. The legacy layout carries exactly
+        /// one unprefixed `worker` per bootstrap server and no count field, so a wider fixture has
+        /// no legacy shadow at all.
+        fn legacy_repr(self) -> CommitteeReprLegacy {
+            assert_eq!(
+                self.workers_per_server, 1,
+                "the legacy layout holds exactly one worker per bootstrap server"
+            );
+            let bootstrap_servers = self
+                .bootstrap_slots()
+                .map(|(slot, key)| {
+                    let repr = BootstrapReprLegacy {
+                        primary: fixture_primary_node(slot),
+                        worker: fixture_worker_node(slot, 0),
+                    };
+                    (key, repr)
+                })
+                .collect();
+            CommitteeReprLegacy {
+                authorities: self.authority_map(),
+                epoch: self.epoch,
+                bootstrap_servers,
+            }
+        }
+
+        /// Build the post-fork shadow this fixture describes.
+        ///
+        /// Like [`Self::legacy_repr`], reaches the shadow reprs straight from the slot-derived keys
+        /// and nodes rather than through [`Self::committee`], so a bug in the gated encoder cannot
+        /// make the two sides of the differential agree.
+        fn v1_repr(self) -> CommitteeReprV1 {
+            let bootstrap_servers = self
+                .bootstrap_slots()
+                .map(|(slot, key)| {
+                    let repr = BootstrapReprV1 {
+                        primary: fixture_primary_node(slot),
+                        workers: (0..self.workers_per_server)
+                            .map(|worker| fixture_worker_node(slot, worker))
+                            .collect(),
+                    };
+                    (key, repr)
+                })
+                .collect();
+            CommitteeReprV1 {
+                authorities: self.authority_map(),
+                epoch: self.epoch,
+                bootstrap_servers,
+                num_workers: self.num_workers(),
+            }
+        }
+    }
+
+    /// The legacy shadow reprs are self-consistent under bcs, reproducible, and describe the same
+    /// value as the [`Committee`] the same fixture builds.
+    ///
+    /// Runs on every lane so the reprs, the fixture and the conversions stay compiled and
+    /// exercised in builds whose gate never selects the legacy layout (non-adiri is post-fork from
+    /// genesis). The byte-level differential against the gated encoder is adiri-only, below.
+    #[test]
+    fn legacy_committee_repr_round_trips() {
+        let fixture = CommitteeWireFixture::single_worker(LEGACY_FIXTURE_EPOCH, 4, 3);
+        let repr = fixture.legacy_repr();
+        let bytes = encode(&repr);
+
+        // a second, independent build of the same fixture encodes to the same bytes: no rng,
+        // clock or OS-assigned port leaked into the fixture
+        assert_eq!(encode(&fixture.legacy_repr()), bytes, "fixture bytes are not reproducible");
+
+        // encode -> decode -> re-encode is byte-identical
+        let decoded: CommitteeReprLegacy =
+            try_decode(&bytes).expect("legacy repr decodes its own bytes");
+        assert_eq!(decoded, repr, "legacy repr lost data through bcs");
+        assert_eq!(encode(&decoded), bytes, "legacy repr re-encode diverged");
+
+        // the shadow and the real committee describe the same value in both directions.
+        // `Committee`'s PartialEq deliberately ignores bootstrap servers, so compare those too.
+        let committee = fixture.committee();
+        let from_repr = committee_from_legacy_repr(&repr);
+        assert_eq!(from_repr, committee, "legacy repr describes a different committee");
+        assert_eq!(
+            from_repr.bootstrap_servers(),
+            committee.bootstrap_servers(),
+            "legacy repr describes different bootstrap servers"
+        );
+        assert_eq!(
+            legacy_repr_from_committee(&committee),
+            repr,
+            "committee projects onto a different legacy repr"
+        );
+
+        // the two bootstrap layouts genuinely differ: the current shape length-prefixes its worker
+        // list, so the same value encodes exactly one byte longer. if these ever matched, the fork
+        // gate — and every assertion built on it — would be testing nothing.
+        let legacy_server = repr.bootstrap_servers.values().next().expect("fixture has servers");
+        let current_server = BootstrapServer::from(legacy_server.clone());
+        assert_eq!(
+            encode(&current_server).len(),
+            encode(legacy_server).len() + 1,
+            "the current bootstrap layout must differ from the legacy one"
+        );
+    }
+
+    /// Pre-fork differential: the epoch-gated [`Committee`] and the derived legacy shadow encode
+    /// to the same bytes, and each side reads what the other wrote.
+    ///
+    /// The `adiri` multi-workers fork epoch is a `u32::MAX` placeholder, so every epoch is
+    /// pre-fork in this lane. `TN_MULTI_WORKERS_FORK_EPOCH` is deliberately not used to stage
+    /// that: the override's `OnceLock` is process-wide and the whole test binary shares one
+    /// process.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn committee_bcs_pre_fork_layout_matches_legacy_repr() {
+        let fixture = CommitteeWireFixture::single_worker(LEGACY_FIXTURE_EPOCH, 4, 3);
+        let committee = fixture.committee();
+        assert!(
+            !crate::forks::multi_workers_fork_active(committee.epoch()),
+            "epoch {} must be pre-fork for this differential to mean anything; is \
+             TN_MULTI_WORKERS_FORK_EPOCH set in the environment, or has the fork been armed?",
+            committee.epoch()
+        );
+
+        let repr = fixture.legacy_repr();
+        let legacy_bytes = encode(&repr);
+        let gated_bytes = encode(&committee);
+
+        // the gated encoder reproduces the pre-#554 derive byte for byte
+        assert_eq!(gated_bytes, legacy_bytes, "pre-fork Committee bytes left the legacy layout");
+
+        // legacy bytes decode through the gated `Committee`: a pack written by a pre-#554 binary
+        // still loads on this build
+        let from_legacy: Committee =
+            try_decode(&legacy_bytes).expect("legacy bytes decode as a Committee");
+        assert_eq!(from_legacy, committee);
+        assert_eq!(from_legacy.bootstrap_servers(), committee.bootstrap_servers());
+        assert_eq!(from_legacy.number_of_workers(), 1);
+
+        // gated bytes decode through the shadow: a pre-#554 binary still reads what this build
+        // writes for a pre-fork epoch
+        let read_back: CommitteeReprLegacy =
+            try_decode(&gated_bytes).expect("pre-fork Committee bytes decode as the legacy repr");
+        assert_eq!(read_back, repr, "pre-fork Committee bytes are not the legacy layout");
+    }
+
+    /// Decode a frozen hex vector, failing loudly on a malformed constant.
+    fn unhex(hex_str: &str) -> Vec<u8> {
+        hex::decode(hex_str).expect("frozen hex vector must be valid hex")
+    }
+
+    /// FROZEN pre-fork committee vector: the bcs bytes of
+    /// `CommitteeWireFixture::single_worker(LEGACY_FIXTURE_EPOCH, 4, 3)` — four authorities and
+    /// three single-worker bootstrap servers, one worker of which advertises rpc — wire-identical
+    /// to the pre-#554 derive output by construction of [`CommitteeReprLegacy`].
+    ///
+    /// This is the layout every committee already on adiri disk is written in: [`Committee`] is
+    /// embedded in `EpochMeta`, the first record of every consensus pack. If this pin breaks, that
+    /// historical layout moved and those packs stop decoding — a compatibility break to fix in the
+    /// encoder, NOT a constant to refresh. The one exception is a move of
+    /// [`LEGACY_FIXTURE_EPOCH`], which is a field of the encoded value and so legitimately shifts
+    /// these bytes. The fixture takes no rng, clock or OS-assigned port, so nothing else can move
+    /// them but an encoder, a field type, or a dependency's serde impl.
+    const GOLDEN_LEGACY_COMMITTEE_HEX: &str = "046085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87356085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87351401010101010101010101010101010101010101016096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad6096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad14020202020202020202020202020202020202020260991387de238ff1a895ccff0d14bbdd0ad15e27504209243d391d5fcd07b6dd620af231d7852a007b4f149e43531ea94402446153bf7a53b5f907d54d1e208fb5b5a1088725b772777f87391ae331d9124c58a66d24c65ddb957314eeb607ca0460991387de238ff1a895ccff0d14bbdd0ad15e27504209243d391d5fcd07b6dd620af231d7852a007b4f149e43531ea94402446153bf7a53b5f907d54d1e208fb5b5a1088725b772777f87391ae331d9124c58a66d24c65ddb957314eeb607ca0414030303030303030303030303030303030303030360ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b8444460ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b8444414000000000000000000000000000000000000000096010000036085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87350b047f00000191029c41cd032408011220b14a3296426492458270c2e577fdc549b6d67155e5800b0bf96c3f4106b4ae71000b047f0000019102a030cd032408011220c602145e9a9f1672b151652377fa8c23fc78ded1add621fe177d33b8ebcd4214006096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad0b047f00000191029c42cd03240801122032fb5b7c292018fbb8b436c83f39526a6035aa410421a8c5f46e8d06de48fa66000b047f0000019102a038cd0324080112201edb6a1734e1f14d1461431b25a7f3ca348acab2fa98e4262685d2b46ce335800060ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b844440b047f00000191029c40cd032408011220e0fcb53429020d03e8f4e471ec73993f9329ad0d76e69cfdfcb08c94aa39fdab000b047f0000019102a028cd032408011220055139b0f6daf33b3fdc294e2bfc1ad914de91f7d6e9f717b4509c047fbc6acc012468747470733a2f2f76616c696461746f72302e6578616d706c652e636f6d3a383534352f01227773733a2f2f76616c696461746f72302e6578616d706c652e636f6d3a383534362f";
+    /// FROZEN post-fork committee vector: the bcs bytes of
+    /// `CommitteeWireFixture::multi_worker(V1_FIXTURE_EPOCH, 4, 3, 2)` — the same authorities and
+    /// servers as [`GOLDEN_LEGACY_COMMITTEE_HEX`], now with two workers per server and a trailing
+    /// `num_workers`, so a diff of the two constants is a diff of the fork itself.
+    ///
+    /// Multi-worker deliberately: it freezes both halves of the layout change (the ULEB128
+    /// worker-list prefix and the trailing count) where a single-worker fixture would only show the
+    /// second. Same warning as the pre-fork pin — this is the layout every post-fork pack is
+    /// written in.
+    const GOLDEN_V1_COMMITTEE_HEX: &str = "046085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87356085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87351401010101010101010101010101010101010101016096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad6096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad14020202020202020202020202020202020202020260991387de238ff1a895ccff0d14bbdd0ad15e27504209243d391d5fcd07b6dd620af231d7852a007b4f149e43531ea94402446153bf7a53b5f907d54d1e208fb5b5a1088725b772777f87391ae331d9124c58a66d24c65ddb957314eeb607ca0460991387de238ff1a895ccff0d14bbdd0ad15e27504209243d391d5fcd07b6dd620af231d7852a007b4f149e43531ea94402446153bf7a53b5f907d54d1e208fb5b5a1088725b772777f87391ae331d9124c58a66d24c65ddb957314eeb607ca0414030303030303030303030303030303030303030360ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b8444460ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b84444140000000000000000000000000000000000000000ffffffff036085ae9977dafa1a29bfeecb4ec68ac8b9690e9adfc6757f6fd30dcc0e040d918c7eee1c50cff8f6e749017ebf77fa1d570f9a74ab3abf73a4ab9a2da56e2603e23f75800adc0f0c6cbfb7c9e3b9044fb7f3fbede2ba642ce75e375d5bbf6e87350b047f00000191029c41cd032408011220b14a3296426492458270c2e577fdc549b6d67155e5800b0bf96c3f4106b4ae7100020b047f0000019102a030cd032408011220c602145e9a9f1672b151652377fa8c23fc78ded1add621fe177d33b8ebcd4214000b047f0000019102a031cd0324080112201ad1a467248480996c12b0f2eebe5082dc5687256fd150b29806142d3ac6f052006096687254e65b83ac8107af98ed534d7ae8b518b0f82fdacf70c890f867a565c33b1b945543e6d7b6bcc63d0720ff6adb130faa68b017b45d4831b4a96c00b5a98deec5a6b6e7cdfe26fb23e94e5905885f5ca534cd45c233d24d44f07a80a5ad0b047f00000191029c42cd03240801122032fb5b7c292018fbb8b436c83f39526a6035aa410421a8c5f46e8d06de48fa6600020b047f0000019102a038cd0324080112201edb6a1734e1f14d1461431b25a7f3ca348acab2fa98e4262685d2b46ce33580000b047f0000019102a039cd032408011220be1e84fd08b72a68647b9cfe4aa9f04ed7726ff7d9d0d1415eeab62c4b1c98090060ac7fa63dfc38bbf3712e27a180391bca4ccabf609c5967a0592eff420b6235f3f2b323051cb099acc3969aca310f7ff4191b2d6db43fafc2c9592f7e5f73981107975d3d92b843891e724dbc9f05b5eee5a3b2b1fc782ede8149f30830b844440b047f00000191029c40cd032408011220e0fcb53429020d03e8f4e471ec73993f9329ad0d76e69cfdfcb08c94aa39fdab00020b047f0000019102a028cd032408011220055139b0f6daf33b3fdc294e2bfc1ad914de91f7d6e9f717b4509c047fbc6acc012468747470733a2f2f76616c696461746f72302e6578616d706c652e636f6d3a383534352f01227773733a2f2f76616c696461746f72302e6578616d706c652e636f6d3a383534362f0b047f0000019102a029cd032408011220a72b23753f2dc308151fba8b061458979bce8ec10e3c6448c27a7cbfd7dc12fd000200000000000000";
+
+    /// PIN (all cfgs): the frozen pre-fork vector, anchored through the derived legacy shadow.
+    ///
+    /// The shadow is `origin/main`-identical by construction, so this keeps the historical bytes
+    /// pinned even in builds whose gate never selects the legacy arm (non-adiri is post-fork from
+    /// genesis, [`LEGACY_FIXTURE_EPOCH`] included). The gated encoder is held to the same constant
+    /// by the adiri test below.
+    #[test]
+    fn golden_legacy_committee_wire_bytes_pinned() {
+        let fixture = CommitteeWireFixture::single_worker(LEGACY_FIXTURE_EPOCH, 4, 3);
+        let repr = fixture.legacy_repr();
+
+        // re-encoding the fixture must reproduce the frozen vector: drift in the fixture, in a
+        // field type or in a serde impl fails here instead of being absorbed silently
+        assert_eq!(
+            hex::encode(encode(&repr)),
+            GOLDEN_LEGACY_COMMITTEE_HEX,
+            "legacy shadow encode diverged from the frozen pre-fork vector"
+        );
+
+        let decoded: CommitteeReprLegacy = try_decode(&unhex(GOLDEN_LEGACY_COMMITTEE_HEX))
+            .expect("frozen pre-fork vector decodes as the legacy repr");
+        assert_eq!(decoded, repr, "decode of the frozen pre-fork vector diverged");
+        assert_eq!(decoded.epoch, LEGACY_FIXTURE_EPOCH, "frozen pre-fork epoch moved");
+        assert_eq!(decoded.authorities.len(), 4, "frozen pre-fork authority count moved");
+        assert_eq!(decoded.bootstrap_servers.len(), 3, "frozen pre-fork server count moved");
+
+        // the two maps carry independent length prefixes but the same keys: every server in the
+        // frozen vector still belongs to an authority in it
+        assert!(
+            decoded.bootstrap_servers.keys().all(|key| decoded.authorities.contains_key(key)),
+            "a frozen bootstrap server is keyed off no authority"
+        );
+
+        // exactly one fixture worker advertises rpc, so both arms of `P2pNode::rpc` are frozen here
+        assert_eq!(
+            decoded.bootstrap_servers.values().filter(|server| server.worker.rpc.is_some()).count(),
+            1,
+            "the frozen pre-fork vector lost its single rpc endpoint"
+        );
+    }
+
+    /// PIN (adiri): the epoch-gated [`Committee`] emits and re-reads the frozen pre-fork vector at
+    /// [`LEGACY_FIXTURE_EPOCH`].
+    ///
+    /// The second, independent anchor of that constant, and the direct proof that the gate selects
+    /// the legacy arm for historical bytes: what a pre-#554 binary wrote decodes here, and what
+    /// this build writes for that epoch is what that binary would have written.
+    #[cfg(feature = "adiri")]
+    #[test]
+    fn golden_legacy_committee_gated_wire_bytes_pinned() {
+        assert!(
+            !crate::forks::multi_workers_fork_active(LEGACY_FIXTURE_EPOCH),
+            "epoch {LEGACY_FIXTURE_EPOCH} must be pre-fork for this pin to mean anything; is \
+             TN_MULTI_WORKERS_FORK_EPOCH set in the environment, or has the fork been armed?"
+        );
+
+        let committee = CommitteeWireFixture::single_worker(LEGACY_FIXTURE_EPOCH, 4, 3).committee();
+        let bytes = encode(&committee);
+        assert_eq!(
+            hex::encode(&bytes),
+            GOLDEN_LEGACY_COMMITTEE_HEX,
+            "pre-fork Committee encode diverged from the frozen pre-fork vector"
+        );
+
+        let decoded: Committee = try_decode(&unhex(GOLDEN_LEGACY_COMMITTEE_HEX))
+            .expect("frozen pre-fork vector decodes as a Committee");
+        assert_eq!(decoded.epoch(), LEGACY_FIXTURE_EPOCH, "frozen pre-fork epoch moved");
+        assert_eq!(decoded.size(), 4, "frozen pre-fork authority count moved");
+        assert_eq!(decoded.bootstrap_servers().len(), 3, "frozen pre-fork server count moved");
+        assert_eq!(decoded.number_of_workers(), 1, "the pre-fork layout carries no worker count");
+        assert!(
+            decoded.bootstrap_servers().values().all(|server| server.num_workers() == 1),
+            "the pre-fork layout holds exactly one worker per bootstrap server"
+        );
+        assert_eq!(decoded, committee, "the frozen pre-fork vector is a different committee");
+        // `Committee`'s PartialEq deliberately ignores bootstrap servers, so compare those too
+        assert_eq!(decoded.bootstrap_servers(), committee.bootstrap_servers());
+
+        // re-encoding what the frozen vector decoded to reproduces it byte for byte: a pre-fork
+        // pack survives the decode/re-append cycle unchanged
+        assert_eq!(encode(&decoded), bytes, "pre-fork re-encode diverged from the frozen vector");
+    }
+
+    /// PIN (all cfgs): the frozen post-fork vector, anchored twice — through the derived four-field
+    /// shadow and through the epoch-gated [`Committee`] itself.
+    ///
+    /// Runs on every lane because [`V1_FIXTURE_EPOCH`] is post-fork under every build, so a single
+    /// vector pins the post-fork bytes for adiri and mainnet alike. The two anchors agreeing is
+    /// also the post-fork half of the layout differential — the gated encoder emits exactly
+    /// what a plain derive on the four-field struct emits — mirroring the pre-fork differential
+    /// above.
+    #[test]
+    fn golden_v1_committee_wire_bytes_pinned() {
+        assert!(
+            crate::forks::multi_workers_fork_active(V1_FIXTURE_EPOCH),
+            "epoch {V1_FIXTURE_EPOCH} must be post-fork for this pin to mean anything; is \
+             TN_MULTI_WORKERS_FORK_EPOCH set in the environment?"
+        );
+
+        let fixture = CommitteeWireFixture::multi_worker(V1_FIXTURE_EPOCH, 4, 3, 2);
+        let repr = fixture.v1_repr();
+        assert_eq!(
+            hex::encode(encode(&repr)),
+            GOLDEN_V1_COMMITTEE_HEX,
+            "post-fork shadow encode diverged from the frozen post-fork vector"
+        );
+
+        let committee = fixture.committee();
+        let bytes = encode(&committee);
+        assert_eq!(
+            hex::encode(&bytes),
+            GOLDEN_V1_COMMITTEE_HEX,
+            "post-fork Committee encode diverged from the frozen post-fork vector"
+        );
+
+        let decoded: Committee = try_decode(&unhex(GOLDEN_V1_COMMITTEE_HEX))
+            .expect("frozen post-fork vector decodes as a Committee");
+        assert_eq!(decoded.epoch(), V1_FIXTURE_EPOCH, "frozen post-fork epoch moved");
+        assert_eq!(decoded.size(), 4, "frozen post-fork authority count moved");
+        assert_eq!(decoded.bootstrap_servers().len(), 3, "frozen post-fork server count moved");
+        assert_eq!(decoded.number_of_workers(), 2, "the frozen post-fork worker count moved");
+        assert!(
+            decoded.bootstrap_servers().values().all(|server| server.num_workers() == 2),
+            "the frozen post-fork vector lost a worker from a length-prefixed list"
+        );
+        assert_eq!(
+            decoded
+                .bootstrap_servers()
+                .values()
+                .flat_map(|server| server.workers.iter())
+                .filter(|worker| worker.rpc.is_some())
+                .count(),
+            1,
+            "the frozen post-fork vector lost its single rpc endpoint"
+        );
+        assert_eq!(decoded, committee, "the frozen post-fork vector is a different committee");
+        assert_eq!(decoded.bootstrap_servers(), committee.bootstrap_servers());
+        assert_eq!(encode(&decoded), bytes, "post-fork re-encode diverged from the frozen vector");
+
+        // the shadow reads the gated bytes back, closing the same loop the pre-fork differential
+        // closes for the legacy arm
+        let read_back: CommitteeReprV1 =
+            try_decode(&bytes).expect("post-fork Committee bytes decode as the post-fork repr");
+        assert_eq!(read_back, repr, "post-fork Committee bytes are not the derived layout");
     }
 
     #[test]

--- a/crates/types/src/forks.rs
+++ b/crates/types/src/forks.rs
@@ -282,6 +282,127 @@ pub fn seed_signature_fork_epoch_override() -> Option<Epoch> {
     })
 }
 
+#[cfg(feature = "adiri")]
+/// First epoch whose [`Committee`](crate::Committee) is bcs-encoded in the multi-worker layout
+/// (#554).
+///
+/// Two fields move at this boundary, both inside the `Committee` value itself:
+/// - each `BootstrapServer` writes `workers`, a length-prefixed sequence of `P2pNode`, where the
+///   legacy layout wrote a single unprefixed `worker`;
+/// - `CommitteeInner` gains a trailing `num_workers`.
+///
+/// bcs is not self-describing, so neither change is backward compatible — `#[serde(default)]`
+/// buys nothing on a binary codec, and a legacy value read as the new layout consumes the
+/// worker's first byte as a sequence length. `Committee` is embedded in `EpochMeta`, the first
+/// record of every consensus pack, so an un-gated layout change bricks decode of every pack
+/// already on disk: an adiri node restarting on the new build cannot read its own history. Below
+/// this epoch the encoder writes the legacy single-worker shape byte-identically to the pre-#554
+/// binary, so packs stay readable in both directions across a mixed fleet.
+///
+/// The gate ([`multi_workers_fork_active`]) always reads the epoch carried inside the value being
+/// encoded or decoded — never node-local committee state — so mixed-epoch containers (pack
+/// records, epoch records, state-sync payloads) decode correctly at any nesting depth and
+/// historical digests are preserved end to end.
+///
+/// PLACEHOLDER: `u32::MAX` practically never fires. Set a concrete future epoch in a dedicated
+/// epoch-setting PR only after every validator and observer runs a gate-capable build. The full
+/// fork schedule is logged at startup so operators can diff it across the fleet; a compile-time
+/// constant that differs between binaries has no other in-protocol detection.
+///
+/// Arming constraint: the concrete epoch must be at least [`CONSENSUS_REGISTRY_FORK_EPOCH`]
+/// (407). Committees below 407 are structurally single-worker — the deployed pre-fork registry
+/// exposes no governance path that raises the worker count — so the legacy layout is lossless
+/// for every epoch this gate leaves dormant. From 407 onward that guarantee becomes operational
+/// rather than structural: the worker count must stay at one until this fork epoch has begun, or
+/// a multi-worker committee gets written in a layout that cannot represent it.
+///
+/// Rollout sequence (standard hard-fork rule): deploy the gate-capable build fleet-wide first
+/// (safe indefinitely while dormant, since it writes and reads the legacy layout for every epoch
+/// below the constant), then land the epoch-setting PR fleet-wide before the fork epoch begins. A
+/// straggler still on an old build past the boundary fails to decode post-fork committees loudly
+/// and drops out rather than silently diverging.
+///
+/// Non-adiri builds (mainnet) have no dormant period: the multi-worker layout is active from
+/// genesis and this constant does not exist there.
+pub const MULTI_WORKERS_FORK_EPOCH: Epoch = u32::MAX;
+
+/// Whether the [`Committee`](crate::Committee) of `epoch` is bcs-encoded in the multi-worker
+/// layout (#554).
+///
+/// Gates both directions of serialization. Callers MUST pass the epoch carried inside the value
+/// being encoded or decoded (the committee's own epoch, the epoch of the pack record being read),
+/// never the running node's `Committee::epoch()` or any other node-local state, so that
+/// historical values keep their historical layout at any nesting depth.
+///
+/// Adiri builds activate at [`MULTI_WORKERS_FORK_EPOCH`]; all other builds are active from
+/// genesis (mainnet never carries the legacy layout). Under `test-utils`, an explicit
+/// `TN_MULTI_WORKERS_FORK_EPOCH` override takes precedence over both (see
+/// [`multi_workers_fork_epoch_override`]), so a test states the fork point it means rather than
+/// inheriting whichever one its feature set happens to select.
+#[inline]
+pub fn multi_workers_fork_active(epoch: Epoch) -> bool {
+    #[cfg(feature = "test-utils")]
+    {
+        multi_workers_fork_epoch_override()
+            .map_or_else(|| multi_workers_build_fork_active(epoch), |fork| epoch >= fork)
+    }
+    #[cfg(not(feature = "test-utils"))]
+    {
+        multi_workers_build_fork_active(epoch)
+    }
+}
+
+/// This build's compile-time fork point for the multi-workers fork, with no test override
+/// applied.
+///
+/// Spelled out in full rather than sharing [`build_fork_active`] (the seed-signature gate)
+/// because the two forks arm independently and must never be tied to one constant.
+///
+/// Unchanged from [`MULTI_WORKERS_FORK_EPOCH`]'s documented contract: adiri (testnet, which
+/// carries pre-#554 packs on disk) stays dormant until the constant is lowered, and every other
+/// build is active from genesis. The genesis default rests on an assumption worth stating: no
+/// non-adiri network holds packs written by a pre-#554 binary, so no such build ever has to read
+/// the legacy single-worker layout. A non-adiri deployment that predates #554 would need its own
+/// dormant period here instead.
+#[inline]
+const fn multi_workers_build_fork_active(epoch: Epoch) -> bool {
+    #[cfg(feature = "adiri")]
+    #[expect(
+        clippy::absurd_extreme_comparisons,
+        reason = "MULTI_WORKERS_FORK_EPOCH is a `u32::MAX` placeholder; `>=` (not `==`) is \
+                  the gate the future epoch-setting PR relies on, and this expectation flags \
+                  itself for removal once that PR lowers the constant"
+    )]
+    {
+        epoch >= MULTI_WORKERS_FORK_EPOCH
+    }
+    #[cfg(not(feature = "adiri"))]
+    {
+        let _ = epoch;
+        true
+    }
+}
+
+/// Test-only override of the effective multi-workers fork epoch, read once from
+/// `TN_MULTI_WORKERS_FORK_EPOCH` (`4294967295` for "never fires", `0` for "active from
+/// genesis").
+///
+/// An environment variable rather than a process-global setter because e2e tests drive real node
+/// processes spawned via `TN_BIN_PATH`, which share no memory with the harness: a static would
+/// silently reach only the in-process tests, and the multi-node tests that actually exercise
+/// epoch close would keep inheriting the build default.
+///
+/// Compiled out entirely without `test-utils`, so a production binary keeps the compile-time
+/// constant and cannot be repointed at runtime by its environment. An unparseable value is
+/// ignored rather than defaulted, leaving the build's own fork point in force.
+#[cfg(feature = "test-utils")]
+pub fn multi_workers_fork_epoch_override() -> Option<Epoch> {
+    static OVERRIDE: std::sync::OnceLock<Option<Epoch>> = std::sync::OnceLock::new();
+    *OVERRIDE.get_or_init(|| {
+        std::env::var("TN_MULTI_WORKERS_FORK_EPOCH").ok().and_then(|raw| raw.trim().parse().ok())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,6 +507,68 @@ mod tests {
             assert_eq!(
                 seed_signature_active(epoch),
                 build_fork_active(epoch),
+                "an unset override must not shift the gate at epoch {epoch}",
+            );
+        });
+    }
+
+    /// Pin the multi-workers gate to the rollout contract this build actually implements.
+    ///
+    /// Carries the same asymmetry [`build_fork_gate_matches_this_builds_rollout_contract`] states
+    /// for the seed-signature gate: "dormant while the constant is `u32::MAX`" holds only under
+    /// `adiri`. Every other build — including the default one that produces both the shipped node
+    /// binary and the e2e binary — is active from genesis, so epoch 1 already uses the
+    /// multi-worker layout there.
+    ///
+    /// Asserts against [`multi_workers_build_fork_active`], the override-free decision, so the
+    /// result does not depend on whether `test-utils` was unified into this build. The grid is
+    /// derived from the constant, so arming the fork does not require editing this test.
+    #[test]
+    fn multi_workers_build_fork_gate_matches_this_builds_rollout_contract() {
+        #[cfg(not(feature = "adiri"))]
+        [0, 1, 2, u32::MAX].into_iter().for_each(|epoch| {
+            assert!(
+                multi_workers_build_fork_active(epoch),
+                "non-adiri builds carry no legacy committee layout and are active from genesis; \
+                 epoch {epoch} must be post-fork",
+            );
+        });
+        #[cfg(feature = "adiri")]
+        {
+            [0, 1, 2, MULTI_WORKERS_FORK_EPOCH - 1].into_iter().for_each(|epoch| {
+                assert!(
+                    !multi_workers_build_fork_active(epoch),
+                    "adiri stays dormant before MULTI_WORKERS_FORK_EPOCH; epoch {epoch} must be \
+                     pre-fork",
+                );
+            });
+            [MULTI_WORKERS_FORK_EPOCH, u32::MAX].into_iter().for_each(|epoch| {
+                assert!(
+                    multi_workers_build_fork_active(epoch),
+                    "the gate must fire from the fork epoch onward (`>=`, not `>`); epoch \
+                     {epoch} must be post-fork",
+                );
+            });
+        }
+    }
+
+    /// With no `TN_MULTI_WORKERS_FORK_EPOCH` in the environment, the test override must be
+    /// completely inert: the gate answers exactly as the compile-time contract does.
+    #[cfg(feature = "test-utils")]
+    #[test]
+    fn multi_workers_override_is_inert_when_unset() {
+        // The override latches in a process-wide `OnceLock`, so a harness launched WITH the
+        // variable set cannot observe the unset behaviour. Fail loudly rather than assert a
+        // property this process cannot hold — a silent skip here would read as a pass.
+        assert!(
+            multi_workers_fork_epoch_override().is_none(),
+            "this test requires a process without TN_MULTI_WORKERS_FORK_EPOCH set; the override \
+             is OnceLock-latched, so run the unset case in its own process",
+        );
+        [0, 1, 2, u32::MAX].into_iter().for_each(|epoch| {
+            assert_eq!(
+                multi_workers_fork_active(epoch),
+                multi_workers_build_fork_active(epoch),
                 "an unset override must not shift the gate at epoch {epoch}",
             );
         });

--- a/crates/types/src/primary/header.rs
+++ b/crates/types/src/primary/header.rs
@@ -160,7 +160,7 @@ impl Header {
 
         // Ensure all worker ids are correct.
         for worker_id in self.inner.payload.values() {
-            if *worker_id as usize >= committee.number_of_workers() {
+            if usize::from(*worker_id) >= committee.number_of_workers() {
                 return Err(HeaderError::UnkownWorkerId);
             }
         }

--- a/crates/types/src/primary/info.rs
+++ b/crates/types/src/primary/info.rs
@@ -1,22 +1,55 @@
 //! Primary information for peers.
-use crate::{get_available_udp_port, NetworkKeypair, P2pNode};
+use crate::{
+    committee::PrimaryWorkersRepr, get_available_udp_port, NetworkKeypair, P2pNode, WorkerId,
+};
 use serde::{Deserialize, Serialize};
 
 /// Information for the Primary.
 ///
 /// Currently, Primary details are fanned out in authority details.
+///
+/// The `workers` list holds one [P2pNode] per worker, indexed by [WorkerId]. Every validator in a
+/// committee must run the same number of workers (a protocol-level value, see
+/// `Committee::number_of_workers`). The list is never empty.
+///
+/// Serialization: the current on-disk shape is `workers: [..]`. The legacy single-worker shape
+/// `worker: {..}` is still accepted on read so existing node-info and validator files load
+/// unchanged; it is written back in the new shape.
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[serde(from = "PrimaryWorkersRepr")]
 pub struct NodeP2pInfo {
     /// The primary's public network settings.
     pub primary: P2pNode,
-    /// The workers's public network settings.
-    pub worker: P2pNode,
+    /// The public network settings for each worker, indexed by [WorkerId].
+    pub workers: Vec<P2pNode>,
+}
+
+impl From<PrimaryWorkersRepr> for NodeP2pInfo {
+    fn from(value: PrimaryWorkersRepr) -> Self {
+        let (primary, workers) = value.into();
+        Self { primary, workers }
+    }
 }
 
 impl NodeP2pInfo {
-    /// Create a new instance of [PrimaryInfo].
-    pub fn new(primary: P2pNode, worker: P2pNode) -> Self {
-        Self { primary, worker }
+    /// Create a new instance of [NodeP2pInfo] with one [P2pNode] per worker.
+    pub fn new(primary: P2pNode, workers: Vec<P2pNode>) -> Self {
+        Self { primary, workers }
+    }
+
+    /// Return the [P2pNode] for `worker_id`, or `None` if this node runs no such worker.
+    pub fn worker(&self, worker_id: WorkerId) -> Option<&P2pNode> {
+        self.workers.get(usize::from(worker_id))
+    }
+
+    /// Return a mutable [P2pNode] for `worker_id`, or `None` if this node runs no such worker.
+    pub fn worker_mut(&mut self, worker_id: WorkerId) -> Option<&mut P2pNode> {
+        self.workers.get_mut(usize::from(worker_id))
+    }
+
+    /// Return the number of workers this node runs.
+    pub fn num_workers(&self) -> usize {
+        self.workers.len()
     }
 }
 
@@ -36,13 +69,73 @@ impl Default for NodeP2pInfo {
                 network_key: NetworkKeypair::generate_ed25519().public().into(),
                 rpc: None,
             },
-            worker: P2pNode {
+            workers: vec![P2pNode {
                 network_address: format!("/ip4/{}/udp/{}/quic-v1", &host, worker_udp_port)
                     .parse()
-                    .expect("multiaddr parsed for primary"),
+                    .expect("multiaddr parsed for worker"),
                 network_key: NetworkKeypair::generate_ed25519().public().into(),
                 rpc: None,
-            },
+            }],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DEFAULT_WORKER_ID;
+
+    /// A [P2pNode] with a fresh random key for serde tests.
+    fn p2p_node() -> P2pNode {
+        let address: crate::Multiaddr =
+            "/ip4/127.0.0.1/udp/4000/quic-v1".parse().expect("multiaddr");
+        let key: crate::NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+        (address, key).into()
+    }
+
+    /// Indent every line of a YAML fragment by two spaces so it nests under a key (the document
+    /// start marker is dropped).
+    fn indent(fragment: &str) -> String {
+        fragment
+            .lines()
+            .filter(|l| *l != "---")
+            .map(|l| format!("  {l}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn new_shape_round_trips() {
+        let info = NodeP2pInfo::new(p2p_node(), vec![p2p_node(), p2p_node()]);
+        let yaml = serde_yaml::to_string(&info).expect("serialize");
+        assert!(yaml.contains("workers:"), "new shape must serialize `workers`: {yaml}");
+        assert!(!yaml.contains("\nworker:"), "new shape must not serialize `worker`: {yaml}");
+        let decoded: NodeP2pInfo = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(decoded, info);
+        assert_eq!(decoded.num_workers(), 2);
+        assert_eq!(decoded.worker(1), info.workers.get(1));
+        assert!(decoded.worker(2).is_none());
+    }
+
+    #[test]
+    fn legacy_shape_decodes_as_one_worker() {
+        let primary = p2p_node();
+        let worker = p2p_node();
+        let expected = NodeP2pInfo::new(primary.clone(), vec![worker.clone()]);
+        let primary_yaml = serde_yaml::to_string(&primary).expect("serialize primary");
+        let worker_yaml = serde_yaml::to_string(&worker).expect("serialize worker");
+        let legacy =
+            format!("primary:\n{}\nworker:\n{}\n", indent(&primary_yaml), indent(&worker_yaml));
+        let decoded: NodeP2pInfo = serde_yaml::from_str(&legacy).expect("legacy deserialize");
+        assert_eq!(decoded, expected);
+        assert_eq!(decoded.worker(DEFAULT_WORKER_ID), Some(&worker));
+    }
+
+    #[test]
+    fn empty_workers_rejected() {
+        let primary_yaml = serde_yaml::to_string(&p2p_node()).expect("serialize primary");
+        let doc = format!("primary:\n{}\nworkers: []\n", indent(&primary_yaml));
+        let result: Result<NodeP2pInfo, _> = serde_yaml::from_str(&doc);
+        assert!(result.is_err(), "empty workers must be rejected");
     }
 }

--- a/crates/types/src/primary/info.rs
+++ b/crates/types/src/primary/info.rs
@@ -1,6 +1,7 @@
 //! Primary information for peers.
 use crate::{
-    committee::PrimaryWorkersRepr, get_available_udp_port, NetworkKeypair, P2pNode, WorkerId,
+    committee::deserialize_primary_workers, get_available_udp_port, NetworkKeypair, P2pNode,
+    WorkerId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,10 +14,10 @@ use serde::{Deserialize, Serialize};
 /// `Committee::number_of_workers`). The list is never empty.
 ///
 /// Serialization: the current on-disk shape is `workers: [..]`. The legacy single-worker shape
-/// `worker: {..}` is still accepted on read so existing node-info and validator files load
-/// unchanged; it is written back in the new shape.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
-#[serde(from = "PrimaryWorkersRepr")]
+/// `worker: {..}` is still accepted on read from human-readable files so existing node-info and
+/// validator files load unchanged; it is written back in the new shape. Binary codecs read the
+/// current shape only.
+#[derive(Serialize, PartialEq, Clone, Debug)]
 pub struct NodeP2pInfo {
     /// The primary's public network settings.
     pub primary: P2pNode,
@@ -24,10 +25,13 @@ pub struct NodeP2pInfo {
     pub workers: Vec<P2pNode>,
 }
 
-impl From<PrimaryWorkersRepr> for NodeP2pInfo {
-    fn from(value: PrimaryWorkersRepr) -> Self {
-        let (primary, workers) = value.into();
-        Self { primary, workers }
+impl<'de> Deserialize<'de> for NodeP2pInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserialize_primary_workers(deserializer)
+            .map(|(primary, workers)| Self { primary, workers })
     }
 }
 

--- a/crates/types/tests/it/committee_sweep_tests.rs
+++ b/crates/types/tests/it/committee_sweep_tests.rs
@@ -1,0 +1,608 @@
+//! Deterministic parameter sweep over the epoch-gated `Committee` wire layout (#554).
+//!
+//! Every combination of (epoch, authority count, bootstrap-server count, workers per server)
+//! below is checked against a byte-length oracle and a byte-exact re-encode. The grid is
+//! exhaustive by construction (an iterator product, not sampled) and every value in it — BLS
+//! keys, network keys, multiaddrs, execution addresses, rpc endpoints — is derived from a
+//! constant plus a slot index, so a failure reproduces byte-for-byte on any machine.
+//!
+//! The oracle is a length identity against an independently-encoded legacy mirror declared in
+//! this file: the gated wire must be exactly the pre-#554 three-field baseline, plus the bytes
+//! the open gate adds and nothing else. Both sides of that identity are measured, never
+//! hardcoded — the surcharge comes from encoding the parts that moved. A round-trip alone
+//! cannot see this: it is a tautology of the same gate on both ends, and would still pass if
+//! the encoder unconditionally wrote (or unconditionally stripped) the multi-worker fields.
+//!
+//! The epoch axis brackets the fork boundary and is derived from
+//! [`tn_types::forks::MULTI_WORKERS_FORK_EPOCH`] itself, so arming the fork retargets this
+//! sweep with no edit here. `TN_MULTI_WORKERS_FORK_EPOCH` is deliberately never set: the
+//! sweep asserts what this build's lane actually does, and an override would only prove that
+//! the override works.
+//!
+//! Grid points the active layout cannot represent are not skipped. Below the fork epoch the
+//! wire holds exactly one worker per bootstrap server and carries no worker count at all, so a
+//! wider committee must be *unrepresentable*: those points assert the encoder fails closed
+//! rather than writing a committee that decodes as single-worker on every node.
+//!
+//! Two tests here are keepers rather than sweeps. The layout selector lives INSIDE the encoded
+//! value — the gate reads the committee's own `epoch`, the second of its four wire fields — so a
+//! corrupted epoch selects the wrong layout for the bytes that follow it. While a legacy arm still
+//! exists (`adiri`) that must fail loudly: a decode that resumed at a wrong offset would hand back
+//! a plausible-but-wrong committee. Without `adiri` the layout is active from genesis, so the same
+//! poke is expected to change the epoch value and nothing else, and the keeper for that lane says
+//! exactly that instead of asserting a failure that could only pass vacuously.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroUsize,
+};
+use tn_types::{
+    encode, forks::multi_workers_fork_active, try_decode, Address, Authority, BlsKeypair,
+    BlsPublicKey, Committee, CommitteeBuilder, Epoch, NetworkKeypair, P2pNode, RpcInfo,
+};
+
+/// Legacy (pre-#554) mirror of one bootstrap server's wire layout: a primary plus a single
+/// unprefixed `worker`.
+///
+/// Derived serde, so it is byte-identical to the `origin/main` `BootstrapServer` derive output BY
+/// CONSTRUCTION — same field types, same order, same attributes. #554 left [`P2pNode`] untouched,
+/// so the real type is reused for the fields themselves; only the field whose shape changed gets
+/// a mirror.
+#[derive(serde::Serialize)]
+struct LegacyBootstrapMirror {
+    /// Mirrors the pre-#554 `BootstrapServer::primary`.
+    primary: P2pNode,
+    /// Mirrors the pre-#554 `BootstrapServer::worker`, the only worker that shape can hold.
+    worker: P2pNode,
+}
+
+/// Independently-encoded legacy (three-field) mirror of one grid point's committee content: the
+/// same fields in `CommitteeInner`'s declaration order, each bootstrap server in its pre-#554
+/// single-worker shape, and NO `num_workers` field — encoded through this derive, never through
+/// `Committee`'s hand-written epoch-gated serializer.
+///
+/// Its encoded length is the sweep's byte-level baseline. `origin/main` interleaved three
+/// `#[serde(skip)]` helper fields between these (`authorities_by_id`, `quorum_threshold`,
+/// `validity_threshold`); skipped fields never reach the wire, so omitting them preserves both
+/// the field set and its order. Names are absent too: bcs writes neither struct nor field names,
+/// so only the types and their order decide the bytes.
+///
+/// For a multi-worker grid point this is the projection the legacy layout *would* have written —
+/// the first worker of each server — and [`SweepPoint::measured_gate_delta`] accounts for
+/// everything the post-fork wire adds on top of it.
+#[derive(serde::Serialize)]
+struct LegacyCommitteeMirror {
+    /// Mirrors `CommitteeInner::authorities`, whose shape #554 left untouched.
+    authorities: BTreeMap<BlsPublicKey, Authority>,
+    /// Mirrors `CommitteeInner::epoch`, the only input the layout gate reads.
+    epoch: Epoch,
+    /// Mirrors `CommitteeInner::bootstrap_servers` in the pre-#554 single-worker shape.
+    bootstrap_servers: BTreeMap<BlsPublicKey, LegacyBootstrapMirror>,
+}
+
+/// The adiri grid derives three of its four epochs from the fork constant, so arming the fork
+/// retargets the sweep without an edit here. That only stays meaningful while at least one epoch
+/// below the constant exists: a fork epoch of zero would make every epoch post-fork and silently
+/// drop both the legacy arm and every fail-closed point from this lane. Subtracting one from the
+/// constant below would also fail const-eval, but this states the requirement rather than leaving
+/// it to an underflow.
+#[cfg(feature = "adiri")]
+const _: () = assert!(tn_types::forks::MULTI_WORKERS_FORK_EPOCH != 0);
+
+/// Epochs swept under `adiri`: the legacy floor, both sides of the fork boundary (the last
+/// pre-fork epoch and the first gate-open one), and the top of the epoch range.
+///
+/// The constant is a dormant `u32::MAX` placeholder today, which collapses the last two entries
+/// onto one another — [`sweep_epochs`] dedupes rather than this list hardcoding today's shape.
+/// `u32::MAX` is itself gate-open even while the fork is dormant, since the gate is `>=`, so this
+/// lane covers both arms before and after arming.
+#[cfg(feature = "adiri")]
+const SWEEP_EPOCHS: [Epoch; 4] = [
+    0,
+    tn_types::forks::MULTI_WORKERS_FORK_EPOCH - 1,
+    tn_types::forks::MULTI_WORKERS_FORK_EPOCH,
+    Epoch::MAX,
+];
+
+/// Epochs swept without `adiri`: the multi-worker layout is active from genesis there, so genesis
+/// plus one later epoch pin the always-post-fork layout in the default-feature suite.
+#[cfg(not(feature = "adiri"))]
+const SWEEP_EPOCHS: [Epoch; 2] = [0, 5];
+
+/// Authority counts swept. Two is the floor, not a choice: `CommitteeInner::load` asserts a
+/// committee larger than one, so a single-authority committee panics before it can be encoded.
+const SWEEP_AUTHORITIES: [u8; 3] = [2, 3, 4];
+
+/// Workers per bootstrap server, which is also the committee's worker count at each grid point:
+/// the single worker the legacy layout can express, and two shapes only the post-fork layout can.
+const SWEEP_WORKERS_PER_SERVER: [u8; 3] = [1, 2, 3];
+
+/// Tag byte closing every BLS scalar this sweep derives, so its authorities are visibly this
+/// file's own fixtures.
+const BLS_SCALAR_TAG: u8 = 0x3B;
+
+/// Seed tag marking a sweep primary's network key, so no primary shares a key with a worker.
+const PRIMARY_SEED_TAG: u8 = 0xD0;
+
+/// Seed tag marking a sweep worker's network key.
+const WORKER_SEED_TAG: u8 = 0xE0;
+
+/// The distinct epochs of [`SWEEP_EPOCHS`].
+///
+/// Deduped rather than listed: while the adiri fork epoch is the `u32::MAX` placeholder, two of
+/// its four entries are the same epoch, and lowering the constant separates them again with no
+/// edit here.
+fn sweep_epochs() -> BTreeSet<Epoch> {
+    SWEEP_EPOCHS.into_iter().collect()
+}
+
+/// Deterministic BLS keypair for sweep authority slot `slot`.
+///
+/// Built from a fixed scalar rather than a seeded rng, so the derived public key — and with it the
+/// `authorities` map order and every encoded byte — is stable across `rand` version bumps as well
+/// as across runs. The leading bytes stay zero, which keeps the scalar far below the BLS12-381
+/// group order and nonzero, the only two values `blst` rejects.
+fn sweep_bls_keypair(slot: u8) -> BlsKeypair {
+    let mut scalar = [0_u8; 32];
+    scalar[30] = slot;
+    scalar[31] = BLS_SCALAR_TAG;
+    BlsKeypair::from_bytes(&scalar).expect("sweep bls scalar is a valid private key")
+}
+
+/// The BLS public key of sweep authority slot `slot`.
+fn sweep_authority_key(slot: u8) -> BlsPublicKey {
+    *sweep_bls_keypair(slot).public()
+}
+
+/// A fixed 32-byte ed25519 secret seed identifying one sweep node.
+fn sweep_seed(tag: u8, authority: u8, worker: u8) -> [u8; 32] {
+    let mut seed = [0_u8; 32];
+    seed[0] = tag;
+    seed[1] = authority;
+    seed[2] = worker;
+    seed
+}
+
+/// A [`P2pNode`] from a fixed ed25519 seed and port.
+///
+/// ed25519 secret keys *are* 32-byte seeds, so a fixed seed yields a fixed public key with no rng
+/// in the path; the multiaddr comes from a literal rather than an OS-assigned port.
+fn sweep_p2p_node(seed: [u8; 32], port: u16, rpc: Option<RpcInfo>) -> P2pNode {
+    P2pNode {
+        network_address: format!("/ip4/127.0.0.1/udp/{port}/quic-v1")
+            .parse()
+            .expect("sweep multiaddr parses"),
+        network_key: NetworkKeypair::ed25519_from_bytes(seed)
+            .expect("a 32-byte array is a valid ed25519 secret seed")
+            .public()
+            .clone()
+            .into(),
+        rpc,
+    }
+}
+
+/// The primary node of sweep authority `authority`. Primaries never advertise rpc.
+fn sweep_primary_node(authority: u8) -> P2pNode {
+    sweep_p2p_node(sweep_seed(PRIMARY_SEED_TAG, authority, 0), 49_000 + u16::from(authority), None)
+}
+
+/// Worker `worker` of sweep authority `authority`.
+///
+/// The first worker of the first authority advertises an rpc endpoint and no other worker does, so
+/// both arms of [`P2pNode::rpc`]'s `Option` appear on the wire at every grid point that carries a
+/// bootstrap server at all.
+fn sweep_worker_node(authority: u8, worker: u8) -> P2pNode {
+    let rpc = (authority == 0 && worker == 0).then(|| RpcInfo {
+        http: "https://sweep0.example.com:8545/".parse().expect("sweep http url"),
+        ws: Some("wss://sweep0.example.com:8546/".parse().expect("sweep ws url")),
+    });
+    sweep_p2p_node(
+        sweep_seed(WORKER_SEED_TAG, authority, worker),
+        50_000 + u16::from(authority) * 8 + u16::from(worker),
+        rpc,
+    )
+}
+
+/// One point of the sweep grid: the committee shape to build and the epoch to build it at.
+///
+/// `Copy` and `Debug` so every assertion below can name the exact point that failed without
+/// threading the four axes through each message.
+#[derive(Clone, Copy, Debug)]
+struct SweepPoint {
+    /// The committee's epoch, the only input the wire-layout gate reads.
+    epoch: Epoch,
+    /// Number of authorities. At least two: `CommitteeInner::load` asserts a committee larger
+    /// than one.
+    authorities: u8,
+    /// Number of bootstrap servers, attached to authority slots `0..bootstrap_servers`.
+    ///
+    /// Swept independently of [`Self::authorities`] because the two maps are independent on the
+    /// wire: a committee may carry fewer bootstrap hints than it has authorities. Letting the two
+    /// lengths differ gives the maps distinct ULEB128 length prefixes, so a layout that read one
+    /// where the other belongs would not line up. Zero is included: an empty server map leaves
+    /// the trailing worker count as the gate's only surcharge.
+    bootstrap_servers: u8,
+    /// Workers each bootstrap server advertises, which is also the committee's worker count.
+    workers_per_server: u8,
+}
+
+impl SweepPoint {
+    /// The committee-level worker count this point describes.
+    fn num_workers(self) -> NonZeroUsize {
+        NonZeroUsize::new(usize::from(self.workers_per_server))
+            .expect("a grid point runs at least one worker per server")
+    }
+
+    /// The `(slot, bls key)` pairs of this point's authorities.
+    fn authority_slots(self) -> impl Iterator<Item = (u8, BlsPublicKey)> {
+        (0..self.authorities).map(|slot| (slot, sweep_authority_key(slot)))
+    }
+
+    /// The `(slot, bls key)` pairs that carry a bootstrap server.
+    ///
+    /// Servers attach to the lowest authority slots, so this is always a prefix of
+    /// [`Self::authority_slots`] and every server is keyed off an authority that exists.
+    fn bootstrap_slots(self) -> impl Iterator<Item = (u8, BlsPublicKey)> {
+        self.authority_slots().take(usize::from(self.bootstrap_servers))
+    }
+
+    /// The worker nodes of the bootstrap server on authority slot `slot`.
+    fn worker_nodes(self, slot: u8) -> Vec<P2pNode> {
+        (0..self.workers_per_server).map(|worker| sweep_worker_node(slot, worker)).collect()
+    }
+
+    /// The `authorities` map this point encodes, which is also the committee's first wire field.
+    ///
+    /// Built straight from the slot-derived keys rather than read back out of
+    /// [`Self::committee`], so it can serve as an independent measure of where that field ends.
+    fn authority_map(self) -> BTreeMap<BlsPublicKey, Authority> {
+        self.authority_slots()
+            .map(|(slot, key)| (key, Authority::new_for_test(key, Address::repeat_byte(slot))))
+            .collect()
+    }
+
+    /// Byte offset of the little-endian `epoch` field inside this point's encoded committee.
+    ///
+    /// bcs writes a struct as its fields back to back with no framing of its own, and
+    /// `authorities` is the first field of both layouts, so the epoch begins exactly where the
+    /// encoded authority map ends. Measured from that map rather than counted by hand, so nothing
+    /// here depends on how bcs sizes a BLS key, an [`Authority`], or a map's ULEB128 length prefix.
+    fn epoch_offset(self) -> usize {
+        encode(&self.authority_map()).len()
+    }
+
+    /// Build the [`Committee`] this point describes.
+    fn committee(self) -> Committee {
+        let mut builder = CommitteeBuilder::new(self.epoch).with_num_workers(self.num_workers());
+        self.authority_slots().for_each(|(slot, key)| {
+            let execution_address = Address::repeat_byte(slot);
+            if slot < self.bootstrap_servers {
+                builder.add_authority_and_bootstrap(
+                    key,
+                    sweep_primary_node(slot),
+                    self.worker_nodes(slot),
+                    execution_address,
+                );
+            } else {
+                builder.add_authority(key, execution_address);
+            }
+        });
+        builder.build()
+    }
+
+    /// Build the legacy mirror this point projects onto.
+    ///
+    /// Reaches the mirror straight from the slot-derived keys and nodes, never through
+    /// [`Self::committee`], so a bug in the gated encoder cannot make the two sides of the length
+    /// identity agree.
+    fn legacy_mirror(self) -> LegacyCommitteeMirror {
+        let bootstrap_servers = self
+            .bootstrap_slots()
+            .map(|(slot, key)| {
+                let mirror = LegacyBootstrapMirror {
+                    primary: sweep_primary_node(slot),
+                    worker: sweep_worker_node(slot, 0),
+                };
+                (key, mirror)
+            })
+            .collect();
+        LegacyCommitteeMirror {
+            authorities: self.authority_map(),
+            epoch: self.epoch,
+            bootstrap_servers,
+        }
+    }
+
+    /// The exact byte count an open gate adds to this point's wire, measured by encoding the parts
+    /// that moved rather than by arithmetic over them.
+    ///
+    /// Three things appear post-fork that the legacy baseline does not carry: the ULEB128 length
+    /// prefix of every bootstrap server's worker list, every worker after the first (the legacy
+    /// shape holds exactly one), and the trailing committee-level `num_workers`. Each is measured
+    /// from `encode` of the part itself, so a change in how bcs frames a sequence or sizes a
+    /// `NonZeroUsize` moves this expectation along with the wire instead of failing against a
+    /// hardcoded constant.
+    fn measured_gate_delta(self) -> usize {
+        let worker_lists: usize = self
+            .bootstrap_slots()
+            .map(|(slot, _)| {
+                let workers = self.worker_nodes(slot);
+                let elements: usize = workers.iter().map(|worker| encode(worker).len()).sum();
+                // bcs frames a sequence as its ULEB128 length followed by the bare elements, so
+                // the prefix is whatever the whole is longer than the sum of its parts
+                let length_prefix = encode(&workers).len() - elements;
+                let workers_after_first: usize =
+                    workers.iter().skip(1).map(|worker| encode(worker).len()).sum();
+                length_prefix + workers_after_first
+            })
+            .sum();
+        encode(&self.num_workers()).len() + worker_lists
+    }
+}
+
+/// Check one grid point: the fail-closed refusal where the layout cannot hold the value, and
+/// otherwise the byte-length oracle against the legacy mirror plus a byte-exact re-encode.
+fn assert_committee_grid_point(point: SweepPoint) {
+    let committee = point.committee();
+    let gate_open = multi_workers_fork_active(point.epoch);
+
+    // fail closed: the pre-fork layout has no field for a worker count and holds exactly one
+    // worker per bootstrap server, so a wider committee must be unrepresentable rather than
+    // truncated on its way to a pack. bcs directly here rather than `encode`, which panics on a
+    // serializer error.
+    if !gate_open && point.workers_per_server > 1 {
+        assert!(
+            bcs::to_bytes(&committee).is_err(),
+            "grid point {point:?}: the pre-fork layout must refuse a committee it cannot hold"
+        );
+        return;
+    }
+
+    let bytes = encode(&committee);
+    let mirror_bytes = encode(&point.legacy_mirror());
+
+    // byte-level oracle, independent of the serde gate: the wire must be exactly the legacy
+    // three-field baseline plus the measured multi-worker surcharge when (and only when) the gate
+    // is open for this epoch. Holds in both cfg lanes — without `adiri` every epoch is gate-open,
+    // so the expectation is baseline + surcharge everywhere.
+    let expected_len = mirror_bytes.len() + if gate_open { point.measured_gate_delta() } else { 0 };
+    assert_eq!(
+        expected_len,
+        bytes.len(),
+        "grid point {point:?} wire length must equal the legacy baseline plus exactly the \
+         epoch-gated multi-worker bytes"
+    );
+
+    // pre-fork the mirror describes the whole wire, not just its length: a pack written by a
+    // pre-#554 binary is byte-identical to what this build writes for that epoch.
+    if !gate_open {
+        assert_eq!(
+            mirror_bytes, bytes,
+            "grid point {point:?} pre-fork bytes must be the legacy layout, not merely its length"
+        );
+    }
+
+    let decoded: Committee = try_decode(&bytes).expect("a committee decodes its own wire bytes");
+    assert_eq!(
+        bytes,
+        encode(&decoded),
+        "grid point {point:?} must re-encode byte-exactly: a pack survives decode and re-append"
+    );
+    assert_eq!(decoded, committee, "grid point {point:?} decoded to a different committee");
+    // `Committee`'s PartialEq deliberately ignores bootstrap servers, so compare those too: they
+    // are the half of this layout change the equality above cannot see.
+    assert_eq!(
+        decoded.bootstrap_servers(),
+        committee.bootstrap_servers(),
+        "grid point {point:?} lost or reshaped a bootstrap server across the round trip"
+    );
+    assert_eq!(
+        usize::from(point.workers_per_server),
+        decoded.number_of_workers(),
+        "grid point {point:?} worker count did not survive the round trip"
+    );
+}
+
+/// The committee shape the two epoch-poke keepers below encode: the point where the two layouts
+/// diverge most, so a wrong-layout read has the least chance of accidentally lining up.
+///
+/// Post-fork every bootstrap server carries a ULEB128-prefixed worker list and the committee
+/// carries a trailing `num_workers`; the legacy shape carries one unprefixed worker per server and
+/// no count at all. Four authorities against three servers also gives the two maps distinct length
+/// prefixes, so a read that landed on the wrong map would not line up either.
+fn epoch_poke_point(epoch: Epoch) -> SweepPoint {
+    SweepPoint { epoch, authorities: 4, bootstrap_servers: 3, workers_per_server: 2 }
+}
+
+/// `bytes` with the four-byte little-endian `epoch` field at `offset` rewritten from `from` to
+/// `to`.
+///
+/// Checks the window it is about to overwrite really holds `from`, so a wrong offset fails here
+/// with a clear message instead of quietly corrupting some other field and leaving the callers
+/// below to prove nothing. The result keeps the original buffer's length, so a decode outcome
+/// follows from the layout the new epoch selects rather than from a buffer that grew or shrank.
+///
+/// # Panics
+///
+/// If `offset` does not hold `from`, if `from == to` (a poke that changes nothing), or if the
+/// rewrite left the bytes unchanged.
+fn poke_epoch(bytes: &[u8], offset: usize, from: Epoch, to: Epoch) -> Vec<u8> {
+    let window: Vec<u8> = bytes.iter().skip(offset).take(4).copied().collect();
+    assert_eq!(
+        from.to_le_bytes().to_vec(),
+        window,
+        "offset {offset} must land on the encoded epoch {from}"
+    );
+    assert_ne!(from, to, "an epoch poke that rewrites the epoch to itself proves nothing");
+
+    let replacement = to.to_le_bytes();
+    let poked: Vec<u8> = bytes
+        .iter()
+        .enumerate()
+        .map(|(position, byte)| {
+            position.checked_sub(offset).and_then(|index| replacement.get(index)).unwrap_or(byte)
+        })
+        .copied()
+        .collect();
+    assert_ne!(bytes, poked.as_slice(), "the poke must actually rewrite the epoch field");
+    poked
+}
+
+/// The epoch grid must straddle the gate the way this build's lane requires, or the sweep passes
+/// vacuously: an adiri grid with no pre-fork epoch silently drops the legacy arm and every
+/// fail-closed point, and a non-adiri grid is meant to be gate-open throughout.
+///
+/// Also the tripwire for an ambient `TN_MULTI_WORKERS_FORK_EPOCH`, which this suite never sets
+/// but a test-utils build would still honor from the environment.
+#[test]
+fn test_committee_sweep_grid_brackets_the_fork() {
+    let gate_states: BTreeSet<bool> =
+        sweep_epochs().into_iter().map(multi_workers_fork_active).collect();
+
+    #[cfg(feature = "adiri")]
+    assert_eq!(
+        BTreeSet::from([false, true]),
+        gate_states,
+        "the adiri grid must cover both gate states; is TN_MULTI_WORKERS_FORK_EPOCH set in \
+         the environment, or has the fork been armed at epoch 0?"
+    );
+
+    #[cfg(not(feature = "adiri"))]
+    assert_eq!(
+        BTreeSet::from([true]),
+        gate_states,
+        "the multi-worker layout is active from genesis without `adiri`, so every swept epoch \
+         must be gate-open; is TN_MULTI_WORKERS_FORK_EPOCH set in the environment?"
+    );
+}
+
+/// The exhaustive grid: every `(epoch, authorities, bootstrap_servers, workers_per_server)`
+/// combination of the sweep axes above, via an iterator product (no sampling, no loop keywords).
+///
+/// Bootstrap-server counts run `0..=authorities` rather than a fixed list, since a server attaches
+/// to an authority slot and a committee cannot carry more hints than it has authorities.
+#[test]
+fn test_committee_layout_parameter_sweep() {
+    sweep_epochs().into_iter().for_each(|epoch| {
+        SWEEP_AUTHORITIES.iter().for_each(|&authorities| {
+            (0..=authorities).for_each(|bootstrap_servers| {
+                SWEEP_WORKERS_PER_SERVER.iter().for_each(|&workers_per_server| {
+                    assert_committee_grid_point(SweepPoint {
+                        epoch,
+                        authorities,
+                        bootstrap_servers,
+                        workers_per_server,
+                    });
+                });
+            });
+        });
+    });
+}
+
+/// Negative keeper (adiri): rewriting the `epoch` field inside an encoded post-fork [`Committee`]
+/// to the dormant side of the fork makes the decoder read everything after it with the legacy field
+/// set, and that decode MUST fail.
+///
+/// The gate reads the epoch carried inside the value, so the layout selector travels with the very
+/// bytes it selects for and one corrupted field can point it at the wrong layout. Succeeding here
+/// is the dangerous outcome, not the reassuring one: it would mean the legacy arm consumed
+/// post-fork bytes at a wrong offset and produced a plausible committee — some other validator set,
+/// worker count or bootstrap topology than the bytes describe — where it should have rejected them.
+///
+/// Adiri-only because it needs a legacy arm to mis-select; every other build is gate-open from
+/// genesis, which the sibling below states instead. Both epochs come from
+/// [`tn_types::forks::MULTI_WORKERS_FORK_EPOCH`], so arming the fork retargets this keeper with
+/// no edit here.
+#[cfg(feature = "adiri")]
+#[test]
+fn test_committee_epoch_corruption_fails_loudly() {
+    let post_fork = tn_types::forks::MULTI_WORKERS_FORK_EPOCH;
+    // the corruption nearest the boundary: one epoch below the gate, which while the constant is
+    // the `u32::MAX` placeholder is a single byte of the encoded epoch
+    let pre_fork = post_fork - 1;
+    assert!(
+        multi_workers_fork_active(post_fork),
+        "epoch {post_fork} must be gate-open for this keeper to encode the post-fork layout; is \
+         TN_MULTI_WORKERS_FORK_EPOCH set in the environment?"
+    );
+    assert!(
+        !multi_workers_fork_active(pre_fork),
+        "epoch {pre_fork} must be dormant for this keeper to mean anything; is \
+         TN_MULTI_WORKERS_FORK_EPOCH set in the environment, or has the fork been armed at \
+         epoch 0?"
+    );
+
+    let point = epoch_poke_point(post_fork);
+    let committee = point.committee();
+    let bytes = encode(&committee);
+
+    // anti-vacuity: the fixture's own bytes must decode, or the failure below could just as well
+    // be a broken fixture
+    let honest: Committee =
+        try_decode(&bytes).expect("the post-fork fixture decodes its own wire bytes");
+    assert_eq!(post_fork, honest.epoch(), "fixture lost its epoch across an honest decode");
+    assert_eq!(
+        usize::from(point.workers_per_server),
+        honest.number_of_workers(),
+        "fixture lost its worker count across an honest decode"
+    );
+
+    let corrupted = poke_epoch(&bytes, point.epoch_offset(), post_fork, pre_fork);
+    assert!(
+        try_decode::<Committee>(&corrupted).is_err(),
+        "an epoch-corrupted committee must fail to decode, not resume at a wrong offset and hand \
+         back a plausible committee"
+    );
+}
+
+/// The gate-open counterpart (non-adiri): with the multi-worker layout active from genesis there is
+/// no legacy arm to mis-select, so poking the `epoch` field changes that value and nothing else.
+///
+/// This is the honest form of the keeper above on a build with a single layout. The poked bytes
+/// still decode, and they re-encode byte-exactly, which is what proves the layout did not shift
+/// under them. Requiring a loud failure here would pass vacuously: the epoch is not a layout
+/// selector on this lane.
+#[cfg(not(feature = "adiri"))]
+#[test]
+fn test_committee_epoch_poke_leaves_the_genesis_active_layout_intact() {
+    // genesis is the poke target because under `adiri` it is the deepest dormant epoch there is,
+    // so this states plainly that no epoch selects a different layout here. no constant marks a
+    // boundary on this lane, so the source epoch is a literal like the rest of the non-adiri grid.
+    let poked_epoch: Epoch = 0;
+    let point = epoch_poke_point(5);
+    assert!(
+        multi_workers_fork_active(point.epoch) && multi_workers_fork_active(poked_epoch),
+        "the multi-worker layout is active from genesis without `adiri`, so both epochs must be \
+         gate-open; is TN_MULTI_WORKERS_FORK_EPOCH set in the environment?"
+    );
+
+    let committee = point.committee();
+    let bytes = encode(&committee);
+
+    // anti-vacuity: the fixture's own bytes must decode, or what follows proves nothing
+    let honest: Committee = try_decode(&bytes).expect("the fixture decodes its own wire bytes");
+    assert_eq!(point.epoch, honest.epoch(), "fixture lost its epoch across an honest decode");
+
+    let corrupted = poke_epoch(&bytes, point.epoch_offset(), point.epoch, poked_epoch);
+    let poked: Committee =
+        try_decode(&corrupted).expect("one layout at every epoch: the poked bytes still decode");
+    assert_eq!(poked_epoch, poked.epoch(), "the poked committee must carry the poked epoch");
+    assert_eq!(
+        committee.number_of_workers(),
+        poked.number_of_workers(),
+        "the poke must not move the worker count"
+    );
+    // `Committee`'s PartialEq deliberately ignores bootstrap servers, so compare those directly:
+    // they are the half of this layout no equality above can see
+    assert_eq!(
+        committee.bootstrap_servers(),
+        poked.bootstrap_servers(),
+        "the poke must not reshape a bootstrap server"
+    );
+    assert_eq!(
+        corrupted,
+        encode(&poked),
+        "the poked committee must re-encode byte-exactly: only the epoch value changed, not the \
+         layout it selects"
+    );
+}

--- a/crates/types/tests/it/main.rs
+++ b/crates/types/tests/it/main.rs
@@ -4,6 +4,7 @@
 
 mod certificate_tests;
 mod committee_props;
+mod committee_sweep_tests;
 mod header_sweep_tests;
 mod nesting_tests;
 mod randomness_tests;


### PR DESCRIPTION
Refs #554 (PR 1 of the multi-worker series; the earlier stack #563-#568 was closed for drift).

## Summary

Lays the configuration and type foundation for N workers per validator while keeping every default at one worker. Data structures that hard-wired a single worker (`NodeP2pInfo.worker`, `BootstrapServer.worker`, the global batch topic, `Committee::number_of_workers() { 1 }`) become per-worker collections and a committee-carried count. No runtime path spawns more than `DEFAULT_WORKER_ID` yet: that is #555-#558.

Two points where this PR departs from the issue text, both because of what landed since it was written:

- **No `Parameters.num_workers`.** Since #844/#846 the worker count's source of truth is the on-chain `WorkerConfigs` contract, read at the previous epoch's closing block. Adding a second, operator-editable copy in the node config would create exactly the desync the issue's constraint 4 warns about. The committee reads the same on-chain value instead (grantkee's suggestion on #554).
- **`worker_txn_topic` no longer exists on main**; only the batch topic is per-worker'd.

## Changes

- [x] `crates/types/src/primary/info.rs` . . . `NodeP2pInfo { primary, workers: Vec<P2pNode> }` with `new(primary, workers)`, `worker(id) -> Option<&P2pNode>`, `worker_mut(id)`, `num_workers()`. Deserialization accepts BOTH the legacy `worker: {..}` map and the new `workers: [..]` list (untagged helper + `#[serde(from)]`); serialization writes the new shape only; an empty `workers` list is a serde error. `Default` stays one worker.
- [x] `crates/types/src/committee.rs` . . . `BootstrapServer { primary, workers }` with the same legacy-compatible deserialize and `worker(id)` / `num_workers()`. The legacy fallback is an untagged enum, which needs `deserialize_any`, so it only runs when the deserializer `is_human_readable()` (YAML / JSON files); bcs (consensus store, consensus pack) reads the current shape directly. `CommitteeInner` gains `num_workers: NonZeroUsize` (`serde(default)` = 1 so existing committee files load unchanged; part of `PartialEq`). `Committee::number_of_workers()` returns it instead of the constant; `Committee::with_num_workers(n)` rebuilds the inner. `CommitteeBuilder::with_num_workers(n)`; `add_bootstrap_server` / `add_authority_and_bootstrap` take the worker list.
- [x] `crates/types/src/primary/header.rs` . . . `Header::validate` compares `usize::from(*worker_id) >= committee.number_of_workers()` (drops the naked `as usize`); the `UnkownWorkerId` rejection is unchanged.
- [x] `crates/config/src/genesis.rs` . . . `NodeInfo::worker_network_key(id)` / `worker_network_address(id)` return `Option`, plus `worker_p2p_nodes()` and `num_workers()`. `NetworkGenesis::validate()` now also requires every validator to declare the SAME non-zero worker count (`agreed_num_workers`), and `create_committee` passes the full worker lists and stamps that agreed count on the genesis committee.
- [x] `crates/config/src/network.rs` . . . `LibP2pConfig::worker_batch_topic(chain_id, worker_id)` returns `tn-worker-{chain_id}-{worker_id}`.
- [x] `crates/config/src/{node.rs,consensus.rs}` . . . `Config::update_worker_network_key(worker_id, key)` (error on a missing worker) and `ConsensusConfig::worker_address(worker_id) -> Option<Multiaddr>`.
- [x] `crates/node/src/manager/node.rs` . . . the count read is factored out of `sync_num_workers_from_chain` into `read_num_workers_at_epoch_entry(reth_env, epoch_first_block)` (same pin, same `retry_provider_faults`, same halt-on-failure policy); `sync_num_workers_from_chain` calls it, behaviour unchanged.
- [x] `crates/node/src/manager/node/start_epoch.rs` . . . `create_committee_from_state` reads the on-chain count through that same helper for BOTH arms (epoch 0: file-loaded committee `.with_num_workers(n)`; later epochs: `CommitteeBuilder::with_num_workers(n)`), using `epoch_info.blockHeight` exactly as the accumulator path does. A failed read or a zero count halts epoch entry (no fail-open arm). Worker address / bootstrap-peer / topic sites use `DEFAULT_WORKER_ID`.
- [x] `crates/consensus/worker/src/network/{handle.rs,handler.rs}` . . . `WorkerNetworkHandle` carries its `worker_id` (new ctor parameter, `worker_id()` accessor) so publish and the gossip handler agree on the per-worker topic.
- [x] `crates/test-utils-committee/src/{builder.rs,authority.rs}` . . . `Builder::number_of_workers(n)`; the `assert_eq!(number_of_workers.get(), 1)` is gone; each authority gets `n` worker `P2pNode`s (worker 0 keeps the `KeyConfig` key, extra fixture workers get fresh keys); the fixture committee is stamped with the count.
- [x] `chain-configs/{mainnet,testnet}/committee.yaml` . . . `worker:` -> `workers: [ ... ]`, one element each, values unchanged (loads identically under the legacy path too).
- [x] Worker-0 accessor migration at every other `p2p_info.worker` site: `keytool/{generate,set_rpc,mod}.rs`, `e2e-tests/tests/it/common.rs`, `network-libp2p` and `worker` integration tests, `batch_fetcher.rs`, `worker.rs`.

## Consensus notes

- **The count that validates is the count that executes.** `Header::validate` (first statement of `vote_inner`, re-run on certificate acceptance) rejects any payload `worker_id >= committee.number_of_workers()`. Before this PR that bound was a compile-time 1; now it is the same `WorkerConfigs` read that sizes the `GasAccumulator` for the epoch, taken at the same block, so the id that a header is allowed to reference and the id execution can account for cannot disagree. Changing the count is still an on-chain, epoch-boundary event (`setNumWorkers`, effective next epoch), so it stays a coordinated upgrade as #554 constraint 4 requires.
- **Halt, do not fail open.** If the count cannot be read at epoch entry the node halts instead of entering the epoch with a guessed committee, matching the existing accumulator policy. A zero count is rejected explicitly.
- **Wire compatibility.** The worker batch topic string changes for worker 0 (`tn-worker-{chain}` -> `tn-worker-{chain}-0`), so nodes on either side of this change do not share a batch mesh. This is a coordinated-upgrade change, same class as the chain-id namespacing that preceded it. If a rolling upgrade matters more than a uniform scheme, worker 0 can keep the legacy string; say so and it is a one-line change plus test.
- **Storage compatibility.** The bcs layout of `Committee` changes (`BootstrapServer.worker` becomes a length-prefixed list, `CommitteeInner` gains a trailing `num_workers`). `EpochMeta` records written by earlier builds (consensus pack, consensus store) will not decode under this layout and vice versa. Fresh round-trips are covered by the tn-storage suites; existing on-disk packs are not. Two ways to take this: bump `PACK_VERSION` with a legacy `EpochMeta` decode (one more commit here or a follow-up), or treat it as part of the same coordinated upgrade as the topic change. Say which and I will do it.
- **Config compatibility.** Validator YAML (`p2p_info.worker`) and committee YAML (`bootstrap_servers.*.worker`, no `num_workers` key) written before this PR load unchanged; unit tests pin both legacy shapes against their one-element new-shape equivalents.

## Testing

Pinned toolchain from the worktree, `-j 2`, every step under `gateledger run -- tnquiet -- ...` (tests under `testledger`):

- `cargo +nightly fmt --all -- --check`: clean.
- `cargo +1.94 check --all-targets` on `tn-types tn-config tn-test-utils-committee tn-node tn-worker telcoin-network-cli e2e-tests tn-network-libp2p`: clean.
- `cargo +1.94 clippy --all-targets --no-deps -- -D warnings` on `tn-types tn-config tn-test-utils-committee tn-node tn-worker telcoin-network-cli` and `-p tn-network-libp2p --lib`: clean. (The e2e-tests and libp2p `--all-targets` test targets carry 25 pre-existing lints outside this diff.)
- `cargo +1.94 test`: `tn-types` `committee` + `primary::info` 31/0 (new: `NodeP2pInfo` / `BootstrapServer` round-trip, legacy-shape, empty-rejected, bcs round-trip of `BootstrapServer` and of a `Committee` with bootstrap servers; committee YAML without `num_workers` -> 1; round-trip with 2; `with_num_workers` keeps derived fields and accepts the default committee), `tn-config` 43/0 (new: genesis `validate` rejects mismatched worker counts, `create_committee` stamps the agreed count; topic test updated), `telcoin-network-cli::keytool` 20/0, `tn-worker --test it` 25/0, `tn-node` lib 61/0.
- Mutation-confirmed the five new load-bearing tests (each seen to FAIL under an in-diff mutant, then restored): legacy arm -> empty list; non-empty check disabled; genesis mismatch predicate disabled; serde default -> 2; `with_num_workers` re-running `load()`.
- Multi-agent review over the staged diff (8 raw findings, 1 high refuted on escalation); the four actionable ones are folded in: `with_num_workers` no longer re-runs `load()` (a missing epoch-0 committee file no longer panics), one shared serde shim for both structs, fixture `node_info` workers are the same `P2pNode`s the committee advertises, and a `warn!` when the on-chain count is above 1 (this node version spawns only worker 0).
- Pinned `+1.94` attest on the second machine caught two things the scoped local gates missed, both fixed: a lib-only unused import (`DEFAULT_WORKER_ID` used only under `cfg(test)`), and 20 tn-storage / tn-primary failures from the untagged serde shim under bcs (see the `committee.rs` bullet); `tn-storage` lib (207/0, covers the 18 `consensus` / `consensus_pack` / `pack_validate` failures) and both `tn-primary` restart tests re-run green after the fix.
- Not run locally: e2e suite.

## Out of scope (next PRs in the series)

- Per-worker swarms, listen addresses, RPC ports and `KeyConfig` worker keys (#555); per-worker `LocalNetwork` (#556); the `EpochManager` spawn loop and `Vec<WorkerNetworkHandle>` (#557); engine initialization (#558); multi-worker tests (#559).
- `RpcNodeInfo` (tn-rpc) still advertises the single worker key/address; it maps to worker 0 for now.
