### PR TITLE
fix(tn-reth): pass the base-fee argument in the eth_syncing rpc test (#1283)

### DIFF
--- a/crates/tn-reth/src/env/rpc.rs
+++ b/crates/tn-reth/src/env/rpc.rs
@@ -408,7 +408,12 @@ mod tests {
         )?;
         let pool = reth_env.init_txn_pool()?;
         let network = crate::worker::WorkerNetwork::new_for_test(reth_env.chainspec());
-        let server = reth_env.get_rpc_server(pool, network.clone(), RpcModule::new(()))?;
+        let server = reth_env.get_rpc_server(
+            pool,
+            network.clone(),
+            BaseFeeContainer::default(),
+            RpcModule::new(()),
+        )?;
         let methods = server.methods_by(|name| name == "eth_syncing");
 
         let synced: serde_json::Value = methods.call("eth_syncing", rpc_params![]).await?;


### PR DESCRIPTION
Closes #1283.

## Problem

`origin/main` (c0bbcb3a) fails `cargo check --workspace --all-targets`:

```
error[E0061]: this method takes 4 arguments but 3 arguments were supplied
   --> crates/tn-reth/src/env/rpc.rs:411:31
    |
411 |         let server = reth_env.get_rpc_server(pool, network.clone(), RpcModule::new(()))?;
    |                               ^^^^^^^^^^^^^^                        ------------------ argument #3 of type `tn_types::gas_accumulator::BaseFeeContainer` is missing
```

`cargo test -p tn-reth --lib` fails the same way, so the tn-reth test suite cannot build on main.

## Root cause

Two PRs crossed:

- #1235 (34f0f83b) added the `base_fee: BaseFeeContainer` parameter to `RethEnv::get_rpc_server` and updated the call sites that existed at the time.
- #1232 (1e4fc55f) merged after #1235, from a branch based on 28b84e49, before the signature change.  Its new test `test_eth_syncing_answers_from_worker_shim_flag` calls the 3-argument form.  The merge was textual, so the stale call landed on main.

Pre-merge CI ran on the #1232 branch, where the 3-argument call was still correct.  Nothing rebuilt the merged result with `--all-targets`.

## Fix

- [x] `crates/tn-reth/src/env/rpc.rs`: pass `BaseFeeContainer::default()` at the `test_eth_syncing_answers_from_worker_shim_flag` call site, the same value the `new_for_temp_chain` path uses (`rpc.rs:200`).  The test asserts `eth_syncing` answers only;  the base-fee value does not reach the assertion.

A sweep of every `get_rpc_server` caller (`crates/node/src/engine/inner.rs:163`, `rpc.rs:200`, `rpc.rs:411`, `rpc.rs:477`) confirms line 411 was the only stale 3-argument site.

## Testing

Differential compile gate under the pinned toolchain, both halves run on this branch:

- Before the fix: `cargo +1.94 check -p tn-reth --all-targets -j 2` reproduces the E0061 at `rpc.rs:411` as the only error.
- After the fix: the same command passes clean.
- `cargo +nightly fmt --all -- --check` passes.

No behavior change;  the change touches one test call site.  CI (`--workspace` nextest and clippy lanes) runs on push, and the pinned `cargo +1.94 test --no-run --workspace` attest runs post-push.
