### PR TITLE
fix(tn-reth): pass the base fee container in the IPC transport test

### DIFF
--- a/crates/tn-reth/src/env/rpc.rs
+++ b/crates/tn-reth/src/env/rpc.rs
@@ -231,7 +231,7 @@ mod tests {
             reth::args::RpcServerArgs::default(),
         )
         .expect("temp chain env");
-        let pool = reth_env.init_txn_pool().expect("txn pool");
+        let pool = reth_env.init_txn_pool(BaseFeeContainer::default()).expect("txn pool");
         let network = WorkerNetwork::new_for_test(reth_env.chainspec());
         let server = reth_env
             .get_rpc_server(pool, network, BaseFeeContainer::default(), RpcModule::new(()))


### PR DESCRIPTION
## Problem

`main` does not compile at `--all-targets` since 743e4a38 ("Merge commit from fork"):

```
error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> crates/tn-reth/src/env/rpc.rs:234:29
    |
234 |         let pool = reth_env.init_txn_pool().expect("txn pool");
```

Every branch that merges current `main` inherits a red `cargo test --no-run --workspace` (and a red clippy `--all-targets` lane), so open PRs go red through no fault of their own.

## Root cause

Two changes crossed without a reconciling edit:

- 297088e5 (#1273) added the `BaseFeeContainer` parameter to `RethEnv::init_txn_pool` and updated the three call sites that existed on `main` at the time.
- 743e4a38 merged the fork-side `test_ipc_transport_serves_only_the_validated_modules`, written against the old zero-argument signature.

The merge is textually clean (different lines), so nothing forced a manual resolution, and no full-workspace test compile gated the merge commit before it landed.

## Fix

- [x] `crates/tn-reth/src/env/rpc.rs`: pass `BaseFeeContainer::default()` to `init_txn_pool` in the IPC transport test, matching the sibling call in `rpc_methods_with_cap`. The test exercises the IPC module allowlist, not fee behavior, so the default container is the right argument.

## Testing

- `cargo +1.94 check --workspace --all-targets -j 2` on 743e4a38 plus this change: green.
- `cargo +1.94 test --no-run --workspace --locked` (the attest command) on a tree containing unpatched 743e4a38: fails with the E0061 above, which is how the skew surfaced.
- `cargo +nightly fmt --all -- --check`: clean.
