### PR TITLE
fix(primary): bound the unreadable-frame sync bail close with a timeout (#1250)

### DIFF
--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -1480,7 +1480,10 @@ where
             .and_then(Result::ok);
             let Some(request) = request else {
                 warn!(target: "primary::network", %peer, "no readable sync request frame");
-                let _ = stream.close().await;
+                // bound the best-effort close for parity with the shed and
+                // unexpected-frame paths: the held admission permit must free
+                // promptly even if the connection's send buffer is backed up.
+                let _ = tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, stream.close()).await;
                 return Ok(());
             };
 


### PR DESCRIPTION
Closes #1250.

## Problem

`process_inbound_sync_stream` acquires an admission permit, then bails on three paths. Two of the bail paths bound their best-effort `stream.close()` with `SYNC_REQUEST_READ_TIMEOUT`:

- the shed path (deny at capacity)
- the unexpected-opening-frame path

The unreadable-opening-frame bail does not. It calls `stream.close().await` bare. In the worst case, a backed-up connection-level send buffer holds the permit longer than intended.

The exposure is small. This path only reads before it bails, so the FIN flushes immediately unless a concurrent sibling serve on the same connection backed up the send buffer. That buffer is itself bounded (per-frame write 10s, serve 200s), and the epoch-stream semaphore caps concurrency at 5 globally. This is a parity fix, not the GHSA-9frf class.

## Fix

- [x] `crates/consensus/primary/src/network/mod.rs`: wrap the close on the unreadable-frame bail in `tokio::time::timeout(SYNC_REQUEST_READ_TIMEOUT, stream.close())`, the same bound the two sibling bail paths use. All three bail paths in this function now release the admission permit within one read-timeout window, independent of peer behavior.

## Testing

- `cargo +nightly fmt -p tn-primary -- --check` green.
- `cargo +1.94 clippy -p tn-primary --all-features --no-deps -- -D warnings` green.
- `cargo +nightly clippy -p tn-primary --all-features --no-deps -- -D warnings` green (CI's clippy toolchain and target scope; the crate's test targets carry pre-existing lints at base that CI does not check, so they are out of this PR's scope).
- No new test: the change substitutes the exact bounded-close expression the two sibling paths already use, and a deterministic test for a close that outlives a timeout needs a peer that applies receive backpressure on a real connection. CI's workspace nextest lane covers the touched function's existing behavior.
