### PR TITLE
fix(network): bound peer-exchange discovery sampling to the missing target (#1253)

### DIFF
--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{NetworkInfo, NetworkResult, RpcInfo},
 };
 use libp2p::{core::ConnectedPoint, kad::PeerInfo, multiaddr::Protocol, Multiaddr, PeerId};
-use rand::seq::{IteratorRandom as _, SliceRandom as _};
+use rand::seq::IteratorRandom as _;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::IpAddr,
@@ -657,8 +657,12 @@ impl PeerManager {
 
         // seed discovery peers from peer exchange
         if current_count < max_discovery_peers {
-            // convert eligible peers to `PeerInfo` for processing
-            let mut peers: Vec<_> = peers
+            // reservoir-sample the missing target number of eligible peers so the
+            // collected buffer and the shuffle stay bounded by the open discovery
+            // slots; the per-entry eligibility pass still visits each codec-bounded entry
+            let peers_to_take = max_discovery_peers - current_count;
+            let mut rng = rand::rng();
+            let peers = peers
                 .into_iter()
                 .filter_map(|(_, (net_key, addrs))| {
                     let info =
@@ -673,20 +677,15 @@ impl PeerManager {
                         None
                     }
                 })
-                .collect();
+                .choose_multiple(&mut rng, peers_to_take);
 
-            debug!(target: "peer-manager", eligible=?peers, "processing peer exchange");
+            debug!(target: "peer-manager", sampled=?peers, "processing peer exchange");
 
-            // shuffle all peers
-            let mut rng = rand::rng();
-            peers.shuffle(&mut rng);
-
-            // add target number of peers for discovery
-            let peers_to_take = max_discovery_peers - current_count;
-            for peer in peers.into_iter().take(peers_to_take) {
+            // add sampled peers for discovery
+            peers.into_iter().for_each(|peer| {
                 debug!(target: "peer-manager", peer=?peer.peer_id, "added peer to discovery peers");
                 self.discovery_peers.insert(peer.peer_id, peer.addrs);
-            }
+            });
         }
     }
 

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -543,6 +543,75 @@ async fn test_process_peer_exchange() {
     assert!(peer_manager.next_dial_request().is_none());
 }
 
+/// Helper to build an exchange map of `count` eligible peers, returning the map and its ids.
+fn eligible_exchange_map(
+    count: usize,
+    seed: u8,
+) -> (HashMap<BlsPublicKey, (NetworkPublicKey, HashSet<Multiaddr>)>, HashSet<PeerId>) {
+    let mut rng = StdRng::from_seed([seed; 32]);
+    (0..count).fold(
+        (HashMap::new(), HashSet::new()),
+        |(mut exchange_map, mut exchanged_peers), _| {
+            let bls = *BlsKeypair::generate(&mut rng).public();
+            let net: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().clone().into();
+            let peer_id: PeerId = net.clone().into();
+            exchanged_peers.insert(peer_id);
+            exchange_map.insert(bls, (net, HashSet::from([create_multiaddr(None)])));
+            (exchange_map, exchanged_peers)
+        },
+    )
+}
+
+#[tokio::test]
+async fn test_process_peer_exchange_bounds_discovery_to_missing_target() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let max_discovery_peers = peer_manager.config.max_discovery_peers();
+
+    // pre-seed some discovery peers so the missing target is smaller than the max
+    let preseeded = 3;
+    let preseeded_peers: HashSet<PeerId> = (0..preseeded)
+        .map(|_| {
+            let peer_id = PeerId::random();
+            peer_manager.discovery_peers.insert(peer_id, vec![create_multiaddr(None)]);
+            peer_id
+        })
+        .collect();
+
+    // build an exchange map with more eligible peers than the missing target
+    let (exchange_map, exchanged_peers) = eligible_exchange_map(max_discovery_peers + 8, 1);
+
+    // process the oversized exchange
+    peer_manager.process_peer_exchange(PeerExchangeMap::from(exchange_map));
+
+    // verify the sample tops up to the max, not to max + preseeded or the full map size
+    assert_eq!(peer_manager.discovery_peers.len(), max_discovery_peers);
+
+    // verify the pre-seeded peers survive and exactly the missing target came from the exchange
+    assert!(preseeded_peers.iter().all(|id| peer_manager.discovery_peers.contains_key(id)));
+    let sampled =
+        peer_manager.discovery_peers.keys().filter(|id| exchanged_peers.contains(id)).count();
+    assert_eq!(sampled, max_discovery_peers - preseeded);
+}
+
+#[tokio::test]
+async fn test_process_peer_exchange_skips_when_discovery_full() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let max_discovery_peers = peer_manager.config.max_discovery_peers();
+
+    // fill discovery peers to the max
+    (0..max_discovery_peers).for_each(|_| {
+        peer_manager.discovery_peers.insert(PeerId::random(), vec![create_multiaddr(None)]);
+    });
+
+    // process an exchange with eligible peers
+    let (exchange_map, exchanged_peers) = eligible_exchange_map(5, 2);
+    peer_manager.process_peer_exchange(PeerExchangeMap::from(exchange_map));
+
+    // verify nothing was added from the exchange
+    assert_eq!(peer_manager.discovery_peers.len(), max_discovery_peers);
+    assert!(peer_manager.discovery_peers.keys().all(|id| !exchanged_peers.contains(id)));
+}
+
 /// Helper to build a distinct, deterministic multiaddr per index.
 ///
 /// All addresses target the same IP with different ports, the shape of a dial-amplification


### PR DESCRIPTION
Closes #1253.

## Problem

`process_peer_exchange` collects every eligible entry of the incoming `PeerExchangeMap` into a `Vec`, shuffles the whole `Vec`, and only then applies `take(peers_to_take)`.  The allocation and the shuffle scale with the sender-controlled entry count, not with the number of discovery slots this node still has open.  Any disconnecting peer can pack the exchange message up to the codec's max message size and make the receiver pay a full collect plus shuffle to insert at most a handful of peers.  The codec bound keeps the entry count finite, so this is a low-severity CPU amplification, not an unbounded DoS.  No attacker coordination is required.

## Fix

- [x] `crates/network-libp2p/src/peers/manager.rs`: reservoir-sample the missing target number of eligible peers directly from the exchange iterator with `IteratorRandom::choose_multiple`, replacing collect + shuffle + take.  The selection stays uniform over the eligible set.  The buffer never holds more than `max_discovery_peers - current_count` entries and no shuffle over the full map runs.  The bound comes from `PeerConfig::max_discovery_peers()`, the same parameter the discovery heartbeat already enforces, so the cap is shared, not guessed.  The per-entry eligibility filter still runs once per incoming entry;  that pass is inherent to reading the message and is cheap membership work, while the expensive allocate-and-shuffle step now tracks the output size.
- [x] Drop the now-unused `SliceRandom` import.

## Testing

- [x] New regression test `test_process_peer_exchange_bounds_discovery_to_missing_target`: with 3 discovery peers pre-seeded, an exchange map holding `max_discovery_peers + 8` eligible peers tops the set up to exactly `max_discovery_peers`, the pre-seeded peers survive, and exactly the missing target number of entries comes from the exchange map.  Confirmed by mutation: with the sample bound lifted, and separately with the bound not subtracting `current_count`, the test fails on the count assertions.
- [x] New regression test `test_process_peer_exchange_skips_when_discovery_full`: with the discovery set already at `max_discovery_peers`, an exchange adds nothing.
- [x] `cargo +nightly fmt -p tn-network-libp2p -- --check` green.
- [x] `cargo +1.94 clippy -p tn-network-libp2p --all-targets --no-deps` green.
- [x] `cargo +1.94 test -p tn-network-libp2p --lib process_peer_exchange` green (both peer-exchange tests).

CI runs the workspace lanes on push;  the pinned `+1.94` attest runs post-push on the second machine.
