### PR TITLE
fix(cli): reject --instance 0 at parse time

### DIFF
--- a/crates/telcoin-network-cli/README.md
+++ b/crates/telcoin-network-cli/README.md
@@ -297,7 +297,7 @@ telcoin-network node \
 | Flag                  | Default        | Description                                                                                    |
 | --------------------- | -------------- | ---------------------------------------------------------------------------------------------- |
 | `--chain`             | none           | Join a named network (`adiri`, `testnet`, `mainnet`)                                           |
-| `--instance`          | none           | Instance number (0-200) for port offsetting. See [Multi-instance setup](#multi-instance-setup) |
+| `--instance`          | none           | Instance number (1-200) for port offsetting. See [Multi-instance setup](#multi-instance-setup) |
 | `--observer`          | `false`        | Run as an observer (no consensus participation)                                                |
 | `--metrics`           | none           | Enable Prometheus metrics at this socket address (e.g. `127.0.0.1:9101`)                       |
 | `--healthcheck`       | none           | TCP health check port. Env: `HEALTHCHECK_TCP_PORT`                                             |
@@ -588,7 +588,7 @@ RUST_LOG=info,consensus=debug,evm=trace telcoin-network node ...
 
 ## Multi-instance setup
 
-The `--instance` flag adjusts port numbers so multiple nodes can run on the same machine without conflicts. Instance numbers range from 0 to 200. This configuration is only recommended for spawning local networks and should not be used in production environments.
+The `--instance` flag adjusts port numbers so multiple nodes can run on the same machine without conflicts. Instance numbers range from 1 to 200; the CLI rejects 0 before the node starts (earlier releases accepted 0 and derived conflicting ports from it). This configuration is only recommended for spawning local networks and should not be used in production environments.
 
 Note: `--instance` does NOT offset `--metrics` (or `--healthcheck`) — pass a distinct
 address per instance, as in the example below.
@@ -599,7 +599,7 @@ address per instance, as in the example below.
 | ------------- | -------------------- | --------------- | --------------- | --------------- |
 | HTTP RPC      | `8545 - N + 1`       | 8545            | 8544            | 8543            |
 | WebSocket RPC | `8546 + (N * 2 - 2)` | 8546            | 8548            | 8550            |
-| IPC path      | `/tmp/tn-{N}.ipc`    | `/tmp/tn-1.ipc` | `/tmp/tn-2.ipc` | `/tmp/tn-3.ipc` |
+| IPC path      | `/tmp/tn.ipc-{N}`    | `/tmp/tn.ipc-1` | `/tmp/tn.ipc-2` | `/tmp/tn.ipc-3` |
 
 Example starting four validators on one machine:
 

--- a/crates/telcoin-network-cli/src/node.rs
+++ b/crates/telcoin-network-cli/src/node.rs
@@ -44,14 +44,15 @@ pub struct NodeCommand<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Configures the ports of the node to avoid conflicts with the defaults.
     /// This is useful for running multiple nodes on the same machine.
     ///
-    /// Max number of instances is 200. It is chosen in a way so that it's not possible to have
-    /// port numbers that conflict with each other.
+    /// Instance numbers run from 1 to 200. The max is chosen in a way so that it's not possible
+    /// to have port numbers that conflict with each other. 0 is rejected at parse time: the port
+    /// arithmetic below subtracts `instance - 1`, which underflows on 0.
     ///
     /// Changes to the following port numbers:
     /// - `HTTP_RPC_PORT`: default - `instance` + 1
     /// - `WS_RPC_PORT`: default + `instance` * 2 - 2
     /// - `IPC_PATH`: default + `-instance`
-    #[arg(long, value_name = "INSTANCE", global = true,  value_parser = value_parser!(u16).range(..=200))]
+    #[arg(long, value_name = "INSTANCE", global = true,  value_parser = value_parser!(u16).range(1..=200))]
     pub instance: Option<u16>,
 
     /// Is this an observer node?  True if set, an observer will never be in the committee
@@ -275,7 +276,34 @@ fn genesis_block_hash(genesis: Genesis) -> B256 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::error::ErrorKind;
     use tn_types::adiri_genesis;
+
+    /// Parse `--instance <raw>` through the node command and return the parsed value, or the
+    /// clap error kind that rejected it.
+    fn parse_instance(raw: &str) -> Result<Option<u16>, ErrorKind> {
+        NodeCommand::<NoArgs>::try_parse_from(["node", "--instance", raw])
+            .map(|cmd| cmd.instance)
+            .map_err(|err| err.kind())
+    }
+
+    /// `--instance 0` must fail at parse time. reth's `adjust_instance_ports` computes
+    /// `instance - 1` on `u16`, so 0 panics under overflow checks and wraps in release (instance
+    /// 0 then takes HTTP port 8546, instance 1's WebSocket port). The upper bound is reth's too.
+    #[test]
+    fn instance_rejects_zero_and_above_max_at_parse() {
+        let rejected = ["0", "201"].map(parse_instance);
+        assert_eq!(rejected, [Err(ErrorKind::ValueValidation), Err(ErrorKind::ValueValidation)]);
+    }
+
+    /// Both ends of the documented `1-200` range parse, and an absent flag stays `None`.
+    #[test]
+    fn instance_accepts_documented_bounds() {
+        let accepted = ["1", "200"].map(parse_instance);
+        assert_eq!(accepted, [Ok(Some(1)), Ok(Some(200))]);
+        let absent = NodeCommand::<NoArgs>::try_parse_from(["node"]).map(|cmd| cmd.instance);
+        assert!(matches!(absent, Ok(None)));
+    }
 
     /// A faucet build configured with the canonical mainnet genesis must refuse to start.
     #[test]

--- a/crates/tn-reth/src/cli.rs
+++ b/crates/tn-reth/src/cli.rs
@@ -521,6 +521,30 @@ mod tests {
         assert_eq!(config.0.txpool.max_account_slots, RETH_MAX_ACCOUNT_SLOTS_PER_SENDER);
     }
 
+    /// The `--instance` port offsets the CLI README documents, checked against the values reth's
+    /// `adjust_instance_ports` resolves from TN's defaults: instance 1 keeps the defaults, each
+    /// further instance moves HTTP down by one and WebSocket up by two, and the IPC suffix is
+    /// appended to the configured path (`/tmp/tn.ipc-2`, not `/tmp/tn-2.ipc`).
+    ///
+    /// The CLI rejects instance 0 at parse time (`telcoin-network-cli`), so the smallest value
+    /// it can hand this function is 1 and the `instance - 1` below never underflows on that path.
+    #[test]
+    fn instance_port_offsets_match_documented_table() -> eyre::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let resolve = |instance: u16| -> eyre::Result<(u16, u16, String)> {
+            let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+            let reth_command = RethCommand::try_parse_from(["tn-reth"])?;
+            let config =
+                RethConfig::new(reth_command, Some(instance), tmp_dir.path(), false, chain);
+            Ok((config.0.rpc.http_port, config.0.rpc.ws_port, config.0.rpc.ipcpath))
+        };
+
+        assert_eq!(resolve(1)?, (8545, 8546, format!("{DEFAULT_IPC_ENDPOINT}-1")));
+        assert_eq!(resolve(2)?, (8544, 8548, format!("{DEFAULT_IPC_ENDPOINT}-2")));
+        assert_eq!(resolve(3)?, (8543, 8550, format!("{DEFAULT_IPC_ENDPOINT}-3")));
+        Ok(())
+    }
+
     /// Build a config the way `new_for_temp_chain` does, then hand its [`PruningArgs`] to `enable`
     /// so a test can turn on exactly one prune knob.
     ///


### PR DESCRIPTION
Closes #1233.

## Problem

`telcoin-network node --instance 0` is accepted by the CLI. The value reaches reth's `NodeConfig::adjust_instance_ports`, which computes `instance - 1` and `instance * 100 - 100` on `u16`:

- Debug, test and `e2e` profile builds (overflow checks on): the node panics at startup with `instance must be non-zero`.
- Release builds (`etc/Dockerfile`, `etc/local-testnet.sh`; no `[profile.release]` in the workspace, so overflow checks are off): the arithmetic wraps. Instance 0 binds HTTP on 8546, which is instance 1's WebSocket port, and writes its IPC socket at `/tmp/tn.ipc-0`. The flag's own guarantee ("not possible to have port numbers that conflict with each other") does not hold.

The CLI README made the bad value look valid: it documented the range as `0-200` and "Instance numbers range from 0 to 200". Its port table also had the IPC row wrong on its own (`/tmp/tn-{N}.ipc`; reth appends the suffix to the configured path, so instance 1 gets `/tmp/tn.ipc-1`).

Raised by shotes on the Cantina collaborative review (comment on `RethConfig::new`). Low severity: operator footgun on a local-network flag, no consensus or funds impact. Nothing in-tree passes 0 (`etc/local-testnet.sh` uses `INSTANCE=$((i+1))`).

## Root cause

`crates/telcoin-network-cli/src/node.rs` declares the flag as `value_parser!(u16).range(..=200)`. The lower bound is open, so clap accepts 0. The reth flag this one is copied from (`crates/cli/commands/src/node.rs` at v1.11.3) uses `range(1..=200)`.

## Fix

- [x] `crates/telcoin-network-cli/src/node.rs`: `.range(..=200)` -> `.range(1..=200)`, same bound as reth. clap now rejects 0 with a value-validation error before any port arithmetic runs. The field's doc comment (which is also the `--help` text) states the `1..=200` range and why 0 is out.
- [x] `crates/telcoin-network-cli/README.md`: flag table `0-200` -> `1-200`; multi-instance section `0 to 200` -> `1 to 200`, with a note that the CLI rejects 0; IPC row of the port table corrected to `/tmp/tn.ipc-{N}`.
- [x] `crates/telcoin-network-cli/src/node.rs` tests: `instance_rejects_zero_and_above_max_at_parse` (`0` and `201` fail with `ErrorKind::ValueValidation`) and `instance_accepts_documented_bounds` (`1` and `200` parse; an absent flag stays `None`).
- [x] `crates/tn-reth/src/cli.rs` tests: `instance_port_offsets_match_documented_table` builds `RethConfig::new` for instances 1, 2 and 3 and asserts the resolved HTTP port, WebSocket port and IPC path equal the README table, so the table and the code stay tied. This is the first port assertion on `RethConfig::new`.

Out of scope, as the issue marks it optional: carrying the instance as `NonZeroU16` through `RethConfig::new`. clap's `.range()` only applies to `TryFrom<i64>` integer types, so that would need a custom value parser for a bound clap already enforces.

## Testing

Pinned toolchain (`rust-toolchain.toml`, 1.94):

```
cargo +1.94 test -p telcoin-network-cli --lib -- node::tests
cargo +1.94 test -p tn-reth --lib -- cli::tests
cargo +nightly fmt --all -- --check
```

Both targets green under the pin (8 passed / 0 failed each, the three new tests included); nightly `fmt --check` clean. CI's nightly fmt/clippy ladder and the full nextest workspace run fire on push; the pinned `+1.94 --workspace` attest runs on the second machine.

Mutation checks on the new tests:

- Reverting the bound to `.range(..=200)` makes `instance_rejects_zero_and_above_max_at_parse` fail on the `0` case (`Ok(Some(0))` where `Err(ValueValidation)` is expected); `201` still rejects, so the failure isolates the lower bound.
- Asserting the README's previous IPC row (`/tmp/tn-1.ipc`) in `instance_port_offsets_match_documented_table` fails against the resolved `/tmp/tn.ipc-1`, so the test reaches reth's arithmetic rather than restating the table.

Both mutations were run and failed exactly there (rc 101), and the restored tree re-ran green.
