### PR TITLE
Refactor the epoch vote certification code.

### DIFF
--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -518,6 +518,12 @@ where
                 if let Some((record, None)) =
                     self.consensus_chain.epochs().get_epoch_by_number(vote.epoch).await
                 {
+                    // Note that forcing the epoch record to be locally generated before accepting
+                    // votes may lead to lagging nodes missing early votes.
+                    // There is a small delay in publishing and a republish
+                    // schedule that should alleviate issues with this.
+                    // The alternative would involve a lot of bookkeeping to track future votes so
+                    // the simplicity of this solution is deliberately selected.
                     // Make sure this is a vote for the same digest we expect for EpochRecord.
                     ensure!(
                         record.digest() == vote.epoch_hash,

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -266,7 +266,7 @@ where
         self.epoch_votes_seen.lock().contains_key(&(author, epoch))
     }
 
-    /// Record a verified `(author, epoch, epoch-record)` vote so later replays are dropped before
+    /// Record a verified `(author, epoch)` vote so later replays are dropped before
     /// the signature check.
     ///
     /// Callers MUST invoke this only after [`EpochVote::check_signature`] succeeds: recording a

--- a/crates/consensus/primary/src/tests/network_tests.rs
+++ b/crates/consensus/primary/src/tests/network_tests.rs
@@ -39,9 +39,9 @@ use tn_types::{
     encode, error::HeaderError, now, to_intent_message, AuthorityIdentifier, BlockHash,
     BlockHeader, BlockNumHash, BlsKeypair, BlsPublicKey, BlsSignature, BlsSigner as _, Certificate,
     CommittedSubDag, ConsensusHeaderDigest, ConsensusNumHash, ConsensusResult, Database, Epoch,
-    EpochDigest, EpochRecord, EpochSeedMessage, EpochVote, ExecHeader, Hash as _, HeaderDigest,
-    ReputationScores, Round, SealedHeader, TaskManager, TnReceiver as _, TnSender as _, VoteDigest,
-    VoteInfo, B256,
+    EpochCertificate, EpochDigest, EpochRecord, EpochSeedMessage, EpochVote, ExecHeader, Hash as _,
+    HeaderDigest, ReputationScores, Round, SealedHeader, TaskManager, TnReceiver as _,
+    TnSender as _, VoteDigest, VoteInfo, B256,
 };
 use tracing::debug;
 
@@ -1167,6 +1167,51 @@ async fn test_epoch_vote_wrong_digest_rejected_before_verify() -> eyre::Result<(
     assert!(
         tokio::time::timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
         "a mismatched-digest vote must not reach the collector"
+    );
+    Ok(())
+}
+
+/// The other half of the ingress gate: a vote for an epoch we hold but that is ALREADY CERTIFIED
+/// (`get_epoch_by_number` returns `Some((record, Some(cert)))`) must be dropped silently — no
+/// error, no penalty, not forwarded. Certification is complete so further votes are surplus, and
+/// the benign drop must not be charged to the (honest) relayer on the gossip path. Companion to
+/// `test_epoch_vote_wrong_digest_rejected_before_verify`, which covers the digest arm.
+#[tokio::test]
+async fn test_epoch_vote_already_certified_epoch_dropped_before_verify() -> eyre::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let TestTypes { committee, handler, consensus_bus, task_manager: _task_manager, .. } =
+        create_test_types(temp_dir.path()).await;
+
+    // Seed the epoch-0 record, then store a certificate for it so the gate sees it as certified.
+    // This branch never verifies the cert, so a minimal one (a valid BLS signature reused from a
+    // vote, empty signer bitmap) is enough to flip `get_epoch_by_number`'s `None` -> `Some(cert)`.
+    let record = seed_uncertified_epoch0(&handler, &committee).await;
+    let auth = committee.authorities().next().expect("committee has authorities");
+    let key_config = auth.consensus_config().key_config().clone();
+    let vote = record.sign_vote(&key_config);
+    let cert = EpochCertificate {
+        epoch_hash: record.digest(),
+        signature: vote.signature,
+        signed_authorities: RoaringBitmap::new(),
+    };
+    handler
+        .consensus_chain()
+        .epochs()
+        .save_certificate(record.digest(), cert)
+        .await
+        .expect("store epoch-0 certificate");
+
+    // The vote is otherwise valid (correct digest, real committee member) — it is dropped ONLY
+    // because the epoch is already certified.
+    let mut rx = consensus_bus.subscribe_new_epoch_votes();
+    let res = handler.process_gossip(&epoch_vote_gossip(vote, 0)).await;
+    assert!(
+        res.is_ok(),
+        "a vote for an already-certified epoch must be dropped without error or penalty: {res:?}"
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
+        "a vote for an already-certified epoch must not reach the collector"
     );
     Ok(())
 }

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -9,8 +9,8 @@ use tn_config::KeyConfig;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBusApp};
 use tn_storage::{consensus::ConsensusChain, epoch_records::EpochRecordDb};
 use tn_types::{
-    BlsAggregateSignature, BlsPublicKey, BlsSignature, Epoch, EpochCertificate, EpochDigest,
-    EpochRecord, EpochVote, Noticer, TaskSpawner, TnReceiver as _,
+    BlsAggregateSignature, BlsPublicKey, BlsSignature, Epoch, EpochCertificate, EpochRecord,
+    EpochVote, ShutdownNotifier, TaskSpawner, TnReceiver as _, TnSender as _,
 };
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
@@ -18,7 +18,7 @@ use tokio::sync::{
 };
 use tracing::{error, info, warn};
 
-type VoteQueue = VecDeque<(Epoch, Sender<EpochVote>, Option<Receiver<EpochVote>>)>;
+type VoteQueue = VecDeque<(Epoch, Sender<EpochVote>)>;
 
 /// Per-iteration wait for the next epoch vote in [`manage_epoch_votes`]'s collection loop.
 pub(crate) const EPOCH_VOTE_RECV_TIMEOUT: Duration = Duration::from_millis(2500);
@@ -63,6 +63,7 @@ async fn manage_epoch_votes(
     primary_network: PrimaryNetworkHandle,
     mut vote_rx: Receiver<EpochVote>,
     consensus_chain: ConsensusChain,
+    node_shutdown: ShutdownNotifier,
 ) {
     let epoch_hash = epoch_rec.digest();
     let mut committee_keys: HashSet<BlsPublicKey> = epoch_rec.committee.iter().copied().collect();
@@ -74,37 +75,24 @@ async fn manage_epoch_votes(
 
     // If we are in the committee, sign and publish our vote
     let me = key_config.primary_public_key();
-    if committee_keys.contains(&me) {
-        committee_keys.remove(&me);
-        let epoch_vote = epoch_rec.sign_vote(&key_config);
-        // The aggregate must hold exactly one signature per bitmap bit, so a
-        // signature is only ever pushed when its authority index is newly
-        // inserted — a redelivered vote can then never desync the two.
-        if let Some(idx) = committee_index.get(&me) {
-            if signed_authorities.insert(*idx as u32) {
-                sigs.push(epoch_vote.signature);
-            }
-        }
-        info!(
-            target: "epoch-manager",
-            "publishing epoch record {epoch_hash}",
-        );
-        let _ = primary_network.publish_epoch_vote(epoch_vote).await;
-        my_vote = Some(epoch_vote);
-    }
     // Collect votes from peers
     let mut reached_quorum = false;
     let mut timeout = EPOCH_VOTE_RECV_TIMEOUT;
     let mut timeouts = 0;
-    let mut alt_recs: HashMap<EpochDigest, usize> = HashMap::default();
     let committee_size = epoch_rec.committee.len() as u64;
     let quorum = epoch_rec.super_quorum();
+    let shutdown = node_shutdown.subscribe();
     loop {
         tokio::select! {
+            _ = &shutdown => return,
             result = tokio::time::timeout(timeout, vote_rx.recv()) => {
                 match result {
                     Ok(None) => break,  // Channel closed- we are done.
                     Ok(Some(vote)) => {
+                        if vote.public_key == me {
+                            // Record our vote if we see it for this epoch so we can revote if/when needed.
+                            my_vote = Some(vote);
+                        }
                         if vote.epoch != epoch_rec.epoch {
                             continue;
                         }
@@ -130,25 +118,12 @@ async fn manage_epoch_votes(
                                 }
                             }
                         } else if vote.epoch_hash != epoch_hash {
-                            // Defense-in-depth: the primary gossip handler now only forwards votes
-                            // whose digest matches the record it holds, so this branch is not
-                            // reached in normal operation (a forked local record instead recovers
-                            // via the epoch-cert download path below).
-                            // Track votes for alternative epoch records — remove key so
-                            // a validator can only vote once (correct or alt), no equivocation.
-                            if committee_keys.remove(&vote.public_key) {
-                                let count = alt_recs.entry(vote.epoch_hash).or_default();
-                                *count += 1;
-                                if *count >= quorum {
-                                    error!(
-                                        target: "epoch-manager",
-                                        "Reached quorum on epoch record {} instead of {}.",
-                                        vote.epoch_hash,
-                                        epoch_hash,
-                                    );
-                                    break;
-                                }
-                            }
+                            error!(
+                                target: "epoch-manager",
+                                "Recieved an epoch record vote for {} instead of {}. This should not be possible (gossip is filtered).",
+                                vote.epoch_hash,
+                                epoch_hash,
+                            );
                         }
                     }
                     Err(_) => {
@@ -173,6 +148,12 @@ async fn manage_epoch_votes(
             target: "epoch-manager",
             "reached quorum on epoch close for {}/{epoch_hash}", epoch_rec.epoch
         );
+        // Republish our vote one final time.  This is not strictly needed but if we were the first
+        // validator to close the epoch and we got no timeouts the laggy validators may have
+        // missed our vote- give them one more chance.
+        if let Some(vote) = my_vote {
+            let _ = primary_network.publish_epoch_vote(vote).await;
+        }
         match BlsAggregateSignature::aggregate(&sigs[..], true) {
             Ok(aggregated_signature) => {
                 let signature: BlsSignature = aggregated_signature.to_signature();
@@ -234,11 +215,12 @@ async fn manage_epoch_votes(
                     {
                         let new_epoch_hash = new_epoch_rec.digest();
                         if new_epoch_hash != epoch_hash {
-                            warn!(
+                            error!(
                                 target: "epoch-manager",
-                                "Over wrote expected epoch record {epoch_hash} with verified epoch record {new_epoch_hash}",
+                                "Network came to consensus on epoch record {new_epoch_hash} we expected epoch record {epoch_hash}, we have forked!",
                             );
-                            save_and_persist_with_logs(&db, new_epoch_rec, cert).await;
+                            // We have forked so shut the node down.
+                            node_shutdown.notify();
                         } else {
                             info!(
                                 target: "epoch-manager",
@@ -265,7 +247,7 @@ async fn manage_epoch_votes(
         if !got_epoch_record {
             error!(
                 target: "epoch-manager",
-                "Failed to retrieve an epoch record for epoch {}",
+                "Failed to retrieve an epoch record for epoch {}- We have a missing epoch certificate, if this is not local then sync will be compromised!",
                 epoch_rec.epoch,
             );
         }
@@ -273,28 +255,23 @@ async fn manage_epoch_votes(
 }
 
 /// Direct a newly received vote to it's task.
-fn get_new_vote_channel(epoch: Epoch, vote_queues: &mut VoteQueue) -> Option<Receiver<EpochVote>> {
-    for q in vote_queues.iter_mut() {
-        if q.0 == epoch {
-            return q.2.take();
-        }
-    }
-    let (epoch_vote_tx, epoch_vote_rx) = mpsc::channel(10_000);
-    if vote_queues.len() >= 5 {
-        vote_queues.pop_front();
-    }
-    vote_queues.push_back((epoch, epoch_vote_tx, None));
-    Some(epoch_vote_rx)
-}
-
-/// Direct a newly received vote to it's task.
-async fn handle_new_vote(vote: EpochVote, vote_queues: &mut VoteQueue) {
+async fn handle_new_vote(
+    vote: EpochVote,
+    vote_queues: &mut VoteQueue,
+    consensus_chain: ConsensusChain,
+    key_config: KeyConfig,
+    primary_network: PrimaryNetworkHandle,
+    task_spawner: &TaskSpawner,
+    node_shutdown: ShutdownNotifier,
+) {
     let mut remove = None;
     let mut found = false;
     for (i, q) in vote_queues.iter().enumerate() {
         if q.0 == vote.epoch {
+            // We already have a collector for this epoch so send to it.
             if q.1.send(vote).await.is_err() {
                 remove = Some(i);
+                break;
             }
             found = true;
             break;
@@ -304,19 +281,36 @@ async fn handle_new_vote(vote: EpochVote, vote_queues: &mut VoteQueue) {
         vote_queues.remove(remove);
     }
     if !found {
-        let latest_epoch = vote_queues.iter().last().map(|q| q.0);
-        if let Some(latest) = latest_epoch {
-            if vote.epoch != latest + 1 {
-                // Only collect for one future epoch.
-                return;
-            }
-        }
+        // We do not have a collector for this epoch so start one and send it this vote.
         let (epoch_vote_tx, epoch_vote_rx) = mpsc::channel(10_000);
+        // If we recieve a valid vote and aren't collecting votes to certify then start.
+        let Some((epoch_rec, None)) =
+            consensus_chain.epochs().get_epoch_by_hash(vote.epoch_hash).await
+        else {
+            // Missing the record or it is certified.  These were pre-checked when the gossip came
+            // in so this should not happen.
+            return;
+        };
+        task_spawner.spawn_task(format!("epoch votes for epoch {}", epoch_rec.epoch), async move {
+            manage_epoch_votes(
+                epoch_rec,
+                key_config,
+                primary_network,
+                epoch_vote_rx,
+                consensus_chain,
+                node_shutdown,
+            )
+            .await;
+            Ok(())
+        });
         if epoch_vote_tx.send(vote).await.is_ok() {
+            // In a properly working system only one collector at a time should run.
+            // Allow some extras though in case we have to handle epoch certification exceptions in
+            // the future.
             if vote_queues.len() >= 5 {
                 vote_queues.pop_front();
             }
-            vote_queues.push_back((vote.epoch, epoch_vote_tx, Some(epoch_vote_rx)));
+            vote_queues.push_back((vote.epoch, epoch_vote_tx));
         }
     }
 }
@@ -332,19 +326,20 @@ pub(crate) fn spawn_epoch_vote_collector(
     key_config: KeyConfig,
     primary_network: PrimaryNetworkHandle,
     node_task_spawner: TaskSpawner,
-    node_shutdown: Noticer,
+    node_shutdown: ShutdownNotifier,
 ) {
     let mut vote_rx = consensus_bus.subscribe_new_epoch_votes();
     let mut epoch_rx = consensus_bus.epoch_record_watch().subscribe();
     let task_spawner = node_task_spawner.clone();
     let mut vote_queues: VoteQueue = VecDeque::with_capacity(5);
+    let shutdown = node_shutdown.subscribe();
 
     node_task_spawner.spawn_critical_task("Epoch Vote Collector", async move {
         loop {
             // Wait for an EpochRecord to arrive
             let epoch_rec = loop {
                 tokio::select! {
-                    _ = &node_shutdown => return Ok(()),
+                    _ = &shutdown => return Ok(()),
                     _ = epoch_rx.changed() => {
                         if let Some(rec) = epoch_rx.borrow_and_update().clone() {
                             break rec;
@@ -354,31 +349,48 @@ pub(crate) fn spawn_epoch_vote_collector(
                         match result {
                             None => return Ok(()),  // Channel closed- we are done.
                             Some(vote) => {
-                                handle_new_vote(vote, &mut vote_queues).await;
+                                handle_new_vote(vote, &mut vote_queues, consensus_chain.clone(), key_config.clone(),
+                                    primary_network.clone(), &task_spawner, node_shutdown.clone()).await;
                             }
                         }
                     }
                 }
             };
 
-            if let Some(epoch_vote_rx) = get_new_vote_channel(epoch_rec.epoch, &mut vote_queues) {
-                let consensus_chain = consensus_chain.clone();
-                let primary_network = primary_network.clone();
-                let key_config = key_config.clone();
-                task_spawner.spawn_task(
-                    format!("epoch votes for epoch {}", epoch_rec.epoch),
-                    async move {
-                        manage_epoch_votes(
-                            epoch_rec,
-                            key_config,
-                            primary_network,
-                            epoch_vote_rx,
-                            consensus_chain,
-                        )
-                        .await;
-                        Ok(())
-                    },
-                );
+            let me = key_config.primary_public_key();
+            if epoch_rec.epoch > 0 {
+                // Lets do a quick check that the previous epoch is certified and if it is not and we were in the committee start a new voting round.
+                if let Some((last_epoch_rec, None)) = consensus_chain.epochs().get_epoch_by_number(epoch_rec.epoch.saturating_sub(1)).await {
+                    // No cert for last epoch.  Were we in the committee?
+                    if last_epoch_rec.committee.contains(&me) {
+                        // If so then lets send a vote out which will trigger a new collection attempt.
+                        let epoch_vote = last_epoch_rec.sign_vote(&key_config);
+                        error!(
+                            target: "epoch-manager",
+                            "Failed to certify last epoch, re-publishing epoch record vote for epoch {} {}", last_epoch_rec.epoch, last_epoch_rec.digest()
+                        );
+                        // Sending our vote to this channel will trigger us to start the vote collector when we get it.
+                        // The other committe members of last epoch should also do the same.
+                        // This should not happen and if it does certification may fail again but retry after an epoch anyway.
+                        let _ = consensus_bus.new_epoch_votes().send(epoch_vote).await;
+                        let _ = primary_network.publish_epoch_vote(epoch_vote).await;
+                    }
+                }
+            }
+            let epoch_hash = epoch_rec.digest();
+            // If we already have a cert (for instance we are catching up) then don't vote.
+            if consensus_chain.epochs().cert_by_digest(epoch_hash).await.is_none() {
+                // If we are in the committee and this epoch is un-certified, sign and publish our vote
+                if epoch_rec.committee.contains(&me) {
+                    let epoch_vote = epoch_rec.sign_vote(&key_config);
+                    info!(
+                        target: "epoch-manager",
+                        "publishing epoch record vote for epoch {} {epoch_hash}", epoch_rec.epoch,
+                    );
+                    // Sending our vote to this channel will trigger us to start the vote collector when we get it.
+                    let _ = consensus_bus.new_epoch_votes().send(epoch_vote).await;
+                    let _ = primary_network.publish_epoch_vote(epoch_vote).await;
+                }
             }
         }
     });
@@ -444,7 +456,7 @@ mod epoch_vote_collector_tests {
     use tn_storage::mem_db::MemDatabase;
     use tn_test_utils::wait_until;
     use tn_test_utils_committee::CommitteeFixture;
-    use tn_types::{BlsKeypair, Notifier, TaskManager, TnSender as _};
+    use tn_types::{BlsKeypair, TaskManager};
 
     /// #1198 startup re-vote: a persisted-but-uncertified latest record re-fires the watch.
     #[tokio::test]
@@ -590,7 +602,7 @@ mod epoch_vote_collector_tests {
         spawn_publish_ack(net_rx);
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         spawn_epoch_vote_collector(
             consensus_chain.clone(),
@@ -598,7 +610,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // Sign votes from the 3 other committee members
@@ -685,7 +697,7 @@ mod epoch_vote_collector_tests {
         });
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         spawn_epoch_vote_collector(
             consensus_chain.clone(),
@@ -693,7 +705,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // Sign votes from the 3 other committee members
@@ -777,7 +789,7 @@ mod epoch_vote_collector_tests {
         });
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         // The node's own vote, as gossip would echo it back
         let echoed_self_vote = epoch_rec.sign_vote(&key_config);
@@ -788,7 +800,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // Buffer the echoed self-vote plus two peer votes: kp1 (self-sign) + kp2 + kp3 = quorum 3
@@ -880,7 +892,7 @@ mod epoch_vote_collector_tests {
         });
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         spawn_epoch_vote_collector(
             consensus_chain.clone(),
@@ -888,7 +900,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // kp2 signs a vote for the ALT epoch record
@@ -981,7 +993,7 @@ mod epoch_vote_collector_tests {
         });
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         spawn_epoch_vote_collector(
             consensus_chain.clone(),
@@ -989,7 +1001,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // The ejected key signs a valid vote for the correct record — must not be counted
@@ -1083,7 +1095,7 @@ mod epoch_vote_collector_tests {
         });
 
         let task_manager = TaskManager::default();
-        let node_shutdown = Notifier::new();
+        let node_shutdown = ShutdownNotifier::new();
 
         spawn_epoch_vote_collector(
             consensus_chain.clone(),
@@ -1091,7 +1103,7 @@ mod epoch_vote_collector_tests {
             key_config,
             primary_network,
             task_manager.get_spawner(),
-            node_shutdown.subscribe(),
+            node_shutdown.clone(),
         );
 
         // Three member votes form quorum without any self-sign from the ejected node

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -299,6 +299,8 @@ async fn handle_new_vote(
             // in so this should not happen.
             return;
         };
+        // Spawn the vote collector in response to a vote if it was missing.
+        // This allows the possibility of recovering a cert with a republished vote even if stale.
         task_spawner.spawn_task(format!("epoch votes for epoch {}", epoch_rec.epoch), async move {
             manage_epoch_votes(
                 epoch_rec,
@@ -419,6 +421,7 @@ pub(crate) fn spawn_epoch_vote_collector(
                     });
                 }
             }
+            // See spawn_epoch_record_collector() for how syncing nodes can keep up there epoch certs if not following the tip.
         }
     });
 }

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -120,7 +120,7 @@ async fn manage_epoch_votes(
                         } else if vote.epoch_hash != epoch_hash {
                             error!(
                                 target: "epoch-manager",
-                                "Recieved an epoch record vote for {} instead of {}. This should not be possible (gossip is filtered).",
+                                "Received an epoch record vote for {} instead of {}. This should not be possible (gossip is filtered).",
                                 vote.epoch_hash,
                                 epoch_hash,
                             );
@@ -360,6 +360,7 @@ pub(crate) fn spawn_epoch_vote_collector(
             let me = key_config.primary_public_key();
             if epoch_rec.epoch > 0 {
                 // Lets do a quick check that the previous epoch is certified and if it is not and we were in the committee start a new voting round.
+                // A syncing node by definition has to have certs for historic epochs so this will not fire during sync.
                 if let Some((last_epoch_rec, None)) = consensus_chain.epochs().get_epoch_by_number(epoch_rec.epoch.saturating_sub(1)).await {
                     // No cert for last epoch.  Were we in the committee?
                     if last_epoch_rec.committee.contains(&me) {
@@ -722,6 +723,11 @@ mod epoch_vote_collector_tests {
         consensus_bus.app().new_epoch_votes().send(vote4).await.unwrap();
 
         // Send the epoch record — collector wakes up, self-signs, reads buffered votes
+        // Seed the uncertified record so the vote-triggered collector's `get_epoch_by_hash`
+        // finds it — production persists the record before firing the watch (see
+        // `write_epoch_record`), so mirror that here.
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
         consensus_bus.app().epoch_record_watch().send_replace(Some(epoch_rec.clone()));
 
         // Wait for collector to aggregate and store
@@ -811,6 +817,11 @@ mod epoch_vote_collector_tests {
         consensus_bus.app().new_epoch_votes().send(epoch_rec.sign_vote(&kc3)).await.unwrap();
 
         // Send the epoch record — collector wakes up, self-signs, reads buffered votes
+        // Seed the uncertified record so the vote-triggered collector's `get_epoch_by_hash`
+        // finds it — production persists the record before firing the watch (see
+        // `write_epoch_record`), so mirror that here.
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
         consensus_bus.app().epoch_record_watch().send_replace(Some(epoch_rec.clone()));
 
         // After reaching quorum the collector waits up to 1s for more votes before aggregating
@@ -922,6 +933,11 @@ mod epoch_vote_collector_tests {
         consensus_bus.app().new_epoch_votes().send(vote4).await.unwrap();
 
         // Send the correct epoch record — collector wakes up, self-signs, reads buffered votes
+        // Seed the uncertified record so the vote-triggered collector's `get_epoch_by_hash`
+        // finds it — production persists the record before firing the watch (see
+        // `write_epoch_record`), so mirror that here.
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
         consensus_bus.app().epoch_record_watch().send_replace(Some(epoch_rec.clone()));
 
         // Wait for collector to aggregate and store.
@@ -1014,6 +1030,11 @@ mod epoch_vote_collector_tests {
         consensus_bus.app().new_epoch_votes().send(epoch_rec.sign_vote(&kc2)).await.unwrap();
 
         // Send the epoch record — collector wakes up, self-signs, reads buffered votes
+        // Seed the uncertified record so the vote-triggered collector's `get_epoch_by_hash`
+        // finds it — production persists the record before firing the watch (see
+        // `write_epoch_record`), so mirror that here.
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
         consensus_bus.app().epoch_record_watch().send_replace(Some(epoch_rec.clone()));
 
         // kp1 (self) + kp2 = 2 < 3: the ejected vote must not tip this over quorum
@@ -1115,6 +1136,11 @@ mod epoch_vote_collector_tests {
         consensus_bus.app().new_epoch_votes().send(epoch_rec.sign_vote(&kc3)).await.unwrap();
 
         // Send the epoch record — the self-sign gate must skip the non-member node key
+        // Seed the uncertified record so the vote-triggered collector's `get_epoch_by_hash`
+        // finds it — production persists the record before firing the watch (see
+        // `write_epoch_record`), so mirror that here.
+        consensus_chain.epochs().save_record(epoch_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
         consensus_bus.app().epoch_record_watch().send_replace(Some(epoch_rec.clone()));
 
         // Quorum (3 of 4) reached without a fourth vote: collector waits its 1s straggler

--- a/crates/node/src/manager/epoch_votes.rs
+++ b/crates/node/src/manager/epoch_votes.rs
@@ -34,6 +34,11 @@ pub(crate) const MAX_EPOCH_VOTE_TIMEOUTS: u32 = 24;
 /// `request_epoch_cert` call) after failing to reach a local vote quorum.
 pub(crate) const EPOCH_CERT_RECOVERY_ATTEMPTS: u32 = 5;
 
+/// Delay before gossiping our freshly-signed epoch vote, so slower nodes can reach the new epoch
+/// and hold its record before our vote arrives (otherwise they drop it and wait for a republish).
+/// The local collector is still seeded immediately; only the outbound gossip is staggered.
+const INITIAL_VOTE_PUBLISH_DELAY: Duration = Duration::from_millis(500);
+
 /// Both save and persist an epoch record and cert with logging.
 async fn save_and_persist_with_logs(
     db: &EpochRecordDb,
@@ -219,7 +224,10 @@ async fn manage_epoch_votes(
                                 target: "epoch-manager",
                                 "Network came to consensus on epoch record {new_epoch_hash} we expected epoch record {epoch_hash}, we have forked!",
                             );
-                            // We have forked so shut the node down.
+                            // We generated a different record than the network certified, so we
+                            // have forked. A fork is not something a node can safely recover from
+                            // (records are deterministic, so ours is simply wrong) — fail-stop
+                            // rather than adopt the network's record and pretend to recover.
                             node_shutdown.notify();
                         } else {
                             info!(
@@ -358,9 +366,19 @@ pub(crate) fn spawn_epoch_vote_collector(
             };
 
             let me = key_config.primary_public_key();
+            // Failsafe for a previous epoch whose certification failed (e.g. some of its committee
+            // were down for an hour or two). It should never fire under normal conditions.
+            //
+            // Deliberately NOT gated on node mode / `is_active_cvv()`: that reflects the CURRENT
+            // committee, but the node we need here was in epoch N-1's committee and may have rotated
+            // out of N's (now an `Observer`) — precisely the node that should re-vote to certify N-1.
+            // Membership in N-1's committee (checked below) is the only correct gate. This is already
+            // sync-safe: state-sync saves each record together with its cert (`epochs().save`) and
+            // never fires `epoch_record_watch`, so a syncing node's historic records are certified and
+            // this arm is skipped.
             if epoch_rec.epoch > 0 {
-                // Lets do a quick check that the previous epoch is certified and if it is not and we were in the committee start a new voting round.
-                // A syncing node by definition has to have certs for historic epochs so this will not fire during sync.
+                // Previous epoch has no cert; if we were in its committee, re-sign and re-publish our
+                // vote to trigger a fresh collection attempt.
                 if let Some((last_epoch_rec, None)) = consensus_chain.epochs().get_epoch_by_number(epoch_rec.epoch.saturating_sub(1)).await {
                     // No cert for last epoch.  Were we in the committee?
                     if last_epoch_rec.committee.contains(&me) {
@@ -390,7 +408,15 @@ pub(crate) fn spawn_epoch_vote_collector(
                     );
                     // Sending our vote to this channel will trigger us to start the vote collector when we get it.
                     let _ = consensus_bus.new_epoch_votes().send(epoch_vote).await;
-                    let _ = primary_network.publish_epoch_vote(epoch_vote).await;
+                    let primary_network_clone = primary_network.clone();
+                    task_spawner.spawn_task("publish_epoch_vote_delayed", async move {
+                        // Stagger the outbound gossip (see INITIAL_VOTE_PUBLISH_DELAY) so slower
+                        // nodes reach the new epoch and hold its record before our vote arrives;
+                        // republishes cover any that still miss it.
+                        tokio::time::sleep(INITIAL_VOTE_PUBLISH_DELAY).await;
+                        let _ = primary_network_clone.publish_epoch_vote(epoch_vote).await;
+                        Ok(())
+                    });
                 }
             }
         }
@@ -452,7 +478,7 @@ mod epoch_vote_collector_tests {
     use tn_network_libp2p::types::{MessageId, NetworkCommand};
     use tn_primary::{
         network::{PrimaryRequest, PrimaryResponse},
-        ConsensusBus,
+        ConsensusBus, NodeMode,
     };
     use tn_storage::mem_db::MemDatabase;
     use tn_test_utils::wait_until;
@@ -1157,6 +1183,104 @@ mod epoch_vote_collector_tests {
         assert!(cert.signed_authorities.contains(2));
 
         // Shutdown
+        node_shutdown.notify();
+    }
+
+    /// The previous-epoch certification failsafe is gated on PREVIOUS-committee membership, NOT on
+    /// node mode. A node that was in epoch N-1's committee but has rotated out of N's committee
+    /// runs as an `Observer` (`is_active_cvv() == false`), yet it must still re-vote to help
+    /// certify an uncertified N-1. Here kp1 is in epoch 0's committee but not epoch 1's; epoch
+    /// 0 needs kp1's failsafe vote to reach quorum, so it certifies only because the failsafe
+    /// is not mode-gated.
+    #[tokio::test]
+    async fn test_previous_epoch_recovery_not_gated_by_node_mode() {
+        let mut rng = StdRng::from_os_rng();
+        let kp1 = BlsKeypair::generate(&mut rng);
+        let kp2 = BlsKeypair::generate(&mut rng);
+        let kp3 = BlsKeypair::generate(&mut rng);
+        let kp4 = BlsKeypair::generate(&mut rng);
+        let pk1 = *kp1.public();
+        let pk2 = *kp2.public();
+        let pk3 = *kp3.public();
+        let pk4 = *kp4.public();
+
+        // Node is kp1: in epoch 0's committee (super_quorum 3) but rotated OUT of epoch 1's.
+        let key_config = KeyConfig::new_with_testing_key(kp1);
+
+        // Previous epoch (0): uncertified, kp1 in committee — the failsafe target.
+        let prev_rec = EpochRecord {
+            epoch: 0,
+            committee: vec![pk1, pk2, pk3, pk4],
+            next_committee: vec![pk2, pk3, pk4],
+            ..Default::default()
+        };
+        let prev_hash = prev_rec.digest();
+        // Current epoch (1): kp1 is NOT in this committee (rotated out).
+        let cur_rec = EpochRecord {
+            epoch: 1,
+            committee: vec![pk2, pk3, pk4],
+            next_committee: vec![pk2, pk3, pk4],
+            ..Default::default()
+        };
+
+        let consensus_bus = ConsensusBus::new();
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let temp_dir = TempDir::with_prefix("prev_epoch_recovery_not_gated").unwrap();
+        let consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), fixture.committee())
+                .await
+                .unwrap();
+
+        // Seed both records uncertified so the collector's `get_epoch_by_*` lookups find them.
+        consensus_chain.epochs().save_record(prev_rec.clone()).await.unwrap();
+        consensus_chain.epochs().save_record(cur_rec.clone()).await.unwrap();
+        consensus_chain.epochs().persist().await.unwrap();
+
+        // Mock network: drain and ack publishes.
+        let (net_tx, mut net_rx) =
+            tokio::sync::mpsc::channel::<NetworkCommand<PrimaryRequest, PrimaryResponse>>(100);
+        let primary_network = PrimaryNetworkHandle::new_for_test(net_tx);
+        tokio::spawn(async move {
+            while let Some(cmd) = net_rx.recv().await {
+                if let NetworkCommand::Publish { reply, .. } = cmd {
+                    let _ = reply.send(Ok(MessageId::new(b"test")));
+                }
+            }
+        });
+
+        let task_manager = TaskManager::default();
+        let node_shutdown = ShutdownNotifier::new();
+
+        // kp1 rotated out of epoch 1's committee, so it runs as an Observer — is_active_cvv() is
+        // false. The failsafe must still fire because kp1 was in epoch 0's committee.
+        consensus_bus.app().node_mode().send_replace(NodeMode::Observer);
+
+        spawn_epoch_vote_collector(
+            consensus_chain.clone(),
+            consensus_bus.app().clone(),
+            key_config,
+            primary_network,
+            task_manager.get_spawner(),
+            node_shutdown.clone(),
+        );
+
+        // Two epoch-0 peers vote — one short of quorum(3). Only kp1's failsafe vote can complete
+        // it.
+        let kc2 = KeyConfig::new_with_testing_key(kp2);
+        let kc3 = KeyConfig::new_with_testing_key(kp3);
+        consensus_bus.app().new_epoch_votes().send(prev_rec.sign_vote(&kc2)).await.unwrap();
+        consensus_bus.app().new_epoch_votes().send(prev_rec.sign_vote(&kc3)).await.unwrap();
+
+        // Epoch 1 arriving triggers the previous-epoch failsafe for epoch 0.
+        consensus_bus.app().epoch_record_watch().send_replace(Some(cur_rec.clone()));
+
+        // Despite the Observer mode, the failsafe re-votes for epoch 0 and completes quorum.
+        wait_until(Duration::from_secs(5), "epoch 0 certified via failsafe", || async {
+            Ok(consensus_chain.epochs().cert_by_digest(prev_hash).await.is_some())
+        })
+        .await
+        .unwrap();
+
         node_shutdown.notify();
     }
 }

--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -749,7 +749,7 @@ where
             self.key_config.clone(),
             primary_network_handle.clone(),
             node_task_manager.get_spawner(),
-            self.node_shutdown.subscribe(),
+            self.node_shutdown.clone(),
         );
 
         // Re-vote from durable storage on restart (issue #1198): the collector above is armed

--- a/crates/storage/src/db_bench.rs
+++ b/crates/storage/src/db_bench.rs
@@ -291,7 +291,7 @@ fn run_battery<DB: Database>(rt: &Runtime, db: &DB) -> Vec<(&'static str, Durati
         ("clear_table 50k", bench_clear_table(rt, db)),
         // Representative node-usage patterns (each resets its own table first).
         ("small_commits 500 x3", bench_small_commits(rt, db)),
-        ("durable_commits 50 x3", bench_durable_commits(rt, db)),
+        ("durable_commits 500 x3", bench_durable_commits(rt, db)),
         ("cert_writes 5k x1.5KB", bench_cert_writes(rt, db)),
         ("batch_writes 200 x256KB", bench_batch_writes(rt, db)),
         ("epoch_clear 20k", bench_epoch_clear(rt, db)),

--- a/crates/storage/src/epoch_records.rs
+++ b/crates/storage/src/epoch_records.rs
@@ -72,6 +72,10 @@ enum EpochDbMessage {
     /// so the caller pays a single actor round trip instead of a record read followed by a
     /// separate cert read.
     EpochByNumber(Epoch, oneshot::Sender<Option<(EpochRecord, Option<EpochCertificate>)>>),
+    /// Retrieve an [`EpochRecord`] and its certificate (if stored) by record digest in one turn,
+    /// so the caller pays a single actor round trip instead of a record read followed by a
+    /// separate cert read.
+    EpochByHash(EpochDigest, oneshot::Sender<Option<(EpochRecord, Option<EpochCertificate>)>>),
     /// True if the database contains a record for the given epoch number.
     ContainsEpoch(Epoch, oneshot::Sender<bool>),
     /// True if the database contains a dummy record for the given epoch 0.
@@ -165,6 +169,17 @@ fn run_db_loop(
                 // interleaving between the two reads. Same failure-collapsing semantics as the
                 // separate `RecordByEpoch`/`CertByDigest` arms.
                 let result = match inner.record_by_epoch(epoch) {
+                    Some(record) => {
+                        let cert = inner.cert_by_digest(record.digest());
+                        Some((record, cert))
+                    }
+                    None => None,
+                };
+                let _ = tx.send(result);
+            }
+            EpochDbMessage::EpochByHash(hash, tx) => {
+                // Same single-turn atomic snapshot as `EpochByNumber`, keyed by record digest.
+                let result = match inner.record_by_digest(hash) {
                     Some(record) => {
                         let cert = inner.cert_by_digest(record.digest());
                         Some((record, cert))
@@ -867,13 +882,19 @@ impl EpochRecordDb {
     }
 
     /// Retrieve the epoch record and certificate (if available) by record digest.
+    ///
+    /// One actor round trip: the record and cert are resolved together on the background thread
+    /// (see [`EpochDbMessage::EpochByHash`]) rather than as two separate lookups.
     pub async fn get_epoch_by_hash(
         &self,
         hash: EpochDigest,
     ) -> Option<(EpochRecord, Option<EpochCertificate>)> {
-        let record = self.record_by_digest(hash).await?;
-        let cert = self.cert_by_digest(record.digest()).await;
-        Some((record, cert))
+        let (tx, rx) = oneshot::channel();
+        if self.tx.send(EpochDbMessage::EpochByHash(hash, tx)).await.is_ok() {
+            rx.await.unwrap_or(None)
+        } else {
+            None
+        }
     }
 
     /// Write a bounded export bundle covering epochs `0..=through_epoch` into fresh records/certs


### PR DESCRIPTION
This should stream line it, make it more DOS resistant and easier to recover if something goes wrong.  It also acknowledges that epoch records are deterministic and drops trying to "recover"- that is a fork.