### PR TITLE
fix(storage): enforce pack header version in PackIter/AsyncPackIter

### DIFF
--- a/crates/storage/src/archive/pack.rs
+++ b/crates/storage/src/archive/pack.rs
@@ -488,7 +488,9 @@ where
     /// This iterator will not see any data in the write cache.
     fn raw_iter(&self) -> Result<PackIter<V, File>, LoadHeaderError> {
         let dat_file = { self.data_file.try_clone()? };
-        PackIter::open(dat_file, self.uid_idx)
+        // Our own header already passed the version gate on open, so requesting exactly its
+        // version re-accepts this file without loosening the iterator's check.
+        PackIter::open(dat_file, self.uid_idx, self.header.version())
     }
 }
 
@@ -892,7 +894,7 @@ mod tests {
             .create(false)
             .open(tmp_path.path().join("pack_test_one"))
             .unwrap();
-        let mut iter = PackIter::open(data_file, 0).unwrap().map(|r| r.unwrap());
+        let mut iter = PackIter::open(data_file, 0, 0).unwrap().map(|r| r.unwrap());
         let v: TestRec = iter.next().unwrap();
         assert_eq!(v.idx, 1);
         assert_eq!(v.name, "Value One");
@@ -1076,7 +1078,7 @@ mod tests {
         let (tmp_dir, _pos) = build_pack_with_decompression_bomb();
         let path = tmp_dir.path().join("pack_bomb");
         let file = File::open(&path).expect("open file");
-        let mut iter = PackIter::<TestRec, _>::open(file, 0).expect("iter open");
+        let mut iter = PackIter::<TestRec, _>::open(file, 0, 0).expect("iter open");
         match iter.next() {
             Some(Err(FetchError::RequestedDecompressSizeTooLarge(max))) => {
                 assert_eq!(max, MAX_RECORD_SIZE);
@@ -1092,7 +1094,7 @@ mod tests {
         let (tmp_dir, _pos) = build_pack_with_decompression_bomb();
         let path = tmp_dir.path().join("pack_bomb");
         let file = tokio::fs::File::open(&path).await.expect("open file");
-        let mut iter = AsyncPackIter::<TestRec, _>::open(file, 0).await.expect("iter open");
+        let mut iter = AsyncPackIter::<TestRec, _>::open(file, 0, 0).await.expect("iter open");
         match iter.next().await {
             Some(Err(FetchError::RequestedDecompressSizeTooLarge(max))) => {
                 assert_eq!(max, MAX_RECORD_SIZE);
@@ -1123,7 +1125,7 @@ mod tests {
         let (tmp_dir, _pos) = build_pack_with_corrupt_zstd_frame();
         let path = tmp_dir.path().join("pack_corrupt");
         let file = File::open(&path).expect("open file");
-        let mut iter = PackIter::<TestRec, _>::open(file, 0).expect("iter open");
+        let mut iter = PackIter::<TestRec, _>::open(file, 0, 0).expect("iter open");
         match iter.next() {
             Some(Err(FetchError::IO(_))) | Some(Err(FetchError::DeserializeValue(_))) => {}
             other => panic!("expected IO or DeserializeValue error, got {other:?}"),
@@ -1137,7 +1139,7 @@ mod tests {
         let (tmp_dir, _pos) = build_pack_with_corrupt_zstd_frame();
         let path = tmp_dir.path().join("pack_corrupt");
         let file = tokio::fs::File::open(&path).await.expect("open file");
-        let mut iter = AsyncPackIter::<TestRec, _>::open(file, 0).await.expect("iter open");
+        let mut iter = AsyncPackIter::<TestRec, _>::open(file, 0, 0).await.expect("iter open");
         match iter.next().await {
             Some(Err(FetchError::IO(_))) | Some(Err(FetchError::DeserializeValue(_))) => {}
             other => panic!("expected IO or DeserializeValue error, got {other:?}"),
@@ -1160,5 +1162,77 @@ mod tests {
         // A valid in-range request still works.
         let len = pack.file_len();
         assert!(pack.read_bytes(0, len).is_ok());
+    }
+
+    /// [`PackIter::open`] must reject a file whose header is stamped with a NEWER version than
+    /// the reader requests ([`LoadHeaderError::InvalidVersion`]) and accept files stamped at or
+    /// below the requested version, mirroring the `open_data_file` gate.
+    #[test]
+    fn test_pack_iter_rejects_newer_version() {
+        let tmp_path = TempDir::with_prefix("test_pack_iter_version").expect("temp dir");
+        let path = tmp_path.path().join("pack_versioned");
+        {
+            // Stamp the file header one version ahead of what the first reader below requests.
+            let mut pack: TestPack =
+                Pack::open(&path, 0, false, PackCompression::None, 1).expect("open pack");
+            pack.append(&TestRec { idx: 1, name: "Value One".to_string() }).expect("append");
+            pack.commit().expect("commit");
+        }
+
+        // A reader requesting an OLDER version must reject the newer file.
+        let file = File::open(&path).expect("open file");
+        match PackIter::<TestRec, _>::open(file, 0, 0) {
+            Err(LoadHeaderError::InvalidVersion) => {}
+            other => panic!("expected InvalidVersion, got {other:?}"),
+        }
+
+        // A reader requesting an EQUAL version accepts the file and reads it.
+        let file = File::open(&path).expect("open file");
+        let mut iter = PackIter::<TestRec, _>::open(file, 0, 1).expect("equal version accepted");
+        assert_eq!(iter.next().expect("one record").expect("record reads").idx, 1);
+
+        // A reader requesting a NEWER version accepts the older file.
+        let file = File::open(&path).expect("open file");
+        let mut iter =
+            PackIter::<TestRec, _>::open(file, 0, 2).expect("newer reader accepts older file");
+        assert_eq!(iter.next().expect("one record").expect("record reads").idx, 1);
+    }
+
+    /// Async twin of [`test_pack_iter_rejects_newer_version`]: [`AsyncPackIter::open`] feeds the
+    /// peer-facing stream import, so it must enforce the same newer-rejected / older-accepted
+    /// version gate.
+    #[tokio::test]
+    async fn test_async_pack_iter_rejects_newer_version() {
+        use crate::archive::pack_iter::AsyncPackIter;
+
+        let tmp_path = TempDir::with_prefix("test_async_pack_iter_version").expect("temp dir");
+        let path = tmp_path.path().join("pack_versioned");
+        {
+            // Stamp the file header one version ahead of what the first reader below requests.
+            let mut pack: TestPack =
+                Pack::open(&path, 0, false, PackCompression::None, 1).expect("open pack");
+            pack.append(&TestRec { idx: 1, name: "Value One".to_string() }).expect("append");
+            pack.commit().expect("commit");
+        }
+
+        // A reader requesting an OLDER version must reject the newer file.
+        let file = tokio::fs::File::open(&path).await.expect("open file");
+        match AsyncPackIter::<TestRec, _>::open(file, 0, 0).await {
+            Err(LoadHeaderError::InvalidVersion) => {}
+            other => panic!("expected InvalidVersion, got {other:?}"),
+        }
+
+        // A reader requesting an EQUAL version accepts the file and reads it.
+        let file = tokio::fs::File::open(&path).await.expect("open file");
+        let mut iter =
+            AsyncPackIter::<TestRec, _>::open(file, 0, 1).await.expect("equal version accepted");
+        assert_eq!(iter.next().await.expect("one record").expect("record reads").idx, 1);
+
+        // A reader requesting a NEWER version accepts the older file.
+        let file = tokio::fs::File::open(&path).await.expect("open file");
+        let mut iter = AsyncPackIter::<TestRec, _>::open(file, 0, 2)
+            .await
+            .expect("newer reader accepts older file");
+        assert_eq!(iter.next().await.expect("one record").expect("record reads").idx, 1);
     }
 }

--- a/crates/storage/src/archive/pack_iter.rs
+++ b/crates/storage/src/archive/pack_iter.rs
@@ -45,8 +45,14 @@ where
     /// Open the iterator using reader as a data source.
     /// Produces an iterator over all the (key, values).  All and records
     /// are returned in insert order.
-    pub fn open(mut reader: R, uid_idx: u64) -> Result<Self, LoadHeaderError> {
+    /// Accepts files stamped at or below `version` and rejects newer ones with
+    /// [`LoadHeaderError::InvalidVersion`], the same gate as `PackInner::open_data_file`.
+    pub fn open(mut reader: R, uid_idx: u64, version: u16) -> Result<Self, LoadHeaderError> {
         let header = DataHeader::load_header(&mut reader, uid_idx)?;
+        if header.version() > version {
+            // Do not allow a newer version than we request but allow an older.
+            return Err(LoadHeaderError::InvalidVersion);
+        }
         if header.appnum() != 1 {
             return Err(LoadHeaderError::InvalidAppNum);
         }
@@ -176,11 +182,17 @@ where
     /// Open the iterator using reader as a data source.
     /// Produces an iterator over all the (key, values).  All and records
     /// are returned in insert order.
-    pub async fn open(mut reader: R, uid_idx: u64) -> Result<Self, LoadHeaderError> {
+    /// Accepts files stamped at or below `version` and rejects newer ones with
+    /// [`LoadHeaderError::InvalidVersion`], the same gate as `PackInner::open_data_file`.
+    pub async fn open(mut reader: R, uid_idx: u64, version: u16) -> Result<Self, LoadHeaderError> {
         let header = DataHeader::load_header_async(&mut reader, uid_idx).await?;
-        // Mirror PackIter::open / PackInner::open_data_file: reject unexpected version/appnum
-        // so the (peer-facing) async path rejects future/foreign formats instead of parsing
-        // them with current-format logic.
+        // Same version/appnum gate as PackIter::open and PackInner::open_data_file: allow files
+        // stamped at or below the requested version (v0 legacy streams stay readable), reject
+        // newer ones so this (peer-facing) async path never parses a future layout with
+        // current-format logic.
+        if header.version() > version {
+            return Err(LoadHeaderError::InvalidVersion);
+        }
         if header.appnum() != 1 {
             return Err(LoadHeaderError::InvalidAppNum);
         }

--- a/crates/storage/src/consensus_pack.rs
+++ b/crates/storage/src/consensus_pack.rs
@@ -914,9 +914,10 @@ impl Inner {
     ) -> Result<Self, PackError> {
         let base_dir = path.as_ref().join(format!("epoch-{epoch}"));
         let _ = create_dir_synced(&base_dir);
-        let mut stream_iter = AsyncPackIter::<PackRecord, R>::open(stream, epoch as u64)
-            .await
-            .map_err(|e| PackError::ReadError(e.to_string()))?;
+        let mut stream_iter =
+            AsyncPackIter::<PackRecord, R>::open(stream, epoch as u64, PACK_VERSION)
+                .await
+                .map_err(|e| PackError::ReadError(e.to_string()))?;
         let mut data = Pack::open(
             base_dir.join(Self::DATA_NAME),
             epoch as u64,
@@ -2987,6 +2988,54 @@ pub(crate) mod test {
             );
         }
         drop(pack);
+    }
+
+    /// A peer streaming a pack whose header is stamped NEWER than [`PACK_VERSION`] must be
+    /// rejected up front by `stream_import` (the version gate in `AsyncPackIter::open`) instead
+    /// of misparsed with current-format logic. The rejection surfaces as
+    /// [`PackError::ReadError`], which `is_missing_static_files` must NOT classify as a normal
+    /// "epoch files absent" miss — callers must propagate it, not collapse it to `None`.
+    #[tokio::test]
+    async fn test_stream_import_rejects_newer_pack_version() {
+        use crate::{
+            archive::pack::Pack,
+            consensus_pack::{PackError, PackRecord},
+        };
+
+        let temp_dir = TempDir::with_prefix("test_stream_newer_version").expect("temp dir");
+        // Build a header-only pack file stamped one version ahead of this reader. The uid_idx
+        // matches the epoch streamed below so only the version gate can reject it.
+        let path = temp_dir.path().join("newer_version");
+        {
+            let _pack: Pack<PackRecord> =
+                Pack::open(&path, 0, false, PackCompression::ZStd, PACK_VERSION + 1)
+                    .expect("open pack");
+        }
+
+        let stream = tokio::fs::File::open(&path).await.expect("stream file");
+        let temp_dir2 = TempDir::with_prefix("test_stream_newer_version2").expect("temp dir");
+        let err = ConsensusPack::stream_import(
+            temp_dir2.path(),
+            stream,
+            0,
+            &EpochRecord::default(),
+            0,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("newer-version stream must be rejected");
+        match &err {
+            PackError::ReadError(msg) => {
+                assert!(msg.contains("invalid version"), "unexpected message: {msg}");
+            }
+            other => panic!("expected ReadError, got {other:?}"),
+        }
+        // A version rejection means the peer's bytes are unreadable, not that the epoch files
+        // are absent on disk: the miss classifier must propagate it as an error.
+        assert!(
+            !err.is_missing_static_files(),
+            "version rejection must not classify as missing static files"
+        );
     }
 
     /// A v0 (batches-first) pack that stores a SHARED batch (one digest referenced by two certs)


### PR DESCRIPTION
- `PackIter::open` and `AsyncPackIter::open` take a new `version: u16` and reject files stamped newer with `LoadHeaderError::InvalidVersion` before the appnum check, the same gate as `PackInner::open_data_file`. Files stamped at or below the requested version stay readable; `stream_import`'s v0 legacy decode branch depends on older files being accepted.
- Version is a parameter, not a crate constant, because the archive layer hosts multiple pack kinds with independent versions.
- `Pack::raw_iter` passes its own already-validated `header.version()`, so local iteration re-accepts exactly the file it came from and existing readers see no behavioral change. `stream_import` passes `PACK_VERSION`, which is where the enforcement lands: the peer-facing path previously parsed unknown future layouts with current-format logic.
- The stale comment in `AsyncPackIter::open` that claimed version/appnum parity with `open_data_file` now matches the code.
- Three new tests: `test_pack_iter_rejects_newer_version` and `test_async_pack_iter_rejects_newer_version` stamp a file one version ahead and assert a newer file is rejected while the equal-version and newer-reader cases read the record; `test_stream_import_rejects_newer_pack_version` pins the peer-path surface, a `PackError::ReadError` containing "invalid version" with `is_missing_static_files()` false, so callers propagate the error instead of treating the epoch as absent.
- Mutation-checked: with the version guard removed all three tests fail at the enforcement assertion; with it restored `cargo nextest run -p tn-storage` passes 210. Workspace `cargo check` and clippy clean.

closes #1227 