### PR TITLE
fix(node): stop the restore-time RecentBlocks scan at the real-header floor

### DIFF
--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -300,7 +300,7 @@ impl ExecutionNodeInner {
         let last_block_number = self.reth_env.last_block_number()?;
         debug!(target: "epoch-manager", ?last_block_number, "restoring last executed output blocks");
         collect_last_output_blocks(
-            |block_num| Ok(self.reth_env.sealed_header_by_number(block_num)?),
+            |block_num| self.reth_env.sealed_header_by_number(block_num).map_err(Into::into),
             last_block_number,
             number,
             self.reth_env.real_header_floor(),

--- a/crates/node/src/engine/inner.rs
+++ b/crates/node/src/engine/inner.rs
@@ -5,7 +5,7 @@
 use crate::error::ExecutionError;
 use eyre::{eyre, OptionExt};
 use jsonrpsee::http_client::HttpClient;
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, ops::ControlFlow, sync::Arc};
 use tn_batch_builder::BatchBuilder;
 use tn_batch_validator::BatchValidator;
 use tn_config::Config;
@@ -299,39 +299,12 @@ impl ExecutionNodeInner {
     ) -> eyre::Result<Vec<SealedHeader>> {
         let last_block_number = self.reth_env.last_block_number()?;
         debug!(target: "epoch-manager", ?last_block_number, "restoring last executed output blocks");
-        let mut result = Vec::with_capacity(number as usize);
-        if number > 0 {
-            let mut block_num = last_block_number;
-            let mut last_nonce;
-            if let Some(header) = self.reth_env.sealed_header_by_number(block_num)? {
-                last_nonce = header.nonce;
-                result.push(header);
-            } else {
-                return Err(eyre::Error::msg(format!("Unable to read block {block_num}")));
-            }
-            let mut blocks = 1;
-            while blocks < number {
-                if block_num == 0 {
-                    break;
-                }
-                block_num -= 1;
-                if let Some(header) = self.reth_env.sealed_header_by_number(block_num)? {
-                    // Do this check so we only track the "finalized" blocks not all the extra
-                    // batches.  Note that the nonce will be the same for all batches in the same
-                    // consensus output but will change for each output (composed of epoch and
-                    // round).
-                    if header.nonce != last_nonce {
-                        last_nonce = header.nonce;
-                        result.push(header);
-                        blocks += 1;
-                    }
-                } else {
-                    return Err(eyre::Error::msg(format!("Unable to read block {block_num}")));
-                }
-            }
-        }
-        result.reverse();
-        Ok(result)
+        collect_last_output_blocks(
+            |block_num| Ok(self.reth_env.sealed_header_by_number(block_num)?),
+            last_block_number,
+            number,
+            self.reth_env.real_header_floor(),
+        )
     }
 
     /// Return an database provider.
@@ -483,4 +456,152 @@ fn decode_committee_keys(
             })
         })
         .collect()
+}
+
+/// Walk headers backward from `tip`, keeping the last block of each consensus output, and never
+/// reading below `scan_floor`.
+///
+/// Every block of one consensus output carries the same header nonce, and the nonce changes at
+/// each output, so a nonce change marks an output's final block. The walk collects up to `number`
+/// of them (returned oldest first) and stops early at `scan_floor`: `0` (genesis) on a
+/// normally-synced node, [`RethEnv::real_header_floor`] on a snapshot-restored datadir. The floor
+/// is what keeps the walk inside real history: below it the datadir holds scaffold dummy headers
+/// whose nonce is always `0`, so the nonce-change condition could never fire again and the walk
+/// would read every header down to block 0 (O(chain-height) synchronous reads inside the startup
+/// path), then hand the caller a synthetic header (issue #1321). The header AT `scan_floor` is
+/// real and stays eligible for collection.
+fn collect_last_output_blocks(
+    read_header: impl Fn(u64) -> eyre::Result<Option<SealedHeader>>,
+    tip: u64,
+    number: u64,
+    scan_floor: u64,
+) -> eyre::Result<Vec<SealedHeader>> {
+    let read = |block_num: u64| {
+        read_header(block_num).and_then(|header| {
+            header.ok_or_else(|| eyre::Error::msg(format!("Unable to read block {block_num}")))
+        })
+    };
+    let want = usize::try_from(number).unwrap_or(usize::MAX);
+    let collected = (number > 0)
+        .then(|| {
+            let tip_header = read(tip)?;
+            let last_nonce = tip_header.nonce;
+            let outcome = (scan_floor..tip).rev().try_fold(
+                (vec![tip_header], last_nonce),
+                |(heads, last_nonce), block_num| {
+                    if heads.len() >= want {
+                        ControlFlow::Break(Ok(heads))
+                    } else {
+                        read(block_num).map_or_else(
+                            |err| ControlFlow::Break(Err(err)),
+                            |header| {
+                                // Only track each output's "finalized" block, not all the extra
+                                // batches: the nonce is shared by every batch of one consensus
+                                // output and changes at the next output (composed of epoch and
+                                // round).
+                                let step = if header.nonce == last_nonce {
+                                    (heads, last_nonce)
+                                } else {
+                                    let nonce = header.nonce;
+                                    (
+                                        heads.into_iter().chain(std::iter::once(header)).collect(),
+                                        nonce,
+                                    )
+                                };
+                                ControlFlow::Continue(step)
+                            },
+                        )
+                    }
+                },
+            );
+            match outcome {
+                ControlFlow::Continue((heads, _)) => Ok(heads),
+                ControlFlow::Break(result) => result,
+            }
+        })
+        .transpose()?
+        .unwrap_or_default();
+    Ok(collected.into_iter().rev().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// A synthetic chain reader: real headers in `real_floor..=tip` where each consensus output
+    /// spans `span` blocks (nonce = 1 + output index, never colliding with the dummy nonce),
+    /// scaffold dummies (zero nonce, like `ExecHeader::default()`) below `real_floor`. `reads`
+    /// counts every header fetch.
+    fn reader(
+        tip: u64,
+        real_floor: u64,
+        span: u64,
+        reads: &Cell<u64>,
+    ) -> impl Fn(u64) -> eyre::Result<Option<SealedHeader>> + '_ {
+        move |number| {
+            reads.set(reads.get() + 1);
+            let nonce =
+                number.checked_sub(real_floor).map_or(0u64, |offset| 1 + offset / span.max(1));
+            Ok((number <= tip).then(|| {
+                SealedHeader::new(
+                    ExecHeader { number, nonce: nonce.into(), ..Default::default() },
+                    B256::ZERO,
+                )
+            }))
+        }
+    }
+
+    /// Regression test for issue #1321: when the real-header window holds fewer distinct nonces
+    /// than requested, the walk must stop at the floor: never read the dummy region below it and
+    /// never push a synthetic (dummy) header into the result.
+    #[test]
+    fn scan_stops_at_restored_floor_and_excludes_dummies() -> eyre::Result<()> {
+        let reads = Cell::new(0u64);
+        // 10_000-block chain, real headers only in 9_745..=10_000, 8 blocks per output => 32
+        // distinct nonces in the window, fewer than the 50 requested
+        let (tip, floor) = (10_000u64, 9_745u64);
+        let result = collect_last_output_blocks(reader(tip, floor, 8, &reads), tip, 50, floor)?;
+
+        // every read stayed inside real history (the window itself, at most)
+        assert!(reads.get() <= tip - floor + 1, "walk read below the floor: {} reads", reads.get());
+        // no synthetic header escaped: every returned block is at or above the floor
+        assert!(result.iter().all(|h| h.number >= floor), "dummy header in result");
+        // the walk still collected the real output heads (one per distinct nonce in the window)
+        assert_eq!(result.len(), 32);
+        let ordered = result.iter().zip(result.iter().skip(1)).all(|(a, b)| a.number < b.number);
+        assert!(ordered, "result is not oldest-first");
+        Ok(())
+    }
+
+    /// Baseline: with no restore floor the walk behaves as before: it collects `number` output
+    /// heads (newest is the tip), one per nonce change, oldest first.
+    #[test]
+    fn scan_collects_output_heads_without_floor() -> eyre::Result<()> {
+        let reads = Cell::new(0u64);
+        // whole chain real, 4 blocks per output
+        let tip = 100u64;
+        let result = collect_last_output_blocks(reader(tip, 0, 4, &reads), tip, 5, 0)?;
+
+        assert_eq!(result.len(), 5);
+        assert_eq!(result.last().map(|h| h.number), Some(tip));
+        let distinct = result.iter().zip(result.iter().skip(1)).all(|(a, b)| a.nonce != b.nonce);
+        assert!(distinct, "collected two blocks of the same consensus output");
+        Ok(())
+    }
+
+    /// A walk that reaches genesis on a short, normally-synced chain stops there: the pre-#1321
+    /// termination, preserved by `scan_floor == 0`.
+    #[test]
+    fn scan_stops_at_genesis_on_short_chain() -> eyre::Result<()> {
+        let reads = Cell::new(0u64);
+        let tip = 6u64;
+        let result = collect_last_output_blocks(reader(tip, 0, 2, &reads), tip, 50, 0)?;
+
+        // blocks 0..=6 at 2 blocks per output hold 4 distinct nonces; the walk reads each block
+        // exactly once, terminates at genesis, and keeps one head per output
+        assert_eq!(reads.get(), tip + 1);
+        assert_eq!(result.len(), 4);
+        Ok(())
+    }
 }

--- a/crates/tn-reth/src/env/mod.rs
+++ b/crates/tn-reth/src/env/mod.rs
@@ -296,6 +296,30 @@ impl RethEnv {
             })
     }
 
+    /// Return the lowest block number whose header is guaranteed REAL on this datadir.
+    ///
+    /// `0` on a normally-synced node: every persisted header is real down to genesis. On a
+    /// snapshot-restored datadir, real headers exist only inside the restore window; every block
+    /// below it is a scaffold dummy (`ExecHeader::default()` with a zero hash and zero nonce,
+    /// `SnapshotRestorer::import_chain_scaffold` in `snapshot.rs`). Backward header walks must
+    /// stop here instead of genesis: below this bound the dummy nonces never change, so a walk
+    /// keyed on nonce changes (`last_executed_output_blocks` in `tn-node`) would read every
+    /// header down to block 0 (O(chain-height) reads inside startup) and hand its caller a
+    /// synthetic header (issue #1321).
+    ///
+    /// Only the snapshot block `B` is persisted (the floor marker), not the window start, so the
+    /// bound is derived: the restore admits a window only if it starts at or below
+    /// `max(1, B - (BLOCKHASH_ANCESTORS - 1))` (`import_chain_scaffold`), making that expression
+    /// the lowest block guaranteed real. The actual window may reach one block lower; stopping
+    /// at the guarantee merely trims the walk by that block, while trusting an unpersisted
+    /// window start could admit a dummy read.
+    pub fn real_header_floor(&self) -> u64 {
+        use tn_storage::exec_state_pack::BLOCKHASH_ANCESTORS;
+        self.inner
+            .restored_state_floor
+            .map_or(0, |b| b.saturating_sub(BLOCKHASH_ANCESTORS - 1).max(1))
+    }
+
     /// Initialize the provider factory and related components
     fn init_provider_factory(
         node_config: &NodeConfig<RethChainSpec>,

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -2529,6 +2529,35 @@ mod tests {
         Ok(())
     }
 
+    /// `real_header_floor` derives the guaranteed-real header bound from the floor marker:
+    /// no marker => 0 (every header is real down to genesis), marker `B` =>
+    /// `max(1, B - (BLOCKHASH_ANCESTORS - 1))`, the bound backward header walks must not cross
+    /// on a restored datadir (issue #1321). The mature-chain (non-clamped) arm is exercised here
+    /// with a hand-written marker; the clamped arm is covered by the scaffold test below.
+    #[tokio::test]
+    async fn real_header_floor_derives_from_the_floor_marker() -> eyre::Result<()> {
+        let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+        let dir = TempDir::new()?;
+        let tm = TaskManager::new("Real Header Floor");
+        let (reth_config, db) = temp_config_and_db(chain.clone(), dir.path())?;
+        let env = RethEnv::new(&reth_config, &tm, db, None, GasAccumulator::default())?;
+        assert_eq!(
+            env.real_header_floor(),
+            0,
+            "a normally-synced datadir must let backward walks reach genesis"
+        );
+        drop(env);
+
+        // a mature restored chain: the marker sits far above the lookback window, so the bound
+        // is `B - (BLOCKHASH_ANCESTORS - 1)`, not the genesis clamp
+        std::fs::write(RethEnv::restored_state_floor_path(&reth_config.0), "100000\n")?;
+        let (reth_config, db) = temp_config_and_db(chain, dir.path())?;
+        let env = RethEnv::new(&reth_config, &tm, db, None, GasAccumulator::default())?;
+        assert_eq!(env.real_header_floor(), 100_000 - (BLOCKHASH_ANCESTORS - 1));
+
+        Ok(())
+    }
+
     /// The scaffold persists the restored-state floor marker as the snapshot's FINAL block `B` —
     /// not the window's first block, because window headers below `B` resolve by hash yet carry
     /// no state — before any chain data commits, and a fresh env over the datadir refuses pinned
@@ -2563,6 +2592,15 @@ mod tests {
 
         let (reth_config, db) = temp_config_and_db(chain, dst_dir.path())?;
         let env = RethEnv::new(&reth_config, &tm, db, None, GasAccumulator::default())?;
+
+        // the real-header bound derives from the marker: max(1, B - (BLOCKHASH_ANCESTORS - 1)),
+        // here clamped to block 1 (B = 5 sits inside the lookback). Backward header walks stop
+        // there instead of reading scaffold dummies (issue #1321)
+        assert_eq!(
+            env.real_header_floor(),
+            1,
+            "a restored env must bound backward header walks at the guaranteed-real floor"
+        );
 
         // below the floor: refused up front, before the (unresolvable) pin hash matters
         let phantom =


### PR DESCRIPTION
Closes #1321.  (Cantina #30)

## Problem

At startup, `try_restore_state` primes the `RecentBlocks` watch through `last_executed_output_blocks(block_capacity)`.  The scan walks headers backward from the tip and counts one block per consensus-output nonce change, stopping only after `block_capacity` distinct nonces or at block 0.

A node bootstrapped from a state snapshot holds real headers only inside the restore window (the anchor plus the `BLOCKHASH_ANCESTORS = 256` lookback).  Every block below the window is a scaffold dummy: `ExecHeader::default()` with a zero hash and a zero nonce.  When the window holds fewer distinct nonces than `block_capacity` (the default capacity is `gc_depth = 50`, so any window averaging more than ~5.1 execution blocks per consensus output qualifies), the scan crosses into the dummy region.  The first dummy counts once (its nonce 0 differs from the last real nonce), and after that the nonce never changes again, so the walk reads every header down to genesis.  On a mature chain that is millions of synchronous `sealed_header_by_number` reads inside the startup path, before networking and consensus come up, and the cost grows linearly with chain height on every restart.  No attacker is required;  the cost is self-inflicted and permanent.

The boundary crossing also pushes one dummy header into the result, so `RecentBlocks` gets seeded with a synthetic header and a `ConsensusNumHash` derived from default values.

## Fix

Bound the scan so it never leaves real history, using state the restore already persists:

- [x] `crates/tn-reth/src/env/mod.rs`: new `RethEnv::real_header_floor()`, the lowest block number guaranteed to hold a real header.  It is `0` on a normally-synced node and `max(1, B - (BLOCKHASH_ANCESTORS - 1))` on a restored datadir, derived from the restored-state floor marker `B`.  The bound is not guessed: `import_chain_scaffold` admits a window only if it starts at or below that expression, so the derivation reuses the exact invariant the restore enforces.  The actual window may start one block lower, but only `B` is persisted, so the derived bound trims at most one legitimately readable header while never admitting a dummy read.
- [x] `crates/node/src/engine/inner.rs`: the backward walk is extracted into `collect_last_output_blocks(read_header, tip, number, scan_floor)` (combinator form, no imperative loop) and its termination changes from "block 0" to the floor.  With no restore the floor is 0 and the walk behaves exactly as before.  On a restored datadir the walk stops at the guaranteed-real floor: it never reads the dummy region and never returns a synthetic header, so the worst case is the restore window plus the live tip region instead of O(chain-height).

## Testing

- New unit tests for `collect_last_output_blocks` (`crates/node/src/engine/inner.rs`), driven by a synthetic reader that counts every header fetch:
  - Regression for #1321: a 10,000-block chain whose real window (9,745..=10,000) holds 32 distinct nonces against a request for 50.  Asserts the walk performs at most window-many reads, returns no header below the floor, and stays oldest-first.
  - Baseline without a floor: collects exactly the requested count, the newest head is the tip, and consecutive heads carry distinct nonces.
  - Genesis termination on a short, normally-synced chain (the pre-existing behavior, preserved by `scan_floor == 0`).
- `real_header_floor` coverage (`crates/tn-reth/src/snapshot.rs`): a new test asserts the absent-marker case returns 0 and a hand-written marker at 100000 yields 99745 (the non-clamped arm);  the existing scaffold test now also asserts the clamped arm (B = 5 yields floor 1) on an env built over a genuinely restored datadir.
- Each new load-bearing test was confirmed by mutation: removing the floor from the walk range, an off-by-one on the collection cap, and a floor derivation that returns `B` itself each make their covering test fail, and all pass again with the real code restored.
- Local static ladder under the pinned toolchain: `cargo +1.94 check -p tn-node -p tn-reth --all-targets`, `cargo +1.94 clippy --no-deps -p tn-node -p tn-reth --all-targets -- -D warnings`, nightly `fmt -- --check` on the touched crates.  CI owns the dynamic tier on push;  the pinned `+1.94` attest runs post-push on the second machine.
