### PR TITLE
fix(node): keep mid-epoch-ejected members in the boundary gossip window (#1244)

### DIFF
--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -329,6 +329,40 @@ where
                 (previous.into_iter().collect(), next)
             };
 
+        // A mid-epoch on-chain ejection mutates the CURRENT epoch's validator array in place,
+        // so the pinned entry read above returns the previous epoch's post-ejection (shrunken)
+        // committee. The ejected member's boundary traffic is still in flight, though: its final
+        // epoch-close vote is authored moments before the shrink lands and re-propagates into
+        // this epoch. `spawn_primary_network_for_epoch` derives both the boundary-publisher
+        // allowlist and the peer manager's penalty-exemption slots from this set, so leaving the
+        // ejected member out has `verify_gossip` rejecting that vote as `UnauthorizedAuthor` and
+        // every peer applying `Penalty::Fatal`: the honest, just-ejected node is permanently
+        // banned network-wide and cannot degrade to a following observer (issue #1244). Restore
+        // the pre-shrink membership from the sealed record chain: epoch N-2's record carries
+        // epoch N-1's committee as it stood at N-1's start (`next_committee`), before any
+        // mid-epoch ejection. Epochs 0 and 1 have no grandparent record (epoch 0's committee is
+        // genesis-configured), so an ejection inside epoch 0 stays out of scope here.
+        //
+        // A missing grandparent record is a corrupt datadir for `resolve_prior_epoch_record`,
+        // but this widening is network hygiene, not a consensus input: fail open (no widening)
+        // and let the stricter path own the halt.
+        let previous_committee_keys = if entered >= 2 {
+            let grandparent = self.consensus_chain.epochs().record_by_epoch(entered - 2).await;
+            if grandparent.is_none() {
+                warn!(
+                    target: "epoch-manager",
+                    entered,
+                    missing_record = entered - 2,
+                    "grandparent epoch record missing or unreadable (record_by_epoch collapses \
+                     storage errors to None); cannot restore pre-shrink members to the boundary \
+                     gossip window"
+                );
+            }
+            widen_previous_committee_with_preshrink(previous_committee_keys, grandparent.as_ref())
+        } else {
+            previous_committee_keys
+        };
+
         let consensus_config = self
             .configure_consensus(network_config, committee, next_committee_keys, prior_epoch_record)
             .await?;
@@ -1022,6 +1056,42 @@ async fn resolve_prior_epoch_record(
     Ok((rec, digest))
 }
 
+/// Restore mid-epoch-ejected members of the previous epoch to its committee-key set.
+///
+/// `grandparent_record` is epoch N-2's sealed record when entering epoch N; its `next_committee`
+/// is epoch N-1's committee as it stood at N-1's start, before any mid-epoch on-chain ejection
+/// shrank the registry's array in place. The union is everyone who operated as a committee member
+/// at any point during epoch N-1: exactly the population whose boundary gossip (epoch-close
+/// votes, the epoch's final consensus output) is still in flight when epoch N's network comes up,
+/// and therefore the population `verify_gossip` and the peer manager's penalty exemption must not
+/// treat as never-committee strangers (issue #1244).
+///
+/// Scope: the returned set feeds ONLY the network layer (gossip publisher authorization and
+/// penalty-exemption slots). Quorum and voting always resolve through the epoch's
+/// `ConsensusConfig` committee, and the epoch-vote handler checks authorship against the sealed
+/// record's (post-shrink) committee, so an ejected member regains no consensus authority. The
+/// grace is deliberate and epoch-bounded: like any rotated-out member in the previous slot, the
+/// restored member is also unbanned and score-primed by `update_committees` for this one epoch,
+/// then ages out of the window at the next boundary.
+fn widen_previous_committee_with_preshrink(
+    onchain_previous: HashSet<BlsPublicKey>,
+    grandparent_record: Option<&EpochRecord>,
+) -> HashSet<BlsPublicKey> {
+    let preshrink: HashSet<BlsPublicKey> = grandparent_record
+        .map(|record| record.next_committee.iter().copied().collect())
+        .unwrap_or_default();
+    let ejected: Vec<BlsPublicKey> = preshrink.difference(&onchain_previous).copied().collect();
+    if !ejected.is_empty() {
+        warn!(
+            target: "epoch-manager",
+            ?ejected,
+            "previous committee shrank mid-epoch: keeping the ejected member(s) in the boundary \
+             gossip window so their in-flight epoch-close traffic is not fatally penalized"
+        );
+    }
+    onchain_previous.into_iter().chain(ejected).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1071,6 +1141,53 @@ mod tests {
         assert_eq!(rec.committee, committee);
         assert_eq!(rec.next_committee, committee);
         assert_eq!(anchor, EpochDigest::default(), "epoch 0 anchors on the default digest");
+    }
+
+    /// A member in the grandparent record's `next_committee` but missing from the on-chain
+    /// (post-ejection) previous-committee read is restored to the boundary window, alongside
+    /// every on-chain member (issue #1244).
+    #[test]
+    fn widen_restores_mid_epoch_ejected_member() {
+        let keys = resolve_test_keys(4);
+        let onchain: HashSet<BlsPublicKey> = keys.iter().copied().take(3).collect();
+        let record = EpochRecord { epoch: 1, next_committee: keys.clone(), ..Default::default() };
+        let widened = widen_previous_committee_with_preshrink(onchain, Some(&record));
+        assert_eq!(widened.len(), 4, "the ejected member is restored");
+        assert!(keys.iter().all(|key| widened.contains(key)));
+    }
+
+    /// Without a grandparent record the on-chain read passes through unchanged.
+    #[test]
+    fn widen_without_grandparent_is_identity() {
+        let keys = resolve_test_keys(3);
+        let onchain: HashSet<BlsPublicKey> = keys.iter().copied().collect();
+        let widened = widen_previous_committee_with_preshrink(onchain.clone(), None);
+        assert_eq!(widened, onchain);
+    }
+
+    /// The result is the UNION: an on-chain member absent from the grandparent record survives
+    /// alongside the restored member, pinning the direction of the merge.
+    #[test]
+    fn widen_keeps_onchain_only_members() {
+        let keys = resolve_test_keys(5);
+        let record_committee: Vec<BlsPublicKey> = keys.iter().copied().take(4).collect();
+        let onchain: HashSet<BlsPublicKey> =
+            keys.iter().copied().take(3).chain(keys.iter().copied().skip(4)).collect();
+        let record =
+            EpochRecord { epoch: 1, next_committee: record_committee, ..Default::default() };
+        let widened = widen_previous_committee_with_preshrink(onchain, Some(&record));
+        assert_eq!(widened.len(), 5, "union keeps both sides");
+        assert!(keys.iter().all(|key| widened.contains(key)));
+    }
+
+    /// When no mid-epoch shrink happened (record and chain agree) the set is unchanged.
+    #[test]
+    fn widen_no_shrink_is_identity() {
+        let keys = resolve_test_keys(4);
+        let onchain: HashSet<BlsPublicKey> = keys.iter().copied().collect();
+        let record = EpochRecord { epoch: 1, next_committee: keys, ..Default::default() };
+        let widened = widen_previous_committee_with_preshrink(onchain.clone(), Some(&record));
+        assert_eq!(widened, onchain);
     }
 
     /// A self-sealed prior record stored WITHOUT a certificate still releases the seed anchor (the

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -186,7 +186,8 @@ where
     ///
     /// These components are short-lived: they exist only for the current epoch and are torn
     /// down at its close. The node mode is (re)identified first, and the previous epoch's
-    /// committee keys — resolved by `run_epoch`'s batched read pinned to `epoch_start_header` —
+    /// committee keys — resolved by `run_epoch`'s batched read pinned to `epoch_start_header`,
+    /// widened with any members ejected on-chain mid-previous-epoch (issue #1244) —
     /// are threaded in so peers from the outgoing committee are not banned during the handover.
     /// `initial_epoch` is threaded down to gate the one-time per-process network setup (see
     /// [`init_network_for_epoch`]).
@@ -582,7 +583,10 @@ where
         // `update_committees` (the previous/current/next slots, issue #715), so the
         // propagation-authorization window and the penalty-exemption window agree rather than
         // dropping gossip from a peer the scoring layer already trusts. Never-committee peers are
-        // still excluded. Built here, before the committee sets are moved into
+        // still excluded. The previous slot includes members ejected on-chain mid-previous-epoch
+        // (`widen_previous_committee_with_preshrink`): their final epoch-close vote is exactly
+        // such in-flight boundary traffic, and excluding them fatally bans an honest node at the
+        // boundary (issue #1244). Built here, before the committee sets are moved into
         // `init_network_for_epoch`. See issues #898 and #912.
         let boundary_publishers: HashSet<BlsPublicKey> = previous_committee_keys
             .iter()


### PR DESCRIPTION
Closes #1244.

## Problem

A validator ejected on-chain mid-epoch is permanently banned by every peer at the next epoch close.  After the ban the ejected node has zero connected primary peers, cannot fetch epoch records, and its canonical head freezes at the ejection boundary.  This breaks the documented contract of `eject::test_committee_member_restarted_mid_epoch_after_ejection` (the ejected validator must keep following the chain as an observer), and that e2e test fails deterministically (2 runs on 2 machines, both timing out at `eject.rs:1098` waiting for the ejected node's head).

No attacker is required.  The race is between an on-chain ejection landing near an epoch close and the ejected member's own honest epoch-close vote.

## Root cause

The failing chain runs through the network layer's boundary window, not the epoch-vote handler that #1244 first suspected (that handler arm maps `InvalidEpochVote` to a Mild penalty, which does not ban):

1.  A mid-epoch ejection mutates the CURRENT epoch's on-chain validator array in place.  The next epoch's pinned entry read (`run_epoch`, `validators_for_epochs_at_header`) therefore returns the previous epoch's post-ejection (shrunken) committee.
2.  `spawn_primary_network_for_epoch` derives both the boundary-publisher allowlist for `epoch_vote_topic` / `consensus_output_topic` and the peer manager's penalty-exemption slots from that set (the previous/current/next window, issues #715, #898, #912).  The ejected member is in no slot, so both protections miss it.
3.  The ejected member's final epoch-close vote is still in flight at the swap (the author gossips it moments before peers record the shrink, and gossipsub re-propagates it).  `verify_gossip` rejects it as `RejectReason::UnauthorizedAuthor`, which resolves to `RejectPenalty::FatalAuthor` and `process_penalty(author, Penalty::Fatal)` (`network-libp2p/src/consensus.rs`).  `Penalty::Fatal` never decays, so every peer converges on a permanent ban.

The log pair from the failing run confirms the site: `committee shrank mid-epoch: ... recording shrunken committee` followed within 200ms by `unauthorized-author gossip - applying fatal penalty to the author ... topic=tn-epoch-vote` and `peer banned`.

## Fix

Restore the pre-shrink membership when entering an epoch.  Epoch N-2's sealed record carries epoch N-1's committee as it stood at N-1's start (`next_committee`), before any mid-epoch ejection.  `run_epoch` now unions that set into the previous-committee keys threaded to the network layer.

- [x] `node/src/manager/node/run_epoch.rs`: new `widen_previous_committee_with_preshrink` helper; the entry path fetches epoch N-2's record and unions its `next_committee` into `previous_committee_keys` (epochs 0 and 1 have no grandparent record and are unchanged).  A missing record fails open with a `warn!` (the widening is network hygiene, not a consensus input;  `resolve_prior_epoch_record` still owns the halt for a corrupt record chain).
- [x] `node/src/manager/node/start_epoch.rs`: boundary-window and `create_consensus` doc comments record the new invariant.

Threat model.  The widened set feeds only gossip publisher authorization and penalty exemption, exactly the two mechanisms that were already deliberately spanning the previous/current/next window so in-flight boundary traffic from a rotating-out committee is not rejected (#912).  A member ejected mid-epoch is an outgoing committee member whose exit came early; it gets the same one-epoch grace every outgoing member already gets, and never-committee peers stay excluded.  It regains no consensus authority: quorum and voting resolve through the epoch's `ConsensusConfig` committee, and the epoch-vote handler still checks authorship against the sealed record's post-shrink committee, so its stale vote is dropped as the benign, non-penalizing `PeerNotInCommittee`.  The derivation is deterministic on every node (sealed record chain), so the allowlist and exemption windows stay identical across honest peers.

## Testing

- New unit tests (`cargo +1.94 test -p tn-node --lib widen_`): the ejected member is restored from the grandparent record, a missing grandparent is identity, and a no-shrink epoch is identity.  The restore test was mutation-confirmed: with the widening call reverted to identity, it fails; restored, it passes.
- Regression gate GREEN locally: `cargo +1.94 test -p e2e-tests --test it -- eject::test_committee_member_restarted_mid_epoch_after_ejection --exact --ignored` (the deterministic failure this fixes) passes on this branch: `test result: ok. 1 passed; 0 failed` in 2458.9s, with the ejected validator following as an observer past the boundary.
- Static ladder locally (nightly `fmt --check`, scoped `clippy -p tn-node --no-deps -- -D warnings`); the workspace CI lanes and the pinned `+1.94` attest run remotely on push.
