### PR TITLE
Cap the EIP-7702 authorization list length at every admission path

### DIFF
--- a/bin/worker-gateway/src/error.rs
+++ b/bin/worker-gateway/src/error.rs
@@ -45,6 +45,9 @@ mod code {
     /// An `eth_sendRawTransaction` payload decoded to a transaction type
     /// outside the network's allowlist (legacy, EIP-2930, EIP-1559, EIP-7702).
     pub(super) const UNSUPPORTED_TRANSACTION_TYPE: i32 = -32008;
+    /// An `eth_sendRawTransaction` payload decoded to an EIP-7702 transaction
+    /// whose authorization list is empty or longer than the network's cap.
+    pub(super) const INVALID_AUTHORIZATION_LIST: i32 = -32009;
     /// The request body could not be read. This is the spec-defined
     /// "Invalid Request" code, not a gateway-range code.
     pub(super) const INVALID_REQUEST: i32 = -32600;
@@ -73,6 +76,10 @@ pub(crate) enum GatewayError {
     /// An `eth_sendRawTransaction` payload decoded to a transaction type
     /// outside the network's allowlist (legacy, EIP-2930, EIP-1559, EIP-7702).
     UnsupportedTransactionType,
+    /// An `eth_sendRawTransaction` payload decoded to an EIP-7702 transaction
+    /// whose authorization list is empty or longer than the network's cap, so
+    /// no batch could ever carry it.
+    InvalidAuthorizationList,
     /// The request body could not be read (e.g. the client aborted mid-body).
     UnreadableBody,
 }
@@ -88,7 +95,9 @@ impl GatewayError {
             Self::LoopDetected => StatusCode::LOOP_DETECTED,
             Self::RequestTimeout => StatusCode::REQUEST_TIMEOUT,
             Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
-            Self::InvalidTransaction | Self::UnsupportedTransactionType => StatusCode::BAD_REQUEST,
+            Self::InvalidTransaction
+            | Self::UnsupportedTransactionType
+            | Self::InvalidAuthorizationList => StatusCode::BAD_REQUEST,
             Self::UnreadableBody => StatusCode::BAD_REQUEST,
         }
     }
@@ -105,6 +114,7 @@ impl GatewayError {
             Self::RateLimited => code::RATE_LIMITED,
             Self::InvalidTransaction => code::INVALID_TRANSACTION,
             Self::UnsupportedTransactionType => code::UNSUPPORTED_TRANSACTION_TYPE,
+            Self::InvalidAuthorizationList => code::INVALID_AUTHORIZATION_LIST,
             Self::UnreadableBody => code::INVALID_REQUEST,
         }
     }
@@ -126,6 +136,9 @@ impl GatewayError {
                 "unsupported transaction type: only legacy, EIP-2930, EIP-1559, and EIP-7702 \
                  transactions are accepted"
             }
+            Self::InvalidAuthorizationList => {
+                "EIP-7702 authorization list length is outside the accepted range"
+            }
             Self::UnreadableBody => "request body could not be read",
         }
     }
@@ -145,6 +158,7 @@ impl GatewayError {
             Self::RateLimited => "rate_limited",
             Self::InvalidTransaction => "invalid_transaction",
             Self::UnsupportedTransactionType => "unsupported_transaction_type",
+            Self::InvalidAuthorizationList => "invalid_authorization_list",
             Self::UnreadableBody => "unreadable_body",
         }
     }
@@ -454,6 +468,10 @@ mod tests {
             error_response(&GatewayError::UnsupportedTransactionType, b"{}").status(),
             StatusCode::BAD_REQUEST
         );
+        assert_eq!(
+            error_response(&GatewayError::InvalidAuthorizationList, b"{}").status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     #[test]
@@ -463,6 +481,7 @@ mod tests {
         assert_eq!(GatewayError::RateLimited.code(), -32006);
         assert_eq!(GatewayError::InvalidTransaction.code(), -32007);
         assert_eq!(GatewayError::UnsupportedTransactionType.code(), -32008);
+        assert_eq!(GatewayError::InvalidAuthorizationList.code(), -32009);
     }
 
     #[test]
@@ -482,6 +501,7 @@ mod tests {
             GatewayError::UnsupportedTransactionType.reason(),
             "unsupported_transaction_type"
         );
+        assert_eq!(GatewayError::InvalidAuthorizationList.reason(), "invalid_authorization_list");
         assert_eq!(GatewayError::UnreadableBody.reason(), "unreadable_body");
     }
 }

--- a/bin/worker-gateway/src/proxy.rs
+++ b/bin/worker-gateway/src/proxy.rs
@@ -203,11 +203,16 @@ fn classify_error(err: reqwest::Error) -> GatewayError {
 /// Shallow pre-flight for `eth_sendRawTransaction`.
 ///
 /// Returns `Some((error, id))` only when `body` is a single
-/// `eth_sendRawTransaction` call whose raw transaction cannot be decoded, or
-/// decodes to a type outside the executable allowlist — legacy, EIP-2930,
-/// EIP-1559, and EIP-7702 are accepted; an EIP-4844 blob transaction is not.
-/// Every other request — including batches, other methods, and any
-/// structurally-off submission — returns `None` and is forwarded unchanged.
+/// `eth_sendRawTransaction` call whose raw transaction cannot be decoded,
+/// decodes to a type outside the executable allowlist (legacy, EIP-2930,
+/// EIP-1559, and EIP-7702 are accepted; an EIP-4844 blob transaction is not),
+/// or decodes to an EIP-7702 transaction whose authorization list fails
+/// [`tn_types::batch_allowlisted_authorization_list`] (empty, or longer than
+/// the network's cap; such a transaction can never execute, so this is not a
+/// false rejection). Every other request, including JSON array batches, other
+/// methods, and any structurally-off submission, returns `None` and is
+/// forwarded unchanged; the worker's own pool is the authoritative enforcement
+/// for the elements of a batch.
 ///
 /// The `id` rides along with the rejection because deciding it required parsing
 /// the body: returning it spares the response path a second parse of the same
@@ -245,6 +250,14 @@ fn screen_raw_transaction(body: &[u8]) -> Option<(GatewayError, RequestId)> {
         Err(_) => Some((GatewayError::InvalidTransaction, id)),
         Ok(tx) if !tn_types::batch_allowlisted_tx_type(&tx) => {
             Some((GatewayError::UnsupportedTransactionType, id))
+        }
+        // Epoch 0: the authorization-list cap is epoch-uniform today, and the
+        // screen only front-runs a rejection the worker's own pool issues. If a
+        // future fork makes the cap epoch-varying, this screen must loosen (use
+        // the largest cap across epochs), never tighten, to preserve the
+        // no-false-rejection property documented above.
+        Ok(tx) if !tn_types::batch_allowlisted_authorization_list(&tx, 0) => {
+            Some((GatewayError::InvalidAuthorizationList, id))
         }
         Ok(_) => None,
     }
@@ -331,6 +344,47 @@ mod tests {
         let raw = tx.into_signed(dummy_signature).encoded_2718();
         let raw_hex = format!("0x{}", tn_types::hex::encode(raw));
         assert!(screen_err(&send_raw(&format!("[\"{raw_hex}\"]"))).is_none());
+    }
+
+    #[test]
+    fn over_cap_eip7702_payload_is_rejected() {
+        use tn_types::{
+            Address, Authorization, Encodable2718, EthSignature, SignableTransaction, TxEip7702,
+            U256,
+        };
+
+        // A type-`0x04` transaction whose authorization list exceeds the
+        // network cap can never execute (see
+        // `tn_types::batch_allowlisted_authorization_list`), so the screen
+        // rejects it before the upstream round-trip. Dummy signatures suffice:
+        // the screen reads the list length and never recovers signers.
+        let dummy_signature = EthSignature::new(U256::from(1), U256::from(1), false);
+        let over_cap = usize::try_from(tn_types::max_tx_authorizations(0))
+            .expect("cap fits usize")
+            .checked_add(1)
+            .expect("cap + 1 fits usize");
+        let authorization_list = (0..over_cap)
+            .map(|_| {
+                Authorization { chain_id: U256::from(2017), address: Address::ZERO, nonce: 1 }
+                    .into_signed(dummy_signature)
+            })
+            .collect();
+        let tx = TxEip7702 {
+            chain_id: 2017,
+            nonce: 0,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 0,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            authorization_list,
+            input: Default::default(),
+        };
+        let raw = tx.into_signed(dummy_signature).encoded_2718();
+        let raw_hex = format!("0x{}", tn_types::hex::encode(raw));
+        let err = screen_err(&send_raw(&format!("[\"{raw_hex}\"]")));
+        assert!(matches!(err, Some(GatewayError::InvalidAuthorizationList)));
     }
 
     #[test]

--- a/crates/batch-builder/src/batch.rs
+++ b/crates/batch-builder/src/batch.rs
@@ -91,19 +91,26 @@ pub fn build_batch<P: TxPool>(
         let tx = pool_tx.to_consensus();
 
         // ignore any transaction type outside the executable allowlist (the
-        // predicate admits legacy, EIP-2930, EIP-1559, and EIP-7702): the batch
-        // validator rejects non-allowlisted batches, so packing one would cost
-        // this node a peer penalty on every vote request. The 4844 arm discards
-        // blob transactions; the else arm is default-deny for any future
-        // decodable type outside the allowlist (no such type exists today)
-        if !tn_types::batch_allowlisted_tx_type(&tx) {
+        // predicate admits legacy, EIP-2930, EIP-1559, and EIP-7702), and the
+        // symmetric bound: an EIP-7702 transaction whose authorization list
+        // falls outside 1..=max_tx_authorizations(epoch). The batch validator
+        // rejects a batch carrying either with a Medium peer penalty, so
+        // packing one would cost this node reputation on every vote request.
+        // The 4844 arm discards blob transactions; the else arm handles the
+        // out-of-bounds authorization list and is default-deny for any future
+        // decodable type outside the allowlist (no such type exists today).
+        // Both feed `remove_unsupported_txs` below so the transaction and its
+        // descendants leave the pool
+        if !tn_types::batch_allowlisted_tx_type(&tx)
+            || !tn_types::batch_allowlisted_authorization_list(&*tx, epoch)
+        {
             if tx.is_eip4844() {
                 best_txs.ignore_eip4844(&pool_tx);
                 debug!(target: "worker::batch_builder", ?pool_tx, "marking eip4844 tx invalid");
                 blob_transactions.push(*tx.hash());
             } else {
                 best_txs.ignore_denylist_type(&pool_tx);
-                debug!(target: "worker::batch_builder", ?pool_tx, "marking non-allowlisted tx type invalid");
+                debug!(target: "worker::batch_builder", ?pool_tx, "marking non-allowlisted or out-of-bounds 7702 tx invalid");
                 unsupported_transactions.push(*tx.hash());
             }
             continue;
@@ -245,5 +252,45 @@ mod tests {
         assert_ne!(changed.balance, U256::MAX);
         // the nonce is still advanced past the highest mined nonce (throughput fix preserved)
         assert_eq!(changed.nonce, 2);
+    }
+
+    /// A type-0x04 transaction whose authorization list exceeds
+    /// `max_tx_authorizations(epoch)` must never be packed: the batch validator
+    /// rejects a batch carrying one with a Medium peer penalty. The builder must
+    /// skip it and evict it from the pool through `remove_unsupported_txs`.
+    #[test]
+    fn over_cap_7702_tx_is_never_packed_and_leaves_the_pool() {
+        let genesis = test_genesis();
+        let chain_id = genesis.config.chain_id;
+        let mut tx_factory = TransactionFactory::new();
+
+        // one tuple past the cap, dummy tuples; the declared gas limit stays under
+        // max_batch_gas(0) so the gas-capacity arm cannot mask the list check
+        let cap = usize::try_from(tn_types::max_tx_authorizations(0)).expect("cap fits usize");
+        let over_cap = tx_factory.create_eip7702_with_authorizations(
+            chain_id,
+            1_000_000,
+            u128::from(MIN_PROTOCOL_BASE_FEE),
+            cap + 1,
+            Bytes::new(),
+        );
+        let hash = *over_cap.hash();
+
+        let pool = TestPool::new(&[over_cap.encoded_2718()]);
+        let removed = pool.removed_unsupported_handle();
+
+        let args = BatchBuilderArgs { pool, beneficiary: Address::ZERO, epoch: 0 };
+        let BatchBuilderOutput { batch, mined_transactions, .. } =
+            build_batch(args, 0, MIN_PROTOCOL_BASE_FEE);
+
+        // never packed
+        assert!(batch.transactions.is_empty(), "over-cap 7702 tx must not be packed");
+        assert!(mined_transactions.is_empty(), "over-cap 7702 tx must not be mined");
+        // evicted from the pool through remove_unsupported_txs
+        assert_eq!(
+            removed.lock().expect("removed lock").as_slice(),
+            &[hash],
+            "over-cap 7702 tx must leave the pool"
+        );
     }
 }

--- a/crates/batch-builder/src/test_utils.rs
+++ b/crates/batch-builder/src/test_utils.rs
@@ -3,7 +3,7 @@
 use crate::{build_batch, BatchBuilderOutput};
 use std::{
     collections::{BTreeMap, HashSet, VecDeque},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 use tn_reth::{
     new_pool_txn, BestTransactions, InvalidPoolTransactionError, PoolTxn, PoolTxnId,
@@ -36,6 +36,10 @@ pub(crate) struct TestPool {
     /// Per-sender balances returned by [`TxPool::get_account_balance`]. A sender that is absent
     /// here reports [`U256::MAX`], preserving the behavior of tests that do not exercise balance.
     balances: BTreeMap<Address, U256>,
+    /// Hashes the builder passed to [`TxPool::remove_unsupported_txs`], shared behind an `Arc`
+    /// so a test can keep a handle and observe evictions after the pool moves into
+    /// [`build_batch`].
+    removed_unsupported: Arc<Mutex<Vec<TxHash>>>,
 }
 
 impl TxPool for TestPool {
@@ -50,10 +54,14 @@ impl TxPool for TestPool {
         self.transactions.retain(|tx| !tx.is_eip4844());
         self.by_id.retain(|_, tx| !tx.is_eip4844());
     }
-    fn remove_unsupported_txs(&mut self, _txs: Vec<TxHash>) {
-        // remove non-allowlisted transaction types from the transactions vec and btreemap
-        self.transactions.retain(|tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
-        self.by_id.retain(|_, tx| tn_types::batch_allowlisted_tx_type(&tx.transaction));
+    fn remove_unsupported_txs(&mut self, txs: Vec<TxHash>) {
+        // mirror the real pool: remove exactly the transactions the builder collected
+        // (non-allowlisted types and out-of-bounds 7702 authorization lists) from the
+        // transactions vec and btreemap, and record them for test observation
+        let removed: HashSet<TxHash> = txs.iter().copied().collect();
+        self.transactions.retain(|tx| !removed.contains(tx.hash()));
+        self.by_id.retain(|_, tx| !removed.contains(tx.hash()));
+        self.removed_unsupported.lock().expect("removed_unsupported lock").extend(txs);
     }
     fn get_account_balance(&self, address: Address) -> U256 {
         self.balances.get(&address).copied().unwrap_or(U256::MAX)
@@ -66,6 +74,13 @@ impl TestPool {
     pub(crate) fn with_balance(mut self, address: Address, balance: U256) -> Self {
         self.balances.insert(address, balance);
         self
+    }
+
+    /// Handle to the hashes passed to [`TxPool::remove_unsupported_txs`]. Clone of the pool's
+    /// shared record, so it stays readable after the pool moves into [`build_batch`].
+    #[cfg(test)]
+    pub(crate) fn removed_unsupported_handle(&self) -> Arc<Mutex<Vec<TxHash>>> {
+        self.removed_unsupported.clone()
     }
 
     /// Sum of the pool transactions' costs, used by tests to compute the expected optimistic
@@ -99,7 +114,12 @@ impl TestPool {
                 valid_tx
             })
             .collect();
-        Self { transactions, by_id: by_id.into_iter().collect(), balances: BTreeMap::new() }
+        Self {
+            transactions,
+            by_id: by_id.into_iter().collect(),
+            balances: BTreeMap::new(),
+            removed_unsupported: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 
     fn best_transactions_int(&self) -> Box<dyn BestTransactions<Item = Arc<PoolTxn>>> {

--- a/crates/batch-validator/src/validator.rs
+++ b/crates/batch-validator/src/validator.rs
@@ -3,9 +3,9 @@
 use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
 use tn_reth::{recover_raw_transaction, recover_signed_transaction, RethEnv, WorkerTxPool};
 use tn_types::{
-    batch_allowlisted_tx_type, max_batch_gas, max_batch_size, BatchValidation,
-    BatchValidationError, BlockHash, Epoch, SealedBatch, TransactionSigned, TransactionTrait as _,
-    Typed2718 as _, WorkerId,
+    batch_allowlisted_authorization_list, batch_allowlisted_tx_type, max_batch_gas, max_batch_size,
+    max_tx_authorizations, BatchValidation, BatchValidationError, BlockHash, Epoch, SealedBatch,
+    TransactionSigned, TransactionTrait as _, Typed2718 as _, WorkerId,
 };
 
 /// Type convenience for implementing block validation errors.
@@ -72,6 +72,9 @@ impl BatchValidation for BatchValidator {
 
         // validate every tx type is on the executable allowlist
         self.validate_tx_type_allowlist(&decoded_txs)?;
+
+        // validate every EIP-7702 authorization list is within the executable bound
+        self.validate_authorization_lists(&decoded_txs, batch.epoch)?;
 
         // validate gas limit
         // Use the parent timestamp for consistency with the batch builder.
@@ -218,6 +221,36 @@ impl BatchValidator {
         })
     }
 
+    /// Validate every EIP-7702 transaction's authorization-list length is in
+    /// `1..=max_tx_authorizations(epoch)`.
+    ///
+    /// Uses the shared [`batch_allowlisted_authorization_list`] predicate: the
+    /// batch builder, the worker gateway, and the pool wrap enforce the same
+    /// predicate on the producing side, so a compliant producer never emits a
+    /// batch this check rejects. An over-cap list can never execute inside a
+    /// batch (its declared gas limit either exceeds [`max_batch_gas`] or fails
+    /// revm's intrinsic-gas gate; see [`max_tx_authorizations`]), and an empty
+    /// list is invalid per EIP-7702, so this rejects only garbage that would
+    /// waste certified work. The length read runs before any per-tuple
+    /// authority recovery, which bounds the unpaid ECDSA work a padded list
+    /// can demand.
+    fn validate_authorization_lists(
+        &self,
+        transactions: &[TransactionSigned],
+        epoch: Epoch,
+    ) -> BatchValidationResult<()> {
+        transactions.iter().find(|tx| !batch_allowlisted_authorization_list(*tx, epoch)).map_or(
+            Ok(()),
+            |tx| {
+                Err(BatchValidationError::InvalidAuthorizationList {
+                    len: tx.authorization_list().map_or(0, |list| list.len()),
+                    max: max_tx_authorizations(epoch),
+                    hash: *tx.hash(),
+                })
+            },
+        )
+    }
+
     /// Helper function for decoding and recovering transactions.
     fn recover_and_validate(
         tx: &[u8],
@@ -251,8 +284,9 @@ mod tests {
     use tn_reth::{test_utils::TransactionFactory, RethChainSpec};
     use tn_test_utils::wait_until;
     use tn_types::{
-        max_batch_gas, test_genesis, Address, Batch, Bytes, Encodable2718 as _, FromHex,
-        GenesisAccount, TaskManager, B256, MIN_PROTOCOL_BASE_FEE, U256,
+        max_batch_gas, max_tx_authorizations, test_genesis, Address, Batch, Bytes,
+        Encodable2718 as _, FromHex, GenesisAccount, TaskManager, B256, MIN_PROTOCOL_BASE_FEE,
+        U256,
     };
 
     /// Return the next valid sealed batch
@@ -682,7 +716,8 @@ mod tests {
     /// A well-formed EIP-7702 transaction passes batch validation: the type
     /// allowlist admits `0x04`, and validation is structural (decode, signer
     /// recovery, size/gas/base-fee) — authorization-tuple contents are an
-    /// execution concern, not a validation concern.
+    /// execution concern, not a validation concern. The single-tuple list also
+    /// proves the admit direction of the authorization-list length check.
     #[tokio::test]
     async fn test_valid_tx_eip7702() {
         let tmp_dir = TempDir::new().unwrap();
@@ -697,6 +732,71 @@ mod tests {
             tx_factory.create_eip7702(validator.reth_env.chainspec().chain_id(), None, 7);
 
         // test batch with eip7702 tx
+        batch.transactions = vec![signed_tx.encoded_2718()];
+
+        assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));
+    }
+
+    /// A batch carrying an EIP-7702 transaction whose authorization list
+    /// exceeds `max_tx_authorizations` is rejected with
+    /// `InvalidAuthorizationList`. The tuples are dummy-signed with a
+    /// mismatched chain id: batch validation never verifies tuple signatures,
+    /// only the list length, so the check must fire regardless of tuple
+    /// validity.
+    #[tokio::test]
+    async fn test_invalid_batch_over_cap_authorization_list() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let TestTools { valid_batch, validator, .. } =
+            test_tools(tmp_dir.path(), &task_manager).await;
+        let (mut batch, _) = valid_batch.split();
+
+        let cap = max_tx_authorizations(batch.epoch);
+        let over_cap = usize::try_from(cap).expect("cap fits in usize") + 1;
+
+        // eip7702 set-code transaction padded one past the cap
+        let mut tx_factory = TransactionFactory::new_random();
+        let signed_tx = tx_factory.create_eip7702_with_authorizations(
+            validator.reth_env.chainspec().chain_id(),
+            1_000_000,
+            7,
+            over_cap,
+            Bytes::new(),
+        );
+
+        batch.transactions = vec![signed_tx.encoded_2718()];
+
+        assert_matches!(
+            validator.validate_batch(batch.clone().seal_slow()),
+            Err(BatchValidationError::InvalidAuthorizationList { len, max, hash: _ })
+                if len == over_cap && max == cap
+        );
+    }
+
+    /// A batch carrying an EIP-7702 transaction with exactly
+    /// `max_tx_authorizations` tuples passes validation: the bound is
+    /// inclusive, and a declared gas limit of `max_batch_gas` still fits the
+    /// batch gas check.
+    #[tokio::test]
+    async fn test_valid_batch_at_cap_authorization_list() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let TestTools { valid_batch, validator, .. } =
+            test_tools(tmp_dir.path(), &task_manager).await;
+        let (mut batch, _) = valid_batch.split();
+
+        let cap = usize::try_from(max_tx_authorizations(batch.epoch)).expect("cap fits in usize");
+
+        // eip7702 set-code transaction with exactly the cap
+        let mut tx_factory = TransactionFactory::new_random();
+        let signed_tx = tx_factory.create_eip7702_with_authorizations(
+            validator.reth_env.chainspec().chain_id(),
+            max_batch_gas(batch.epoch),
+            7,
+            cap,
+            Bytes::new(),
+        );
+
         batch.transactions = vec![signed_tx.encoded_2718()];
 
         assert_matches!(validator.validate_batch(batch.clone().seal_slow()), Ok(()));

--- a/crates/consensus/worker/src/network/error.rs
+++ b/crates/consensus/worker/src/network/error.rs
@@ -87,7 +87,10 @@ impl WorkerNetworkError {
                     // medium
                     BatchValidationError::InvalidEpoch { .. }
                     | BatchValidationError::InvalidTx4844(_)
-                    | BatchValidationError::UnsupportedTxType { .. } => Some(Penalty::Medium),
+                    | BatchValidationError::UnsupportedTxType { .. }
+                    | BatchValidationError::InvalidAuthorizationList { .. } => {
+                        Some(Penalty::Medium)
+                    }
                     // severe
                     BatchValidationError::RecoverTransaction(_, _) => Some(Penalty::Severe),
                     // fatal

--- a/crates/tn-reth/src/env/rpc.rs
+++ b/crates/tn-reth/src/env/rpc.rs
@@ -16,17 +16,12 @@ use reth::rpc::{
     builder::{config::RethRpcServerConfig as _, RpcModuleBuilder, RpcServerHandle},
     eth::{EthApi, EthApiBuilder},
 };
-use reth_provider::providers::BlockchainProvider;
 use reth_rpc_eth_api::RpcNodeCore;
 use reth_rpc_eth_types::EthConfig;
-use reth_transaction_pool::{blobstore::DiskFileBlobStore, EthTransactionPool};
 
 use crate::{
-    error::TnRethResult,
-    evm::TnEvmConfig,
-    traits::{TNExecution, TelcoinNode},
-    worker::WorkerNetwork,
-    RethEnv, RpcServer, WorkerTxPool,
+    error::TnRethResult, traits::TNExecution, worker::WorkerNetwork, RethEnv, RpcServer,
+    TnEthTransactionPool, WorkerTxPool,
 };
 
 /// Apply the operator's [`EthConfig`] values to the `eth` API builder.
@@ -73,11 +68,7 @@ impl RethEnv {
         network: WorkerNetwork,
         other: impl Into<Methods>,
     ) -> RpcServer {
-        let transaction_pool: EthTransactionPool<
-            BlockchainProvider<TelcoinNode>,
-            DiskFileBlobStore,
-            TnEvmConfig,
-        > = transaction_pool.into();
+        let transaction_pool: TnEthTransactionPool = transaction_pool.into();
         let tn_execution = Arc::new(TNExecution);
         let rpc_builder = RpcModuleBuilder::default()
             .with_provider(self.inner.blockchain_provider.clone())

--- a/crates/tn-reth/src/txn_pool.rs
+++ b/crates/tn-reth/src/txn_pool.rs
@@ -25,12 +25,11 @@
 
 use futures::StreamExt as _;
 use reth::transaction_pool::{
-    blobstore::DiskFileBlobStore, BlockInfo as RethBlockInfo, EthTransactionPool,
-    TransactionValidationTaskExecutor,
+    blobstore::DiskFileBlobStore, BlockInfo as RethBlockInfo, TransactionValidationTaskExecutor,
 };
 use reth_chainspec::ChainSpec;
 use reth_node_builder::{NodeConfig, RethTransactionPoolConfig};
-use reth_primitives_traits::SignerRecoverable;
+use reth_primitives_traits::{SealedBlock as RethSealedBlock, SignerRecoverable};
 use reth_provider::{
     providers::BlockchainProvider, AccountReader as _, CanonStateNotification,
     CanonStateSubscriptions as _, Chain, ChangedAccount,
@@ -39,16 +38,17 @@ use reth_rpc_eth_types::utils::recover_raw_transaction as reth_recover_raw_trans
 use reth_transaction_pool::{
     error::{
         Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
-        PoolError,
+        PoolError, PoolTransactionError,
     },
-    AddedTransactionOutcome, BestTransactions, CanonicalStateUpdate, EthPooledTransaction,
-    PoolSize, PoolTransaction, PoolUpdateKind, TransactionEvents, TransactionOrigin,
-    TransactionPool as _, TransactionPoolExt as _, ValidPoolTransaction,
+    AddedTransactionOutcome, BestTransactions, CanonicalStateUpdate, CoinbaseTipOrdering,
+    EthPooledTransaction, EthTransactionValidator, Pool, PoolSize, PoolTransaction, PoolUpdateKind,
+    TransactionEvents, TransactionOrigin, TransactionPool as _, TransactionPoolExt as _,
+    TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction,
 };
 use std::{sync::Arc, time::Instant};
 use tn_types::{
-    Address, EnvKzgSettings, Recovered, SealedBlock, TaskError, TaskSpawner, TransactionSigned,
-    TxHash, MIN_PROTOCOL_BASE_FEE, U256,
+    max_tx_authorizations, Address, EnvKzgSettings, Recovered, SealedBlock, TaskError, TaskSpawner,
+    TransactionSigned, TransactionTrait, TxHash, MIN_PROTOCOL_BASE_FEE, U256,
 };
 use tracing::{debug, info, trace, warn};
 
@@ -92,22 +92,256 @@ pub trait TxPool {
     fn get_account_balance(&self, address: Address) -> U256;
 }
 
+/// The worker's concrete reth pool type: reth's `Pool` over the eth validator wrapped in
+/// [`TnPoolValidator`].
+///
+/// Reth's `EthTransactionPool` alias hard-codes the validator to `EthTransactionValidator`,
+/// so once the validator is wrapped the pool type must be spelled out here instead.
+pub type TnEthTransactionPool = Pool<
+    TransactionValidationTaskExecutor<
+        TnPoolValidator<
+            EthTransactionValidator<
+                BlockchainProvider<TelcoinNode>,
+                EthPooledTransaction,
+                TnEvmConfig,
+            >,
+        >,
+    >,
+    CoinbaseTipOrdering<EthPooledTransaction>,
+    DiskFileBlobStore,
+>;
+
 /// A telcoin network transaction pool.
 ///
 /// The second field is a handle to the blockchain provider, retained so the pool can read a
 /// sender's canonical balance when constructing optimistic pool updates after mining a batch
 /// (see [`TxPool::get_account_balance`]).
 #[derive(Clone, Debug)]
-pub struct WorkerTxPool(
-    EthTransactionPool<BlockchainProvider<TelcoinNode>, DiskFileBlobStore, TnEvmConfig>,
-    BlockchainProvider<TelcoinNode>,
-);
+pub struct WorkerTxPool(TnEthTransactionPool, BlockchainProvider<TelcoinNode>);
 
-impl From<WorkerTxPool>
-    for EthTransactionPool<BlockchainProvider<TelcoinNode>, DiskFileBlobStore, TnEvmConfig>
-{
+impl From<WorkerTxPool> for TnEthTransactionPool {
     fn from(value: WorkerTxPool) -> Self {
         value.0
+    }
+}
+
+/// Pool rejection for an EIP-7702 transaction whose authorization list is longer than
+/// [`max_tx_authorizations`].
+///
+/// Upstream reth owns [`InvalidPoolTransactionError`] and none of its variants describe an
+/// over-long authorization list ([`Eip7702PoolTransactionError::MissingEip7702AuthorizationList`]
+/// is the inverse case), so this TN type rides in [`InvalidPoolTransactionError::Other`]
+/// instead of borrowing a wrong-semantics upstream kind.
+#[derive(Debug, thiserror::Error)]
+#[error("EIP-7702 authorization list length {len} exceeds maximum {max}")]
+pub struct AuthorizationListLengthExceeded {
+    /// Number of authorization tuples the transaction declares.
+    len: usize,
+    /// The enforced cap, [`max_tx_authorizations`] at epoch 0.
+    max: u64,
+}
+
+/// Error outcome for a survivor the inner validator returned no outcome for.
+///
+/// Reachable only if the wrapped validator violates its one-outcome-per-input contract;
+/// [`TnPoolValidator::validate_transactions`] degrades loudly with this error instead of
+/// silently dropping the transaction's outcome.
+#[derive(Debug, thiserror::Error)]
+#[error("inner transaction validator returned no outcome for this transaction")]
+struct MissingInnerValidationOutcome;
+
+impl PoolTransactionError for AuthorizationListLengthExceeded {
+    /// `true`: the bound is static, so the transaction can never become valid and belongs
+    /// nowhere near the pool. The flag only feeds devp2p peer reputation, which TN does not
+    /// run (see [`new_pool_txn`]: `propagate` is always `false`), so it cannot penalize a
+    /// local RPC submitter; reth surfaces the rejection to the submitter as a plain
+    /// invalid-transaction RPC error either way.
+    fn is_bad_transaction(&self) -> bool {
+        true
+    }
+
+    /// Expose the concrete type so callers can downcast the boxed error.
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Result of [`TnPoolValidator`]'s pre-admission screen on one transaction.
+///
+/// A dedicated enum rather than `Result`: both arms carry payload the caller moves out of,
+/// and the two-phase batched merge in `validate_transactions` reads better over named arms.
+enum Screened<Tx: PoolTransaction> {
+    /// The transaction failed the screen; the rejection outcome is final.
+    Rejected(TransactionValidationOutcome<Tx>),
+    /// The transaction passed the screen and goes to the inner validator.
+    Admitted(TransactionOrigin, Tx),
+}
+
+/// Pre-admission wrap around reth's transaction validator that bounds the EIP-7702
+/// authorization-list length before any per-tuple work runs.
+///
+/// Reth's `EthTransactionValidator` recovers every authorization tuple's signer during
+/// validation, before the sender has paid any fee, so a padded list buys ~1,200 unpaid ECDSA
+/// recoveries per transaction. This wrap reads the list length first and rejects an over-cap
+/// transaction without calling the inner validator: the length read pre-empts the per-tuple
+/// recovery work.
+///
+/// The cap is [`max_tx_authorizations`] at epoch 0: the cap is epoch-uniform today, and the
+/// batch validator enforces the epoch-precise bound. An over-cap transaction can never
+/// execute (see [`max_tx_authorizations`] for the derivation), so the screen rejects only
+/// garbage.
+///
+/// The empty-list case is deliberately NOT rejected here: the inner eth validator already
+/// returns [`Eip7702PoolTransactionError::MissingEip7702AuthorizationList`] for it and
+/// callers may match on that kind.
+#[derive(Debug)]
+pub struct TnPoolValidator<V> {
+    /// The wrapped validator, delegated to for every transaction that passes the screen.
+    inner: V,
+}
+
+impl<V> TnPoolValidator<V> {
+    /// Wrap `inner` with the TN authorization-list length screen.
+    pub fn new(inner: V) -> Self {
+        Self { inner }
+    }
+}
+
+impl<V> TnPoolValidator<V>
+where
+    V: TransactionValidator,
+    V::Transaction: TransactionTrait,
+{
+    /// Screen one transaction against the authorization-list cap.
+    ///
+    /// A non-7702 transaction reports no authorization list and always passes. A list
+    /// length that does not fit `u64` is over any cap and rejects.
+    fn screen(
+        &self,
+        origin: TransactionOrigin,
+        transaction: V::Transaction,
+    ) -> Screened<V::Transaction> {
+        let max = max_tx_authorizations(0);
+        let len = transaction.authorization_list().map_or(0, |list| list.len());
+        let over_cap = u64::try_from(len).map_or(true, |len| len > max);
+        if over_cap {
+            Screened::Rejected(TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::Other(Box::new(AuthorizationListLengthExceeded {
+                    len,
+                    max,
+                })),
+            ))
+        } else {
+            Screened::Admitted(origin, transaction)
+        }
+    }
+}
+
+impl<V> TransactionValidator for TnPoolValidator<V>
+where
+    V: TransactionValidator,
+    V::Transaction: TransactionTrait,
+{
+    type Transaction = V::Transaction;
+    type Block = V::Block;
+
+    /// Screen, then delegate. The cap check runs before the inner validator, so an over-cap
+    /// transaction costs one length read, never the inner validator's state reads or its
+    /// per-tuple authority recovery.
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        match self.screen(origin, transaction) {
+            Screened::Rejected(outcome) => outcome,
+            Screened::Admitted(origin, transaction) => {
+                self.inner.validate_transaction(origin, transaction).await
+            }
+        }
+    }
+
+    /// Batched validation with the screen applied per transaction.
+    ///
+    /// The wrapped `EthTransactionValidator` overrides this method with a batched path
+    /// (`validate_batch`) that shares one state-provider handle across the whole slice.
+    /// This override preserves it: screen every transaction, send the survivors to the
+    /// inner batched call, and merge the outcomes back in the original input order, since
+    /// callers rely on positional correspondence.
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        // One slot per input position: `Some` holds a screen rejection, `None` marks a
+        // survivor whose outcome comes from the inner batched call.
+        let (slots, survivors) = transactions
+            .into_iter()
+            .map(|(origin, transaction)| self.screen(origin, transaction))
+            .fold((Vec::new(), Vec::new()), |(mut slots, mut survivors), item| match item {
+                Screened::Rejected(outcome) => {
+                    slots.push(Some(outcome));
+                    (slots, survivors)
+                }
+                Screened::Admitted(origin, transaction) => {
+                    slots.push(None);
+                    survivors.push((origin, transaction));
+                    (slots, survivors)
+                }
+            });
+        // Capture the survivor hashes before the inner call consumes the transactions, so a
+        // missing inner outcome can still be reported against the right transaction.
+        let survivor_hashes: Vec<TxHash> =
+            survivors.iter().map(|(_, transaction)| *transaction.hash()).collect();
+        let inner_outcomes = self.inner.validate_transactions(survivors).await;
+        // The inner call must return exactly one outcome per survivor in order; filling each
+        // `None` slot with the next inner outcome restores the original positions. The count
+        // is an upstream contract this wrapper cannot enforce, so a mismatch degrades loudly
+        // (a warning plus an explicit `Error` outcome per unmatched slot) instead of silently
+        // dropping outcomes or misattributing them to the wrong transaction.
+        if inner_outcomes.len() != survivor_hashes.len() {
+            warn!(
+                target: "txpool",
+                expected = survivor_hashes.len(),
+                got = inner_outcomes.len(),
+                "inner validator returned a mismatched outcome count; padding with errors"
+            );
+        }
+        let mut inner_outcomes = inner_outcomes.into_iter();
+        let mut remaining_hashes = survivor_hashes.into_iter();
+        slots
+            .into_iter()
+            .map(|slot| {
+                slot.unwrap_or_else(|| {
+                    // One hash per `None` slot by construction; the zero-hash fallback is
+                    // unreachable and only keeps this arm total.
+                    let hash = remaining_hashes.next().unwrap_or_default();
+                    inner_outcomes.next().unwrap_or_else(|| {
+                        TransactionValidationOutcome::Error(
+                            hash,
+                            Box::new(MissingInnerValidationOutcome),
+                        )
+                    })
+                })
+            })
+            .collect()
+    }
+
+    /// Same-origin batched validation; routes through [`Self::validate_transactions`] so
+    /// the screen and the inner batched path both apply.
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_transactions(transactions.into_iter().map(move |tx| (origin, tx))).await
+    }
+
+    /// Delegate to the inner validator: the trait default is a no-op, and silently dropping
+    /// the call would freeze the inner validator's fork and tip tracking.
+    fn on_new_head_block(&self, new_tip_block: &RethSealedBlock<Self::Block>) {
+        self.inner.on_new_head_block(new_tip_block)
     }
 }
 
@@ -150,10 +384,21 @@ impl WorkerTxPool {
         .kzg_settings(EnvKzgSettings::Default)
         .with_local_transactions_config(pool_config.local_transactions_config.clone())
         .with_additional_tasks(node_config.txpool.additional_validation_tasks)
-        .build_with_tasks(task_spawner.clone(), blob_store.clone());
+        .build_with_tasks(task_spawner.clone(), blob_store.clone())
+        // Wrap the eth validator with the TN authorization-list cap screen. `map` takes
+        // the validator out of its `Arc` via `Arc::into_inner(..).unwrap()`, which is safe
+        // only because the executor is freshly built on this line and no clone of it
+        // exists yet.
+        .map(TnPoolValidator::new);
 
-        let transaction_pool =
-            reth_transaction_pool::Pool::eth_pool(validator, blob_store, pool_config);
+        // `Pool::eth_pool` is pinned to the unwrapped `EthTransactionValidator`, so build
+        // the wrapped pool through the generic constructor with the same default ordering.
+        let transaction_pool = Pool::new(
+            validator,
+            CoinbaseTipOrdering::<EthPooledTransaction>::default(),
+            blob_store,
+            pool_config,
+        );
 
         info!(target: "tn::execution", "Transaction pool initialized");
 
@@ -586,6 +831,10 @@ mod tests {
     /// the reason for the outcome. Admission therefore proves the validator's type gate in
     /// [`WorkerTxPool::new`] lets type 0x04 through, matching the batch allowlist
     /// (`tn_types::batch_allowlisted_tx_type`) and TN's execution of set-code transactions.
+    ///
+    /// It also proves the [`TnPoolValidator`] screen admits an in-range authorization list
+    /// (one tuple here) and delegates to the inner validator: rejection at the screen would
+    /// fail the admission assertion below.
     #[tokio::test]
     async fn test_pool_accepts_eip7702_transaction() {
         let tmp_dir = TempDir::new().unwrap();
@@ -605,6 +854,51 @@ mod tests {
         assert_eq!(s.pending, 1);
         assert_eq!(s.blob, 0);
         assert!(pool.get(&hash).is_some());
+    }
+
+    /// The unpaid-ECDSA-amplification bound: the pool rejects an EIP-7702 transaction whose
+    /// authorization list exceeds `tn_types::max_tx_authorizations`, and the rejection
+    /// carries TN's [`AuthorizationListLengthExceeded`] kind, an error only the
+    /// [`TnPoolValidator`] screen produces, so its presence proves the screen fired before
+    /// the inner validator ran. The tuples are dummy-signed (wrong chain id): the screen
+    /// reads only the list length, so no per-tuple work has to succeed for the rejection.
+    #[tokio::test]
+    async fn test_pool_rejects_over_cap_eip7702_authorization_list() {
+        use reth_transaction_pool::error::PoolErrorKind;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let mut tx_factory = TransactionFactory::new_random();
+        let (chain, reth_env, pool) = funded_pool_for_test(&tx_factory, &tmp_dir, &task_manager);
+
+        let gas_price = reth_env.get_gas_price().unwrap();
+        let cap = usize::try_from(max_tx_authorizations(0)).expect("cap fits usize");
+        let signed = tx_factory.create_eip7702_with_authorizations(
+            chain.chain_id(),
+            1_000_000,
+            gas_price,
+            cap + 1,
+            Bytes::new(),
+        );
+
+        // The call returns a rejection (no panic) and the error kind is TN's own.
+        let result = pool.add_raw_transaction_external(signed).await;
+        let err = result.expect_err("over-cap 7702 txn must be rejected");
+        let PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Other(boxed)) =
+            &err.kind
+        else {
+            panic!("expected the TN authorization-list cap rejection, got: {err:?}");
+        };
+        assert!(
+            boxed.as_any().downcast_ref::<AuthorizationListLengthExceeded>().is_some(),
+            "expected AuthorizationListLengthExceeded, got: {boxed:?}"
+        );
+
+        // Nothing entered any sub-pool.
+        let s = pool.pool_size();
+        assert_eq!(s.pending, 0);
+        assert_eq!(s.queued, 0);
+        assert_eq!(s.blob, 0);
     }
 
     #[tokio::test]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -99,6 +99,28 @@ pub use libp2p::{multiaddr::Protocol, Multiaddr};
 pub fn batch_allowlisted_tx_type<T: Typed2718>(tx: &T) -> bool {
     tx.is_legacy() || tx.is_eip2930() || tx.is_eip1559() || tx.is_eip7702()
 }
+
+/// Whether a transaction's EIP-7702 authorization list is within the batch
+/// executable bound: `true` for any non-7702 transaction; for a type-0x04
+/// transaction, `true` iff the list length is in
+/// `1..=max_tx_authorizations(epoch)`.
+///
+/// One predicate shared by the batch validator, the batch builder, the worker
+/// gateway, and the pool wrap so producers and validators can never disagree
+/// on the bound. See [`max_tx_authorizations`] for the derivation and the
+/// no-false-rejection argument: an over-cap transaction can never execute
+/// inside a batch, so rejecting it refuses only garbage.
+///
+/// The empty list is excluded because EIP-7702 declares an empty
+/// authorization list invalid (revm rejects it at execution; reth's pool
+/// rejects it at admission), so a batch carrying one wastes certified work.
+pub fn batch_allowlisted_authorization_list<T: TransactionTrait>(tx: &T, epoch: Epoch) -> bool {
+    !tx.is_eip7702()
+        || tx.authorization_list().is_some_and(|list| {
+            u64::try_from(list.len())
+                .is_ok_and(|len| (1..=max_tx_authorizations(epoch)).contains(&len))
+        })
+}
 pub use reth_primitives::{
     Account, Block, BlockBody, EthPrimitives, NodePrimitives, PooledTransaction, Receipt,
     Recovered, RecoveredBlock, SealedBlock, SealedHeader, Transaction, TransactionSigned,
@@ -131,5 +153,64 @@ mod allowlist_tests {
                 "type {rejected:#04x} must be rejected"
             );
         }
+    }
+
+    /// Build a type-0x04 transaction carrying `n` dummy-signed authorization
+    /// tuples. The predicate only reads the list length, so dummy signatures
+    /// suffice.
+    fn tx_7702_with_tuples(n: usize) -> TxEip7702 {
+        let dummy_signature = EthSignature::new(U256::from(1), U256::from(1), false);
+        let authorization_list = (0..n)
+            .map(|_| {
+                Authorization { chain_id: U256::from(2017), address: Address::ZERO, nonce: 1 }
+                    .into_signed(dummy_signature)
+            })
+            .collect();
+        TxEip7702 {
+            chain_id: 2017,
+            nonce: 0,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 0,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            authorization_list,
+            input: Default::default(),
+        }
+    }
+
+    #[test]
+    fn max_tx_authorizations_is_pinned_to_1199() {
+        // (30,000,000 - 21,000) / 25,000 = 1199. A change here changes what
+        // every enforcement site admits — it must be deliberate.
+        assert_eq!(max_tx_authorizations(0), 1199);
+    }
+
+    #[test]
+    fn authorization_list_predicate_truth_table() {
+        // Non-7702 transactions always pass: the bound applies to type 0x04 only.
+        let non_7702 = TxEip1559 {
+            chain_id: 2017,
+            nonce: 0,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 0,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Default::default(),
+        };
+        assert!(batch_allowlisted_authorization_list(&non_7702, 0), "non-7702 must pass");
+
+        // 7702: empty is invalid per EIP-7702, 1..=cap passes, cap+1 fails.
+        let cap = usize::try_from(max_tx_authorizations(0)).expect("cap fits usize");
+        assert!(!batch_allowlisted_authorization_list(&tx_7702_with_tuples(0), 0), "empty list");
+        assert!(batch_allowlisted_authorization_list(&tx_7702_with_tuples(1), 0), "one tuple");
+        assert!(batch_allowlisted_authorization_list(&tx_7702_with_tuples(cap), 0), "at cap");
+        assert!(
+            !batch_allowlisted_authorization_list(&tx_7702_with_tuples(cap + 1), 0),
+            "over cap"
+        );
     }
 }

--- a/crates/types/src/worker/sealed_batch.rs
+++ b/crates/types/src/worker/sealed_batch.rs
@@ -204,6 +204,44 @@ pub fn max_batch_size(_epoch: Epoch) -> usize {
     1_000_000
 }
 
+/// Intrinsic gas of the cheapest transaction (EIP-2 base cost, 21,000).
+///
+/// Local mirror of the protocol constant. tn-types must not grow a revm
+/// dependency, so the value lives here with a pinning unit test instead.
+const BASE_TX_GAS: u64 = 21_000;
+
+/// Intrinsic gas charged per EIP-7702 authorization tuple (25,000).
+///
+/// Mirror of `revm_primitives::eip7702::PER_EMPTY_ACCOUNT_COST`. tn-types must
+/// not grow a revm dependency, so the value lives here with a pinning unit
+/// test instead.
+const PER_EMPTY_ACCOUNT_COST: u64 = 25_000;
+
+/// Max EIP-7702 authorization-list length a batch transaction may carry at
+/// `_epoch`. Currently (30,000,000 - 21,000) / 25,000 = 1199.
+///
+/// Derivation: each authorization tuple costs at least
+/// [`PER_EMPTY_ACCOUNT_COST`] intrinsic gas on top of [`BASE_TX_GAS`]. A
+/// type-0x04 transaction with more than this many tuples must either declare
+/// `gas_limit >= 21_000 + 25_000 * N > max_batch_gas` (so no batch can ever
+/// carry it: the batch validator sums declared gas limits against
+/// [`max_batch_gas`]) or under-declare and be rejected by revm's
+/// intrinsic-gas gate (`CallGasCostMoreThanGasLimit`) before any per-tuple
+/// authority recovery. Either way the transaction can never execute, so every
+/// enforcement site that uses this bound rejects only garbage: no valid
+/// transaction is ever refused.
+///
+/// The DoS this bounds: each tuple costs one unpaid ECDSA recovery at pool
+/// admission (reth recovers authorities during validation). The cap bounds
+/// that work to 1199 recoveries per transaction, and enforcement sites check
+/// the list length BEFORE the recovery runs.
+///
+/// The epoch parameter mirrors [`max_batch_gas`] and auto-tracks a future
+/// fork that raises batch gas. Currently epoch-uniform.
+pub fn max_tx_authorizations(_epoch: Epoch) -> u64 {
+    max_batch_gas(_epoch).saturating_sub(BASE_TX_GAS) / PER_EMPTY_ACCOUNT_COST
+}
+
 /// Defines the validation procedure for receiving either a new single transaction (from a client)
 /// of a batch of transactions (from another validator).
 ///
@@ -322,6 +360,22 @@ pub enum BatchValidationError {
     UnsupportedTxType {
         /// The EIP-2718 type byte of the offending transaction.
         tx_type: u8,
+        /// Hash of the offending transaction.
+        hash: BlockHash,
+    },
+    /// The batch contains an EIP-7702 transaction whose authorization-list
+    /// length falls outside `1..=max_tx_authorizations(epoch)`.
+    ///
+    /// An empty list is invalid per EIP-7702 (revm rejects it at execution),
+    /// and a list longer than [`max_tx_authorizations`] can never execute
+    /// inside a batch (see that function's doc comment), so this rejects only
+    /// garbage that would waste certified work.
+    #[error("Proposed batch contains EIP-7702 transaction with authorization list length {len} outside 1..={max}. Tx hash: {hash}")]
+    InvalidAuthorizationList {
+        /// The authorization-list length of the offending transaction.
+        len: usize,
+        /// The maximum length allowed at the batch's epoch.
+        max: u64,
         /// Hash of the offending transaction.
         hash: BlockHash,
     },


### PR DESCRIPTION
Stacked on #1154 (`fix/eip7702-gas-penalty-numerator`).  Follows up the review thread there: wrap the RPC-side pool validation and enforce a TN authorization-list length bound, with the batch validator updated to enforce the same bound.

## Problem

#1154 turns on type `0x04` admission, and reth's pool validation recovers the signer of every authorization tuple (to track authority accounts) before the transaction has paid anything.  The tuple count was unbounded at admission: a single `eth_sendRawTransaction` body can carry tens of thousands of tuples, and every one costs the node an ECDSA recovery even when the transaction is then rejected and never pays a fee.  The batch side had the same gap in the other direction: batch validation sums declared gas limits only, so a certified batch could carry a `0x04` transaction with a padded list that no honest node would ever have built.

## Fix

One bound, derived from real protocol parameters and enforced symmetrically on every producing and validating path:

- [x] `crates/types/src/worker/sealed_batch.rs`: `max_tx_authorizations(epoch)` = `(max_batch_gas(epoch) - 21_000) / 25_000` = 1199.  Each tuple costs `PER_EMPTY_ACCOUNT_COST` (25,000) intrinsic gas, so a `0x04` transaction with more tuples must either declare `gas_limit` above what any batch can carry, or under-declare and be rejected by revm's intrinsic-gas gate before per-tuple recovery.  Either way it can never execute;  every site below rejects only garbage, so there are no false rejections.  The bound tracks `max_batch_gas` automatically if a future fork raises it.
- [x] `crates/types/src/lib.rs`: `batch_allowlisted_authorization_list` predicate (non-`0x04`: admitted;  `0x04`: list length in `1..=cap`), shared by the batch validator, the batch builder, and the worker gateway so producers and validators can never disagree, in the same pattern as `batch_allowlisted_tx_type`.
- [x] `crates/tn-reth/src/txn_pool.rs`: `TnPoolValidator` wraps reth's eth validator via `TransactionValidationTaskExecutor::map`.  The screen is cheap-first and attacker-independent: it reads the list length and rejects over-cap transactions before the inner validator runs, so the per-tuple recovery work never happens.  The batched `validate_transactions` override preserves reth's shared-state-provider fast path and merges outcomes back in input order, degrading loudly (a warning plus explicit `Error` outcomes) if the inner validator ever breaks its one-outcome-per-input contract.  Covers every ingress: RPC, gossip resubmission, the observer forwarder requeue, and epoch-close repooling all funnel through this validator.
- [x] `crates/batch-validator/src/validator.rs`: `validate_authorization_lists` rejects a batch carrying an out-of-bounds `0x04` transaction with the new `BatchValidationError::InvalidAuthorizationList`.
- [x] `crates/consensus/worker/src/network/error.rs`: the new variant carries a Medium peer penalty, the same tier as `UnsupportedTxType`.
- [x] `crates/batch-builder/src/batch.rs`: the builder never packs an out-of-bounds `0x04` transaction (it would cost this node a peer penalty on every vote request) and removes it and its descendants from the pool.
- [x] `bin/worker-gateway`: the `eth_sendRawTransaction` screen front-runs the rejection (`-32009`, `invalid_authorization_list`).  The screen only rejects what the worker's own pool rejects, so the documented no-false-rejection property holds.

The pool screen evaluates the cap at epoch 0 with a comment noting the cap is epoch-uniform today;  the batch validator enforces the epoch-precise bound.

## Testing

- `cargo +nightly-2026-03-20 fmt --all -- --check` green.
- `cargo +1.94 check --all-targets` and `cargo +1.94 clippy --all-targets --no-deps` green on `tn-types`, `tn-worker`, `tn-reth`, `tn-batch-builder`, `tn-batch-validator`, `tn-worker-gateway`.
- New unit tests at every enforcement site: cap value pin (1199) and predicate truth table (tn-types);  over-cap rejection with the boxed `AuthorizationListLengthExceeded` kind (pool);  over-cap batch rejected, at-cap batch accepted (batch validator);  over-cap transaction never packed and removed from the pool (batch builder);  over-cap payload rejected with stable code and reason label (gateway).  All authorization tuples in tests are dummy-signed;  no path under test verifies tuple signatures.
- Mutation confirmation: with `max_tx_authorizations` mutated to `u64::MAX` (cap never binds), the new rejection tests at each site fail;  restored, they pass.
- Workspace CI (fmt, clippy `-D warnings`, nextest) runs on push;  the pinned `+1.94` attest runs post-push as usual.
