### PR TITLE
TEL precompile follow-ups: event mirror, harness fidelity, rejection gas

### DIFF
--- a/crates/tn-reth/src/evm/bls_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/bls_precompile/mod.rs
@@ -253,9 +253,20 @@ mod tests {
         .abi_encode()
     }
 
-    /// Decodes the ABI-encoded `bool` returned by a `blsVerify` call.
+    /// Decodes the ABI-encoded `bool` returned by a `blsVerify` call, pinning the return to the
+    /// canonical 32-byte word rather than only its decoded value.
+    ///
+    /// The decoder is more permissive than the ABI it decodes, so decoding alone would not catch a
+    /// regression in the return encoding. It reads one word and ignores every trailing byte, so an
+    /// over-wide return still decodes (`vec![false].abi_encode()` decodes as `true` - the leading
+    /// offset word is read as the bool), and it detokenizes any non-zero word to `true`, so a
+    /// dirty word such as `0x00..02` decodes as `true` too. The validating `abi_decode_validate`
+    /// closes neither: it only requires the leading 31 bytes to be zero. The round-trip equality -
+    /// not the decode - is therefore what pins the width and canonicity.
     fn decode_bool(bytes: &[u8]) -> bool {
-        <bool as SolValue>::abi_decode(bytes).expect("decode bool return")
+        let decoded = <bool as SolValue>::abi_decode(bytes).expect("decode bool return");
+        assert_eq!(bytes, decoded.abi_encode(), "return is the canonical 32-byte ABI bool");
+        decoded
     }
 
     // --- `bls_verify` crypto semantics -----------------------------------------------------------

--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -38,6 +38,10 @@ use tn_types::{Bytes, TxKind, U256};
 /// precompile.
 pub use crate::evm::tel_precompile::test_utils::GENESIS_SUPPLY;
 
+/// Halt classification, re-exported so tests can name the reason
+/// [`assert_halt_consuming_all_gas`] hands back without importing revm themselves.
+pub use reth_revm::context::result::{HaltReason, OutOfGasError};
+
 // --- Type aliases ---
 
 /// EVM context type used by the test harness, backed by an [`InMemoryDB`].
@@ -66,6 +70,12 @@ pub const USER: Address = address!("1111100000000000000000000000000000000001");
 
 /// Test address used as a transfer/mint recipient in unit and integration tests.
 pub const RECIPIENT: Address = address!("2222222000000000000000000000000000000002");
+
+/// Gas limit [`TestEnv::exec_default`] attaches to a call.
+///
+/// Named so tests that assert on gas consumption can refer to the same number the call was given
+/// instead of repeating the literal.
+pub const DEFAULT_GAS_LIMIT: u64 = 100_000;
 
 /// Code deployed at [`TELCOIN_PRECOMPILE_ADDRESS`] in genesis: a bare `INVALID` opcode.
 ///
@@ -282,9 +292,9 @@ impl TestEnv {
         self.exec_value_to(caller, TELCOIN_PRECOMPILE_ADDRESS, calldata, gas_limit, value)
     }
 
-    /// Execute a precompile call with the default gas limit (100,000).
+    /// Execute a precompile call with [`DEFAULT_GAS_LIMIT`].
     pub fn exec_default(&mut self, caller: Address, calldata: Vec<u8>) -> TestResult {
-        self.exec(caller, calldata, 100_000)
+        self.exec(caller, calldata, DEFAULT_GAS_LIMIT)
     }
 
     /// Read the native account balance of `account`.
@@ -351,6 +361,28 @@ pub fn assert_not_success(result: &TestResult) {
     if let Ok(ExecutionResult::Success { .. }) = result {
         panic!("expected non-success, got Success")
     }
+}
+
+/// Assert that the result is `Ok(ExecutionResult::Halt { .. })` charged the full `gas_limit`, and
+/// return the halt reason.
+///
+/// A precompile rejection is a halt rather than a revert, and revm hands back unspent gas only for
+/// instruction results that are `is_ok_or_revert()`. A rejected top-level transaction is therefore
+/// charged its whole `gas_limit`, and a rejected sub-call loses the entire 63/64 it was forwarded.
+///
+/// [`assert_not_success`] cannot hold that line: it accepts `Err`, `Revert`, and `Halt` alike, so a
+/// revm change or a dispatcher rewrite that turned a rejection into a gas-refunding revert would
+/// leave every rejection test green while the documented gas semantics silently changed. Use this
+/// helper in the tests that exist to back that claim, and keep [`assert_not_success`] for the ones
+/// that only care that the call did not go through.
+///
+/// Panics on `Err(..)`, on `Ok(Success { .. })`, on `Ok(Revert { .. })`, and on a halt whose
+/// `gas_used` is not exactly `gas_limit`.
+pub fn assert_halt_consuming_all_gas(result: &TestResult, gas_limit: u64) -> &HaltReason {
+    let r = result.as_ref().expect("expected Ok(Halt), got Err");
+    let ExecutionResult::Halt { reason, gas_used } = r else { panic!("expected Halt, got {r:?}") };
+    assert_eq!(*gas_used, gas_limit, "a halt spends the whole gas limit");
+    reason
 }
 
 /// Extract the logs emitted by a successful execution, in emission order.

--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -67,6 +67,13 @@ pub const USER: Address = address!("1111100000000000000000000000000000000001");
 /// Test address used as a transfer/mint recipient in unit and integration tests.
 pub const RECIPIENT: Address = address!("2222222000000000000000000000000000000002");
 
+/// Code deployed at [`TELCOIN_PRECOMPILE_ADDRESS`] in genesis: a bare `INVALID` opcode.
+///
+/// The precompile map short-circuits before any bytecode load, so this is never executed. It
+/// exists so the account is not EIP-158-empty when its balance is zero, matching
+/// `chain-configs/mainnet/genesis.yaml`.
+const PRECOMPILE_GENESIS_CODE: Bytes = Bytes::from_static(&[0xfe]);
+
 // --- Test environment ---
 
 /// Lightweight in-memory EVM environment for testing the native precompiles.
@@ -81,8 +88,9 @@ pub const RECIPIENT: Address = address!("222222200000000000000000000000000000000
 /// - [`GOVERNANCE_SAFE_ADDRESS`] — governance caller
 /// - [`USER`] — unprivileged caller
 ///
-/// The TEL precompile account at [`TELCOIN_PRECOMPILE_ADDRESS`] is funded with 1000 wei and
-/// seeded with [`GENESIS_SUPPLY`] in `totalSupply`.
+/// The TEL precompile account at [`TELCOIN_PRECOMPILE_ADDRESS`] is funded with 1000 wei, given
+/// the same `0xfe` code mainnet genesis assigns it, and seeded with [`GENESIS_SUPPLY`] in
+/// `totalSupply`.
 #[derive(Debug)]
 pub struct TestEnv {
     /// The EVM instance with in-memory state and the precompiles registered.
@@ -128,13 +136,20 @@ impl TestEnv {
             },
         );
 
+        // Mirror the mainnet genesis account for the precompile: zero nonce, the requested
+        // balance, and `0xfe` code (`chain-configs/mainnet/genesis.yaml`). The code is what keeps
+        // the account out of EIP-158 state clearing once its balance drains to zero, so tests that
+        // burn the pool empty exercise the same account shape production has. An empty account
+        // here would only diverge once something finalizes the journal, which this harness never
+        // does, but the divergence is free to remove.
+        let precompile_code = Bytecode::new_raw(PRECOMPILE_GENESIS_CODE);
         db.insert_account_info(
             TELCOIN_PRECOMPILE_ADDRESS,
             AccountInfo {
                 balance: precompile_bal,
                 nonce: 0,
-                code_hash: KECCAK_EMPTY,
-                code: None,
+                code_hash: precompile_code.hash_slow(),
+                code: Some(precompile_code),
                 ..Default::default()
             },
         );

--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -10,10 +10,13 @@
 //! `tel_precompile::test_utils` as an extension of
 //! [`TestEnv`]. The stateless BLS precompile needs no extra harness.
 
-use crate::evm::{
-    bls_precompile::add_bls_precompile,
-    context::{TNEvmContext, TelcoinEvm},
-    tel_precompile::{add_telcoin_precompile, TELCOIN_PRECOMPILE_ADDRESS},
+use crate::{
+    evm::{
+        bls_precompile::add_bls_precompile,
+        context::{TNEvmContext, TelcoinEvm},
+        tel_precompile::{add_telcoin_precompile, TELCOIN_PRECOMPILE_ADDRESS},
+    },
+    system_calls::PRECOMPILE_GENESIS_BYTECODE,
 };
 use alloy_evm::precompiles::PrecompilesMap;
 use reth_revm::{
@@ -76,13 +79,6 @@ pub const RECIPIENT: Address = address!("222222200000000000000000000000000000000
 /// Named so tests that assert on gas consumption can refer to the same number the call was given
 /// instead of repeating the literal.
 pub const DEFAULT_GAS_LIMIT: u64 = 100_000;
-
-/// Code deployed at [`TELCOIN_PRECOMPILE_ADDRESS`] in genesis: a bare `INVALID` opcode.
-///
-/// The precompile map short-circuits before any bytecode load, so this is never executed. It
-/// exists so the account is not EIP-158-empty when its balance is zero, matching
-/// `chain-configs/mainnet/genesis.yaml`.
-const PRECOMPILE_GENESIS_CODE: Bytes = Bytes::from_static(&[0xfe]);
 
 // --- Test environment ---
 
@@ -147,12 +143,15 @@ impl TestEnv {
         );
 
         // Mirror the mainnet genesis account for the precompile: zero nonce, the requested
-        // balance, and `0xfe` code (`chain-configs/mainnet/genesis.yaml`). The code is what keeps
-        // the account out of EIP-158 state clearing once its balance drains to zero, so tests that
-        // burn the pool empty exercise the same account shape production has. An empty account
-        // here would only diverge once something finalizes the journal, which this harness never
-        // does, but the divergence is free to remove.
-        let precompile_code = Bytecode::new_raw(PRECOMPILE_GENESIS_CODE);
+        // balance, and the bare `INVALID` byte `chain-configs/mainnet/genesis.yaml` assigns
+        // `0x7e1`, taken from `PRECOMPILE_GENESIS_BYTECODE` rather than restated here so the
+        // harness cannot drift from the constant the rest of the crate builds genesis accounts
+        // from. The precompile map short-circuits before any bytecode load, so the byte never
+        // executes; it is there to keep the account out of EIP-158 state clearing once its balance
+        // drains to zero, so tests that burn the pool empty exercise the same account shape
+        // production has. An empty account here would only diverge once something finalizes the
+        // journal, which this harness never does, but the divergence is free to remove.
+        let precompile_code = Bytecode::new_raw(Bytes::from_static(PRECOMPILE_GENESIS_BYTECODE));
         db.insert_account_info(
             TELCOIN_PRECOMPILE_ADDRESS,
             AccountInfo {
@@ -340,6 +339,70 @@ impl Default for TestEnv {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// --- Gas probe bytecode ---
+
+/// Call opcode a [`gas_probe_code`] probe uses to reach the precompile.
+///
+/// The variant fixes both the opcode byte and the operand count: `CALL` takes seven stack
+/// operands, `DELEGATECALL` and `STATICCALL` take six, having no `value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeCall {
+    /// `CALL` (`0xf1`) — a direct frame; the only one of the three carrying `value`.
+    Call,
+    /// `DELEGATECALL` (`0xf4`) — an indirect frame, refused by the direct-call guard.
+    DelegateCall,
+    /// `STATICCALL` (`0xfa`) — a read-only frame, refused for every mutating selector.
+    StaticCall,
+}
+
+/// Runtime bytecode that measures what a sub-call into `0x7e1` costs its caller.
+///
+/// Reads `GAS` on either side of a `call`-family instruction that forwards everything available to
+/// the precompile, and returns three words: the gas the frame held before the call, the call's
+/// success flag, and the gas it held after. Nothing propagates the inner failure, so the probe
+/// frame returns normally and the three words reach the transaction output even when the callee
+/// halts — which is the point, since a relay that reverted on failure would erase the measurement.
+///
+/// Disassembly (the `value` push is emitted for [`ProbeCall::Call`] only):
+/// ```text
+///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+///   GAS                                            // gas before
+///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize,
+///                                                  // argsOffset
+///   PUSH1 0                                        // value (CALL only)
+///   PUSH2 0x07e1; GAS; <CALL|DELEGATECALL|STATICCALL>
+///   GAS                                            // gas after
+///   PUSH1 0x40; MSTORE                             // mem[64] = gas after
+///   PUSH1 0x20; MSTORE                             // mem[32] = success flag
+///   PUSH1 0x00; MSTORE                             // mem[0]  = gas before
+///   PUSH1 0x60; PUSH1 0; RETURN                    // return those three words
+/// ```
+pub fn gas_probe_code(call: ProbeCall) -> Bytes {
+    let (opcode, pushes_value) = match call {
+        ProbeCall::Call => (0xf1, true),
+        ProbeCall::DelegateCall => (0xf4, false),
+        ProbeCall::StaticCall => (0xfa, false),
+    };
+    let mut code = vec![
+        0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+        0x5a, // GAS -> gas before
+        0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
+        0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
+    ];
+    if pushes_value {
+        code.extend_from_slice(&[0x60, 0x00]); // value = 0
+    }
+    code.extend_from_slice(&[
+        0x61, 0x07, 0xe1, 0x5a, opcode, // PUSH2 0x07e1; GAS; <call opcode>
+        0x5a,   // GAS -> gas after
+        0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
+        0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
+        0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
+        0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
+    ]);
+    code.into()
 }
 
 // --- Assertion helpers ---

--- a/crates/tn-reth/src/evm/precompile_test_utils.rs
+++ b/crates/tn-reth/src/evm/precompile_test_utils.rs
@@ -25,7 +25,7 @@ use reth_revm::{
     db::InMemoryDB,
     handler::{instructions::EthInstructions, EthPrecompiles, Handler, MainnetHandler},
     inspector::NoOpInspector,
-    primitives::{address, Address, KECCAK_EMPTY},
+    primitives::{address, Address, Log, KECCAK_EMPTY},
     state::AccountInfo,
     Database, MainContext,
 };
@@ -351,6 +351,13 @@ pub fn assert_not_success(result: &TestResult) {
     if let Ok(ExecutionResult::Success { .. }) = result {
         panic!("expected non-success, got Success")
     }
+}
+
+/// Extract the logs emitted by a successful execution, in emission order.
+///
+/// Panics if the result is not a success.
+pub fn extract_logs(result: &TestResult) -> &[Log] {
+    assert_success(result).logs()
 }
 
 /// Extract the raw output bytes from a successful execution result.

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -123,6 +123,8 @@ After `claim` succeeds, both the amount and timestamp storage slots are zeroed, 
 
 Token holdings are native account balances, so any direct value transfer (e.g., `CALL` with value) changes a holder's TEL balance without going through the precompile. Off-chain indexers that track issuance/destruction must watch the precompile's `Mint`, `Claim`, `Burn`, and `Transfer(0x0,…)`/`Transfer(…,0x0)` events; ordinary user-to-user TEL movement is observable as native value transfers in transaction traces.
 
+One movement into the precompile does have an event: `burn` is payable, and the wei it receives arrives through the EVM's own transfer, which emits nothing. `handle_burn` therefore emits `Transfer(caller, 0x7e1, msg.value)` before the burn events whenever the call carries value, so an indexer reconstructing TEL as an ERC-20 from these logs never sees the pool pay out wei it was not seen receiving. The mirror reports the attached value, which may exceed the burned amount — the excess stays in the pool and is destroyed by a later `burn`.
+
 ### Total supply accounting
 
 `totalSupply` is only updated by `claim` (increment) and `burn` (decrement). It does **not** account for native balance changes outside the precompile (e.g., gas fees, coinbase rewards). The genesis value must be set correctly at chain initialization.
@@ -190,16 +192,19 @@ Native-balance mutations (`balance_incr` / `balance_decr` in `claim`, `burn`, an
 
 ### `burn` — 8,000 gas
 
-| Operation                | Access                | Gas        |
-| ------------------------ | --------------------- | ---------- |
-| load_account(precompile) | cold                  | 2,600      |
-| SLOAD totalSupply        | cold                  | 2,100      |
-| SSTORE totalSupply       | warm, nonzero→nonzero | 2,900      |
-| LOG1 (Burn, 32 B)        | —                     | 1,006      |
-| LOG3 (Transfer, 32 B)    | —                     | 1,756      |
-| **Total**                |                       | **10,362** |
+| Operation                     | Access                | Gas        |
+| ----------------------------- | --------------------- | ---------- |
+| load_account(precompile)      | cold                  | 2,600      |
+| SLOAD totalSupply             | cold                  | 2,100      |
+| SSTORE totalSupply            | warm, nonzero→nonzero | 2,900      |
+| LOG3 (inbound Transfer, 32 B) | value-funded only     | 1,756      |
+| LOG1 (Burn, 32 B)             | —                     | 1,006      |
+| LOG3 (Transfer, 32 B)         | —                     | 1,756      |
+| **Total**                     |                       | **12,118** |
 
-**Status: Undercharged** — 0.77× headroom. Gas constant is 2,362 below worst-case EVM cost.
+**Status: Undercharged** — 0.66× headroom. Gas constant is 4,118 below worst-case EVM cost. A
+zero-value burn skips the inbound `Transfer` and costs 10,362 (0.77× headroom). Burning is
+governance-only, so the subsidy is not reachable by untrusted callers.
 
 ### `mint` (faucet) — 30,000 gas
 

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -101,6 +101,19 @@ This matters because staticcall-into-precompile is a live pattern in this codeba
 
 Four regression tests pin both directions, reaching the precompile through the `STATICCALL` relay in `crates/tn-reth/tests/it/precompile_relays.rs`: `test_staticcall_cannot_mutate_precompile_state` and `test_staticcall_still_serves_read_only_selectors` (mainnet, in `tel_precompile_props.rs`), and `test_staticcall_cannot_grant_mint_role` and `test_staticcall_still_serves_has_mint_role` (`faucet`, in `tel_precompile_faucet_props.rs`).
 
+### Rejection semantics: halt, not revert
+
+Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. revm maps that to `InstructionResult::PrecompileError`, which is a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and a precompile error is neither.
+
+So a rejected call is not a cheap failure:
+
+- A **sub-call** into `0x7e1` loses the entire 63/64 of the caller's gas that was forwarded to it, leaving the calling frame the 1/64 it withheld.
+- A **top-level transaction** is charged its full `gas_limit` and reported as `Halt`, not `Revert`.
+
+The `false` a rejected `CALL` pushes on the stack is therefore not usefully actionable. A contract written as "forward `msg.value` into `0x7e1`, then branch on the returned boolean" reaches the branch with 1/64 of its gas and, in practice, dies there — a pattern worth noting because a value-bearing call that used to succeed (for example `0x7e1.call{value: v}(totalSupply())`, which cost ~2,100 before the payability gate) now consumes the caller's whole budget.
+
+This behaviour is not new with the payability gate; the `STATICCALL` refusal has always had it, and the gates match each other on purpose. Consuming the limit is the EVM's ordinary price for an invalid operation, and reaching either gate means the caller violated a documented rule. Callers should satisfy those rules up front — do not attach value to anything but `burn`, do not reach mutating selectors from a static frame — rather than expecting to detect the rejection and continue.
+
 ### Timelock bypass (`faucet` feature)
 
 The `faucet` feature **removes the 7-day timelock** on minting. A mainnet binary must never be compiled with this feature enabled. The feature is set at compile time — there is no runtime toggle.

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -114,7 +114,9 @@ Four regression tests pin both directions, reaching the precompile through the `
 
 ### Rejection semantics: halt, not revert
 
-Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own gas-limit precheck, `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. revm maps `PrecompileError::OutOfGas`, which is what the `gas_limit < GAS_COST` precheck in each handler returns, to `InstructionResult::PrecompileOOG`, and every other variant to `InstructionResult::PrecompileError` (`revm-handler`'s `precompile_provider.rs`). Both are a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and neither halt is.
+Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own gas-limit precheck, `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. The provider that runs `0x7e1` is `alloy-evm`'s `PrecompilesMap` — `add_telcoin_precompile` registers into that map, and the factory names it as the EVM's `Precompiles` type — so `PrecompilesMap::run` (`alloy-evm`'s `precompiles.rs`) is what maps `PrecompileError::OutOfGas`, which is what the `gas_limit < GAS_COST` precheck in each handler returns, to `InstructionResult::PrecompileOOG`, and every other variant to `InstructionResult::PrecompileError`. Both are a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and neither halt is.
+
+Which provider runs is load-bearing rather than a citation detail. revm's own `EthPrecompiles` makes the identical split, but it additionally stashes the error string for a call at journal depth 1, which `revm-handler`'s `post_execution.rs` promotes to `HaltReason::PrecompileErrorWithContext(message)`. `PrecompilesMap` stashes nothing, so a rejected top-level call here halts with the bare `HaltReason::PrecompileError` and surfaces no reason on the receipt at all — which is what the unit tests in `mod.rs` assert, and what makes the "the halt carries no message" claim in `docs/src/evm-compatibility.md` true.
 
 So a rejected call is not a cheap failure:
 
@@ -141,6 +143,8 @@ Token holdings are native account balances, so any direct value transfer (e.g., 
 
 One movement into the precompile does have an event: `burn` is payable, and the wei it receives arrives through the EVM's own transfer, which emits nothing. `handle_burn` therefore emits `Transfer(caller, 0x7e1, msg.value)` before the burn events whenever the call carries value, so an indexer reconstructing TEL as an ERC-20 from these logs never sees the pool pay out wei it was not seen receiving. The mirror reports the attached value, which may exceed the burned amount — the excess stays in the pool and is destroyed by a later `burn`.
 
+That mirror makes the log stream a complete account of the pool's balance across every path that runs precompile code, which is not the same as every path. `SELFDESTRUCT` remains a logless inlet: under EIP-6780 (active from genesis, `cancunTime: 0`) the beneficiary credit still happens — only the account deletion was removed — so a contract self-destructing to `0x7e1` tops the pool up with no log and no precompile frame to observe it, and a later `burn` of that wei emits an outbound `Transfer` for wei nothing was seen sending. The precompile cannot see such a credit, so there is nothing to emit; an indexer should reconcile against the account's native balance rather than treat the log stream as closed.
+
 ### Total supply accounting
 
 `totalSupply` is only updated by `claim` (increment) and `burn` (decrement). It does **not** account for native balance changes outside the precompile (e.g., gas fees, coinbase rewards). The genesis value must be set correctly at chain initialization.
@@ -152,7 +156,7 @@ The genesis account at `0x7e1` is `nonce: "0x0"`, `balance: "0x0"`, `code: "0xfe
 - It keeps the account non-empty, so EIP-158 state clearing never prunes it. An account with zero nonce, zero balance, and no code is deleted at the end of any block that touches it, which would silently wipe the `totalSupply` slot at slot 100 and every pending mint. The precompile's balance legitimately drains to zero after a `burn` of the whole pool, so this is a reachable state, not a theoretical one.
 - It makes a call that bypasses precompile dispatch fail rather than succeed against an EOA. With no code, `0x7e1` is an EOA and a plain call to it returns success; `INVALID` halts the frame instead. The constant's own doc also notes that reth skips calls to accounts with no bytecode, which the code field avoids.
 
-Anything that seeds state under `0x7e1` — a faucet mint role, for example — must extend this account rather than replace it; dropping the `code` field reintroduces the pruning bug. `faucet_mint_role_slot` in `mod.rs` carries the same warning, and the in-memory harness gives its precompile account the identical shape so tests that burn the pool empty exercise the production account shape (`crates/tn-reth/src/evm/precompile_test_utils.rs:75`, `:139-155`).
+Anything that seeds state under `0x7e1` — a faucet mint role, for example — must extend this account rather than replace it; dropping the `code` field reintroduces the pruning bug. `faucet_mint_role_slot` in `mod.rs` carries the same warning, and the in-memory harness gives its precompile account the identical shape — reading the same `PRECOMPILE_GENESIS_BYTECODE` rather than restating the byte — so tests that burn the pool empty exercise the production account shape (`TestEnv::new_with_balances` in `crates/tn-reth/src/evm/precompile_test_utils.rs`).
 
 ## Gas costs
 
@@ -217,19 +221,21 @@ Native-balance mutations (`balance_incr` / `balance_decr` in `claim`, `burn`, an
 
 ### `burn` — 8,000 gas
 
-| Operation                     | Access                | Gas        |
-| ----------------------------- | --------------------- | ---------- |
-| load_account(precompile)      | cold                  | 2,600      |
-| SLOAD totalSupply             | cold                  | 2,100      |
-| SSTORE totalSupply            | warm, nonzero→nonzero | 2,900      |
-| LOG3 (inbound Transfer, 32 B) | value-funded only     | 1,756      |
-| LOG1 (Burn, 32 B)             | —                     | 1,006      |
-| LOG3 (Transfer, 32 B)         | —                     | 1,756      |
-| **Total**                     |                       | **12,118** |
+| Operation                     | Access                       | Gas       |
+| ----------------------------- | ---------------------------- | --------- |
+| load_account(precompile)      | warm (pre-warmed precompile) | 100       |
+| SLOAD totalSupply             | cold                         | 2,100     |
+| SSTORE totalSupply            | warm, nonzero→nonzero        | 2,900     |
+| LOG3 (inbound Transfer, 32 B) | value-funded only            | 1,756     |
+| LOG1 (Burn, 32 B)             | —                            | 1,006     |
+| LOG3 (Transfer, 32 B)         | —                            | 1,756     |
+| **Total**                     |                              | **9,618** |
 
-**Status: Undercharged** — 0.66× headroom. Gas constant is 4,118 below worst-case EVM cost. A
-zero-value burn skips the inbound `Transfer` and costs 10,362 (0.77× headroom). Burning is
-governance-only, so the subsidy is not reachable by untrusted callers.
+**Status: Undercharged on a value-funded burn only** — 0.83× headroom, 1,618 below worst case. A
+zero-value burn skips the inbound `Transfer`, costs 7,862, and is fully covered (1.02×). This is
+the one table whose `load_account` targets the precompile's own account rather than a recipient:
+revm pre-warms every registered precompile address before any frame runs, so `0x7e1` is never cold
+here. Burning is governance-only, so the subsidy is not reachable by untrusted callers.
 
 ### `mint` (faucet) — 30,000 gas
 

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -113,6 +113,8 @@ After `claim` succeeds, both the amount and timestamp storage slots are zeroed, 
 
 Token holdings are native account balances, so any direct value transfer (e.g., `CALL` with value) changes a holder's TEL balance without going through the precompile. Off-chain indexers that track issuance/destruction must watch the precompile's `Mint`, `Claim`, `Burn`, and `Transfer(0x0,…)`/`Transfer(…,0x0)` events; ordinary user-to-user TEL movement is observable as native value transfers in transaction traces.
 
+One movement into the precompile does have an event: `burn` is payable, and the wei it receives arrives through the EVM's own transfer, which emits nothing. `handle_burn` therefore emits `Transfer(caller, 0x7e1, msg.value)` before the burn events whenever the call carries value, so an indexer reconstructing TEL as an ERC-20 from these logs never sees the pool pay out wei it was not seen receiving. The mirror reports the attached value, which may exceed the burned amount — the excess stays in the pool and is destroyed by a later `burn`.
+
 ### Total supply accounting
 
 `totalSupply` is only updated by `claim` (increment) and `burn` (decrement). It does **not** account for native balance changes outside the precompile (e.g., gas fees, coinbase rewards). The genesis value must be set correctly at chain initialization.
@@ -180,16 +182,19 @@ Native-balance mutations (`balance_incr` / `balance_decr` in `claim`, `burn`, an
 
 ### `burn` — 8,000 gas
 
-| Operation                | Access                | Gas        |
-| ------------------------ | --------------------- | ---------- |
-| load_account(precompile) | cold                  | 2,600      |
-| SLOAD totalSupply        | cold                  | 2,100      |
-| SSTORE totalSupply       | warm, nonzero→nonzero | 2,900      |
-| LOG1 (Burn, 32 B)        | —                     | 1,006      |
-| LOG3 (Transfer, 32 B)    | —                     | 1,756      |
-| **Total**                |                       | **10,362** |
+| Operation                     | Access                | Gas        |
+| ----------------------------- | --------------------- | ---------- |
+| load_account(precompile)      | cold                  | 2,600      |
+| SLOAD totalSupply             | cold                  | 2,100      |
+| SSTORE totalSupply            | warm, nonzero→nonzero | 2,900      |
+| LOG3 (inbound Transfer, 32 B) | value-funded only     | 1,756      |
+| LOG1 (Burn, 32 B)             | —                     | 1,006      |
+| LOG3 (Transfer, 32 B)         | —                     | 1,756      |
+| **Total**                     |                       | **12,118** |
 
-**Status: Undercharged** — 0.77× headroom. Gas constant is 2,362 below worst-case EVM cost.
+**Status: Undercharged** — 0.66× headroom. Gas constant is 4,118 below worst-case EVM cost. A
+zero-value burn skips the inbound `Transfer` and costs 10,362 (0.77× headroom). Burning is
+governance-only, so the subsidy is not reachable by untrusted callers.
 
 ### `mint` (faucet) — 30,000 gas
 

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -111,6 +111,19 @@ This matters because staticcall-into-precompile is a live pattern in this codeba
 
 Four regression tests pin both directions, reaching the precompile through the `STATICCALL` relay in `crates/tn-reth/tests/it/precompile_relays.rs`: `test_staticcall_cannot_mutate_precompile_state` and `test_staticcall_still_serves_read_only_selectors` (mainnet, in `tel_precompile_props.rs`), and `test_staticcall_cannot_grant_mint_role` and `test_staticcall_still_serves_has_mint_role` (`faucet`, in `tel_precompile_faucet_props.rs`).
 
+### Rejection semantics: halt, not revert
+
+Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. revm maps that to `InstructionResult::PrecompileError`, which is a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and a precompile error is neither.
+
+So a rejected call is not a cheap failure:
+
+- A **sub-call** into `0x7e1` loses the entire 63/64 of the caller's gas that was forwarded to it, leaving the calling frame the 1/64 it withheld.
+- A **top-level transaction** is charged its full `gas_limit` and reported as `Halt`, not `Revert`.
+
+The `false` a rejected `CALL` pushes on the stack is therefore not usefully actionable. A contract written as "forward `msg.value` into `0x7e1`, then branch on the returned boolean" reaches the branch with 1/64 of its gas and, in practice, dies there — a pattern worth noting because a value-bearing call that used to succeed (for example `0x7e1.call{value: v}(totalSupply())`, which cost ~2,100 before the payability gate) now consumes the caller's whole budget.
+
+This behaviour is not new with the payability gate; the `STATICCALL` refusal has always had it, and the gates match each other on purpose. Consuming the limit is the EVM's ordinary price for an invalid operation, and reaching either gate means the caller violated a documented rule. Callers should satisfy those rules up front — do not attach value to anything but `burn`, do not reach mutating selectors from a static frame — rather than expecting to detect the rejection and continue.
+
 ### Timelock bypass (`faucet` feature)
 
 The `faucet` feature **removes the 7-day timelock** on minting. A mainnet binary must never be compiled with this feature enabled. The feature is set at compile time — there is no runtime toggle.

--- a/crates/tn-reth/src/evm/tel_precompile/README.md
+++ b/crates/tn-reth/src/evm/tel_precompile/README.md
@@ -12,7 +12,7 @@ The precompile is registered as a `DynPrecompile` inside reth's `PrecompilesMap`
 | `burnable.rs`   | Timelocked `mint`/`claim` lifecycle, `burn`, and the `totalSupply()` view (mainnet)            |
 | `faucet.rs`     | Instant `mint` with role management (testnet, `faucet` feature)                                |
 | `helpers.rs`    | Storage slot derivation + balance manipulation helpers                                         |
-| `test_utils.rs` | In-memory EVM test harness (gated behind `#[cfg(test)]` / `test-utils` feature)                |
+| `test_utils.rs` | TEL-specific test helpers on top of the shared harness in `../precompile_test_utils.rs` (gated behind `#[cfg(test)]` / `test-utils` feature) |
 
 ## Storage layout
 
@@ -42,13 +42,14 @@ claim(recipient)  →  [if block.timestamp >= unlock_ts]
                      totalSupply += amount
                      clear pending slots
 
-burn(amount)  →  precompile.balance -= amount  (sent to address(0))
+burn(amount)  →  [msg.value, if attached, was already credited to precompile.balance]
+                 precompile.balance -= amount  (sent to address(0))
                  totalSupply -= amount
 ```
 
 - **`mint`**: Governance-only. Creates a pending mint with a 7-day timelock. A second `mint` overwrites the previous pending amount (can be used to cancel by minting 0).
 - **`claim`**: Governance-only. Finalizes the pending mint after the timelock has expired.
-- **`burn`**: Governance-only. Destroys tokens held by the precompile's own account.
+- **`burn`**: Governance-only, and the only payable selector. Destroys tokens held by the precompile's own account. Attached `msg.value` is credited to that account by the EVM before the handler runs, so it tops up the pool the burn draws from: `msg.value == amount` funds and burns in one transaction, and any excess stays in the pool for a later `burn`. See "Native balance equivalence" for the log that mirrors the top-up.
 
 ### Testnet (`faucet` feature)
 
@@ -113,14 +114,16 @@ Four regression tests pin both directions, reaching the precompile through the `
 
 ### Rejection semantics: halt, not revert
 
-Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. revm maps that to `InstructionResult::PrecompileError`, which is a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and a precompile error is neither.
+Every rejection the precompile issues — the `STATICCALL` refusal above, the `call value: selector is not payable` refusal, an unrecognised selector, and each handler's own gas-limit precheck, `unauthorized`, calldata-length, and arithmetic errors — is a `PrecompileError`. revm maps `PrecompileError::OutOfGas`, which is what the `gas_limit < GAS_COST` precheck in each handler returns, to `InstructionResult::PrecompileOOG`, and every other variant to `InstructionResult::PrecompileError` (`revm-handler`'s `precompile_provider.rs`). Both are a **halt**, not a revert, and a halt consumes every unit of gas the frame was given: unspent gas is returned only for results that are `is_ok_or_revert()`, and neither halt is.
 
 So a rejected call is not a cheap failure:
 
 - A **sub-call** into `0x7e1` loses the entire 63/64 of the caller's gas that was forwarded to it, leaving the calling frame the 1/64 it withheld.
 - A **top-level transaction** is charged its full `gas_limit` and reported as `Halt`, not `Revert`.
 
-The `false` a rejected `CALL` pushes on the stack is therefore not usefully actionable. A contract written as "forward `msg.value` into `0x7e1`, then branch on the returned boolean" reaches the branch with 1/64 of its gas and, in practice, dies there — a pattern worth noting because a value-bearing call that used to succeed (for example `0x7e1.call{value: v}(totalSupply())`, which cost ~2,100 before the payability gate) now consumes the caller's whole budget.
+The `false` a rejected `CALL` pushes on the stack is therefore not usefully actionable. A contract written as "forward `msg.value` into `0x7e1`, then branch on the returned boolean" reaches the branch with 1/64 of its gas and, in practice, dies there. The change bites hardest on a value-bearing call that used to succeed: `0x7e1.call{value: v}(totalSupply())` cost on the order of 9,000 gas before the payability gate, and now consumes the caller's whole budget.
+
+The precompile's own 2,100 charge is the small part of that 9,000. `CALL` charges 100 for the account access (revm pre-warms every registered precompile address, so `0x7e1` is never cold) plus a flat 9,000 for attaching nonzero value. That 9,000 buys the callee a 2,300 gas stipend on top of the forwarded gas, which more than covers the 2,100, so 200 of it comes back unspent: `100 + 9,000 + 2,100 - 2,300 = 8,900` net, before the caller's own memory and calldata costs. The 25,000 empty-account surcharge never applies, because the genesis `0x7e1` account carries code (see "Genesis account and the `0xfe` code" below).
 
 This behaviour is not new with the payability gate; the `STATICCALL` refusal has always had it, and the gates match each other on purpose. Consuming the limit is the EVM's ordinary price for an invalid operation, and reaching either gate means the caller violated a documented rule. Callers should satisfy those rules up front — do not attach value to anything but `burn`, do not reach mutating selectors from a static frame — rather than expecting to detect the rejection and continue.
 
@@ -134,13 +137,22 @@ After `claim` succeeds, both the amount and timestamp storage slots are zeroed, 
 
 ### Native balance equivalence
 
-Token holdings are native account balances, so any direct value transfer (e.g., `CALL` with value) changes a holder's TEL balance without going through the precompile. Off-chain indexers that track issuance/destruction must watch the precompile's `Mint`, `Claim`, `Burn`, and `Transfer(0x0,…)`/`Transfer(…,0x0)` events; ordinary user-to-user TEL movement is observable as native value transfers in transaction traces.
+Token holdings are native account balances, so any direct value transfer (e.g., `CALL` with value) changes a holder's TEL balance without going through the precompile. Off-chain indexers that track issuance/destruction must watch the precompile's `Mint`, `Claim`, `Burn`, the `Transfer(0x0,…)`/`Transfer(…,0x0)` mint and burn legs, and the inbound `Transfer(caller, 0x7e1, msg.value)` a value-funded `burn` emits (below — neither of its legs is `0x0`); ordinary user-to-user TEL movement is observable as native value transfers in transaction traces.
 
 One movement into the precompile does have an event: `burn` is payable, and the wei it receives arrives through the EVM's own transfer, which emits nothing. `handle_burn` therefore emits `Transfer(caller, 0x7e1, msg.value)` before the burn events whenever the call carries value, so an indexer reconstructing TEL as an ERC-20 from these logs never sees the pool pay out wei it was not seen receiving. The mirror reports the attached value, which may exceed the burned amount — the excess stays in the pool and is destroyed by a later `burn`.
 
 ### Total supply accounting
 
 `totalSupply` is only updated by `claim` (increment) and `burn` (decrement). It does **not** account for native balance changes outside the precompile (e.g., gas fees, coinbase rewards). The genesis value must be set correctly at chain initialization.
+
+### Genesis account and the `0xfe` code
+
+The genesis account at `0x7e1` is `nonce: "0x0"`, `balance: "0x0"`, `code: "0xfe"` (`chain-configs/mainnet/genesis.yaml:46-49`). That code is a single `0xfe` (`INVALID`) byte, defined once as `PRECOMPILE_GENESIS_BYTECODE` in `crates/tn-reth/src/system_calls.rs:47-54`. The precompile map short-circuits before any bytecode load, so the byte never executes; it is there for what its presence does to the account:
+
+- It keeps the account non-empty, so EIP-158 state clearing never prunes it. An account with zero nonce, zero balance, and no code is deleted at the end of any block that touches it, which would silently wipe the `totalSupply` slot at slot 100 and every pending mint. The precompile's balance legitimately drains to zero after a `burn` of the whole pool, so this is a reachable state, not a theoretical one.
+- It makes a call that bypasses precompile dispatch fail rather than succeed against an EOA. With no code, `0x7e1` is an EOA and a plain call to it returns success; `INVALID` halts the frame instead. The constant's own doc also notes that reth skips calls to accounts with no bytecode, which the code field avoids.
+
+Anything that seeds state under `0x7e1` — a faucet mint role, for example — must extend this account rather than replace it; dropping the `code` field reintroduces the pruning bug. `faucet_mint_role_slot` in `mod.rs` carries the same warning, and the in-memory harness gives its precompile account the identical shape so tests that burn the pool empty exercise the production account shape (`crates/tn-reth/src/evm/precompile_test_utils.rs:75`, `:139-155`).
 
 ## Gas costs
 
@@ -259,20 +271,24 @@ governance-only, so the subsidy is not reachable by untrusted callers.
 
 ## Testing
 
-Test infrastructure lives in `test_utils.rs` and is the single source of truth for both unit tests (in each module's `#[cfg(test)] mod tests`) and integration tests (in `crates/tn-reth/tests/it/`).
+The shared in-memory EVM harness lives in `crates/tn-reth/src/evm/precompile_test_utils.rs`; `test_utils.rs` in this directory layers the TEL token helpers (`mint`, `get_total_supply`, `set_total_supply`, `GENESIS_SUPPLY`) onto it. Together they are the single source of truth for both unit tests (in each module's `#[cfg(test)] mod tests`) and integration tests (in `crates/tn-reth/tests/it/`).
 
 Example: read totalSupply by calling `0x18160ddd` with no arguments.
 
+CI and `make test` both run the suite through nextest (`.github/workflows/pr.yaml`, `Makefile:111`), so use nextest here too:
+
 ```bash
-# Unit tests (mainnet mint)
-cargo test -p tn-reth --lib tel_precompile
+# Unit tests (mainnet)
+cargo nextest run -p tn-reth --features test-utils --lib -E 'test(tel_precompile)'
 
-# Unit tests (faucet mint)
-cargo test -p tn-reth --lib tel_precompile --features faucet
+# Integration tests (mainnet)
+cargo nextest run -p tn-reth --features test-utils --test it -E 'test(tel_precompile)'
 
-# Integration tests
-cargo test -p tn-reth --features test-utils --test it -- tel_precompile
+# Unit tests (faucet)
+cargo nextest run -p tn-reth --features "test-utils,faucet" --lib -E 'test(tel_precompile)'
 
-# Integration tests with faucet
-cargo test -p tn-reth --features "test-utils,faucet" --test it -- tel_precompile
+# Integration tests (faucet)
+cargo nextest run -p tn-reth --features "test-utils,faucet" --test it -E 'test(tel_precompile)'
 ```
+
+`-E 'test(tel_precompile)'` matches the full test path, so `--lib` selects the `evm::tel_precompile::*` unit tests and `--test it` selects the matching modules under `crates/tn-reth/tests/it/`. All four commands are needed because the `faucet` feature changes which tests compile rather than merely adding to them. The integration sets are disjoint — `tel_precompile_props` and `pipeline_tel_precompile_props` compile only on mainnet, `tel_precompile_faucet_props` only under `faucet` — and the unit sets overlap without either containing the other, since some mainnet unit tests do not compile under `faucet`.

--- a/crates/tn-reth/src/evm/tel_precompile/burnable.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/burnable.rs
@@ -4,7 +4,12 @@
 //! 1. **`mint(uint256)`** — governance creates a pending mint with a 7-day timelock.
 //! 2. **`claim(address)`** — only governance can finalize the mint after the timelock expires,
 //!    crediting governance safe's native balance and incrementing `totalSupply`.
-//! 3. **`burn(uint256)`** — governance destroys tokens held by the precompile account.
+//! 3. **`burn(uint256)`** — governance destroys tokens held by the precompile account. `burn` is
+//!    the one payable selector: the EVM credits attached `msg.value` to the precompile before the
+//!    handler runs, topping up the pool the burn draws from, so `msg.value == amount` funds and
+//!    burns in one transaction and any excess stays in the pool for a later `burn`. That transfer
+//!    happens inside the EVM and emits nothing, so the handler mirrors it as an inbound
+//!    `Transfer(caller, precompile, msg.value)` log ahead of the burn events.
 //!
 //! The timelock provides a safety window for governance to cancel malicious mints before
 //! tokens enter circulation. A second `mint` call **overwrites** any pending mint, which

--- a/crates/tn-reth/src/evm/tel_precompile/burnable.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/burnable.rs
@@ -55,7 +55,8 @@ sol! {
     event Claim(address indexed recipient, uint256 amount);
     /// Emitted when tokens are burned.
     event Burn(uint256 amount);
-    /// Emitted when tokens are minted (from address(0)) or burned (to address(0)).
+    /// Emitted when tokens are minted (from address(0)), burned (to address(0)), or sent to the
+    /// precompile as call value funding a `burn`.
     event Transfer(address indexed from, address indexed to, uint256 value);
 }
 
@@ -342,6 +343,14 @@ pub(super) fn handle_claim(
 ///
 /// Decrements the precompile's native balance by `amount`, then decrements `totalSupply`.
 ///
+/// `value` is the call value the EVM credited to the precompile before this handler ran. The
+/// dispatcher's payability gate admits it for this selector alone, and only when the precompile is
+/// the actual transfer target, so nonzero `value` is always `caller` topping up the pool this
+/// handler draws from. That transfer happens inside the EVM and emits nothing, so the handler
+/// mirrors it as `Transfer(caller, precompile, value)` ahead of the burn events: an indexer
+/// reconstructing TEL as an ERC-20 from these logs would otherwise watch tokens leave a pool they
+/// were never seen entering, and drift negative.
+///
 /// # Access control
 /// Governance-only via [`has_governance_role`].
 pub(super) fn handle_burn(
@@ -349,14 +358,17 @@ pub(super) fn handle_burn(
     calldata: &[u8],
     caller: Address,
     gas_limit: u64,
+    value: U256,
 ) -> PrecompileResult {
     /// Flat charge for destroying tokens held by the precompile.
     ///
     /// A cold `load_account` of the precompile itself (`2_600`), a cold `SLOAD` plus warm
-    /// `nonzero -> nonzero` `SSTORE` of the supply slot (`2_100 + 2_900`), and the `Burn` and
-    /// `Transfer` logs (`1_006 + 1_756`): `10_362` total. At `8_000` this covers `0.77x` of the
-    /// worst case, so `burn` is **undercharged** by `2_362` relative to equivalent Solidity.
-    /// Burning is governance-only, so the subsidy is not reachable by untrusted callers.
+    /// `nonzero -> nonzero` `SSTORE` of the supply slot (`2_100 + 2_900`), the `Burn` and
+    /// `Transfer` logs (`1_006 + 1_756`), and — on a value-funded burn only — the inbound
+    /// `Transfer` mirroring the top-up (`1_756`): `12_118` total. At `8_000` this covers `0.66x`
+    /// of the worst case, so `burn` is **undercharged** by `4_118` relative to equivalent
+    /// Solidity. Burning is governance-only, so the subsidy is not reachable by untrusted
+    /// callers.
     ///
     /// Derived in this module's `README.md`, "Gas costs" / "`burn`".
     const GAS_COST: u64 = 8_000;
@@ -388,6 +400,22 @@ pub(super) fn handle_burn(
     internals
         .sstore(TELCOIN_PRECOMPILE_ADDRESS, TOTAL_SUPPLY_SLOT, new_supply)
         .map_err(|e| PrecompileError::Other(format!("sstore failed: {e:?}").into()))?;
+
+    // Emit Transfer(caller, precompile, value) — mirrors the EVM's own silent value transfer
+    // that funded this burn, keeping the event log a complete account of the pool's balance.
+    if !value.is_zero() {
+        let funding_log = reth_revm::primitives::Log::new(
+            TELCOIN_PRECOMPILE_ADDRESS,
+            vec![
+                Transfer::SIGNATURE_HASH,
+                caller.into_word(),
+                TELCOIN_PRECOMPILE_ADDRESS.into_word(),
+            ],
+            value.to_be_bytes_vec().into(),
+        )
+        .ok_or_else(|| PrecompileError::Other("Failed to create Transfer log".into()))?;
+        internals.log(funding_log);
+    }
 
     // Emit Burn(uint256 amount)
     let topic0 = Burn::SIGNATURE_HASH;

--- a/crates/tn-reth/src/evm/tel_precompile/burnable.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/burnable.rs
@@ -367,12 +367,13 @@ pub(super) fn handle_burn(
 ) -> PrecompileResult {
     /// Flat charge for destroying tokens held by the precompile.
     ///
-    /// A cold `load_account` of the precompile itself (`2_600`), a cold `SLOAD` plus warm
-    /// `nonzero -> nonzero` `SSTORE` of the supply slot (`2_100 + 2_900`), the `Burn` and
-    /// `Transfer` logs (`1_006 + 1_756`), and — on a value-funded burn only — the inbound
-    /// `Transfer` mirroring the top-up (`1_756`): `12_118` total. At `8_000` this covers `0.66x`
-    /// of the worst case, so `burn` is **undercharged** by `4_118` relative to equivalent
-    /// Solidity. Burning is governance-only, so the subsidy is not reachable by untrusted
+    /// A warm `load_account` of the precompile itself (`100`: revm pre-warms every registered
+    /// precompile address, so `0x7e1` is never cold), a cold `SLOAD` plus warm `nonzero ->
+    /// nonzero` `SSTORE` of the supply slot (`2_100 + 2_900`), and the `Burn` and `Transfer` logs
+    /// (`1_006 + 1_756`): `7_862` for a zero-value burn, which the flat `8_000` covers in full
+    /// (`1.02x`). A value-funded burn adds the inbound `Transfer` mirroring the top-up (`1_756`)
+    /// for `9_618`, and is therefore **undercharged** by `1_618` (`0.83x`) relative to equivalent
+    /// Solidity. Burning is governance-only, so that subsidy is not reachable by untrusted
     /// callers.
     ///
     /// Derived in this module's `README.md`, "Gas costs" / "`burn`".
@@ -406,8 +407,13 @@ pub(super) fn handle_burn(
         .sstore(TELCOIN_PRECOMPILE_ADDRESS, TOTAL_SUPPLY_SLOT, new_supply)
         .map_err(|e| PrecompileError::Other(format!("sstore failed: {e:?}").into()))?;
 
-    // Emit Transfer(caller, precompile, value) — mirrors the EVM's own silent value transfer
-    // that funded this burn, keeping the event log a complete account of the pool's balance.
+    // Emit Transfer(caller, precompile, value) — mirrors the EVM's own silent value transfer that
+    // funded this burn, keeping the event log a complete account of the pool's balance across
+    // every path that runs precompile code. One inlet stays outside those paths: under EIP-6780 a
+    // `SELFDESTRUCT` naming 0x7e1 as beneficiary still transfers its balance (only the account
+    // deletion was removed), crediting the pool with no log and no frame here to observe it. An
+    // indexer should reconcile against the account's native balance rather than treat this log
+    // stream as closed.
     if !value.is_zero() {
         let funding_log = reth_revm::primitives::Log::new(
             TELCOIN_PRECOMPILE_ADDRESS,

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -193,7 +193,9 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 /// balance, a plain value send reverts on the calldata-length check above, and the genesis
 /// account starts with zero balance, so attaching value to `burn(amount)` is the sanctioned inlet
 /// for the pool it draws from: `msg.value == amount` funds and burns in one transaction, and any
-/// excess stays in the pool for later burns. The classification is a payable-list rather than a
+/// excess stays in the pool for later burns. The EVM's own transfer of that value emits nothing,
+/// so [`handle_burn`](burnable::handle_burn) mirrors it as an inbound `Transfer` log — see there.
+/// The classification is a payable-list rather than a
 /// reject-list for the same fail-safe reason as the static gate: a selector added later rejects
 /// value unless it is explicitly named payable, and an unrecognised value-bearing selector
 /// reports [`NON_PAYABLE_CALL_VALUE`] rather than `"Unknown function selector"`. Inside a
@@ -244,9 +246,13 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
         burnable::claimCall::SELECTOR => {
             burnable::handle_claim(&mut input.internals, calldata, input.caller, input.gas)
         }
-        burnable::burnCall::SELECTOR => {
-            burnable::handle_burn(&mut input.internals, calldata, input.caller, input.gas)
-        }
+        burnable::burnCall::SELECTOR => burnable::handle_burn(
+            &mut input.internals,
+            calldata,
+            input.caller,
+            input.gas,
+            input.value,
+        ),
         // Read-only functions
         burnable::totalSupplyCall::SELECTOR => {
             burnable::handle_total_supply(&mut input.internals, input.gas)
@@ -278,7 +284,7 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
 mod tests {
     use super::*;
     use crate::evm::precompile_test_utils::*;
-    use alloy::sol_types::SolCall;
+    use alloy::sol_types::{SolCall, SolEvent};
     use tn_config::GOVERNANCE_SAFE_ADDRESS;
 
     #[test]
@@ -353,6 +359,59 @@ mod tests {
         assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), U256::ZERO);
         assert_eq!(env.get_balance(GOVERNANCE_SAFE_ADDRESS), gov_before - amount);
         assert_eq!(env.get_total_supply(), supply_before - amount);
+    }
+
+    #[test]
+    fn test_value_funded_burn_mirrors_the_top_up_as_a_transfer() {
+        let one_tel = U256::from(10).pow(U256::from(18));
+        let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
+        let value = U256::from(500);
+        let amount = U256::from(200);
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            burnCall { amount }.abi_encode(),
+            100_000,
+            value,
+        );
+        let logs = extract_logs(&result);
+        // Three logs: the mirrored top-up, then the burn pair. Without the first, an indexer
+        // rebuilding balances from these events sees the pool pay out wei it never received.
+        assert_eq!(logs.len(), 3);
+        assert_eq!(
+            logs[0].topics(),
+            [
+                burnable::Transfer::SIGNATURE_HASH,
+                GOVERNANCE_SAFE_ADDRESS.into_word(),
+                TELCOIN_PRECOMPILE_ADDRESS.into_word(),
+            ]
+        );
+        // The mirror reports the attached value, not the burned amount.
+        assert_eq!(U256::from_be_slice(logs[0].data.data.as_ref()), value);
+        assert_eq!(logs[1].topics(), [burnable::Burn::SIGNATURE_HASH]);
+        assert_eq!(
+            logs[2].topics(),
+            [
+                burnable::Transfer::SIGNATURE_HASH,
+                TELCOIN_PRECOMPILE_ADDRESS.into_word(),
+                Address::ZERO.into_word(),
+            ]
+        );
+        assert_eq!(U256::from_be_slice(logs[2].data.data.as_ref()), amount);
+    }
+
+    #[test]
+    fn test_zero_value_burn_emits_no_inbound_transfer() {
+        // The pool is pre-funded, so this burn moves no wei into the precompile.
+        let mut env = TestEnv::new();
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            burnCall { amount: U256::from(100) }.abi_encode(),
+            100_000,
+            U256::ZERO,
+        );
+        let logs = extract_logs(&result);
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].topics(), [burnable::Burn::SIGNATURE_HASH]);
     }
 
     #[test]

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -331,7 +331,9 @@ mod tests {
 
     #[test]
     fn test_burn_value_funds_pool_and_burns() {
-        // The pool starts empty (mainnet genesis also allocates the account zero balance).
+        // The pool starts empty, as it does on mainnet: genesis allocates the account zero
+        // balance with `0xfe` code, the nonzero code being what exempts it from EIP-158 state
+        // clearing while the balance sits at zero.
         let one_tel = U256::from(10).pow(U256::from(18));
         let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
         let amount = U256::from(500);

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -205,6 +205,26 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 /// exemption requires [`PrecompileInput::target_address`] to be the precompile itself, so
 /// apparent value that never funded the pool could not authorize a draw from it even if an
 /// indirect frame reached this check.
+///
+/// # Rejection gas semantics
+///
+/// Every rejection here — the static-call refusal, the payability refusal, an unrecognised
+/// selector, and each handler's own `unauthorized` / decode / arithmetic error — returns
+/// [`PrecompileError`], which revm turns into `InstructionResult::PrecompileError`: a **halt**,
+/// not a revert. A halt consumes all the gas the frame was given. revm returns the unspent
+/// remainder only for results that are `is_ok_or_revert()` (`revm-handler`'s
+/// `insert_call_outcome` for a sub-call, `last_frame_result` for the top level), and a precompile
+/// error is neither, so a rejected sub-call loses the entire 63/64 it was forwarded and a
+/// rejected top-level transaction is charged its full `gas_limit`.
+///
+/// For callers this is a cliff rather than a soft failure. A contract that forwards `msg.value`
+/// into [`TELCOIN_PRECOMPILE_ADDRESS`] and inspects the returned boolean does get `false` — a
+/// non-ok call result pushes zero — but it holds only the 1/64 it retained, so the outer frame
+/// dies instead of handling the failure. The pre-existing static-call refusal has always behaved
+/// this way and the payability refusal deliberately matches it: consuming the limit is the
+/// EVM's standard price for an invalid operation, and a value-bearing call to a non-payable
+/// selector is a caller bug. Callers must satisfy the precompile's rules up front rather than
+/// plan to recover from a rejection.
 fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
     // Refuse DELEGATECALL/CALLCODE before anything else. See "Direct-call guard" above.
     input

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -179,6 +179,26 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 /// additionally requires [`PrecompileInput::target_address`] to be the precompile itself:
 /// apparent value never funded the pool, so it cannot authorize a draw from it, and such calls
 /// are rejected like every other value-bearing call.
+///
+/// # Rejection gas semantics
+///
+/// Every rejection here — the static-call refusal, the payability refusal, an unrecognised
+/// selector, and each handler's own `unauthorized` / decode / arithmetic error — returns
+/// [`PrecompileError`], which revm turns into `InstructionResult::PrecompileError`: a **halt**,
+/// not a revert. A halt consumes all the gas the frame was given. revm returns the unspent
+/// remainder only for results that are `is_ok_or_revert()` (`revm-handler`'s
+/// `insert_call_outcome` for a sub-call, `last_frame_result` for the top level), and a precompile
+/// error is neither, so a rejected sub-call loses the entire 63/64 it was forwarded and a
+/// rejected top-level transaction is charged its full `gas_limit`.
+///
+/// For callers this is a cliff rather than a soft failure. A contract that forwards `msg.value`
+/// into [`TELCOIN_PRECOMPILE_ADDRESS`] and inspects the returned boolean does get `false` — a
+/// non-ok call result pushes zero — but it holds only the 1/64 it retained, so the outer frame
+/// dies instead of handling the failure. The pre-existing static-call refusal has always behaved
+/// this way and the payability refusal deliberately matches it: consuming the limit is the
+/// EVM's standard price for an invalid operation, and a value-bearing call to a non-payable
+/// selector is a caller bug. Callers must satisfy the precompile's rules up front rather than
+/// plan to recover from a rejection.
 fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
     if input.data.len() < 4 {
         return Err(PrecompileError::Other("Invalid input: too short".into()));

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -210,16 +210,27 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 ///
 /// Every rejection here — the static-call refusal, the payability refusal, an unrecognised
 /// selector, and each handler's own gas-limit precheck, `unauthorized`, decode, and arithmetic
-/// errors — returns [`PrecompileError`]. revm splits that into two instruction results: the
+/// errors — returns [`PrecompileError`]. The provider that runs it is `alloy-evm`'s
+/// `PrecompilesMap`: [`add_telcoin_precompile`] registers into that map and the factory names it
+/// as the EVM's `Precompiles` type, so `PrecompilesMap::run` (`alloy-evm`'s `precompiles.rs`) is
+/// what splits the error into two instruction results, keyed on `PrecompileError::is_oog`. The
 /// `gas_limit < GAS_COST` precheck each handler runs returns `PrecompileError::OutOfGas`, which
-/// maps to `InstructionResult::PrecompileOOG`, and every other variant maps to
-/// `InstructionResult::PrecompileError` (`revm-handler`'s `precompile_provider.rs`, keyed on
-/// `PrecompileError::is_oog`). Both are a **halt**, not a revert, and a halt consumes all the gas
-/// the frame was given. revm returns the unspent remainder only for results that are
-/// `is_ok_or_revert()` (`revm-handler`'s `insert_call_outcome` for a sub-call,
+/// maps to `InstructionResult::PrecompileOOG`; every other variant maps to
+/// `InstructionResult::PrecompileError`. Both are a **halt**, not a revert, and a halt consumes
+/// all the gas the frame was given. revm returns the unspent remainder only for results that are
+/// `is_ok_or_revert()` (`revm-handler`'s `EthFrame::return_result` for a sub-call,
 /// `last_frame_result` for the top level), and neither halt is, so a rejected sub-call loses the
 /// entire 63/64 it was forwarded and a rejected top-level transaction is charged its full
 /// `gas_limit`.
+///
+/// Which provider runs is load-bearing rather than a citation detail. revm's own `EthPrecompiles`
+/// makes the identical `is_oog` split, but it additionally stashes the error string for a call at
+/// journal depth 1, which `revm-handler`'s `post_execution.rs` promotes to
+/// `HaltReason::PrecompileErrorWithContext(message)`. `PrecompilesMap` stashes nothing, so a
+/// rejected top-level call here halts with the bare `HaltReason::PrecompileError` and surfaces no
+/// reason on the receipt at all. That is what the bare-variant assertions in this module's tests
+/// pin, and what makes the "the halt carries no message" claim in
+/// `docs/src/evm-compatibility.md` true.
 ///
 /// For callers this is a cliff rather than a soft failure. A contract that forwards `msg.value`
 /// into [`TELCOIN_PRECOMPILE_ADDRESS`] and inspects the returned boolean does get `false` — a
@@ -315,6 +326,9 @@ mod tests {
     fn test_input_too_short() {
         let mut env = TestEnv::new();
         let result = env.exec_default(GOVERNANCE_SAFE_ADDRESS, vec![0xAB, 0xCD]);
+        // The *bare* variant is what pins the provider: revm's `EthPrecompiles` would report
+        // `PrecompileErrorWithContext` at this depth, `alloy-evm`'s `PrecompilesMap` reports no
+        // reason at all. A dependency bump that swapped them fails here rather than mysteriously.
         assert_eq!(
             assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
             &HaltReason::PrecompileError
@@ -421,7 +435,7 @@ mod tests {
         let result = env.exec_with_value(
             GOVERNANCE_SAFE_ADDRESS,
             burnCall { amount }.abi_encode(),
-            100_000,
+            DEFAULT_GAS_LIMIT,
             value,
         );
         let logs = extract_logs(&result);
@@ -464,7 +478,7 @@ mod tests {
         let result = env.exec_with_value(
             GOVERNANCE_SAFE_ADDRESS,
             burnCall { amount: U256::from(100) }.abi_encode(),
-            100_000,
+            DEFAULT_GAS_LIMIT,
             U256::ZERO,
         );
         let logs = extract_logs(&result);
@@ -588,43 +602,9 @@ mod tests {
 
     #[test]
     fn test_rejected_sub_call_loses_the_gas_it_was_forwarded() {
-        /// Runtime bytecode that measures what a rejected sub-call costs its caller.
-        ///
-        /// Reads `GAS` on either side of a plain `CALL` into `0x7e1` that forwards everything
-        /// available, and returns three words: the gas the frame held before the call, the
-        /// call's success flag, and the gas it held after. Nothing propagates the inner
-        /// failure, so this frame returns normally and the three words reach the transaction
-        /// output.
-        ///
-        /// Disassembly:
-        /// ```text
-        ///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
-        ///   GAS                                            // gas before
-        ///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize,
-        ///                                                  // argsOffset
-        ///   PUSH1 0; PUSH2 0x07e1; GAS; CALL               // value, address, gas
-        ///   GAS                                            // gas after
-        ///   PUSH1 0x40; MSTORE                             // mem[64] = gas after
-        ///   PUSH1 0x20; MSTORE                             // mem[32] = success flag
-        ///   PUSH1 0x00; MSTORE                             // mem[0]  = gas before
-        ///   PUSH1 0x60; PUSH1 0; RETURN                    // return those three words
-        /// ```
-        const PROBE_CODE: &[u8] = &[
-            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
-            0x5a, // GAS -> gas before
-            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
-            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
-            0x60, 0x00, // value = 0
-            0x61, 0x07, 0xe1, 0x5a, 0xf1, // PUSH2 0x07e1; GAS; CALL
-            0x5a, // GAS -> gas after
-            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
-            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
-            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
-            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
-        ];
         const PROBE: Address = address!("5555555000000000000000000000000000000005");
         let mut env = TestEnv::new();
-        env.deploy_code(PROBE, PROBE_CODE.into());
+        env.deploy_code(PROBE, gas_probe_code(ProbeCall::Call));
         let mut unknown = vec![0xDE, 0xAD, 0xBE, 0xEF];
         unknown.extend_from_slice(&[0u8; 32]);
 
@@ -651,24 +631,9 @@ mod tests {
         // `test_delegatecall_burn_refused_with_and_without_value` reverts on failure, which
         // erases the evidence.
 
-        /// The `CALL` gas probe with the `value` operand dropped and `DELEGATECALL` (`0xf4`) in
-        /// place of `CALL` (`0xf1`); `DELEGATECALL` takes six stack operands rather than seven.
-        /// Returns the same three words.
-        const PROBE_CODE: &[u8] = &[
-            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
-            0x5a, // GAS -> gas before
-            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
-            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
-            0x61, 0x07, 0xe1, 0x5a, 0xf4, // PUSH2 0x07e1; GAS; DELEGATECALL
-            0x5a, // GAS -> gas after
-            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
-            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
-            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
-            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
-        ];
         const PROBE: Address = address!("6666666000000000000000000000000000000006");
         let mut env = TestEnv::new();
-        env.deploy_code(PROBE, PROBE_CODE.into());
+        env.deploy_code(PROBE, gas_probe_code(ProbeCall::DelegateCall));
 
         // `totalSupply` would be served by a direct call and needs no authorization, so the only
         // thing refusing this frame is the indirect-entry guard.
@@ -683,23 +648,9 @@ mod tests {
         // precedent the payability refusal was matched to, so its gas semantics are worth
         // pinning rather than assuming.
 
-        /// The `DELEGATECALL` gas probe with `STATICCALL` (`0xfa`) in place of `DELEGATECALL`
-        /// (`0xf4`); the two take the same six stack operands. Returns the same three words.
-        const PROBE_CODE: &[u8] = &[
-            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
-            0x5a, // GAS -> gas before
-            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
-            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
-            0x61, 0x07, 0xe1, 0x5a, 0xfa, // PUSH2 0x07e1; GAS; STATICCALL
-            0x5a, // GAS -> gas after
-            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
-            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
-            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
-            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
-        ];
         const PROBE: Address = address!("7777777000000000000000000000000000000007");
         let mut env = TestEnv::new();
-        env.deploy_code(PROBE, PROBE_CODE.into());
+        env.deploy_code(PROBE, gas_probe_code(ProbeCall::StaticCall));
 
         // `burn` mutates, so the static gate refuses it before dispatch — ahead of the handler's
         // own authorization check, which would also have refused this caller.

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -209,13 +209,17 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 /// # Rejection gas semantics
 ///
 /// Every rejection here — the static-call refusal, the payability refusal, an unrecognised
-/// selector, and each handler's own `unauthorized` / decode / arithmetic error — returns
-/// [`PrecompileError`], which revm turns into `InstructionResult::PrecompileError`: a **halt**,
-/// not a revert. A halt consumes all the gas the frame was given. revm returns the unspent
-/// remainder only for results that are `is_ok_or_revert()` (`revm-handler`'s
-/// `insert_call_outcome` for a sub-call, `last_frame_result` for the top level), and a precompile
-/// error is neither, so a rejected sub-call loses the entire 63/64 it was forwarded and a
-/// rejected top-level transaction is charged its full `gas_limit`.
+/// selector, and each handler's own gas-limit precheck, `unauthorized`, decode, and arithmetic
+/// errors — returns [`PrecompileError`]. revm splits that into two instruction results: the
+/// `gas_limit < GAS_COST` precheck each handler runs returns `PrecompileError::OutOfGas`, which
+/// maps to `InstructionResult::PrecompileOOG`, and every other variant maps to
+/// `InstructionResult::PrecompileError` (`revm-handler`'s `precompile_provider.rs`, keyed on
+/// `PrecompileError::is_oog`). Both are a **halt**, not a revert, and a halt consumes all the gas
+/// the frame was given. revm returns the unspent remainder only for results that are
+/// `is_ok_or_revert()` (`revm-handler`'s `insert_call_outcome` for a sub-call,
+/// `last_frame_result` for the top level), and neither halt is, so a rejected sub-call loses the
+/// entire 63/64 it was forwarded and a rejected top-level transaction is charged its full
+/// `gas_limit`.
 ///
 /// For callers this is a cliff rather than a soft failure. A contract that forwards `msg.value`
 /// into [`TELCOIN_PRECOMPILE_ADDRESS`] and inspects the returned boolean does get `false` — a

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -168,7 +168,9 @@ const NON_PAYABLE_CALL_VALUE: &str = "call value: selector is not payable";
 /// balance, a plain value send reverts on the calldata-length check above, and the genesis
 /// account starts with zero balance, so attaching value to `burn(amount)` is the sanctioned inlet
 /// for the pool it draws from: `msg.value == amount` funds and burns in one transaction, and any
-/// excess stays in the pool for later burns. The classification is a payable-list rather than a
+/// excess stays in the pool for later burns. The EVM's own transfer of that value emits nothing,
+/// so [`handle_burn`](burnable::handle_burn) mirrors it as an inbound `Transfer` log — see there.
+/// The classification is a payable-list rather than a
 /// reject-list for the same fail-safe reason as the static gate: a selector added later rejects
 /// value unless it is explicitly named payable, and an unrecognised value-bearing selector
 /// reports [`NON_PAYABLE_CALL_VALUE`] rather than `"Unknown function selector"`. Inside a
@@ -212,9 +214,13 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
         burnable::claimCall::SELECTOR => {
             burnable::handle_claim(&mut input.internals, calldata, input.caller, input.gas)
         }
-        burnable::burnCall::SELECTOR => {
-            burnable::handle_burn(&mut input.internals, calldata, input.caller, input.gas)
-        }
+        burnable::burnCall::SELECTOR => burnable::handle_burn(
+            &mut input.internals,
+            calldata,
+            input.caller,
+            input.gas,
+            input.value,
+        ),
         // Read-only functions
         burnable::totalSupplyCall::SELECTOR => {
             burnable::handle_total_supply(&mut input.internals, input.gas)
@@ -246,7 +252,7 @@ fn telcoin_precompile(mut input: PrecompileInput<'_>) -> PrecompileResult {
 mod tests {
     use super::*;
     use crate::evm::precompile_test_utils::*;
-    use alloy::sol_types::SolCall;
+    use alloy::sol_types::{SolCall, SolEvent};
     use tn_config::GOVERNANCE_SAFE_ADDRESS;
 
     #[test]
@@ -321,6 +327,59 @@ mod tests {
         assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), U256::ZERO);
         assert_eq!(env.get_balance(GOVERNANCE_SAFE_ADDRESS), gov_before - amount);
         assert_eq!(env.get_total_supply(), supply_before - amount);
+    }
+
+    #[test]
+    fn test_value_funded_burn_mirrors_the_top_up_as_a_transfer() {
+        let one_tel = U256::from(10).pow(U256::from(18));
+        let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
+        let value = U256::from(500);
+        let amount = U256::from(200);
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            burnCall { amount }.abi_encode(),
+            100_000,
+            value,
+        );
+        let logs = extract_logs(&result);
+        // Three logs: the mirrored top-up, then the burn pair. Without the first, an indexer
+        // rebuilding balances from these events sees the pool pay out wei it never received.
+        assert_eq!(logs.len(), 3);
+        assert_eq!(
+            logs[0].topics(),
+            [
+                burnable::Transfer::SIGNATURE_HASH,
+                GOVERNANCE_SAFE_ADDRESS.into_word(),
+                TELCOIN_PRECOMPILE_ADDRESS.into_word(),
+            ]
+        );
+        // The mirror reports the attached value, not the burned amount.
+        assert_eq!(U256::from_be_slice(logs[0].data.data.as_ref()), value);
+        assert_eq!(logs[1].topics(), [burnable::Burn::SIGNATURE_HASH]);
+        assert_eq!(
+            logs[2].topics(),
+            [
+                burnable::Transfer::SIGNATURE_HASH,
+                TELCOIN_PRECOMPILE_ADDRESS.into_word(),
+                Address::ZERO.into_word(),
+            ]
+        );
+        assert_eq!(U256::from_be_slice(logs[2].data.data.as_ref()), amount);
+    }
+
+    #[test]
+    fn test_zero_value_burn_emits_no_inbound_transfer() {
+        // The pool is pre-funded, so this burn moves no wei into the precompile.
+        let mut env = TestEnv::new();
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            burnCall { amount: U256::from(100) }.abi_encode(),
+            100_000,
+            U256::ZERO,
+        );
+        let logs = extract_logs(&result);
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].topics(), [burnable::Burn::SIGNATURE_HASH]);
     }
 
     #[test]

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -315,7 +315,10 @@ mod tests {
     fn test_input_too_short() {
         let mut env = TestEnv::new();
         let result = env.exec_default(GOVERNANCE_SAFE_ADDRESS, vec![0xAB, 0xCD]);
-        assert_not_success(&result);
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
     }
 
     #[test]
@@ -324,7 +327,12 @@ mod tests {
         let mut data = vec![0xDE, 0xAD, 0xBE, 0xEF];
         data.extend_from_slice(&[0u8; 32]);
         let result = env.exec_default(GOVERNANCE_SAFE_ADDRESS, data);
-        assert_not_success(&result);
+        // the fallthrough halts rather than reverting, so the sender is charged the whole limit
+        // instead of being handed back the unspent remainder.
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
     }
 
     #[test]
@@ -332,15 +340,26 @@ mod tests {
         let mut env = TestEnv::new();
         let pool_before = env.get_balance(TELCOIN_PRECOMPILE_ADDRESS);
         let user_before = env.get_balance(USER);
-        let result =
-            env.exec_with_value(USER, totalSupplyCall {}.abi_encode(), 100_000, U256::from(1));
-        assert_not_success(&result);
+        let result = env.exec_with_value(
+            USER,
+            totalSupplyCall {}.abi_encode(),
+            DEFAULT_GAS_LIMIT,
+            U256::from(1),
+        );
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
         // The journaled value transfer is reverted: neither balance moves.
         assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before);
         assert_eq!(env.get_balance(USER), user_before);
         // Positive control: the same call without value succeeds.
-        let result =
-            env.exec_with_value(USER, totalSupplyCall {}.abi_encode(), 100_000, U256::ZERO);
+        let result = env.exec_with_value(
+            USER,
+            totalSupplyCall {}.abi_encode(),
+            DEFAULT_GAS_LIMIT,
+            U256::ZERO,
+        );
         assert_success(&result);
     }
 
@@ -350,12 +369,20 @@ mod tests {
         let mut env = TestEnv::new();
         let pool_before = env.get_balance(TELCOIN_PRECOMPILE_ADDRESS);
         let calldata = mintCall { amount: U256::from(500) }.abi_encode();
-        let result =
-            env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata.clone(), 100_000, U256::from(1));
-        assert_not_success(&result);
+        let result = env.exec_with_value(
+            GOVERNANCE_SAFE_ADDRESS,
+            calldata.clone(),
+            DEFAULT_GAS_LIMIT,
+            U256::from(1),
+        );
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
         assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before);
         // Positive control: the same call without value succeeds.
-        let result = env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata, 100_000, U256::ZERO);
+        let result =
+            env.exec_with_value(GOVERNANCE_SAFE_ADDRESS, calldata, DEFAULT_GAS_LIMIT, U256::ZERO);
         assert_success(&result);
     }
 
@@ -401,6 +428,13 @@ mod tests {
         // Three logs: the mirrored top-up, then the burn pair. Without the first, an indexer
         // rebuilding balances from these events sees the pool pay out wei it never received.
         assert_eq!(logs.len(), 3);
+        // Every log comes from the precompile and carries a full 32-byte ABI word. The value
+        // assertions below decode with `from_be_slice`, which accepts a short slice, so only the
+        // length check catches a trimmed encoding.
+        for log in logs {
+            assert_eq!(log.address, TELCOIN_PRECOMPILE_ADDRESS);
+            assert_eq!(log.data.data.len(), 32);
+        }
         assert_eq!(
             logs[0].topics(),
             [
@@ -435,6 +469,10 @@ mod tests {
         );
         let logs = extract_logs(&result);
         assert_eq!(logs.len(), 2);
+        for log in logs {
+            assert_eq!(log.address, TELCOIN_PRECOMPILE_ADDRESS);
+            assert_eq!(log.data.data.len(), 32);
+        }
         assert_eq!(logs[0].topics(), [burnable::Burn::SIGNATURE_HASH]);
     }
 
@@ -501,5 +539,202 @@ mod tests {
         let result = env.exec(GOVERNANCE_SAFE_ADDRESS, calldata, 200_000);
         assert_success(&result);
         assert_eq!(env.get_balance(TELCOIN_PRECOMPILE_ADDRESS), pool_before - amount);
+    }
+
+    #[test]
+    fn test_handler_rejection_halts_consuming_all_gas() {
+        // Every dispatcher gate passes here — a direct, non-static, zero-value call carrying a
+        // recognised selector — so the refusal comes from the handler's own authorization check.
+        // It is charged on the same terms as the gates above it.
+        let mut env = TestEnv::new();
+        let calldata = burnCall { amount: U256::from(1) }.abi_encode();
+        let result = env.exec(USER, calldata.clone(), DEFAULT_GAS_LIMIT);
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, DEFAULT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
+        // Positive control: the same burn from governance is served.
+        assert_success(&env.exec(GOVERNANCE_SAFE_ADDRESS, calldata, DEFAULT_GAS_LIMIT));
+    }
+
+    #[test]
+    fn test_gas_precheck_halts_as_oog_while_a_gate_halts_as_precompile_error() {
+        // A handler's `gas_limit < GAS_COST` precheck returns `PrecompileError::OutOfGas`, which
+        // revm maps to `PrecompileOOG`; every other rejection maps to `PrecompileError`. Both
+        // halt and both spend the limit, so only the reason separates them.
+        //
+        // 23,000 clears the intrinsic cost of either transaction below but leaves the precompile
+        // frame short of the 2,100 `totalSupply` prechecks.
+        const TIGHT_GAS_LIMIT: u64 = 23_000;
+        let mut env = TestEnv::new();
+        let calldata = totalSupplyCall {}.abi_encode();
+        let result = env.exec(USER, calldata.clone(), TIGHT_GAS_LIMIT);
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, TIGHT_GAS_LIMIT),
+            &HaltReason::OutOfGas(OutOfGasError::Precompile)
+        );
+        // At the same limit an unknown selector is refused before any handler runs, so it never
+        // reaches a gas precheck and reports the other reason.
+        let mut unknown = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        unknown.extend_from_slice(&[0u8; 32]);
+        let result = env.exec(USER, unknown, TIGHT_GAS_LIMIT);
+        assert_eq!(
+            assert_halt_consuming_all_gas(&result, TIGHT_GAS_LIMIT),
+            &HaltReason::PrecompileError
+        );
+        // Positive control: with room to run, the precheck passes and the view is served.
+        assert_success(&env.exec(USER, calldata, DEFAULT_GAS_LIMIT));
+    }
+
+    #[test]
+    fn test_rejected_sub_call_loses_the_gas_it_was_forwarded() {
+        /// Runtime bytecode that measures what a rejected sub-call costs its caller.
+        ///
+        /// Reads `GAS` on either side of a plain `CALL` into `0x7e1` that forwards everything
+        /// available, and returns three words: the gas the frame held before the call, the
+        /// call's success flag, and the gas it held after. Nothing propagates the inner
+        /// failure, so this frame returns normally and the three words reach the transaction
+        /// output.
+        ///
+        /// Disassembly:
+        /// ```text
+        ///   CALLDATASIZE; PUSH1 0; PUSH1 0; CALLDATACOPY   // mem[0..csize] = calldata
+        ///   GAS                                            // gas before
+        ///   PUSH1 0; PUSH1 0; CALLDATASIZE; PUSH1 0;       // retSize, retOffset, argsSize,
+        ///                                                  // argsOffset
+        ///   PUSH1 0; PUSH2 0x07e1; GAS; CALL               // value, address, gas
+        ///   GAS                                            // gas after
+        ///   PUSH1 0x40; MSTORE                             // mem[64] = gas after
+        ///   PUSH1 0x20; MSTORE                             // mem[32] = success flag
+        ///   PUSH1 0x00; MSTORE                             // mem[0]  = gas before
+        ///   PUSH1 0x60; PUSH1 0; RETURN                    // return those three words
+        /// ```
+        const PROBE_CODE: &[u8] = &[
+            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+            0x5a, // GAS -> gas before
+            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
+            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
+            0x60, 0x00, // value = 0
+            0x61, 0x07, 0xe1, 0x5a, 0xf1, // PUSH2 0x07e1; GAS; CALL
+            0x5a, // GAS -> gas after
+            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
+            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
+            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
+            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
+        ];
+        const PROBE: Address = address!("5555555000000000000000000000000000000005");
+        let mut env = TestEnv::new();
+        env.deploy_code(PROBE, PROBE_CODE.into());
+        let mut unknown = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        unknown.extend_from_slice(&[0u8; 32]);
+
+        // The caller does observe the failure — a non-ok sub-call pushes zero — but it is left
+        // holding only the 1/64 it withheld. A revert would have handed the remainder back.
+        assert_probe_lost_forwarded_gas(&env.exec_to(USER, PROBE, unknown, 200_000));
+
+        // Positive control: the same probe over a served call gets its unspent gas back, which is
+        // what makes the bound above a measurement rather than an artifact of the harness.
+        let result = env.exec_to(USER, PROBE, totalSupplyCall {}.abi_encode(), 200_000);
+        let (before, flag, after) = decode_gas_probe(&result);
+        assert_eq!(flag, U256::from(1));
+        assert!(
+            after > before / 2,
+            "a served sub-call returns its unspent gas: {after} of {before} left"
+        );
+    }
+
+    #[test]
+    fn test_indirect_entry_refusal_burns_the_forwarded_gas() {
+        // No transaction can reach the direct-call guard from the top level: a transaction always
+        // enters 0x7e1 with `target_address == bytecode_address`. Its gas semantics are therefore
+        // only observable from a sub-call, and the relay in
+        // `test_delegatecall_burn_refused_with_and_without_value` reverts on failure, which
+        // erases the evidence.
+
+        /// The `CALL` gas probe with the `value` operand dropped and `DELEGATECALL` (`0xf4`) in
+        /// place of `CALL` (`0xf1`); `DELEGATECALL` takes six stack operands rather than seven.
+        /// Returns the same three words.
+        const PROBE_CODE: &[u8] = &[
+            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+            0x5a, // GAS -> gas before
+            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
+            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
+            0x61, 0x07, 0xe1, 0x5a, 0xf4, // PUSH2 0x07e1; GAS; DELEGATECALL
+            0x5a, // GAS -> gas after
+            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
+            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
+            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
+            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
+        ];
+        const PROBE: Address = address!("6666666000000000000000000000000000000006");
+        let mut env = TestEnv::new();
+        env.deploy_code(PROBE, PROBE_CODE.into());
+
+        // `totalSupply` would be served by a direct call and needs no authorization, so the only
+        // thing refusing this frame is the indirect-entry guard.
+        let calldata = totalSupplyCall {}.abi_encode();
+        assert_probe_lost_forwarded_gas(&env.exec_to(USER, PROBE, calldata, 200_000));
+    }
+
+    #[test]
+    fn test_static_call_refusal_burns_the_forwarded_gas() {
+        // Like the direct-call guard, the static gate is out of reach from the top level: a
+        // transaction's own frame is never static. The rustdoc leans on this refusal as the
+        // precedent the payability refusal was matched to, so its gas semantics are worth
+        // pinning rather than assuming.
+
+        /// The `DELEGATECALL` gas probe with `STATICCALL` (`0xfa`) in place of `DELEGATECALL`
+        /// (`0xf4`); the two take the same six stack operands. Returns the same three words.
+        const PROBE_CODE: &[u8] = &[
+            0x36, 0x60, 0x00, 0x60, 0x00, 0x37, // CALLDATACOPY(0, 0, CALLDATASIZE)
+            0x5a, // GAS -> gas before
+            0x60, 0x00, 0x60, 0x00, // retSize = 0, retOffset = 0
+            0x36, 0x60, 0x00, // argsSize = CALLDATASIZE, argsOffset = 0
+            0x61, 0x07, 0xe1, 0x5a, 0xfa, // PUSH2 0x07e1; GAS; STATICCALL
+            0x5a, // GAS -> gas after
+            0x60, 0x40, 0x52, // MSTORE(0x40, gas after)
+            0x60, 0x20, 0x52, // MSTORE(0x20, success flag)
+            0x60, 0x00, 0x52, // MSTORE(0x00, gas before)
+            0x60, 0x60, 0x60, 0x00, 0xf3, // RETURN(0, 0x60)
+        ];
+        const PROBE: Address = address!("7777777000000000000000000000000000000007");
+        let mut env = TestEnv::new();
+        env.deploy_code(PROBE, PROBE_CODE.into());
+
+        // `burn` mutates, so the static gate refuses it before dispatch — ahead of the handler's
+        // own authorization check, which would also have refused this caller.
+        let calldata = burnCall { amount: U256::from(1) }.abi_encode();
+        assert_probe_lost_forwarded_gas(&env.exec_to(USER, PROBE, calldata, 200_000));
+
+        // Positive control: the read-only selector stays served inside the same static frame,
+        // and keeps its unspent gas.
+        let calldata = totalSupplyCall {}.abi_encode();
+        let result = env.exec_to(USER, PROBE, calldata, 200_000);
+        let (before, flag, after) = decode_gas_probe(&result);
+        assert_eq!(flag, U256::from(1));
+        assert!(after > before / 2, "a served sub-call keeps its unspent gas: {after} of {before}");
+    }
+
+    /// Assert a gas probe recorded a refused sub-call: a zero success flag, and a caller left
+    /// holding no more than the 1/64 it withheld. A rejection that reverted instead of halting
+    /// would return the forwarded 63/64 and blow the upper bound wide open, while leaving the
+    /// flag zero either way.
+    fn assert_probe_lost_forwarded_gas(result: &TestResult) {
+        let (before, flag, after) = decode_gas_probe(result);
+        assert!(flag.is_zero(), "a halted sub-call pushes a zero flag, got {flag}");
+        assert!(after > 0, "caller should keep the 1/64 it withheld");
+        assert!(
+            after <= before / 64,
+            "a refused sub-call should burn the forwarded 63/64: {after} of {before} left"
+        );
+    }
+
+    /// Decode the three words a gas probe returns: the gas the calling frame held before the
+    /// sub-call, the sub-call's success flag, and the gas it held after.
+    fn decode_gas_probe(result: &TestResult) -> (u64, U256, u64) {
+        let out = extract_output_bytes(result);
+        assert_eq!(out.len(), 96, "gas probe returns three 32-byte words");
+        let word = |i: usize| U256::from_be_slice(&out[i * 32..(i + 1) * 32]);
+        (word(0).to::<u64>(), word(1), word(2).to::<u64>())
     }
 }

--- a/crates/tn-reth/src/evm/tel_precompile/mod.rs
+++ b/crates/tn-reth/src/evm/tel_precompile/mod.rs
@@ -299,7 +299,9 @@ mod tests {
 
     #[test]
     fn test_burn_value_funds_pool_and_burns() {
-        // The pool starts empty (mainnet genesis also allocates the account zero balance).
+        // The pool starts empty, as it does on mainnet: genesis allocates the account zero
+        // balance with `0xfe` code, the nonzero code being what exempts it from EIP-158 state
+        // clearing while the balance sits at zero.
         let one_tel = U256::from(10).pow(U256::from(18));
         let mut env = TestEnv::new_with_balances(one_tel, one_tel, U256::ZERO);
         let amount = U256::from(500);

--- a/crates/tn-reth/tests/it/pipeline_helpers.rs
+++ b/crates/tn-reth/tests/it/pipeline_helpers.rs
@@ -16,6 +16,7 @@ use tn_config::GOVERNANCE_SAFE_ADDRESS;
 use tn_reth::mintCall;
 use tn_reth::{
     payload::TNPayload,
+    system_calls::PRECOMPILE_GENESIS_BYTECODE,
     test_utils::{precompile_test_utils::GENESIS_SUPPLY, TransactionFactory},
     totalSupplyCall, ExecutedBlock, NewCanonicalChain, RethChainSpec, RethEnv,
     TELCOIN_PRECOMPILE_ADDRESS,
@@ -175,18 +176,27 @@ impl PipelineTestEnv {
                     .with_balance(governance_safe_balance)
                     .with_code(Some(Bytes::from_static(GOVERNANCE_FORWARDER_BYTECODE))),
             ),
-            // Precompile account with balance and total supply storage
+            // Precompile account with balance and total supply storage.
+            //
+            // `extend_accounts` replaces the canonical `0x7e1` entry inherited from
+            // `test_genesis()` rather than merging into it, so the genesis code has to be restated
+            // here. Without it the account is code-less, and once its balance reaches zero (a full
+            // burn of the pool) it is empty by EIP-158 and gets cleared at the end of the block
+            // that touched it - taking the total supply slot with it.
             (
                 TELCOIN_PRECOMPILE_ADDRESS,
-                GenesisAccount::default().with_balance(precompile_balance).with_storage(Some({
-                    let mut storage = std::collections::BTreeMap::new();
-                    // Slot 100 = totalSupply
-                    storage.insert(
-                        tn_types::B256::from(U256::from(100)),
-                        tn_types::B256::from(total_supply),
-                    );
-                    storage
-                })),
+                GenesisAccount::default()
+                    .with_balance(precompile_balance)
+                    .with_code(Some(Bytes::from_static(PRECOMPILE_GENESIS_BYTECODE)))
+                    .with_storage(Some({
+                        let mut storage = std::collections::BTreeMap::new();
+                        // Slot 100 = totalSupply
+                        storage.insert(
+                            tn_types::B256::from(U256::from(100)),
+                            tn_types::B256::from(total_supply),
+                        );
+                        storage
+                    })),
             ),
         ];
         #[cfg(feature = "faucet")]

--- a/crates/tn-reth/tests/it/pipeline_tel_precompile_props.rs
+++ b/crates/tn-reth/tests/it/pipeline_tel_precompile_props.rs
@@ -9,10 +9,11 @@ use alloy::sol_types::SolCall;
 use proptest::prelude::*;
 use tn_config::GOVERNANCE_SAFE_ADDRESS;
 use tn_reth::{
-    burnCall, claimCall, mintCall, test_utils::precompile_test_utils::GENESIS_SUPPLY,
-    TELCOIN_PRECOMPILE_ADDRESS, TIMELOCK_DURATION,
+    burnCall, claimCall, mintCall, system_calls::PRECOMPILE_GENESIS_BYTECODE,
+    test_utils::precompile_test_utils::GENESIS_SUPPLY, TELCOIN_PRECOMPILE_ADDRESS,
+    TIMELOCK_DURATION,
 };
-use tn_types::U256;
+use tn_types::{Bytes, U256};
 
 // ==============================
 // Mint / Claim / Burn properties
@@ -470,6 +471,72 @@ proptest! {
             precompile_after,
             precompile_before,
             "precompile balance should be unchanged after failed burn"
+        );
+    }
+}
+
+// ==============================
+// EIP-158 state clearing
+// ==============================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    /// Burning the entire pool leaves the precompile account - and its `totalSupply` slot - intact.
+    ///
+    /// The account never sends a transaction, so its nonce stays zero, and a full burn takes its
+    /// balance to zero. Only the canonical genesis `0xfe` code keeps it non-empty under EIP-158
+    /// state clearing: a code-less account is deleted at the end of the block that touched it,
+    /// taking `totalSupply` with it. Seeding genesis by replacing the canonical `0x7e1` entry
+    /// rather than extending it drops that code and reintroduces the deletion.
+    #[test]
+    fn prop_pipeline_full_burn_preserves_precompile_account(
+        pool_tel in 1u64..1_000u64,
+        residual_supply_tel in 1u64..1_000u64,
+    ) {
+        let one_tel = U256::from(10).pow(U256::from(18));
+        let large_balance = one_tel * U256::from(1_000_000_000u64);
+        let pool = one_tel * U256::from(pool_tel);
+        // supply strictly exceeds the pool so a surviving slot reads back nonzero, which a wiped
+        // slot never can
+        let total_supply = pool + one_tel * U256::from(residual_supply_tel);
+
+        let mut env = PipelineTestEnv::new_with_custom_state(
+            total_supply,
+            pool,
+            large_balance,
+            large_balance,
+            large_balance,
+            large_balance,
+        );
+
+        // the harness genesis must reproduce the production account shape, code included
+        prop_assert_eq!(
+            env.reth_env.account_code(&TELCOIN_PRECOMPILE_ADDRESS).expect("read precompile code"),
+            Some(Bytes::from_static(PRECOMPILE_GENESIS_BYTECODE)),
+            "precompile genesis account must carry its canonical code"
+        );
+
+        let burn_tx = env.governance_tx(burnCall { amount: pool }.abi_encode());
+        let block = env.execute_block(vec![burn_tx]).expect("execute burn block");
+        assert!(env.tx_succeeded(&block, 0), "full-pool burn should succeed");
+
+        prop_assert_eq!(
+            env.get_balance(TELCOIN_PRECOMPILE_ADDRESS),
+            U256::ZERO,
+            "burning the whole pool should leave a zero balance"
+        );
+        prop_assert!(
+            env.reth_env
+                .retrieve_account(&TELCOIN_PRECOMPILE_ADDRESS)
+                .expect("retrieve precompile account")
+                .is_some(),
+            "precompile account was cleared by EIP-158 once the pool hit zero"
+        );
+        prop_assert_eq!(
+            env.get_total_supply(),
+            total_supply - pool,
+            "totalSupply should survive a full burn"
         );
     }
 }

--- a/docs/src/evm-compatibility.md
+++ b/docs/src/evm-compatibility.md
@@ -63,6 +63,7 @@ Governance is the on-chain governance safe at `0x0000000000000000000000000000000
 * Bridges and DeFi protocols that need ERC-20 semantics should integrate **WTEL**, exactly as they would WETH on Ethereum.
 * Indexers tracking supply should watch the precompile's `Mint`/`Claim`/`Burn`/`Transfer` events; ordinary TEL movement is visible as native value transfers in transaction traces, not as log events.
 * Indexers that reconstruct TEL as an ERC-20 balance sheet from those `Transfer` logs must credit the inbound `Transfer(caller, 0x7e1, msg.value)` on a value-funded burn. It exists for exactly this audience: skip it and the precompile's balance drifts negative, because tokens leave a pool they were never seen entering.
+* Even with that log credited, the `Transfer` stream is a complete account of the precompile's balance only across paths that run precompile code. `SELFDESTRUCT` naming `0x7e1` as its beneficiary still transfers the balance under EIP-6780 — only the account deletion was removed — and does so with no log and no precompile frame, so the precompile cannot mirror it. Reconcile against `0x7e1`'s native balance rather than treating the log stream as closed.
 
 ### BLS Precompile: Signature Verification
 

--- a/docs/src/evm-compatibility.md
+++ b/docs/src/evm-compatibility.md
@@ -18,6 +18,8 @@ The sections below cover the areas where TN diverges from mainnet Ethereum behav
 
 TN registers two additional precompiles beyond the standard Ethereum set: a TEL token-issuance precompile at `0x7e1` and a BLS12-381 signature verifier at `0xb151`. The standard precompiles (`0x01`-`0x0a` etc.) are unchanged.
 
+Both custom addresses hold a single `0xfe` (`INVALID`) byte of code in genesis, so `eth_getCode` returns `0xfe` for them, not `0x`. Tooling that infers "not a contract" from empty code will be wrong about these two addresses. The nonzero code is there for two reasons: it keeps the accounts non-empty, which exempts them from EIP-158 state clearing (an account holding only storage counts as empty and would be deleted, wiping the TEL supply counter), and it makes any call that bypasses precompile dispatch fail on the invalid instruction instead of succeeding against an EOA.
+
 ### TEL Precompile: Token Issuance
 
 The **TEL precompile** at address `0x00000000000000000000000000000000000007e1` owns the native token's supply lifecycle: minting, claiming, and burning, plus a `totalSupply()` view.
@@ -37,8 +39,10 @@ Only issuance authority and the supply counter require protocol-level state, so 
 | -------- | ------ | --- | -------- |
 | `mint(uint256 amount)` | Governance only | 41,000 | Creates a pending mint under a **7-day timelock**. A second `mint` overwrites the pending amount (minting 0 cancels) |
 | `claim(address recipient)` | Governance only | 25,000 | After the timelock expires: credits `recipient`'s native balance, increments `totalSupply`, clears the pending slots |
-| `burn(uint256 amount)` | Governance only | 8,000 | Destroys tokens held by the precompile's own account and decrements `totalSupply`. The only payable selector |
+| `burn(uint256 amount)` | Governance only | 8,000 | Destroys `amount` from the precompile's own balance and decrements `totalSupply`. The only payable selector: attached value funds the pool it draws from |
 | `totalSupply()` | Any caller | 2,100 | Returns the current circulating supply. Callable from `STATICCALL` |
+
+`burn` is the chain's only payable inlet at `0x7e1`, and like every other issuance selector it is governance-gated. The EVM credits `msg.value` to the precompile account before the handler runs, so attaching value tops up the pool the burn destroys from. Calling `burn(amount)` with `msg.value == amount` funds and burns in a single transaction. Any excess stays in the precompile's balance for a later burn: it is not refunded, and no selector ever pays balance back out. The genesis account starts at zero balance, a plain value send with empty calldata is refused, and every other selector rejects nonzero value, so a governance `burn` is the only way an ordinary call can add TEL to the pool.
 
 On testnet builds compiled with the `faucet` feature, `mint` becomes an instant `mint(address recipient, uint256 amount)` with no timelock, and governance can delegate minting via `grantMintRole(address)` / `revokeMintRole(address)` / `hasMintRole(address)`. Mainnet binaries are never built with this feature.
 
@@ -46,9 +50,11 @@ Governance is the on-chain governance safe at `0x0000000000000000000000000000000
 
 #### Notable Behaviors
 
+* **Direct calls only:** `DELEGATECALL` and `CALLCODE` into `0x7e1` still reach the precompile, because revm looks a precompile up by the frame's code address alone. The dispatcher refuses them with `telcoin precompile: only a direct call to 0x7e1 is permitted`. Under `DELEGATECALL` the caller identity the access gates would check is inherited from the parent frame, while the handlers still read and write the canonical `0x7e1` ledger, so authorizing such a frame would mean trusting a spoofable address. The check runs before the calldata length check and before selector dispatch, so read-only selectors are refused through those opcodes too. Only a plain `CALL` or `STATICCALL` reaches a handler.
 * **`STATICCALL` write protection:** inside a static frame only the read-only selectors are served (`totalSupply`, plus `hasMintRole` on faucet builds); every state-mutating selector is refused with `static call: state mutation not permitted`.
 * **Non-payable by default:** every selector except `burn` rejects nonzero call value with `call value: selector is not payable`, so stray TEL cannot be stranded at the precompile.
-* **Events:** `Mint(recipient, amount, unlockTimestamp)`, `Claim(recipient, amount)`, `Burn(amount)`, plus ERC-20-style `Transfer` events from `address(0)` on claim/faucet-mint and to `address(0)` on burn. Ordinary native TEL transfers do **not** emit `Transfer` events.
+* **Rejections consume all gas:** every refusal above, plus every `unauthorized`, decode, or arithmetic failure inside a handler, is a **halt**, not a revert. revm returns unspent gas only for calls that succeed or revert, and a precompile error is neither. A rejected sub-call therefore loses every unit of gas it was forwarded. Under EIP-150's default forwarding that is 63/64 of the caller's remaining gas, leaving the calling frame only the 1/64 it withheld. A rejected top-level transaction is charged its full `gas_limit`. The zero such a call pushes on the stack (`false` to a Solidity caller) is not a result to branch on: the gas needed to act on it has already been spent. Probing `0x7e1` with a value-carrying call to see what it does costs the whole gas budget. Satisfy the direct-call, access, static, and payability rules up front rather than planning to recover from a refusal. Neither form surfaces the reason: the call returns no data, and the halt carries no message, so a caller cannot tell from the receipt which rule it broke.
+* **Events:** `Mint(recipient, amount, unlockTimestamp)`, `Claim(recipient, amount)`, `Burn(amount)`, plus ERC-20-style `Transfer` events: from `address(0)` on claim and faucet-mint, to `address(0)` on burn, and, when a burn is funded with call value, an inbound `Transfer(caller, 0x7e1, msg.value)` that mirrors the value transfer the EVM performs silently. That inbound log is the one `Transfer` where neither leg is `address(0)`, and its data field carries the attached value, not the burned amount; the two need not match. A value-funded burn emits three logs in this order: `Transfer(caller -> 0x7e1, msg.value)`, `Burn(amount)`, `Transfer(0x7e1 -> address(0), amount)`. Ordinary native TEL transfers do **not** emit `Transfer` events.
 * **Supply accounting:** `totalSupply` changes only via `claim` and `burn`. It does not track native balance movement such as gas fees or validator rewards.
 
 #### Implications for Integrations
@@ -56,6 +62,7 @@ Governance is the on-chain governance safe at `0x0000000000000000000000000000000
 * Wallets and explorers should treat TEL as the **native asset** (like ETH), never as a token at `0x7e1`.
 * Bridges and DeFi protocols that need ERC-20 semantics should integrate **WTEL**, exactly as they would WETH on Ethereum.
 * Indexers tracking supply should watch the precompile's `Mint`/`Claim`/`Burn`/`Transfer` events; ordinary TEL movement is visible as native value transfers in transaction traces, not as log events.
+* Indexers that reconstruct TEL as an ERC-20 balance sheet from those `Transfer` logs must credit the inbound `Transfer(caller, 0x7e1, msg.value)` on a value-funded burn. It exists for exactly this audience: skip it and the precompile's balance drifts negative, because tokens leave a pool they were never seen entering.
 
 ### BLS Precompile: Signature Verification
 
@@ -163,7 +170,7 @@ nonce = (epoch << 32) | round
 | Gas costs            | Standard                             | Standard (identical)          |
 | Transaction types    | Legacy, EIP-2930, EIP-1559, EIP-4844 | Legacy, EIP-2930, EIP-1559    |
 | Native asset ERC-20  | Requires WETH wrapper                | Requires WTEL wrapper         |
-| Custom precompiles   | None                                 | TEL issuance at `0x7e1`, BLS verify at `0xb151` |
+| Custom precompiles   | None                                 | TEL issuance at `0x7e1`, BLS verify at `0xb151` (both report `0xfe` code) |
 | Base fee destination | Burned                               | Base-fee address (governance) |
 | Blob transactions    | Supported                            | Not used                      |
 | Contract languages   | Solidity, Vyper, etc.                | Same                          |


### PR DESCRIPTION
- `burn` with value now emits `Transfer(caller, 0x7e1, msg.value)` before the burn events. The EVM's own transfer into the pool emits nothing, so an indexer reconstructing TEL as an ERC-20 from precompile logs saw the pool pay out wei it was never seen receiving, and attaching more value than the burned amount left the excess with no event at all. Two tests pin the log set for value-funded and zero-value burns.
- The flat 8,000 gas charge for `burn` is unchanged and absorbs the extra log. Worst case moves from 10,362 to 12,118 (0.77x to 0.66x headroom); burning is governance-only, so the subsidy is not reachable by untrusted callers. README gas table updated.
- The test harness now builds `0x7e1` with the `0xfe` code mainnet genesis gives it instead of an EIP-158-empty account at zero balance. No assertion could observe the difference, since `MainnetHandler::run` never finalizes the journal, but pool-draining tests such as `test_burn_value_funds_pool_and_burns` end with the pool at exactly zero, which is the state the code exempts from clearing in production.
- Documented that a precompile rejection halts rather than reverts, consuming all the gas the frame was given: a rejected sub-call loses the 63/64 it was forwarded, a rejected top-level transaction is charged its full limit, and the `false` it pushes arrives with 1/64 of the gas left to act on it. Unchanged from the static-call refusal, which has always worked this way, but the payability gate exposes it to a new class of caller.

closes #1239