### PR TITLE
fix(tn-reth): floor snapshot-scaffold heights out of the canonical execution check

### DIFF
--- a/crates/consensus/primary/src/recent_blocks.rs
+++ b/crates/consensus/primary/src/recent_blocks.rs
@@ -79,13 +79,13 @@ impl RecentBlocks {
     }
 
     /// Is hash a recent block we have executed?
-    ///
-    /// A zero hash never matches: no real executed block seals to `B256::ZERO`, and a snapshot
-    /// restore fabricates its pre-window scaffold headers with exactly that hash. If such a dummy
-    /// is ever seeded into the ring, a peer could clear the execution-result check by referencing
-    /// it, so the zero hash is rejected outright before the ring is scanned.
     pub fn contains_execution_hash(&self, hash: BlockHash) -> bool {
-        hash != BlockHash::ZERO && self.executed_blocks.iter().any(|block| block.hash() == hash)
+        for block in &self.executed_blocks {
+            if block.hash() == hash {
+                return true;
+            }
+        }
+        false
     }
 
     /// Is hash (consensus output) in a recent block we have executed?
@@ -144,29 +144,5 @@ mod tests {
         assert_eq!(recent.latest_consensus_block_num_hash(), consensus_num_hash);
         assert_eq!(recent.latest_execution_block_num_hash(), executed.num_hash());
         assert!(recent.contains_execution_hash(executed.hash()));
-    }
-
-    #[test]
-    fn contains_execution_hash_rejects_the_zero_hash() {
-        use tn_types::BlockHash;
-
-        let mut recent = RecentBlocks::new(4);
-        let cnh = ConsensusNumHash::new(12, ConsensusHeaderDigest::from([3u8; 32]));
-
-        // a genuinely executed block resolves by its true (non-zero) sealed hash
-        let real = SealedHeader::seal_slow(ExecHeader { number: 9, ..Default::default() });
-        recent.push_latest(3, cnh, Some(real.clone()));
-        assert!(recent.contains_execution_hash(real.hash()));
-
-        // seed a zero-hash scaffold dummy the way a snapshot restore would, then confirm it can
-        // never clear the execution-result check: a Byzantine header referencing a scaffold
-        // height carries exactly this `B256::ZERO`
-        let dummy =
-            SealedHeader::new(ExecHeader { number: 3, ..Default::default() }, BlockHash::ZERO);
-        recent.push_latest(4, cnh, Some(dummy));
-        assert!(
-            !recent.contains_execution_hash(BlockHash::ZERO),
-            "a zero-hash dummy in the ring must not be reported as an executed block"
-        );
     }
 }

--- a/crates/consensus/primary/src/recent_blocks.rs
+++ b/crates/consensus/primary/src/recent_blocks.rs
@@ -79,13 +79,13 @@ impl RecentBlocks {
     }
 
     /// Is hash a recent block we have executed?
+    ///
+    /// A zero hash never matches: no real executed block seals to `B256::ZERO`, and a snapshot
+    /// restore fabricates its pre-window scaffold headers with exactly that hash. If such a dummy
+    /// is ever seeded into the ring, a peer could clear the execution-result check by referencing
+    /// it, so the zero hash is rejected outright before the ring is scanned.
     pub fn contains_execution_hash(&self, hash: BlockHash) -> bool {
-        for block in &self.executed_blocks {
-            if block.hash() == hash {
-                return true;
-            }
-        }
-        false
+        hash != BlockHash::ZERO && self.executed_blocks.iter().any(|block| block.hash() == hash)
     }
 
     /// Is hash (consensus output) in a recent block we have executed?
@@ -144,5 +144,29 @@ mod tests {
         assert_eq!(recent.latest_consensus_block_num_hash(), consensus_num_hash);
         assert_eq!(recent.latest_execution_block_num_hash(), executed.num_hash());
         assert!(recent.contains_execution_hash(executed.hash()));
+    }
+
+    #[test]
+    fn contains_execution_hash_rejects_the_zero_hash() {
+        use tn_types::BlockHash;
+
+        let mut recent = RecentBlocks::new(4);
+        let cnh = ConsensusNumHash::new(12, ConsensusHeaderDigest::from([3u8; 32]));
+
+        // a genuinely executed block resolves by its true (non-zero) sealed hash
+        let real = SealedHeader::seal_slow(ExecHeader { number: 9, ..Default::default() });
+        recent.push_latest(3, cnh, Some(real.clone()));
+        assert!(recent.contains_execution_hash(real.hash()));
+
+        // seed a zero-hash scaffold dummy the way a snapshot restore would, then confirm it can
+        // never clear the execution-result check: a Byzantine header referencing a scaffold
+        // height carries exactly this `B256::ZERO`
+        let dummy =
+            SealedHeader::new(ExecHeader { number: 3, ..Default::default() }, BlockHash::ZERO);
+        recent.push_latest(4, cnh, Some(dummy));
+        assert!(
+            !recent.contains_execution_hash(BlockHash::ZERO),
+            "a zero-hash dummy in the ring must not be reported as an executed block"
+        );
     }
 }

--- a/crates/tn-reth/src/env/helpers.rs
+++ b/crates/tn-reth/src/env/helpers.rs
@@ -573,20 +573,34 @@ impl CanonicalExecutionReader for RethEnv {
     /// whether `number` is *durably* canonical, so an in-memory-tip-aware read would defeat the
     /// question by reporting speculatively executed blocks as confirmed.
     fn canonical_execution_hash(&self, number: BlockNumber) -> Option<B256> {
-        // A read error (e.g. a transient provider/DB error) is treated as "not confirmed" rather
-        // than as a canonical match, so the caller keeps its conservative fork handling.
-        self.sealed_header_by_number(number)
-            .inspect_err(|error| {
-                tracing::debug!(
-                    target: "tn::reth",
-                    ?error,
-                    number,
-                    "canonical_execution_hash: canonical DB read failed; treating as unconfirmed"
-                );
-            })
-            .ok()
-            .flatten()
-            .map(|header| header.hash())
+        // A snapshot-restored datadir scaffolds the whole region below its restored-state floor
+        // `B`: zero-hash dummy headers below the window and real-hashed but stateless window
+        // headers within it. None of these are blocks this node executed, so confirming one as
+        // canonical would let a peer's header that references a scaffold height clear the
+        // execution-result check — a zero-hash dummy reads back as its own `B256::ZERO` hash and
+        // matches a poison `latest_execution_block`. The region below the floor is refused here,
+        // mirroring `read_only_state_db`'s floor guard, so the DB fallback can never attest it.
+        self.inner.restored_state_floor.filter(|floor| number < *floor).map_or_else(
+            // not below the floor (or a normally-synced node): answer from the canonical DB.
+            // A read error (e.g. a transient provider/DB error) is treated as "not confirmed"
+            // rather than as a canonical match, so the caller keeps its conservative fork handling.
+            || {
+                self.sealed_header_by_number(number)
+                    .inspect_err(|error| {
+                        tracing::debug!(
+                            target: "tn::reth",
+                            ?error,
+                            number,
+                            "canonical_execution_hash: canonical DB read failed; treating as unconfirmed"
+                        );
+                    })
+                    .ok()
+                    .flatten()
+                    .map(|header| header.hash())
+            },
+            // below the restored-state floor: the scaffold region, never attested as canonical.
+            |_floor| None,
+        )
     }
 }
 

--- a/crates/tn-reth/src/snapshot.rs
+++ b/crates/tn-reth/src/snapshot.rs
@@ -2536,6 +2536,7 @@ mod tests {
     #[tokio::test]
     async fn scaffold_persists_restored_state_floor_and_env_refuses_below_it() -> eyre::Result<()> {
         use crate::error::StateReadError;
+        use tn_types::CanonicalExecutionReader;
 
         let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
         let dst_dir = TempDir::new()?;
@@ -2630,6 +2631,29 @@ mod tests {
         assert!(
             !err.to_string().contains("below this datadir's restored-state floor"),
             "the floor must not refuse a pin at the floor itself, got: {err}"
+        );
+
+        // #1323: the CanonicalExecutionReader DB fallback (consensus `wait_for_execution`) must
+        // refuse the whole scaffold region below the floor. Below `B` it attests no block — not
+        // even a window-interior height whose header carries a real hash, and certainly not a
+        // zero-hash dummy that would otherwise read back as its own `B256::ZERO`. So a peer's
+        // header referencing a scaffold `latest_execution_block` can never clear the execution
+        // check on a restored node, which is what let the poison certify network-wide. At the
+        // floor the reader answers truthfully from the DB.
+        assert_eq!(
+            env.canonical_execution_hash(2),
+            None,
+            "a below-floor height must never be attested as canonical execution"
+        );
+        assert_eq!(
+            env.canonical_execution_hash(3),
+            None,
+            "a window-interior height below B must never be attested as canonical execution"
+        );
+        assert_eq!(
+            env.canonical_execution_hash(5),
+            Some(h5.hash()),
+            "the block at the floor must resolve to its real canonical execution hash"
         );
 
         Ok(())


### PR DESCRIPTION
## What (Cantina #28)

Fixes #1323.  A snapshot restore scaffolds every pre-window execution header
with a `B256::ZERO` placeholder hash so the reth static files stay contiguous
below the restore window.  The vote-time canonical-execution check read those
placeholders directly from the DB, so a snapshot-restored validator would
attest a `(scaffold_height, B256::ZERO)` pair as canonical execution and let a
peer clear the execution-result gate against a block that was never executed.

## Fix

`RethEnv` now carries the restore window start `B` as `restored_state_floor`.
`canonical_execution_hash` refuses any lookup below the floor, so a scaffold
height resolves to `None` instead of the zero placeholder and can never be
attested as canonical.  On a fresh or normally-synced node `restored_state_floor`
is `None`, so the guard is a strict no-op.

## Scope note

An earlier revision of this change also rejected the zero hash inside the
`RecentBlocks` ring as defence-in-depth.  That reject was **dropped** for two
reasons:

1. **It defends an unreachable path.**  The scaffold dummies are written only to
   the reth static files, never seeded into the `RecentBlocks` ring.  The ring is
   primed from `last_executed_output_blocks`, which carry real sealed hashes, so
   a scaffold height is never a ring member.  The canonical-DB floor guard is the
   only reachable accept path for a scaffold height, and it is fully closed here.
2. **It broke a legitimate sentinel.**  `{0, B256::ZERO}` is the default
   "genesis / no execution yet" execution pointer that healthy nodes query
   through `wait_for_execution` before their first execution.  A blanket zero-hash
   reject in the ring makes that query miss and hangs the gate;  two `tn-node`
   integration tests reproduced the hang.

The canonical-DB floor guard is the load-bearing fix and closes #1323 on its own.

## Testing

- `tn-reth` unit test asserting `canonical_execution_hash` returns `None` for a
  height below the restore floor and the real hash at/above it.
- Manual mutation confirm: neutering the floor guard makes the unit test fail
  (mutant killed).
- The two `tn-node` integration tests that caught the earlier ring-guard
  regression (`test_entry_reads_static_fee_at_boundary`,
  `test_sync_then_catchup_recovers_two_worker_accumulator`) pass single-threaded.
- `fmt --check`, `check --all-targets`, `clippy --all-targets --no-deps -D warnings`
  on `tn-reth`.
