### PR TITLE
feat(consensus,config,network-types): per-worker LocalNetwork seam (#556, PR 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11801,6 +11801,7 @@ dependencies = [
  "rustversion",
  "serde",
  "tn-types",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -549,7 +549,9 @@ mod tests {
         let address = Address::from(U160::from(33));
         let client = LocalNetwork::new_with_empty_id();
         let worker_to_primary = Arc::new(MockWorkerToPrimaryHang {});
-        client.set_worker_to_primary_local_handler(worker_to_primary);
+        client
+            .set_worker_to_primary_local_handler(worker_to_primary)
+            .expect("register mock primary handler");
         let temp_dir = TempDir::new().unwrap();
         let store = open_db(temp_dir.path());
         let qw = TestMakeBlockQuorumWaiter::new_test();
@@ -679,7 +681,9 @@ mod tests {
         let address = Address::from(U160::from(33));
         let client = LocalNetwork::new_with_empty_id();
         let worker_to_primary = Arc::new(MockWorkerToPrimaryHang {});
-        client.set_worker_to_primary_local_handler(worker_to_primary);
+        client
+            .set_worker_to_primary_local_handler(worker_to_primary)
+            .expect("register mock primary handler");
         let temp_dir = TempDir::new().unwrap();
         let store = open_db(temp_dir.path());
         let seal_timeout = Duration::from_secs(5);

--- a/crates/batch-builder/tests/it/build_batches.rs
+++ b/crates/batch-builder/tests/it/build_batches.rs
@@ -41,7 +41,9 @@ async fn test_make_batch_el_to_cl() -> eyre::Result<()> {
 
     // Mock the primary client to always succeed.
     let mock_server = MockWorkerToPrimary();
-    network_client.set_worker_to_primary_local_handler(Arc::new(mock_server));
+    network_client
+        .set_worker_to_primary_local_handler(Arc::new(mock_server))
+        .expect("register mock primary handler");
 
     let qw = TestMakeBlockQuorumWaiter::new_test();
     let timeout = Duration::from_secs(5);

--- a/crates/config/src/consensus.rs
+++ b/crates/config/src/consensus.rs
@@ -3,7 +3,7 @@ use crate::{
     Config, ConfigFmt, ConfigTrait as _, KeyConfig, NetworkConfig, Parameters, TelcoinDirs,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 use tn_network_types::local::LocalNetwork;
@@ -22,7 +22,12 @@ struct ConsensusConfigInner<DB> {
     node_storage: DB,
     key_config: KeyConfig,
     authority: Option<Authority>,
-    local_network: LocalNetwork,
+    /// One [`LocalNetwork`] per worker id, keyed by the committee's worker ids.
+    ///
+    /// Each worker communicates with the primary over its own instance: this is the seam for
+    /// future process separation. Sized from [`Committee::number_of_workers`], the chain-derived
+    /// count, so the key set cannot drift from the committee the config carries.
+    local_networks: BTreeMap<WorkerId, LocalNetwork>,
     network_config: NetworkConfig,
     genesis: HashMap<HeaderDigest, Certificate>,
     /// Digest of the previous epoch's `EpochRecord` ([`EpochDigest::default`] for epoch 0).
@@ -189,7 +194,10 @@ where
         // peer penalty routes the config through the running swarm.
         network_config.peer_config().score_config.validate()?;
 
-        let local_network = LocalNetwork::new(key_config.primary_public_key());
+        let local_networks = committee
+            .worker_ids()
+            .map(|worker_id| (worker_id, LocalNetwork::new(key_config.primary_public_key())))
+            .collect();
 
         let primary_public_key = key_config.primary_public_key();
         let authority = committee.authority_by_key(&primary_public_key);
@@ -208,7 +216,7 @@ where
                 node_storage,
                 key_config,
                 authority,
-                local_network,
+                local_networks,
                 network_config,
                 genesis,
                 prior_epoch_record,
@@ -292,12 +300,26 @@ where
         &self.inner.config.parameters
     }
 
-    /// Returns a reference to the local network configuration.
+    /// Returns a reference to the given worker's local network.
     ///
     /// Contains network identity and local networking setup information.
-    /// This is how Primary <-> Workers communicate.
-    pub fn local_network(&self) -> &LocalNetwork {
-        &self.inner.local_network
+    /// This is how the Primary and worker `worker_id` communicate.
+    ///
+    /// Total over any input: `None` for an id outside the committee's worker set. Callers must
+    /// surface the miss (this accessor is reached with peer-supplied ids), never fall back to
+    /// another worker's instance.
+    pub fn local_network(&self, worker_id: WorkerId) -> Option<&LocalNetwork> {
+        self.inner.local_networks.get(&worker_id)
+    }
+
+    /// Returns every worker's local network with its id, in ascending worker-id order.
+    ///
+    /// The primary registers its worker-to-primary handler on each instance through this.
+    pub fn local_networks(&self) -> impl Iterator<Item = (WorkerId, &LocalNetwork)> {
+        self.inner
+            .local_networks
+            .iter()
+            .map(|(worker_id, local_network)| (*worker_id, local_network))
     }
 
     /// Returns a reference to the network configuration.

--- a/crates/consensus/executor/Cargo.toml
+++ b/crates/consensus/executor/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [dependencies]
 futures.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
 tn-storage = { workspace = true }
 tn-network-types = { workspace = true }

--- a/crates/consensus/executor/src/subscriber.rs
+++ b/crates/consensus/executor/src/subscriber.rs
@@ -4,21 +4,30 @@ use crate::{errors::SubscriberResult, metrics::ExecutorMetrics, SubscriberError}
 use futures::{stream::FuturesOrdered, StreamExt, TryStreamExt};
 use state_sync::{last_consensus_parent, save_consensus, spawn_state_sync};
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     sync::Arc,
     time::Duration,
 };
 use tn_config::ConsensusConfig;
-use tn_network_types::{local::LocalNetwork, PrimaryToWorkerClient};
+use tn_network_types::PrimaryToWorkerClient;
 use tn_primary::{network::PrimaryNetworkHandle, ConsensusBus, ConsensusBusApp, NodeMode};
 use tn_storage::consensus::ConsensusChain;
 use tn_types::{
     encode, to_intent_message, Address, AuthorityIdentifier, Batch, BlockHash, BlsSigner as _,
     CertifiedBatch, CommittedSubDag, Committee, ConsensusHeader, ConsensusHeaderDigest,
     ConsensusOutput, ConsensusResult, Database, Hash as _, Noticer, TaskManager, TaskSpawner,
-    Timestamp, TimestampSec, TnReceiver, TnSender,
+    Timestamp, TimestampSec, TnReceiver, TnSender, WorkerId,
 };
 use tracing::{debug, error, info, instrument, warn};
+
+/// Interval between stall warnings while a worker's batch-fetch leg is outstanding.
+///
+/// The fetch itself is deliberately unbounded: the sub-dag is committed, so a quorum holds
+/// its batches and `BatchFetcher::fetch_for_primary` retries until they arrive. Cancelling
+/// on a deadline would fail-stop the node during a transient outage (a restart re-enters
+/// the identical wait, a crash loop exactly when the node is furthest behind). The watchdog
+/// keeps the unbounded wait but makes a stall loud instead of silent.
+const FETCH_BATCHES_STALL_WARN_INTERVAL: Duration = Duration::from_secs(300);
 
 /// The `Subscriber` receives certificates sequenced by the consensus and waits until the
 /// downloaded all the transactions references by the certificates; it then
@@ -44,8 +53,6 @@ struct Inner {
     authority_id: Option<AuthorityIdentifier>,
     /// The committee for the epoch.
     committee: Committee,
-    /// The client to request worker batches and build consensus output.
-    client: LocalNetwork,
     /// Access to the consensus chain data.
     consensus_chain: ConsensusChain,
     /// Epoch boundary time.
@@ -66,7 +73,6 @@ pub fn spawn_subscriber<DB: Database>(
 ) {
     let authority_id = config.authority_id();
     let committee = config.committee().clone();
-    let client = config.local_network().clone();
     let mode = consensus_bus.app().current_node_mode();
     info!(target: "tn::observer", node_mode = ?mode, "subscriber starting in mode");
     let subscriber = Subscriber {
@@ -76,7 +82,6 @@ pub fn spawn_subscriber<DB: Database>(
         inner: Arc::new(Inner {
             authority_id,
             committee,
-            client,
             consensus_chain: consensus_chain.clone(),
             epoch_boundary,
             metrics: ExecutorMetrics::default(),
@@ -444,12 +449,14 @@ impl<DB: Database> Subscriber<DB> {
             return Ok(ConsensusOutput::new_with_subdag(sub_dag, parent_hash, number));
         }
 
-        let mut batch_set: BTreeSet<BlockHash> = BTreeSet::new();
+        // Partition the payload per worker id so each digest is fetched through the local
+        // network instance of the worker that owns it (dedup within a worker via the set).
+        let mut batches_by_worker: BTreeMap<WorkerId, BTreeSet<BlockHash>> = BTreeMap::new();
 
         let mut batch_digests = VecDeque::with_capacity(num_certs);
         for header in sub_dag.headers() {
-            for (digest, _) in header.payload().iter() {
-                batch_set.insert(*digest);
+            for (digest, worker_id) in header.payload().iter() {
+                batches_by_worker.entry(*worker_id).or_default().insert(*digest);
                 batch_digests.push_back(*digest);
             }
         }
@@ -464,7 +471,7 @@ impl<DB: Database> Subscriber<DB> {
         // MAX_HEADER_NUM_OF_BATCHES` unique digests.  The consensus-pack reader
         // (`max_batches_per_output`) uses that same bound, so every output built here can
         // later be reconstructed from pack storage.
-        let mut fetched_batches = self.fetch_batches_from_peers(batch_set).await?;
+        let mut fetched_batches = self.fetch_batches_from_peers(batches_by_worker).await?;
 
         let mut batches = Vec::with_capacity(num_certs);
         // map all fetched batches to their respective certificates for applying block rewards
@@ -553,38 +560,79 @@ impl<DB: Database> Subscriber<DB> {
         ))
     }
 
+    /// Warn every [`FETCH_BATCHES_STALL_WARN_INTERVAL`] while a worker's fetch leg is
+    /// outstanding.
+    ///
+    /// Never resolves; the caller races it against the fetch itself, so it only ever adds
+    /// log lines and cannot cancel the fetch.
+    async fn stall_watchdog(worker_id: WorkerId) -> std::convert::Infallible {
+        futures::stream::unfold((), |()| async {
+            tokio::time::sleep(FETCH_BATCHES_STALL_WARN_INTERVAL).await;
+            Some(((), ()))
+        })
+        .for_each(|()| {
+            warn!(
+                target: "subscriber",
+                worker_id,
+                "batch fetch from worker still outstanding; waiting on local db or peers"
+            );
+            futures::future::ready(())
+        })
+        .await;
+        // the unfold stream above is infinite, so `for_each` never completes
+        futures::future::pending().await
+    }
+
     /// Send message to relevant workers to fetch batches for execution.
     ///
-    /// The worker is responsible for retrieving the batch from it's local DB or fetching from
-    /// peers.
+    /// One request per worker id, over that worker's local network instance; the worker is
+    /// responsible for retrieving the batch from its local DB or fetching from peers. The
+    /// legs run concurrently, each raced against a stall watchdog that warns every
+    /// [`FETCH_BATCHES_STALL_WARN_INTERVAL`] without cancelling, and any leg's real error
+    /// fails the whole fetch (an incomplete output can never execute).
     async fn fetch_batches_from_peers(
         &self,
-        batch_digests: BTreeSet<BlockHash>,
+        batches_by_worker: BTreeMap<WorkerId, BTreeSet<BlockHash>>,
     ) -> SubscriberResult<HashMap<BlockHash, Batch>> {
-        let mut fetched_blocks = HashMap::new();
+        let num_digests: usize = batches_by_worker.values().map(BTreeSet::len).sum();
+        debug!(target: "subscriber", "Attempting to fetch {num_digests} digests from workers");
 
-        debug!(target: "subscriber", "Attempting to fetch {} digests from workers", batch_digests.len());
-        let batches = match self.inner.client.fetch_batches(batch_digests).await {
-            Ok(resp) => resp,
-            Err(e) => {
-                error!(target: "subscriber", "Failed to fetch batches from peers: {e:?}");
-                self.inner.metrics.batch_fetch_failures_total.increment(1);
-                return Err(SubscriberError::ClientRequestsFailed);
+        let legs = batches_by_worker.into_iter().map(|(worker_id, digests)| {
+            // Sub-dag payloads passed `Header::validate`'s worker-id bounds check, so a
+            // missing instance means the committee's worker set and this config disagree:
+            // a protocol-level failure, surfaced with the variant that exists for it.
+            let client = self.config.local_network(worker_id).cloned();
+            async move {
+                let client = client.ok_or(SubscriberError::UnexpectedWorkerId(worker_id))?;
+                let fetch = std::pin::pin!(client.fetch_batches(digests));
+                let watchdog = std::pin::pin!(Self::stall_watchdog(worker_id));
+                match futures::future::select(fetch, watchdog).await {
+                    futures::future::Either::Left((result, _)) => result.map_err(|e| {
+                        error!(target: "subscriber", worker_id, "Failed to fetch batches from peers: {e:?}");
+                        SubscriberError::ClientRequestsFailed
+                    }),
+                    futures::future::Either::Right((never, _)) => match never {},
+                }
             }
-        };
-
-        for (digest, block) in batches.into_iter() {
-            debug!(
-                target: "subscriber",
-                "Block {:?} took {:?} seconds since it was received to when it was fetched for execution",
-                digest,
-                block.received_at().map(|t| t.elapsed().as_secs_f64()),
-            );
-
-            fetched_blocks.insert(digest, block);
-        }
-
-        Ok(fetched_blocks)
+        });
+        futures::future::try_join_all(legs)
+            .await
+            .inspect_err(|_| self.inner.metrics.batch_fetch_failures_total.increment(1))
+            .map(|fetched| {
+                fetched
+                    .into_iter()
+                    .flatten()
+                    .map(|(digest, block)| {
+                        debug!(
+                            target: "subscriber",
+                            "Block {:?} took {:?} seconds since it was received to when it was fetched for execution",
+                            digest,
+                            block.received_at().map(|t| t.elapsed().as_secs_f64()),
+                        );
+                        (digest, block)
+                    })
+                    .collect()
+            })
     }
 }
 
@@ -855,5 +903,90 @@ mod tests {
             !matches!(consensus_chain.consensus_header_by_number(2).await, Ok(Some(_))),
             "output 2 (past the failed fetch) must not be persisted",
         );
+    }
+}
+
+#[cfg(test)]
+mod worker_fanout_tests {
+    use super::*;
+    use std::num::NonZeroUsize;
+    use tempfile::TempDir;
+    use tn_network_types::MockPrimaryToWorkerClient;
+    use tn_storage::mem_db::MemDatabase;
+    use tn_test_utils::CommitteeFixture;
+    use tokio::sync::mpsc;
+
+    /// One fetch leg per worker id, merged into one result; an id with no local network
+    /// instance is the protocol violation `UnexpectedWorkerId` (issue #556).
+    #[tokio::test]
+    async fn fetch_batches_from_peers_fans_out_per_worker() {
+        let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+        let primary = fixture.authorities().next().unwrap();
+        let base = primary.consensus_config().clone();
+        // a two-worker committee sizes the per-worker local networks
+        let committee =
+            base.committee().with_num_workers(NonZeroUsize::new(2).expect("2 is not 0"));
+        let config = ConsensusConfig::new_with_committee_for_test(
+            base.config().clone(),
+            base.node_storage().clone(),
+            base.key_config().clone(),
+            committee,
+            base.network_config().clone(),
+        )
+        .expect("two-worker consensus config");
+
+        // each worker's instance serves a disjoint batch
+        let digest_0 = BlockHash::random();
+        let digest_1 = BlockHash::random();
+        let batch = Batch::default();
+        config
+            .local_network(0)
+            .expect("worker 0 local network")
+            .set_primary_to_worker_local_handler(Arc::new(MockPrimaryToWorkerClient {
+                batches: HashMap::from([(digest_0, batch.clone())]),
+            }))
+            .expect("register worker 0 mock");
+        config
+            .local_network(1)
+            .expect("worker 1 local network")
+            .set_primary_to_worker_local_handler(Arc::new(MockPrimaryToWorkerClient {
+                batches: HashMap::from([(digest_1, batch)]),
+            }))
+            .expect("register worker 1 mock");
+
+        let temp_dir = TempDir::new().expect("temp dir");
+        let consensus_chain =
+            ConsensusChain::new_for_test(temp_dir.path().to_owned(), config.committee().clone())
+                .await
+                .expect("consensus chain");
+        let (tx, _rx) = mpsc::channel(5);
+        let consensus_bus = ConsensusBus::new();
+        let subscriber = Subscriber {
+            consensus_bus: consensus_bus.app().clone(),
+            config: config.clone(),
+            network_handle: PrimaryNetworkHandle::new_for_test(tx),
+            inner: Arc::new(Inner {
+                authority_id: config.authority_id(),
+                committee: config.committee().clone(),
+                consensus_chain,
+                epoch_boundary: u64::MAX,
+                metrics: ExecutorMetrics::default(),
+            }),
+        };
+
+        // both legs fetch concurrently and the results merge
+        let by_worker =
+            BTreeMap::from([(0, BTreeSet::from([digest_0])), (1, BTreeSet::from([digest_1]))]);
+        let fetched =
+            subscriber.fetch_batches_from_peers(by_worker).await.expect("both worker legs succeed");
+        assert!(fetched.contains_key(&digest_0), "worker 0's batch fetched");
+        assert!(fetched.contains_key(&digest_1), "worker 1's batch fetched");
+
+        // an id outside the committee's worker set is a protocol violation
+        let unknown = BTreeMap::from([(7, BTreeSet::from([digest_0]))]);
+        assert!(matches!(
+            subscriber.fetch_batches_from_peers(unknown).await,
+            Err(SubscriberError::UnexpectedWorkerId(7))
+        ));
     }
 }

--- a/crates/consensus/executor/tests/it/main.rs
+++ b/crates/consensus/executor/tests/it/main.rs
@@ -75,7 +75,11 @@ async fn test_output_to_header() -> eyre::Result<()> {
 
     // Set up mock worker.
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     let leader_schedule = LeaderSchedule::from_store(
         committee.clone(),
@@ -190,7 +194,11 @@ async fn test_executor_output_ordering() -> eyre::Result<()> {
         create_signed_certificates_for_rounds(1..=11, &fixture, &[]);
 
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     let leader_schedule = LeaderSchedule::from_store(
         committee.clone(),
@@ -296,7 +304,11 @@ async fn test_executor_batch_fetching() -> eyre::Result<()> {
 
     let batch_count = batches.len();
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     let leader_schedule = LeaderSchedule::from_store(
         committee.clone(),
@@ -490,7 +502,11 @@ async fn test_duplicate_batch_digest() -> eyre::Result<()> {
 
     // set up mock worker with all batches
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches: all_batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     let leader_schedule = LeaderSchedule::from_store(
         committee.clone(),
@@ -624,7 +640,11 @@ async fn test_subscriber_dup_batch_across_certs() -> eyre::Result<()> {
     .into_iter()
     .collect();
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches: mock_batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     // two round 1 certificates from different authorities sharing batch_1
     let authorities: Vec<_> = fixture.authorities().map(|a| a.id()).collect();

--- a/crates/consensus/primary/src/network/mod.rs
+++ b/crates/consensus/primary/src/network/mod.rs
@@ -33,7 +33,7 @@ use tn_storage::{
 use tn_types::{
     encode, BlsPublicKey, BlsSignature, Certificate, ConsensusHeaderDigest, ConsensusOutput,
     ConsensusResult, Database, Epoch, EpochCertificate, EpochDigest, EpochRecord, EpochVote,
-    Header, HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote,
+    Header, HeaderDigest, Round, TaskError, TaskSpawner, TnReceiver, TnSender, Vote, WorkerId,
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, warn};
@@ -1562,29 +1562,51 @@ where
 }
 
 /// Defines how the network receiver handles incoming workers messages.
+///
+/// One instance is bound to each worker's `LocalNetwork` with that worker's id: the binding is
+/// what establishes the reporting worker's identity. A message whose stamped id disagrees with
+/// the instance it arrived on is rejected before it reaches the proposer's digest channel or
+/// the payload store, so a mis-wired (or, once workers are remote, misbehaving) worker cannot
+/// impersonate another worker's lane.
 #[derive(Clone)]
 pub(super) struct WorkerReceiverHandler<DB> {
+    /// The worker id this instance is bound to.
+    worker_id: WorkerId,
     consensus_bus: ConsensusBus,
     payload_store: DB,
 }
 
 impl<DB: PayloadStore> WorkerReceiverHandler<DB> {
-    /// Create a new instance of Self.
-    pub(crate) fn new(consensus_bus: ConsensusBus, payload_store: DB) -> Self {
-        Self { consensus_bus, payload_store }
+    /// Create a new instance of Self bound to `worker_id`.
+    pub(crate) fn new(worker_id: WorkerId, consensus_bus: ConsensusBus, payload_store: DB) -> Self {
+        Self { worker_id, consensus_bus, payload_store }
+    }
+
+    /// Reject a message stamped with a different worker id than this instance is bound to.
+    fn check_worker_id(&self, message_worker_id: WorkerId) -> eyre::Result<()> {
+        if message_worker_id == self.worker_id {
+            Ok(())
+        } else {
+            Err(eyre::eyre!(
+                "message stamped with worker id {message_worker_id} arrived on the local network \
+                 instance bound to worker id {}",
+                self.worker_id
+            ))
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl<DB: Database> WorkerToPrimaryClient for WorkerReceiverHandler<DB> {
     async fn report_own_batch(&self, message: WorkerOwnBatchMessage) -> eyre::Result<()> {
+        self.check_worker_id(message.worker_id())?;
         let (tx_ack, rx_ack) = oneshot::channel();
         let response = self
             .consensus_bus
             .our_digests()
             .send(OurDigestMessage {
-                digest: message.digest,
-                worker_id: message.worker_id,
+                digest: message.digest(),
+                worker_id: message.worker_id(),
                 ack_channel: tx_ack,
             })
             .await?;
@@ -1596,7 +1618,8 @@ impl<DB: Database> WorkerToPrimaryClient for WorkerReceiverHandler<DB> {
     }
 
     async fn report_others_batch(&self, message: WorkerOthersBatchMessage) -> eyre::Result<()> {
-        self.payload_store.write_payload(&message.digest, &message.worker_id)?;
+        self.check_worker_id(message.worker_id())?;
+        self.payload_store.write_payload(&message.digest(), &message.worker_id())?;
         Ok(())
     }
 }

--- a/crates/consensus/primary/src/primary.rs
+++ b/crates/consensus/primary/src/primary.rs
@@ -32,7 +32,7 @@ impl<DB: Database> Primary<DB> {
         consensus_bus: &ConsensusBus,
         primary_network: PrimaryNetworkHandle,
         state_sync: StateSynchronizer<DB>,
-    ) -> Self {
+    ) -> eyre::Result<Self> {
         // Write the parameters to the logs.
         config.parameters().tracing();
 
@@ -42,14 +42,18 @@ impl<DB: Database> Primary<DB> {
             config.authority().as_ref().map(|a| a.protocol_key().encode_base58()),
         );
 
-        let worker_receiver_handler =
-            WorkerReceiverHandler::new(consensus_bus.clone(), config.node_storage().clone());
+        // Register as the worker-to-primary handler on every worker's local network, each
+        // handler bound to that instance's worker id so the seam establishes the reporting
+        // worker's identity instead of trusting the message's self-stamped id.
+        config.local_networks().try_for_each(|(worker_id, local_network)| {
+            local_network.set_worker_to_primary_local_handler(Arc::new(WorkerReceiverHandler::new(
+                worker_id,
+                consensus_bus.clone(),
+                config.node_storage().clone(),
+            )))
+        })?;
 
-        config
-            .local_network()
-            .set_worker_to_primary_local_handler(Arc::new(worker_receiver_handler));
-
-        Self { primary_network, state_sync }
+        Ok(Self { primary_network, state_sync })
     }
 
     /// Spawns the primary.

--- a/crates/consensus/primary/src/proposer.rs
+++ b/crates/consensus/primary/src/proposer.rs
@@ -115,9 +115,19 @@ pub(crate) struct Proposer<DB: ProposerStore> {
     last_parents: Vec<Certificate>,
     /// Holds the certificate of the last leader (if any).
     last_leader: Option<Certificate>,
-    /// Holds the batches' digests waiting to be included in the next header.
-    /// Digests are roughly oldest to newest, and popped in FIFO order from the front.
-    digests: VecDeque<ProposerDigest>,
+    /// Holds the batches' digests waiting to be included in the next header, one FIFO queue
+    /// per worker (issue #556): within a worker digests stay oldest to newest and pop from
+    /// the front, and there is no total order across workers. Header slots are shared across
+    /// the workers that have pending digests so one busy worker cannot starve another's
+    /// lane. `BTreeMap` (not `HashMap`) so slot allocation walks the workers in a stable
+    /// ascending order.
+    digests: BTreeMap<WorkerId, VecDeque<ProposerDigest>>,
+    /// Round-robin cursor for header slot allocation: the worker id the next header's slot
+    /// walk starts from. Advanced past the last lane granted a slot, so when more workers
+    /// have pending digests than a header holds, the rounds resume where the previous
+    /// header stopped instead of restarting at the lowest id (which would permanently
+    /// starve the high-id lanes).
+    next_lane: WorkerId,
     /// Holds the map of proposed previous round headers and their digest messages, to ensure that
     /// all batches' digest included will eventually be re-sent.
     proposed_headers: BTreeMap<Round, Header>,
@@ -231,7 +241,8 @@ impl<DB: Database> Proposer<DB> {
             round: recovered_round,
             last_parents: genesis,
             last_leader: None,
-            digests: VecDeque::with_capacity(2 * config.parameters().max_header_num_of_batches),
+            digests: BTreeMap::new(),
+            next_lane: 0,
             proposed_headers: BTreeMap::new(),
             leader_schedule,
             advance_round: true,
@@ -632,44 +643,43 @@ impl<DB: Database> Proposer<DB> {
 
         // re-insert batches for any proposed header from a round below the current commit
         //
-        // ensure batches are FIFO to re-send them
+        // ensure batches stay FIFO within each worker to re-send them
         //
-        // payloads: oldest -> newest
-        let mut digests_to_resend = VecDeque::new();
+        // payloads: oldest -> newest, partitioned per worker (issue #556)
+        let mut digests_to_resend: BTreeMap<WorkerId, VecDeque<ProposerDigest>> = BTreeMap::new();
         // Oldest to newest rounds.
         let mut retransmit_rounds = Vec::new();
 
-        // loop through proposed headers in order by round
-        for (header_round, header) in &mut self.proposed_headers {
-            // break once headers pass the committed round
-            if *header_round > max_committed_round {
-                break;
-            }
-
-            let mut digests = header
-                .payload()
-                .into_iter()
-                .map(|(k, v)| ProposerDigest { digest: *k, worker_id: *v })
-                .collect();
-
-            // add payloads and system messages from oldest to newest
-            digests_to_resend.append(&mut digests);
-            retransmit_rounds.push(*header_round);
-        }
+        // walk proposed headers in order by round, up to the committed round
+        self.proposed_headers
+            .iter()
+            .take_while(|(header_round, _)| **header_round <= max_committed_round)
+            .for_each(|(header_round, header)| {
+                // add payloads from oldest to newest into each worker's lane
+                header.payload().iter().for_each(|(digest, worker_id)| {
+                    digests_to_resend
+                        .entry(*worker_id)
+                        .or_default()
+                        .push_back(ProposerDigest { digest: *digest, worker_id: *worker_id });
+                });
+                retransmit_rounds.push(*header_round);
+            });
 
         // process rounds that need to be retransmitted
         if !retransmit_rounds.is_empty() {
-            let num_digests_to_resend = digests_to_resend.len();
+            let num_digests_to_resend: usize = digests_to_resend.values().map(VecDeque::len).sum();
 
-            // prepend missing batches from previous round and update `self`
-            digests_to_resend.append(&mut self.digests);
+            // prepend the reproposed batches to each worker's pending queue and update `self`
+            std::mem::take(&mut self.digests).into_iter().for_each(|(worker_id, mut pending)| {
+                digests_to_resend.entry(worker_id).or_default().append(&mut pending);
+            });
             self.digests = digests_to_resend;
 
             // remove the old headers that failed
             // the proposed blocks are included in the next header
-            for round in &retransmit_rounds {
+            retransmit_rounds.iter().for_each(|round| {
                 self.proposed_headers.remove(round);
-            }
+            });
 
             warn!(
                 target: "primary::proposer",
@@ -677,6 +687,49 @@ impl<DB: Database> Proposer<DB> {
                 self.proposed_headers.len()
             );
         }
+    }
+
+    /// Total number of digests pending across all workers.
+    ///
+    /// The `enough_digests` header trigger counts the total, not any single worker's queue.
+    fn pending_digests_len(&self) -> usize {
+        self.digests.values().map(VecDeque::len).sum()
+    }
+
+    /// Select up to `max_header_num_of_batches` digests for the next header.
+    ///
+    /// Header slots are distributed uniformly across the workers with pending digests: rounds
+    /// of one digest per worker in ascending worker-id order, FIFO within each worker, until
+    /// the cap is reached or every queue is empty. A worker's unused share flows to the
+    /// workers that still have digests (issue #556). The walk starts at [`Self::next_lane`]
+    /// and the cursor advances past the last lane served, so slots rotate across headers
+    /// and no lane is excluded permanently when more workers have digests than a header
+    /// holds. With one worker this is exactly the old single-queue FIFO drain.
+    fn drain_digests_for_header(&mut self) -> VecDeque<ProposerDigest> {
+        let queues = &self.digests;
+        let max_depth = queues.values().map(VecDeque::len).max().unwrap_or(0);
+        // Ascending worker ids, rotated to start at the cursor.
+        let lanes: Vec<WorkerId> = queues
+            .range(self.next_lane..)
+            .chain(queues.range(..self.next_lane))
+            .map(|(id, _)| *id)
+            .collect();
+        // One entry per (round, worker) pair with a digest at that queue depth, in slot
+        // order; each worker id appears exactly its queue length before the cap applies.
+        let order: Vec<WorkerId> = (0..max_depth)
+            .flat_map(|depth| {
+                lanes
+                    .iter()
+                    .copied()
+                    .filter(move |id| queues.get(id).is_some_and(|queue| queue.len() > depth))
+            })
+            .take(self.max_header_num_of_batches)
+            .collect();
+        self.next_lane = order.last().map_or(self.next_lane, |last| last.wrapping_add(1));
+        order
+            .into_iter()
+            .filter_map(|worker_id| self.digests.get_mut(&worker_id).and_then(VecDeque::pop_front))
+            .collect()
     }
 
     /// Conditions are met to propose the next header.
@@ -730,8 +783,7 @@ impl<DB: Database> Proposer<DB> {
             // create new header
             None => {
                 // collect values from &mut self for this header
-                let num_of_digests = self.digests.len().min(self.max_header_num_of_batches);
-                let digests: VecDeque<_> = self.digests.drain(..num_of_digests).collect();
+                let digests = self.drain_digests_for_header();
                 let parents = std::mem::take(&mut self.last_parents);
                 let authority_id = self.authority_id.clone();
                 let prior_epoch_record = self.prior_epoch_record;
@@ -845,7 +897,7 @@ impl<DB: Database> Proposer<DB> {
                     // parse message into parts
                     let (ack, digest) = msg.process();
                     let _ = ack.send(());
-                    self.digests.push_back(digest);
+                    self.digests.entry(digest.worker_id).or_default().push_back(digest);
                 }
                 // check for new parent certificates
                 // synchronizer sends collection of certificates when there is quorum (2f+1)
@@ -875,7 +927,7 @@ impl<DB: Database> Proposer<DB> {
                 .app()
                 .metrics()
                 .proposer_pending_digests
-                .set(self.digests.len() as f64);
+                .set(self.pending_digests_len() as f64);
 
             if pending_header.is_some() {
                 // continue the loop, don't try to propose a header since we are already working
@@ -899,7 +951,7 @@ impl<DB: Database> Proposer<DB> {
             //      - this is happy path
             //      - vote for leader or leader already has enough votes to trigger commit
             let enough_parents = !self.last_parents.is_empty();
-            let enough_digests = self.digests.len() >= self.header_num_of_batches_threshold;
+            let enough_digests = self.pending_digests_len() >= self.header_num_of_batches_threshold;
 
             // evaluate conditions for bool value
             let should_create_header = enough_parents

--- a/crates/consensus/primary/src/state_sync/header_validator.rs
+++ b/crates/consensus/primary/src/state_sync/header_validator.rs
@@ -125,7 +125,11 @@ where
         // Build Synchronize requests to workers.
         let mut synchronize_handles = Vec::new();
         for (worker_id, digests) in missing {
-            let client = self.config.local_network().clone();
+            // `worker_id` is peer-supplied (it comes off the header payload at the top of this
+            // fn): an id outside the committee's worker set must surface as the header error
+            // the variant exists for - never a skip, a fallback instance, or a panic.
+            let client =
+                self.config.local_network(worker_id).cloned().ok_or(HeaderError::UnkownWorkerId)?;
             let retry_config = RetryConfig::default(); // 30s timeout
             let handle = retry_config.retry(move || {
                 let digests = digests.clone();

--- a/crates/consensus/primary/src/tests/primary_tests.rs
+++ b/crates/consensus/primary/src/tests/primary_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::PrimaryNetworkError,
-    network::{handler::RequestHandler, PrimaryResponse},
+    network::{handler::RequestHandler, PrimaryResponse, WorkerReceiverHandler},
     state_sync::StateSynchronizer,
     ConsensusBus,
 };
@@ -13,14 +13,17 @@ use std::{
     time::Duration,
 };
 use tempfile::TempDir;
-use tn_network_types::MockPrimaryToWorkerClient;
+use tn_network_types::{
+    MockPrimaryToWorkerClient, WorkerOthersBatchMessage, WorkerOwnBatchMessage,
+    WorkerToPrimaryClient,
+};
 use tn_primary::test_utils::make_optimal_signed_certificates;
 use tn_reth::test_utils::fixture_batch_with_transactions;
 use tn_storage::{consensus::ConsensusChain, mem_db::MemDatabase, CertificateStore, PayloadStore};
 use tn_test_utils_committee::CommitteeFixture;
 use tn_types::{
     error::HeaderError, now, BlockNumHash, Certificate, Committee, ConsensusHeaderDigest,
-    ConsensusNumHash, ExecHeader, Hash as _, SealedHeader, TaskManager,
+    ConsensusNumHash, ExecHeader, Hash as _, SealedHeader, TaskManager, TnReceiver, B256,
 };
 use tokio::time::timeout;
 
@@ -587,7 +590,8 @@ async fn test_request_vote_missing_batches() {
     let authority_id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_peer = *author.authority().protocol_key();
-    let client = primary.consensus_config().local_network().clone();
+    let client =
+        primary.consensus_config().local_network(0).expect("worker 0 local network").clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();
     let payload_store = primary.consensus_config().node_storage().clone();
@@ -649,7 +653,9 @@ async fn test_request_vote_missing_batches() {
     // Set up mock worker.
     let mock_server = MockPrimaryToWorkerClient::default();
 
-    client.set_primary_to_worker_local_handler(Arc::new(mock_server));
+    client
+        .set_primary_to_worker_local_handler(Arc::new(mock_server))
+        .expect("register mock worker client");
 
     cb.app().committed_round_updates().send_replace(1);
     // Verify Handler synchronizes missing batches and generates a Vote.
@@ -669,7 +675,8 @@ async fn test_request_vote_already_voted() {
     let id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_peer = *author.authority().protocol_key();
-    let client = primary.consensus_config().local_network().clone();
+    let client =
+        primary.consensus_config().local_network(0).expect("worker 0 local network").clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();
     let payload_store = primary.consensus_config().node_storage().clone();
@@ -722,7 +729,9 @@ async fn test_request_vote_already_voted() {
     // Set up mock worker.
     let mock_server = MockPrimaryToWorkerClient::default();
 
-    client.set_primary_to_worker_local_handler(Arc::new(mock_server));
+    client
+        .set_primary_to_worker_local_handler(Arc::new(mock_server))
+        .expect("register mock worker client");
 
     // Verify Handler generates a Vote.
     let test_header = author
@@ -784,7 +793,8 @@ async fn test_request_vote_created_at_in_future() {
     let id = primary.id();
     let author = fixture.authorities().nth(2).unwrap();
     let author_peer = *author.authority().protocol_key();
-    let client = primary.consensus_config().local_network().clone();
+    let client =
+        primary.consensus_config().local_network(0).expect("worker 0 local network").clone();
 
     let certificate_store = primary.consensus_config().node_storage().clone();
     let payload_store = primary.consensus_config().node_storage().clone();
@@ -837,7 +847,9 @@ async fn test_request_vote_created_at_in_future() {
     // Set up mock worker.
     let mock_server = MockPrimaryToWorkerClient::default();
 
-    client.set_primary_to_worker_local_handler(Arc::new(mock_server));
+    client
+        .set_primary_to_worker_local_handler(Arc::new(mock_server))
+        .expect("register mock worker client");
 
     // Verify Handler generates a Vote.
 
@@ -905,4 +917,46 @@ async fn test_request_vote_created_at_in_future() {
         panic!("not a vote!");
     };
     assert!(created_at <= now());
+}
+
+/// The primary's worker-to-primary handler is bound to one worker id per local network
+/// instance (issue #556): a message stamped with a different id is rejected before anything
+/// reaches the proposer's digest channel or the payload store.
+#[tokio::test]
+async fn test_worker_receiver_handler_bound_to_worker_id() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let primary = fixture.authorities().next().unwrap();
+    let payload_store = primary.consensus_config().node_storage().clone();
+    let cb = ConsensusBus::new();
+    let handler = WorkerReceiverHandler::new(1, cb.clone(), payload_store.clone());
+
+    // mismatched ids never reach the bus or the store
+    assert!(handler.report_own_batch(WorkerOwnBatchMessage::new(0, B256::random())).await.is_err());
+    let foreign_digest = B256::random();
+    assert!(handler
+        .report_others_batch(WorkerOthersBatchMessage::new(foreign_digest, 0))
+        .await
+        .is_err());
+    assert!(!payload_store.contains_payload(foreign_digest, 0).expect("store read"));
+
+    // a matching id flows through: ack the digest like the proposer would
+    let mut rx_digests = cb.subscribe_our_digests();
+    let own_digest = B256::random();
+    let ack = tokio::spawn(async move {
+        let msg = rx_digests.recv().await.expect("digest reaches the bus");
+        let _ = msg.ack_channel.send(());
+        (msg.digest, msg.worker_id)
+    });
+    handler
+        .report_own_batch(WorkerOwnBatchMessage::new(1, own_digest))
+        .await
+        .expect("matching id accepted");
+    assert_eq!(ack.await.expect("ack task"), (own_digest, 1));
+
+    let others_digest = B256::random();
+    handler
+        .report_others_batch(WorkerOthersBatchMessage::new(others_digest, 1))
+        .await
+        .expect("matching id accepted");
+    assert!(payload_store.contains_payload(others_digest, 1).expect("store read"));
 }

--- a/crates/consensus/primary/src/tests/proposer_tests.rs
+++ b/crates/consensus/primary/src/tests/proposer_tests.rs
@@ -522,10 +522,11 @@ async fn test_process_committed_headers() {
 
         // round 3's digests should have been prepended to self.digests
         assert!(!proposer.digests.is_empty(), "round 3 digests should be re-queued");
-        assert_eq!(proposer.digests.len(), 2, "round 3 had two digests");
+        assert_eq!(proposer.pending_digests_len(), 2, "round 3 had two digests");
 
         // verify the re-queued digests match round 3's payload
-        let requeued: Vec<BlockHash> = proposer.digests.iter().map(|pd| pd.digest).collect();
+        let requeued: Vec<BlockHash> =
+            proposer.digests.values().flatten().map(|pd| pd.digest).collect();
         assert!(requeued.contains(&d3a), "d3a should be re-queued");
         assert!(requeued.contains(&d3b), "d3b should be re-queued");
 
@@ -573,4 +574,119 @@ async fn test_process_committed_headers() {
         assert!(proposer.proposed_headers.contains_key(&5));
         assert!(proposer.proposed_headers.contains_key(&6));
     }
+}
+
+/// Header slots are shared across workers: a deep worker-0 backlog cannot starve worker 1
+/// (issue #556). Slots interleave one-per-worker in ascending id order, FIFO within a
+/// worker, and a worker's unused share flows to the workers that still have digests.
+#[tokio::test]
+async fn test_drain_digests_shares_header_slots_across_workers() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let cb = ConsensusBus::new();
+    let task_manager = TaskManager::default();
+    let mut proposer = Proposer::new(
+        primary.consensus_config(),
+        primary.consensus_config().authority_id().expect("authority"),
+        cb.clone(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
+    );
+    assert_eq!(proposer.max_header_num_of_batches, 10, "test assumes the default header cap");
+
+    // worker 0 queues a deep backlog, worker 1 only three digests
+    let w0: Vec<B256> = (0..15).map(|_| B256::random()).collect();
+    let w1: Vec<B256> = (0..3).map(|_| B256::random()).collect();
+    proposer.digests.insert(
+        0,
+        w0.iter().map(|digest| ProposerDigest { digest: *digest, worker_id: 0 }).collect(),
+    );
+    proposer.digests.insert(
+        1,
+        w1.iter().map(|digest| ProposerDigest { digest: *digest, worker_id: 1 }).collect(),
+    );
+
+    let selected = proposer.drain_digests_for_header();
+    assert_eq!(selected.len(), 10, "header fills to the cap");
+
+    // rounds of one-per-worker while both lanes have digests, then worker 0 takes the rest
+    let expected = vec![w0[0], w1[0], w0[1], w1[1], w0[2], w1[2], w0[3], w0[4], w0[5], w0[6]];
+    let got: Vec<B256> = selected.iter().map(|digest| digest.digest).collect();
+    assert_eq!(got, expected, "slots interleave per worker, FIFO within each worker");
+
+    // worker 1 fully drained, worker 0 keeps its FIFO tail for the next header
+    assert_eq!(proposer.digests.get(&1).map(VecDeque::len), Some(0));
+    let remaining: Vec<B256> =
+        proposer.digests.get(&0).expect("worker 0 lane").iter().map(|d| d.digest).collect();
+    assert_eq!(remaining, w0[7..].to_vec(), "worker 0 tail stays FIFO");
+}
+
+/// With a single worker the fair drain is exactly the old FIFO drain.
+#[tokio::test]
+async fn test_drain_digests_single_worker_is_fifo() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let cb = ConsensusBus::new();
+    let task_manager = TaskManager::default();
+    let mut proposer = Proposer::new(
+        primary.consensus_config(),
+        primary.consensus_config().authority_id().expect("authority"),
+        cb.clone(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
+    );
+
+    let cap = proposer.max_header_num_of_batches;
+    let w0: Vec<B256> = (0..cap + 2).map(|_| B256::random()).collect();
+    proposer.digests.insert(
+        0,
+        w0.iter().map(|digest| ProposerDigest { digest: *digest, worker_id: 0 }).collect(),
+    );
+
+    let selected = proposer.drain_digests_for_header();
+    let got: Vec<B256> = selected.iter().map(|digest| digest.digest).collect();
+    assert_eq!(got, w0[..cap].to_vec(), "single worker drains FIFO up to the cap");
+    let remaining: Vec<B256> =
+        proposer.digests.get(&0).expect("worker 0 lane").iter().map(|d| d.digest).collect();
+    assert_eq!(remaining, w0[cap..].to_vec(), "the tail stays queued in order");
+}
+
+/// When more workers have pending digests than a header holds, the slot walk rotates
+/// across headers via the cursor, so no lane is excluded permanently (the depth-0 round
+/// alone already overflows the cap).
+#[tokio::test]
+async fn test_drain_digests_rotates_across_headers_when_lanes_exceed_cap() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().next().unwrap();
+    let cb = ConsensusBus::new();
+    let task_manager = TaskManager::default();
+    let mut proposer = Proposer::new(
+        primary.consensus_config(),
+        primary.consensus_config().authority_id().expect("authority"),
+        cb.clone(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
+        task_manager.get_spawner(),
+    );
+    assert_eq!(proposer.max_header_num_of_batches, 10, "test assumes the default header cap");
+
+    // twelve lanes with one digest each; lane 0 carries a persistent extra backlog
+    (0..12u16).for_each(|worker_id| {
+        let depth = if worker_id == 0 { 2 } else { 1 };
+        proposer.digests.insert(
+            worker_id,
+            (0..depth).map(|_| ProposerDigest { digest: B256::random(), worker_id }).collect(),
+        );
+    });
+
+    let first: Vec<WorkerId> =
+        proposer.drain_digests_for_header().iter().map(|digest| digest.worker_id).collect();
+    assert_eq!(first, (0..10).collect::<Vec<_>>(), "first header serves lanes 0-9");
+
+    // the next header resumes at lane 10 instead of restarting at lane 0
+    let second: Vec<WorkerId> =
+        proposer.drain_digests_for_header().iter().map(|digest| digest.worker_id).collect();
+    assert_eq!(second, vec![10, 11, 0], "the cursor rotates the walk to the unserved lanes");
 }

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -278,7 +278,12 @@ where
             return Err(WorkerNetworkError::NonCommitteeBatch);
         }
 
-        let client = self.consensus_config.local_network().clone();
+        let client = self.consensus_config.local_network(self.id).cloned().ok_or_else(|| {
+            WorkerNetworkError::Internal(format!(
+                "no local network instance for worker id {}",
+                self.id
+            ))
+        })?;
         let store = self.consensus_config.node_storage().clone();
         // validate batch - log error if invalid
         self.validator
@@ -295,7 +300,7 @@ where
 
         // notify primary for payload store
         client
-            .report_others_batch(WorkerOthersBatchMessage { digest, worker_id: self.id })
+            .report_others_batch(WorkerOthersBatchMessage::new(digest, self.id))
             .await
             .map_err(|e| WorkerNetworkError::Internal(e.to_string()))?;
 

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -36,7 +36,7 @@ pub fn new_worker<DB: Database>(
     network_handle: WorkerNetworkHandle,
     forwarder: Arc<dyn TxnForwarder>,
     consensus_chain: ConsensusChain,
-) -> Worker<DB, QuorumWaiter> {
+) -> eyre::Result<Worker<DB, QuorumWaiter>> {
     info!(target: "worker::worker", "Boot worker node with id {} key {:?}", id, consensus_config.key_config().primary_public_key());
 
     let batch_fetcher = BatchFetcher::new(
@@ -45,18 +45,23 @@ pub fn new_worker<DB: Database>(
         consensus_chain,
         WorkerMetrics::new_for_worker(id),
     );
-    consensus_config.local_network().set_primary_to_worker_local_handler(Arc::new(
-        PrimaryReceiverHandler {
-            store: consensus_config.node_storage().clone(),
-            network: Some(network_handle.clone()),
-            batch_fetcher,
-            validator,
-        },
-    ));
+    // This worker's own local network instance: a worker id outside the committee's worker
+    // set is a wiring bug, surfaced as an error rather than a fallback onto another
+    // worker's instance.
+    let local_network = consensus_config
+        .local_network(id)
+        .cloned()
+        .ok_or_else(|| eyre::eyre!("no local network instance for worker id {id}"))?;
+    local_network.set_primary_to_worker_local_handler(Arc::new(PrimaryReceiverHandler {
+        store: consensus_config.node_storage().clone(),
+        network: Some(network_handle.clone()),
+        batch_fetcher,
+        validator,
+    }))?;
     let batch_provider = new_worker_internal(
         id,
         &consensus_config,
-        consensus_config.local_network().clone(),
+        local_network,
         network_handle.clone(),
         forwarder,
     );
@@ -68,7 +73,7 @@ pub fn new_worker<DB: Database>(
         consensus_config.worker_address(id).map_or_else(|| "<no address>".to_string(), |addr| addr.to_string())
     );
 
-    batch_provider
+    Ok(batch_provider)
 }
 
 /// Builds a new batch provider responsible for handling client transactions.
@@ -377,7 +382,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         }
 
         // Send the batch to the primary.
-        let message = WorkerOwnBatchMessage { worker_id: self.id, digest };
+        let message = WorkerOwnBatchMessage::new(self.id, digest);
         if let Err(err) = self.client.report_own_batch(message).await {
             error!(target: "worker::batch_provider", "Failed to report our batch: {err:?}");
             Err(BlockSealError::FailedToReport)

--- a/crates/consensus/worker/tests/it/batch_provider_tests.rs
+++ b/crates/consensus/worker/tests/it/batch_provider_tests.rs
@@ -17,7 +17,9 @@ async fn make_batch() {
 
     // Mock the primary client to always succeed.
     let mock_server = MockWorkerToPrimary();
-    client.set_worker_to_primary_local_handler(Arc::new(mock_server));
+    client
+        .set_worker_to_primary_local_handler(Arc::new(mock_server))
+        .expect("register mock primary handler");
 
     // Spawn a `BatchProvider` instance.
     let id = 0;
@@ -71,7 +73,9 @@ async fn observer_seal_without_admission_returns_not_validator() {
 
     // Mock the primary client to always succeed.
     let mock_server = MockWorkerToPrimary();
-    client.set_worker_to_primary_local_handler(Arc::new(mock_server));
+    client
+        .set_worker_to_primary_local_handler(Arc::new(mock_server))
+        .expect("register mock primary handler");
 
     // A `BatchProvider` instance without a quorum waiter: the observer path.
     let id = 0;

--- a/crates/consensus/worker/tests/it/network_tests.rs
+++ b/crates/consensus/worker/tests/it/network_tests.rs
@@ -7,6 +7,7 @@ use tn_network_libp2p::{
     types::{NetworkCommand, NetworkHandle},
     GossipMessage, Penalty, TopicHash,
 };
+use tn_network_types::MockWorkerToPrimary;
 use tn_storage::{mem_db::MemDatabase, tables::NodeBatchesCache};
 use tn_test_utils::CommitteeFixture;
 use tn_types::{
@@ -60,6 +61,14 @@ fn create_test_types_with_chain_id(chain_id: u64) -> TestTypes {
         0,
         chain_id,
     );
+    // The primary registers on each worker's local network in production before any worker
+    // spawns; the report path surfaces a missing handler as an error (issue #556), so the
+    // tests bind a mock in its place.
+    config
+        .local_network(worker_id)
+        .expect("worker 0 local network")
+        .set_worker_to_primary_local_handler(Arc::new(MockWorkerToPrimary()))
+        .expect("register mock primary handler");
     let handler = RequestHandler::new(worker_id, batch_validator, config, network_handle);
     TestTypes { committee, handler, task_manager, network_commands_rx }
 }
@@ -79,6 +88,12 @@ fn create_test_types_with_validator(
     let (tx, network_commands_rx) = mpsc::channel(10);
     let network_handle =
         WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0, 0);
+    // See `create_test_types_with_chain_id`: the report path needs a bound handler.
+    config
+        .local_network(worker_id)
+        .expect("worker 0 local network")
+        .set_worker_to_primary_local_handler(Arc::new(MockWorkerToPrimary()))
+        .expect("register mock primary handler");
     let handler = RequestHandler::new(worker_id, validator, config, network_handle);
     (TestTypes { committee, handler, task_manager, network_commands_rx }, store)
 }

--- a/crates/network-types/Cargo.toml
+++ b/crates/network-types/Cargo.toml
@@ -28,3 +28,6 @@ rustversion = "1.0.9"
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/network-types/src/local.rs
+++ b/crates/network-types/src/local.rs
@@ -53,15 +53,39 @@ impl LocalNetwork {
     }
 
     /// Set the handler for worker to primary messages.
-    pub fn set_worker_to_primary_local_handler(&self, handler: Arc<dyn WorkerToPrimaryClient>) {
+    ///
+    /// A handler binds exactly once: a second registration is a wiring bug (two components
+    /// claiming the same seam would otherwise alias silently, last writer winning), so it
+    /// returns an error instead of overwriting.
+    pub fn set_worker_to_primary_local_handler(
+        &self,
+        handler: Arc<dyn WorkerToPrimaryClient>,
+    ) -> eyre::Result<()> {
         let mut inner = self.inner.write();
-        inner.worker_to_primary_handler = Some(handler);
+        if inner.worker_to_primary_handler.is_some() {
+            Err(eyre::eyre!("worker to primary handler already set"))
+        } else {
+            inner.worker_to_primary_handler = Some(handler);
+            Ok(())
+        }
     }
 
     /// Set the handler for primary to worker messages.
-    pub fn set_primary_to_worker_local_handler(&self, handler: Arc<dyn PrimaryToWorkerClient>) {
+    ///
+    /// A handler binds exactly once: a second registration is a wiring bug (two components
+    /// claiming the same seam would otherwise alias silently, last writer winning), so it
+    /// returns an error instead of overwriting.
+    pub fn set_primary_to_worker_local_handler(
+        &self,
+        handler: Arc<dyn PrimaryToWorkerClient>,
+    ) -> eyre::Result<()> {
         let mut inner = self.inner.write();
-        inner.primary_to_worker_handler = Some(handler);
+        if inner.primary_to_worker_handler.is_some() {
+            Err(eyre::eyre!("primary to worker handler already set"))
+        } else {
+            inner.primary_to_worker_handler = Some(handler);
+            Ok(())
+        }
     }
 
     /// Get the handler for worker to primary messages.
@@ -105,19 +129,71 @@ impl PrimaryToWorkerClient for LocalNetwork {
 impl WorkerToPrimaryClient for LocalNetwork {
     async fn report_own_batch(&self, request: WorkerOwnBatchMessage) -> eyre::Result<()> {
         if let Some(c) = self.get_worker_to_primary_handler().await {
-            c.report_own_batch(request).await?;
+            c.report_own_batch(request).await
         } else {
-            tracing::warn!(target = "local_network", "working to primary handler not set yet!");
+            // A missing handler must surface as an error, symmetric with `synchronize` /
+            // `fetch_batches` below: swallowing it would let `Worker::seal` report success
+            // while the digest never reached the proposer, and the batch builder would evict
+            // the batch's transactions from the pool as mined.
+            tracing::warn!(target = "local_network", "worker to primary handler not set yet!");
+            Err(eyre::eyre!("worker to primary handler not set yet"))
         }
-        Ok(())
     }
 
     async fn report_others_batch(&self, request: WorkerOthersBatchMessage) -> eyre::Result<()> {
         if let Some(c) = self.get_worker_to_primary_handler().await {
-            c.report_others_batch(request).await?;
+            c.report_others_batch(request).await
         } else {
-            tracing::warn!(target = "local_network", "working to primary handler not set yet!");
+            // See `report_own_batch`: a missing handler is an error, never a silent drop.
+            tracing::warn!(target = "local_network", "worker to primary handler not set yet!");
+            Err(eyre::eyre!("worker to primary handler not set yet"))
         }
-        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MockPrimaryToWorkerClient, MockWorkerToPrimary};
+
+    #[tokio::test]
+    async fn report_paths_surface_a_missing_handler() {
+        let local = LocalNetwork::new_with_empty_id();
+
+        // no handler: both report paths error instead of swallowing the message
+        let own = WorkerOwnBatchMessage::new(0, BlockHash::default());
+        assert!(local.report_own_batch(own.clone()).await.is_err());
+        let others = WorkerOthersBatchMessage::new(BlockHash::default(), 0);
+        assert!(local.report_others_batch(others.clone()).await.is_err());
+
+        // registered handler: both paths succeed
+        local
+            .set_worker_to_primary_local_handler(Arc::new(MockWorkerToPrimary()))
+            .expect("first registration");
+        assert!(local.report_own_batch(own).await.is_ok());
+        assert!(local.report_others_batch(others).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn handlers_bind_exactly_once() {
+        let local = LocalNetwork::new_with_empty_id();
+
+        local
+            .set_worker_to_primary_local_handler(Arc::new(MockWorkerToPrimary()))
+            .expect("first registration");
+        assert!(
+            local.set_worker_to_primary_local_handler(Arc::new(MockWorkerToPrimary())).is_err(),
+            "a second registration is a wiring bug"
+        );
+
+        local
+            .set_primary_to_worker_local_handler(Arc::new(MockPrimaryToWorkerClient::default()))
+            .expect("first registration");
+        assert!(
+            local
+                .set_primary_to_worker_local_handler(Arc::new(MockPrimaryToWorkerClient::default()))
+                .is_err(),
+            "a second registration is a wiring bug"
+        );
     }
 }

--- a/crates/network-types/src/notify.rs
+++ b/crates/network-types/src/notify.rs
@@ -19,21 +19,61 @@ pub struct WorkerSynchronizeMessage {
 }
 
 /// Used by worker to inform primary it sealed a new batch.
+///
+/// Fields are private so the id is stamped once at the sending seam and read-only after:
+/// these messages never cross the peer wire, and a mutable id would let any holder re-route
+/// a digest to another worker's identity.
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct WorkerOwnBatchMessage {
     /// The worker's id.
-    pub worker_id: WorkerId,
+    worker_id: WorkerId,
     /// The digest for the batch that reached quorum.
-    pub digest: BlockHash,
+    digest: BlockHash,
+}
+
+impl WorkerOwnBatchMessage {
+    /// Create a new message stamped with the sending worker's id.
+    pub fn new(worker_id: WorkerId, digest: BlockHash) -> Self {
+        Self { worker_id, digest }
+    }
+
+    /// The worker's id.
+    pub fn worker_id(&self) -> WorkerId {
+        self.worker_id
+    }
+
+    /// The digest for the batch that reached quorum.
+    pub fn digest(&self) -> BlockHash {
+        self.digest
+    }
 }
 
 /// Used by worker to inform primary it received a batch from another authority.
+///
+/// Fields are private for the same reason as [`WorkerOwnBatchMessage`].
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct WorkerOthersBatchMessage {
     /// The peer worker's batch digest.
-    pub digest: BlockHash,
+    digest: BlockHash,
     /// The worker's id.
-    pub worker_id: WorkerId,
+    worker_id: WorkerId,
+}
+
+impl WorkerOthersBatchMessage {
+    /// Create a new message stamped with the receiving worker's id.
+    pub fn new(digest: BlockHash, worker_id: WorkerId) -> Self {
+        Self { digest, worker_id }
+    }
+
+    /// The peer worker's batch digest.
+    pub fn digest(&self) -> BlockHash {
+        self.digest
+    }
+
+    /// The worker's id.
+    pub fn worker_id(&self) -> WorkerId {
+        self.worker_id
+    }
 }
 
 /// Used by workers to send a new batch to peers.

--- a/crates/node/src/manager/node/run_epoch.rs
+++ b/crates/node/src/manager/node/run_epoch.rs
@@ -333,6 +333,20 @@ where
             .configure_consensus(network_config, committee, next_committee_keys, prior_epoch_record)
             .await?;
 
+        // Epoch-entry agreement check (issue #556): the committee's worker count sizes the
+        // per-worker `LocalNetwork` seam, while the accumulator was sized from the on-chain
+        // `WorkerConfigs` state read above. Both derive from the same source, so a mismatch
+        // means the views disagree; refuse to start the epoch rather than run with aliased
+        // worker lanes or feed the accumulator ids it would panic on.
+        eyre::ensure!(
+            consensus_config.committee().number_of_workers() == gas_accumulator.num_workers(),
+            "epoch entry: committee carries {} workers but the gas accumulator holds {} slots - \
+             the chain-derived worker count and the committee disagree; refusing to start the \
+             epoch",
+            consensus_config.committee().number_of_workers(),
+            gas_accumulator.num_workers(),
+        );
+
         // The networks need their one-time, per-process setup (start listening, register bootstrap
         // peers) on the first iteration that actually reaches `create_consensus`. This is usually
         // the `Initial` epoch, but the replay above can return early before

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -429,10 +429,7 @@ where
         .await?;
 
         // spawn primary - create node and spawn network
-        let primary =
-            PrimaryNode::new(consensus_config.clone(), consensus_bus, network_handle, state_sync);
-
-        Ok(primary)
+        PrimaryNode::new(consensus_config.clone(), consensus_bus, network_handle, state_sync)
     }
 
     /// Construct the epoch's [`WorkerNode`] and bring up its [`WorkerNetwork`].

--- a/crates/node/src/primary.rs
+++ b/crates/node/src/primary.rs
@@ -116,12 +116,12 @@ impl<CDB: ConsensusDatabase> PrimaryNode<CDB> {
         consensus_bus: ConsensusBus,
         network: PrimaryNetworkHandle,
         state_sync: StateSynchronizer<CDB>,
-    ) -> PrimaryNode<CDB> {
-        let primary = Primary::new(consensus_config.clone(), &consensus_bus, network, state_sync);
+    ) -> eyre::Result<PrimaryNode<CDB>> {
+        let primary = Primary::new(consensus_config.clone(), &consensus_bus, network, state_sync)?;
 
         let inner = PrimaryNodeInner { consensus_config, consensus_bus, primary };
 
-        Self { internal: Arc::new(RwLock::new(inner)) }
+        Ok(Self { internal: Arc::new(RwLock::new(inner)) })
     }
 
     pub async fn start(

--- a/crates/node/src/worker.rs
+++ b/crates/node/src/worker.rs
@@ -32,16 +32,14 @@ impl<CDB: ConsensusDatabase> WorkerNodeInner<CDB> {
     ///
     /// Return the task manager for the worker and the [Worker] struct for spawning execution tasks.
     async fn new_worker(&mut self) -> eyre::Result<Worker<CDB, QuorumWaiter>> {
-        let batch_provider = new_worker(
+        new_worker(
             self.id,
             self.validator.clone(),
             self.consensus_config.clone(),
             self.network_handle.clone(),
             self.forwarder.clone(),
             self.consensus_chain.clone(),
-        );
-
-        Ok(batch_provider)
+        )
     }
 }
 

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -2765,7 +2765,11 @@ async fn spawn_consensus(
 
     // Set up mock worker.
     let mock_client = Arc::new(MockPrimaryToWorkerClient { batches });
-    config.local_network().set_primary_to_worker_local_handler(mock_client);
+    config
+        .local_network(0)
+        .expect("worker 0 local network")
+        .set_primary_to_worker_local_handler(mock_client)
+        .expect("register mock worker client");
 
     let leader_schedule = LeaderSchedule::from_store(
         committee.clone(),

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -979,6 +979,15 @@ impl Committee {
         self.inner.num_workers.get()
     }
 
+    /// Return the worker ids in use for this committee, in ascending order.
+    ///
+    /// Yields `0..number_of_workers()` without any numeric cast: the iterator walks the
+    /// [`WorkerId`] domain directly and stops at the committee's count, so a count beyond
+    /// `WorkerId`'s range simply saturates at the ids that can exist on a header.
+    pub fn worker_ids(&self) -> impl Iterator<Item = WorkerId> + '_ {
+        (0..=WorkerId::MAX).take_while(|id| usize::from(*id) < self.number_of_workers())
+    }
+
     /// Return a copy of this committee with the worker count set to `num_workers`.
     ///
     /// The epoch-0 committee is loaded from the committee file, whose count is a default; the
@@ -2020,6 +2029,17 @@ mod tests {
             .authorities()
             .iter()
             .all(|authority| widened.authority(&authority.id()).is_some()));
+    }
+
+    #[test]
+    fn worker_ids_walk_the_committee_count_in_order() {
+        // default count: one worker, id 0
+        assert_eq!(Committee::default().worker_ids().collect::<Vec<_>>(), vec![0]);
+
+        // widened count: ascending ids 0..n
+        let widened = Committee::default()
+            .with_num_workers(std::num::NonZeroUsize::new(3).expect("3 is not 0"));
+        assert_eq!(widened.worker_ids().collect::<Vec<_>>(), vec![0, 1, 2]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #556.

## Summary

Give every worker its own `LocalNetwork` instance for primary communication, and share the proposer's header slots across workers.  This is PR 3 of the multi-worker series (#554 - #559): the seam lands before the spawn loop (#557), and with one worker the node behaves as before, except that two silent failure modes now surface loudly (called out below).

## Changes

- [x] `crates/config/src/consensus.rs`: `ConsensusConfigInner` holds `local_networks: BTreeMap<WorkerId, LocalNetwork>`, one instance per committee worker id, built in `new_with_committee` from `Committee::worker_ids()`.  The key set derives from the chain-carried count (#554 / #1219), not from any per-operator value, so it cannot drift from the committee the config carries.  The accessor is total: `local_network(worker_id) -> Option<&LocalNetwork>`;  `local_networks()` iterates all instances in ascending id order.
- [x] `crates/types/src/committee.rs`: `Committee::worker_ids()` walks `0..number_of_workers()` over the `WorkerId` domain directly, with no numeric cast.
- [x] `crates/network-types/src/local.rs`: `report_own_batch` / `report_others_batch` return `Err` on a missing handler, symmetric with `synchronize` / `fetch_batches`.  Before, they warned and returned `Ok(())`: a missed registration made `Worker::seal` report success, the batch builder took its success branch and evicted the batch's transactions from the pool as mined, and the digest never reached the proposer.  The `FailedToReport` branch built for exactly this case was unreachable; it is now reachable.  Handler setters are one-shot: a second registration returns `Err` instead of silently overwriting.
- [x] `crates/network-types/src/notify.rs`: `WorkerOwnBatchMessage` / `WorkerOthersBatchMessage` fields are private behind constructors and read accessors, so the worker id is stamped once at the sending seam and is read-only after.
- [x] `crates/consensus/primary/src/network/mod.rs` and `primary.rs`: the primary registers a `WorkerReceiverHandler` on every worker's instance, each handler bound to that instance's worker id.  A message whose stamped id disagrees with the instance it arrived on is rejected before the digest channel or the payload store.  The seam establishes the reporting worker's identity instead of trusting the message's self-stamped id . . . the invariant the comment block in `header_validator.rs` attributes to the primary, now actually enforced.  No attacker is required today (all senders are in-process), but once workers are separate processes the id arrives over a wire, and this binding is what keeps it trustworthy.
- [x] `crates/consensus/primary/src/state_sync/header_validator.rs`: the missing-batch sync loop fetches `local_network(worker_id)` per worker.  `worker_id` is peer-supplied here, so an id outside the committee's worker set becomes `HeaderError::UnkownWorkerId` (never a skip, a fallback instance, or a panic).
- [x] `crates/consensus/worker/src/worker.rs` and `network/handler.rs`: a worker takes its own instance by id; a miss surfaces as an error (`new_worker` now returns `eyre::Result`).
- [x] `crates/consensus/executor/src/subscriber.rs`: `fetch_batches` partitions `header.payload()` per `WorkerId`, and `fetch_batches_from_peers` fans out one concurrent leg per worker over that worker's instance (`try_join_all`, merged).  Each leg is raced against a stall watchdog that warns every 300 s without cancelling: the fetch stays unbounded on purpose (the sub-dag is committed, so a quorum holds its batches and `BatchFetcher::fetch_for_primary` retries until they arrive; a hard deadline would fail-stop the node during a transient outage and, on operator restart, re-enter the identical window against the still-unreachable peers).  The issue amendment asked for a per-leg timeout; self-review flagged that restart hazard, so this lands as loud-stall-not-cancel . . . flip to a terminal deadline in review if preferred.  A payload worker id with no instance is `SubscriberError::UnexpectedWorkerId` (sub-dag payloads passed `Header::validate`, so this is a protocol violation, not a routine miss).
- [x] `crates/consensus/primary/src/proposer.rs`: the pending digest queue becomes one FIFO lane per worker (`BTreeMap<WorkerId, VecDeque<ProposerDigest>>`).  Header slots are distributed uniformly across the workers with pending digests: rounds of one digest per worker in ascending id order until `max_header_num_of_batches` fills, so a busy worker cannot head-of-line block a quiet one (design discussion recorded on #556, 2026-08-18).  A round-robin cursor persists across headers: the walk resumes after the last lane served, so when more workers have pending digests than a header holds, no lane is excluded permanently.  FIFO holds within each lane; there is no total order across lanes.  `enough_digests` counts the total across lanes; repropose returns an expired header's digests to the front of its lanes.  With one worker the drain is exactly the old FIFO.
- [x] `crates/node`: epoch entry refuses to start when the committee's worker count disagrees with the gas accumulator's slot count.  Both derive from the on-chain `WorkerConfigs` state, so a mismatch means the views disagree; refusing beats running with aliased worker lanes or feeding the accumulator ids it panics on.  `PrimaryNode::new` and the worker spawn path propagate the new fallible registrations.

## Behavior at `num_workers = 1`

Identical wiring: one instance, id 0, same registration order.  Two deliberate deltas, both converting silent failures to loud ones:

1.  A batch report that reaches an unregistered seam now fails `seal()` (transactions stay in the pool) instead of silently discarding the digest while evicting the transactions as mined.
2.  A batch fetch against an unresponsive worker now warns every 300 s while it waits, instead of stalling forever with no signal anywhere.  Liveness is unchanged: the fetch still completes whenever the batches arrive.

## Testing

New tests, each confirmed by reverting the code it guards and watching it fail:

- `tn-types`: `worker_ids_walk_the_committee_count_in_order`
- `tn-network-types`: `report_paths_surface_a_missing_handler`, `handlers_bind_exactly_once`
- `tn-primary`: `test_worker_receiver_handler_bound_to_worker_id` (identity binding), `test_drain_digests_shares_header_slots_across_workers` (fair slot sharing, starvation regression), `test_drain_digests_rotates_across_headers_when_lanes_exceed_cap` (cursor rotation when lanes exceed the header cap), `test_drain_digests_single_worker_is_fifo` (degenerate case)
- `tn-executor`: `fetch_batches_from_peers_fans_out_per_worker` (per-worker legs, merge, `UnexpectedWorkerId`)

Local static ladder under the pinned +1.94 toolchain: fmt, check with all targets, and clippy (scoped `-p` list, `--no-deps`, `-D warnings`) over the eight touched crates, plus nightly `fmt -- --check`.  Targeted test runs for the crates above under the pinned toolchain.  CI runs the full workspace ladder on push.

## Out of scope

Per-worker swarms (#555), the `EpochManager` spawn loop and collections (#557), engine initialization (#558), and the per-worker tx-pool base-fee isolation discussed on the issue.
