### PR TITLE
Tn docs vcs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,23 +1,32 @@
-# Documentation site (mdBook -> GitHub Pages).
+# Documentation site (mdBook -> GitHub Pages), with versioning.
 #
-# Builds the mdBook site from docs/ and publishes it to GitHub Pages whenever a merge
-# into main touches the book (docs/** or this workflow), or on demand via
-# workflow_dispatch. Merges that leave the book untouched are skipped by the paths
-# filter, so the public site always matches the docs on main without redundant deploys.
+# Every deploy assembles the full multi-version site from scratch:
+#   - main is built to the site root and served as "latest" (the default);
+#   - every v* tag whose tree contains docs/book.toml is built under /<tag>/;
+#   - versions.json at the site root lists the tags (newest first) and feeds
+#     the version picker in the book header (docs/theme/tn-custom.js).
+# Tags that predate the docs directory are skipped automatically.
 #
-# One-time repo setup: Settings -> Pages -> Source must be set to "GitHub Actions"
-# (not "Deploy from a branch"), and the github-pages environment's deployment rules
-# must allow deployments from main; without both, the deploy job fails before
-# actions/deploy-pages runs.
+# Triggers: merges into main that touch the book (docs/** or this workflow),
+# any v* tag push (GitHub does not apply path filters to tag pushes), or
+# workflow_dispatch. Rebuilding everything keeps the "GitHub Actions" Pages
+# source, which replaces the whole site on each deployment.
+#
+# One-time repo setup: Settings -> Pages -> Source must be set to "GitHub
+# Actions" (not "Deploy from a branch"), and the github-pages environment's
+# deployment rules must allow deployments from main and from v* tags; without
+# both, the deploy job fails before actions/deploy-pages runs.
 #
 # Local preview: `make book` (build) or `make book-serve` (live-reload) -- both
 # require `cargo install mdbook --version 0.5.4 --locked` to match the version
-# pinned below.
+# pinned below. Local builds have no versions.json, so the picker only shows
+# the current version.
 name: Documentation
 
 on:
   push:
     branches: [main]
+    tags: ["v*"]
     paths:
       - "docs/**"
       - ".github/workflows/docs.yaml"
@@ -34,28 +43,69 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  # Path prefix the site is served under. At the docs.telcoin.network DNS
+  # cutover, flip this to "" (and site-url in docs/book.toml to "/").
+  SITE_ROOT: /telcoin-network
+
 jobs:
-  # Build the static site with the pinned mdBook and hand it to the deploy job as a
-  # Pages artifact.
+  # Build latest + every tagged version with the pinned mdBook and hand the
+  # assembled site to the deploy job as a Pages artifact.
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
-      # Plain checkout: the docs build never touches the tn-contracts submodule.
+      # Full-history checkout: version builds check out each v* tag in a
+      # worktree, and "latest" always builds from main even when the trigger
+      # is a tag push. The docs build never touches the tn-contracts submodule.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install mdbook
         uses: taiki-e/install-action@v2
         with:
           tool: mdbook@0.5.4
 
-      - name: Build the book
-        run: mdbook build docs
+      - name: Build the versioned site
+        run: |
+          set -euo pipefail
+          site="$PWD/site"
+          mkdir -p "$site"
+
+          # Latest: always main, regardless of which ref triggered the run.
+          # site-url is overridden per build (mdBook reads MDBOOK_* env vars)
+          # so asset paths and the 404 page resolve under each prefix.
+          git worktree add --detach wt-latest origin/main
+          MDBOOK_OUTPUT__HTML__SITE_URL="${SITE_ROOT}/" \
+            mdbook build wt-latest/docs --dest-dir "$site"
+
+          # One build per v* tag that has a book; older tags without docs/
+          # are skipped. Newest first so versions.json is already sorted.
+          versions=()
+          for tag in $(git tag -l 'v*' | sort -rV); do
+            if ! git cat-file -e "${tag}:docs/book.toml" 2>/dev/null; then
+              echo "skipping ${tag}: no docs/book.toml"
+              continue
+            fi
+            git worktree add --detach "wt-${tag}" "refs/tags/${tag}"
+            MDBOOK_OUTPUT__HTML__SITE_URL="${SITE_ROOT}/${tag}/" \
+              mdbook build "wt-${tag}/docs" --dest-dir "${site}/${tag}"
+            versions+=("$tag")
+          done
+
+          # Manifest for the header version picker ("latest" is implicit).
+          if [ "${#versions[@]}" -eq 0 ]; then
+            echo '{"versions":[]}' > "${site}/versions.json"
+          else
+            printf '%s\n' "${versions[@]}" | jq -R . | jq -s '{versions: .}' > "${site}/versions.json"
+          fi
+          cat "${site}/versions.json"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/book
+          path: site
 
   # Publish the artifact to the github-pages environment.
   deploy:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ See [docs/src/gas-penalty.md](docs/src/gas-penalty.md) for the formula, examples
 Developer documentation lives in [`docs/`](docs/) and is built into a static site with [mdBook](https://rust-lang.github.io/mdBook/) 0.5.4.
 Markdown sources are in `docs/src/`, with `docs/src/SUMMARY.md` defining the sidebar.
 `docs/book.toml` is the book configuration and `docs/theme/` holds the site theme.
-CI publishes the book to GitHub Pages whenever a merge into `main` touches `docs/` or the docs workflow (`.github/workflows/docs.yaml`).
+CI publishes the book to GitHub Pages whenever a merge into `main` touches `docs/` or the docs workflow (`.github/workflows/docs.yaml`), and on every `v*` tag push.
+The site is versioned: `main` is served at the site root as **latest** (the default), and every `v*` tag that contains `docs/book.toml` is served under `/<tag>/`; readers switch versions with the picker in the book header.
+Intended site behaviors (version switching, sidebar, header, cursor) are pinned in [`docs/ux.md`](docs/ux.md) — update it in the same PR when a theme change intentionally alters one.
 
 To preview locally, install mdBook with `cargo install mdbook --version 0.5.4 --locked`, then:
 

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -202,6 +202,18 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                             </button>
                         </div>
+                        <!-- TN-EDIT E7: version picker. tn-custom.js labels the button with the
+                             version this build lives under (site root = latest, /vX.Y.Z/ = tag)
+                             and fills the menu from versions.json at the site root, which CI
+                             writes when it assembles the multi-version site. Local builds have
+                             no versions.json and list only the current version. -->
+                        <div class="tn-version-picker">
+                            <button type="button" id="tn-version-button" class="tn-version-button" aria-haspopup="listbox" aria-expanded="false" aria-controls="tn-version-menu" title="Switch documentation version">
+                                <span class="tn-version-label">latest</span>
+                                <svg class="tn-version-caret" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+                            </button>
+                            <ul id="tn-version-menu" class="tn-version-menu" role="listbox" aria-label="Documentation versions" hidden></ul>
+                        </div>
                         {{#if print_enable}}
                         <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
                             {{fa "solid" "print" "print-button"}}

--- a/docs/theme/tn-custom.css
+++ b/docs/theme/tn-custom.css
@@ -338,10 +338,125 @@ ul#mdbook-searchresults em {
 
 /* Without JS the switch cannot work; the no-JS palette follows the OS.
    The search pill is also JS-driven (stock hides .left-buttons buttons only,
-   and E2 moved the search toggle into .right-buttons). */
+   and E2 moved the search toggle into .right-buttons). The version picker
+   button is caught by the same .right-buttons rule. */
 html:not(.js) .tn-theme-switch,
 html:not(.js) .right-buttons button {
     display: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* Version picker (E7) + version notices                               */
+/* ------------------------------------------------------------------ */
+
+.tn-version-picker {
+    position: relative;
+    display: inline-flex;
+}
+
+.tn-version-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 34px;
+    padding: 0 12px;
+    border: 1px solid var(--tn-border);
+    border-radius: 999px;
+    background: var(--tn-surface);
+    color: var(--tn-muted);
+    font-family: inherit;
+    font-size: 1.3rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.tn-version-button:hover {
+    border-color: var(--sidebar-active);
+    color: var(--fg);
+}
+
+.tn-version-caret {
+    flex: none;
+    transition: transform 0.15s ease;
+}
+
+.tn-version-button[aria-expanded="true"] .tn-version-caret {
+    transform: rotate(180deg);
+}
+
+.tn-version-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    inset-inline-end: 0;
+    z-index: 300;
+    min-width: 168px;
+    margin: 0;
+    padding: 6px;
+    list-style: none;
+    background: var(--bg);
+    border: 1px solid var(--tn-border);
+    border-radius: 10px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.tn-version-menu li {
+    margin: 0;
+}
+
+.tn-version-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    padding: 7px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 1.3rem;
+    text-align: start;
+    cursor: pointer;
+}
+
+.tn-version-option:hover {
+    background: var(--tn-surface-2);
+}
+
+.tn-version-option.current {
+    color: var(--sidebar-active);
+    font-weight: 600;
+}
+
+.tn-version-option.current::after {
+    content: "\2713";
+    font-size: 1.2rem;
+}
+
+/* Banners injected at the top of the content by tn-custom.js: a standing
+   amber notice on old-version pages, and a blue one explaining a fallback
+   landing when the requested page does not exist in this version. */
+.tn-version-notice {
+    margin: 0 0 20px;
+    padding: 10px 14px;
+    border: 1px solid var(--tn-border);
+    border-radius: 8px;
+    font-size: 1.4rem;
+}
+
+.tn-version-notice a {
+    color: var(--sidebar-active);
+}
+
+.tn-version-notice-old {
+    border-color: rgba(247, 178, 51, 0.55);
+    background: rgba(247, 178, 51, 0.12);
+}
+
+.tn-version-notice-missing {
+    border-color: rgba(55, 174, 255, 0.55);
+    background: rgba(55, 174, 255, 0.12);
 }
 
 /* ------------------------------------------------------------------ */
@@ -784,6 +899,13 @@ blockquote:not(.blockquote-tag) {
         margin: 0 8px;
     }
 
+    /* The version pill stays (unlike the desktop-chrome links above) so old
+       versions remain reachable on phones; it just sheds some padding. */
+    .tn-version-button {
+        padding: 0 9px;
+        gap: 4px;
+    }
+
     .content h1 {
         font-size: 2.6rem;
     }
@@ -792,6 +914,8 @@ blockquote:not(.blockquote-tag) {
 @media print {
     .tn-theme-switch,
     #mdbook-menu-bar .tn-search-pill,
+    .tn-version-picker,
+    .tn-version-notice,
     #tn-page-toc {
         display: none !important;
     }

--- a/docs/theme/tn-custom.js
+++ b/docs/theme/tn-custom.js
@@ -221,3 +221,186 @@
         }
     });
 })();
+
+(function tnVersionPicker() {
+    // Companion to TN-EDIT E7 in index.hbs. CI publishes the book from main at
+    // the site root ("latest") and each v* tag under /<tag>/, plus a
+    // versions.json manifest at the site root. This fills the header picker
+    // from that manifest and switches versions keeping the reader on the same
+    // page when the target version has it. The expected behavior is pinned in
+    // docs/ux.md — update that file if this changes.
+    var button = document.getElementById('tn-version-button');
+    var menu = document.getElementById('tn-version-menu');
+    if (!button || !menu || typeof path_to_root === 'undefined') {
+        return;
+    }
+    var labelEl = button.querySelector('.tn-version-label');
+
+    // Book root of this build, then split it into site root + version name.
+    // A build living in a /v…/ directory is a tagged version; anything else
+    // (site root, custom domain root, local mdbook serve) is "latest".
+    var bookRoot = new URL(path_to_root || '.', window.location.href);
+    var segments = bookRoot.pathname.split('/').filter(Boolean);
+    var lastSegment = segments[segments.length - 1];
+    var current = 'latest';
+    var siteRoot = bookRoot;
+    if (lastSegment && /^v\d/.test(lastSegment)) {
+        current = lastSegment;
+        siteRoot = new URL('..', bookRoot);
+    }
+    labelEl.textContent = current;
+
+    function stripIndex(pathname) {
+        return pathname.replace(/index\.html$/, '');
+    }
+
+    // Pending "intended page" from an earlier switch that fell back to a
+    // version's start page. It survives until the reader either reaches that
+    // page in another version or navigates elsewhere on their own.
+    var intended = null;
+    try {
+        intended = JSON.parse(sessionStorage.getItem('tn-version-intended'));
+    } catch (e) {
+        intended = null;
+    }
+    if (intended && (typeof intended.page !== 'string' ||
+        stripIndex(window.location.pathname) !== stripIndex(intended.landedAt || ''))) {
+        intended = null;
+        try {
+            sessionStorage.removeItem('tn-version-intended');
+        } catch (e) { }
+    }
+
+    var versions = [{ name: 'latest', root: siteRoot }];
+
+    function switchTo(version) {
+        var relPage = window.location.pathname.slice(bookRoot.pathname.length);
+        var desired = intended ? intended.page : relPage;
+        var target = new URL(desired, version.root);
+        function fallBack() {
+            // Target version lacks the page: remember it, land on that
+            // version's start page, and explain there (see banner below).
+            try {
+                sessionStorage.setItem('tn-version-intended', JSON.stringify({
+                    page: desired,
+                    landedAt: version.root.pathname,
+                }));
+            } catch (e) { }
+            window.location.href = version.root.href;
+        }
+        fetch(target.href, { method: 'HEAD' }).then(function (response) {
+            if (response.ok) {
+                try {
+                    sessionStorage.removeItem('tn-version-intended');
+                } catch (e) { }
+                window.location.href = target.href + window.location.hash;
+            } else {
+                fallBack();
+            }
+        }).catch(fallBack);
+    }
+
+    function closeMenu() {
+        menu.hidden = true;
+        button.setAttribute('aria-expanded', 'false');
+    }
+
+    button.addEventListener('click', function (e) {
+        e.stopPropagation();
+        var opening = menu.hidden;
+        menu.hidden = !opening;
+        button.setAttribute('aria-expanded', opening ? 'true' : 'false');
+    });
+    document.addEventListener('click', function (e) {
+        if (!menu.hidden && e.target.closest && !e.target.closest('.tn-version-picker')) {
+            closeMenu();
+        }
+    });
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+            closeMenu();
+        }
+    });
+
+    function renderMenu() {
+        menu.innerHTML = '';
+        versions.forEach(function (version) {
+            var item = document.createElement('li');
+            item.setAttribute('role', 'option');
+            item.setAttribute('aria-selected', version.name === current ? 'true' : 'false');
+            var choice = document.createElement('button');
+            choice.type = 'button';
+            choice.className = 'tn-version-option';
+            choice.textContent = version.name;
+            if (version.name === current) {
+                choice.classList.add('current');
+            }
+            choice.addEventListener('click', function () {
+                closeMenu();
+                if (version.name !== current) {
+                    switchTo(version);
+                }
+            });
+            item.appendChild(choice);
+            menu.appendChild(item);
+        });
+    }
+
+    renderMenu();
+    fetch(new URL('versions.json', siteRoot).href, { cache: 'no-cache' }).then(function (response) {
+        return response.ok ? response.json() : null;
+    }).then(function (manifest) {
+        if (manifest && Array.isArray(manifest.versions)) {
+            manifest.versions.forEach(function (tag) {
+                if (typeof tag === 'string' && /^v\d/.test(tag)) {
+                    versions.push({ name: tag, root: new URL(tag + '/', siteRoot) });
+                }
+            });
+            renderMenu();
+        }
+    }).catch(function () {
+        // No manifest (local build): the menu keeps only the current version.
+    });
+
+    // Content banners: a standing "old version" notice on every non-latest
+    // page, and a one-off explanation when a switch fell back here because
+    // the requested page does not exist in this version.
+    var main = document.querySelector('#mdbook-content > main');
+    if (!main) {
+        return;
+    }
+    if (current !== 'latest') {
+        var banner = document.createElement('div');
+        banner.className = 'tn-version-notice tn-version-notice-old';
+        var text = document.createElement('span');
+        text.appendChild(document.createTextNode('You are viewing documentation for '));
+        var strong = document.createElement('strong');
+        strong.textContent = current;
+        text.appendChild(strong);
+        text.appendChild(document.createTextNode('. '));
+        var latestLink = document.createElement('a');
+        latestLink.href = siteRoot.href;
+        latestLink.textContent = 'View the latest version';
+        latestLink.addEventListener('click', function (e) {
+            e.preventDefault();
+            switchTo(versions[0]);
+        });
+        text.appendChild(latestLink);
+        text.appendChild(document.createTextNode('.'));
+        banner.appendChild(text);
+        main.insertBefore(banner, main.firstChild);
+    }
+    if (intended) {
+        var notice = document.createElement('div');
+        notice.className = 'tn-version-notice tn-version-notice-missing';
+        var noticeText = document.createElement('span');
+        noticeText.appendChild(document.createTextNode('The page you were reading ('));
+        var code = document.createElement('code');
+        code.textContent = intended.page || 'index.html';
+        noticeText.appendChild(code);
+        noticeText.appendChild(document.createTextNode(') is not available in ' + current +
+            ', so you are on its start page. Switching to a version that includes the page will take you back to it.'));
+        notice.appendChild(noticeText);
+        main.insertBefore(notice, main.firstChild);
+    }
+})();

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -1,0 +1,89 @@
+# Docs UX behavior registry
+
+This file is the contract for how the documentation site is supposed to
+behave. It lives outside `docs/src/` on purpose: it is **not** rendered into
+the book — it exists so intentional UX decisions survive theme refactors and
+mdBook upgrades. Before changing anything in `docs/theme/` or the docs CI,
+check the entries below; if a change intentionally alters a behavior, update
+its entry (and note the commit) in the same PR. If a behavior regresses
+without an entry change, that is a bug.
+
+Behaviors are grouped by area. Commit hashes refer to the history of the
+branch that introduced the docs and its successors.
+
+## Versioning
+
+- **Version picker.** The header's right-button cluster contains a version
+  pill immediately after the theme switch. It shows the version the current
+  build lives under and opens a dropdown of all published versions. `latest`
+  is always listed first and is the default: it is the build of `main`,
+  served at the site root. Tagged versions (`v*` tags whose tree contains
+  `docs/book.toml`) are served under `/<tag>/` and listed newest-first from
+  `versions.json`, which CI writes at the site root on every deploy.
+- **Same-page switching.** Switching versions keeps the reader on the page
+  they were reading when the target version has it (checked with a HEAD
+  request; the `#fragment` is preserved).
+- **Missing-page fallback.** If the target version does not have the page,
+  the reader lands on that version's start page with a notice explaining
+  that the requested page is not available in this version. The requested
+  page is remembered for the session: switching to a version that does have
+  it returns the reader to that page. Navigating anywhere else drops the
+  remembered page — from then on, switching follows the current page again.
+- **Old-version banner.** Every page of a non-latest version shows a banner
+  ("You are viewing documentation for vX.Y.Z") with a link that switches to
+  latest using the same same-page-with-fallback rules.
+- **Local builds.** `mdbook build`/`serve` have no `versions.json`; the
+  picker degrades to showing only the current version and nothing errors.
+
+## Header
+
+- **Logo.** The wordmark swaps with the theme: `tn-light.svg` on light,
+  `tn-dark.svg` on dark. Below 768px the wordmark is always replaced by the
+  square TEL badge (`tel-badge.svg`); between 768px and 899px the badge also
+  takes over whenever the sidebar is open, because the overlay squeezes the
+  header too much for the wordmark. All logo art is SVG. (c513775b,
+  61b30594, 52558404)
+- **Desktop-only chrome.** The print, repository, and edit links hide below
+  768px; the search pill collapses to its icon. The theme switch and the
+  version pill always remain. (c513775b)
+- **Search.** The search pill shows a ⌘K hint and opens a floating centered
+  panel; `⌘K`/`Ctrl+K` and `/`/`s` all open it. (c513775b)
+- **Theme switch.** A three-way Light / System / Dark pill relays clicks to
+  the hidden stock theme list so book.js keeps ownership of theme state and
+  localStorage. Only the light and navy palettes ship. (c513775b)
+
+## Cursor
+
+- The default cursor across the site is the TEL badge, rendered at 24px from
+  `tel-cursor.svg` with a PNG fallback for Safari, with the hotspot at the
+  badge's center (12,12) so clicks land where the logo's center sits.
+  Interactive elements still show their native cursors (pointer, text).
+  (da39018d, 06a7e888, a9a126d1)
+
+## Sidebar
+
+- **Whole-row links.** Each chapter row is one visual pill: hovering
+  anywhere on the row highlights the row as a single element, the pointer
+  cursor covers the entire `<li>`, and clicking anywhere on the row (not
+  just the link text) navigates. The fold chevron is a fixed 20px button
+  whose glyph rotates in place without escaping the row. (6032ef17,
+  0b296421)
+- **Active-row collapse.** Clicking the row of the page the reader is
+  already on toggles its section fold instead of reloading the page.
+  (61b30594)
+- **Overlay persistence.** Below 1080px the sidebar is an overlay that stock
+  mdBook closes on every page load. An open sidebar stays open across
+  in-book navigation for the rest of the session; a fresh visit still starts
+  closed, and shrinking the window still collapses it. (61b30594)
+
+## Content
+
+- **No blank pages.** Every page reachable from the sidebar has at least a
+  brief description of its contents — section indexes must introduce and
+  link their children. (cb42dcb1)
+- **On this page rail.** At 1280px and wider, a right-hand rail lists the
+  page's h2/h3 headings with a deterministic scroll-spy: the active entry is
+  the last heading above the reading line, and reaching the bottom marks the
+  last heading. (c513775b)
+- **Sticky header clearance.** Page titles are never hidden under the
+  sticky header on load or on anchor jumps. (c513775b)


### PR DESCRIPTION
- add version control when `v*` tags published 
- ux.md to preserve expected behaviors