### PR TITLE
fix(network): bound discovery inserts at max_discovery_peers (#1252)

### DIFF
--- a/crates/network-libp2p/src/peers/manager.rs
+++ b/crates/network-libp2p/src/peers/manager.rs
@@ -1111,12 +1111,31 @@ impl PeerManager {
 
     /// Process newly discovered peers for potential dial attempts.
     ///
-    /// Only eligible peers are stored for dialing during heartbeat.
+    /// Only eligible peers are stored for dialing during heartbeat. The set is bounded to
+    /// `max_discovery_peers` at insert time, so the bound holds within a heartbeat window
+    /// instead of relying on the next heartbeat to prune overshoot (issue #1252). The bound is
+    /// enforced by merging the newcomers and then randomly evicting down to the cap, never by
+    /// rejecting newcomers: a first-come cap would let whoever fills the set first (or an
+    /// attacker feeding eligible-but-unreachable ids) own the pool and starve fresh kad
+    /// results, while random eviction over the union keeps the pool rotating exactly like the
+    /// heartbeat prune it mirrors. [`Self::process_peer_exchange`] stays fill-to-spare-capacity
+    /// only, which keeps kad-discovered peers prioritized over exchange peers.
     pub(crate) fn process_peers_for_discovery(&mut self, mut peers: Vec<PeerInfo>) {
         peers.retain(|peer| self.eligible_for_discovery(peer));
-        let peers: HashSet<_> = peers.into_iter().map(|info| (info.peer_id, info.addrs)).collect();
         trace!(target: "peer-manager", ?peers, "adding eligible peers to discovery map");
-        self.discovery_peers.extend(peers);
+        self.discovery_peers.extend(peers.into_iter().map(|info| (info.peer_id, info.addrs)));
+
+        // sample down to the cap over old and new entries alike
+        let max_discovery_peers = self.config.max_discovery_peers();
+        let excess = self.discovery_peers.len().saturating_sub(max_discovery_peers);
+        if excess > 0 {
+            let mut rng = rand::rng();
+            let to_remove: Vec<PeerId> =
+                self.discovery_peers.keys().copied().choose_multiple(&mut rng, excess);
+            to_remove.into_iter().for_each(|peer| {
+                self.discovery_peers.remove(&peer);
+            });
+        }
     }
 
     /// Check peer counts and initiate dial attempts to maintain connection targets.

--- a/crates/network-libp2p/src/tests/network_tests.rs
+++ b/crates/network-libp2p/src/tests/network_tests.rs
@@ -1493,16 +1493,19 @@ async fn test_goodbye_falls_back_to_embedded_exchange_for_legacy_peer() -> eyre:
         let mut goodbye_tx = Some(goodbye_tx);
         loop {
             if let SwarmEvent::Behaviour(request_response::Event::Message {
-                message: request_response::Message::Request { request, channel, .. },
+                message:
+                    request_response::Message::Request {
+                        request: TestWorkerRequest::PeerExchange(map),
+                        channel,
+                        ..
+                    },
                 ..
             }) = raw_swarm.select_next_some().await
             {
-                if let TestWorkerRequest::PeerExchange(map) = request {
-                    let ack = TestWorkerResponse::from(PeerExchangeMap::default());
-                    let _ = raw_swarm.behaviour_mut().send_response(channel, ack);
-                    if let Some(tx) = goodbye_tx.take() {
-                        let _ = tx.send(map);
-                    }
+                let ack = TestWorkerResponse::from(PeerExchangeMap::default());
+                let _ = raw_swarm.behaviour_mut().send_response(channel, ack);
+                if let Some(tx) = goodbye_tx.take() {
+                    let _ = tx.send(map);
                 }
             }
         }

--- a/crates/network-libp2p/src/tests/peer_manager.rs
+++ b/crates/network-libp2p/src/tests/peer_manager.rs
@@ -1687,6 +1687,46 @@ async fn test_process_peers_for_discovery_filters_duplicates() {
     assert_eq!(peer_manager.discovery_peers.remove(&peer_id), Some(vec![addr]));
 }
 
+// Regression (issue #1252): `process_peers_for_discovery` bounds the set to
+// `max_discovery_peers` at insert time, so overshoot never persists until the
+// next heartbeat prune. The bound is enforced by random eviction over old and
+// new entries alike, never by rejecting newcomers, so no first-come occupant
+// can starve fresh kad results out of the pool.
+#[tokio::test]
+async fn test_process_peers_for_discovery_caps_inserts() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let max_discovery = peer_manager.config.max_discovery_peers();
+
+    // flood past the cap in a single batch
+    let flood: Vec<_> = (0..max_discovery + 10)
+        .map(|_| PeerInfo { peer_id: PeerId::random(), addrs: vec![create_multiaddr(None)] })
+        .collect();
+    peer_manager.process_peers_for_discovery(flood);
+
+    // capped at insert time - no transient overshoot
+    assert_eq!(peer_manager.discovery_peers.len(), max_discovery);
+
+    // at the cap, another batch still leaves the set exactly at the cap
+    let second_flood: Vec<_> = (0..10)
+        .map(|_| PeerInfo { peer_id: PeerId::random(), addrs: vec![create_multiaddr(None)] })
+        .collect();
+    peer_manager.process_peers_for_discovery(second_flood);
+    assert_eq!(peer_manager.discovery_peers.len(), max_discovery);
+
+    // an address update for a tracked peer replaces its entry without growing
+    // the set, and with no excess nothing is evicted
+    let tracked_id = peer_manager.discovery_peers.keys().next().copied();
+    let new_addr = create_multiaddr(None);
+    tracked_id.into_iter().for_each(|tracked_id| {
+        peer_manager.process_peers_for_discovery(vec![PeerInfo {
+            peer_id: tracked_id,
+            addrs: vec![new_addr.clone()],
+        }]);
+        assert_eq!(peer_manager.discovery_peers.len(), max_discovery);
+        assert_eq!(peer_manager.discovery_peers.remove(&tracked_id), Some(vec![new_addr.clone()]));
+    });
+}
+
 // Regression (issue #777 Part B): the node's own peer id must never be added to
 // the discovery feed. A self entry (learned via kad closest-peers or peer
 // exchange) would otherwise be selected for a self-dial during the heartbeat.


### PR DESCRIPTION
Closes #1252.

## Problem

`process_peers_for_discovery` extends `discovery_peers` with every eligible peer it receives.  There is no bound at insert time.  A kad closest-peers response is attacker-influenced input, so one burst of responses can grow the set past `max_discovery_peers` until the next `discovery_heartbeat` prunes it.  The sibling inlet `process_peer_exchange` already enforces its bound at insert time, so the two discovery inlets enforce different bounds on the same set.  The overshoot is transient and self-correcting, so this is defense-in-depth, not a standalone OOM.

## Fix

- [x] `crates/network-libp2p/src/peers/manager.rs`: `process_peers_for_discovery` merges the eligible newcomers, then randomly evicts down to `max_discovery_peers` over old and new entries alike.  The bound now holds at the end of every call, not only at the next heartbeat.
- [x] The bound is enforced by eviction, never by rejecting newcomers.  A first-come cap would let whoever fills the set first (or an attacker feeding `max_discovery_peers` eligible-but-unreachable ids while the node sits at `target_num_peers` and dials nothing) own the pool and starve fresh kad results indefinitely.  Random eviction over the union keeps the pool rotating with exactly the selection semantics of the heartbeat prune it mirrors, so no attacker-independent behavior changes.
- [x] The bound is the same shared config value (`PeerConfig::max_discovery_peers`) that the PEX inlet and the heartbeat prune already use.  No new constant is introduced.  `process_peer_exchange` stays fill-to-spare-capacity only, which keeps kad-discovered peers prioritized over exchange peers, per its doc.
- [x] Doc comment on the function states the bound, the eviction rationale, and the kad-over-PEX prioritization.

## Testing

- [x] New regression test `test_process_peers_for_discovery_caps_inserts`: a single batch of `max_discovery_peers + 10` eligible peers lands the set exactly at the cap;  a second batch at the cap leaves it exactly at the cap;  an address update for a tracked peer replaces its entry without growing the set and evicts nothing.  The test is deterministic (size assertions only, no sleeps, no wall-clock assumptions).
- [x] Mutation-confirmed: with the sample-down arm reverted to the old unconditional `extend`, the new test fails;  with the fix restored, it passes.
- [x] Local static ladder: `cargo +nightly fmt -- --check` and scoped `clippy -p tn-network-libp2p --all-targets --all-features --no-deps -- -D warnings` green;  `cargo test -p tn-network-libp2p` green.
- [x] Existing discovery tests (duplicate filtering, self-id filtering, heartbeat pruning) unchanged and passing;  the heartbeat prune still runs as the backstop.
