### PR TITLE
Use alloy artifacts for ConsensusRegistry events

### DIFF
--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -99,7 +99,7 @@ use crate::{
     system_calls::{
         decode_worker_fee_configs, log_registry_event,
         ConsensusRegistry::{self, RewardInfo, ValidatorStatus},
-        WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS,
+        RegistryEvents, WorkerConfigs, CONSENSUS_REGISTRY_ADDRESS,
     },
     SYSTEM_ADDRESS,
 };
@@ -258,22 +258,27 @@ pub(crate) struct TNBlockExecutor<Evm, Spec, R: ReceiptBuilder> {
 
 /// Surface the logs a successful system call emitted, off-consensus.
 ///
-/// A system call produces no receipt, so the `ConsensusRegistry` lifecycle events its
-/// `onlySystemCall` paths emit (`NewEpoch`, `ValidatorActivated`, `ValidatorExited`,
-/// `ValidatorSlashed`, `ValidatorRetired`, `NextCommitteeSizeUpdated`, ...) are otherwise visible
-/// only in the `trace!(?res)` dump. Each log from [`CONSENSUS_REGISTRY_ADDRESS`] is decoded into
-/// its typed event and emitted at `info!` by [`log_registry_event`], named, so an operator's log
-/// shows every epoch boundary, activation, exit, slash, and retirement. A registry log whose
-/// topic the binding does not know, and any log from another contract (the `WorkerConfigs`
-/// writes emit `WorkerConfigUpdated`), are emitted raw at `debug!` with address, topics, and
-/// data: never dropped, never promoted to a line that looks decoded.
+/// A system call produces no receipt (see [`TNBlockExecutor::transact_and_commit_system_call`],
+/// which owns that constraint), so the `ConsensusRegistry` lifecycle events its `onlySystemCall`
+/// paths emit are otherwise visible only in the `trace!(?res)` dump. Each log from
+/// [`CONSENSUS_REGISTRY_ADDRESS`] is decoded into its typed event and emitted at `info!` by
+/// [`log_registry_event`], named, so an operator's log shows every epoch boundary, activation,
+/// exit, slash, and retirement.
+///
+/// Decoding goes through [`RegistryEvents`], generated from the compiled artifact, so it covers
+/// the registry's whole event ABI rather than the subset the call surface curates — including the
+/// inherited ERC-721 `Transfer` that a slash-to-zero ejection's NFT burn emits, which is named
+/// here rather than falling through as an unknown topic. A registry log whose topic even that
+/// binding does not know (a redeployed contract this build predates), and any log from another
+/// contract (the `WorkerConfigs` writes emit `WorkerConfigUpdated`), are emitted raw at `debug!`
+/// with address, topics, and data: never dropped, never promoted to a line that looks decoded.
 ///
 /// Observational only: reads the logs, writes nothing. Epoch boundaries are rare and emit a
 /// bounded handful of events (one per activation/exit plus `NewEpoch`), so `info!` does not flood
 /// the log, and a non-closing block never reaches this function.
 fn surface_system_call_logs(description: &str, logs: &[Log]) {
     logs.iter().map(classify_system_call_log).for_each(|classified| match classified {
-        SystemCallLog::Registry(event) => log_registry_event(description, event),
+        SystemCallLog::Registry(log, event) => log_registry_event(description, log, &event),
         SystemCallLog::UnknownRegistryTopic(log, error) => debug!(
             target: "engine",
             %error,
@@ -296,21 +301,24 @@ fn surface_system_call_logs(description: &str, logs: &[Log]) {
 /// Split out of the emitting function so the classification is testable without a tracing
 /// subscriber: the variant decides which log line fires, and the decoded payload rides inside it.
 enum SystemCallLog<'a> {
-    /// A log from [`CONSENSUS_REGISTRY_ADDRESS`] that decoded into a bound registry event.
-    Registry(ConsensusRegistry::ConsensusRegistryEvents),
-    /// A log from [`CONSENSUS_REGISTRY_ADDRESS`] whose topic the `sol!` binding does not know,
-    /// with the decode error.
+    /// A log from [`CONSENSUS_REGISTRY_ADDRESS`] that decoded into a bound registry event, paired
+    /// with the raw log it came from. [`log_registry_event`] names the event by looking its
+    /// topic-0 up in the artifact's selector table, so the source log rides along rather than
+    /// being re-encoded to recover a hash the caller already has.
+    Registry(&'a Log, RegistryEvents),
+    /// A log from [`CONSENSUS_REGISTRY_ADDRESS`] whose topic the artifact binding does not know,
+    /// with the decode error. Reachable only against a registry deployment newer than this build.
     UnknownRegistryTopic(&'a Log, alloy::sol_types::Error),
     /// A log from any other contract.
     Foreign(&'a Log),
 }
 
-/// Classify one system-call log: a registry log is decoded through the `sol!` events binding,
-/// every other log passes through untouched.
+/// Classify one system-call log: a registry log is decoded through the artifact-generated events
+/// binding, every other log passes through untouched.
 fn classify_system_call_log(log: &Log) -> SystemCallLog<'_> {
     if log.address == CONSENSUS_REGISTRY_ADDRESS {
-        ConsensusRegistry::ConsensusRegistryEvents::decode_log(log)
-            .map(|decoded| SystemCallLog::Registry(decoded.data))
+        RegistryEvents::decode_log(log)
+            .map(|decoded| SystemCallLog::Registry(log, decoded.data))
             .unwrap_or_else(|error| SystemCallLog::UnknownRegistryTopic(log, error))
     } else {
         SystemCallLog::Foreign(log)
@@ -366,11 +374,9 @@ where
     /// No receipt is built for a system call, matching Ethereum: the logs it emits reach neither
     /// the receipts root, the header `logs_bloom`, nor `eth_getLogs`, and they must not, since
     /// adding them would change `receipts_root` and be a hard fork. The success arm instead hands
-    /// them to [`surface_system_call_logs`], which decodes the registry's lifecycle events and
-    /// emits them node-side at `info!`, the only place an operator sees a `NewEpoch`,
-    /// `ValidatorActivated`, `ValidatorExited`, or `ValidatorSlashed`. That path is observational
-    /// only and runs after the result is known good; it touches neither `res.state` nor the gas
-    /// accounting.
+    /// them to [`surface_system_call_logs`], which is where the node-side `info!` lines and their
+    /// rationale live. That path is observational only and runs after the result is known good;
+    /// it touches neither `res.state` nor the gas accounting.
     fn transact_and_commit_system_call(
         &mut self,
         contract: Address,
@@ -2061,13 +2067,13 @@ mod tests {
     /// Pins the classification the off-consensus log surfacing in
     /// `transact_and_commit_system_call` depends on: a real `concludeEpoch` system call against
     /// the deployed registry, run on a side-effect-free EVM at the genesis tip, must emit a log
-    /// that [`classify_system_call_log`] routes to `SystemCallLog::Registry(NewEpoch)` carrying
-    /// the decoded next epoch id and committee, and no log that falls through as
+    /// that [`classify_system_call_log`] routes to `SystemCallLog::Registry(_, NewEpoch)`
+    /// carrying the decoded next epoch id and committee, and no log that falls through as
     /// `UnknownRegistryTopic` or `Foreign`. The unit test in `system_calls.rs` round-trips a
-    /// hand-built log through the binding; this one runs the contract's own emit, so a topic
-    /// drift between the Solidity `NewEpoch(EpochInfo)` signature and the `sol!` binding (which
-    /// would silently demote every epoch boundary to the raw "unknown topic" line) fails here
-    /// rather than in an operator's log.
+    /// hand-built log through the binding; this one runs the contract's own emit against the
+    /// deployed bytecode, so a divergence between the artifact this crate compiles against and
+    /// the registry actually deployed in genesis (which would silently demote every epoch
+    /// boundary to the raw "unknown topic" line) fails here rather than in an operator's log.
     ///
     /// Contract note: `concludeEpoch` emits the STARTING committee of the new epoch, which at
     /// genesis is the initial validator set the constructor seeded for epochs 0..=2 in ceremony
@@ -2075,7 +2081,7 @@ mod tests {
     /// equals the sorted `newCommittee` passed in (which the contract files for epoch 3).
     #[tokio::test]
     async fn system_call_logs_classify_to_named_registry_events() -> eyre::Result<()> {
-        use ConsensusRegistry::ConsensusRegistryEvents as E;
+        use crate::system_calls::RegistryEvents as E;
 
         let genesis = test_genesis_with_consensus_registry(4);
         let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
@@ -2132,7 +2138,7 @@ mod tests {
         let unclassified: Vec<(Address, Vec<B256>)> = logs
             .iter()
             .zip(classified.iter())
-            .filter(|(_, c)| !matches!(c, SystemCallLog::Registry(_)))
+            .filter(|(_, c)| !matches!(c, SystemCallLog::Registry(..)))
             .map(|(log, _)| (log.address, log.topics().to_vec()))
             .collect();
         assert!(
@@ -2143,14 +2149,14 @@ mod tests {
         // (a) the `NewEpoch` for the next epoch carries the decoded id and committee
         let new_epoch_count = classified
             .iter()
-            .filter(|c| matches!(c, SystemCallLog::Registry(E::NewEpoch(_))))
+            .filter(|c| matches!(c, SystemCallLog::Registry(_, E::NewEpoch(_))))
             .count();
         let matching = classified
             .iter()
             .filter(|c| {
                 matches!(
                     c,
-                    SystemCallLog::Registry(E::NewEpoch(e))
+                    SystemCallLog::Registry(_, E::NewEpoch(e))
                         if e.epoch.epochId == expected_epoch_id
                             && e.epoch.committee == new_committee
                 )

--- a/crates/tn-reth/src/evm/block.rs
+++ b/crates/tn-reth/src/evm/block.rs
@@ -269,13 +269,22 @@ pub(crate) struct TNBlockExecutor<Evm, Spec, R: ReceiptBuilder> {
 /// the registry's whole event ABI rather than the subset the call surface curates — including the
 /// inherited ERC-721 `Transfer` that a slash-to-zero ejection's NFT burn emits, which is named
 /// here rather than falling through as an unknown topic. A registry log whose topic even that
-/// binding does not know (a redeployed contract this build predates), and any log from another
+/// binding does not know (a deployment this build's artifact does not cover, in either direction —
+/// see [`SystemCallLog::UnknownRegistryTopic`]), and any log from another
 /// contract (the `WorkerConfigs` writes emit `WorkerConfigUpdated`), are emitted raw at `debug!`
 /// with address, topics, and data: never dropped, never promoted to a line that looks decoded.
 ///
-/// Observational only: reads the logs, writes nothing. Epoch boundaries are rare and emit a
-/// bounded handful of events (one per activation/exit plus `NewEpoch`), so `info!` does not flood
-/// the log, and a non-closing block never reaches this function.
+/// Observational only: reads the logs, writes nothing, and a non-closing block never reaches this
+/// function. Volume per closing block: `applyIncentives` emits nothing; `concludeEpoch` emits
+/// `NewEpoch` plus one event per queue entry (activation, exit, or stake-version settlement, which
+/// adds up to two) — bounded by the ConsensusNFT supply, not by the committee size;
+/// `migrateValidatorSets` emits exactly one `ValidatorSetsMigrated`, once, at the fork. So `info!`
+/// is not a flood risk today. `applySlashes` is the exception to watch: it adds one
+/// `ValidatorSlashed` per entry and roughly five more per slash-to-zero ejection, and its bound is
+/// the system-call gas cap rather than the validator count, because the slash array is
+/// caller-supplied and the contract does not dedupe it. That is moot while
+/// [`TNBlockExecutor::epoch_boundary_slashes`] returns an empty list, but enabling slashing should
+/// revisit this level rather than assume the bound above.
 fn surface_system_call_logs(description: &str, logs: &[Log]) {
     logs.iter().map(classify_system_call_log).for_each(|classified| match classified {
         SystemCallLog::Registry(log, event) => log_registry_event(description, log, &event),
@@ -307,7 +316,13 @@ enum SystemCallLog<'a> {
     /// being re-encoded to recover a hash the caller already has.
     Registry(&'a Log, RegistryEvents),
     /// A log from [`CONSENSUS_REGISTRY_ADDRESS`] whose topic the artifact binding does not know,
-    /// with the decode error. Reachable only against a registry deployment newer than this build.
+    /// with the decode error. Reachable against any deployment whose event ABI this build's
+    /// artifact does not cover, an OLDER one as readily as a newer one: on an `adiri` build below
+    /// `CONSENSUS_REGISTRY_FORK_EPOCH` the legacy close is what runs at every production epoch
+    /// close today, and it routes its logs through this same classifier. Both pinned deployments
+    /// are covered all the same — the pre-fork registry's 18 events are a byte-identical subset of
+    /// the artifact's 27, so even a pre-fork `NewEpoch` decodes by name. An unknown topic here is
+    /// a genuine fallback, not a sign of a redeploy that never happened.
     UnknownRegistryTopic(&'a Log, alloy::sol_types::Error),
     /// A log from any other contract.
     Foreign(&'a Log),
@@ -2125,9 +2140,8 @@ mod tests {
         let logs = res.result.logs();
         assert!(
             !logs.is_empty(),
-            "concludeEpoch succeeded (gas used {}) but emitted {} logs",
-            res.result.gas_used(),
-            logs.len()
+            "concludeEpoch succeeded (gas used {}) but emitted no logs",
+            res.result.gas_used()
         );
 
         let classified: Vec<SystemCallLog<'_>> =
@@ -2162,13 +2176,126 @@ mod tests {
                 )
             })
             .count();
-        assert!(
-            matching >= 1,
-            "expected NewEpoch(epochId {expected_epoch_id}, committee {new_committee:?}); saw \
-             {new_epoch_count} NewEpoch log(s) among {} log(s), gas used {}",
+        assert_eq!(
+            matching,
+            1,
+            "expected exactly one NewEpoch(epochId {expected_epoch_id}, committee \
+             {new_committee:?}); saw {new_epoch_count} NewEpoch log(s) among {} log(s), gas used {}",
             logs.len(),
             res.result.gas_used()
         );
+
+        Ok(())
+    }
+
+    /// The sibling pin for the inherited half of the log surface: a slash-to-zero ejection's
+    /// ERC-721 `Transfer`, driven by the contract's own `_burn` rather than by a hand-built log.
+    ///
+    /// `applySlashes` with `amount >= balance` takes the ejection branch (`balances[v] > amount`
+    /// is false), which runs `_consensusBurn` → `_burnConsensusNFT` → OpenZeppelin's ERC-721
+    /// `_burn`, so the burn `Transfer(validator, 0x0, tokenId)` is emitted from
+    /// [`CONSENSUS_REGISTRY_ADDRESS`] on a system-call path — a path that produces no receipt, so
+    /// this log line is the only place it surfaces. The unit test in `system_calls.rs` pins the
+    /// same event from a hand-built log; this one proves the real contract's emit classifies,
+    /// which a binding limited to the registry's OWN events cannot do: it would route the burn to
+    /// `SystemCallLog::UnknownRegistryTopic` and demote every ejection to the raw `debug!` line.
+    ///
+    /// Runs on the same side-effect-free EVM at the genesis tip as the `concludeEpoch` test above.
+    /// Ejecting one of four genesis validators leaves three eligible and three-member epoch-1 and
+    /// epoch-2 committees, which clears the registry's `_checkCommitteeSize` guard, so the whole
+    /// `_consensusBurn` path runs to the burn instead of reverting on committee size.
+    #[tokio::test]
+    async fn system_call_logs_classify_a_slash_ejection_burn_transfer() -> eyre::Result<()> {
+        use crate::system_calls::RegistryEvents as E;
+
+        let genesis = test_genesis_with_consensus_registry(4);
+        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+        let tmp_dir = TempDir::new()?;
+        let task_manager = TaskManager::new("System Call Burn Log Test");
+        let reth_env =
+            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)?;
+
+        let EpochState { epoch, validators: committee, .. } =
+            reth_env.epoch_state_from_canonical_tip()?;
+        assert_eq!(epoch, 0);
+        assert_eq!(committee.len(), 4, "genesis seeds four Active validators");
+        let victim = committee[0].validatorAddress;
+
+        // side-effect-free EVM at the genesis tip: the call runs, nothing is committed
+        let mut tn_evm = reth_env.tn_evm(chain.sealed_genesis_header().hash())?;
+
+        // read the outstanding stake-backed balance rather than hardcoding the genesis stake: the
+        // registry ejects only when `balances[victim] <= slash.amount`, so this is the exact
+        // threshold amount, and reading it keeps the test correct if the seeded `StakeConfig`
+        // changes
+        let (outstanding, _initial_stake, _rewards) = reth_env
+            .call_consensus_registry::<_, (U256, U256, U256)>(
+                &mut tn_evm,
+                ConsensusRegistry::getBalanceBreakdownCall { validatorAddress: victim }
+                    .abi_encode()
+                    .into(),
+            )?;
+        assert!(outstanding > U256::ZERO, "a genesis validator is staked");
+
+        let calldata = ConsensusRegistry::applySlashesCall {
+            slashes: vec![ConsensusRegistry::Slash {
+                validatorAddress: victim,
+                amount: outstanding,
+            }],
+        }
+        .abi_encode()
+        .into();
+        let res =
+            tn_evm.transact_system_call(SYSTEM_ADDRESS, CONSENSUS_REGISTRY_ADDRESS, calldata)?;
+
+        // (a) the call succeeded, so the ejection actually ran
+        assert!(
+            res.result.is_success(),
+            "applySlashes at genesis must succeed, got {:?}",
+            res.result
+        );
+        let logs = res.result.logs();
+        assert!(
+            !logs.is_empty(),
+            "applySlashes succeeded (gas used {}) but emitted no logs",
+            res.result.gas_used()
+        );
+
+        let classified: Vec<SystemCallLog<'_>> =
+            logs.iter().map(classify_system_call_log).collect();
+
+        // (b) every log the ejection emits decodes to a named registry event: nothing falls
+        // through as an unknown topic or as a foreign contract's log
+        let unclassified: Vec<(Address, Vec<B256>)> = logs
+            .iter()
+            .zip(classified.iter())
+            .filter(|(_, c)| !matches!(c, SystemCallLog::Registry(..)))
+            .map(|(log, _)| (log.address, log.topics().to_vec()))
+            .collect();
+        assert!(
+            unclassified.is_empty(),
+            "logs that did not decode to a registry event (address, topics): {unclassified:?}"
+        );
+
+        // (c) exactly one of them is the NFT burn: a token sent to the zero address
+        let burns: Vec<(Address, U256)> = classified
+            .iter()
+            .filter_map(|c| match c {
+                SystemCallLog::Registry(_, E::Transfer(t)) if t.to == Address::ZERO => {
+                    Some((t.from, t.tokenId))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            burns.len(),
+            1,
+            "expected exactly one ERC-721 burn Transfer(_, 0x0, _); saw {burns:?} among {} \
+             classified log(s), gas used {}",
+            logs.len(),
+            res.result.gas_used()
+        );
+        assert_eq!(burns[0].0, victim, "the burned consensus NFT was the slashed validator's");
 
         Ok(())
     }

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -3,13 +3,20 @@
 //! These compile into types for interacting with smart contracts through
 //! System Calls.
 //!
-//! The `sol!` blocks bind three contracts from the tn-contracts submodule:
-//! - `ConsensusRegistry` — validator lifecycle (mint/stake/activate/exit/burn), epoch and committee
-//!   views, the three epoch-boundary mutators the protocol invokes as system calls in the closing
-//!   block (`applyIncentives`, then `applySlashes`, then `concludeEpoch`), and the contract's
-//!   events. System calls build no receipt, so the lifecycle events those mutators emit are
-//!   surfaced node-side only: [`log_registry_event`] names and emits each one at `info!` from the
-//!   system-call path in `evm/block.rs`.
+//! The `sol!` blocks bind four surfaces from the tn-contracts submodule. The registry is split
+//! across two of them — a hand-written CALL surface and a generated LOG surface — because the two
+//! have opposite requirements: calls need richer Rust types than a JSON ABI can express, logs need
+//! coverage a hand-written list cannot guarantee.
+//! - `ConsensusRegistry` — the hand-written call surface: validator lifecycle
+//!   (mint/stake/activate/exit/burn), epoch and committee views, and the three epoch-boundary
+//!   mutators the protocol invokes as system calls in the closing block (`applyIncentives`, then
+//!   `applySlashes`, then `concludeEpoch`). Curated, not exhaustive: it binds what the node calls
+//!   and decodes, in the Rust types the node needs.
+//! - [`registry_abi`] — the registry's log surface, generated from the compiled Foundry artifact
+//!   and therefore covering the contract's WHOLE event ABI, inherited events included. System calls
+//!   build no receipt, so the events the boundary mutators emit are surfaced node-side only:
+//!   [`log_registry_event`] names and emits each one at `info!` from the system-call path in
+//!   `evm/block.rs`.
 //! - `LegacyConsensusRegistry` — the pre-fork registry's epoch-close surface, frozen so pre-fork
 //!   epoch closes replay byte-identically (see the code-hash gate in `evm/block.rs`).
 //! - `WorkerConfigs` — per-worker base-fee strategy used for base fee adjustment, plus the
@@ -24,7 +31,10 @@
 //! NOTE: slashing is not live — the protocol calls `applySlashes` with an empty array. Do not
 //! assume validators can currently be slashed in-protocol.
 
-use alloy::{primitives::address, sol};
+use alloy::{
+    primitives::{address, Log},
+    sol,
+};
 use tn_types::{
     gas_accumulator::{WorkerConfigEntry, WorkerFeeConfig},
     Address, Epoch,
@@ -164,94 +174,6 @@ sol!(
         struct ProofOfPossession {
             bytes signature;
         }
-
-        // Events, mirrored from `IConsensusRegistry.sol`. System calls produce no receipt, so
-        // the events the `onlySystemCall` entry points emit (`concludeEpoch`: `NewEpoch`,
-        // `ValidatorActivated`, `ValidatorExited`, plus the stake-version settlement pair
-        // `ValidatorStakeVersionUpgraded` / `RefundQueued`; `applySlashes`: `ValidatorSlashed`,
-        // `ValidatorExited`, `ValidatorRetired`, `NextCommitteeSizeUpdated`, `RefundQueued`;
-        // `migrateValidatorSets`: `ValidatorSetsMigrated`) never reach a receipts root, the header
-        // bloom, or `eth_getLogs`. The node decodes them off-consensus through
-        // [`log_registry_event`] and emits them at `info!`. The full interface is bound, not only
-        // the system-call subset, so a future emit added behind `onlySystemCall` decodes by name
-        // instead of falling through as an unknown topic. Each signature's selector is pinned
-        // against the Solidity ABI by `registry_event_selectors_match_the_solidity_interface`.
-
-        /// A validator first staked, entering the `Staked` lifecycle state.
-        #[derive(Debug)]
-        event ValidatorStaked(ValidatorInfo validator);
-        /// A staked validator self-activated, entering the activation queue.
-        #[derive(Debug)]
-        event ValidatorPendingActivation(ValidatorInfo validator);
-        /// A validator's activation resolved at epoch conclusion or at genesis.
-        #[derive(Debug)]
-        event ValidatorActivated(ValidatorInfo validator);
-        /// An active validator requested exit, entering the exit queue.
-        #[derive(Debug)]
-        event ValidatorPendingExit(ValidatorInfo validator);
-        /// A pending-exit validator was removed from the active set by the protocol.
-        #[derive(Debug)]
-        event ValidatorExited(ValidatorInfo validator);
-        /// A validator was permanently retired; its address can never rejoin.
-        #[derive(Debug)]
-        event ValidatorRetired(ValidatorInfo validator);
-        /// One slash applied to a validator's outstanding balance.
-        #[derive(Debug)]
-        event ValidatorSlashed(Slash slash);
-        /// A new epoch began at epoch conclusion.
-        #[derive(Debug)]
-        event NewEpoch(EpochInfo epoch);
-        /// Governance updated a validator's geographic region.
-        #[derive(Debug)]
-        event ValidatorRegionUpdated(address indexed validatorAddress, uint8 region);
-        /// A stake originator claimed accrued rewards or unstaked.
-        #[derive(Debug)]
-        event RewardsClaimed(address indexed claimant, uint256 rewards);
-        /// A validator's stake version was upgraded in place.
-        #[derive(Debug)]
-        event ValidatorStakeVersionUpgraded(
-            address indexed validatorAddress,
-            uint8 oldVersion,
-            uint8 newVersion,
-            uint256 oldStakeAmount,
-            uint256 newStakeAmount
-        );
-        /// An in-service validator queued a stake version change for settlement in
-        /// `concludeEpoch`.
-        #[derive(Debug)]
-        event StakeVersionChangeRequested(
-            address indexed validatorAddress, uint8 targetVersion, uint32 requestEpoch, uint256 escrow
-        );
-        /// A pending stake version change was withdrawn before settlement.
-        #[derive(Debug)]
-        event StakeVersionChangeCanceled(address indexed validatorAddress);
-        /// A refund or escrow return was credited for a later `claimRefund` pull.
-        #[derive(Debug)]
-        event RefundQueued(address indexed recipient, uint256 amount);
-        /// An accumulated refund credit was claimed.
-        #[derive(Debug)]
-        event RefundClaimed(address indexed recipient, uint256 amount);
-        /// Governance or the protocol adjusted the next epoch's committee size.
-        #[derive(Debug)]
-        event NextCommitteeSizeUpdated(uint16 oldSize, uint16 newSize, uint256 numActiveValidators);
-        /// `migrateValidatorSets` back-filled the per-status sets during the in-place upgrade.
-        #[derive(Debug)]
-        event ValidatorSetsMigrated(uint256 eligibleValidatorCount);
-        /// Governance authored a new global stake-config version.
-        #[derive(Debug)]
-        event StakeVersionAuthored(
-            uint8 indexed version,
-            uint256 stakeAmount,
-            uint256 minWithdrawAmount,
-            uint256 epochIssuance,
-            uint32 epochDuration
-        );
-        /// Governance toggled whether `topUpSlashedStake` is restricted to the top-up authority.
-        #[derive(Debug)]
-        event TopUpAuthorityRequirementUpdated(bool required);
-        /// A slashed validator's balance was restored to its version's full stake amount.
-        #[derive(Debug)]
-        event ValidatorStakeToppedUp(address indexed validatorAddress, uint256 amount);
 
         /// Initialize the contract.
         #[derive(Debug)]
@@ -432,6 +354,46 @@ sol!(
     }
 );
 
+/// The `ConsensusRegistry`'s log surface, generated from the compiled Foundry artifact rather
+/// than transcribed alongside the call surface above.
+///
+/// Generated because a transcription can drift and can be incomplete, and both failure modes are
+/// silent. `sol!` reads `tn-contracts/artifacts/ConsensusRegistry.json` at compile time and
+/// `include_bytes!`es it, so a rebuilt artifact rebuilds this crate and every topic-0 here is by
+/// construction the one the deployed contract emits. A hand-written signature that drifted by a
+/// single parameter type would not fail to compile — it would just stop matching, demoting its
+/// event to the raw "unknown topic" line at every epoch boundary.
+///
+/// Completeness matters as much as accuracy, because the registry emits events it does not
+/// declare. `applySlashes` slashing a validator to zero burns its consensus NFT
+/// (`_consensusBurn` → `_burnConsensusNFT` → OpenZeppelin's ERC-721 `_burn`), so an ejection emits
+/// an ERC-721 `Transfer` from [`CONSENSUS_REGISTRY_ADDRESS`] on a system-call path. The artifact
+/// carries the inherited ERC-721/Ownable/Pausable events; a list of the registry's own events
+/// does not.
+///
+/// The call surface stays hand-written because this binding cannot replace it: a JSON ABI
+/// flattens Solidity `enum`s to `uint8`, so it yields neither the typed
+/// `ConsensusRegistry::ValidatorStatus` (a JSON-RPC wire type) nor the per-type `serde` derives
+/// the node's epoch state carries.
+// `missing_docs` is allowed for the module, not the crate: `sol!` documents every item it emits
+// except the newtypes it lowers Solidity `enum`s to (`IConsensusRegistry::ValidatorStatus` here),
+// and neither an attribute on the invocation (ignored on macro calls) nor one forwarded through it
+// reaches them. Nothing hand-written belongs in here, so the allow costs no coverage.
+#[allow(missing_docs)]
+pub mod registry_abi {
+    alloy::sol!(
+        #[derive(Debug)]
+        ConsensusRegistry,
+        "../../tn-contracts/artifacts/ConsensusRegistry.json"
+    );
+}
+
+/// Every event the deployed `ConsensusRegistry` can emit, decodable from a log by topic-0.
+///
+/// Aliased out of [`registry_abi`] so call sites are not three module hops deep; the enum is
+/// the only thing this crate uses from that binding.
+pub use registry_abi::ConsensusRegistry::ConsensusRegistryEvents as RegistryEvents;
+
 /// Emit one decoded `ConsensusRegistry` event at `info!` under the `engine` target, named.
 ///
 /// The only consumer is the system-call path in `evm/block.rs`: a system call produces no
@@ -441,36 +403,17 @@ sol!(
 /// Solidity event name so a log filter on it is stable across wording changes, and `detail` is
 /// the decoded payload. Purely observational: nothing here reads or writes state.
 ///
-/// Exhaustive over the events enum on purpose: binding a new event in the `sol!` block without
-/// naming it here is a compile error, not a silently unnamed log line.
-pub(crate) fn log_registry_event(
-    description: &str,
-    event: ConsensusRegistry::ConsensusRegistryEvents,
-) {
-    use ConsensusRegistry::ConsensusRegistryEvents as E;
-    let emit = |name: &'static str, detail: &dyn core::fmt::Debug| info!(target: "engine", event = name, ?detail, "{description} emitted registry event");
-    match event {
-        E::ValidatorStaked(e) => emit("ValidatorStaked", &e),
-        E::ValidatorPendingActivation(e) => emit("ValidatorPendingActivation", &e),
-        E::ValidatorActivated(e) => emit("ValidatorActivated", &e),
-        E::ValidatorPendingExit(e) => emit("ValidatorPendingExit", &e),
-        E::ValidatorExited(e) => emit("ValidatorExited", &e),
-        E::ValidatorRetired(e) => emit("ValidatorRetired", &e),
-        E::ValidatorSlashed(e) => emit("ValidatorSlashed", &e),
-        E::NewEpoch(e) => emit("NewEpoch", &e),
-        E::ValidatorRegionUpdated(e) => emit("ValidatorRegionUpdated", &e),
-        E::RewardsClaimed(e) => emit("RewardsClaimed", &e),
-        E::ValidatorStakeVersionUpgraded(e) => emit("ValidatorStakeVersionUpgraded", &e),
-        E::StakeVersionChangeRequested(e) => emit("StakeVersionChangeRequested", &e),
-        E::StakeVersionChangeCanceled(e) => emit("StakeVersionChangeCanceled", &e),
-        E::RefundQueued(e) => emit("RefundQueued", &e),
-        E::RefundClaimed(e) => emit("RefundClaimed", &e),
-        E::NextCommitteeSizeUpdated(e) => emit("NextCommitteeSizeUpdated", &e),
-        E::ValidatorSetsMigrated(e) => emit("ValidatorSetsMigrated", &e),
-        E::StakeVersionAuthored(e) => emit("StakeVersionAuthored", &e),
-        E::TopUpAuthorityRequirementUpdated(e) => emit("TopUpAuthorityRequirementUpdated", &e),
-        E::ValidatorStakeToppedUp(e) => emit("ValidatorStakeToppedUp", &e),
-    }
+/// The name is looked up in the artifact-generated selector table by the log's own topic-0, so it
+/// is the Solidity name by construction and needs no per-event arm to stay in step with the
+/// binding. `log` must be the log `event` was decoded from — the caller pairs them, and that
+/// pairing is what makes the lookup total; the fallback covers only a caller that broke it.
+pub(crate) fn log_registry_event(description: &str, log: &Log, event: &RegistryEvents) {
+    let name = log
+        .topics()
+        .first()
+        .and_then(|topic0| RegistryEvents::name_by_selector(topic0.0))
+        .unwrap_or("Unknown");
+    info!(target: "engine", event = name, detail = ?event, "{description} emitted registry event");
 }
 
 /// The state of consensus retrieved from chain.
@@ -592,7 +535,7 @@ mod tests {
     use super::*;
     use alloy::{
         primitives::{aliases::U184, keccak256, Bytes, B256, U256},
-        sol_types::SolCall,
+        sol_types::{SolCall, SolEventInterface as _},
     };
 
     /// The hand-written `delegationDigest` binding must track the on-chain 4-argument selector. If
@@ -605,139 +548,91 @@ mod tests {
         assert_eq!(ConsensusRegistry::delegationDigestCall::SELECTOR, expected);
     }
 
-    /// Every event bound in the `ConsensusRegistry` `sol!` block must carry the topic-0 hash the
-    /// deployed contract emits. The signatures below are the `tn-contracts`
-    /// `artifacts/ConsensusRegistry.json` ABI (struct params flattened to their tuple types), so
-    /// a drift between the Rust binding and the Solidity interface fails here instead of making
-    /// the system-call log path fall through to "unknown topic" at every epoch boundary. The row
-    /// count is pinned to the enum's `COUNT` so a newly bound event cannot ship unpinned.
+    /// The generated binding must name what the deployed registry actually emits, and only that.
+    ///
+    /// Three pins, each covering a distinct way the log path in `evm/block.rs` goes wrong:
+    /// a `NewEpoch` round-trips through the contract's own ABI encoding, decodes to its payload,
+    /// and resolves to the Solidity name `log_registry_event` puts in the `event` field; the
+    /// ERC-721 `Transfer` the registry inherits decodes too, which the curated call surface's
+    /// own-events-only list could not do; and a signature the registry ABI does not contain is
+    /// rejected rather than mis-decoded. The last two are the seam `surface_system_call_logs`
+    /// relies on to route decoded events to `log_registry_event` and everything else to the raw
+    /// `debug!` line.
+    ///
+    /// The `Transfer` pin is a regression guard, not a curiosity: `applySlashes` slashing a
+    /// validator to zero burns its consensus NFT (`_consensusBurn` → `_burnConsensusNFT` →
+    /// OpenZeppelin `_burn`), so an ejection emits an ERC-721 `Transfer` from the registry
+    /// address on a system-call path — the one log an operator most needs named.
     #[test]
-    fn registry_event_selectors_match_the_solidity_interface() {
-        use alloy::sol_types::{SolEvent, SolEventInterface};
-        let expected: [(&str, B256); 20] = [
-            (
-                "ValidatorStaked((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorStaked::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorPendingActivation((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorPendingActivation::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorActivated((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorActivated::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorPendingExit((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorPendingExit::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorExited((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorExited::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorRetired((address,uint32,uint32,uint8,bool,uint8,uint8))",
-                ConsensusRegistry::ValidatorRetired::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorSlashed((address,uint256))",
-                ConsensusRegistry::ValidatorSlashed::SIGNATURE_HASH,
-            ),
-            (
-                "NewEpoch((address[],uint256,uint64,uint32,uint32,uint8))",
-                ConsensusRegistry::NewEpoch::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorRegionUpdated(address,uint8)",
-                ConsensusRegistry::ValidatorRegionUpdated::SIGNATURE_HASH,
-            ),
-            ("RewardsClaimed(address,uint256)", ConsensusRegistry::RewardsClaimed::SIGNATURE_HASH),
-            (
-                "ValidatorStakeVersionUpgraded(address,uint8,uint8,uint256,uint256)",
-                ConsensusRegistry::ValidatorStakeVersionUpgraded::SIGNATURE_HASH,
-            ),
-            (
-                "StakeVersionChangeRequested(address,uint8,uint32,uint256)",
-                ConsensusRegistry::StakeVersionChangeRequested::SIGNATURE_HASH,
-            ),
-            (
-                "StakeVersionChangeCanceled(address)",
-                ConsensusRegistry::StakeVersionChangeCanceled::SIGNATURE_HASH,
-            ),
-            ("RefundQueued(address,uint256)", ConsensusRegistry::RefundQueued::SIGNATURE_HASH),
-            ("RefundClaimed(address,uint256)", ConsensusRegistry::RefundClaimed::SIGNATURE_HASH),
-            (
-                "NextCommitteeSizeUpdated(uint16,uint16,uint256)",
-                ConsensusRegistry::NextCommitteeSizeUpdated::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorSetsMigrated(uint256)",
-                ConsensusRegistry::ValidatorSetsMigrated::SIGNATURE_HASH,
-            ),
-            (
-                "StakeVersionAuthored(uint8,uint256,uint256,uint256,uint32)",
-                ConsensusRegistry::StakeVersionAuthored::SIGNATURE_HASH,
-            ),
-            (
-                "TopUpAuthorityRequirementUpdated(bool)",
-                ConsensusRegistry::TopUpAuthorityRequirementUpdated::SIGNATURE_HASH,
-            ),
-            (
-                "ValidatorStakeToppedUp(address,uint256)",
-                ConsensusRegistry::ValidatorStakeToppedUp::SIGNATURE_HASH,
-            ),
-        ];
-        assert_eq!(
-            expected.len(),
-            <ConsensusRegistry::ConsensusRegistryEvents as SolEventInterface>::COUNT,
-            "every bound registry event must be pinned here"
-        );
-        expected.iter().for_each(|(signature, hash)| {
-            assert_eq!(keccak256(signature), *hash, "topic-0 drift for {signature}");
-        });
-    }
-
-    /// A registry log from a system call must decode into its named event, and a log carrying a
-    /// topic the binding does not know must be rejected rather than mis-decoded: that pair is the
-    /// seam `surface_system_call_logs` (`evm/block.rs`) relies on to route a decoded event to
-    /// `log_registry_event` and everything else to the raw `debug!` line. Round-trips a
-    /// `NewEpoch` through `encode_log_data` so the oracle is the contract's own ABI encoding.
-    #[test]
-    fn registry_log_decodes_to_named_event_and_rejects_unknown_topic() {
+    fn registry_binding_names_inherited_and_own_events_and_rejects_foreign_topics() {
         use alloy::{
             primitives::{Log, LogData},
-            sol_types::{SolEvent, SolEventInterface},
+            sol_types::SolEvent as _,
         };
-        let epoch = ConsensusRegistry::EpochInfo {
-            committee: vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)],
-            epochIssuance: U256::from(7u64),
-            blockHeight: 42,
-            epochId: 3,
-            epochDuration: 600,
-            stakeVersion: 1,
-        };
-        let emitted = ConsensusRegistry::NewEpoch { epoch: epoch.clone() };
-        let log = Log { address: CONSENSUS_REGISTRY_ADDRESS, data: emitted.encode_log_data() };
-        let decoded = ConsensusRegistry::ConsensusRegistryEvents::decode_log(&log)
-            .expect("registry NewEpoch log must decode");
-        assert_eq!(decoded.address, CONSENSUS_REGISTRY_ADDRESS);
-        assert!(
-            matches!(decoded.data, ConsensusRegistry::ConsensusRegistryEvents::NewEpoch(ref e) if e.epoch == epoch),
-            "decoded the wrong event or payload"
-        );
+        use registry_abi::{ConsensusRegistry as abi, IConsensusRegistry};
 
-        // negative control: a foreign topic-0 must not decode into any registry event
-        let foreign = Log {
+        let name_of = |log: &Log| {
+            log.topics().first().and_then(|topic0| RegistryEvents::name_by_selector(topic0.0))
+        };
+
+        // (a) the registry's own `NewEpoch`, encoded by the binding the contract's ABI generated
+        let committee = vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)];
+        let emitted = abi::NewEpoch {
+            epoch: IConsensusRegistry::EpochInfo {
+                committee: committee.clone(),
+                epochIssuance: U256::from(7u64),
+                blockHeight: 42,
+                epochId: 3,
+                epochDuration: 600,
+                stakeVersion: 1,
+            },
+        };
+        let log = Log { address: CONSENSUS_REGISTRY_ADDRESS, data: emitted.encode_log_data() };
+        let decoded = RegistryEvents::decode_log(&log).expect("registry NewEpoch log must decode");
+        assert_eq!(decoded.address, CONSENSUS_REGISTRY_ADDRESS);
+        let RegistryEvents::NewEpoch(new_epoch) = &decoded.data else {
+            panic!("decoded the wrong event: {:?}", decoded.data)
+        };
+        assert_eq!(new_epoch.epoch.epochId, 3);
+        assert_eq!(new_epoch.epoch.committee, committee);
+        assert_eq!(name_of(&log), Some("NewEpoch"), "the `event` log field must carry the name");
+
+        // (b) the inherited ERC-721 `Transfer` an `applySlashes` ejection emits: `from` the
+        // validator, `to` the zero address, `tokenId` the burned consensus NFT (all indexed)
+        let validator = Address::repeat_byte(0x33);
+        let burn = Log {
             address: CONSENSUS_REGISTRY_ADDRESS,
             data: LogData::new_unchecked(
-                vec![keccak256("Transfer(address,address,uint256)")],
+                vec![
+                    keccak256("Transfer(address,address,uint256)"),
+                    validator.into_word(),
+                    Address::ZERO.into_word(),
+                    B256::from(U256::from(7u64)),
+                ],
                 Bytes::new(),
             ),
         };
+        let decoded = RegistryEvents::decode_log(&burn)
+            .expect("the inherited ERC-721 Transfer an ejection emits must decode");
         assert!(
-            ConsensusRegistry::ConsensusRegistryEvents::decode_log(&foreign).is_err(),
-            "an unknown topic must be rejected, not decoded"
+            matches!(decoded.data, RegistryEvents::Transfer(ref e) if e.from == validator),
+            "decoded the wrong event or payload: {:?}",
+            decoded.data
         );
+        assert_eq!(name_of(&burn), Some("Transfer"));
+
+        // (c) negative control: `WorkerConfigs`' own event, whose signature the registry ABI does
+        // not contain, must be rejected rather than mis-decoded
+        let foreign_signature = "WorkerConfigUpdated(uint256,uint8,uint64,uint184)";
+        let foreign = Log {
+            address: CONSENSUS_REGISTRY_ADDRESS,
+            data: LogData::new_unchecked(vec![keccak256(foreign_signature)], Bytes::new()),
+        };
+        assert!(
+            RegistryEvents::decode_log(&foreign).is_err(),
+            "a topic the registry ABI does not declare must be rejected, not decoded"
+        );
+        assert_eq!(name_of(&foreign), None, "and it must not be named either");
     }
 
     /// An unknown strategy id must decode fail-open to `Eip1559` (deterministic per build), never

--- a/crates/tn-reth/src/system_calls.rs
+++ b/crates/tn-reth/src/system_calls.rs
@@ -12,11 +12,11 @@
 //!   mutators the protocol invokes as system calls in the closing block (`applyIncentives`, then
 //!   `applySlashes`, then `concludeEpoch`). Curated, not exhaustive: it binds what the node calls
 //!   and decodes, in the Rust types the node needs.
-//! - [`registry_abi`] — the registry's log surface, generated from the compiled Foundry artifact
-//!   and therefore covering the contract's WHOLE event ABI, inherited events included. System calls
-//!   build no receipt, so the events the boundary mutators emit are surfaced node-side only:
-//!   [`log_registry_event`] names and emits each one at `info!` from the system-call path in
-//!   `evm/block.rs`.
+//! - `registry_abi` (crate-private; [`RegistryEvents`] is its public face) — the registry's log
+//!   surface, generated from the compiled Foundry artifact and therefore covering the contract's
+//!   WHOLE event ABI, inherited events included. System calls build no receipt, so the events the
+//!   boundary mutators emit are surfaced node-side only: [`log_registry_event`] names and emits
+//!   each one at `info!` from the system-call path in `evm/block.rs`.
 //! - `LegacyConsensusRegistry` — the pre-fork registry's epoch-close surface, frozen so pre-fork
 //!   epoch closes replay byte-identically (see the code-hash gate in `evm/block.rs`).
 //! - `WorkerConfigs` — per-worker base-fee strategy used for base fee adjustment, plus the
@@ -375,12 +375,18 @@ sol!(
 /// flattens Solidity `enum`s to `uint8`, so it yields neither the typed
 /// `ConsensusRegistry::ValidatorStatus` (a JSON-RPC wire type) nor the per-type `serde` derives
 /// the node's epoch state carries.
-// `missing_docs` is allowed for the module, not the crate: `sol!` documents every item it emits
-// except the newtypes it lowers Solidity `enum`s to (`IConsensusRegistry::ValidatorStatus` here),
-// and neither an attribute on the invocation (ignored on macro calls) nor one forwarded through it
-// reaches them. Nothing hand-written belongs in here, so the allow costs no coverage.
-#[allow(missing_docs)]
-pub mod registry_abi {
+/// `pub(crate)` deliberately: the whole artifact expands to ~77 call structs, 48 error types, and
+/// the two bytecode statics, none of which this crate uses and all of which would otherwise become
+/// `tn-reth` public API duplicating the hand-written call surface above. The
+/// [`RegistryEvents`] re-export below is the one supported entry point, and it stays public.
+// Both allows are scoped to the module rather than the crate, and neither can be narrowed further:
+// an attribute on a macro invocation is ignored by rustc, and one forwarded through `sol!` does not
+// reach the items it emits. `missing_docs` covers the newtypes `sol!` lowers Solidity `enum`s to
+// (`IConsensusRegistry::ValidatorStatus` here), the only items it emits undocumented;
+// `unreachable_pub` covers the `pub` items the macro emits inside this now-private module. Nothing
+// hand-written belongs in here, so the allows cost no coverage.
+#[allow(missing_docs, unreachable_pub)]
+pub(crate) mod registry_abi {
     alloy::sol!(
         #[derive(Debug)]
         ConsensusRegistry,
@@ -390,8 +396,9 @@ pub mod registry_abi {
 
 /// Every event the deployed `ConsensusRegistry` can emit, decodable from a log by topic-0.
 ///
-/// Aliased out of [`registry_abi`] so call sites are not three module hops deep; the enum is
-/// the only thing this crate uses from that binding.
+/// Aliased out of the crate-private `registry_abi` so call sites are not three module hops
+/// deep; the enum is the only thing this crate uses from that binding, and this alias is the
+/// only part of it that is public API.
 pub use registry_abi::ConsensusRegistry::ConsensusRegistryEvents as RegistryEvents;
 
 /// Emit one decoded `ConsensusRegistry` event at `info!` under the `engine` target, named.


### PR DESCRIPTION
Stacked on this branch. Same behavior, sourced from the compiled artifact instead of transcribed by hand

**Replaced with generated code**
- 20 hand-written `event` decls → `sol!` over `tn-contracts/artifacts/ConsensusRegistry.json` (27 events, inherited ones included)
- 20-arm naming match in `log_registry_event` → `name_by_selector(topic0)`, the table the macro already emits
- Dropped the 20-row selector test — with a generated binding it compares the artifact against itself
- The macro's `include_bytes!` rebuilds the crate when the artifact moves, so topic-0 drift is impossible, not just tested for

**Fix**
- ERC-721 `Transfer` was unbound. A slash-to-zero ejection burns the consensus NFT (`_consensusBurn` → `_burnConsensusNFT` → `_burn`), so ejections logged the raw `debug!` "unknown topic" line — invisible at default level
- The old negative-control test used `Transfer` as its example of a *foreign* topic; it's one of the registry's own
- New test slashes a genesis validator to its exact balance and asserts all five emitted logs classify, one being the burn. Can't pass on a 20-event binding

**Kept hand-written**
- The call surface. A JSON ABI flattens Solidity enums to `uint8`, which would cost the typed `ValidatorStatus` — a `tn_getValidators` wire type — and the per-type serde derives
- `LegacyConsensusRegistry`, still frozen

**Review pass**
- `UnknownRegistryTopic` doc said "only a deployment newer than this build"; an older one qualifies too, and below fork 407 the legacy close is the live path. Pre-fork's 18 events verified a byte-identical subset of the artifact's 27
- Log-volume note stopped understating `applySlashes` — caller-supplied, undeduped, bounded by the gas cap
- `registry_abi` → `pub(crate)`; only the `RegistryEvents` alias needs to be public
