### PR TITLE
fix(batch-builder): skip empty batch proposals

### DIFF
--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -575,11 +575,14 @@ mod tests {
         );
         assert!(txpool.pending_transactions().is_empty());
 
-        let outcome = timeout(Duration::from_secs(1), done)
-            .await
-            .map_err(std::io::Error::other)?
-            .map_err(std::io::Error::other)?
-            .map_err(std::io::Error::other)?;
+        let outcome = tokio::select! {
+            outcome = done => outcome
+                .map_err(std::io::Error::other)?
+                .map_err(std::io::Error::other)?,
+            _ = from_batch_builder.recv() => {
+                Err::<BuildOutcome, _>(std::io::Error::other("empty batch reached worker"))?
+            }
+        };
         assert_matches!(outcome, BuildOutcome::Empty);
         assert_matches!(
             from_batch_builder.try_recv(),
@@ -604,16 +607,25 @@ mod tests {
             .send(Ok(outcome))
             .map_err(|_| std::io::Error::other("build result receiver closed"))?;
         batch_builder.pending_task = Some(done);
-        let builder_task = tokio::spawn(batch_builder.run());
+        let mut builder_task = Box::pin(batch_builder.run());
 
-        // Virtual time makes the stale-tick and immediate-rebuild assertions deterministic.
-        assert!(timeout(delay - Duration::from_millis(1), from_batch_builder.recv())
-            .await
-            .is_err());
-        let (batch, ack) = timeout(delay, from_batch_builder.recv())
-            .await
-            .map_err(std::io::Error::other)?
-            .ok_or_else(|| std::io::Error::other("worker channel closed"))?;
+        // Register the reset deadline before advancing time. Reth's blocking validation
+        // tasks inhibit paused-clock auto-advance, so move the clock explicitly.
+        assert!(futures_util::poll!(&mut builder_task).is_pending());
+        tokio::time::advance(delay - Duration::from_millis(1)).await;
+        assert!(futures_util::poll!(&mut builder_task).is_pending());
+        assert_matches!(
+            from_batch_builder.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        );
+        tokio::time::advance(Duration::from_millis(1)).await;
+        let (batch, ack) = tokio::select! {
+            result = &mut builder_task => Err(std::io::Error::other(format!(
+                "builder exited before proposing a batch: {result:?}"
+            ))),
+            batch = from_batch_builder.recv() =>
+                batch.ok_or_else(|| std::io::Error::other("worker channel closed")),
+        }?;
         assert_eq!(batch.batch().transactions().len(), 1);
         let encoded = batch
             .batch()
@@ -623,13 +635,10 @@ mod tests {
         assert_eq!(recover_raw_transaction(encoded).map_err(std::io::Error::other)?.hash(), &hash);
         assert_eq!(txpool.pending_transactions().len(), 1);
 
-        // Acknowledge a fatal result to terminate and join the builder deterministically.
+        // Acknowledge a fatal result to terminate the builder deterministically.
         ack.send(Err(BlockSealError::FatalDBFailure))
             .map_err(|_| std::io::Error::other("batch acknowledgement receiver closed"))?;
-        assert_matches!(
-            builder_task.await.map_err(std::io::Error::other)?,
-            Err(BatchBuilderError::FatalDBFailure)
-        );
+        assert_matches!(builder_task.await, Err(BatchBuilderError::FatalDBFailure));
         Ok(())
     }
 

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -568,7 +568,7 @@ mod tests {
         assert_eq!(txpool.pending_transactions().len(), 1);
         let done = batch_builder.spawn_execution_task();
         txpool.update_canonical_state(
-            &chain.sealed_genesis_block(),
+            &batch_builder.last_canonical_update,
             None,
             vec![],
             vec![ChangedAccount { address: tx_factory.address(), nonce: 0, balance: U256::ZERO }],
@@ -589,7 +589,7 @@ mod tests {
         // Make the same transaction affordable before the loop consumes the empty result.
         // This also proves that an empty build did not remove it from the pool.
         txpool.update_canonical_state(
-            &chain.sealed_genesis_block(),
+            &batch_builder.last_canonical_update,
             None,
             vec![],
             vec![ChangedAccount {

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -533,113 +533,128 @@ mod tests {
     /// Drain the pending pool after the build gate but before the spawned task is polled.
     /// The empty result must never reach the worker, and the run loop must defer a newly
     /// affordable transaction until the reset batch delay has elapsed.
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn empty_build_after_pending_pool_drain_is_deferred() -> std::io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let TestTools { mut tx_factory, execution_components, task_manager } =
-            get_test_tools(tmp_dir.path());
-        let TestExecutionComponents { reth_env, txpool, chain } = execution_components;
-        let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
-        let delay = Duration::from_millis(100);
-        let mut batch_builder = BatchBuilder::new(
-            &reth_env,
-            txpool.clone(),
-            to_worker,
-            Address::ZERO,
-            delay,
-            task_manager.get_spawner(),
-            0,
-            MIN_PROTOCOL_BASE_FEE,
-            0,
-        )
-        .map_err(std::io::Error::other)?;
-        let hash = tx_factory
-            .create_and_submit_eip1559_pool_tx(
-                chain.clone(),
-                u128::from(MIN_PROTOCOL_BASE_FEE),
-                Address::ZERO,
-                U256::from(10),
+        // Keep setup, spawned builds and acknowledgement bounded by a running clock.
+        timeout(Duration::from_secs(10), async {
+            let tmp_dir = TempDir::new()?;
+            let TestTools { mut tx_factory, execution_components, task_manager } =
+                get_test_tools(tmp_dir.path());
+            let TestExecutionComponents { reth_env, txpool, chain } = execution_components;
+            let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
+            let delay = Duration::from_millis(100);
+            let mut batch_builder = BatchBuilder::new(
+                &reth_env,
                 txpool.clone(),
+                to_worker,
+                Address::ZERO,
+                delay,
+                task_manager.get_spawner(),
+                0,
+                MIN_PROTOCOL_BASE_FEE,
+                0,
             )
-            .await;
+            .map_err(std::io::Error::other)?;
+            let hash = tx_factory
+                .create_and_submit_eip1559_pool_tx(
+                    chain.clone(),
+                    u128::from(MIN_PROTOCOL_BASE_FEE),
+                    Address::ZERO,
+                    U256::from(10),
+                    txpool.clone(),
+                )
+                .await;
 
-        // Match the run loop's gate, then spawn without yielding. This single-threaded
-        // runtime cannot poll the build task before the synchronous canonical update below.
-        assert_eq!(txpool.pending_transactions().len(), 1);
-        let done = batch_builder.spawn_execution_task();
-        txpool.update_canonical_state(
-            &batch_builder.last_canonical_update,
-            None,
-            vec![],
-            vec![ChangedAccount { address: tx_factory.address(), nonce: 0, balance: U256::ZERO }],
-        );
-        assert!(txpool.pending_transactions().is_empty());
+            // Match the run loop's gate, then spawn without yielding. This single-threaded
+            // runtime cannot poll the build task before the synchronous canonical update below.
+            assert_eq!(txpool.pending_transactions().len(), 1);
+            let done = batch_builder.spawn_execution_task();
+            txpool.update_canonical_state(
+                &batch_builder.last_canonical_update,
+                None,
+                vec![],
+                vec![ChangedAccount {
+                    address: tx_factory.address(),
+                    nonce: 0,
+                    balance: U256::ZERO,
+                }],
+            );
+            assert!(txpool.pending_transactions().is_empty());
 
-        let outcome = tokio::select! {
-            outcome = done => outcome
-                .map_err(std::io::Error::other)?
-                .map_err(std::io::Error::other)?,
-            _ = from_batch_builder.recv() => {
-                Err::<BuildOutcome, _>(std::io::Error::other("empty batch reached worker"))?
-            }
-        };
-        assert_matches!(outcome, BuildOutcome::Empty);
-        assert_matches!(
-            from_batch_builder.try_recv(),
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
-        );
+            let outcome = tokio::select! {
+                outcome = done => outcome
+                    .map_err(std::io::Error::other)?
+                    .map_err(std::io::Error::other)?,
+                _ = from_batch_builder.recv() => {
+                    Err::<BuildOutcome, _>(std::io::Error::other("empty batch reached worker"))?
+                }
+            };
+            assert_matches!(outcome, BuildOutcome::Empty);
+            assert_matches!(
+                from_batch_builder.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            );
 
-        // Make the same transaction affordable before the loop consumes the empty result.
-        // This also proves that an empty build did not remove it from the pool.
-        txpool.update_canonical_state(
-            &batch_builder.last_canonical_update,
-            None,
-            vec![],
-            vec![ChangedAccount {
-                address: tx_factory.address(),
-                nonce: 0,
-                balance: U256::from(1_000_000_000_u64),
-            }],
-        );
-        assert_eq!(txpool.pending_transactions().len(), 1);
-        let (result, done) = oneshot::channel();
-        result
-            .send(Ok(outcome))
-            .map_err(|_| std::io::Error::other("build result receiver closed"))?;
-        batch_builder.pending_task = Some(done);
-        let mut builder_task = Box::pin(batch_builder.run());
+            // Make the same transaction affordable before the loop consumes the empty result.
+            // This also proves that an empty build did not remove it from the pool.
+            txpool.update_canonical_state(
+                &batch_builder.last_canonical_update,
+                None,
+                vec![],
+                vec![ChangedAccount {
+                    address: tx_factory.address(),
+                    nonce: 0,
+                    balance: U256::from(1_000_000_000_u64),
+                }],
+            );
+            assert_eq!(txpool.pending_transactions().len(), 1);
+            let (result, done) = oneshot::channel();
+            result
+                .send(Ok(outcome))
+                .map_err(|_| std::io::Error::other("build result receiver closed"))?;
+            batch_builder.pending_task = Some(done);
+            tokio::time::pause();
+            let mut builder_task = Box::pin(batch_builder.run());
 
-        // Register the reset deadline before advancing time. Reth's blocking validation
-        // tasks inhibit paused-clock auto-advance, so move the clock explicitly.
-        assert!(futures_util::poll!(&mut builder_task).is_pending());
-        tokio::time::advance(delay - Duration::from_millis(1)).await;
-        assert!(futures_util::poll!(&mut builder_task).is_pending());
-        assert_matches!(
-            from_batch_builder.try_recv(),
-            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
-        );
-        tokio::time::advance(Duration::from_millis(1)).await;
-        let (batch, ack) = tokio::select! {
-            result = &mut builder_task => Err(std::io::Error::other(format!(
-                "builder exited before proposing a batch: {result:?}"
-            ))),
-            batch = from_batch_builder.recv() =>
-                batch.ok_or_else(|| std::io::Error::other("worker channel closed")),
-        }?;
-        assert_eq!(batch.batch().transactions().len(), 1);
-        let encoded = batch
-            .batch()
-            .transactions()
-            .first()
-            .ok_or_else(|| std::io::Error::other("missing transaction"))?;
-        assert_eq!(recover_raw_transaction(encoded).map_err(std::io::Error::other)?.hash(), &hash);
-        assert_eq!(txpool.pending_transactions().len(), 1);
+            // Register the reset deadline before advancing time. Reth's blocking validation
+            // tasks inhibit paused-clock auto-advance, so move the clock explicitly.
+            assert!(futures_util::poll!(&mut builder_task).is_pending());
+            tokio::time::advance(delay.saturating_sub(Duration::from_millis(1))).await;
+            assert!(futures_util::poll!(&mut builder_task).is_pending());
+            assert_matches!(
+                from_batch_builder.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            );
+            // Resume before awaiting spawned work so both the interval and watchdog can
+            // progress without depending on exact paused-clock timer boundaries.
+            tokio::time::resume();
+            let (batch, ack) = tokio::select! {
+                result = &mut builder_task => Err(std::io::Error::other(format!(
+                    "builder exited before proposing a batch: {result:?}"
+                ))),
+                batch = from_batch_builder.recv() =>
+                    batch.ok_or_else(|| std::io::Error::other("worker channel closed")),
+            }?;
+            assert_eq!(batch.batch().transactions().len(), 1);
+            let encoded = batch
+                .batch()
+                .transactions()
+                .first()
+                .ok_or_else(|| std::io::Error::other("missing transaction"))?;
+            assert_eq!(
+                recover_raw_transaction(encoded).map_err(std::io::Error::other)?.hash(),
+                &hash
+            );
+            assert_eq!(txpool.pending_transactions().len(), 1);
 
-        // Acknowledge a fatal result to terminate the builder deterministically.
-        ack.send(Err(BlockSealError::FatalDBFailure))
-            .map_err(|_| std::io::Error::other("batch acknowledgement receiver closed"))?;
-        assert_matches!(builder_task.await, Err(BatchBuilderError::FatalDBFailure));
-        Ok(())
+            // Acknowledge a fatal result to terminate the builder deterministically.
+            ack.send(Err(BlockSealError::FatalDBFailure))
+                .map_err(|_| std::io::Error::other("batch acknowledgement receiver closed"))?;
+            assert_matches!(builder_task.await, Err(BatchBuilderError::FatalDBFailure));
+            Ok(())
+        })
+        .await
+        .map_err(|_| std::io::Error::other("empty-build regression exceeded its 10-second limit"))?
     }
 
     #[tokio::test]

--- a/crates/batch-builder/src/lib.rs
+++ b/crates/batch-builder/src/lib.rs
@@ -53,6 +53,9 @@ struct MinedBatchResult {
 /// this as the `Err` of the surrounding [`BatchBuilderResult`].
 #[derive(Debug)]
 enum BuildOutcome {
+    /// Transaction selection produced no batch to propose. Defer the next build without
+    /// sealing, updating the pool, or changing the forward-admission backoff.
+    Empty,
     /// The batch reached quorum (or a forward task was admitted to deliver it): prune the
     /// mined transactions from the pool and apply the account changes.
     Mined(MinedBatchResult),
@@ -184,7 +187,7 @@ impl BatchBuilder {
     ///
     /// The task performs the following actions:
     /// - create a batch
-    /// - send the batch to worker's batch proposer
+    /// - defer an empty batch, otherwise send it to the worker's batch proposer
     /// - wait for ack that quorum was reached
     /// - convert result to fatal/non-fatal
     /// - return result
@@ -211,6 +214,11 @@ impl BatchBuilder {
 
             // this is safe to call without a semaphore bc it's held as a single `Option`
             let BatchBuilderOutput { batch, mined_transactions, changed_accounts } = build_batch(build_args, worker_id, base_fee);
+            // Canonical updates can drain the pending pool after the run loop's build gate.
+            // Selection can also skip every candidate. Neither case should reach the worker.
+            if batch.transactions().is_empty() {
+                let _ = result.send(Ok(BuildOutcome::Empty));
+            } else {
             let batch = batch.seal_slow();
             span.record("batch", batch.digest().to_string());
 
@@ -276,6 +284,7 @@ impl BatchBuilder {
                         error!(target: "worker::batch_builder", ?e, "failed to send block builder result to block builder task");
                     }
                 }
+            }
             }
             Ok(())
         }.instrument(span_clone));
@@ -430,7 +439,7 @@ impl BatchBuilder {
                     let outcome = res??;
 
                     // Refusal backoff bookkeeping (issue #1145): a refusal arms or extends the
-                    // backoff, anything mined ends it. Refused and Failed then take the
+                    // backoff, anything mined ends it. Empty, Refused and Failed take the
                     // pre-existing empty-mined path below: no pool update, one deferred build,
                     // park until a wake-up.
                     let MinedBatchResult { mined_transactions, changed_accounts } = match outcome {
@@ -442,7 +451,7 @@ impl BatchBuilder {
                                 changed_accounts: vec![],
                             }
                         }
-                        BuildOutcome::Failed => MinedBatchResult {
+                        BuildOutcome::Empty | BuildOutcome::Failed => MinedBatchResult {
                             mined_transactions: vec![],
                             changed_accounts: vec![],
                         },
@@ -520,6 +529,109 @@ mod tests {
     };
     use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
     use tokio::time::timeout;
+
+    /// Drain the pending pool after the build gate but before the spawned task is polled.
+    /// The empty result must never reach the worker, and the run loop must defer a newly
+    /// affordable transaction until the reset batch delay has elapsed.
+    #[tokio::test(start_paused = true)]
+    async fn empty_build_after_pending_pool_drain_is_deferred() -> std::io::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let TestTools { mut tx_factory, execution_components, task_manager } =
+            get_test_tools(tmp_dir.path());
+        let TestExecutionComponents { reth_env, txpool, chain } = execution_components;
+        let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
+        let delay = Duration::from_millis(100);
+        let mut batch_builder = BatchBuilder::new(
+            &reth_env,
+            txpool.clone(),
+            to_worker,
+            Address::ZERO,
+            delay,
+            task_manager.get_spawner(),
+            0,
+            MIN_PROTOCOL_BASE_FEE,
+            0,
+        )
+        .map_err(std::io::Error::other)?;
+        let hash = tx_factory
+            .create_and_submit_eip1559_pool_tx(
+                chain.clone(),
+                u128::from(MIN_PROTOCOL_BASE_FEE),
+                Address::ZERO,
+                U256::from(10),
+                txpool.clone(),
+            )
+            .await;
+
+        // Match the run loop's gate, then spawn without yielding. This single-threaded
+        // runtime cannot poll the build task before the synchronous canonical update below.
+        assert_eq!(txpool.pending_transactions().len(), 1);
+        let done = batch_builder.spawn_execution_task();
+        txpool.update_canonical_state(
+            &chain.sealed_genesis_block(),
+            None,
+            vec![],
+            vec![ChangedAccount { address: tx_factory.address(), nonce: 0, balance: U256::ZERO }],
+        );
+        assert!(txpool.pending_transactions().is_empty());
+
+        let outcome = timeout(Duration::from_secs(1), done)
+            .await
+            .map_err(std::io::Error::other)?
+            .map_err(std::io::Error::other)?
+            .map_err(std::io::Error::other)?;
+        assert_matches!(outcome, BuildOutcome::Empty);
+        assert_matches!(
+            from_batch_builder.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        );
+
+        // Make the same transaction affordable before the loop consumes the empty result.
+        // This also proves that an empty build did not remove it from the pool.
+        txpool.update_canonical_state(
+            &chain.sealed_genesis_block(),
+            None,
+            vec![],
+            vec![ChangedAccount {
+                address: tx_factory.address(),
+                nonce: 0,
+                balance: U256::from(1_000_000_000_u64),
+            }],
+        );
+        assert_eq!(txpool.pending_transactions().len(), 1);
+        let (result, done) = oneshot::channel();
+        result
+            .send(Ok(outcome))
+            .map_err(|_| std::io::Error::other("build result receiver closed"))?;
+        batch_builder.pending_task = Some(done);
+        let builder_task = tokio::spawn(batch_builder.run());
+
+        // Virtual time makes the stale-tick and immediate-rebuild assertions deterministic.
+        assert!(timeout(delay - Duration::from_millis(1), from_batch_builder.recv())
+            .await
+            .is_err());
+        let (batch, ack) = timeout(delay, from_batch_builder.recv())
+            .await
+            .map_err(std::io::Error::other)?
+            .ok_or_else(|| std::io::Error::other("worker channel closed"))?;
+        assert_eq!(batch.batch().transactions().len(), 1);
+        let encoded = batch
+            .batch()
+            .transactions()
+            .first()
+            .ok_or_else(|| std::io::Error::other("missing transaction"))?;
+        assert_eq!(recover_raw_transaction(encoded).map_err(std::io::Error::other)?.hash(), &hash);
+        assert_eq!(txpool.pending_transactions().len(), 1);
+
+        // Acknowledge a fatal result to terminate and join the builder deterministically.
+        ack.send(Err(BlockSealError::FatalDBFailure))
+            .map_err(|_| std::io::Error::other("batch acknowledgement receiver closed"))?;
+        assert_matches!(
+            builder_task.await.map_err(std::io::Error::other)?,
+            Err(BatchBuilderError::FatalDBFailure)
+        );
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_make_block_no_ack_txs_in_pool_still() {

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -295,9 +295,18 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         admitted.then_some(()).ok_or(BlockSealError::NotValidator)
     }
 
-    /// Seal and broadcast the current batch.
+    /// Seal and broadcast the current batch, treating empty batches as a successful no-op.
     #[instrument(level = "debug", skip_all, fields(batch_size = sealed_batch.size(), num_txs = sealed_batch.batch.transactions.len()))]
     pub async fn seal(&self, sealed_batch: SealedBatch) -> Result<(), BlockSealError> {
+        if sealed_batch.batch.transactions.is_empty() {
+            Ok(())
+        } else {
+            self.seal_non_empty(sealed_batch).await
+        }
+    }
+
+    /// Forward or attest a batch after `seal` has confirmed it contains transactions.
+    async fn seal_non_empty(&self, sealed_batch: SealedBatch) -> Result<(), BlockSealError> {
         let Some(quorum_waiter) = &self.quorum_waiter else {
             // We are not a validator so need to send any transactions out for a CVV to pickup.
             return self.disburse_txns(sealed_batch).await;

--- a/crates/consensus/worker/tests/it/batch_provider_tests.rs
+++ b/crates/consensus/worker/tests/it/batch_provider_tests.rs
@@ -1,13 +1,92 @@
 //! Unit tests for the worker's batch provider.
-use std::{sync::Arc, time::Duration};
+use futures::FutureExt as _;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tempfile::TempDir;
+use tn_network_libp2p::types::NetworkHandle;
 use tn_network_types::{local::LocalNetwork, MockWorkerToPrimary};
 use tn_reth::test_utils::transaction;
-use tn_storage::{open_db, tables::NodeBatchesCache};
-use tn_types::{
-    error::BlockSealError, test_chain_spec_arc, Batch, Database, NoopTxnForwarder, TaskManager,
+use tn_storage::{
+    mem_db::MemDatabase,
+    open_db,
+    tables::{NodeBatchesCache, OurNodeBatchesCache},
 };
-use tn_worker::{test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle};
+use tn_types::{
+    error::BlockSealError, test_chain_spec_arc, Batch, Database, NoopTxnForwarder, SealedBatch,
+    TaskManager, TaskSpawner,
+};
+use tn_worker::{
+    quorum_waiter::{QuorumWaiterError, QuorumWaiterTrait},
+    test_utils::TestMakeBlockQuorumWaiter,
+    Worker, WorkerNetworkHandle,
+};
+use tokio::sync::{mpsc, oneshot};
+
+/// Quorum waiter that records calls synchronously and immediately accepts each batch.
+#[derive(Clone, Default)]
+struct RecordingQuorumWaiter {
+    /// Number of batches submitted for quorum verification.
+    calls: Arc<AtomicUsize>,
+}
+
+impl QuorumWaiterTrait for RecordingQuorumWaiter {
+    /// Record the call and resolve quorum without a spawned task or elapsed-time dependency.
+    fn verify_batch(
+        &self,
+        _batch: SealedBatch,
+        _timeout: Duration,
+        _task_spawner: &TaskSpawner,
+    ) -> oneshot::Receiver<Result<(), QuorumWaiterError>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(()));
+        rx
+    }
+}
+
+/// Empty seals complete immediately without quorum, network, storage, or primary effects.
+fn assert_empty_seal_is_noop(quorum_waiter: Option<RecordingQuorumWaiter>) {
+    let store = MemDatabase::default();
+    let task_manager = TaskManager::default();
+    let (tx, mut rx) = mpsc::channel(1);
+    let batch_provider = Worker::new(
+        0,
+        quorum_waiter.clone(),
+        // Reporting without a registered primary handler would fail the seal.
+        LocalNetwork::new_with_empty_id(),
+        store.clone(),
+        Duration::from_secs(5),
+        WorkerNetworkHandle::new(NetworkHandle::new(tx), task_manager.get_spawner(), 0, 0, 0),
+        Arc::new(NoopTxnForwarder),
+        Vec::new(),
+    );
+    let empty_batch = Batch::default().seal_slow();
+    let digest = empty_batch.digest();
+
+    // A network command would remain pending because the receiver sends no response.
+    assert!(matches!(batch_provider.seal(empty_batch).now_or_never(), Some(Ok(()))));
+    assert!(quorum_waiter.is_none_or(|waiter| waiter.calls.load(Ordering::SeqCst) == 0));
+    assert!(matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+    assert!(store.get::<OurNodeBatchesCache>(&digest).is_ok_and(|batch| batch.is_none()));
+    assert!(store.get::<NodeBatchesCache>(&digest).is_ok_and(|batch| batch.is_none()));
+}
+
+/// A committee validator drops an empty batch before seeking quorum or broadcasting it.
+#[tokio::test]
+async fn validator_empty_seal_is_noop() {
+    assert_empty_seal_is_noop(Some(RecordingQuorumWaiter::default()));
+}
+
+/// An observer also drops an empty batch without discovering forwarding endpoints.
+#[tokio::test]
+async fn observer_empty_seal_is_noop() {
+    assert_empty_seal_is_noop(None);
+}
 
 #[tokio::test]
 async fn make_batch() {


### PR DESCRIPTION
Closes #1338.

## Problem

A canonical account update can drain the pending pool after the batch builder's gate but before transaction selection. The resulting empty batch was sealed and sent to the worker, which requested quorum even though peers reject empty batches. This can happen to an honest validator with no attacker required, wasting a proposal and producing misleading peer-penalty signals.

## Changes

- [x] **Defer empty builds:** return an explicit empty outcome before sealing or sending to the worker. Reuse the existing timer reset and deferred-build path without updating the pool, recording a seal failure, or changing refusal backoff.
- [x] **Guard the worker boundary:** acknowledge empty batches as a successful no-op before forwarding, quorum, persistence, reporting, or broadcast.
- [x] **Add bounded regressions:** demote the pending transaction before the spawned build runs, verify no empty proposal, and verify that the restored transaction is proposed after the batch delay. Pause time only for the deterministic early-rebuild assertion, then resume before awaiting spawned work, with a 10-second watchdog. Cover empty validator and observer seals with no quorum, network, or storage effects.

## Testing

- Passed: `gateledger run -- cargo +nightly-2026-03-20 fmt --all --check` and `git diff --check`.
- Passed: independent diff review, including CI-weakening and timer/backoff checks.
- Passed in [hosted validation](https://github.com/Telcoin-Association/telcoin-network/actions/runs/34290539093): `./etc/ci-lanes.sh clippy` (both passes), `./etc/ci-lanes.sh test-default --build-only`, and `./etc/ci-lanes.sh test-adiri --build-only`.
- Passed: `NEXTEST_PROFILE=issue1338-strict ./etc/ci-lanes.sh test-default`, 1,709 passed and 32 skipped in 141.337 seconds. The empty-build regression passed in 0.234 seconds within this full suite.
- Passed: `NEXTEST_PROFILE=issue1338-strict ./etc/ci-lanes.sh test-adiri`, 907 passed and 6 skipped in 59.449 seconds.
- The validation profile preserves existing test groups, disables retries, and fails any test reaching 60 seconds with no grace period. No `SLOW` events occurred in the run.
- Passed: all three production regressions before and after mutation checks. Disabling the builder guard fails with `empty batch reached worker`; disabling the worker guard fails the validator's immediate-success assertion. Both are actual test failures, not compilation failures or timeouts. The observer control still passes with the worker guard disabled, confirming its existing empty-disbursement behavior.
- Passed: deliberately replacing the initial build result with a permanently pending future makes the regression fail in 10.011 seconds with `empty-build regression exceeded its 10-second limit`. Restoring the source restores all three passing regressions.

Exact regression command:

```sh
cargo nextest run --locked --workspace --no-fail-fast --retries 0 -- \
  tests::empty_build_after_pending_pool_drain_is_deferred \
  batch_provider_tests::validator_empty_seal_is_noop \
  batch_provider_tests::observer_empty_seal_is_noop --exact
```

Validation commit `59dbb3c8` has identical Rust sources to PR head `a2ee92ae`. Its only additional change is the workflow code that runs the regressions, mutations, watchdog check, and strict full suites. That workflow change is outside this PR. Source and configuration mutations are restored before the job completes.

Pending: archive/RocksDB guards and the ignored all-feature e2e suite on the PR head, followed by maintainer on-chain attestation. Maintainer PR-head compile/test lanes are skipped by repository policy; `verify-on-chain` is currently red because this commit is unattested. This PR remains draft.
