### PR TITLE
fix(engine): log skipped duplicate transactions at debug with the tx hash

### DIFF
--- a/crates/tn-reth/src/env/execution.rs
+++ b/crates/tn-reth/src/env/execution.rs
@@ -169,7 +169,7 @@ impl RethEnv {
                     // allow transaction errors (ie - duplicates)
                     //
                     // it's possible that another worker's batch included this transaction
-                    warn!(target: "engine", %error,  "skipping invalid transaction: {:#?}", recovered);
+                    debug!(target: "engine", %error, tx_hash = ?recovered.hash(), "skipping invalid transaction");
                     // expected in normal operation - see the field docs, this is not an alert
                     RETH_METRICS.invalid_txs_skipped_total.increment(1);
                     continue;


### PR DESCRIPTION
Closes #1263.  (Cantina #24)

## Problem

The block builder logs every skipped `InvalidTx` at `warn!` and pretty-prints the full recovered transaction with `{:#?}`, calldata included (`crates/tn-reth/src/env/execution.rs`).

Three parts of the same block disagree with that level.  The code comment calls the case "expected in normal operation".  The `invalid_txs_skipped_total` metric docs describe it as expected duplicate traffic across workers.  The default filter (`info,evm=debug`) still delivers every occurrence to operator logs.

With multiple workers, duplicate skips are routine, so the default log fills with multi-kilobyte transaction dumps under normal load.  The noise is also attacker-inflatable at no marginal cost: a sender pays once for one large-calldata transaction, and the node dumps it at `warn!` on every skip when it lands in more than one worker's batch.  Disk use stays bounded by reth `LogArgs` file rotation;  the real damage is signal quality for operators who alert on `warn`.

The `error!` above this path (signer-recovery failure) is unchanged.  That path fires only when a certified batch carries undecodable bytes, which is Byzantine behavior and intentionally alertable.

## Fix

- [x] `crates/tn-reth/src/env/execution.rs`: downgrade the skip log to `debug!` and log the transaction hash instead of the full `{:#?}` dump.  The `invalid_txs_skipped_total` metric remains the operator-facing signal for this case.

## Testing

Log-level-only change;  no behavior change and no new items to document.  Local static ladder: `cargo +nightly fmt --all -- --check`, `cargo +1.94 check -p tn-reth`, and `cargo +1.94 clippy -p tn-reth --all-targets --no-deps -- -D warnings`, all green.  CI runs the full workspace ladder (nightly fmt, workspace clippy `-D warnings`, nextest) on push, and the pinned `+1.94` attest runs on the second machine post-push.
