### PR TITLE
fix(node): keep bootstrap servers out of epoch committees

### DIFF
--- a/crates/node/src/manager/node.rs
+++ b/crates/node/src/manager/node.rs
@@ -663,16 +663,13 @@ where
     ) -> eyre::Result<Self> {
         // Note this can only fail if the consensus DB is very broken (bad path for instance).
         // So we will panic for now, this will kill the node on startup for a critical error.
-        let committee_zero = if let Ok(committee_zero) =
+        let committee_zero =
             Config::load_from_path::<Committee>(tn_datadir.committee_path(), ConfigFmt::YAML)
-        {
-            committee_zero
-        } else {
-            error!(target: "epoch-manager", "Unable to load committee zero from the genesis committee!");
-            return Err(eyre::eyre!(
-                "unable to load committee zero (genesis committee), this is fatal"
-            ));
-        };
+                .map_err(|_| {
+                    error!(target: "epoch-manager", "Unable to load committee zero from the genesis committee!");
+                    eyre::eyre!("unable to load committee zero (genesis committee), this is fatal")
+                })?;
+        let bootstrap_servers = committee_zero.bootstrap_servers();
         let epochs_db_path = tn_datadir.epochs_db_path();
         let _ = std::fs::create_dir_all(&epochs_db_path);
         let consensus_chain = ConsensusChain::new(epochs_db_path, committee_zero)?;
@@ -691,17 +688,6 @@ where
         let worker_event_streams = (0..builder.tn_config.node_info.p2p_info.num_workers())
             .map(|_| QueChannel::new())
             .collect();
-        let bootstrap_servers = if let Ok(committee_zero) =
-            Config::load_from_path_or_default::<Committee>(
-                tn_datadir.committee_path(),
-                ConfigFmt::YAML,
-            ) {
-            committee_zero.bootstrap_servers()
-        } else {
-            error!(target: "epoch-manager", "Unable to load bootstrap servers from the genesis committee!");
-            BTreeMap::new()
-        };
-
         // Spawn the state exporter once, only when the feature is enabled.
         let exec_state_exporter =
             builder.enable_state_export.then(ExecStateExporter::spawn).transpose()?;

--- a/crates/node/src/manager/node/start_epoch.rs
+++ b/crates/node/src/manager/node/start_epoch.rs
@@ -339,7 +339,8 @@ where
     ///
     /// Epoch 0 has no on-chain history, so the genesis committee is loaded from the
     /// committee file on disk. Every later epoch is built with a [`CommitteeBuilder`] from the
-    /// statically configured bootstrap servers plus the on-chain validator set for that epoch.
+    /// on-chain validator set for that epoch. Bootstrap dial hints stay in the manager's
+    /// process-lifetime configuration instead of being copied into later committees.
     ///
     /// In both cases the committee's worker count comes from the on-chain `WorkerConfigs` state
     /// at the previous epoch's closing block (`epoch_first_block - 1`; genesis state for epoch
@@ -378,17 +379,9 @@ where
             .with_num_workers(num_workers)
         } else {
             let mut committee_builder = CommitteeBuilder::new(epoch).with_num_workers(num_workers);
-            for (key, bootstrap) in &self.bootstrap_servers {
-                committee_builder.add_bootstrap_server(
-                    *key,
-                    bootstrap.primary.clone(),
-                    bootstrap.workers.clone(),
-                );
-            }
-
-            for validator in validators {
-                committee_builder.add_authority(validator.0, validator.1.validatorAddress);
-            }
+            validators.into_iter().for_each(|(key, validator)| {
+                committee_builder.add_authority(key, validator.validatorAddress);
+            });
             committee_builder.build()
         };
 
@@ -612,12 +605,8 @@ where
             .map(|a| *a.protocol_key())
             .collect();
 
-        let bootstrap_peers = consensus_config
-            .committee()
-            .bootstrap_servers()
-            .iter()
-            .map(|(k, v)| (*k, v.primary.clone()))
-            .collect();
+        let bootstrap_peers =
+            self.bootstrap_servers.iter().map(|(k, v)| (*k, v.primary.clone())).collect();
         let next_committee_keys: HashSet<BlsPublicKey> =
             consensus_config.next_committee_keys().iter().copied().collect();
         // Publishers authorized for the epoch-boundary topics (`epoch_vote_topic`,
@@ -823,9 +812,8 @@ where
             .map(|a| *a.protocol_key())
             .collect();
 
-        let bootstrap_peers = consensus_config
-            .committee()
-            .bootstrap_servers()
+        let bootstrap_peers = self
+            .bootstrap_servers
             .iter()
             // worker 0 always exists (the non-empty list invariant is enforced at deserialize).
             // for higher ids a missing entry drops the peer, which is correct: a peer that runs

--- a/crates/types/src/committee.rs
+++ b/crates/types/src/committee.rs
@@ -1079,17 +1079,6 @@ impl CommitteeBuilder {
         self.authorities.insert(protocol_key, authority);
     }
 
-    /// Add a bootstrap server to the committee builder.
-    pub fn add_bootstrap_server(
-        &mut self,
-        protocol_key: BlsPublicKey,
-        primary_node: P2pNode,
-        worker_nodes: Vec<P2pNode>,
-    ) {
-        let bootstrap = BootstrapServer::new(primary_node, worker_nodes);
-        self.bootstrap_server.insert(protocol_key, bootstrap);
-    }
-
     /// Build the [Committee].
     pub fn build(self) -> Committee {
         Committee::new(self.authorities, self.epoch, self.bootstrap_server, self.num_workers)


### PR DESCRIPTION
Closes #1349.

## Problem

The epoch manager copies genesis bootstrap servers into every later committee, then reads them back during primary and worker network setup. These process-wide discovery hints already live in the manager.

## Changes

- [x] **Load genesis once in `EpochManager::new`** and retain its bootstrap servers before moving the committee into the consensus chain.
- [x] **Read primary and worker bootstrap peers from the manager**, preserving filtering for peers without the requested worker ID.
- [x] **Build later committees from on-chain validators** and remove the unused `CommitteeBuilder::add_bootstrap_server` method.

Peer authorization still comes from the previous/current/next committee sets. Bootstrap registration remains once per process, before the initial committee update, including when restarting after epoch 0. Genesis committee files and committee serialization retain their existing formats.

## Testing

- Passed: `cargo +nightly-2026-03-20 fmt --all -- --check` through `gateledger`.
- Passed: `git diff --check` and a strict diff review, including all remaining bootstrap readers and the removed API's callers.
- The `diffclass`, `apidelta`, and `buildplan` ladder retains the full 25-crate dependency closure for Clippy.
- Not run: the planned Clippy command exhausted its 300-second `tnquiet` wait behind another active build (exit 75, before Cargo started).
- Pending: workspace check, Clippy, nextest, and the maintainer's pinned Rust 1.94 attestation suite. GitHub skips the compile and test lanes for maintainer-authored PRs.
- Confirmed: [the PR workflow](https://github.com/Telcoin-Association/telcoin-network/actions/runs/34409413557) skipped its compile/test lanes and failed `verify-on-chain` because commit `50e05dd4cbaba3615ded362080847fe8d66626a8` has no attestation. A maintainer must run `make attest` on that commit, then request a review to rerun the check.
